### PR TITLE
Added ability to specify name when uploading using SpatieMediaLibraryFileUpload

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -15,7 +15,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 {
     protected string | Closure | null $collection = null;
 
-    protected string | Closure | null $usingName = null;
+    protected string | Closure | null $mediaName = null;
 
     protected function setUp(): void
     {
@@ -87,7 +87,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
             $media = $mediaAdder
                 ->usingFileName($filename)
-                ->usingName($component->getUsingName())
+                ->usingName($component->getMediaName())
                 ->toMediaCollection($component->getCollection(), $component->getDiskName());
 
             return $media->getAttributeValue('uuid');
@@ -125,15 +125,15 @@ class SpatieMediaLibraryFileUpload extends FileUpload
         return $this->evaluate($this->collection) ?? 'default';
     }
 
-    public function usingName(string | Closure | null $usingName): static
+    public function mediaName(string | Closure | null $name): static
     {
-        $this->usingName = $usingName;
+        $this->mediaName = $name;
 
         return $this;
     }
 
-    public function getUsingName(): string
+    public function getMediaName(): ?string
     {
-        return $this->evaluate($this->usingName) ?? null;
+        return $this->evaluate($this->mediaName);
     }
 }

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -87,7 +87,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
             $media = $mediaAdder
                 ->usingFileName($filename)
-                ->usingName($component->getMediaName())
+                ->usingName($component->getMediaName() ?? '')
                 ->toMediaCollection($component->getCollection(), $component->getDiskName());
 
             return $media->getAttributeValue('uuid');

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -15,6 +15,8 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 {
     protected string | Closure | null $collection = null;
 
+    protected string | Closure | null $usingName = null;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -85,6 +87,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
             $media = $mediaAdder
                 ->usingFileName($filename)
+                ->usingName($component->getUsingName())
                 ->toMediaCollection($component->getCollection(), $component->getDiskName());
 
             return $media->getAttributeValue('uuid');
@@ -120,5 +123,17 @@ class SpatieMediaLibraryFileUpload extends FileUpload
     public function getCollection(): string
     {
         return $this->evaluate($this->collection) ?? 'default';
+    }
+
+    public function usingName(string | Closure | null $usingName): static
+    {
+        $this->usingName = $usingName;
+
+        return $this;
+    }
+
+    public function getUsingName(): string
+    {
+        return $this->evaluate($this->usingName) ?? null;
     }
 }


### PR DESCRIPTION
Provides ability to specify the name of a file to be stored in the `media` table. Usage:

```
SpatieMediaLibraryFileUpload::make('myfiles')
    ->collection('myfiles')
    ->usingName('the_name_of_my_file')

//we can now use:
$post->getFirstMediaUrl('myfiles', 'the_name_of_my_file')

```