### PR TITLE
Fix double return typo in navigation docs

### DIFF
--- a/packages/admin/docs/02-resources/01-getting-started.md
+++ b/packages/admin/docs/02-resources/01-getting-started.md
@@ -506,7 +506,7 @@ Alternatively, you may use the `getNavigationGroup()` method to set a dynamic gr
 ```php
 protected static function getNavigationGroup(): ?string
 {
-    return return __('filament/navigation.groups.shop');
+    return __('filament/navigation.groups.shop');
 }
 ```
 


### PR DESCRIPTION
Fix for a simple typo in the admin panel navigation doc, a double return on the getNavigationGroup() method example.