### PR TITLE
Adding alias for table filter method `column`

### DIFF
--- a/packages/tables/docs/04-filters.md
+++ b/packages/tables/docs/04-filters.md
@@ -97,7 +97,7 @@ SelectFilter::make('status')
     ])
 ```
 
-Select filters do not require a custom `query()` method. The column name used to scope the query is the name of the filter. To customize this, you may use the `field()` method:
+Select filters do not require a custom `query()` method. The column name used to scope the query is the name of the filter. To customize this, you may use the `attribute()` method:
 
 ```php
 use Filament\Tables\Filters\SelectFilter;
@@ -108,7 +108,7 @@ SelectFilter::make('status')
         'reviewing' => 'Reviewing',
         'published' => 'Published',
     ])
-    ->field('status_id')
+    ->attribute('status_id')
 ```
 
 #### Relationship select filters
@@ -146,7 +146,7 @@ MultiSelectFilter::make('status')
     ])
 ```
 
-Multi-select filters do not require a custom `query()` method. The column name used to scope the query is the name of the filter. To customize this, you may use the `field()` method:
+Multi-select filters do not require a custom `query()` method. The column name used to scope the query is the name of the filter. To customize this, you may use the `attribute()` method:
 
 ```php
 use Filament\Tables\Filters\MultiSelectFilter;
@@ -157,7 +157,7 @@ MultiSelectFilter::make('status')
         'reviewing' => 'Reviewing',
         'published' => 'Published',
     ])
-    ->field('status_id')
+    ->attribute('status_id')
 ```
 
 #### Relationship multi-select filters
@@ -189,14 +189,14 @@ TernaryFilter::make('email_verified_at')
     ->nullable()
 ```
 
-The column name used to scope the query is the name of the filter. To customize this, you may use the `field()` method:
+The column name used to scope the query is the name of the filter. To customize this, you may use the `attribute()` method:
 
 ```php
 use Filament\Tables\Filters\TernaryFilter;
 
 TernaryFilter::make('verified')
     ->nullable()
-    ->field('status_id')
+    ->attribute('status_id')
 ```
 
 You may customise the query used for each state of the ternary filter, using the `queries()` method:

--- a/packages/tables/docs/04-filters.md
+++ b/packages/tables/docs/04-filters.md
@@ -97,7 +97,7 @@ SelectFilter::make('status')
     ])
 ```
 
-Select filters do not require a custom `query()` method. The column name used to scope the query is the name of the filter. To customize this, you may use the `column()` method:
+Select filters do not require a custom `query()` method. The column name used to scope the query is the name of the filter. To customize this, you may use the `field()` method:
 
 ```php
 use Filament\Tables\Filters\SelectFilter;
@@ -108,7 +108,7 @@ SelectFilter::make('status')
         'reviewing' => 'Reviewing',
         'published' => 'Published',
     ])
-    ->column('status_id')
+    ->field('status_id')
 ```
 
 #### Relationship select filters
@@ -146,7 +146,7 @@ MultiSelectFilter::make('status')
     ])
 ```
 
-Multi-select filters do not require a custom `query()` method. The column name used to scope the query is the name of the filter. To customize this, you may use the `column()` method:
+Multi-select filters do not require a custom `query()` method. The column name used to scope the query is the name of the filter. To customize this, you may use the `field()` method:
 
 ```php
 use Filament\Tables\Filters\MultiSelectFilter;
@@ -157,7 +157,7 @@ MultiSelectFilter::make('status')
         'reviewing' => 'Reviewing',
         'published' => 'Published',
     ])
-    ->column('status_id')
+    ->field('status_id')
 ```
 
 #### Relationship multi-select filters
@@ -189,14 +189,14 @@ TernaryFilter::make('email_verified_at')
     ->nullable()
 ```
 
-The column name used to scope the query is the name of the filter. To customize this, you may use the `column()` method:
+The column name used to scope the query is the name of the filter. To customize this, you may use the `field()` method:
 
 ```php
 use Filament\Tables\Filters\TernaryFilter;
 
 TernaryFilter::make('verified')
     ->nullable()
-    ->column('status_id')
+    ->field('status_id')
 ```
 
 You may customise the query used for each state of the ternary filter, using the `queries()` method:

--- a/packages/tables/src/Filters/Concerns/HasRelationship.php
+++ b/packages/tables/src/Filters/Concerns/HasRelationship.php
@@ -16,7 +16,7 @@ trait HasRelationship
 
     public function relationship(string $relationshipName, string $titleColumnName = null, Closure $callback = null): static
     {
-        $this->column("{$relationshipName}.{$titleColumnName}");
+        $this->attribute("{$relationshipName}.{$titleColumnName}");
 
         $this->modifyRelationshipQueryUsing = $callback;
 
@@ -60,7 +60,7 @@ trait HasRelationship
 
     public function queriesRelationships(): bool
     {
-        return Str::of($this->getColumn())->contains('.');
+        return Str::of($this->getAttribute())->contains('.');
     }
 
     protected function getRelationship(): Relation | Builder
@@ -72,11 +72,11 @@ trait HasRelationship
 
     protected function getRelationshipName(): string
     {
-        return (string) Str::of($this->getColumn())->beforeLast('.');
+        return (string) Str::of($this->getAttribute())->beforeLast('.');
     }
 
     protected function getRelationshipTitleColumnName(): string
     {
-        return (string) Str::of($this->getColumn())->afterLast('.');
+        return (string) Str::of($this->getAttribute())->afterLast('.');
     }
 }

--- a/packages/tables/src/Filters/MultiSelectFilter.php
+++ b/packages/tables/src/Filters/MultiSelectFilter.php
@@ -71,17 +71,19 @@ class MultiSelectFilter extends BaseFilter
         return $query;
     }
 
-    /** @deprecated use `->attribute()` on the filter instead */
-    public function column(string | Closure | null $name): static
+    public function attribute(string | Closure | null $name): static
     {
-        $this->attribute($name);
+        $this->attribute = $name;
 
         return $this;
     }
 
-    public function attribute(string | Closure | null $name): static
+    /**
+     * @deprecated Use `attribute()` instead.
+     */
+    public function column(string | Closure | null $name): static
     {
-        $this->attribute = $name;
+        $this->attribute($name);
 
         return $this;
     }
@@ -93,15 +95,17 @@ class MultiSelectFilter extends BaseFilter
         return $this;
     }
 
-    /** @deprecated use `->getAttribute()` instead */
-    public function getColumn(): string
-    {
-        return $this->getAttribute();
-    }
-
     public function getAttribute(): string
     {
         return $this->evaluate($this->attribute) ?? $this->getName();
+    }
+
+    /**
+     * @deprecated Use `getAttribute()` instead.
+     */
+    public function getColumn(): string
+    {
+        return $this->getAttribute();
     }
 
     protected function getFormField(): Select

--- a/packages/tables/src/Filters/MultiSelectFilter.php
+++ b/packages/tables/src/Filters/MultiSelectFilter.php
@@ -14,7 +14,7 @@ class MultiSelectFilter extends BaseFilter
     use Concerns\HasPlaceholder;
     use Concerns\HasRelationship;
 
-    protected string | Closure | null $column = null;
+    protected string | Closure | null $attribute = null;
 
     protected bool | Closure $isStatic = false;
 
@@ -66,21 +66,22 @@ class MultiSelectFilter extends BaseFilter
         }
 
         /** @var Builder $query */
-        $query = $query->whereIn($this->getColumn(), $data['values']);
+        $query = $query->whereIn($this->getAttribute(), $data['values']);
 
         return $query;
     }
 
+    /** @deprecated use `->attribute()` on the filter instead */
     public function column(string | Closure | null $name): static
     {
-        $this->column = $name;
+        $this->attribute($name);
 
         return $this;
     }
 
-    public function field(string | Closure | null $name): static
+    public function attribute(string | Closure | null $name): static
     {
-        $this->column($name);
+        $this->attribute = $name;
 
         return $this;
     }
@@ -92,9 +93,15 @@ class MultiSelectFilter extends BaseFilter
         return $this;
     }
 
+    /** @deprecated use `->getAttribute()` instead */
     public function getColumn(): string
     {
-        return $this->evaluate($this->column) ?? $this->getName();
+        return $this->getAttribute();
+    }
+
+    public function getAttribute(): string
+    {
+        return $this->evaluate($this->attribute) ?? $this->getName();
     }
 
     protected function getFormField(): Select

--- a/packages/tables/src/Filters/MultiSelectFilter.php
+++ b/packages/tables/src/Filters/MultiSelectFilter.php
@@ -78,6 +78,13 @@ class MultiSelectFilter extends BaseFilter
         return $this;
     }
 
+    public function field(string | Closure | null $name): static
+    {
+        $this->column($name);
+
+        return $this;
+    }
+
     public function static(bool | Closure $condition = true): static
     {
         $this->isStatic = $condition;

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -12,7 +12,7 @@ class SelectFilter extends BaseFilter
     use Concerns\HasPlaceholder;
     use Concerns\HasRelationship;
 
-    protected string | Closure | null $column = null;
+    protected string | Closure | null $attribute = null;
 
     protected bool | Closure $isStatic = false;
 
@@ -63,19 +63,20 @@ class SelectFilter extends BaseFilter
             );
         }
 
-        return $query->where($this->getColumn(), $data['value']);
+        return $query->where($this->getAttribute(), $data['value']);
     }
 
+    /** @deprecated use `->attribute()` on the filter instead */
     public function column(string | Closure | null $name): static
     {
-        $this->column = $name;
+        $this->attribute($name);
 
         return $this;
     }
 
-    public function field(string | Closure | null $name): static
+    public function attribute(string | Closure | null $name): static
     {
-        $this->column($name);
+        $this->attribute = $name;
 
         return $this;
     }
@@ -94,9 +95,15 @@ class SelectFilter extends BaseFilter
         return $this;
     }
 
+    /** @deprecated use `->getAttribute()` instead */
     public function getColumn(): string
     {
-        return $this->evaluate($this->column) ?? $this->getName();
+        return $this->getAttribute();
+    }
+
+    public function getAttribute(): string
+    {
+        return $this->evaluate($this->attribute) ?? $this->getName();
     }
 
     protected function getFormField(): Select

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -73,6 +73,13 @@ class SelectFilter extends BaseFilter
         return $this;
     }
 
+    public function field(string | Closure | null $name): static
+    {
+        $this->column($name);
+
+        return $this;
+    }
+
     public function static(bool | Closure $condition = true): static
     {
         $this->isStatic = $condition;

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -66,17 +66,19 @@ class SelectFilter extends BaseFilter
         return $query->where($this->getAttribute(), $data['value']);
     }
 
-    /** @deprecated use `->attribute()` on the filter instead */
-    public function column(string | Closure | null $name): static
+    public function attribute(string | Closure | null $name): static
     {
-        $this->attribute($name);
+        $this->attribute = $name;
 
         return $this;
     }
 
-    public function attribute(string | Closure | null $name): static
+    /**
+     * @deprecated Use `attribute()` instead.
+     */
+    public function column(string | Closure | null $name): static
     {
-        $this->attribute = $name;
+        $this->attribute($name);
 
         return $this;
     }
@@ -95,15 +97,17 @@ class SelectFilter extends BaseFilter
         return $this;
     }
 
-    /** @deprecated use `->getAttribute()` instead */
-    public function getColumn(): string
-    {
-        return $this->getAttribute();
-    }
-
     public function getAttribute(): string
     {
         return $this->evaluate($this->attribute) ?? $this->getName();
+    }
+
+    /**
+     * @deprecated Use `getAttribute()` instead.
+     */
+    public function getColumn(): string
+    {
+        return $this->getAttribute();
     }
 
     protected function getFormField(): Select

--- a/packages/tables/src/Filters/TernaryFilter.php
+++ b/packages/tables/src/Filters/TernaryFilter.php
@@ -70,7 +70,7 @@ class TernaryFilter extends SelectFilter
                     );
                 }
 
-                return $query->whereNotNull($this->getColumn());
+                return $query->whereNotNull($this->getAttribute());
             },
             false: function (Builder $query): Builder {
                 if ($this->queriesRelationships()) {
@@ -81,7 +81,7 @@ class TernaryFilter extends SelectFilter
                     );
                 }
 
-                return $query->whereNull($this->getColumn());
+                return $query->whereNull($this->getAttribute());
             },
         );
 
@@ -100,7 +100,7 @@ class TernaryFilter extends SelectFilter
                     );
                 }
 
-                return $query->where($this->getColumn(), true);
+                return $query->where($this->getAttribute(), true);
             },
             false: function (Builder $query): Builder {
                 if ($this->queriesRelationships()) {
@@ -111,7 +111,7 @@ class TernaryFilter extends SelectFilter
                     );
                 }
 
-                return $query->where($this->getColumn(), false);
+                return $query->where($this->getAttribute(), false);
             },
         );
 

--- a/tests/src/Tables/FilterTest.php
+++ b/tests/src/Tables/FilterTest.php
@@ -87,3 +87,19 @@ it('can remove all table filters', function () {
         ->removeTableFilters()
         ->assertCanSeeTableRecords($posts);
 });
+
+it('can filter records using an attribute', function() {
+
+    $posts = Post::factory()->count(10)->create();
+
+    $unpublishedPosts = $posts->where('is_published', false);
+
+    livewire(PostsTable::class)
+        ->assertCanSeeTableRecords($posts)
+        ->filterTable('is_published_select', false)
+        ->assertCanSeeTableRecords($unpublishedPosts)
+        ->filterTable('is_published_select', true)
+        ->assertCanNotSeeTableRecords($unpublishedPosts);
+
+
+});

--- a/tests/src/Tables/FilterTest.php
+++ b/tests/src/Tables/FilterTest.php
@@ -88,15 +88,15 @@ it('can remove all table filters', function () {
         ->assertCanSeeTableRecords($posts);
 });
 
-it('can filter records using an attribute', function () {
+it('can use a custom attribute for the `SelectFilter`', function () {
     $posts = Post::factory()->count(10)->create();
 
     $unpublishedPosts = $posts->where('is_published', false);
 
     livewire(PostsTable::class)
         ->assertCanSeeTableRecords($posts)
-        ->filterTable('is_published_select', false)
+        ->filterTable('select_filter_attribute', false)
         ->assertCanSeeTableRecords($unpublishedPosts)
-        ->filterTable('is_published_select', true)
+        ->filterTable('select_filter_attribute', true)
         ->assertCanNotSeeTableRecords($unpublishedPosts);
 });

--- a/tests/src/Tables/FilterTest.php
+++ b/tests/src/Tables/FilterTest.php
@@ -88,8 +88,7 @@ it('can remove all table filters', function () {
         ->assertCanSeeTableRecords($posts);
 });
 
-it('can filter records using an attribute', function() {
-
+it('can filter records using an attribute', function () {
     $posts = Post::factory()->count(10)->create();
 
     $unpublishedPosts = $posts->where('is_published', false);
@@ -100,6 +99,4 @@ it('can filter records using an attribute', function() {
         ->assertCanSeeTableRecords($unpublishedPosts)
         ->filterTable('is_published_select', true)
         ->assertCanNotSeeTableRecords($unpublishedPosts);
-
-
 });

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -45,9 +45,9 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
             Tables\Filters\SelectFilter::make('is_published_select')
                 ->options([
                     true => 'Published',
-                    false => 'Not Published'
+                    false => 'Not Published',
                 ])
-                ->attribute('is_published')
+                ->attribute('is_published'),
         ];
     }
 

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -42,7 +42,7 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
                 ->query(fn (Builder $query) => $query->where('is_published', true)),
             Tables\Filters\SelectFilter::make('author')
                 ->relationship('author', 'name'),
-            Tables\Filters\SelectFilter::make('is_published_select')
+            Tables\Filters\SelectFilter::make('select_filter_attribute')
                 ->options([
                     true => 'Published',
                     false => 'Not Published',

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -42,6 +42,12 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
                 ->query(fn (Builder $query) => $query->where('is_published', true)),
             Tables\Filters\SelectFilter::make('author')
                 ->relationship('author', 'name'),
+            Tables\Filters\SelectFilter::make('is_published_select')
+                ->options([
+                    true => 'Published',
+                    false => 'Not Published'
+                ])
+                ->attribute('is_published')
         ];
     }
 


### PR DESCRIPTION
New method `field` added as alias to `column` in `SelectFilter` and `MultiSelectFilter` to better represent how the method can be used as per #3998. Docs also amended.