### PR TITLE
fix: give computed properties a higher precedence than forms

### DIFF
--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -3,13 +3,13 @@
 namespace Filament\Forms\Concerns;
 
 use Closure;
-use Livewire\WithFileUploads;
-use Illuminate\Contracts\View\View;
-use Livewire\TemporaryUploadedFile;
 use Filament\Forms\ComponentContainer;
+use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\ValidationException;
 use Livewire\Exceptions\PropertyNotFoundException;
+use Livewire\TemporaryUploadedFile;
+use Livewire\WithFileUploads;
 
 trait InteractsWithForms
 {

--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -30,7 +30,7 @@ trait InteractsWithForms
     {
         try {
             return parent::__get($property);
-        } catch (PropertyNotFoundException $e) {
+        } catch (PropertyNotFoundException $exception) {
             if ((! $this->isCachingForms) && $form = $this->getCachedForm($property)) {
                 return $form;
             }
@@ -39,7 +39,7 @@ trait InteractsWithForms
                 return $this->getModalViewOnce();
             }
 
-            throw $e;
+            throw $exception;
         }
     }
 

--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -3,12 +3,13 @@
 namespace Filament\Forms\Concerns;
 
 use Closure;
-use Filament\Forms\ComponentContainer;
+use Livewire\WithFileUploads;
 use Illuminate\Contracts\View\View;
+use Livewire\TemporaryUploadedFile;
+use Filament\Forms\ComponentContainer;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\ValidationException;
-use Livewire\TemporaryUploadedFile;
-use Livewire\WithFileUploads;
+use Livewire\Exceptions\PropertyNotFoundException;
 
 trait InteractsWithForms
 {
@@ -27,15 +28,19 @@ trait InteractsWithForms
 
     public function __get($property)
     {
-        if ((! $this->isCachingForms) && $form = $this->getCachedForm($property)) {
-            return $form;
-        }
+        try {
+            return parent::__get($property);
+        } catch (PropertyNotFoundException $e) {
+            if ((! $this->isCachingForms) && $form = $this->getCachedForm($property)) {
+                return $form;
+            }
 
-        if ($property === 'modal') {
-            return $this->getModalViewOnce();
-        }
+            if ($property === 'modal') {
+                return $this->getModalViewOnce();
+            }
 
-        return parent::__get($property);
+            throw $e;
+        }
     }
 
     protected function getModalViewOnce(): ?View

--- a/tests/src/Forms/ComputedPropertyTest.php
+++ b/tests/src/Forms/ComputedPropertyTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Filament\Tests\TestCase;
+use Filament\Forms\Components\TextInput;
+use Filament\Tests\Forms\Fixtures\Livewire;
+use Pest\Expectation;
+
+uses(TestCase::class);
+
+test('computed properties used to generate form schema can be accessed before caching forms', function () {
+    expect(ComputedPropertySchema::make())
+        ->getTheSchema()
+        ->toBeArray()
+        ->sequence(
+            fn (Expectation $expect) => $expect->toBeInstanceOf(TextInput::class)
+        );
+});
+
+class ComputedPropertySchema extends Livewire
+{
+    public function getFormSchema(): array
+    {
+        return $this->schema;
+    }
+
+    public function getSchemaProperty()
+    {
+        return [
+            TextInput::make(''),
+        ];
+    }
+
+    public function getTheSchema()
+    {
+        return $this->schema;
+    }
+}

--- a/tests/src/Forms/ComputedPropertyTest.php
+++ b/tests/src/Forms/ComputedPropertyTest.php
@@ -9,7 +9,7 @@ uses(TestCase::class);
 
 test('computed properties used to generate form schema can be accessed before caching forms', function () {
     expect(ComputedPropertySchema::make())
-        ->getTheSchema()
+        ->getSchema()
         ->toBeArray()
         ->sequence(
             fn (Expectation $expect) => $expect->toBeInstanceOf(TextInput::class)
@@ -30,7 +30,7 @@ class ComputedPropertySchema extends Livewire
         ];
     }
 
-    public function getTheSchema()
+    public function getSchema()
     {
         return $this->schema;
     }

--- a/tests/src/Forms/ComputedPropertyTest.php
+++ b/tests/src/Forms/ComputedPropertyTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use Filament\Tests\TestCase;
 use Filament\Forms\Components\TextInput;
 use Filament\Tests\Forms\Fixtures\Livewire;
+use Filament\Tests\TestCase;
 use Pest\Expectation;
 
 uses(TestCase::class);


### PR DESCRIPTION
Came across a bug whilst working on a regular `filament/forms` project.

If a computed property is used inside of `getFormSchema()` and you try to access the computed property before interacting with the form, an exception would be thrown.

This was down to all forms being cached before allowing Livewire's own `__get()` method to check if the property is even a valid computed one.

These changes swap the logic round so that computed properties are always checked first and in the case a computed property doesn't exist on the Livewire component, Filament's own logic will be executed (caching forms, checking modals, etc).

The test case is the simplest reproduction of my exact scenario:
- calling an action which uses the computed property
- that triggering the caching of forms
- therefore trying to use that computed property again

Removing the changes in `__get()`, you'll see the test case failing.