### PR TITLE
Fix to match Spatie Media Library default behaviour when media name is not specified.

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -94,7 +94,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
             $media = $mediaAdder
                 ->usingFileName($filename)
-                ->usingName($component->getMediaName() ?? '')
+                ->usingName($component->getMediaName() ?? pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME))
                 ->withCustomProperties($component->getCustomProperties())
                 ->toMediaCollection($component->getCollection(), $component->getDiskName());
 

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -92,15 +92,15 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
             $filename = $component->getUploadedFileNameForStorage($file);
             
-            $media = $mediaAdder
+            $mediaAdder
                 ->usingFileName($filename)
                 ->withCustomProperties($component->getCustomProperties());
 
             if (filled($mediaName = $component->getMediaName())) {
-                $media->usingName($mediaName);
+                $mediaAdder->usingName($mediaName);
             }
             
-            $media->toMediaCollection($component->getCollection(), $component->getDiskName());
+            $media = $mediaAdder->toMediaCollection($component->getCollection(), $component->getDiskName());
 
             return $media->getAttributeValue('uuid');
         });

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -91,12 +91,16 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             $mediaAdder = $record->addMediaFromString($file->get());
 
             $filename = $component->getUploadedFileNameForStorage($file);
-
+            
             $media = $mediaAdder
                 ->usingFileName($filename)
-                ->usingName($component->getMediaName() ?? pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME))
                 ->withCustomProperties($component->getCustomProperties())
-                ->toMediaCollection($component->getCollection(), $component->getDiskName());
+
+            if (filled($mediaName = $component->getMediaName())) {
+                $media->usingName($mediaName);
+            }
+            
+            $media->toMediaCollection($component->getCollection(), $component->getDiskName());
 
             return $media->getAttributeValue('uuid');
         });

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -94,7 +94,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             
             $media = $mediaAdder
                 ->usingFileName($filename)
-                ->withCustomProperties($component->getCustomProperties())
+                ->withCustomProperties($component->getCustomProperties());
 
             if (filled($mediaName = $component->getMediaName())) {
                 $media->usingName($mediaName);


### PR DESCRIPTION
In Spatie Media Library

if you never call ->usingName() while adding to the collection

the name column will by default be the file name without the extension. That is 'abc.pdf' will be 'abc' in the name column of media table. See Line 103 of this file

https://github.com/spatie/laravel-medialibrary/blob/f98d24ac31fcd63e04e9f44389695ba4fa6eaa87/src/MediaCollections/FileAdder.php#L103

However in filament SpatieMediaLibraryFileUpload field, if ->mediaName('value') is not called, it pass in '' to ->usingName() which is almost certainly not wanted.

This PR preserves the original name spatie media library will use.