### PR TITLE
Changes logout on the account-widget to POST

### DIFF
--- a/packages/admin/resources/views/widgets/account-widget.blade.php
+++ b/packages/admin/resources/views/widgets/account-widget.blade.php
@@ -15,14 +15,16 @@
                     {{ __('filament::widgets/account-widget.welcome', ['user' => \Filament\Facades\Filament::getUserName($user)]) }}
                 </h2>
 
-                <p class="text-sm">
+                <form method="POST" action="{{ route('filament.auth.logout') }}" class="text-sm">
+                    @csrf
+
                     <a href="{{ route('filament.auth.logout') }}" @class([
                         'text-gray-600 hover:text-primary-500 focus:outline-none focus:underline',
                         'dark:text-gray-300 dark:hover:text-primary-500' => config('filament.dark_mode'),
-                    ])>
+                    ]) onclick="event.preventDefault(); this.closest('form').submit();">
                         {{ __('filament::widgets/account-widget.buttons.logout.label') }}
                     </a>
-                </p>
+                </form>
             </div>
         </div>
     </x-filament::card>

--- a/packages/admin/resources/views/widgets/account-widget.blade.php
+++ b/packages/admin/resources/views/widgets/account-widget.blade.php
@@ -15,15 +15,18 @@
                     {{ __('filament::widgets/account-widget.welcome', ['user' => \Filament\Facades\Filament::getUserName($user)]) }}
                 </h2>
 
-                <form method="POST" action="{{ route('filament.auth.logout') }}" class="text-sm">
+                <form action="{{ route('filament.auth.logout') }}" method="post" class="text-sm">
                     @csrf
 
-                    <a href="{{ route('filament.auth.logout') }}" @class([
-                        'text-gray-600 hover:text-primary-500 focus:outline-none focus:underline',
-                        'dark:text-gray-300 dark:hover:text-primary-500' => config('filament.dark_mode'),
-                    ]) onclick="event.preventDefault(); this.closest('form').submit();">
+                    <button
+                        type="submit"
+                        @class([
+                            'text-gray-600 hover:text-primary-500 focus:outline-none focus:underline',
+                            'dark:text-gray-300 dark:hover:text-primary-500' => config('filament.dark_mode'),
+                        ])
+                    >
                         {{ __('filament::widgets/account-widget.buttons.logout.label') }}
-                    </a>
+                    </button>
                 </form>
             </div>
         </div>


### PR DESCRIPTION
#1870 changed the logout route to no longer support a `GET` request. This updates `account_widget.blade.php` to send a `POST` request to the logout route.