### PR TITLE
Unique Chart JS Variable

### DIFF
--- a/packages/admin/resources/views/widgets/chart-widget.blade.php
+++ b/packages/admin/resources/views/widgets/chart-widget.blade.php
@@ -6,10 +6,10 @@
     <div {!! ($pollingInterval = $this->getPollingInterval()) ? "wire:poll.{$pollingInterval}=\"updateChartData\"" : '' !!}>
         <canvas
             x-data="{
-                chart: null,
+                {{ $this->getChartVariableName() }}: null,
 
                 init: function () {
-                    chart = new Chart(
+                    {{ $this->getChartVariableName() }} = new Chart(
                         $el,
                         {
                             type: '{{ $this->getType() }}',
@@ -19,9 +19,9 @@
                     )
 
                     $wire.on('updateChartData', async ({ data }) => {
-                        chart.data = data
+                        {{ $this->getChartVariableName() }}.data = data
 
-                        chart.update('resize')
+                        {{ $this->getChartVariableName() }}.update('resize')
                     })
                 }
             }"

--- a/packages/admin/src/Widgets/ChartWidget.php
+++ b/packages/admin/src/Widgets/ChartWidget.php
@@ -14,14 +14,22 @@ class ChartWidget extends Widget
 
     protected static string $view = 'filament::widgets.chart-widget';
 
+    private string $chartVariable;
+
     public function mount()
     {
         $this->dataChecksum = $this->generateDataChecksum();
+        $this->chartVariable = 'chart' . uniqid();
     }
 
     protected function generateDataChecksum(): string
     {
         return md5(json_encode($this->getData()));
+    }
+
+    protected function getChartVariableName(): string
+    {
+        return $this->chartVariable;
     }
 
     protected function getData(): array
@@ -43,6 +51,7 @@ class ChartWidget extends Widget
     {
         return static::$pollingInterval;
     }
+
 
     public function updateChartData()
     {

--- a/packages/admin/src/Widgets/ChartWidget.php
+++ b/packages/admin/src/Widgets/ChartWidget.php
@@ -52,7 +52,6 @@ class ChartWidget extends Widget
         return static::$pollingInterval;
     }
 
-
     public function updateChartData()
     {
         $newDataChecksum = $this->generateDataChecksum();

--- a/packages/admin/src/Widgets/ChartWidget.php
+++ b/packages/admin/src/Widgets/ChartWidget.php
@@ -14,7 +14,7 @@ class ChartWidget extends Widget
 
     protected static string $view = 'filament::widgets.chart-widget';
 
-    private string $chartVariable;
+    private string $chartVariable = 'chart';
 
     public function mount()
     {

--- a/packages/admin/src/Widgets/ChartWidget.php
+++ b/packages/admin/src/Widgets/ChartWidget.php
@@ -19,7 +19,7 @@ class ChartWidget extends Widget
     public function mount()
     {
         $this->dataChecksum = $this->generateDataChecksum();
-        $this->chartVariable = 'chart' . uniqid();
+        $this->chartVariable = uniqid('chart_');
     }
 
     protected function generateDataChecksum(): string


### PR DESCRIPTION
This MR Provides a possible solution for chart.js rerender bug.

When having multiple charts within one page and triggering a rerendering with 'updateChartData' - only the last Chart is update. It seems like the chart js variable gets overwritten if multiple charts are on one page and only one chart gets updated (instead of every chart)

```
<select class="float-right" wire:model="selectedChartOption" wire:change="updateChartData">
```

The images explain the problem. While the left chart should have been updated, the right chart gets rerendered with the Data of the left chart.

![image](https://user-images.githubusercontent.com/10706512/146960376-1f5d90e4-c168-4571-ba35-b090c998f2d1.png)
![image](https://user-images.githubusercontent.com/10706512/146960390-449ef941-cdd1-4a8d-a6cd-3a7041007e5c.png)
