### PR TITLE
Add missing imports to navigation docs

### DIFF
--- a/packages/admin/docs/05-navigation.md
+++ b/packages/admin/docs/05-navigation.md
@@ -142,6 +142,7 @@ use App\Filament\Pages\Settings;
 use App\Filament\Resources\UserResource;
 use Filament\Facades\Filament;
 use Filament\Navigation\NavigationBuilder;
+use Filament\Navigation\NavigationItem;
 
 Filament::navigation(function (NavigationBuilder $builder): NavigationBuilder {
     return $builder->items([

--- a/packages/admin/docs/05-navigation.md
+++ b/packages/admin/docs/05-navigation.md
@@ -52,6 +52,7 @@ You may customize navigation groups by calling `Filament::registerNavigationGrou
 
 ```php
 use Filament\Facades\Filament;
+use Filament\Navigation\NavigationGroup;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider


### PR DESCRIPTION
Added 'use Filament\Navigation\NavigationGroup;' to the cusotmizing navigation groups section