### PR TITLE
Fix wrong method name used in docs

### DIFF
--- a/packages/admin/docs/02-resources/02-listing-records.md
+++ b/packages/admin/docs/02-resources/02-listing-records.md
@@ -179,7 +179,7 @@ public static function table(Table $table): Table
 
 When making the table reorderable, a new button will be available on the table to toggle reordering. Pagination will be disabled in reorder mode to allow you to move records between pages.
 
-The `reorderable()` method passes in the name of a column to store the record order in. If you use something like [`spatie/eloquent-sortable`](https://github.com/spatie/eloquent-sortable) with an order column such as `order_column`, you may pass this in to `orderable()`:
+The `reorderable()` method passes in the name of a column to store the record order in. If you use something like [`spatie/eloquent-sortable`](https://github.com/spatie/eloquent-sortable) with an order column such as `order_column`, you may pass this in to `reorderable()`:
 
 ```php
 use Filament\Resources\Table;


### PR DESCRIPTION
Hi filament teams,

just spot a wrong method name used in docs, it should be `reorderable()` instead of `orderable()`

PS: Love what filament team brings to the community, Thank you !