### PR TITLE
Added $default to askRequired in CanValidateInput

### DIFF
--- a/packages/support/src/Commands/Concerns/CanValidateInput.php
+++ b/packages/support/src/Commands/Concerns/CanValidateInput.php
@@ -7,9 +7,9 @@ use Illuminate\Support\Facades\Validator;
 
 trait CanValidateInput
 {
-    protected function askRequired(string $question, string $field): string
+    protected function askRequired(string $question, string $field, string $default = ''): string
     {
-        return $this->validateInput(fn () => $this->ask($question), $field, ['required']);
+        return $this->validateInput(fn () => $this->ask($question, $default), $field, ['required']);
     }
 
     protected function validateInput(Closure $callback, string $field, array $rules): string

--- a/packages/support/src/Commands/Concerns/CanValidateInput.php
+++ b/packages/support/src/Commands/Concerns/CanValidateInput.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Validator;
 
 trait CanValidateInput
 {
-    protected function askRequired(string $question, string $field, string $default = ''): string
+    protected function askRequired(string $question, string $field, ?string $default = null): string
     {
         return $this->validateInput(fn () => $this->ask($question, $default), $field, ['required']);
     }


### PR DESCRIPTION
I'm using this in a package with some fairly complex commands, and it just makes for a much better experience if I can let them call the command with no args, then walk them through each one with sane defaults on the ask() prompts.

Couldn't find a test that covered this, and not experienced enough with tests to write one from scratch.  But tested by hand with and without a default on askRequired() and it worked fine.  If there is an existing test, point me at it and I'll extend it to cover this.