### PR TITLE
Adds rows / keys / values editing to KeyValue form component

### DIFF
--- a/packages/forms/resources/views/components/key-value.blade.php
+++ b/packages/forms/resources/views/components/key-value.blade.php
@@ -48,7 +48,7 @@
                                     x-model="row.key"
                                     x-on:input="updateState"
                                     {!! ($placeholder = $getKeyPlaceholder()) ? "placeholder=\"{$placeholder}\"" : '' !!}
-                                    @if ((! $canEditRows()) || (! $canEditKeys()) || $isDisabled())
+                                    @if ((! $canEditKeys()) || $isDisabled())
                                         disabled
                                     @endif
                                     class="w-full px-4 py-3 font-mono text-sm bg-transparent border-0 focus:ring-0"
@@ -61,7 +61,7 @@
                                     x-model="row.value"
                                     x-on:input="updateState"
                                     {!! ($placeholder = $getValuePlaceholder()) ? "placeholder=\"{$placeholder}\"" : '' !!}
-                                    @if ((! $canEditRows()) || (! $canEditValues()) || $isDisabled())
+                                    @if ((! $canEditValues()) || $isDisabled())
                                         disabled
                                     @endif
                                     class="w-full px-4 py-3 font-mono text-sm bg-transparent border-0 focus:ring-0"
@@ -86,7 +86,7 @@
                 </tbody>
             </table>
 
-            @if ($canAddRows() && $canEditRows() && (! $isDisabled()))
+            @if ($canAddRows() && (! $isDisabled()))
                 <button
                     x-on:click="addRow"
                     type="button"

--- a/packages/forms/resources/views/components/key-value.blade.php
+++ b/packages/forms/resources/views/components/key-value.blade.php
@@ -48,7 +48,7 @@
                                     x-model="row.key"
                                     x-on:input="updateState"
                                     {!! ($placeholder = $getKeyPlaceholder()) ? "placeholder=\"{$placeholder}\"" : '' !!}
-                                    @if ((! $canEditKeys()) || $isDisabled())
+                                    @if ((! $canEditRows()) || (! $canEditKeys()) || $isDisabled())
                                         disabled
                                     @endif
                                     class="w-full px-4 py-3 font-mono text-sm bg-transparent border-0 focus:ring-0"
@@ -61,7 +61,7 @@
                                     x-model="row.value"
                                     x-on:input="updateState"
                                     {!! ($placeholder = $getValuePlaceholder()) ? "placeholder=\"{$placeholder}\"" : '' !!}
-                                    @if ((! $canEditKeys()) || $isDisabled())
+                                    @if ((! $canEditRows()) || (! $canEditValues()) || $isDisabled())
                                         disabled
                                     @endif
                                     class="w-full px-4 py-3 font-mono text-sm bg-transparent border-0 focus:ring-0"
@@ -86,7 +86,7 @@
                 </tbody>
             </table>
 
-            @if ($canAddRows() && $canEditKeys() && (! $isDisabled()))
+            @if ($canAddRows() && $canEditRows() && (! $isDisabled()))
                 <button
                     x-on:click="addRow"
                     type="button"

--- a/packages/forms/src/Components/KeyValue.php
+++ b/packages/forms/src/Components/KeyValue.php
@@ -14,8 +14,6 @@ class KeyValue extends Field
 
     protected bool | Closure $shouldDisableAddingRows = false;
 
-    protected bool | Closure $shouldDisableEditingRows = false;
-
     protected bool | Closure $shouldDisableDeletingRows = false;
 
     protected bool | Closure $shouldDisableEditingKeys = false;
@@ -75,13 +73,6 @@ class KeyValue extends Field
         return $this;
     }
 
-    public function disableEditingRows(bool | Closure $condition = true): static
-    {
-        $this->shouldDisableEditingRows = $condition;
-
-        return $this;
-    }
-
     public function disableDeletingRows(bool | Closure $condition = true): static
     {
         $this->shouldDisableDeletingRows = $condition;
@@ -134,11 +125,6 @@ class KeyValue extends Field
     public function canAddRows(): bool
     {
         return ! $this->evaluate($this->shouldDisableAddingRows);
-    }
-
-    public function canEditRows(): bool
-    {
-        return ! $this->evaluate($this->shouldDisableEditingRows);
     }
 
     public function canDeleteRows(): bool

--- a/packages/forms/src/Components/KeyValue.php
+++ b/packages/forms/src/Components/KeyValue.php
@@ -14,9 +14,13 @@ class KeyValue extends Field
 
     protected bool | Closure $shouldDisableAddingRows = false;
 
+    protected bool | Closure $shouldDisableEditingRows = false;
+
     protected bool | Closure $shouldDisableDeletingRows = false;
 
     protected bool | Closure $shouldDisableEditingKeys = false;
+
+    protected bool | Closure $shouldDisableEditingValues = false;
 
     protected string | Closure | null $deleteButtonLabel = null;
 
@@ -71,6 +75,13 @@ class KeyValue extends Field
         return $this;
     }
 
+    public function disableEditingRows(bool | Closure $condition = true): static
+    {
+        $this->shouldDisableEditingRows = $condition;
+
+        return $this;
+    }
+
     public function disableDeletingRows(bool | Closure $condition = true): static
     {
         $this->shouldDisableDeletingRows = $condition;
@@ -81,6 +92,13 @@ class KeyValue extends Field
     public function disableEditingKeys(bool | Closure $condition = true): static
     {
         $this->shouldDisableEditingKeys = $condition;
+
+        return $this;
+    }
+
+    public function disableEditingValues(bool | Closure $condition = true): static
+    {
+        $this->shouldDisableEditingValues = $condition;
 
         return $this;
     }
@@ -118,6 +136,11 @@ class KeyValue extends Field
         return ! $this->evaluate($this->shouldDisableAddingRows);
     }
 
+    public function canEditRows(): bool
+    {
+        return ! $this->evaluate($this->shouldDisableEditingRows);
+    }
+
     public function canDeleteRows(): bool
     {
         return ! $this->evaluate($this->shouldDisableDeletingRows);
@@ -126,6 +149,11 @@ class KeyValue extends Field
     public function canEditKeys(): bool
     {
         return ! $this->evaluate($this->shouldDisableEditingKeys);
+    }
+
+    public function canEditValues(): bool
+    {
+        return ! $this->evaluate($this->shouldDisableEditingValues);
     }
 
     public function getAddButtonLabel(): string


### PR DESCRIPTION
When we disable key editing using `->disableEditingKeys()`, values cannot be edited too.

This PR introduces two new methods to handle editing:

`->disableEditingValues()` - Disables only values editing.
`->disableEditingRows()` - Disables both key and value editing.