### PR TITLE
fix: adding $set target to loading in table

### DIFF
--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -59,7 +59,7 @@ class Table extends ViewComponent
 
     protected string $viewIdentifier = 'table';
 
-    public const LOADING_TARGETS = ['gotoPage', 'tableFilters', 'resetTableFiltersForm', 'tableSearchQuery', 'tableRecordsPerPage'];
+    public const LOADING_TARGETS = ['gotoPage', 'tableFilters', 'resetTableFiltersForm', 'tableSearchQuery', 'tableRecordsPerPage', '$set'];
 
     final public function __construct(HasTable $livewire)
     {


### PR DESCRIPTION
When we have a form or a select with `->searcheable()` in filters it don't start the loading state on the table.