### PR TITLE
Remove extra brackets

### DIFF
--- a/packages/tables/docs/07-testing.md
+++ b/packages/tables/docs/07-testing.md
@@ -274,10 +274,10 @@ it('can load existing post data for editing', function () {
 
     livewire(PostResource\Pages\ListPosts::class)
         ->mountTableAction(EditAction::class, $post)
-        ->assertTableActionDataSet([[
+        ->assertTableActionDataSet([
             'title' => $post->title,
         ])
-        ->setTableActionData([[
+        ->setTableActionData([
             'title' => $title = fake()->words(asText: true),
         ])
         ->callMountedTableAction()


### PR DESCRIPTION
Typo; removed the extra brackets.