### PR TITLE
[2.x] Add new `CanFormatState::words()` helper method

### DIFF
--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -89,6 +89,16 @@ TextColumn::make('description')
     })
 ```
 
+## Limiting word count
+
+You may limit the number of `words()` displayed in the cell:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('description')->words(10)
+```
+
 ## Wrapping content
 
 If you'd like your column's content to wrap if it's too long, you may use the `wrap()` method:

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -88,6 +88,19 @@ trait CanFormatState
         return $this;
     }
 
+    public function words(int $words = 100, string $end = '...'): static
+    {
+        $this->formatStateUsing(static function ($state) use ($words, $end): ?string {
+            if (blank($state)) {
+                return null;
+            }
+
+            return Str::words($state, $words, $end);
+        });
+
+        return $this;
+    }
+
     public function prefix(string | Closure $prefix): static
     {
         $this->prefix = $prefix;


### PR DESCRIPTION
We already have a `limit()` helper here. Since Laravel already provides a `Str::words()` utility, it makes sense to also provide a shorthand on the column.