### PR TITLE
[3.x] feature: add support for `readonly` input fields

### DIFF
--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -62,7 +62,7 @@
                         'min' => (! $isConcealed) ? $getMinValue() : null,
                         'minlength' => (! $isConcealed) ? $getMinLength() : null,
                         'placeholder' => $getPlaceholder(),
-                        'readonly' => $isReadonly(),
+                        'readonly' => $isReadOnly(),
                         'required' => $isRequired() && (! $isConcealed),
                         'step' => $getStep(),
                         'type' => $hasMask ? 'text' : $getType(),

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -62,6 +62,7 @@
                         'min' => (! $isConcealed) ? $getMinValue() : null,
                         'minlength' => (! $isConcealed) ? $getMinLength() : null,
                         'placeholder' => $getPlaceholder(),
+                        'readonly' => $isReadonly(),
                         'required' => $isRequired() && (! $isConcealed),
                         'step' => $getStep(),
                         'type' => $hasMask ? 'text' : $getType(),

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -29,6 +29,7 @@
                     'maxlength' => (! $isConcealed) ? $getMaxLength() : null,
                     'minlength' => (! $isConcealed) ? $getMinLength() : null,
                     'placeholder' => $getPlaceholder(),
+                    'readonly' => $isReadonly(),
                     'required' => $isRequired() && (! $isConcealed),
                     'rows' => $getRows(),
                     $applyStateBindingModifiers('wire:model') => $getStatePath(),

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -29,7 +29,7 @@
                     'maxlength' => (! $isConcealed) ? $getMaxLength() : null,
                     'minlength' => (! $isConcealed) ? $getMinLength() : null,
                     'placeholder' => $getPlaceholder(),
-                    'readonly' => $isReadonly(),
+                    'readonly' => $isReadOnly(),
                     'required' => $isRequired() && (! $isConcealed),
                     'rows' => $getRows(),
                     $applyStateBindingModifiers('wire:model') => $getStatePath(),

--- a/packages/forms/src/Components/Concerns/CanBeReadonly.php
+++ b/packages/forms/src/Components/Concerns/CanBeReadonly.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Filament\Forms\Components\Concerns;
+
+use Closure;
+use Filament\Forms\Components\Component;
+use Filament\Forms\Contracts\HasForms;
+use Illuminate\Support\Arr;
+
+trait CanBeReadonly
+{
+    protected bool | Closure $isReadonly = false;
+
+    public function readonly(bool | Closure $condition = true): static
+    {
+        $this->isReadonly = $condition;
+
+        return $this;
+    }
+
+    public function readonlyOn(string | array $contexts): static
+    {
+        $this->readonly(static function (string $context, HasForms $livewire) use ($contexts): bool {
+            foreach (Arr::wrap($contexts) as $readonlyContext) {
+                if ($readonlyContext === $context || $livewire instanceof $readonlyContext) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
+
+        return $this;
+    }
+
+    public function isReadonly(): bool
+    {
+        return $this->evaluate($this->isReadonly);
+    }
+}

--- a/packages/forms/src/Components/Concerns/CanBeReadonly.php
+++ b/packages/forms/src/Components/Concerns/CanBeReadonly.php
@@ -6,22 +6,22 @@ use Closure;
 use Filament\Forms\Contracts\HasForms;
 use Illuminate\Support\Arr;
 
-trait CanBeReadonly
+trait CanBeReadOnly
 {
-    protected bool | Closure $isReadonly = false;
+    protected bool | Closure $isReadOnly = false;
 
-    public function readonly(bool | Closure $condition = true): static
+    public function readOnly(bool | Closure $condition = true): static
     {
-        $this->isReadonly = $condition;
+        $this->isReadOnly = $condition;
 
         return $this;
     }
 
-    public function readonlyOn(string | array $contexts): static
+    public function readOnlyOn(string | array $contexts): static
     {
-        $this->readonly(static function (string $context, HasForms $livewire) use ($contexts): bool {
-            foreach (Arr::wrap($contexts) as $readonlyContext) {
-                if ($readonlyContext === $context || $livewire instanceof $readonlyContext) {
+        $this->readOnly(static function (string $context, HasForms $livewire) use ($contexts): bool {
+            foreach (Arr::wrap($contexts) as $readOnlyContext) {
+                if ($readOnlyContext === $context || $livewire instanceof $readOnlyContext) {
                     return true;
                 }
             }
@@ -32,8 +32,8 @@ trait CanBeReadonly
         return $this;
     }
 
-    public function isReadonly(): bool
+    public function isReadOnly(): bool
     {
-        return $this->evaluate($this->isReadonly);
+        return $this->evaluate($this->isReadOnly);
     }
 }

--- a/packages/forms/src/Components/Concerns/CanBeReadonly.php
+++ b/packages/forms/src/Components/Concerns/CanBeReadonly.php
@@ -3,7 +3,6 @@
 namespace Filament\Forms\Components\Concerns;
 
 use Closure;
-use Filament\Forms\Components\Component;
 use Filament\Forms\Contracts\HasForms;
 use Illuminate\Support\Arr;
 

--- a/packages/forms/src/Components/TextInput.php
+++ b/packages/forms/src/Components/TextInput.php
@@ -13,7 +13,7 @@ class TextInput extends Field implements Contracts\CanBeLengthConstrained, CanHa
     use Concerns\CanBeAutocapitalized;
     use Concerns\CanBeAutocompleted;
     use Concerns\CanBeLengthConstrained;
-    use Concerns\CanBeReadonly;
+    use Concerns\CanBeReadOnly;
     use Concerns\HasAffixes;
     use Concerns\HasExtraInputAttributes;
     use Concerns\HasInputMode;

--- a/packages/forms/src/Components/TextInput.php
+++ b/packages/forms/src/Components/TextInput.php
@@ -13,6 +13,7 @@ class TextInput extends Field implements Contracts\CanBeLengthConstrained, CanHa
     use Concerns\CanBeAutocapitalized;
     use Concerns\CanBeAutocompleted;
     use Concerns\CanBeLengthConstrained;
+    use Concerns\CanBeReadonly;
     use Concerns\HasAffixes;
     use Concerns\HasExtraInputAttributes;
     use Concerns\HasInputMode;

--- a/packages/forms/src/Components/Textarea.php
+++ b/packages/forms/src/Components/Textarea.php
@@ -10,6 +10,7 @@ class Textarea extends Field implements Contracts\CanBeLengthConstrained
     use Concerns\CanBeAutocapitalized;
     use Concerns\CanBeAutocompleted;
     use Concerns\CanBeLengthConstrained;
+    use Concerns\CanBeReadonly;
     use Concerns\HasExtraInputAttributes;
     use Concerns\HasPlaceholder;
     use HasExtraAlpineAttributes;

--- a/packages/forms/src/Components/Textarea.php
+++ b/packages/forms/src/Components/Textarea.php
@@ -10,7 +10,7 @@ class Textarea extends Field implements Contracts\CanBeLengthConstrained
     use Concerns\CanBeAutocapitalized;
     use Concerns\CanBeAutocompleted;
     use Concerns\CanBeLengthConstrained;
-    use Concerns\CanBeReadonly;
+    use Concerns\CanBeReadOnly;
     use Concerns\HasExtraInputAttributes;
     use Concerns\HasPlaceholder;
     use HasExtraAlpineAttributes;

--- a/packages/forms/src/Testing/TestsForms.php
+++ b/packages/forms/src/Testing/TestsForms.php
@@ -204,6 +204,29 @@ class TestsForms
         };
     }
 
+    public function assertFormFieldIsReadonly(): Closure
+    {
+        return function (string $fieldName, string $formName = 'form'): static {
+            /** @phpstan-ignore-next-line  */
+            $this->assertFormFieldExists($fieldName, $formName);
+
+            /** @var ComponentContainer $form */
+            $form = $this->instance()->{$formName};
+
+            /** @var Field $field */
+            $field = $form->getFlatFields(withHidden: true)[$fieldName];
+
+            $livewireClass = $this->instance()::class;
+
+            Assert::assertTrue(
+                $field->isReadonly(),
+                "Failed asserting that a field with the name [{$fieldName}] is readonly on the form named [{$formName}] on the [{$livewireClass}] component."
+            );
+
+            return $this;
+        };
+    }
+
     public function assertFormFieldIsHidden(): Closure
     {
         return function (string $fieldName, string $formName = 'form'): static {

--- a/packages/forms/src/Testing/TestsForms.php
+++ b/packages/forms/src/Testing/TestsForms.php
@@ -204,7 +204,7 @@ class TestsForms
         };
     }
 
-    public function assertFormFieldIsReadonly(): Closure
+    public function assertFormFieldIsReadOnly(): Closure
     {
         return function (string $fieldName, string $formName = 'form'): static {
             /** @phpstan-ignore-next-line  */
@@ -219,8 +219,8 @@ class TestsForms
             $livewireClass = $this->instance()::class;
 
             Assert::assertTrue(
-                $field->isReadonly(),
-                "Failed asserting that a field with the name [{$fieldName}] is readonly on the form named [{$formName}] on the [{$livewireClass}] component."
+                $field->isReadOnly(),
+                "Failed asserting that a field with the name [{$fieldName}] is read-only on the form named [{$formName}] on the [{$livewireClass}] component."
             );
 
             return $this;


### PR DESCRIPTION
Only added to `TextInput` and `Textarea` since those are the only input types that semantically support `readonly`.