### PR TITLE
Check for hidden when counting bulk actions in isTableSelectionEnabled

### DIFF
--- a/packages/tables/src/Concerns/CanSelectRecords.php
+++ b/packages/tables/src/Concerns/CanSelectRecords.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Tables\Concerns;
 
+use Filament\Tables\Actions\BulkAction;
 use Filament\Tables\Contracts\HasRelationshipTable;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -54,6 +55,11 @@ trait CanSelectRecords
 
     public function isTableSelectionEnabled(): bool
     {
-        return (bool) count($this->getCachedTableBulkActions());
+        return (bool) count(
+            array_filter(
+                $this->getCachedTableBulkActions(),
+                fn(BulkAction $action): bool => !$action->isHidden(),
+            )
+        );
     }
 }

--- a/packages/tables/src/Concerns/CanSelectRecords.php
+++ b/packages/tables/src/Concerns/CanSelectRecords.php
@@ -55,11 +55,9 @@ trait CanSelectRecords
 
     public function isTableSelectionEnabled(): bool
     {
-        return (bool) count(
-            array_filter(
-                $this->getCachedTableBulkActions(),
-                fn (BulkAction $action): bool => ! $action->isHidden(),
-            )
-        );
+        return (bool) count(array_filter(
+            $this->getCachedTableBulkActions(),
+            fn (BulkAction $action): bool => ! $action->isHidden(),
+        ));
     }
 }

--- a/packages/tables/src/Concerns/CanSelectRecords.php
+++ b/packages/tables/src/Concerns/CanSelectRecords.php
@@ -58,7 +58,7 @@ trait CanSelectRecords
         return (bool) count(
             array_filter(
                 $this->getCachedTableBulkActions(),
-                fn(BulkAction $action): bool => !$action->isHidden(),
+                fn (BulkAction $action): bool => ! $action->isHidden(),
             )
         );
     }


### PR DESCRIPTION
At the moment, if all bulk actions are hidden, we still get checkboxes and an empty kebab menu.

Note that I only added a check for !hidden(), as this is how it is handled elsewhere (like getBulkActions() in the main Table component.  My inclination would be to check !hidden() && visible().  Lmk if I should be checking both.