### PR TITLE
Add aria label to sidebar expand and collapse buttons

### DIFF
--- a/packages/admin/resources/lang/en/layout.php
+++ b/packages/admin/resources/lang/en/layout.php
@@ -22,9 +22,11 @@ return [
             'label' => 'Sign out',
         ],
 
-        'sidebar' => [
-            'collapse' => 'Collapse sidebar',
-            'expand' => 'Expand sidebar',
+        'toggle_sidebar' => [
+            'label' => [
+                'collapse' => 'Collapse sidebar',
+                'expand' => 'Expand sidebar',
+            ],
         ],
 
         'user_menu' => [

--- a/packages/admin/resources/lang/en/layout.php
+++ b/packages/admin/resources/lang/en/layout.php
@@ -22,6 +22,11 @@ return [
             'label' => 'Sign out',
         ],
 
+        'sidebar' => [
+            'collapse' => 'Collapse sidebar',
+            'expand' => 'Expand sidebar',
+        ],
+
         'user_menu' => [
             'label' => 'User Menu',
         ],

--- a/packages/admin/resources/lang/en/layout.php
+++ b/packages/admin/resources/lang/en/layout.php
@@ -22,11 +22,16 @@ return [
             'label' => 'Sign out',
         ],
 
-        'toggle_sidebar' => [
-            'label' => [
-                'collapse' => 'Collapse sidebar',
-                'expand' => 'Expand sidebar',
+        'sidebar' => [
+            
+            'collapse' => [
+                'label' => 'Collapse sidebar',
             ],
+            
+            'expand' => [
+                'label' => 'Expand sidebar',
+            ],
+            
         ],
 
         'user_menu' => [

--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -29,7 +29,7 @@
                 <button
                     type="button"
                     class="filament-sidebar-collapse-button shrink-0 hidden lg:flex items-center justify-center w-10 h-10 text-primary-500 rounded-full hover:bg-gray-500/5 focus:bg-primary-500/10 focus:outline-none"
-                    :aria-label="$store.sidebar.isOpen ? 'Collapse sidebar' : 'Open sidebar'"
+                    :aria-label="$store.sidebar.isOpen ? 'Collapse sidebar' : 'Expand sidebar'"
                     x-on:click.stop="$store.sidebar.isOpen ? $store.sidebar.close() : $store.sidebar.open()"
                     x-transition:enter="lg:transition delay-100"
                     x-transition:enter-start="opacity-0"
@@ -57,7 +57,7 @@
             <button
                 type="button"
                 class="filament-sidebar-close-button shrink-0 flex items-center justify-center w-10 h-10 text-primary-500 rounded-full hover:bg-gray-500/5 focus:bg-primary-500/10 focus:outline-none"
-                :aria-label="$store.sidebar.isOpen ? 'Collapse sidebar' : 'Open sidebar'"
+                :aria-label="$store.sidebar.isOpen ? 'Collapse sidebar' : 'Expand sidebar'"
                 x-on:click.stop="$store.sidebar.isOpen ? $store.sidebar.close() : $store.sidebar.open()"
                 x-show="(! $store.sidebar.isOpen) && @js(config('filament.layout.sidebar.collapsed_width') !== 0)"
                 x-transition:enter="lg:transition delay-100"

--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -29,7 +29,7 @@
                 <button
                     type="button"
                     class="filament-sidebar-collapse-button shrink-0 hidden lg:flex items-center justify-center w-10 h-10 text-primary-500 rounded-full hover:bg-gray-500/5 focus:bg-primary-500/10 focus:outline-none"
-                    :aria-label="$store.sidebar.isOpen ? 'Collapse sidebar' : 'Expand sidebar'"
+                    :aria-label="$store.sidebar.isOpen ? '{{ __('filament::layout.buttons.sidebar.collapse') }}' : '{{ __('filament::layout.buttons.sidebar.expand') }}'"
                     x-on:click.stop="$store.sidebar.isOpen ? $store.sidebar.close() : $store.sidebar.open()"
                     x-transition:enter="lg:transition delay-100"
                     x-transition:enter-start="opacity-0"
@@ -57,7 +57,7 @@
             <button
                 type="button"
                 class="filament-sidebar-close-button shrink-0 flex items-center justify-center w-10 h-10 text-primary-500 rounded-full hover:bg-gray-500/5 focus:bg-primary-500/10 focus:outline-none"
-                :aria-label="$store.sidebar.isOpen ? 'Collapse sidebar' : 'Expand sidebar'"
+                :aria-label="$store.sidebar.isOpen ? '{{ __('filament::layout.buttons.sidebar.collapse') }}' : '{{ __('filament::layout.buttons.sidebar.expand') }}'"
                 x-on:click.stop="$store.sidebar.isOpen ? $store.sidebar.close() : $store.sidebar.open()"
                 x-show="(! $store.sidebar.isOpen) && @js(config('filament.layout.sidebar.collapsed_width') !== 0)"
                 x-transition:enter="lg:transition delay-100"

--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -29,7 +29,7 @@
                 <button
                     type="button"
                     class="filament-sidebar-collapse-button shrink-0 hidden lg:flex items-center justify-center w-10 h-10 text-primary-500 rounded-full hover:bg-gray-500/5 focus:bg-primary-500/10 focus:outline-none"
-                    :aria-label="$store.sidebar.isOpen ? '{{ __('filament::layout.buttons.sidebar.collapse') }}' : '{{ __('filament::layout.buttons.sidebar.expand') }}'"
+                    :aria-label="$store.sidebar.isOpen ? '{{ __('filament::layout.buttons.sidebar.collapse.label') }}' : '{{ __('filament::layout.buttons.sidebar.expand.label') }}'"
                     x-on:click.stop="$store.sidebar.isOpen ? $store.sidebar.close() : $store.sidebar.open()"
                     x-transition:enter="lg:transition delay-100"
                     x-transition:enter-start="opacity-0"
@@ -57,7 +57,7 @@
             <button
                 type="button"
                 class="filament-sidebar-close-button shrink-0 flex items-center justify-center w-10 h-10 text-primary-500 rounded-full hover:bg-gray-500/5 focus:bg-primary-500/10 focus:outline-none"
-                :aria-label="$store.sidebar.isOpen ? '{{ __('filament::layout.buttons.sidebar.collapse') }}' : '{{ __('filament::layout.buttons.sidebar.expand') }}'"
+                :aria-label="$store.sidebar.isOpen ? '{{ __('filament::layout.buttons.sidebar.collapse.label') }}' : '{{ __('filament::layout.buttons.sidebar.expand.label') }}'"
                 x-on:click.stop="$store.sidebar.isOpen ? $store.sidebar.close() : $store.sidebar.open()"
                 x-show="(! $store.sidebar.isOpen) && @js(config('filament.layout.sidebar.collapsed_width') !== 0)"
                 x-transition:enter="lg:transition delay-100"

--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -29,6 +29,7 @@
                 <button
                     type="button"
                     class="filament-sidebar-collapse-button shrink-0 hidden lg:flex items-center justify-center w-10 h-10 text-primary-500 rounded-full hover:bg-gray-500/5 focus:bg-primary-500/10 focus:outline-none"
+                    :aria-label="$store.sidebar.isOpen ? 'Collapse sidebar' : 'Open sidebar'"
                     x-on:click.stop="$store.sidebar.isOpen ? $store.sidebar.close() : $store.sidebar.open()"
                     x-transition:enter="lg:transition delay-100"
                     x-transition:enter-start="opacity-0"
@@ -56,6 +57,7 @@
             <button
                 type="button"
                 class="filament-sidebar-close-button shrink-0 flex items-center justify-center w-10 h-10 text-primary-500 rounded-full hover:bg-gray-500/5 focus:bg-primary-500/10 focus:outline-none"
+                :aria-label="$store.sidebar.isOpen ? 'Collapse sidebar' : 'Open sidebar'"
                 x-on:click.stop="$store.sidebar.isOpen ? $store.sidebar.close() : $store.sidebar.open()"
                 x-show="(! $store.sidebar.isOpen) && @js(config('filament.layout.sidebar.collapsed_width') !== 0)"
                 x-transition:enter="lg:transition delay-100"


### PR DESCRIPTION
This PR adds an aria-label to the sidebar expand/collapse button. 

Since the buttons is an SVG, screen readers are unable to tell users what the button does. With this change, screen readers (at least macOS' VoiceOver) will announce "expand sidebar" or "collapse sidebar" depending on the status of the side bar.

Current warning in Brave's Lighthouse tool:
![Lighthouse warning showing button does not have an accessible name](https://user-images.githubusercontent.com/1141514/199610322-0a9e927c-8601-401d-a35e-80a7dcfc64a2.png)