### PR TITLE
Adding ability to exclude self from relationship

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -479,7 +479,7 @@ class Select extends Field
                 ->when(
                     $component->getModelInstance() &&
                         get_class($relationship->getRelated()) == get_class($component->getModelInstance()) &&
-                        $this->getExcludeSelf(),
+                        $component->getExcludeSelf(),
                     function ($query) use ($component) {
                         $query->whereKeyNot($component->getModelInstance()->getKey());
                     }
@@ -533,7 +533,7 @@ class Select extends Field
                 ->when(
                     $component->getModelInstance() &&
                         get_class($relationship->getRelated()) == get_class($component->getModelInstance()) &&
-                        $this->getExcludeSelf(),
+                        $component->getExcludeSelf(),
                     function ($query) use ($component) {
                         $query->whereKeyNot($component->getModelInstance()->getKey());
                     }

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -453,14 +453,14 @@ class Select extends Field
         return $this;
     }
 
-    public function excludeSelf(bool | Closure $excludeSelf = true) : static
+    public function excludeSelf(bool | Closure $excludeSelf = true): static
     {
         $this->excludeSelf = $excludeSelf;
 
         return $this;
     }
 
-    public function getExcludeSelf() : bool
+    public function getExcludeSelf(): bool
     {
         return $this->evaluate($this->excludeSelf);
     }
@@ -482,7 +482,8 @@ class Select extends Field
                         $this->getExcludeSelf(),
                     function ($query) use ($component) {
                         $query->whereKeyNot($component->getModelInstance()->getKey());
-                });
+                    }
+                );
 
             if ($callback) {
                 $relationshipQuery = $component->evaluate($callback, [
@@ -535,7 +536,8 @@ class Select extends Field
                         $this->getExcludeSelf(),
                     function ($query) use ($component) {
                         $query->whereKeyNot($component->getModelInstance()->getKey());
-                    });
+                    }
+                );
 
             if ($callback) {
                 $relationshipQuery = $component->evaluate($callback, [


### PR DESCRIPTION
This is a tentative PR to provide the ability to exclude the current record for selection in a self-referential relationship. For example, if you have a `Category` model which has `parent` and `children` relationships which are mapped to other `Category` objects, you will most likely not want to to set the same record as a parent or a child. This PR includes `excludeSelf()` which removes the record from the options in a field where `relationship` is used.

There is probably more to do to this but wanted to just sound it out and see if it was worth continuing with.

Unsure where to put a test for this. If this looks okay, let me know where the best place to put that and I'll add.