### PR TITLE
🤏 small typo under authorizing soft deletes

### DIFF
--- a/packages/admin/docs/02-resources/06-deleting-records.md
+++ b/packages/admin/docs/02-resources/06-deleting-records.md
@@ -155,6 +155,6 @@ They also have the ability to bulk-delete records if the `deleteAny()` method of
 
 ### Authorizing soft deletes
 
-The `forceDelete()` policu method is used to prevent a single soft-deleted record from being force-deleted. `forceDeleteAny()` is used to prevent records from being bulk force-deleted. Filament uses the `forceDeleteAny()` method because iterating through multiple records and checking the `forceDelete()` policy is not very performant.
+The `forceDelete()` policy method is used to prevent a single soft-deleted record from being force-deleted. `forceDeleteAny()` is used to prevent records from being bulk force-deleted. Filament uses the `forceDeleteAny()` method because iterating through multiple records and checking the `forceDelete()` policy is not very performant.
 
-The `restore()` policu method is used to prevent a single soft-deleted record from being restored. `restoreAny()` is used to prevent records from being bulk restored. Filament uses the `restoreAny()` method because iterating through multiple records and checking the `restore()` policy is not very performant.
+The `restore()` policy method is used to prevent a single soft-deleted record from being restored. `restoreAny()` is used to prevent records from being bulk restored. Filament uses the `restoreAny()` method because iterating through multiple records and checking the `restore()` policy is not very performant.


### PR DESCRIPTION
Fixed two typos, `policu` to `policy`