### PR TITLE
fix: Nav item badge component color

### DIFF
--- a/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/item.blade.php
@@ -55,7 +55,7 @@
         @if (filled($badge))
             <x-filament::layouts.app.sidebar.badge
                 :badge="$badge"
-                :color="$badgeColor"
+                :badge-color="$badgeColor"
                 :active="$active"
             />
         @endif


### PR DESCRIPTION
The navigation badge component expects prop badgeColor but prop :color was being passed. Updated to :badge-color.