### PR TITLE
Use create() instead of save() for BelongsTo relationships whev saving.

### DIFF
--- a/packages/forms/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
+++ b/packages/forms/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
@@ -51,13 +51,12 @@ trait EntanglesStateWithSingularRelationship
                 $record->setLocale($activeLocale);
             }
 
-            $record->fill($state);
-
             $relationship = $component->getRelationship();
 
             if ($relationship instanceof BelongsTo) {
-                $relationship->associate($record->save());
+                $relationship->associate($record->create($state));
             } else {
+                $record->fill($state);
                 $relationship->save($record);
             }
         });


### PR DESCRIPTION
Need to use $record->create($state) to feed to associate(), not save(), because save() returns a boolean, not the model, and associate() needs the model.