### PR TITLE
Add ability to hide widgets

### DIFF
--- a/src/FilamentServiceProvider.php
+++ b/src/FilamentServiceProvider.php
@@ -255,7 +255,8 @@ class FilamentServiceProvider extends ServiceProvider
             })
             ->filter(function ($class) {
                 return is_subclass_of($class, Widget::class) &&
-                    ! (new ReflectionClass($class))->isAbstract();
+                    ! (new ReflectionClass($class))->isAbstract() &&
+                    ($class::$hidden ?? false) === false;
             })
             ->each(fn ($widget) => Filament::registerWidget($widget));
     }

--- a/stubs/Widget.stub
+++ b/stubs/Widget.stub
@@ -7,4 +7,9 @@ use Filament\Widgets\Widget;
 class {{ class }} extends Widget
 {
     public static $view = '{{ view }}';
+
+    /**
+     * @var bool $hidden
+     */
+    public static $hidden = false;
 }


### PR DESCRIPTION
Hello,

This PR adds the ability to hide widgets with a static property. Use case is when you have developed some widgets that are not required anymore, but you don't want to remove them as they may be needed on the near future.

I think this can be made more useful by adding a static function `hide()` which defaults to `false`, so you can show or hide the widget at runtime (for example, show a widget based on user roles, or on some metrics). I would add it (backwards compatible) if that adds more value to this PR.