### PR TITLE
fix: wrong key used in failure notification

### DIFF
--- a/packages/support/src/Actions/Concerns/CanNotify.php
+++ b/packages/support/src/Actions/Concerns/CanNotify.php
@@ -36,7 +36,7 @@ trait CanNotify
         $message = $this->evaluate($this->failureNotificationMessage);
 
         if (filled($message)) {
-            $this->notify('failure', $message);
+            $this->notify('danger', $message);
         }
 
         return $this;


### PR DESCRIPTION
The css class used to display failure notification is `danger` instead of `failure`.

This PR fixes that wrong class/key use.