### PR TITLE
Dispatch event

### DIFF
--- a/packages/support/src/Actions/Concerns/HasAction.php
+++ b/packages/support/src/Actions/Concerns/HasAction.php
@@ -8,6 +8,8 @@ trait HasAction
 {
     protected Closure | string | null $action = null;
 
+    protected Closure | string | null $dispatch = null;
+
     public function action(Closure | string | null $action): static
     {
         $this->action = $action;
@@ -24,5 +26,17 @@ trait HasAction
         }
 
         return $action;
+    }
+
+    public function dispatch(string $event): static
+    {
+        $this->dispatch = $event;
+
+        return $this;
+    }
+
+    public function getDispatch(): string|null
+    {
+        return $this->dispatch;
     }
 }

--- a/packages/tables/resources/views/components/actions/action.blade.php
+++ b/packages/tables/resources/views/components/actions/action.blade.php
@@ -12,6 +12,14 @@
     } else {
         $wireClickAction = "mountTableAction('{$action->getName()}')";
     }
+
+	if ((! $action->getDispatch()) || $action->getUrl()) {
+        $alpineClickAction = null;
+    } elseif ($record = $action->getRecord()) {
+		$alpineClickAction = "\$dispatch('{$action->getDispatch()}', {$action->getDispatchData($record)})";
+    } else {
+        $alpineClickAction = "\$dispatch('{$action->getDispatch()}'";
+    }
 @endphp
 
 <x-dynamic-component
@@ -20,6 +28,7 @@
     :attributes="\Filament\Support\prepare_inherited_attributes($attributes)->merge($action->getExtraAttributes())"
     :tag="$action->getUrl() ? 'a' : 'button'"
     :wire:click="$wireClickAction"
+    x-on:click="{!! $alpineClickAction !!}"
     :href="$action->isEnabled() ? $action->getUrl() : null"
     :target="$action->shouldOpenUrlInNewTab() ? '_blank' : null"
     :disabled="$action->isDisabled()"

--- a/packages/tables/src/Actions/Concerns/CanDispatchAlpineEvents.php
+++ b/packages/tables/src/Actions/Concerns/CanDispatchAlpineEvents.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Filament\Tables\Actions\Concerns;
+
+use Closure;
+
+trait CanDispatchAlpineEvents
+{
+    protected null | array | Closure $dispatchData = null;
+
+    public function dispatchData(array | Closure $dispatchData): static
+    {
+        $this->dispatchData = $dispatchData;
+
+        return $this;
+    }
+
+    public function getDispatchData(): string
+    {
+        return $this->evaluate($this->dispatchData);
+    }
+}

--- a/tests/src/Tables/ActionTest.php
+++ b/tests/src/Tables/ActionTest.php
@@ -110,3 +110,10 @@ it('can state whether a table action exists', function () {
         ->assertTableActionExists('exists')
         ->assertTableActionDoesNotExist('does_not_exist');
 });
+
+it('can see x-on:click with alpine dispatch with event name and data', function () {
+    $post = Post::factory()->create();
+
+    livewire(PostsTable::class)
+        ->assertSeeHtml('x-on:click="$dispatch(&#039;test-event&#039;, {&quot;id&quot;:1})"', true);
+});

--- a/tests/src/Tables/Fixtures/DispatchTestAction.php
+++ b/tests/src/Tables/Fixtures/DispatchTestAction.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Filament\Tests\Tables\Fixtures;
+
+use Filament\Support\Actions\Concerns\CanCustomizeProcess;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\Concerns\CanDispatchAlpineEvents;
+use Filament\Tables\Actions\Concerns\InteractsWithRelationship;
+use Filament\Tables\Contracts\HasTable;
+use Illuminate\Database\Eloquent\Model;
+
+class DispatchTestAction extends Action
+{
+    use CanCustomizeProcess;
+    use InteractsWithRelationship;
+    use CanDispatchAlpineEvents;
+
+    public static function getDefaultName(): ?string
+    {
+        return 'dispatch-test';
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->label(__('Dispatch Test'));
+
+        $this->color('danger');
+
+        $this->icon('heroicon-s-map');
+
+        $this->dispatch('test-event');
+
+        $this->dispatchData(function (Model $record) {
+            return json_encode([
+                'id' => $record->id,
+            ]);
+        });
+    }
+}

--- a/tests/src/Tables/Fixtures/DispatchTestAction.php
+++ b/tests/src/Tables/Fixtures/DispatchTestAction.php
@@ -6,7 +6,6 @@ use Filament\Support\Actions\Concerns\CanCustomizeProcess;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\Concerns\CanDispatchAlpineEvents;
 use Filament\Tables\Actions\Concerns\InteractsWithRelationship;
-use Filament\Tables\Contracts\HasTable;
 use Illuminate\Database\Eloquent\Model;
 
 class DispatchTestAction extends Action

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -103,8 +103,7 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
         return [
             Tables\Actions\EditAction::make(),
             Tables\Actions\DeleteAction::make(),
-            DispatchTestAction::make()
-                ->dispatch('test-event'),
+            DispatchTestAction::make(),
         ];
     }
 

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -103,6 +103,8 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
         return [
             Tables\Actions\EditAction::make(),
             Tables\Actions\DeleteAction::make(),
+            DispatchTestAction::make()
+                ->dispatch('test-event'),
         ];
     }
 


### PR DESCRIPTION
I'm not sure if I've done this right, like it maybe should be in a concern of it's own rather than sharing HasAction, and I'm confused by the fromCallable stuff on the getAction() method in HasAction, I tried doing it that way with getDispatch(), but was blowing up.  And my test case is a bit primitive, but I can't think of any other test, all I can test on the server side is that the x-on:click is there.  And should probably bake in json_encoding the getDispatchData() return.

Anyway, happy to fix stuff if I need to.  Just didn't want to invest too much time if you weren't interested in merging this feature.  In case you were wondering, this is the kind of thing I need it for, where I want to dispatch an event from a table row to a map.  It's probably possible with the existing mountTableAction() event through Livewire, but that's a round trip to the server and back, which seems a bit much when the event just needs to travel 2 inches up the page.  :)

https://www.screencast.com/t/o4vlQs3js