### PR TITLE
Revert "small avatar image, bg-primary background"

### DIFF
--- a/packages/admin/resources/views/components/user-avatar.blade.php
+++ b/packages/admin/resources/views/components/user-avatar.blade.php
@@ -4,7 +4,7 @@
 
 <div
     {{ $attributes->class([
-        'w-10 h-10 rounded-full bg-primary-500 bg-cover bg-center',
+        'w-10 h-10 rounded-full bg-gray-200 bg-cover bg-center',
         'dark:bg-gray-900' => config('filament.dark_mode'),
     ]) }}
     style="background-image: url('{{ \Filament\Facades\Filament::getUserAvatarUrl($user) }}')"

--- a/packages/admin/src/AvatarProviders/UiAvatarsProvider.php
+++ b/packages/admin/src/AvatarProviders/UiAvatarsProvider.php
@@ -16,6 +16,6 @@ class UiAvatarsProvider implements Contracts\AvatarProvider
             ->map(fn (string $segment): string => filled($segment) ? mb_substr($segment, 0, 1) : '')
             ->join(' ');
 
-        return 'https://ui-avatars.com/api/?name=' . urlencode($name) . '&color=FFFFFF&background=ffffff00&format=svg';
+        return 'https://ui-avatars.com/api/?name=' . urlencode($name) . '&color=FFFFFF&background=111827';
     }
 }


### PR DESCRIPTION
Reverts filamentphp/filament#4486

The PR updated the avatar background color to a striking primary color.
In my opinion, this is bad design.

Also, the dark mode avatar color wasn't updated, which leads to inconsistency between dark and light mode.

I suggest to revert this change and discuss potential design changes related to the avatar for v3.