### PR TITLE
Show a failure message if (soft)delete / restore isn't successful

### DIFF
--- a/packages/admin/src/Pages/Actions/DeleteAction.php
+++ b/packages/admin/src/Pages/Actions/DeleteAction.php
@@ -43,9 +43,13 @@ class DeleteAction extends Action
         });
 
         $this->action(function (): void {
-            $this->process(static fn (Model $record) => $record->delete());
+            $result = $this->process(static fn (Model $record) => $record->delete());
 
-            $this->success();
+            if ($result) {
+                $this->success();
+            } else {
+                $this->failure();
+            }
         });
     }
 }

--- a/packages/admin/src/Pages/Actions/ForceDeleteAction.php
+++ b/packages/admin/src/Pages/Actions/ForceDeleteAction.php
@@ -31,9 +31,13 @@ class ForceDeleteAction extends Action
         $this->requiresConfirmation();
 
         $this->action(function (): void {
-            $this->process(static fn (Model $record) => $record->forceDelete());
+            $result = $this->process(static fn (Model $record) => $record->forceDelete());
 
-            $this->success();
+            if ($result) {
+                $this->success();
+            } else {
+                $this->failure();
+            }
         });
 
         $this->visible(static function (Model $record): bool {

--- a/packages/admin/src/Pages/Actions/RestoreAction.php
+++ b/packages/admin/src/Pages/Actions/RestoreAction.php
@@ -39,9 +39,13 @@ class RestoreAction extends Action
                 return;
             }
 
-            $this->process(static fn () => $record->restore());
+            $result = $this->process(static fn () => $record->restore());
 
-            $this->success();
+            if ($result) {
+                $this->success();
+            } else {
+                $this->failure();
+            }
         });
 
         $this->visible(static function (Model $record): bool {

--- a/packages/tables/src/Actions/DeleteAction.php
+++ b/packages/tables/src/Actions/DeleteAction.php
@@ -41,9 +41,13 @@ class DeleteAction extends Action
         });
 
         $this->action(function (): void {
-            $this->process(static fn (Model $record) => $record->delete());
+            $result = $this->process(static fn (Model $record) => $record->delete());
 
-            $this->success();
+            if ($result) {
+                $this->success();
+            } else {
+                $this->failure();
+            }
         });
     }
 }

--- a/packages/tables/src/Actions/ForceDeleteAction.php
+++ b/packages/tables/src/Actions/ForceDeleteAction.php
@@ -33,9 +33,13 @@ class ForceDeleteAction extends Action
         $this->requiresConfirmation();
 
         $this->action(function (): void {
-            $this->process(static fn (Model $record) => $record->forceDelete());
+            $result = $this->process(static fn (Model $record) => $record->forceDelete());
 
-            $this->success();
+            if ($result) {
+                $this->success();
+            } else {
+                $this->failure();
+            }
         });
 
         $this->visible(static function (Model $record): bool {

--- a/packages/tables/src/Actions/RestoreAction.php
+++ b/packages/tables/src/Actions/RestoreAction.php
@@ -33,17 +33,21 @@ class RestoreAction extends Action
         $this->requiresConfirmation();
 
         $this->action(function (): void {
-            $this->process(function (Model $record): void {
+            $result = $this->process(function (Model $record): void {
                 if (! method_exists($record, 'restore')) {
                     $this->failure();
 
                     return;
                 }
 
-                $record->restore();
+                return $record->restore();
             });
 
-            $this->success();
+            if ($result) {
+                $this->success();
+            } else {
+                $this->failure();
+            }
         });
 
         $this->visible(static function (Model $record): bool {


### PR DESCRIPTION
Hello,

When soft-deleting, deleting or restoring a record, a success notification is shown even if the action wasn't successful. This PR checks the model action result and shows a failure if it isn't successful.