### PR TITLE
Fix link target in column

### DIFF
--- a/packages/tables/resources/views/components/columns/column.blade.php
+++ b/packages/tables/resources/views/components/columns/column.blade.php
@@ -38,7 +38,7 @@
     @elseif ($url || ($recordUrl && $action === null))
         <a
             href="{{ $url ?: $recordUrl }}"
-            {{ $shouldOpenUrlInNewTab ? 'target="_blank"' : null }}
+            {!! $shouldOpenUrlInNewTab ? 'target="_blank"' : null !!}
             class="block"
         >
             {{ $slot }}


### PR DESCRIPTION
Currently renders `target=""_blank""`, after proposed change `target="_blank"`

The double-double quotes prevent some browsers such as FF to properly open links in a new tab