### PR TITLE
Adds drag and drop reordering to tables

### DIFF
--- a/packages/tables/resources/views/components/table.blade.php
+++ b/packages/tables/resources/views/components/table.blade.php
@@ -50,6 +50,10 @@
                 @endforeach
 
                 <th scope="col"></th>
+
+                @if($table->isReorderable())
+                    <th scope="col"></th>
+                @endif
             </tr>
         </thead>
 
@@ -60,7 +64,7 @@
                     wire:loading.class="opacity-50"
                     class="{{ $loop->index % 2 ? 'bg-gray-50' : 'bg-white' }}"
                     @if($table->isReorderable())
-                      wire:sortable.item="{{ $record->getKey() }}"
+                        wire:sortable.item="{{ $record->getKey() }}"
                     @endif
                 >
                     <td class="p-4 whitespace-nowrap">
@@ -83,12 +87,18 @@
                             {{ $recordAction->render($record) }}
                         @endforeach
                     </td>
+
+                    @if($table->isReorderable())
+                        <td class="px-6 border-l cursor-move whitespace-nowrap"  wire:sortable.handle>
+                            <x-heroicon-o-menu-alt-4 class="w-4 h-4 text-gray-500"/>
+                        </td>
+                    @endif
                 </tr>
             @empty
                 <tr>
                     <td
                         class="px-6 py-4 whitespace-nowrap"
-                        colspan="{{ count($table->getVisibleColumns()) + 2 }}"
+                        colspan="{{ count($table->getVisibleColumns()) + ($table->isReorderable()?3:2) }}"
                     >
                         <div class="flex items-center justify-center h-16">
                             <p class="font-mono text-xs text-gray-500">

--- a/packages/tables/resources/views/components/table.blade.php
+++ b/packages/tables/resources/views/components/table.blade.php
@@ -53,12 +53,15 @@
             </tr>
         </thead>
 
-        <tbody class="text-sm leading-tight divide-y divide-gray-200">
+        <tbody class="text-sm leading-tight divide-y divide-gray-200"  @if($table->isReorderable()) wire:sortable="{{  $table->getReorderAction() }}" @endif>
             @forelse ($records as $record)
                 <tr
                     wire:key="{{ $record->getKey() }}"
                     wire:loading.class="opacity-50"
-                    class="{{ $loop->index % 2 ? 'bg-gray-50' : null }}"
+                    class="{{ $loop->index % 2 ? 'bg-gray-50' : 'bg-white' }}"
+                    @if($table->isReorderable())
+                      wire:sortable.item="{{ $record->getKey() }}"
+                    @endif
                 >
                     <td class="p-4 whitespace-nowrap">
                         <input
@@ -98,3 +101,8 @@
         </tbody>
     </table>
 </div>
+@if($table->isReorderable())
+    @push('filament-scripts')
+        <script src="https://cdn.jsdelivr.net/gh/livewire/sortable@v0.x.x/dist/livewire-sortable.js"></script>
+    @endpush
+@endif

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -14,6 +14,8 @@ class Table
 
     protected $filters = [];
 
+    protected $reorderAction;
+
     protected $hasPagination = true;
 
     protected $isFilterable = true;
@@ -21,6 +23,8 @@ class Table
     protected $isSearchable = true;
 
     protected $isSortable = true;
+
+    protected $isReorderable = true;
 
     protected $primaryColumnAction;
 
@@ -72,6 +76,14 @@ class Table
     public function disableSorting()
     {
         $this->isSortable = false;
+
+        return $this;
+    }
+
+
+    public function disableReordering()
+    {
+        $this->isReorderable = false;
 
         return $this;
     }
@@ -136,6 +148,11 @@ class Table
         return $this->recordActions;
     }
 
+    public function getReorderAction()
+    {
+        return $this->reorderAction;
+    }
+
     public function getVisibleColumns()
     {
         $columns = collect($this->getColumns())
@@ -176,6 +193,12 @@ class Table
         return $this->isSortable && collect($this->columns)
                 ->filter(fn ($column) => $column->isSortable())
                 ->count();
+    }
+
+
+    public function isReorderable()
+    {
+        return $this->isReorderable && !is_null($this->reorderAction);
     }
 
     public static function make()
@@ -237,7 +260,14 @@ class Table
     {
         return $this->shouldPrimaryColumnUrlOpenInNewTab;
     }
+ 
+    public function reorderable($action =  null)
+    {
+        $this->reorderAction = $action;
 
+        return $this;
+    }
+    
     public function sortable($sortable)
     {
         $this->sortable = $sortable;

--- a/src/Resources/Pages/ListRecords.php
+++ b/src/Resources/Pages/ListRecords.php
@@ -28,6 +28,8 @@ class ListRecords extends Page
 
     public $sortable = true;
 
+    public $reorderAction;
+
     public static $view = 'filament::resources.pages.list-records';
 
     public function canCreate()
@@ -88,7 +90,8 @@ class ListRecords extends Page
                         ->when(fn ($record) => Filament::can('update', $record)),
                 ])
                 ->searchable($this->searchable)
-                ->sortable($this->sortable),
+                ->sortable($this->sortable)
+                ->reorderable($this->reorderAction),
         );
     }
 


### PR DESCRIPTION
Uses https://github.com/livewire/sortable to manage table reordering. 

Adds new method to Table : reorderable($action)

Passing a valid livewire action into the method activates it and includes the https://github.com/livewire/sortable library to handle all the drag and drop functionality.

Demo
https://user-images.githubusercontent.com/209072/111874531-b67d6f80-898d-11eb-9947-4a70999b1237.mov

