### PR TITLE
Adding getContext() shortcut for form builde

### DIFF
--- a/packages/forms/docs/06-advanced.md
+++ b/packages/forms/docs/06-advanced.md
@@ -44,16 +44,6 @@ function ($state) {
 }
 ```
 
-If you wish to access the current component context, define a `$context` parameter.
-
-Within the admin panel, this will default to 'edit' or 'create'.  In the standalone forms builder it will default to your component class name, but can be set using the `getContext('foo')` method in your component.
-
-```php
-function ($context) {
-    // ...
-}
-```
-
 If you wish to access the current component instance, define a `$component` parameter:
 
 ```php
@@ -105,6 +95,16 @@ function (Closure $set) {
     //...
 }
 ```
+
+If you're writing a form for an admin panel resource or relation manager, and you wish to check if a form is `create`, `edit` or `view`, use the `$context` parameter:
+
+```php
+function (string $context) {
+    // ...
+}
+```
+
+> Outside of the admin panel, you can set a form's context by defining a `getFormContext()` method on your Livewire component.
 
 Callbacks are evaluated using Laravel's `app()->call()` under the hood, so you are able to combine multiple parameters in any order:
 

--- a/packages/forms/docs/06-advanced.md
+++ b/packages/forms/docs/06-advanced.md
@@ -44,6 +44,16 @@ function ($state) {
 }
 ```
 
+If you wish to access the current component context, define a `$context` parameter.
+
+Within the admin panel, this will default to 'edit' or 'create'.  In the standalone forms builder it will default to your component class name, but can be set using the `getContext('foo')` method in your component.
+
+```php
+function ($context) {
+    // ...
+}
+```
+
 If you wish to access the current component instance, define a `$component` parameter:
 
 ```php

--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -278,10 +278,10 @@ trait InteractsWithForms
     {
         return [
             'form' => $this->makeForm()
-                ->context($this->getFormContext())
                 ->schema($this->getFormSchema())
                 ->model($this->getFormModel())
-                ->statePath($this->getFormStatePath()),
+                ->statePath($this->getFormStatePath())
+                ->context($this->getFormContext()),
         ];
     }
 

--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -278,10 +278,16 @@ trait InteractsWithForms
     {
         return [
             'form' => $this->makeForm()
+                ->context($this->getContext())
                 ->schema($this->getFormSchema())
                 ->model($this->getFormModel())
                 ->statePath($this->getFormStatePath()),
         ];
+    }
+
+    protected function getContext(): ?string
+    {
+        return null;
     }
 
     protected function getFormStatePath(): ?string

--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -278,14 +278,14 @@ trait InteractsWithForms
     {
         return [
             'form' => $this->makeForm()
-                ->context($this->getContext())
+                ->context($this->getFormContext())
                 ->schema($this->getFormSchema())
                 ->model($this->getFormModel())
                 ->statePath($this->getFormStatePath()),
         ];
     }
 
-    protected function getContext(): ?string
+    protected function getFormContext(): ?string
     {
         return null;
     }


### PR DESCRIPTION
As discussed with @danharrin added getContext() method, and docs for $context in the closure customization section.  Lmk if you want the wording of the doc section modified.