### PR TITLE
Fix for BadgeColumn colours assigns colour to only last condition

### DIFF
--- a/packages/tables/src/Columns/Concerns/HasColors.php
+++ b/packages/tables/src/Columns/Concerns/HasColors.php
@@ -28,6 +28,14 @@ trait HasColors
                     $stateColor = $condition;
                 } elseif ($condition instanceof Closure && $condition($state, $record)) {
                     $stateColor = $color;
+                } elseif (is_array($condition)) {
+                    $conditions = $condition;
+
+                    foreach ($conditions as $condition) {
+                        if ($state === $condition) {
+                            $stateColor = $color;
+                        }
+                    }
                 } elseif ($condition === $state) {
                     $stateColor = $color;
                 }


### PR DESCRIPTION
When different conditions are assigned to same colour, it assigns the colour only to last condition.

**Example **
```
colors([
  'warning' => 'processing',
  'warning' => 'scheduled',
  'warning' => 'escrowed',
])

 The warning colour will only be assigned to the last condition which is 'escrowed'.
```

This PR accepts assigning an array of conditions to a colour.
```
colors([
  'warning' => [
     'processing',
     'scheduled',
     'escrowed',
  ]
])
```