### PR TITLE
Rich Editor support for trix-active

### DIFF
--- a/packages/forms/resources/css/components/rich-editor.css
+++ b/packages/forms/resources/css/components/rich-editor.css
@@ -5,3 +5,7 @@
 .dark .trix-button-group {
     @apply border-gray-600;
 }
+
+trix-toolbar .filament-forms-rich-editor-component-toolbar-button.trix-active {
+    @apply text-white bg-primary-600;
+}


### PR DESCRIPTION
![trixs](https://user-images.githubusercontent.com/14203328/200138238-968086f9-cd91-4fe4-ae21-8c616dadbb90.png)
Trix adds `trix-active` to the button if the selected text has formatting applied to it.