### PR TITLE
Mitigate multiple network requests

### DIFF
--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -27,6 +27,7 @@
             <label class="flex items-center space-x-3 rtl:space-x-reverse">
                 <input
                     {!! $isDisabled ? 'disabled' : null !!}
+                    wire:loading.attr="disabled"
                     type="checkbox"
                     value="{{ $optionValue }}"
                     dusk="filament.forms.{{ $getStatePath() }}"

--- a/packages/forms/resources/views/components/checkbox.blade.php
+++ b/packages/forms/resources/views/components/checkbox.blade.php
@@ -15,6 +15,7 @@
             <input
                 {!! $isAutofocused() ? 'autofocus' : null !!}
                 {!! $isDisabled() ? 'disabled' : null !!}
+                wire:loading.attr="disabled"
                 id="{{ $getId() }}"
                 type="checkbox"
                 {{ $applyStateBindingModifiers('wire:model') }}="{{ $getStatePath() }}"

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -53,6 +53,7 @@
                                     'border-danger-600 ring-1 ring-inset ring-danger-600' => $errors->has($getStatePath()),
                                 ]) }}
                                 {!! ($isDisabled || $isOptionDisabled($value, $label)) ? 'disabled' : null !!}
+                                wire:loading.attr="disabled"
                             />
                         </div>
 

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -36,6 +36,7 @@
                 }"
                 {!! $isAutofocused() ? 'autofocus' : null !!}
                 {!! $isDisabled() ? 'disabled' : null !!}
+                wire:loading.attr="disabled"
                 id="{{ $getId() }}"
                 dusk="filament.forms.{{ $getStatePath() }}"
                 type="button"


### PR DESCRIPTION
When some "clickable" inputs are reactive, they generate a lot of unnecessary networks requests, if the user "multi-clicks".
As network requests might be slow, the result is a field that slowly toggles multiple times and it might not end up in the state that the user expects.
It's better to disable the field while waiting for Livewire.
It doesn't prevent the problem entirely but some requests are prevented.