### PR TITLE
Allow resource manager buttons to be navigable via keyboard

### DIFF
--- a/packages/admin/resources/views/components/resources/relation-managers/index.blade.php
+++ b/packages/admin/resources/views/components/resources/relation-managers/index.blade.php
@@ -29,9 +29,6 @@
                         wire:click="$set('activeRelationManager', {{ filled($tabKey) ? "'{$tabKey}'" : 'null' }})"
                         @if ($activeManager === $tabKey)
                             aria-selected
-                            tabindex="0"
-                        @else
-                            tabindex="-1"
                         @endif
                         role="tab"
                         type="button"


### PR DESCRIPTION
This PR allows the buttons that are clicked to display relationships on view resource pages to be navigated to via the keyboard.

![View resource page](https://user-images.githubusercontent.com/1141514/199357046-49248226-d3f6-4ea3-860f-4d7c085bfcd0.png)

---

Currently, the button that represents the _selected_ relationship can be navigated by keyboard but the other buttons are not navigable so they cannot be selected using only keyboard shortcuts (meaning hitting tab multiple times until the button is highlighted and then hitting space or enter)

https://user-images.githubusercontent.com/1141514/199355375-d8b8f710-39e7-4bc9-a717-9e181fb531d8.mp4

With this PR inactive buttons are navigable and selectable via the keyboard (using space or enter)

https://user-images.githubusercontent.com/1141514/199355380-df5d0ce4-3971-47f6-a957-827d48623342.mp4

---

I believe this change helps screen readers as well. When I was testing the page a couple weeks ago with macOS' VoiceOver feature, it announced both buttons ("Pages" and "Sites" in this case) as selected which obviously is not the case. Unfortunately, I can't provide more details now because I accidentally changed some VoiceOver settings and it isn't reading the selected status for anything right now 😅