### PR TITLE
[2.x] feature: allow ignoring policies in authorization checks

### DIFF
--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -64,7 +64,7 @@ class Resource
 
     protected static int $globalSearchResultsLimit = 50;
 
-    protected static bool $ignorePolicies = false;
+    protected static bool $shouldIgnorePolicies = false;
 
     public static function form(Form $form): Form
     {
@@ -113,10 +113,14 @@ class Resource
 
     public static function can(string $action, ?Model $record = null): bool
     {
+        if (static::shouldIgnorePolicies()) {
+            return true;
+        }
+
         $policy = Gate::getPolicyFor($model = static::getModel());
         $user = Filament::auth()->user();
 
-        if ($policy === null || static::shouldIgnorePolicies()) {
+        if ($policy === null) {
             return true;
         }
 
@@ -129,12 +133,12 @@ class Resource
 
     public static function ignorePolicies(bool $condition = true): void
     {
-        static::$ignorePolicies = $condition;
+        static::$shouldIgnorePolicies = $condition;
     }
 
     public static function shouldIgnorePolicies(): bool
     {
-        return static::$ignorePolicies;
+        return static::$shouldIgnorePolicies;
     }
 
     public static function canViewAny(): bool

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -64,6 +64,8 @@ class Resource
 
     protected static int $globalSearchResultsLimit = 50;
 
+    protected static bool $ignorePolicies = false;
+
     public static function form(Form $form): Form
     {
         return $form;
@@ -114,7 +116,7 @@ class Resource
         $policy = Gate::getPolicyFor($model = static::getModel());
         $user = Filament::auth()->user();
 
-        if ($policy === null) {
+        if ($policy === null || static::shouldIgnorePolicies()) {
             return true;
         }
 
@@ -123,6 +125,16 @@ class Resource
         }
 
         return Gate::forUser($user)->check($action, $record ?? $model);
+    }
+
+    public static function ignorePolicies(bool $condition = true): void
+    {
+        static::$ignorePolicies = $condition;
+    }
+
+    public static function shouldIgnorePolicies(): bool
+    {
+        return static::$ignorePolicies;
     }
 
     public static function canViewAny(): bool


### PR DESCRIPTION
Introduces a couple of new methods `Resource::ignorePolicies(bool $condition = true)` and `Resource::shouldIgnorePolicies()`.

Right now, Filament is auto-wired to check policies by default and the only way to change that behaviour is to override the `Resource::can()` method.

That process is a little tedious on each resource, even if you abstract that logic into a trait. This PR makes it as simple as calling `MyResource::ignorePolicies()` in a service provider, you could even do it for all resources by calling it on the base `Resource` class instead.

There are valid usecases for this, e.g. your policies are all wired up for the front-end and you're installing Filament into an existing application (my personal use case), but you don't want to modify your existing policies.