### PR TITLE
Feat add support for belongs to relationship

### DIFF
--- a/packages/tables/docs/03-columns/06-badge.md
+++ b/packages/tables/docs/03-columns/06-badge.md
@@ -45,7 +45,6 @@ BadgeColumn::make('status')
     ])
 ```
 
-
 Or dynamically calculate the color based on the `$state` and / or `$record` as second parameter:
 
 ```php

--- a/packages/tables/docs/03-columns/06-badge.md
+++ b/packages/tables/docs/03-columns/06-badge.md
@@ -45,15 +45,20 @@ BadgeColumn::make('status')
     ])
 ```
 
-Or dynamically calculate the color based on the `$record` and / or `$state`:
+
+Or dynamically calculate the color based on the `$state` and / or `$record` as second parameter:
 
 ```php
 use Filament\Tables\Columns\BadgeColumn;
 
 BadgeColumn::make('status')
-    ->icon(static function ($state): string {
-        if ($state === 'published') {
+    ->icon(static function ($state,$record): string {
+        if ($record->status === 'published') {
             return 'success';
+        }
+
+        if ($state === 'reviewing') {
+            return 'warning';
         }
         
         return 'secondary';


### PR DESCRIPTION


While generating a filament resource,
If there is a column that ends with _id, We will guess there may be a BelongsTo relation.

Then we will try to guess the relationship function , and if the function exist, then the form field will be a Select field instead of a Text field with the relationship.

But there will be a question what will be the titleColumnName for the relation,
We will try to guess the table name, If we can not guess the table name, titleColumnName will be id,
Else if we can guess the table name, we will look for if there is any column named name/title,

If so the titleColumnName will be set accordingly. Else it will be set to id;

Why this PR?

Okay, If there is a column name ends with '_id' and there is a relation for this we can assume it will be select field rather than a text field.

This is noting big, but while i am generating a filament resource using --generate flag, I we may love it is set automatically. :)