### PR TITLE
CHG: Add Arrayable return type to repeater

### DIFF
--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -3,6 +3,7 @@
 namespace Filament\Forms\Concerns;
 
 use Filament\Forms\Components\BaseFileUpload;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
@@ -217,7 +218,7 @@ trait HasState
         return $state;
     }
 
-    public function getRawState(): array
+    public function getRawState(): array | Arrayable
     {
         return data_get($this->getLivewire(), $this->getStatePath()) ?? [];
     }


### PR DESCRIPTION
As discussed in discord, I just added the Arrayable return type to `getRawState()` of the `Repeater` class