### PR TITLE
RTL small ui fixes on table loading indicator

### DIFF
--- a/packages/tables/resources/views/components/filters/indicators.blade.php
+++ b/packages/tables/resources/views/components/filters/indicators.blade.php
@@ -60,7 +60,7 @@
                     <x-filament-support::loading-indicator
                         wire:loading.delay
                         wire:target="removeTableFilters,removeTableFilter"
-                        class="animate-spin w-5 h-5"
+                        class="w-5 h-5"
                     />
                 </div>
 

--- a/packages/tables/resources/views/components/reorder/indicator.blade.php
+++ b/packages/tables/resources/views/components/reorder/indicator.blade.php
@@ -10,7 +10,7 @@
     <x-filament-support::loading-indicator
         wire:loading.delay
         wire:target="reorderTable"
-        class="animate-spin w-4 h-4 mr-3 text-primary-500"
+        class="w-4 h-4 mr-3 rtl:mr-0 rtl:ml-3 text-primary-500"
     />
 
     <span>

--- a/packages/tables/resources/views/components/selection-indicator.blade.php
+++ b/packages/tables/resources/views/components/selection-indicator.blade.php
@@ -11,7 +11,7 @@
 >
     <x-filament-support::loading-indicator
         x-show="isLoading"
-        class="inline-block w-4 h-4 mr-3 animate-spin text-primary-500"
+        class="inline-block w-4 h-4 mr-3 rtl:mr-0 rtl:ml-3 text-primary-500"
     />
 
     <span @class(['dark:text-white' => config('tables.dark_mode')]) x-text="window.pluralize(@js(__('tables::table.selection_indicator.selected_count')), selectedRecords.length, { count: selectedRecords.length })"></span>


### PR DESCRIPTION
- [x] Remove duplicate `animate-spin` class
- [x] Add `rtl:mr-0 rtl:ml-3` to table indicators