### PR TITLE
fix: Hide chart widget divider if it has no header

### DIFF
--- a/packages/admin/resources/views/widgets/chart-widget.blade.php
+++ b/packages/admin/resources/views/widgets/chart-widget.blade.php
@@ -1,9 +1,11 @@
 <x-filament::widget class="filament-widgets-chart-widget">
     <x-filament::card>
         <div class="flex items-center justify-between gap-8">
-            <x-filament::card.heading>
-                {{ $this->getHeading() }}
-            </x-filament::card.heading>
+            @if($heading = $this->getHeading())
+                <x-filament::card.heading>
+                    {{ $heading }}
+                </x-filament::card.heading>
+            @endif
 
             @if ($filters = $this->getFilters())
                 <select
@@ -23,7 +25,9 @@
             @endif
         </div>
 
-        <x-filament::hr />
+        @if($heading || $filters)
+            <x-filament::hr />
+        @endif
 
         <div {!! ($pollingInterval = $this->getPollingInterval()) ? "wire:poll.{$pollingInterval}=\"updateChartData\"" : '' !!}>
             <canvas

--- a/packages/admin/resources/views/widgets/chart-widget.blade.php
+++ b/packages/admin/resources/views/widgets/chart-widget.blade.php
@@ -1,7 +1,11 @@
+@php
+    $heading = $this->getHeading();
+@endphp
+
 <x-filament::widget class="filament-widgets-chart-widget">
     <x-filament::card>
         <div class="flex items-center justify-between gap-8">
-            @if($heading = $this->getHeading())
+            @if ($heading)
                 <x-filament::card.heading>
                     {{ $heading }}
                 </x-filament::card.heading>
@@ -25,7 +29,7 @@
             @endif
         </div>
 
-        @if($heading || $filters)
+        @if ($heading || $filters)
             <x-filament::hr />
         @endif
 

--- a/packages/admin/resources/views/widgets/chart-widget.blade.php
+++ b/packages/admin/resources/views/widgets/chart-widget.blade.php
@@ -1,36 +1,36 @@
 @php
-    $filters = $this->getFilters();
     $heading = $this->getHeading();
+    $filters = $this->getFilters();
 @endphp
 
 <x-filament::widget class="filament-widgets-chart-widget">
     <x-filament::card>
-        <div class="flex items-center justify-between gap-8">
-            @if ($heading)
-                <x-filament::card.heading>
-                    {{ $heading }}
-                </x-filament::card.heading>
-            @endif
-
-            @if ($filters)
-                <select
-                    wire:model="filter"
-                    @class([
-                        'text-gray-900 border-gray-300 block h-10 transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500',
-                        'dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200 dark:focus:border-primary-500' => config('filament.dark_mode'),
-                    ])
-                    wire:loading.class="animate-pulse"
-                >
-                    @foreach ($filters as $value => $label)
-                        <option value="{{ $value }}">
-                            {{ $label }}
-                        </option>
-                    @endforeach
-                </select>
-            @endif
-        </div>
-
         @if ($heading || $filters)
+            <div class="flex items-center justify-between gap-8">
+                @if ($heading)
+                    <x-filament::card.heading>
+                        {{ $heading }}
+                    </x-filament::card.heading>
+                @endif
+
+                @if ($filters)
+                    <select
+                        wire:model="filter"
+                        @class([
+                            'text-gray-900 border-gray-300 block h-10 transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500',
+                            'dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200 dark:focus:border-primary-500' => config('filament.dark_mode'),
+                        ])
+                        wire:loading.class="animate-pulse"
+                    >
+                        @foreach ($filters as $value => $label)
+                            <option value="{{ $value }}">
+                                {{ $label }}
+                            </option>
+                        @endforeach
+                    </select>
+                @endif
+            </div>
+
             <x-filament::hr />
         @endif
 

--- a/packages/admin/resources/views/widgets/chart-widget.blade.php
+++ b/packages/admin/resources/views/widgets/chart-widget.blade.php
@@ -1,4 +1,5 @@
 @php
+    $filters = $this->getFilters();
     $heading = $this->getHeading();
 @endphp
 
@@ -11,7 +12,7 @@
                 </x-filament::card.heading>
             @endif
 
-            @if ($filters = $this->getFilters())
+            @if ($filters)
                 <select
                     wire:model="filter"
                     @class([


### PR DESCRIPTION
Hide `<x-filament::hr />`  from chart-widget header if not set header or filters.