### PR TITLE
Adding assertions to test column data

### DIFF
--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -95,6 +95,10 @@ namespace Livewire\Testing {
 
         public function assertTableColumnHidden(string $name): static {}
 
+        public function assertTableColumnDataSet($record, $name, $value): static {}
+
+        public function assertTableColumnDataNotSet($record, $name, $value): static {}
+
         public function sortTable(?string $name = null, ?string $direction = null): static {}
 
         public function searchTable(?string $search = null): static {}

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -95,9 +95,9 @@ namespace Livewire\Testing {
 
         public function assertTableColumnHidden(string $name): static {}
 
-        public function assertTableColumnDataSet($record, $name, $value): static {}
+        public function assertTableColumnStateSet(string $name, $value, $record): static {}
 
-        public function assertTableColumnDataNotSet($record, $name, $value): static {}
+        public function assertTableColumnStateNotSet(string $name, $value, $record): static {}
 
         public function sortTable(?string $name = null, ?string $direction = null): static {}
 

--- a/packages/tables/docs/06-testing.md
+++ b/packages/tables/docs/06-testing.md
@@ -91,6 +91,23 @@ it('can search posts by title', function () {
 });
 ```
 
+### State
+
+To assert that a certain column has a state for a record:
+
+```php
+use function Pest\Livewire\livewire;
+
+it('can get post author names', function () {
+    $posts = Post::factory()->count(10)->create();
+
+    $post = $posts->first();
+
+    livewire(PostResource\Pages\ListPosts::class)
+        ->assertTableColumnStateSet('author.name', $post->author->name, record: $post);
+});
+```
+
 ### Authorization
 
 To ensure that a particular user cannot see a column, you can use the `assertTableColumnHidden()` method:

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -97,9 +97,9 @@ class TestsColumns
         };
     }
 
-    public function assertTableColumnDataSet(): Closure
+    public function assertTableColumnStateSet(): Closure
     {
-        return function ($record, $name, $value): static {
+        return function (string $name, $value, $record): static {
             /** @phpstan-ignore-next-line */
             $this->assertTableColumnExists($name);
 
@@ -108,20 +108,24 @@ class TestsColumns
 
             $column = $livewire->getCachedTableColumn($name);
 
+            if (! ($record instanceof Model)) {
+                $record = $livewire->getTableRecord($record);
+            }
+
             $column->record($record);
 
             Assert::assertTrue(
                 $column->getState() == $value,
-                message: "Failed asserting that a table column with name [{$name}] has value of [{$value}] on the [{$livewireClass}] component.",
+                message: "Failed asserting that a table column with name [{$name}] has value of [{$value}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
             );
 
             return $this;
         };
     }
 
-    public function assertTableColumnDataNotSet(): Closure
+    public function assertTableColumnStateNotSet(): Closure
     {
-        return function ($record, $name, $value): static {
+        return function (string $name, $value, $record): static {
             /** @phpstan-ignore-next-line */
             $this->assertTableColumnExists($name);
 
@@ -130,11 +134,15 @@ class TestsColumns
 
             $column = $livewire->getCachedTableColumn($name);
 
+            if (! ($record instanceof Model)) {
+                $record = $livewire->getTableRecord($record);
+            }
+
             $column->record($record);
 
             Assert::assertFalse(
                 $column->getState() == $value,
-                message: "Failed asserting that a table column with name [{$name}] does not have a value of [{$value}] on the [{$livewireClass}] component.",
+                message: "Failed asserting that a table column with name [{$name}] does not have a value of [{$value}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
             );
 
             return $this;

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -97,9 +97,9 @@ class TestsColumns
         };
     }
 
-    public function assertTableColumnDataSet() : Closure
+    public function assertTableColumnDataSet(): Closure
     {
-        return function ($record, $name, $value) : static {
+        return function ($record, $name, $value): static {
             /** @phpstan-ignore-next-line */
             $this->assertTableColumnExists($name);
 
@@ -119,9 +119,9 @@ class TestsColumns
         };
     }
 
-    public function assertTableColumnDataNotSet() : Closure
+    public function assertTableColumnDataNotSet(): Closure
     {
-        return function ($record, $name, $value) : static {
+        return function ($record, $name, $value): static {
             /** @phpstan-ignore-next-line */
             $this->assertTableColumnExists($name);
 

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -97,6 +97,50 @@ class TestsColumns
         };
     }
 
+    public function assertTableColumnDataSet() : Closure
+    {
+        return function ($record, $name, $value) : static {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableColumnExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $column = $livewire->getCachedTableColumn($name);
+
+            $column->record($record);
+
+            Assert::assertTrue(
+                $column->getState() == $value,
+                message: "Failed asserting that a table column with name [{$name}] has value of [{$value}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertTableColumnDataNotSet() : Closure
+    {
+        return function ($record, $name, $value) : static {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableColumnExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $column = $livewire->getCachedTableColumn($name);
+
+            $column->record($record);
+
+            Assert::assertFalse(
+                $column->getState() == $value,
+                message: "Failed asserting that a table column with name [{$name}] does not have a value of [{$value}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
     public function callTableColumnAction(): Closure
     {
         return function (string $name, $record = null): static {

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -86,11 +86,9 @@ it('can call a column action object', function () {
 });
 
 it('can state whether a column has the correct value', function () {
-
     $post = Post::factory()->create();
 
     livewire(PostsTable::class)
         ->assertTableColumnDataSet($post, 'with_value', 'correct value')
         ->assertTableColumnDataNotSet($post, 'with_value', 'incorrect value');
-
 });

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -89,6 +89,6 @@ it('can state whether a column has the correct value', function () {
     $post = Post::factory()->create();
 
     livewire(PostsTable::class)
-        ->assertTableColumnDataSet($post, 'with_value', 'correct value')
-        ->assertTableColumnDataNotSet($post, 'with_value', 'incorrect value');
+        ->assertTableColumnStateSet('with_state', 'correct state', $post)
+        ->assertTableColumnStateNotSet('with_state', 'incorrect state', $post);
 });

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -84,3 +84,13 @@ it('can call a column action object', function () {
         ->callTableAction('column-action-object', $post)
         ->assertEmitted('column-action-object-called');
 });
+
+it('can state whether a column has the correct value', function () {
+
+    $post = Post::factory()->create();
+
+    livewire(PostsTable::class)
+        ->assertTableColumnDataSet($post, 'with_value', 'correct value')
+        ->assertTableColumnDataNotSet($post, 'with_value', 'incorrect value');
+
+});

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -33,7 +33,7 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
             Tables\Columns\TextColumn::make('hidden')
                 ->hidden(),
             Tables\Columns\TextColumn::make('with_value')
-                ->getStateUsing(fn() => 'correct value')
+                ->getStateUsing(fn () => 'correct value'),
         ];
     }
 

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -32,8 +32,8 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
             Tables\Columns\TextColumn::make('visible'),
             Tables\Columns\TextColumn::make('hidden')
                 ->hidden(),
-            Tables\Columns\TextColumn::make('with_value')
-                ->getStateUsing(fn () => 'correct value'),
+            Tables\Columns\TextColumn::make('with_state')
+                ->getStateUsing(fn () => 'correct state'),
         ];
     }
 

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -32,6 +32,8 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
             Tables\Columns\TextColumn::make('visible'),
             Tables\Columns\TextColumn::make('hidden')
                 ->hidden(),
+            Tables\Columns\TextColumn::make('with_value')
+                ->getStateUsing(fn() => 'correct value')
         ];
     }
 


### PR DESCRIPTION
```
assertTableColumnDataSet($record, $name, $value)
assertTableColumnDataNotSet($record, $name, $value)
```
Went for passing in the record rather than the key as it was simpler but can look at reworking if it is preferred. Am thinking the context of any test would have the object to hand anyway.