### PR TITLE
feat: add `registerViteTheme`

### DIFF
--- a/packages/admin/docs/08-appearance.md
+++ b/packages/admin/docs/08-appearance.md
@@ -167,9 +167,7 @@ use Illuminate\Foundation\Vite;
 
 Filament::serving(function () {
     // Using Vite
-    Filament::registerTheme(
-        app(Vite::class)('resources/css/filament.css'),
-    );
+    Filament::registerViteTheme('resources/css/filament.css');
 
     // Using Laravel Mix
     Filament::registerTheme(

--- a/packages/admin/src/Facades/Filament.php
+++ b/packages/admin/src/Facades/Filament.php
@@ -42,7 +42,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void registerScriptData(array $data)
  * @method static void registerStyles(array $styles)
  * @method static void registerTheme(string | Htmlable | null $theme)
- * @method static void registerThemeUsingVite(string | array $theme, string $buildDirectory = null)
+ * @method static void registerViteTheme(string | array $theme, string $buildDirectory = null)
  * @method static void registerUserMenuItems(array $items)
  * @method static void registerWidgets(array $widgets)
  * @method static Htmlable renderHook(string $name)

--- a/packages/admin/src/Facades/Filament.php
+++ b/packages/admin/src/Facades/Filament.php
@@ -42,6 +42,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void registerScriptData(array $data)
  * @method static void registerStyles(array $styles)
  * @method static void registerTheme(string | Htmlable | null $theme)
+ * @method static void registerThemeUsingVite(string | array $theme, string $buildDirectory = null)
  * @method static void registerUserMenuItems(array $items)
  * @method static void registerWidgets(array $widgets)
  * @method static Htmlable renderHook(string $name)

--- a/packages/admin/src/Facades/Filament.php
+++ b/packages/admin/src/Facades/Filament.php
@@ -42,7 +42,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void registerScriptData(array $data)
  * @method static void registerStyles(array $styles)
  * @method static void registerTheme(string | Htmlable | null $theme)
- * @method static void registerViteTheme(string | array $theme, string $buildDirectory = null)
+ * @method static void registerViteTheme(string | array $theme, string | null $buildDirectory = null)
  * @method static void registerUserMenuItems(array $items)
  * @method static void registerWidgets(array $widgets)
  * @method static Htmlable renderHook(string $name)

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -16,6 +16,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Vite;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
@@ -145,9 +146,9 @@ class FilamentManager
         $this->theme = $theme;
     }
 
-    public function registerViteTheme(string | array $theme, string $buildDirectory = null): void
+    public function registerViteTheme(string | array $theme, ?string $buildDirectory = null): void
     {
-        $this->theme = app(\Illuminate\Foundation\Vite::class)($theme, $buildDirectory);
+        $this->theme = app(Vite::class)($theme, $buildDirectory);
     }
 
     public function registerUserMenuItems(array $items): void

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -48,10 +48,6 @@ class FilamentManager
 
     protected string | Htmlable | null $theme = null;
 
-    protected string | array | null $viteTheme = null;
-
-    protected ?string $viteBuildDirectory = null;
-
     protected array $userMenuItems = [];
 
     protected array $widgets = [];
@@ -149,10 +145,9 @@ class FilamentManager
         $this->theme = $theme;
     }
 
-    public function registerThemeUsingVite(string | array $theme, string $buildDirectory = null): void
+    public function registerViteTheme(string | array $theme, string $buildDirectory = null): void
     {
-        $this->viteTheme = $theme;
-        $this->viteBuildDirectory = $buildDirectory;
+        $this->theme = app(\Illuminate\Foundation\Vite::class)($theme, $buildDirectory);
     }
 
     public function registerUserMenuItems(array $items): void
@@ -350,10 +345,6 @@ class FilamentManager
 
     public function getThemeLink(): Htmlable
     {
-        if ($this->viteTheme) {
-            return app(\Illuminate\Foundation\Vite::class)($this->viteTheme, $this->viteBuildDirectory);
-        }
-
         if (Str::of($this->theme)->contains('<link')) {
             return $this->theme instanceof Htmlable ? $this->theme : new HtmlString($this->theme);
         }

--- a/packages/admin/src/FilamentManager.php
+++ b/packages/admin/src/FilamentManager.php
@@ -48,6 +48,10 @@ class FilamentManager
 
     protected string | Htmlable | null $theme = null;
 
+    protected string | array | null $viteTheme = null;
+
+    protected ?string $viteBuildDirectory = null;
+
     protected array $userMenuItems = [];
 
     protected array $widgets = [];
@@ -143,6 +147,12 @@ class FilamentManager
     public function registerTheme(string | Htmlable | null $theme): void
     {
         $this->theme = $theme;
+    }
+
+    public function registerThemeUsingVite(string | array $theme, string $buildDirectory = null): void
+    {
+        $this->viteTheme = $theme;
+        $this->viteBuildDirectory = $buildDirectory;
     }
 
     public function registerUserMenuItems(array $items): void
@@ -340,6 +350,10 @@ class FilamentManager
 
     public function getThemeLink(): Htmlable
     {
+        if ($this->viteTheme) {
+            return app(\Illuminate\Foundation\Vite::class)($this->viteTheme, $this->viteBuildDirectory);
+        }
+
         if (Str::of($this->theme)->contains('<link')) {
             return $this->theme instanceof Htmlable ? $this->theme : new HtmlString($this->theme);
         }


### PR DESCRIPTION
This pull request is an attempt at providing a better solution for using a theme with Vite. 

A new `registerThemeUsingVite` is introduced: it accepts a single or a list of assets, as well as a build directory as the second parameter.

```php
Filament::registerViteTheme('resources/css/filament.css');
```

I think this is cleaner than the current recommended approach:

```php
Filament::registerTheme(
    app(Vite::class)('resources/css/filament.css'),
);
```

I would understand if you think this is superfluous though.