### PR TITLE
Clean up actions

### DIFF
--- a/packages/actions/resources/views/button-action.blade.php
+++ b/packages/actions/resources/views/button-action.blade.php
@@ -3,7 +3,7 @@
     component="filament-actions::button"
     :outlined="$isOutlined()"
     :icon-position="$getIconPosition()"
-    class="filament-page-button-action"
+    class="filament-actions-button-action"
 >
     {{ $getLabel() }}
 </x-filament-actions::action>

--- a/packages/actions/resources/views/components/actions.blade.php
+++ b/packages/actions/resources/views/components/actions.blade.php
@@ -17,7 +17,7 @@
     @if (count($actions))
         <div
             {{ $attributes->class([
-                'filament-page-actions',
+                'filament-actions-actions',
                 'flex flex-wrap items-center gap-4' => ! $fullWidth,
                 match ($alignment) {
                     'center' => 'justify-center',

--- a/packages/actions/resources/views/components/group.blade.php
+++ b/packages/actions/resources/views/components/group.blade.php
@@ -9,14 +9,14 @@
     'tooltip' => null,
 ])
 
-<x-filament-support::dropdown
+<x-filament-actions::dropdown
     :dark-mode="$darkMode"
     :placement="$dropdownPlacement ?? 'bottom-end'"
     teleport
     {{ $attributes }}
 >
     <x-slot name="trigger">
-        <x-filament-support::icon-button
+        <x-filament-actions::icon-button
             :color="$color"
             :dark-mode="$darkMode"
             :icon="$icon"
@@ -26,14 +26,14 @@
             <x-slot name="label">
                 {{ $label }}
             </x-slot>
-        </x-filament-support::icon-button>
+        </x-filament-actions::icon-button>
     </x-slot>
 
-    <x-filament-support::dropdown.list>
+    <x-filament-actions::dropdown.list>
         @foreach ($actions as $action)
             @if (! $action->isHidden())
                 {{ $action }}
             @endif
         @endforeach
-    </x-filament-support::dropdown.list>
-</x-filament-support::dropdown>
+    </x-filament-actions::dropdown.list>
+</x-filament-actions::dropdown>

--- a/packages/actions/resources/views/components/hr.blade.php
+++ b/packages/actions/resources/views/components/hr.blade.php
@@ -1,4 +1,4 @@
 <x-filament-support::hr
     :attributes="\Filament\Support\prepare_inherited_attributes($attributes)"
-    :dark-mode="config('filament.dark_mode')"
+    :dark-mode="config('filament-actions.dark_mode')"
 />

--- a/packages/actions/resources/views/grouped-action.blade.php
+++ b/packages/actions/resources/views/grouped-action.blade.php
@@ -2,7 +2,7 @@
     :action="$action"
     component="filament-actions::dropdown.list.item"
     :icon="$action->getGroupedIcon()"
-    class="filament-grouped-action"
+    class="filament-actions-grouped-action"
 >
     {{ $getLabel() }}
 </x-filament-actions::action>

--- a/packages/actions/resources/views/icon-button-action.blade.php
+++ b/packages/actions/resources/views/icon-button-action.blade.php
@@ -2,5 +2,5 @@
     :action="$action"
     :label="$getLabel()"
     component="filament-actions::icon-button"
-    class="filament-page-icon-button-action"
+    class="filament-actions-icon-button-action"
 />

--- a/packages/actions/resources/views/link-action.blade.php
+++ b/packages/actions/resources/views/link-action.blade.php
@@ -2,7 +2,7 @@
     :action="$action"
     component="filament-actions::link"
     :icon-position="$getIconPosition()"
-    class="filament-page-link-action"
+    class="filament-actions-link-action"
 >
     {{ $getLabel() }}
 </x-filament-actions::action>

--- a/packages/actions/resources/views/modal/actions/button-action.blade.php
+++ b/packages/actions/resources/views/modal/actions/button-action.blade.php
@@ -26,7 +26,7 @@
     :icon-position="$getIconPosition()"
     :size="$getSize()"
     :attributes="$getExtraAttributeBag()"
-    class="filament-page-modal-button-action"
+    class="filament-actions-modal-button-action"
 >
     {{ $getLabel() }}
 </x-filament-actions::button>

--- a/packages/actions/resources/views/select-action.blade.php
+++ b/packages/actions/resources/views/select-action.blade.php
@@ -1,4 +1,4 @@
-<div class="filament-page-select-action">
+<div class="filament-actions-select-action">
     <label for="{{ $getId() }}" class="sr-only">
         {{ $getLabel() }}
     </label>


### PR DESCRIPTION
Fixes use of `config()` inside the actions package to use the package's config.

Other note, there's a reference of `filament/filament` config here: https://github.com/filamentphp/filament/blob/03e4d84063b26cd913563d1a10f362070dc1196d/packages/actions/resources/views/components/modal/actions.blade.php#L3
~~Shouldn't that be moved to the actions package config instead? Or probably even better, make it configurable on the action so we can move to `configureUsing()` instead of using the config.~~
I'm not sure how I feel about having that view inside the actions package when it's clearly used for `filament/filament`.

Also, what should the dusk selector be here?
https://github.com/filamentphp/filament/blob/8ef19eb5249a7e6f13067a45cb5cdfdc77e1b341/packages/forms/resources/views/components/actions/action.blade.php#L26