### PR TITLE
Document individual search query string

### DIFF
--- a/packages/tables/docs/02-getting-started.md
+++ b/packages/tables/docs/02-getting-started.md
@@ -441,7 +441,8 @@ protected $queryString = [
     'tableFilters',
     'tableSortColumn',
     'tableSortDirection',
-    'tableSearchQuery' => ['except' => ''],
+    'tableSearchQuery' => ['except' => ''], // For global search
+    'tableColumnSearchQueries',  // For individual search
 ];
 ```
 

--- a/packages/tables/docs/02-getting-started.md
+++ b/packages/tables/docs/02-getting-started.md
@@ -441,8 +441,8 @@ protected $queryString = [
     'tableFilters',
     'tableSortColumn',
     'tableSortDirection',
-    'tableSearchQuery' => ['except' => ''], // For global search
-    'tableColumnSearchQueries',  // For individual search
+    'tableSearchQuery' => ['except' => ''],
+    'tableColumnSearchQueries',
 ];
 ```
 

--- a/packages/tables/docs/03-columns/01-getting-started.md
+++ b/packages/tables/docs/03-columns/01-getting-started.md
@@ -179,7 +179,7 @@ You may optionally persist the search in the query string:
 
 ```php
 protected $queryString = [
-    ...,
+    // ...
     'tableColumnSearchQueries',
 ];
 ```

--- a/packages/tables/docs/03-columns/01-getting-started.md
+++ b/packages/tables/docs/03-columns/01-getting-started.md
@@ -175,7 +175,7 @@ use Filament\Tables\Columns\TextColumn;
 TextColumn::make('title')->searchable(isIndividual: true, isGlobal: false)
 ```
 
-If you want to have the search persisted in the query string, you have to add `tableColumnSearchQueries` to the `queryString` property :
+You may optionally persist the search in the query string:
 
 ```php
     protected $queryString = [

--- a/packages/tables/docs/03-columns/01-getting-started.md
+++ b/packages/tables/docs/03-columns/01-getting-started.md
@@ -175,6 +175,15 @@ use Filament\Tables\Columns\TextColumn;
 TextColumn::make('title')->searchable(isIndividual: true, isGlobal: false)
 ```
 
+If you want to have the search persisted in the query string, you have to add `tableColumnSearchQueries` to the `queryString` property :
+
+```php
+    protected $queryString = [
+        ...,
+        'tableColumnSearchQueries',
+    ];
+```
+
 ### Persist search in session
 
 To persist the table or individual column search in the user's session, override the `shouldPersistTableSearchInSession()` or `shouldPersistTableColumnSearchInSession()` method on the Livewire component:

--- a/packages/tables/docs/03-columns/01-getting-started.md
+++ b/packages/tables/docs/03-columns/01-getting-started.md
@@ -175,7 +175,7 @@ use Filament\Tables\Columns\TextColumn;
 TextColumn::make('title')->searchable(isIndividual: true, isGlobal: false)
 ```
 
-You may optionally persist the search in the query string:
+You may optionally persist the searches in the query string:
 
 ```php
 protected $queryString = [

--- a/packages/tables/docs/03-columns/01-getting-started.md
+++ b/packages/tables/docs/03-columns/01-getting-started.md
@@ -178,10 +178,10 @@ TextColumn::make('title')->searchable(isIndividual: true, isGlobal: false)
 You may optionally persist the search in the query string:
 
 ```php
-    protected $queryString = [
-        ...,
-        'tableColumnSearchQueries',
-    ];
+protected $queryString = [
+    ...,
+    'tableColumnSearchQueries',
+];
 ```
 
 ### Persist search in session


### PR DESCRIPTION
I added the information of how getting the individual search into the query string, since nothing was written in the doc.