### PR TITLE
Fix dropdown item label from truncating too early

### DIFF
--- a/packages/support/resources/views/components/dropdown/list/item.blade.php
+++ b/packages/support/resources/views/components/dropdown/list/item.blade.php
@@ -28,7 +28,7 @@
         'group-hover:text-warning-100 group-focus:text-warning-100' => $color === 'warning' && $hasHoverAndFocusState,
     ]);
 
-    $labelClasses = 'filament-dropdown-list-item-label truncate';
+    $labelClasses = 'filament-dropdown-list-item-label truncate w-full text-left';
 
     $iconClasses = \Illuminate\Support\Arr::toCssClasses([
         'filament-dropdown-list-item-icon mr-2 h-5 w-5 rtl:ml-2 rtl:mr-0',


### PR DESCRIPTION
I saw that the items on the profile dropdown menu are being truncated even they still have space to grow.

<img width="284" alt="Screenshot 2022-10-22 at 17 19 41" src="https://user-images.githubusercontent.com/15916288/197347648-48f7a5c9-3563-4e99-adaa-dd2575240d06.png">

I made a quick fix for that. But I would recommend someone with more experience with this codebase, to confirm that this change is not breaking other dropdown menus.

Thanks.