### PR TITLE
Add class to record wire click action button so it can easily be targeted for custom CSS

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -501,7 +501,7 @@
                                             @if ($recordUrl)
                                                 <a
                                                     href="{{ $recordUrl }}"
-                                                    class="flex-1 block py-3"
+                                                    class="filament-tables-record-url-link flex-1 block py-3"
                                                 >
                                                     <x-tables::columns.layout
                                                         :components="$getColumnsLayout()"
@@ -525,7 +525,7 @@
                                                     wire:loading.attr="disabled"
                                                     wire:loading.class="cursor-wait opacity-70"
                                                     type="button"
-                                                    class="flex-1 block py-3 filament-tables-record-click-action"
+                                                    class="filament-tables-record-action-button flex-1 block py-3"
                                                 >
                                                     <x-tables::columns.layout
                                                         :components="$getColumnsLayout()"

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -525,7 +525,7 @@
                                                     wire:loading.attr="disabled"
                                                     wire:loading.class="cursor-wait opacity-70"
                                                     type="button"
-                                                    class="flex-1 block py-3"
+                                                    class="flex-1 block py-3 filament-tables-record-click-action"
                                                 >
                                                     <x-tables::columns.layout
                                                         :components="$getColumnsLayout()"


### PR DESCRIPTION
When using `protected function getTableRecordActionUsing(): ?Closure` a button gets wrapped around the record with the wire:click action.

Since the button doesn't have a `width: 100%;` we ran into some issues with our table columns that had a Split wrapped around them.

If we add a css class to the button wrapper it can be easily targeted and everyone can add their own css to the wrapper.