### PR TITLE
Upgrade blade-ui-kit/blade-heroicons

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     },
     "require-dev": {
         "akaunting/laravel-money": "^1.2|^2.0|^3.0",
-        "blade-ui-kit/blade-heroicons": "^1.2",
+        "blade-ui-kit/blade-heroicons": "^2.0",
         "danharrin/livewire-rate-limiting": "^0.3|^1.0",
         "doctrine/dbal": "^3.2",
         "filament/support": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8347b0c3af009519b0661e3307812367",
+    "content-hash": "82d3739dfee31f94536b86ae2b2c4be7",
     "packages": [],
     "packages-dev": [
         {
@@ -221,25 +221,25 @@
         },
         {
             "name": "blade-ui-kit/blade-heroicons",
-            "version": "1.3.1",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/blade-ui-kit/blade-heroicons.git",
-                "reference": "a2749abc7b8eb6149ff643ffa99a3d33a2de7961"
+                "reference": "36bbf7386d600706f96e83ec4ca75d3817c46f3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/blade-ui-kit/blade-heroicons/zipball/a2749abc7b8eb6149ff643ffa99a3d33a2de7961",
-                "reference": "a2749abc7b8eb6149ff643ffa99a3d33a2de7961",
+                "url": "https://api.github.com/repos/blade-ui-kit/blade-heroicons/zipball/36bbf7386d600706f96e83ec4ca75d3817c46f3d",
+                "reference": "36bbf7386d600706f96e83ec4ca75d3817c46f3d",
                 "shasum": ""
             },
             "require": {
                 "blade-ui-kit/blade-icons": "^1.1",
-                "illuminate/support": "^8.0|^9.0",
-                "php": "^7.4|^8.0"
+                "illuminate/support": "^9.0",
+                "php": "^8.0"
             },
             "require-dev": {
-                "orchestra/testbench": "^6.0|^7.0",
+                "orchestra/testbench": "^7.0",
                 "phpunit/phpunit": "^9.0"
             },
             "type": "library",
@@ -274,7 +274,7 @@
             ],
             "support": {
                 "issues": "https://github.com/blade-ui-kit/blade-heroicons/issues",
-                "source": "https://github.com/blade-ui-kit/blade-heroicons/tree/1.3.1"
+                "source": "https://github.com/blade-ui-kit/blade-heroicons/tree/2.0.5"
             },
             "funding": [
                 {
@@ -286,7 +286,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-02T11:50:13+00:00"
+            "time": "2022-11-02T12:52:36+00:00"
         },
         {
             "name": "blade-ui-kit/blade-icons",
@@ -12371,5 +12371,5 @@
         "composer-runtime-api": "^2.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/packages/admin/resources/views/components/global-search/input.blade.php
+++ b/packages/admin/resources/views/components/global-search/input.blade.php
@@ -8,7 +8,7 @@
             'absolute inset-y-0 left-0 flex items-center justify-center w-10 h-10 text-gray-500 pointer-events-none group-focus-within:text-primary-500',
             'dark:text-gray-400' => config('filament.dark_mode'),
         ])>
-            <x-heroicon-o-search class="w-5 h-5" wire:loading.remove.delay wire:target="search" />
+            <x-heroicon-o-magnifying-glass class="w-5 h-5" wire:loading.remove.delay wire:target="search" />
 
             <x-filament-support::loading-indicator class="w-5 h-5" wire:loading.delay wire:target="search" />
         </span>

--- a/packages/admin/resources/views/components/layouts/app/topbar/user-menu.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/topbar/user-menu.blade.php
@@ -101,7 +101,7 @@
 
         <x-filament::dropdown.list.item
             :color="$logoutItem?->getColor() ?? 'secondary'"
-            :icon="$logoutItem?->getIcon() ?? 'heroicon-s-logout'"
+            :icon="$logoutItem?->getIcon() ?? 'heroicon-s-arrow-right-on-rectangle'"
             :action="$logoutItem?->getUrl() ?? route('filament.auth.logout')"
             method="post"
             tag="form"

--- a/packages/admin/src/Pages/Actions/ReplicateAction.php
+++ b/packages/admin/src/Pages/Actions/ReplicateAction.php
@@ -15,6 +15,6 @@ class ReplicateAction extends Action implements ReplicatesRecords
     {
         $this->baseSetUp();
 
-        $this->groupedIcon('heroicon-s-duplicate');
+        $this->groupedIcon('heroicon-s-square-2-stack');
     }
 }

--- a/packages/admin/src/Pages/Actions/RestoreAction.php
+++ b/packages/admin/src/Pages/Actions/RestoreAction.php
@@ -28,7 +28,7 @@ class RestoreAction extends Action
 
         $this->color('secondary');
 
-        $this->groupedIcon('heroicon-s-reply');
+        $this->groupedIcon('heroicon-s-arrow-uturn-left');
 
         $this->requiresConfirmation();
 

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -494,7 +494,7 @@ class Resource
 
     protected static function getNavigationIcon(): string
     {
-        return static::$navigationIcon ?? 'heroicon-o-collection';
+        return static::$navigationIcon ?? 'heroicon-o-rectangle-stack';
     }
 
     public static function navigationIcon(?string $icon): void

--- a/packages/forms/composer.json
+++ b/packages/forms/composer.json
@@ -9,7 +9,7 @@
     },
     "require": {
         "php": "^8.0",
-        "blade-ui-kit/blade-heroicons": "^1.2",
+        "blade-ui-kit/blade-heroicons": "^2.0",
         "danharrin/date-format-converter": "^0.3",
         "filament/notifications": "self.version",
         "filament/support": "self.version",

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -114,7 +114,7 @@
                                             {{ __('forms::components.builder.buttons.move_item.label') }}
                                         </span>
 
-                                        <x-heroicon-s-switch-vertical class="w-4 h-4"/>
+                                        <x-heroicon-s-arrows-up-down class="w-4 h-4"/>
                                     </button>
                                 @endunless
 
@@ -162,7 +162,7 @@
                                                     {{ __('forms::components.builder.buttons.clone_item.label') }}
                                                 </span>
 
-                                                <x-heroicon-s-duplicate class="w-4 h-4"/>
+                                                <x-heroicon-s-square-2-stack class="w-4 h-4"/>
                                             </button>
                                         </li>
                                     @endif
@@ -195,13 +195,13 @@
                                                 type="button"
                                                 class="flex items-center justify-center flex-none w-10 h-10 text-gray-400 transition hover:text-gray-500"
                                             >
-                                                <x-heroicon-s-minus-sm class="w-4 h-4" x-show="! isCollapsed"/>
+                                                <x-heroicon-s-minus-small class="w-4 h-4" x-show="! isCollapsed"/>
 
                                                 <span class="sr-only" x-show="! isCollapsed">
                                                     {{ __('forms::components.builder.buttons.collapse_item.label') }}
                                                 </span>
 
-                                                <x-heroicon-s-plus-sm class="w-4 h-4" x-show="isCollapsed" x-cloak/>
+                                                <x-heroicon-s-plus-small class="w-4 h-4" x-show="isCollapsed" x-cloak/>
 
                                                 <span class="sr-only" x-show="isCollapsed" x-cloak>
                                                     {{ __('forms::components.builder.buttons.expand_item.label') }}

--- a/packages/forms/resources/views/components/key-value.blade.php
+++ b/packages/forms/resources/views/components/key-value.blade.php
@@ -113,7 +113,7 @@
                                                 type="button"
                                                 class="text-gray-600 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
                                             >
-                                                <x-heroicon-o-switch-vertical class="w-4 h-4" />
+                                                <x-heroicon-o-arrows-up-down class="w-4 h-4" />
 
                                                 <span class="sr-only">
                                                     {{ $getReorderButtonLabel() }}

--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -117,7 +117,7 @@
                                                 {{ __('forms::components.repeater.buttons.move_item.label') }}
                                             </span>
 
-                                            <x-heroicon-s-switch-vertical class="w-4 h-4"/>
+                                            <x-heroicon-s-arrows-up-down class="w-4 h-4"/>
                                         </button>
                                     @endunless
 
@@ -182,13 +182,13 @@
                                                     type="button"
                                                     class="flex items-center justify-center flex-none w-10 h-10 text-gray-400 transition hover:text-gray-500"
                                                 >
-                                                    <x-heroicon-s-minus-sm class="w-4 h-4" x-show="! isCollapsed"/>
+                                                    <x-heroicon-s-minus-small class="w-4 h-4" x-show="! isCollapsed"/>
 
                                                     <span class="sr-only" x-show="! isCollapsed">
                                                         {{ __('forms::components.repeater.buttons.collapse_item.label') }}
                                                     </span>
 
-                                                    <x-heroicon-s-plus-sm class="w-4 h-4" x-show="isCollapsed" x-cloak/>
+                                                    <x-heroicon-s-plus-small class="w-4 h-4" x-show="isCollapsed" x-cloak/>
 
                                                     <span class="sr-only" x-show="isCollapsed" x-cloak>
                                                         {{ __('forms::components.repeater.buttons.expand_item.label') }}

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -90,7 +90,7 @@
                             <span class="text-start" x-text="tag"></span>
 
                             @unless ($isDisabled())
-                                <x-heroicon-s-x class="w-3 h-3 shrink-0" />
+                                <x-heroicon-s-x-mark class="w-3 h-3 shrink-0" />
                             @endunless
                         </button>
                     </template>

--- a/packages/notifications/composer.json
+++ b/packages/notifications/composer.json
@@ -9,7 +9,7 @@
     },
     "require": {
         "php": "^8.0",
-        "blade-ui-kit/blade-heroicons": "^1.2",
+        "blade-ui-kit/blade-heroicons": "^2.0",
         "filament/support": "self.version",
         "illuminate/contracts": "^8.6|^9.0",
         "illuminate/filesystem": "^8.6|^9.0",

--- a/packages/notifications/resources/views/components/close-button.blade.php
+++ b/packages/notifications/resources/views/components/close-button.blade.php
@@ -1,4 +1,4 @@
-<x-heroicon-s-x
+<x-heroicon-s-x-mark
     class="filament-notifications-close-button h-4 w-4 cursor-pointer text-gray-400"
     x-on:click="close"
 />

--- a/packages/support/resources/views/components/actions/group.blade.php
+++ b/packages/support/resources/views/components/actions/group.blade.php
@@ -2,7 +2,7 @@
     'actions',
     'color' => null,
     'darkMode' => false,
-    'icon' => 'heroicon-o-dots-vertical',
+    'icon' => 'heroicon-o-ellipsis-vertical',
     'label' => __('filament-support::actions/group.trigger.label'),
     'size' => null,
     'tooltip' => null,

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -143,7 +143,7 @@
                             x-on:click="close()"
                         @endif
                     >
-                        <x-heroicon-s-x
+                        <x-heroicon-s-x-mark
                             class="filament-modal-close-button h-4 w-4 cursor-pointer text-gray-400"
                             title="__('filament-support::components/modal.actions.close.label')"
                             tabindex="-1"

--- a/packages/tables/composer.json
+++ b/packages/tables/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^8.0",
         "akaunting/laravel-money": "^1.2|^2.0|^3.0",
-        "blade-ui-kit/blade-heroicons": "^1.2",
+        "blade-ui-kit/blade-heroicons": "^2.0",
         "filament/forms": "self.version",
         "filament/notifications": "self.version",
         "filament/support": "self.version",

--- a/packages/tables/resources/views/components/bulk-actions/trigger.blade.php
+++ b/packages/tables/resources/views/components/bulk-actions/trigger.blade.php
@@ -1,5 +1,5 @@
 <x-tables::icon-button
-    icon="heroicon-o-dots-vertical"
+    icon="heroicon-o-ellipsis-vertical"
     :label="__('tables::table.buttons.open_actions.label')"
     x-cloak
     {{ $attributes->class(['filament-tables-bulk-actions-trigger']) }}

--- a/packages/tables/resources/views/components/filters/indicators.blade.php
+++ b/packages/tables/resources/views/components/filters/indicators.blade.php
@@ -29,7 +29,7 @@
                             type="button"
                             class="ml-1 -mr-2 rtl:mr-1 rtl:-ml-2 p-1 -my-1 hover:bg-gray-500/10 rounded-full"
                         >
-                            <x-heroicon-s-x class="w-3 h-3" />
+                            <x-heroicon-s-x-mark class="w-3 h-3" />
 
                             <span class="sr-only">
                                 {{ __('tables::table.filters.buttons.remove.label') }}
@@ -50,7 +50,7 @@
                 ])
             >
                 <div class="w-5 h-5 flex items-center justify-center">
-                    <x-heroicon-s-x
+                    <x-heroicon-s-x-mark
                         :x-tooltip.raw="__('tables::table.filters.buttons.remove_all.tooltip')"
                         wire:loading.remove.delay
                         wire:target="removeTableFilters,removeTableFilter"

--- a/packages/tables/resources/views/components/filters/trigger.blade.php
+++ b/packages/tables/resources/views/components/filters/trigger.blade.php
@@ -3,7 +3,7 @@
 ])
 
 <x-tables::icon-button
-    icon="heroicon-o-filter"
+    icon="heroicon-o-funnel"
     :label="__('tables::table.buttons.filter.label')"
     :indicator="$indicatorsCount"
     {{ $attributes->class(['filament-tables-filters-trigger']) }}

--- a/packages/tables/resources/views/components/reorder/handle.blade.php
+++ b/packages/tables/resources/views/components/reorder/handle.blade.php
@@ -5,5 +5,5 @@
         'dark:text-gray-400 dark:group-hover:text-primary-400' => config('tables.dark_mode'),
     ]) }}
 >
-    <x-heroicon-s-menu class="block h-4 w-4" />
+    <x-heroicon-s-bars-3 class="block h-4 w-4" />
 </button>

--- a/packages/tables/resources/views/components/reorder/trigger.blade.php
+++ b/packages/tables/resources/views/components/reorder/trigger.blade.php
@@ -4,7 +4,7 @@
 
 <x-tables::icon-button
     wire:click="toggleTableReordering"
-    :icon="$enabled ? 'heroicon-o-check' : 'heroicon-o-selector'"
+    :icon="$enabled ? 'heroicon-o-check' : 'heroicon-o-chevron-up-down'"
     :label="$enabled ? __('tables::table.buttons.disable_reordering.label') : __('tables::table.buttons.enable_reordering.label')"
     {{ $attributes->class(['filament-tables-reordering-trigger']) }}
 />

--- a/packages/tables/resources/views/components/search-input.blade.php
+++ b/packages/tables/resources/views/components/search-input.blade.php
@@ -9,7 +9,7 @@
 
     <div class="relative group">
         <span class="absolute inset-y-0 left-0 flex items-center justify-center w-9 h-9 text-gray-400 pointer-events-none group-focus-within:text-primary-500">
-            <x-heroicon-o-search class="w-5 h-5" />
+            <x-heroicon-o-magnifying-glass class="w-5 h-5" />
         </span>
 
         <input

--- a/packages/tables/resources/views/components/toggleable/trigger.blade.php
+++ b/packages/tables/resources/views/components/toggleable/trigger.blade.php
@@ -1,5 +1,5 @@
 <x-tables::icon-button
-    icon="heroicon-o-view-boards"
+    icon="heroicon-o-view-columns"
     :label="__('tables::table.buttons.toggle_columns.label')"
     {{ $attributes->class(['filament-tables-column-toggling-trigger']) }}
 />

--- a/packages/tables/src/Actions/DetachAction.php
+++ b/packages/tables/src/Actions/DetachAction.php
@@ -31,7 +31,7 @@ class DetachAction extends Action
 
         $this->color('danger');
 
-        $this->icon('heroicon-s-x');
+        $this->icon('heroicon-s-x-mark');
 
         $this->requiresConfirmation();
 

--- a/packages/tables/src/Actions/DetachBulkAction.php
+++ b/packages/tables/src/Actions/DetachBulkAction.php
@@ -32,7 +32,7 @@ class DetachBulkAction extends BulkAction
 
         $this->color('danger');
 
-        $this->icon('heroicon-s-x');
+        $this->icon('heroicon-s-x-mark');
 
         $this->requiresConfirmation();
 

--- a/packages/tables/src/Actions/DissociateAction.php
+++ b/packages/tables/src/Actions/DissociateAction.php
@@ -30,7 +30,7 @@ class DissociateAction extends Action
 
         $this->color('danger');
 
-        $this->icon('heroicon-s-x');
+        $this->icon('heroicon-s-x-mark');
 
         $this->requiresConfirmation();
 

--- a/packages/tables/src/Actions/DissociateBulkAction.php
+++ b/packages/tables/src/Actions/DissociateBulkAction.php
@@ -31,7 +31,7 @@ class DissociateBulkAction extends BulkAction
 
         $this->color('danger');
 
-        $this->icon('heroicon-s-x');
+        $this->icon('heroicon-s-x-mark');
 
         $this->requiresConfirmation();
 

--- a/packages/tables/src/Actions/ReplicateAction.php
+++ b/packages/tables/src/Actions/ReplicateAction.php
@@ -15,6 +15,6 @@ class ReplicateAction extends Action implements ReplicatesRecords
     {
         $this->baseSetUp();
 
-        $this->icon('heroicon-s-duplicate');
+        $this->icon('heroicon-s-square-2-stack');
     }
 }

--- a/packages/tables/src/Actions/RestoreAction.php
+++ b/packages/tables/src/Actions/RestoreAction.php
@@ -28,7 +28,7 @@ class RestoreAction extends Action
 
         $this->color('secondary');
 
-        $this->icon('heroicon-s-reply');
+        $this->icon('heroicon-s-arrow-uturn-left');
 
         $this->requiresConfirmation();
 

--- a/packages/tables/src/Actions/RestoreBulkAction.php
+++ b/packages/tables/src/Actions/RestoreBulkAction.php
@@ -31,7 +31,7 @@ class RestoreBulkAction extends BulkAction
 
         $this->color('secondary');
 
-        $this->icon('heroicon-s-reply');
+        $this->icon('heroicon-s-arrow-uturn-left');
 
         $this->requiresConfirmation();
 

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -185,7 +185,7 @@ class Table extends ViewComponent
         /** @var TableComponent $livewire */
         $livewire = $this->getLivewire();
 
-        return invade($livewire)->getTableEmptyStateIcon() ?? 'heroicon-o-x';
+        return invade($livewire)->getTableEmptyStateIcon() ?? 'heroicon-o-x-mark';
     }
 
     public function getFilters(): array

--- a/tests/src/Admin/Fixtures/Pages/Settings.php
+++ b/tests/src/Admin/Fixtures/Pages/Settings.php
@@ -10,7 +10,7 @@ class Settings extends Page
 {
     protected static string $view = 'admin.fixtures.pages.settings';
 
-    protected static ?string $navigationIcon = 'heroicon-o-cog';
+    protected static ?string $navigationIcon = 'heroicon-o-cog-8-tooth';
 
     protected static ?int $navigationSort = 2;
 

--- a/tests/src/Admin/Fixtures/Resources/PostCategoryResource.php
+++ b/tests/src/Admin/Fixtures/Resources/PostCategoryResource.php
@@ -12,7 +12,7 @@ class PostCategoryResource extends Resource
 
     protected static ?string $navigationGroup = 'Blog';
 
-    protected static ?string $navigationIcon = 'heroicon-o-collection';
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
 
     public static function getPages(): array
     {

--- a/tests/src/Admin/Navigation/NavigationBuilderTest.php
+++ b/tests/src/Admin/Navigation/NavigationBuilderTest.php
@@ -50,7 +50,7 @@ it('can register navigation', function () {
                             ->getIcon()->toBe('heroicon-o-user'),
                         fn ($item) => $item
                             ->getLabel()->toBe('Settings')
-                            ->getIcon()->toBe('heroicon-o-cog'),
+                            ->getIcon()->toBe('heroicon-o-cog-8-tooth'),
                     )
                     ->each->toBeInstanceOf(NavigationItem::class),
             fn ($group) => $group
@@ -63,7 +63,7 @@ it('can register navigation', function () {
                             ->getIcon()->toBe('heroicon-o-document-text'),
                         fn ($item) => $item
                             ->getLabel()->toBe('Post Categories')
-                            ->getIcon()->toBe('heroicon-o-collection'),
+                            ->getIcon()->toBe('heroicon-o-rectangle-stack'),
                     )
                     ->each->toBeInstanceOf(NavigationItem::class),
             fn ($group) => $group
@@ -100,7 +100,7 @@ it('can register navigation groups individually', function () {
                         ->getIcon()->toBe('heroicon-o-document-text'),
                     fn ($item) => $item
                         ->getLabel()->toBe('Post Categories')
-                        ->getIcon()->toBe('heroicon-o-collection'),
+                        ->getIcon()->toBe('heroicon-o-rectangle-stack'),
                 )
                 ->each->toBeInstanceOf(NavigationItem::class),
         );

--- a/tests/src/Admin/Navigation/NavigationTest.php
+++ b/tests/src/Admin/Navigation/NavigationTest.php
@@ -23,7 +23,7 @@ it('can register navigation items from resources and pages', function () {
                             ->getIcon()->toBe('heroicon-o-user'),
                         fn ($item) => $item
                             ->getLabel()->toBe('Settings')
-                            ->getIcon()->toBe('heroicon-o-cog'),
+                            ->getIcon()->toBe('heroicon-o-cog-8-tooth'),
                     )
                     ->each->toBeInstanceOf(NavigationItem::class),
             fn ($group) => $group
@@ -36,7 +36,7 @@ it('can register navigation items from resources and pages', function () {
                             ->getIcon()->toBe('heroicon-o-document-text'),
                         fn ($item) => $item
                             ->getLabel()->toBe('Post Categories')
-                            ->getIcon()->toBe('heroicon-o-collection'),
+                            ->getIcon()->toBe('heroicon-o-rectangle-stack'),
                     )
                     ->each->toBeInstanceOf(NavigationItem::class),
             fn ($group) => $group


### PR DESCRIPTION
Filament uses blade-heroicons `^1.2`. This version is no longer updated and newer heroicons are not added to this package.

This PR upgrades blade-heroicons to `^2.0`. 

I'm not sure if this mergeable in the current state. Some icons are renamed from version 1.x to 2.x, which makes them not backwards compatible. Also version 2.x is not compatible with Laravel 8. 

On the other hand, being stuck on 1.x forever might not be the greatest path forward.