### PR TITLE
Fix extra spacing above wizard

### DIFF
--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -61,7 +61,7 @@
     x-on:next-wizard-step.window="if ($event.detail.statePath === '{{ $getStatePath() }}') nextStep()"
     x-cloak
     {!! $getId() ? "id=\"{$getId()}\"" : null !!}
-    {{ $attributes->merge($getExtraAttributes())->class(['space-y-6 filament-forms-wizard-component']) }}
+    {{ $attributes->merge($getExtraAttributes())->class(['grid gap-y-6 filament-forms-wizard-component']) }}
     {{ $getExtraAlpineAttributeBag() }}
 >
     <input


### PR DESCRIPTION
A tiny PR to remove the initial whitespace in the wizard component. The hidden input field is causing the parent's `space-y-*` utility to apply a top margin to the first visible element which is unneeded. Using `grid` and `gap-y-*` is preferable here because it ignores hidden first child elements.

Edit: After looking at Tailwinds's `space-*` utilities again, it correctly handles elements with an attribute of `hidden`, so alternatively that can be added to the `input` component, but I haven't seen that used in Filament (or anywhere really) so the first method may be the way to go.