### PR TITLE
Update Documentation for badge column

### DIFF
--- a/packages/tables/docs/03-columns/06-badge.md
+++ b/packages/tables/docs/03-columns/06-badge.md
@@ -45,7 +45,6 @@ BadgeColumn::make('status')
     ])
 ```
 
-
 Or dynamically calculate the color based on the `$state` and / or `$record` as second parameter:
 
 ```php

--- a/packages/tables/docs/03-columns/06-badge.md
+++ b/packages/tables/docs/03-columns/06-badge.md
@@ -45,15 +45,20 @@ BadgeColumn::make('status')
     ])
 ```
 
-Or dynamically calculate the color based on the `$record` and / or `$state`:
+
+Or dynamically calculate the color based on the `$state` and / or `$record` as second parameter:
 
 ```php
 use Filament\Tables\Columns\BadgeColumn;
 
 BadgeColumn::make('status')
-    ->icon(static function ($state): string {
-        if ($state === 'published') {
+    ->icon(static function ($state,$record): string {
+        if ($record->status === 'published') {
             return 'success';
+        }
+
+        if ($state === 'reviewing') {
+            return 'warning';
         }
         
         return 'secondary';


### PR DESCRIPTION
As everywhere callback function are evaluated, we can access method params just using proper naming,

But badge column color and icon methods callback functions are not evaluated,  just accepting only one param in callback function will always give the state not the whole record. And it's bit confusing .