### PR TITLE
Fix minor typo

### DIFF
--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -1281,7 +1281,7 @@ You can add a button to open each file in a new tab with the `enableOpen()` meth
 use Filament\Forms\Components\FileUpload;
 
 FileUpload::make('attachments')
-    ->multipe()
+    ->multiple()
     ->enableOpen()
 ```
 


### PR DESCRIPTION
Fixes a minor typo - incorrect spelling. `multipe()` -> `multiple()`