### PR TITLE
Fix components registration in subdirectory when using wildcard

### DIFF
--- a/packages/admin/src/FilamentServiceProvider.php
+++ b/packages/admin/src/FilamentServiceProvider.php
@@ -233,7 +233,7 @@ class FilamentServiceProvider extends PluginServiceProvider
                     ) : null;
 
                     if (is_string($variableNamespace)) {
-                        $variableNamespace = explode('\\', $variableNamespace)[0];
+                        $variableNamespace = (string) Str::of($variableNamespace)->before('\\');
                     }
 
                     return (string) $namespace

--- a/packages/admin/src/FilamentServiceProvider.php
+++ b/packages/admin/src/FilamentServiceProvider.php
@@ -232,6 +232,10 @@ class FilamentServiceProvider extends PluginServiceProvider
                             ->replace(['/'], ['\\']),
                     ) : null;
 
+                    if (is_string($variableNamespace)) {
+                        $variableNamespace = explode('\\', $variableNamespace)[0];
+                    }
+
                     return (string) $namespace
                         ->append('\\', $file->getRelativePathname())
                         ->replace('*', $variableNamespace)


### PR DESCRIPTION
When you have a wildcard configuration (for Resources/Pages/Widgets) and your components are in subdirectory, `$variableNamespace` returns a bad value and the components are not loaded.

The fix is not very elegant, I haven't found a simpler solution than this.

[Related issue](https://github.com/filamentphp/filament/issues/4748)