### PR TITLE
Feat: Form Components `columnSpanFull`

### DIFF
--- a/packages/forms/src/Components/Concerns/CanSpanColumns.php
+++ b/packages/forms/src/Components/Concerns/CanSpanColumns.php
@@ -28,6 +28,13 @@ trait CanSpanColumns
         return $this;
     }
 
+    public function columnSpanFull(): static
+    {
+        $this->columnSpan('full');
+
+        return $this;
+    }
+
     public function getColumnSpan(int | string | null $breakpoint = null): array | int | string | null
     {
         $span = $this->columnSpan;


### PR DESCRIPTION
Most of the times I use `->columnSpan()`, its for `->columnSpan('full')`.
This PR adds a `->columnSpanFull()`, a dedicated method allows IDE autocompletion, hence better DX