### PR TITLE
Feat: Add Support For BelongsToRelationship

### DIFF
--- a/packages/admin/src/Commands/Concerns/CanGenerateResources.php
+++ b/packages/admin/src/Commands/Concerns/CanGenerateResources.php
@@ -2,10 +2,13 @@
 
 namespace Filament\Commands\Concerns;
 
+use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types;
 use Filament\Forms;
 use Filament\Tables;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Throwable;
 
@@ -14,6 +17,7 @@ trait CanGenerateResources
     protected function getResourceFormSchema(string $model): string
     {
         $table = $this->getModelTable($model);
+
 
         if (! $table) {
             return $this->indentString('//', 4);
@@ -45,6 +49,17 @@ trait CanGenerateResources
                 default => Forms\Components\TextInput::class,
             };
 
+            $guessedRelationName = null;
+            if(Str::of($column->getName())->endsWith('_id')){
+
+                $guessedRelationName = $this->guessBelongsToSelectRelationName($column,$model);
+                if(!empty($guessedRelationName)){
+                    $titleColumnName = $this->guessBelongsToSelectRelationTitleColumnName($column,$model);
+                    $componentData['type'] = Forms\Components\Select::class;
+                    $componentData['relationship'] = ["'$guessedRelationName",$titleColumnName."'"];
+                }
+            }
+
             if ($type === Forms\Components\TextInput::class) {
                 if (Str::of($column->getName())->contains(['email'])) {
                     $componentData['email'] = [];
@@ -63,7 +78,7 @@ trait CanGenerateResources
                 $componentData['required'] = [];
             }
 
-            if (in_array($type, [Forms\Components\TextInput::class, Forms\Components\Textarea::class]) && ($length = $column->getLength())) {
+            if (in_array($type, [Forms\Components\TextInput::class, Forms\Components\Textarea::class]) && ($length = $column->getLength()) && empty($guessedRelationName)) {
                 $componentData['maxLength'] = [$length];
             }
 
@@ -197,5 +212,79 @@ trait CanGenerateResources
         } catch (Throwable $exception) {
             return null;
         }
+    }
+
+    protected function getTableSchemaByTableName(string $model, $tableName): ?Table
+    {
+        if ((! class_exists($model)) && (! class_exists($model = "App\\Models\\{$model}"))) {
+            return null;
+        }
+
+        $model = app($model);
+
+        try {
+            return $model
+                ->getConnection()
+                ->getDoctrineSchemaManager()
+                ->listTableDetails($tableName);
+        } catch (Throwable $exception) {
+            return null;
+        }
+    }
+
+    protected function guessBelongsToSelectRelationName(AbstractAsset $column, string $model) :string
+    {
+        $modelReflection = invade(new $model);
+        $hasRelation = false;
+        $guessedRelationName = Str::of($column->getName())->replaceLast("_id",'');
+        if($modelReflection->reflected->hasMethod($guessedRelationName)){
+            $hasRelation = true;
+        }
+
+        if(!$hasRelation){
+            $guessedRelationName = $guessedRelationName->camel();
+            if($modelReflection->reflected->hasMethod($guessedRelationName)){
+                $hasRelation = true;
+            }
+        }
+
+
+        try {
+            if ($modelReflection->reflected->getMethod($guessedRelationName)->getReturnType() == BelongsTo::class) {
+                $hasRelation = true;
+            }
+        } catch (\ReflectionException $e) {
+            $hasRelation = false;
+        }
+
+        return  $hasRelation?$guessedRelationName:"";
+    }
+
+    protected function guessBelongsToSelectRelationTableName(AbstractAsset $column) : string{
+        $tempTableName = Str::of($column->getName())->replaceLast("_id",'');
+        $tableName = "";
+        if(Schema::hasTable(Str::of($tempTableName)->plural())){
+            $tableName = Str::of($tempTableName)->plural();
+        }else if(Schema::hasTable($tempTableName)){
+            $tableName =$tempTableName;
+        }
+        return $tableName;
+    }
+
+    protected function guessBelongsToSelectRelationTitleColumnName(AbstractAsset $column, string $model) : string{
+        $tableName = $this->guessBelongsToSelectRelationTableName($column);
+        $titleKey = "";
+        $primaryKey ="";
+        if(empty($tableName)){
+            $titleKey = "id";
+        }else{
+            $schema = $this->getTableSchemaByTableName($model,$tableName);
+            $primaryKey = $schema->getPrimaryKey()->getColumns()[0];
+            $columns = collect(array_keys($schema->getColumns()));
+            $titleKey = $columns->contains('name')
+                ?"name":($columns->contains('title')?'title':"");
+        }
+
+        return empty($titleKey)?$primaryKey:$titleKey;
     }
 }

--- a/packages/admin/src/Commands/Concerns/CanGenerateResources.php
+++ b/packages/admin/src/Commands/Concerns/CanGenerateResources.php
@@ -18,7 +18,6 @@ trait CanGenerateResources
     {
         $table = $this->getModelTable($model);
 
-
         if (! $table) {
             return $this->indentString('//', 4);
         }
@@ -50,13 +49,12 @@ trait CanGenerateResources
             };
 
             $guessedRelationName = null;
-            if(Str::of($column->getName())->endsWith('_id')){
-
-                $guessedRelationName = $this->guessBelongsToSelectRelationName($column,$model);
-                if(!empty($guessedRelationName)){
-                    $titleColumnName = $this->guessBelongsToSelectRelationTitleColumnName($column,$model);
+            if (Str::of($column->getName())->endsWith('_id')) {
+                $guessedRelationName = $this->guessBelongsToSelectRelationName($column, $model);
+                if (! empty($guessedRelationName)) {
+                    $titleColumnName = $this->guessBelongsToSelectRelationTitleColumnName($column, $model);
                     $componentData['type'] = Forms\Components\Select::class;
-                    $componentData['relationship'] = ["'$guessedRelationName",$titleColumnName."'"];
+                    $componentData['relationship'] = ["'$guessedRelationName", $titleColumnName . "'"];
                 }
             }
 
@@ -232,22 +230,21 @@ trait CanGenerateResources
         }
     }
 
-    protected function guessBelongsToSelectRelationName(AbstractAsset $column, string $model) :string
+    protected function guessBelongsToSelectRelationName(AbstractAsset $column, string $model): string
     {
         $modelReflection = invade(new $model);
         $hasRelation = false;
-        $guessedRelationName = Str::of($column->getName())->replaceLast("_id",'');
-        if($modelReflection->reflected->hasMethod($guessedRelationName)){
+        $guessedRelationName = Str::of($column->getName())->replaceLast('_id', '');
+        if ($modelReflection->reflected->hasMethod($guessedRelationName)) {
             $hasRelation = true;
         }
 
-        if(!$hasRelation){
+        if (! $hasRelation) {
             $guessedRelationName = $guessedRelationName->camel();
-            if($modelReflection->reflected->hasMethod($guessedRelationName)){
+            if ($modelReflection->reflected->hasMethod($guessedRelationName)) {
                 $hasRelation = true;
             }
         }
-
 
         try {
             if ($modelReflection->reflected->getMethod($guessedRelationName)->getReturnType() == BelongsTo::class) {
@@ -257,34 +254,37 @@ trait CanGenerateResources
             $hasRelation = false;
         }
 
-        return  $hasRelation?$guessedRelationName:"";
+        return  $hasRelation ? $guessedRelationName : '';
     }
 
-    protected function guessBelongsToSelectRelationTableName(AbstractAsset $column) : string{
-        $tempTableName = Str::of($column->getName())->replaceLast("_id",'');
-        $tableName = "";
-        if(Schema::hasTable(Str::of($tempTableName)->plural())){
+    protected function guessBelongsToSelectRelationTableName(AbstractAsset $column): string
+    {
+        $tempTableName = Str::of($column->getName())->replaceLast('_id', '');
+        $tableName = '';
+        if (Schema::hasTable(Str::of($tempTableName)->plural())) {
             $tableName = Str::of($tempTableName)->plural();
-        }else if(Schema::hasTable($tempTableName)){
-            $tableName =$tempTableName;
+        } elseif (Schema::hasTable($tempTableName)) {
+            $tableName = $tempTableName;
         }
+
         return $tableName;
     }
 
-    protected function guessBelongsToSelectRelationTitleColumnName(AbstractAsset $column, string $model) : string{
+    protected function guessBelongsToSelectRelationTitleColumnName(AbstractAsset $column, string $model): string
+    {
         $tableName = $this->guessBelongsToSelectRelationTableName($column);
-        $titleKey = "";
-        $primaryKey ="";
-        if(empty($tableName)){
-            $titleKey = "id";
-        }else{
-            $schema = $this->getTableSchemaByTableName($model,$tableName);
+        $titleKey = '';
+        $primaryKey = '';
+        if (empty($tableName)) {
+            $titleKey = 'id';
+        } else {
+            $schema = $this->getTableSchemaByTableName($model, $tableName);
             $primaryKey = $schema->getPrimaryKey()->getColumns()[0];
             $columns = collect(array_keys($schema->getColumns()));
             $titleKey = $columns->contains('name')
-                ?"name":($columns->contains('title')?'title':"");
+                ? 'name' : ($columns->contains('title') ? 'title' : '');
         }
 
-        return empty($titleKey)?$primaryKey:$titleKey;
+        return empty($titleKey) ? $primaryKey : $titleKey;
     }
 }

--- a/packages/admin/src/Commands/MakeResourceCommand.php
+++ b/packages/admin/src/Commands/MakeResourceCommand.php
@@ -138,7 +138,7 @@ class MakeResourceCommand extends Command
         $this->copyStubToApp('Resource', $resourcePath, [
             'eloquentQuery' => $this->indentString($eloquentQuery, 1),
             'formSchema' => $this->option('generate') ? $this->getResourceFormSchema(
-                ($modelNamespace !== '' ? $modelNamespace : 'App\Models') . '\\' . $modelClass,
+                'App\Models' . ($modelNamespace !== '' ? "\\{$modelNamespace}" : '') . '\\' . $modelClass,
             ) : $this->indentString('//', 4),
             'model' => $model === 'Resource' ? 'Resource as ResourceModel' : $model,
             'modelClass' => $model === 'Resource' ? 'ResourceModel' : $modelClass,
@@ -150,7 +150,7 @@ class MakeResourceCommand extends Command
             'tableActions' => $this->indentString($tableActions, 4),
             'tableBulkActions' => $this->indentString($tableBulkActions, 4),
             'tableColumns' => $this->option('generate') ? $this->getResourceTableColumns(
-                ($modelNamespace !== '' ? $modelNamespace : 'App\Models') . '\\' . $modelClass
+                'App\Models' . ($modelNamespace !== '' ? "\\{$modelNamespace}" : '') . '\\' . $modelClass,
             ) : $this->indentString('//', 4),
             'tableFilters' => $this->indentString(
                 $this->option('soft-deletes') ? 'Tables\Filters\TrashedFilter::make(),' : '//',


### PR DESCRIPTION
While generating a filament resource,
If there is a column that ends with _id, We will guess there may be a BelongsTo relation.

Then we will try to guess the relationship function , and if the function exist, then the form field will be a Select field instead of a Text field with the relationship.

But there will be a question what will be the titleColumnName for the relation,
We will try to guess the table name, If we can not guess the table name, titleColumnName will be id,
Else if we can guess the table name, we will look for if there is any column named name/title,

If so the titleColumnName will be set accordingly. Else it will be set to id;

Why this PR?

Okay, If there is a column name ends with '_id' and there is a relation for this we can assume it will be select field rather than a text field.

This is noting big, but while i am generating a filament resource using --generate flag, We may love if it is set automatically. :)