### PR TITLE
remove pointer-events-none in section.blade.php to allow clickable links in description.

### DIFF
--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -64,7 +64,7 @@
             </h3>
 
             @if ($description = $getDescription())
-                <p class="text-gray-500 text-base pointer-events-none">
+                <p class="text-gray-500 text-base">
                     {{ $description }}
                 </p>
             @endif


### PR DESCRIPTION
I want to add a link to an external website in the description of a section, but pointer-events-none disallow links to be clicked.

https://tailwindcss.com/docs/pointer-events#controlling-pointer-event-behavior

```php
// Want the link in the description to be clickable.
Section::make('Xyz Card Game')
                ->description(new HtmlString( 
                    'Check out the reference at <a href="https://www.reference-guide.com" target="_blank">Reference</a>'
                ))
                ->schema([
                    // ...
                ]),
```