### PR TITLE
Normalize wire:keys in table mount action forms

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -869,7 +869,7 @@
 
         <x-tables::modal
             :id="$this->id . '-table-action'"
-            :wire:key="$action ? $this->id . '.table' . ($getMountedActionRecordKey() ? '.records.' . $getMountedActionRecordKey() : null) . '.actions.' . $action->getName() . '.modal' : null"
+            :wire:key="$action ? $this->id . '.table.actions.' . $action->getName() . '.modal' : null"
             :visible="filled($action)"
             :width="$action?->getModalWidth()"
             :slide-over="$action?->isModalSlideOver()"


### PR DESCRIPTION
Remove record based identifier from wire key in mounted table actions