### PR TITLE
Add toggle sidebar label on mobile

### DIFF
--- a/packages/admin/resources/views/components/topbar.blade.php
+++ b/packages/admin/resources/views/components/topbar.blade.php
@@ -10,6 +10,7 @@
         <button
             x-cloak
             x-data="{}"
+            x-bind:aria-label="$store.sidebar.isOpen ? '{{ __('filament::layout.buttons.sidebar.collapse.label') }}' : '{{ __('filament::layout.buttons.sidebar.expand.label') }}'"
             x-on:click="$store.sidebar.isOpen ? $store.sidebar.close() : $store.sidebar.open()"
             @class([
                 'filament-sidebar-open-button shrink-0 flex items-center justify-center w-10 h-10 text-primary-500 rounded-full hover:bg-gray-500/5 focus:bg-primary-500/10 focus:outline-none',


### PR DESCRIPTION
Not sure if we just use the same translations here or need to add new ones for open and close instead of expand and collapse. @danharrin, thoughts?