### PR TITLE
fix: exclude double tabindex in DateTimePicker

### DIFF
--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -42,6 +42,7 @@
             aria-label="{{ $getPlaceholder() }}"
             dusk="filament.forms.{{ $getStatePath() }}.open"
             type="button"
+            tabindex="-1"
             @if ($isDisabled()) disabled @endif
             {{ $getExtraTriggerAttributeBag()->class([
                 'bg-white relative w-full border py-2 pl-3 pr-10 rtl:pl-10 rtl:pr-3 text-start cursor-default rounded-lg shadow-sm',


### PR DESCRIPTION
When tabbing between form components, **DateTimePicker** will take two tabs to move onto the next component. This PR adds tabindex="-1" to button element that wraps the input.