### PR TITLE
feature: add filament classes to sidebar group dividers

### DIFF
--- a/packages/app/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/app/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -110,8 +110,8 @@
                 />
 
                 @if (! $loop->last)
-                    <li>
-                        <div class="border-t -mr-6 rtl:-mr-auto rtl:-ml-6 dark:border-gray-700"></div>
+                    <li class="filament-sidebar-group-divider-wrapper">
+                        <div class="border-t -mr-6 rtl:-mr-auto rtl:-ml-6 dark:border-gray-700 filament-sidebar-group-divider"></div>
                     </li>
                 @endif
             @endforeach

--- a/packages/app/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/app/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -110,7 +110,7 @@
                 />
 
                 @if (! $loop->last)
-                    <li class="filament-sidebar-group-divider-wrapper">
+                    <li class="filament-sidebar-group-divider-container">
                         <div class="border-t -mr-6 rtl:-mr-auto rtl:-ml-6 dark:border-gray-700 filament-sidebar-group-divider"></div>
                     </li>
                 @endif


### PR DESCRIPTION
Feel free to rename the classes. At the moment I'm doing this like:

```css
.filament-sidebar-nav > ul > li:not(.filament-sidebar-group) {

}
```

Sure we can all agree having a dedicated class is nicer.