### PR TITLE
Additional column assertions

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -127,16 +127,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.242.1",
+            "version": "3.243.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "9bfd85f696fff6a9b7810f1361751ad33a9b23d1"
+                "reference": "c4ac1ff8f40f11fcf0d8e58b3d13838a44a8a582"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/9bfd85f696fff6a9b7810f1361751ad33a9b23d1",
-                "reference": "9bfd85f696fff6a9b7810f1361751ad33a9b23d1",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/c4ac1ff8f40f11fcf0d8e58b3d13838a44a8a582",
+                "reference": "c4ac1ff8f40f11fcf0d8e58b3d13838a44a8a582",
                 "shasum": ""
             },
             "require": {
@@ -215,9 +215,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.242.1"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.243.2"
             },
-            "time": "2022-11-11T19:59:24+00:00"
+            "time": "2022-11-15T13:14:49+00:00"
         },
         {
             "name": "blade-ui-kit/blade-heroicons",
@@ -2047,7 +2047,7 @@
         },
         {
             "name": "filament/support",
-            "version": "2.x-dev",
+            "version": "dev-feat/column-assertions",
             "dist": {
                 "type": "path",
                 "url": "packages/support",
@@ -2891,16 +2891,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v9.39.0",
+            "version": "v9.40.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "67e674709e1e7db14f304a871481f310822d68c5"
+                "reference": "9611fdaf2db5759b8299802d7185bcdbee0340bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/67e674709e1e7db14f304a871481f310822d68c5",
-                "reference": "67e674709e1e7db14f304a871481f310822d68c5",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/9611fdaf2db5759b8299802d7185bcdbee0340bb",
+                "reference": "9611fdaf2db5759b8299802d7185bcdbee0340bb",
                 "shasum": ""
             },
             "require": {
@@ -3073,7 +3073,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-11-08T14:47:39+00:00"
+            "time": "2022-11-15T16:13:22+00:00"
         },
         {
             "name": "laravel/pint",
@@ -8594,16 +8594,16 @@
         },
         {
             "name": "spatie/laravel-package-tools",
-            "version": "1.13.6",
+            "version": "1.13.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-package-tools.git",
-                "reference": "c377cc7223655c2278c148c1685b8b5a78af5c65"
+                "reference": "4af8e608184471b5568af6265ebb0ca0025c131a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/c377cc7223655c2278c148c1685b8b5a78af5c65",
-                "reference": "c377cc7223655c2278c148c1685b8b5a78af5c65",
+                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/4af8e608184471b5568af6265ebb0ca0025c131a",
+                "reference": "4af8e608184471b5568af6265ebb0ca0025c131a",
                 "shasum": ""
             },
             "require": {
@@ -8613,8 +8613,9 @@
             "require-dev": {
                 "mockery/mockery": "^1.5",
                 "orchestra/testbench": "^7.7",
+                "pestphp/pest": "^1.22",
                 "phpunit/phpunit": "^9.5.24",
-                "spatie/test-time": "^1.3"
+                "spatie/pest-plugin-test-time": "^1.1"
             },
             "type": "library",
             "autoload": {
@@ -8641,7 +8642,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-package-tools/issues",
-                "source": "https://github.com/spatie/laravel-package-tools/tree/1.13.6"
+                "source": "https://github.com/spatie/laravel-package-tools/tree/1.13.7"
             },
             "funding": [
                 {
@@ -8649,7 +8650,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-10-11T06:37:42+00:00"
+            "time": "2022-11-15T09:10:09+00:00"
         },
         {
             "name": "spatie/laravel-ray",

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -109,6 +109,18 @@ namespace Livewire\Testing {
 
         public function assertTableColumnStateNotSet(string $name, $value, $record): static {}
 
+        public function assertTableColumnFormattedStateSet(string $name, $value, $record): static {}
+
+        public function assertTableColumnFormattedStateNotSet(string $name, $value, $record): static {}
+
+        public function assertTableColumnHasExtraAttributes(string $name, $value, $record): static {}
+
+        public function assertTableColumnDoesNotHaveExtraAttributes(string $name, $value, $record): static {}
+
+        public function assertTableColumnHasDescription(string $name, $description, $record, $position = 'below'): static {}
+
+        public function assertTableColumnDoesNotHaveDescription(string $name, $description, $record, $position = 'below'): static {}
+
         public function sortTable(?string $name = null, ?string $direction = null): static {}
 
         public function searchTable(?string $search = null): static {}

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -172,6 +172,178 @@ class TestsColumns
         };
     }
 
+    public function assertTableColumnFormattedStateSet(): Closure
+    {
+        return function (string $name, $value, $record): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableColumnExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $column = $livewire->getCachedTableColumn($name);
+
+            if (! ($record instanceof Model)) {
+                $record = $livewire->getTableRecord($record);
+            }
+
+            $column->record($record);
+
+            Assert::assertTrue(
+                /** @var \Filament\Tables\Columns\TextColumn $column */
+                $column->getFormattedState() == $value,
+                message: "Failed asserting that a table column with name [{$name}] has a formatted state of [{$value}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+
+        };
+    }
+
+    public function assertTableColumnFormattedStateNotSet(): Closure
+    {
+        return function (string $name, $value, $record): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableColumnExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $column = $livewire->getCachedTableColumn($name);
+
+            if (! ($record instanceof Model)) {
+                $record = $livewire->getTableRecord($record);
+            }
+
+            $column->record($record);
+
+            Assert::assertFalse(
+            /** @var \Filament\Tables\Columns\TextColumn $column */
+                $column->getFormattedState() == $value,
+                message: "Failed asserting that a table column with name [{$name}] does not have a formatted state of [{$value}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+
+        };
+    }
+
+    public function assertTableColumnHasExtraAttributes(): Closure
+    {
+        return function (string $name, array $attributes, $record) {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableColumnExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $column = $livewire->getCachedTableColumn($name);
+
+            if (! ($record instanceof Model)) {
+                $record = $livewire->getTableRecord($record);
+            }
+
+            $column->record($record);
+
+            $attributes_string = print_r($attributes, true);
+
+            Assert::assertTrue(
+            /** @var \Filament\Tables\Columns\TextColumn $column */
+                $column->getExtraAttributes() == $attributes,
+                message: "Failed asserting that a table column with name [{$name}] has extra attributes [{$attributes_string}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertTableColumnDoesNotHaveExtraAttributes(): Closure
+    {
+        return function (string $name, array $attributes, $record) {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableColumnExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $column = $livewire->getCachedTableColumn($name);
+
+            if (! ($record instanceof Model)) {
+                $record = $livewire->getTableRecord($record);
+            }
+
+            $column->record($record);
+
+            $attributes_string = print_r($attributes, true);
+
+            Assert::assertFalse(
+            /** @var \Filament\Tables\Columns\TextColumn $column */
+                $column->getExtraAttributes() == $attributes,
+                message: "Failed asserting that a table column with name [{$name}] does not have extra attributes [{$attributes_string}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertTableColumnHasDescription(): Closure
+    {
+        return function (string $name, $description, $record, string $position = 'below') {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableColumnExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $column = $livewire->getCachedTableColumn($name);
+
+            if (! ($record instanceof Model)) {
+                $record = $livewire->getTableRecord($record);
+            }
+
+            $column->record($record);
+
+            $description_to_test = $position == 'above' ? $column->getDescriptionAbove() : $column->getDescriptionBelow();
+
+            Assert::assertTrue(
+            /** @var \Filament\Tables\Columns\TextColumn $column */
+                $description_to_test == $description,
+                message: "Failed asserting that a table column with name [{$name}] has description [{$description}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertTableColumnDoesNotHaveDescription(): Closure
+    {
+        return function (string $name, $description, $record, string $position = 'below') {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableColumnExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $column = $livewire->getCachedTableColumn($name);
+
+            if (! ($record instanceof Model)) {
+                $record = $livewire->getTableRecord($record);
+            }
+
+            $column->record($record);
+
+            $description_to_test = $position == 'above' ? $column->getDescriptionAbove() : $column->getDescriptionBelow();
+
+            Assert::assertFalse(
+            /** @var \Filament\Tables\Columns\TextColumn $column */
+                $description_to_test == $description,
+                message: "Failed asserting that a table column with name [{$name}] does not have description [{$description}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
     public function callTableColumnAction(): Closure
     {
         return function (string $name, $record = null): static {

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -196,7 +196,6 @@ class TestsColumns
             );
 
             return $this;
-
         };
     }
 
@@ -218,13 +217,12 @@ class TestsColumns
             $column->record($record);
 
             Assert::assertFalse(
-            /** @var \Filament\Tables\Columns\TextColumn $column */
+                /** @var \Filament\Tables\Columns\TextColumn $column */
                 $column->getFormattedState() == $value,
                 message: "Failed asserting that a table column with name [{$name}] does not have a formatted state of [{$value}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
             );
 
             return $this;
-
         };
     }
 
@@ -248,7 +246,7 @@ class TestsColumns
             $attributes_string = print_r($attributes, true);
 
             Assert::assertTrue(
-            /** @var \Filament\Tables\Columns\TextColumn $column */
+                /** @var \Filament\Tables\Columns\TextColumn $column */
                 $column->getExtraAttributes() == $attributes,
                 message: "Failed asserting that a table column with name [{$name}] has extra attributes [{$attributes_string}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
             );
@@ -277,7 +275,7 @@ class TestsColumns
             $attributes_string = print_r($attributes, true);
 
             Assert::assertFalse(
-            /** @var \Filament\Tables\Columns\TextColumn $column */
+                /** @var \Filament\Tables\Columns\TextColumn $column */
                 $column->getExtraAttributes() == $attributes,
                 message: "Failed asserting that a table column with name [{$name}] does not have extra attributes [{$attributes_string}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
             );
@@ -306,7 +304,7 @@ class TestsColumns
             $description_to_test = $position == 'above' ? $column->getDescriptionAbove() : $column->getDescriptionBelow();
 
             Assert::assertTrue(
-            /** @var \Filament\Tables\Columns\TextColumn $column */
+                /** @var \Filament\Tables\Columns\TextColumn $column */
                 $description_to_test == $description,
                 message: "Failed asserting that a table column with name [{$name}] has description [{$description}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
             );
@@ -335,7 +333,7 @@ class TestsColumns
             $description_to_test = $position == 'above' ? $column->getDescriptionAbove() : $column->getDescriptionBelow();
 
             Assert::assertFalse(
-            /** @var \Filament\Tables\Columns\TextColumn $column */
+                /** @var \Filament\Tables\Columns\TextColumn $column */
                 $description_to_test == $description,
                 message: "Failed asserting that a table column with name [{$name}] does not have description [{$description}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
             );

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -297,7 +297,7 @@ class TestsColumns
             if (! ($record instanceof Model)) {
                 $record = $livewire->getTableRecord($record);
             }
-                
+
             $column->record($record);
 
             $actualDescription = $position == 'above' ? $column->getDescriptionAbove() : $column->getDescriptionBelow();

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -181,6 +181,7 @@ class TestsColumns
             $livewire = $this->instance();
             $livewireClass = $livewire::class;
 
+            /** @var \Filament\Tables\Columns\TextColumn $column */
             $column = $livewire->getCachedTableColumn($name);
 
             if (! ($record instanceof Model)) {
@@ -190,7 +191,6 @@ class TestsColumns
             $column->record($record);
 
             Assert::assertTrue(
-                /** @var \Filament\Tables\Columns\TextColumn $column */
                 $column->getFormattedState() == $value,
                 message: "Failed asserting that a table column with name [{$name}] has a formatted state of [{$value}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
             );
@@ -208,6 +208,7 @@ class TestsColumns
             $livewire = $this->instance();
             $livewireClass = $livewire::class;
 
+            /** @var \Filament\Tables\Columns\TextColumn $column */
             $column = $livewire->getCachedTableColumn($name);
 
             if (! ($record instanceof Model)) {
@@ -217,7 +218,6 @@ class TestsColumns
             $column->record($record);
 
             Assert::assertFalse(
-                /** @var \Filament\Tables\Columns\TextColumn $column */
                 $column->getFormattedState() == $value,
                 message: "Failed asserting that a table column with name [{$name}] does not have a formatted state of [{$value}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
             );
@@ -243,12 +243,11 @@ class TestsColumns
 
             $column->record($record);
 
-            $attributes_string = print_r($attributes, true);
+            $attributesString = print_r($attributes, true);
 
             Assert::assertTrue(
-                /** @var \Filament\Tables\Columns\TextColumn $column */
                 $column->getExtraAttributes() == $attributes,
-                message: "Failed asserting that a table column with name [{$name}] has extra attributes [{$attributes_string}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+                message: "Failed asserting that a table column with name [{$name}] has extra attributes [{$attributesString}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -272,12 +271,11 @@ class TestsColumns
 
             $column->record($record);
 
-            $attributes_string = print_r($attributes, true);
+            $attributesString = print_r($attributes, true);
 
             Assert::assertFalse(
-                /** @var \Filament\Tables\Columns\TextColumn $column */
                 $column->getExtraAttributes() == $attributes,
-                message: "Failed asserting that a table column with name [{$name}] does not have extra attributes [{$attributes_string}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+                message: "Failed asserting that a table column with name [{$name}] does not have extra attributes [{$attributesString}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -293,19 +291,19 @@ class TestsColumns
             $livewire = $this->instance();
             $livewireClass = $livewire::class;
 
+            /** @var \Filament\Tables\Columns\TextColumn $column */
             $column = $livewire->getCachedTableColumn($name);
 
             if (! ($record instanceof Model)) {
                 $record = $livewire->getTableRecord($record);
             }
-
+                
             $column->record($record);
 
-            $description_to_test = $position == 'above' ? $column->getDescriptionAbove() : $column->getDescriptionBelow();
+            $actualDescription = $position == 'above' ? $column->getDescriptionAbove() : $column->getDescriptionBelow();
 
             Assert::assertTrue(
-                /** @var \Filament\Tables\Columns\TextColumn $column */
-                $description_to_test == $description,
+                $actualDescription == $description,
                 message: "Failed asserting that a table column with name [{$name}] has description [{$description}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
             );
 
@@ -322,6 +320,7 @@ class TestsColumns
             $livewire = $this->instance();
             $livewireClass = $livewire::class;
 
+            /** @var \Filament\Tables\Columns\TextColumn $column */
             $column = $livewire->getCachedTableColumn($name);
 
             if (! ($record instanceof Model)) {
@@ -330,11 +329,10 @@ class TestsColumns
 
             $column->record($record);
 
-            $description_to_test = $position == 'above' ? $column->getDescriptionAbove() : $column->getDescriptionBelow();
+            $actualDescription = $position == 'above' ? $column->getDescriptionAbove() : $column->getDescriptionBelow();
 
             Assert::assertFalse(
-                /** @var \Filament\Tables\Columns\TextColumn $column */
-                $description_to_test == $description,
+                $actualDescription == $description,
                 message: "Failed asserting that a table column with name [{$name}] does not have description [{$description}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
             );
 

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -92,3 +92,29 @@ it('can state whether a column has the correct value', function () {
         ->assertTableColumnStateSet('with_state', 'correct state', $post)
         ->assertTableColumnStateNotSet('with_state', 'incorrect state', $post);
 });
+
+it('can state whether a column has the correct formatted value', function () {
+    $post = Post::factory()->create();
+
+    livewire(PostsTable::class)
+        ->assertTableColumnFormattedStateSet('formatted_state', 'formatted state', $post)
+        ->assertTableColumnFormattedStateNotSet('formatted_state', 'incorrect formatted state', $post);
+});
+
+it('can state whether a column has extra attributes', function () {
+    $post = Post::factory()->create();
+
+    livewire(PostsTable::class)
+        ->assertTableColumnHasExtraAttributes('extra_attributes', ['class' => 'text-danger-500'], $post)
+        ->assertTableColumnDoesNotHaveExtraAttributes('extra_attributes', ['class' => 'text-primary-500'], $post);
+});
+
+it('can state whether a column has a description', function () {
+    $post = Post::factory()->create();
+
+    livewire(PostsTable::class)
+        ->assertTableColumnHasDescription('with_description', 'description below', $post)
+        ->assertTableColumnHasDescription('with_description', 'description above', $post, 'above')
+        ->assertTableColumnDoesNotHaveDescription('with_description', 'incorrect description below', $post)
+        ->assertTableColumnDoesNotHaveDescription('with_description', 'incorrect description above', $post, 'above');
+});

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -35,14 +35,14 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
             Tables\Columns\TextColumn::make('with_state')
                 ->getStateUsing(fn () => 'correct state'),
             Tables\Columns\TextColumn::make('formatted_state')
-                ->formatStateUsing(fn() => "formatted state"),
+                ->formatStateUsing(fn () => 'formatted state'),
             Tables\Columns\TextColumn::make('extra_attributes')
                 ->extraAttributes([
-                    'class' => 'text-danger-500'
+                    'class' => 'text-danger-500',
                 ]),
             Tables\Columns\TextColumn::make('with_description')
                 ->description('description below')
-                ->description('description above', 'above')
+                ->description('description above', 'above'),
         ];
     }
 

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -34,6 +34,15 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
                 ->hidden(),
             Tables\Columns\TextColumn::make('with_state')
                 ->getStateUsing(fn () => 'correct state'),
+            Tables\Columns\TextColumn::make('formatted_state')
+                ->formatStateUsing(fn() => "formatted state"),
+            Tables\Columns\TextColumn::make('extra_attributes')
+                ->extraAttributes([
+                    'class' => 'text-danger-500'
+                ]),
+            Tables\Columns\TextColumn::make('with_description')
+                ->description('description below')
+                ->description('description above', 'above')
         ];
     }
 


### PR DESCRIPTION
Some additional assertions for a few items which could potentially be useful:

To test against `formatStateUsing()`
```
assertTableColumnFormattedStateSet(string $name, $value, $record)
assertTableColumnFormattedStateNotSet(string $name, $value, $record)
```

To test against `extraAttributes()`
```
assertTableColumnHasExtraAttributes(string $name, $value, $record)
assertTableColumnDoesNotHaveExtraAttributes(string $name, $value, $record)
```

To test against `description()`
```
assertTableColumnHasDescription(string $name, $description, $record, $position = 'below')
assertTableColumnDoesNotHaveDescription(string $name, $description, $record, $position = 'below')
```