### PR TITLE
feature: Add affixes to BooleanColumn and IconColumn

### DIFF
--- a/packages/tables/resources/views/columns/boolean-column.blade.php
+++ b/packages/tables/resources/views/columns/boolean-column.blade.php
@@ -11,10 +11,6 @@
         'warning' => 'text-warning-500',
         default => 'text-gray-700',
     };
-
-    $affixLabelClasses = [
-        'whitespace-nowrap group-focus-within:text-primary-500',
-    ];
 @endphp
 
 <div

--- a/packages/tables/resources/views/columns/boolean-column.blade.php
+++ b/packages/tables/resources/views/columns/boolean-column.blade.php
@@ -11,13 +11,34 @@
         'warning' => 'text-warning-500',
         default => 'text-gray-700',
     };
+
+    $affixLabelClasses = [
+        'whitespace-nowrap group-focus-within:text-primary-500',
+    ];
 @endphp
 
-<div {{ $attributes->merge($getExtraAttributes())->class(['px-4 py-3 filament-tables-boolean-column']) }}>
+<div
+    {{ $attributes->merge($getExtraAttributes())->class([
+        'px-4 py-3 filament-tables-boolean-column',
+        'flex flex-row gap-x-2'
+    ]) }}
+>
+    @if ($prefix = $getPrefix())
+        <span class="whitespace-nowrap group-focus-within:text-primary-500">
+                {{ $prefix }}
+        </span>
+    @endif
+
     @if ($state !== null)
         <x-dynamic-component
             :component="$stateIcon"
             :class="'w-6 h-6' . ' ' . $stateColor"
         />
+    @endif
+
+    @if ($suffix = $getSuffix())
+        <span class="whitespace-nowrap group-focus-within:text-primary-500">
+            {{ $suffix }}
+        </span>
     @endif
 </div>

--- a/packages/tables/resources/views/columns/boolean-column.blade.php
+++ b/packages/tables/resources/views/columns/boolean-column.blade.php
@@ -25,7 +25,7 @@
 >
     @if ($prefix = $getPrefix())
         <span class="whitespace-nowrap group-focus-within:text-primary-500">
-                {{ $prefix }}
+            {{ $prefix }}
         </span>
     @endif
 

--- a/packages/tables/resources/views/columns/icon-column.blade.php
+++ b/packages/tables/resources/views/columns/icon-column.blade.php
@@ -9,11 +9,28 @@
     };
 @endphp
 
-<div {{ $attributes->merge($getExtraAttributes())->class(['px-4 py-3 filament-tables-icon-column']) }}>
-    @if ($getStateIcon())
+<div
+    {{ $attributes->merge($getExtraAttributes())->class([
+        'px-4 py-3 filament-tables-icon-column',
+        'flex flex-row gap-x-2'
+    ]) }}
+>
+    @if($prefix = $getPrefix())
+        <span class="whitespace-nowrap group-focus-within:text-primary-500">
+            {{ $prefix }}
+        </span>
+    @endif
+
+    @if ($icon = $getStateIcon())
         <x-dynamic-component
             :component="$getStateIcon()"
             :class="'w-6 h-6 ' . $stateColor"
         />
+    @endif
+
+    @if ($suffix = $getSuffix())
+        <span class="whitespace-nowrap group-focus-within:text-primary-500">
+        {{ $suffix }}
+        </span>
     @endif
 </div>

--- a/packages/tables/resources/views/columns/icon-column.blade.php
+++ b/packages/tables/resources/views/columns/icon-column.blade.php
@@ -23,14 +23,14 @@
 
     @if ($icon = $getStateIcon())
         <x-dynamic-component
-            :component="$getStateIcon()"
+            :component="$icon"
             :class="'w-6 h-6 ' . $stateColor"
         />
     @endif
 
     @if ($suffix = $getSuffix())
         <span class="whitespace-nowrap group-focus-within:text-primary-500">
-        {{ $suffix }}
+            {{ $suffix }}
         </span>
     @endif
 </div>

--- a/packages/tables/src/Columns/BooleanColumn.php
+++ b/packages/tables/src/Columns/BooleanColumn.php
@@ -3,11 +3,10 @@
 namespace Filament\Tables\Columns;
 
 use Closure;
-use Filament\Tables\Columns\Concerns\HasAffixes;
 
 class BooleanColumn extends Column
 {
-    use HasAffixes;
+    use Concerns\HasAffixes;
 
     protected string $view = 'tables::columns.boolean-column';
 

--- a/packages/tables/src/Columns/BooleanColumn.php
+++ b/packages/tables/src/Columns/BooleanColumn.php
@@ -3,9 +3,12 @@
 namespace Filament\Tables\Columns;
 
 use Closure;
+use Filament\Tables\Columns\Concerns\HasAffixes;
 
 class BooleanColumn extends Column
 {
+    use HasAffixes;
+
     protected string $view = 'tables::columns.boolean-column';
 
     protected string | Closure | null $falseColor = null;

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -13,13 +13,11 @@ use Illuminate\Support\Str;
 
 trait CanFormatState
 {
+    use HasAffixes;
+
     protected ?Closure $formatStateUsing = null;
 
     protected ?int $limit = null;
-
-    protected string | Closure | null $prefix = null;
-
-    protected string | Closure | null $suffix = null;
 
     protected string | Closure | null $timezone = null;
 
@@ -88,20 +86,6 @@ trait CanFormatState
         return $this;
     }
 
-    public function prefix(string | Closure $prefix): static
-    {
-        $this->prefix = $prefix;
-
-        return $this;
-    }
-
-    public function suffix(string | Closure $suffix): static
-    {
-        $this->suffix = $suffix;
-
-        return $this;
-    }
-
     public function html(): static
     {
         return $this->formatStateUsing(static fn ($state): HtmlString => $state instanceof HtmlString ? $state : Str::of($state)->sanitizeHtml()->toHtmlString());
@@ -141,12 +125,12 @@ trait CanFormatState
             ]);
         }
 
-        if ($this->prefix) {
-            $state = $this->evaluate($this->prefix) . $state;
+        if ($prefix = $this->getPrefix()) {
+            $state = $prefix . $state;
         }
 
-        if ($this->suffix) {
-            $state = $state . $this->evaluate($this->suffix);
+        if ($suffix = $this->getSuffix()) {
+            $state = $state . $suffix;
         }
 
         return $state;

--- a/packages/tables/src/Columns/Concerns/HasAffixes.php
+++ b/packages/tables/src/Columns/Concerns/HasAffixes.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Filament\Tables\Columns\Concerns;
+
+use Closure;
+
+trait HasAffixes
+{
+    protected string | Closure | null $prefix = null;
+
+    protected string | Closure | null $suffix = null;
+
+    public function prefix(string | Closure $prefix): static
+    {
+        $this->prefix = $prefix;
+
+        return $this;
+    }
+
+    public function suffix(string | Closure $suffix): static
+    {
+        $this->suffix = $suffix;
+
+        return $this;
+    }
+
+    public function getPrefix(): ?string
+    {
+        return $this->evaluate($this->prefix);
+    }
+
+    public function getSuffix(): ?string
+    {
+        return $this->evaluate($this->suffix);
+    }
+}

--- a/packages/tables/src/Columns/IconColumn.php
+++ b/packages/tables/src/Columns/IconColumn.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Support\Arrayable;
 class IconColumn extends Column
 {
     use Concerns\HasColors;
+    use Concerns\HasAffixes;
 
     protected string $view = 'tables::columns.icon-column';
 


### PR DESCRIPTION
This PR adds the ability to add suffixes and prefixes to boolean columns. This is handy in situations where you want to add some more context to a boolean, but where you don't want to create a new text column (e.g. because there's too much whitespace).

<img width="906" alt="Schermafbeelding 2022-08-27 om 15 35 00" src="https://user-images.githubusercontent.com/59207045/187032557-5036f5eb-c58b-492c-ae07-95a4bc4bfff3.png">
