### PR TITLE
[2.x] Add enum support for Select and Select Filters

### DIFF
--- a/packages/forms/src/Components/Concerns/HasOptions.php
+++ b/packages/forms/src/Components/Concerns/HasOptions.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Filament\Forms\Components\Concerns;
+
+use Closure;
+use Illuminate\Contracts\Support\Arrayable;
+
+trait HasOptions
+{
+    protected string |array | Arrayable | Closure $options = [];
+
+    public function options(string |array | Arrayable | Closure $options): static
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
+    public function getOptions(): array
+    {
+        $options = $this->evaluate($this->options);
+
+        if (is_string($options)) {
+            $options = collect($options::cases())
+                ->mapWithKeys(function ($eachEnumInstance) {
+                    return [$eachEnumInstance?->value ?? $eachEnumInstance->name => $eachEnumInstance->name];
+                })
+                ->toArray();
+        }
+
+        if ($options instanceof Arrayable) {
+            $options = $options->toArray();
+        }
+
+        return $options;
+    }
+}

--- a/packages/forms/src/Components/Concerns/HasOptions.php
+++ b/packages/forms/src/Components/Concerns/HasOptions.php
@@ -7,9 +7,9 @@ use Illuminate\Contracts\Support\Arrayable;
 
 trait HasOptions
 {
-    protected string |array | Arrayable | Closure $options = [];
+    protected array | Arrayable | string | Closure $options = [];
 
-    public function options(string |array | Arrayable | Closure $options): static
+    public function options(array | Arrayable | string | Closure $options): static
     {
         $this->options = $options;
 
@@ -20,12 +20,8 @@ trait HasOptions
     {
         $options = $this->evaluate($this->options);
 
-        if (is_string($options)) {
-            $options = collect($options::cases())
-                ->mapWithKeys(function ($eachEnumInstance) {
-                    return [$eachEnumInstance?->value ?? $eachEnumInstance->name => $eachEnumInstance->name];
-                })
-                ->toArray();
+        if (is_string($options) && class_exists($options)) {
+            $options = collect($options::cases())->mapWithKeys(fn ($case) => [($case?->value ?? $case->name) => $case->name]);
         }
 
         if ($options instanceof Arrayable) {

--- a/packages/forms/src/Components/MultiSelect.php
+++ b/packages/forms/src/Components/MultiSelect.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Support\Arrayable;
 class MultiSelect extends Field
 {
     use Concerns\HasExtraAlpineAttributes;
+    use Concerns\HasOptions;
     use Concerns\HasPlaceholder;
 
     protected string $view = 'forms::components.multi-select';
@@ -15,8 +16,6 @@ class MultiSelect extends Field
     protected ?Closure $getOptionLabelsUsing = null;
 
     protected ?Closure $getSearchResultsUsing = null;
-
-    protected array | Closure $options = [];
 
     protected string | Closure | null $noSearchResultsMessage = null;
 
@@ -65,13 +64,6 @@ class MultiSelect extends Field
         return $this;
     }
 
-    public function options(array | Arrayable | Closure $options): static
-    {
-        $this->options = $options;
-
-        return $this;
-    }
-
     public function noSearchResultsMessage(string | Closure | null $message): static
     {
         $this->noSearchResultsMessage = $message;
@@ -97,17 +89,6 @@ class MultiSelect extends Field
         }
 
         return $labels;
-    }
-
-    public function getOptions(): array
-    {
-        $options = $this->evaluate($this->options);
-
-        if ($options instanceof Arrayable) {
-            $options = $options->toArray();
-        }
-
-        return $options;
     }
 
     public function getNoSearchResultsMessage(): string

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Support\Arrayable;
 class Select extends Field
 {
     use Concerns\HasExtraAlpineAttributes;
+    use Concerns\HasOptions;
     use Concerns\HasPlaceholder;
 
     protected string $view = 'forms::components.select';
@@ -23,8 +24,6 @@ class Select extends Field
     protected bool | Closure $isSearchable = false;
 
     protected ?array $searchColumns = null;
-
-    protected array | Arrayable | Closure $options = [];
 
     protected string | Closure | null $noSearchResultsMessage = null;
 
@@ -87,13 +86,6 @@ class Select extends Field
         return $this;
     }
 
-    public function options(array | Arrayable | Closure $options): static
-    {
-        $this->options = $options;
-
-        return $this;
-    }
-
     public function searchable(bool | array | Closure $condition = true): static
     {
         if (is_array($condition)) {
@@ -126,17 +118,6 @@ class Select extends Field
         return $this->evaluate($this->getOptionLabelUsing, [
             'value' => $this->getState(),
         ]);
-    }
-
-    public function getOptions(): array
-    {
-        $options = $this->evaluate($this->options);
-
-        if ($options instanceof Arrayable) {
-            $options = $options->toArray();
-        }
-
-        return $options;
     }
 
     public function getNoSearchResultsMessage(): string

--- a/packages/tables/src/Filters/Concerns/HasOptions.php
+++ b/packages/tables/src/Filters/Concerns/HasOptions.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Filament\Tables\Filters\Concerns;
+
+use Closure;
+use Illuminate\Contracts\Support\Arrayable;
+
+trait HasOptions
+{
+    protected string |array | Arrayable | Closure $options = [];
+
+    public function options(string |array | Arrayable | Closure $options): static
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
+    public function getOptions(): array
+    {
+        $options = $this->evaluate($this->options);
+
+        if ($options === null) {
+            $options = $this->queriesRelationships() ? $this->getRelationshipOptions() : [];
+        }
+
+        if (is_string($options)) {
+            $options = collect($options::cases())
+                ->mapWithKeys(function ($eachEnumInstance) {
+                    return [$eachEnumInstance?->value ?? $eachEnumInstance->name => $eachEnumInstance->name];
+                })
+                ->toArray();
+        }
+
+        if ($options instanceof Arrayable) {
+            $options = $options->toArray();
+        }
+
+        return $options;
+    }
+}

--- a/packages/tables/src/Filters/Concerns/HasOptions.php
+++ b/packages/tables/src/Filters/Concerns/HasOptions.php
@@ -7,9 +7,9 @@ use Illuminate\Contracts\Support\Arrayable;
 
 trait HasOptions
 {
-    protected string |array | Arrayable | Closure $options = [];
+    protected array | Arrayable | string | Closure $options = [];
 
-    public function options(string |array | Arrayable | Closure $options): static
+    public function options(array | Arrayable | string | Closure $options): static
     {
         $this->options = $options;
 
@@ -24,12 +24,8 @@ trait HasOptions
             $options = $this->queriesRelationships() ? $this->getRelationshipOptions() : [];
         }
 
-        if (is_string($options)) {
-            $options = collect($options::cases())
-                ->mapWithKeys(function ($eachEnumInstance) {
-                    return [$eachEnumInstance?->value ?? $eachEnumInstance->name => $eachEnumInstance->name];
-                })
-                ->toArray();
+        if (is_string($options) && class_exists($options)) {
+            $options = collect($options::cases())->mapWithKeys(fn ($case) => [($case?->value ?? $case->name) => $case->name]);
         }
 
         if ($options instanceof Arrayable) {

--- a/packages/tables/src/Filters/MultiSelectFilter.php
+++ b/packages/tables/src/Filters/MultiSelectFilter.php
@@ -12,13 +12,12 @@ use Illuminate\Support\Str;
 
 class MultiSelectFilter extends Filter
 {
+    use Concerns\HasOptions;
     use Concerns\HasPlaceholder;
 
     protected string | Closure | null $column = null;
 
     protected bool | Closure $isStatic = false;
-
-    protected array | Arrayable | Closure | null $options = null;
 
     protected function setUp(): void
     {
@@ -67,13 +66,6 @@ class MultiSelectFilter extends Filter
         return $this;
     }
 
-    public function options(string | array | Arrayable | Closure | null $options): static
-    {
-        $this->options = $options;
-
-        return $this;
-    }
-
     public function relationship(string $relationshipName, string $displayColumnName): static
     {
         $this->column("{$relationshipName}.{$displayColumnName}");
@@ -91,29 +83,6 @@ class MultiSelectFilter extends Filter
     public function getColumn(): string
     {
         return $this->evaluate($this->column) ?? $this->getName();
-    }
-
-    public function getOptions(): array
-    {
-        $options = $this->evaluate($this->options);
-
-        if ($options === null) {
-            $options = $this->queriesRelationships() ? $this->getRelationshipOptions() : [];
-        }
-
-        if (is_string($options)) {
-            $options = collect($options::cases())
-                ->mapWithKeys(function ($eachEnumInstance) {
-                    return [$eachEnumInstance?->value ?? $eachEnumInstance->name => $eachEnumInstance->name];
-                })
-                ->toArray();
-        }
-
-        if ($options instanceof Arrayable) {
-            $options = $options->toArray();
-        }
-
-        return $options;
     }
 
     protected function getRelationshipOptions(): array

--- a/packages/tables/src/Filters/MultiSelectFilter.php
+++ b/packages/tables/src/Filters/MultiSelectFilter.php
@@ -67,7 +67,7 @@ class MultiSelectFilter extends Filter
         return $this;
     }
 
-    public function options(array | Arrayable | Closure | null $options): static
+    public function options(string | array | Arrayable | Closure | null $options): static
     {
         $this->options = $options;
 
@@ -99,6 +99,14 @@ class MultiSelectFilter extends Filter
 
         if ($options === null) {
             $options = $this->queriesRelationships() ? $this->getRelationshipOptions() : [];
+        }
+
+        if (is_string($options)) {
+            $options = collect($options::cases())
+                ->mapWithKeys(function ($eachEnumInstance) {
+                    return [$eachEnumInstance?->value ?? $eachEnumInstance->name => $eachEnumInstance->name];
+                })
+                ->toArray();
         }
 
         if ($options instanceof Arrayable) {

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -69,6 +69,17 @@ class SelectFilter extends Filter
         return $this;
     }
 
+    public function enum(string $enumClass): static
+    {
+        $this->options = collect($enumClass::cases())
+            ->mapWithKeys(function ($eachEnumInstance) {
+                return [$eachEnumInstance?->value ?? $eachEnumInstance->name => $eachEnumInstance->name];
+            })
+            ->toArray();
+
+        return $this;
+    }
+
     public function relationship(string $relationshipName, string $displayColumnName): static
     {
         $this->column("{$relationshipName}.{$displayColumnName}");

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -62,20 +62,9 @@ class SelectFilter extends Filter
         return $this;
     }
 
-    public function options(array | Arrayable | Closure | null $options): static
+    public function options(string | array | Arrayable | Closure | null $options): static
     {
         $this->options = $options;
-
-        return $this;
-    }
-
-    public function enum(string $enumClass): static
-    {
-        $this->options = collect($enumClass::cases())
-            ->mapWithKeys(function ($eachEnumInstance) {
-                return [$eachEnumInstance?->value ?? $eachEnumInstance->name => $eachEnumInstance->name];
-            })
-            ->toArray();
 
         return $this;
     }
@@ -105,6 +94,14 @@ class SelectFilter extends Filter
 
         if ($options === null) {
             $options = $this->queriesRelationships() ? $this->getRelationshipOptions() : [];
+        }
+
+        if (is_string($options)) {
+            $options = collect($options::cases())
+                ->mapWithKeys(function ($eachEnumInstance) {
+                    return [$eachEnumInstance?->value ?? $eachEnumInstance->name => $eachEnumInstance->name];
+                })
+                ->toArray();
         }
 
         if ($options instanceof Arrayable) {

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -12,13 +12,12 @@ use Illuminate\Support\Str;
 
 class SelectFilter extends Filter
 {
+    use Concerns\HasOptions;
     use Concerns\HasPlaceholder;
 
     protected string | Closure | null $column = null;
 
     protected bool | Closure $isStatic = false;
-
-    protected array | Arrayable | Closure | null $options = null;
 
     protected function setUp(): void
     {
@@ -62,13 +61,6 @@ class SelectFilter extends Filter
         return $this;
     }
 
-    public function options(string | array | Arrayable | Closure | null $options): static
-    {
-        $this->options = $options;
-
-        return $this;
-    }
-
     public function relationship(string $relationshipName, string $displayColumnName): static
     {
         $this->column("{$relationshipName}.{$displayColumnName}");
@@ -86,29 +78,6 @@ class SelectFilter extends Filter
     public function getColumn(): string
     {
         return $this->evaluate($this->column) ?? $this->getName();
-    }
-
-    public function getOptions(): array
-    {
-        $options = $this->evaluate($this->options);
-
-        if ($options === null) {
-            $options = $this->queriesRelationships() ? $this->getRelationshipOptions() : [];
-        }
-
-        if (is_string($options)) {
-            $options = collect($options::cases())
-                ->mapWithKeys(function ($eachEnumInstance) {
-                    return [$eachEnumInstance?->value ?? $eachEnumInstance->name => $eachEnumInstance->name];
-                })
-                ->toArray();
-        }
-
-        if ($options instanceof Arrayable) {
-            $options = $options->toArray();
-        }
-
-        return $options;
     }
 
     protected function getRelationshipOptions(): array


### PR DESCRIPTION
Lets say i have a Enum class like this.

```
<?php

enum UserStatus
{
    case UnVerified;
    case Verified;
    case InActive;
    case Disabled;
}
```

So right now i have to do something like this

```
Select::make('user_status')
                        ->label('Status')
                        ->options(
                            collect(UserStatus::cases())
                                ->map(function (UserStatus $userStatus) {
                                    return [
                                        'name' => $userStatus->name,
                                        'value' => $userStatus->value,
                                    ];
                                })
                                ->pluck('name', 'value')
                        ),
```

So this PR add support for passing enum key values into SelectFilter.

```
SelectFilter::make('Status')
            ->column('user_status')
            ->enum(UserStatus::class),
```


