### PR TITLE
Add parameter overrides to column searchable and sortable

### DIFF
--- a/packages/tables/src/Columns/Column.php
+++ b/packages/tables/src/Columns/Column.php
@@ -20,7 +20,11 @@ class Column
 
     protected $isSearchable = false;
 
+    protected $searchUsing = false;
+
     protected $isSortable = false;
+
+    protected $sortUsing = false;
 
     protected $label;
 
@@ -179,9 +183,19 @@ class Column
         return $this->isSearchable && $this->getValueUsing === null;
     }
 
+    public function getSearchUsing()
+    {
+        return $this->searchUsing;
+    }
+
     public function isSortable()
     {
         return $this->isSortable && $this->getValueUsing === null;
+    }
+
+    public function getSortUsing()
+    {
+        return $this->sortUsing;
     }
 
     public function label($label)
@@ -253,19 +267,21 @@ class Column
         ]));
     }
 
-    public function searchable()
+    public function searchable($searchUsing = false)
     {
-        $this->configure(function () {
+        $this->configure(function () use ($searchUsing) {
             $this->isSearchable = true;
+            $this->searchUsing = $searchUsing;
         });
 
         return $this;
     }
 
-    public function sortable()
+    public function sortable($sortUsing = false)
     {
-        $this->configure(function () {
+        $this->configure(function () use ($sortUsing) {
             $this->isSortable = true;
+            $this->sortUsing = $sortUsing;
         });
 
         return $this;


### PR DESCRIPTION
In reference to this discussion https://github.com/laravel-filament/filament/discussions/51

This PR allows the `->searchable()` and `->sortable()` methods of the Column to accept a parameter to override a column's default search or sort behaviour.

Main example use case is where a resource column's  value is accessed via a model's `getXXXXXAttribute` where the underlying field does not exist in the table definition.  Refer to the above linked discussion for an example use case.



