### PR TITLE
fix: Wizard steps indicator responsiveness

### DIFF
--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -83,20 +83,15 @@
     <ol
         {!! $getLabel() ? 'aria-label="' . $getLabel() . '"' : null !!}
         role="list"
-        @if (count($getChildComponentContainer()->getComponents()) >= 4)
+
             @class([
-            'border border-gray-300 shadow-sm bg-white rounded-xl overflow-hidden divide-y divide-gray-300 grid md:grid-cols-2 md:divide-y-0',
+            'border border-gray-300 shadow-sm bg-white rounded-xl overflow-hidden divide-y divide-gray-300 md:flex flex-wrap md:divide-y-0',
             'dark:bg-gray-800 dark:border-gray-700 dark:divide-gray-700' => config('forms.dark_mode'),
             ])
-        @else
-            @class([
-                'border border-gray-300 shadow-sm bg-white rounded-xl overflow-hidden divide-y divide-gray-300 md:flex md:divide-y-0',
-                'dark:bg-gray-800 dark:border-gray-700 dark:divide-gray-700' => config('forms.dark_mode'),
-            ])
-        @endif
+
     >
         @foreach ($getChildComponentContainer()->getComponents() as $step)
-            <li class="group relative overflow-hidden md:flex-1">
+            <li class="group relative overflow-hidden w-full md:w-1/2">
                 <button
                     type="button"
                     x-on:click="if (isStepClickable(step, {{ $loop->index }})) step = '{{ $step->getId() }}'"

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -83,12 +83,10 @@
     <ol
         {!! $getLabel() ? 'aria-label="' . $getLabel() . '"' : null !!}
         role="list"
-
-            @class([
+        @class([
             'border border-gray-300 shadow-sm bg-white rounded-xl overflow-hidden divide-y divide-gray-300 md:flex flex-wrap md:divide-y-0',
             'dark:bg-gray-800 dark:border-gray-700 dark:divide-gray-700' => config('forms.dark_mode'),
-            ])
-
+        ])
     >
         @foreach ($getChildComponentContainer()->getComponents() as $step)
             <li class="group relative overflow-hidden w-full md:w-1/2">

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -83,10 +83,17 @@
     <ol
         {!! $getLabel() ? 'aria-label="' . $getLabel() . '"' : null !!}
         role="list"
-        @class([
-            'border border-gray-300 shadow-sm bg-white rounded-xl overflow-hidden divide-y divide-gray-300 md:flex md:divide-y-0',
+        @if (count($getChildComponentContainer()->getComponents()) >= 4)
+            @class([
+            'border border-gray-300 shadow-sm bg-white rounded-xl overflow-hidden divide-y divide-gray-300 grid md:grid-cols-2 md:divide-y-0',
             'dark:bg-gray-800 dark:border-gray-700 dark:divide-gray-700' => config('forms.dark_mode'),
-        ])
+            ])
+        @else
+            @class([
+                'border border-gray-300 shadow-sm bg-white rounded-xl overflow-hidden divide-y divide-gray-300 md:flex md:divide-y-0',
+                'dark:bg-gray-800 dark:border-gray-700 dark:divide-gray-700' => config('forms.dark_mode'),
+            ])
+        @endif
     >
         @foreach ($getChildComponentContainer()->getComponents() as $step)
             <li class="group relative overflow-hidden md:flex-1">


### PR DESCRIPTION
Hi team, 

Just working with the wizard and ran into this visual issue when having more than 4 steps

![Screenshot 2022-09-29 at 10 17 30](https://user-images.githubusercontent.com/68377016/192993331-85391357-4d0d-4a19-aba7-9b537e09b6ac.png)

I've added a count check then switch to grid if there are 4 or more steps

![Screenshot 2022-09-29 at 10 16 46](https://user-images.githubusercontent.com/68377016/192993227-7ab4c2a1-47db-4dc6-837e-49569db702d1.png)

I've tried to make the code more readable but I'm aware that It could/should be refactored inline.

There's probably more that could be done with the borders but I think it works really well with the two column grid layout

Kind regards
