### PR TITLE
Fix file upload not loading correctly in secondary tabs and collapsed sections

### DIFF
--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -41,7 +41,7 @@
 
     <div
         @if ($isCollapsible())
-            x-show="! isCollapsed"
+            x-bind:class="{ 'invisible h-0 p-0': isCollapsed }"
             x-bind:aria-expanded="(! isCollapsed).toString()"
         @endif
     >

--- a/packages/forms/resources/views/components/tabs/tab.blade.php
+++ b/packages/forms/resources/views/components/tabs/tab.blade.php
@@ -3,7 +3,7 @@
     id="{{ $getId() }}"
     role="tabpanel"
     tabindex="0"
-    x-bind:class="{ '!invisible !h-0 !p-0': tab !== '{{ $getId() }}' }"
+    x-bind:class="{ 'invisible h-0 p-0': tab !== '{{ $getId() }}' }"
     {{ $attributes->merge($getExtraAttributes())->class(['p-6 focus:outline-none filament-forms-tabs-component-tab']) }}
 >
     {{ $getChildComponentContainer() }}

--- a/packages/forms/resources/views/components/tabs/tab.blade.php
+++ b/packages/forms/resources/views/components/tabs/tab.blade.php
@@ -3,7 +3,7 @@
     id="{{ $getId() }}"
     role="tabpanel"
     tabindex="0"
-    x-show="tab === '{{ $getId() }}'"
+    x-bind:class="{ '!invisible !h-0 !p-0': tab !== '{{ $getId() }}' }"
     {{ $attributes->merge($getExtraAttributes())->class(['p-6 focus:outline-none filament-forms-tabs-component-tab']) }}
 >
     {{ $getChildComponentContainer() }}


### PR DESCRIPTION
Fixes https://github.com/laravel-filament/filament/issues/1967

Replaces `x-show` with a custom set of classes that hide the tabs without using `display: none`. This is the workaround proposed in the FilePond issue (https://github.com/pqina/filepond/issues/819#issuecomment-1077313749).