### PR TITLE
Allow arbitrary depth dotted relations in TextColumn

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanFormatArrayState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatArrayState.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Filament\Tables\Columns\Concerns;
+
+use Closure;
+use Illuminate\Support\HtmlString;
+
+trait CanFormatArrayState
+{
+    protected ?int $limit = null;
+
+    public function formatArrayStateUsing(?Closure $callback): static
+    {
+        $this->mutateArrayStateUsing = $callback;
+
+        return $this;
+    }
+
+    public function ul(): static
+    {
+        $this->mutateArrayStateUsing(function ($state) {
+            return new HtmlString(
+                '<ul><li>' . implode('</li><li>', $state) . '</li></ul>'
+            );
+        });
+
+        return $this;
+    }
+
+    public function ol(): static
+    {
+        $this->mutateArrayStateUsing(function ($state) {
+            return new HtmlString(
+                '<ol><li>' . implode('</li><li>', $state) . '</li></ol>'
+            );
+        });
+
+        return $this;
+    }
+
+    public function grid(int $columns = 1, $gap = 2): static
+    {
+        $this->mutateArrayStateUsing(function ($state) use ($columns, $gap) {
+            return new HtmlString(
+                "<div class='grid grid-cols-{$columns} gap-{$gap}'><div>" .
+                implode('</div><div>', $state) .
+                '</div></div>'
+            );
+        });
+
+        return $this;
+    }
+}

--- a/packages/tables/src/Columns/Concerns/HasState.php
+++ b/packages/tables/src/Columns/Concerns/HasState.php
@@ -4,9 +4,6 @@ namespace Filament\Tables\Columns\Concerns;
 
 use BackedEnum;
 use Closure;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Arr;
 
 trait HasState
@@ -44,18 +41,15 @@ trait HasState
             interface_exists(BackedEnum::class) &&
             ($state instanceof BackedEnum) &&
             property_exists($state, 'value')
-        )
-        {
+        ) {
             $state = $state->value;
         }
 
-        if ($state === null)
-        {
+        if ($state === null) {
             $state = value($this->getDefaultState());
         }
 
-        if (is_array($state))
-        {
+        if (is_array($state)) {
             $state = $this->mutateArrayState($state);
         }
 
@@ -68,13 +62,11 @@ trait HasState
 
         $state = Arr::get($record, $this->getName());
 
-        if ($state !== null)
-        {
+        if ($state !== null) {
             return $state;
         }
 
-        if (!$this->queriesRelationships($record))
-        {
+        if (! $this->queriesRelationships($record)) {
             return null;
         }
 
@@ -88,30 +80,25 @@ trait HasState
     protected function collectRelationValues($relationshipName, $restOfName, $record, &$results)
     {
         $relationshipName = (string) str($restOfName)->before('.');
-        $restOfName       = (string) str($restOfName)->after('.');
+        $restOfName = (string) str($restOfName)->after('.');
 
-        if (!method_exists($record, $relationshipName))
-        {
+        if (! method_exists($record, $relationshipName)) {
             return [];
         }
 
-        if (!str($restOfName)->contains('.'))
-        {
+        if (! str($restOfName)->contains('.')) {
             $state = $record->{$relationshipName}()->pluck($restOfName);
 
             return $state->toArray();
-        }
-        else
-        {
+        } else {
             $related = $record->{$relationshipName}();
 
-            foreach ($related->get() as $relatedRecord)
-            {
+            foreach ($related->get() as $relatedRecord) {
                 $results = array_merge(
                     $results,
                     $this->collectRelationValues($relationshipName, $restOfName, $relatedRecord, $results)
                 );
-            };
+            }
         }
 
         return $results;

--- a/packages/tables/src/Columns/Concerns/HasState.php
+++ b/packages/tables/src/Columns/Concerns/HasState.php
@@ -84,24 +84,19 @@ trait HasState
     {
         $relationshipName = array_shift($relationships);
 
-        if (!method_exists($record, $relationshipName))
-        {
+        if (! method_exists($record, $relationshipName)) {
             return [];
         }
 
-        if (count($relationships) === 1)
-        {
+        if (count($relationships) === 1) {
             return $record->{$relationshipName}()->pluck(array_shift($relationships))->toArray();
-        }
-        else
-        {
-            foreach ($record->{$relationshipName}()->get() as $relatedRecord)
-            {
+        } else {
+            foreach ($record->{$relationshipName}()->get() as $relatedRecord) {
                 $results = array_merge(
                     $results,
                     $this->collectRelationValues($relationships, $relatedRecord, $results)
                 );
-            };
+            }
 
             return $results;
         }

--- a/packages/tables/src/Columns/Concerns/HasState.php
+++ b/packages/tables/src/Columns/Concerns/HasState.php
@@ -44,18 +44,15 @@ trait HasState
             interface_exists(BackedEnum::class) &&
             ($state instanceof BackedEnum) &&
             property_exists($state, 'value')
-        )
-        {
+        ) {
             $state = $state->value;
         }
 
-        if ($state === null)
-        {
+        if ($state === null) {
             $state = value($this->getDefaultState());
         }
 
-        if (is_array($state))
-        {
+        if (is_array($state)) {
             $state = $this->mutateArrayState($state);
         }
 
@@ -68,13 +65,11 @@ trait HasState
 
         $state = Arr::get($record, $this->getName());
 
-        if ($state !== null)
-        {
+        if ($state !== null) {
             return $state;
         }
 
-        if (!$this->queriesRelationships($record))
-        {
+        if (!$this->queriesRelationships($record)) {
             return null;
         }
 
@@ -90,23 +85,19 @@ trait HasState
         $relationshipName = (string) str($restOfName)->before('.');
         $restOfName       = (string) str($restOfName)->after('.');
 
-        if (!method_exists($record, $relationshipName))
-        {
+        if (!method_exists($record, $relationshipName)) {
             return [];
         }
 
-        if (!str($restOfName)->contains('.'))
-        {
+        if (!str($restOfName)->contains('.')) {
             $state = $record->{$relationshipName}()->pluck($restOfName);
 
             return $state->toArray();
         }
-        else
-        {
+        else {
             $related = $record->{$relationshipName}();
 
-            foreach ($related->get() as $relatedRecord)
-            {
+            foreach ($related->get() as $relatedRecord) {
                 $results = array_merge(
                     $results,
                     $this->collectRelationValues($relationshipName, $restOfName, $relatedRecord, $results)

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -9,6 +9,7 @@ class TextColumn extends Column
 {
     use Concerns\CanBeCopied;
     use Concerns\CanFormatState;
+    use Concerns\CanFormatArrayState;
     use Concerns\HasColor;
     use Concerns\HasDescription;
     use Concerns\HasFontFamily;

--- a/tests/database/factories/CommentFactory.php
+++ b/tests/database/factories/CommentFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Filament\Tests\Database\Factories;
+
+use Filament\Tests\Models\Post;
+use Filament\Tests\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class CommentFactory extends Factory
+{
+    protected $model = Post::class;
+
+    public function definition(): array
+    {
+        return [
+            'author_id' => User::factory(),
+            'post_id' => Post::factory(),
+            'content' => $this->faker->paragraph(),
+            'is_published' => $this->faker->boolean(),
+            'tags' => $this->faker->words(),
+            'title' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/tests/database/migrations/create_comments_table.php
+++ b/tests/database/migrations/create_comments_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('comments', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('author_id');
+            $table->foreignId('post_id');
+            $table->text('content')->nullable();
+            $table->boolean('is_published')->default(true);
+            $table->json('tags')->nullable();
+            $table->string('title');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('comment');
+    }
+};

--- a/tests/src/Models/Comment.php
+++ b/tests/src/Models/Comment.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Filament\Tests\Models;
+
+use Filament\Tests\Database\Factories\CommentFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Comment extends Model
+{
+    use HasFactory;
+
+    protected $casts = [
+        'is_published' => 'boolean',
+        'tags' => 'array',
+    ];
+
+    protected $guarded = [];
+
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'author_id');
+    }
+
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class, 'post_id');
+    }
+
+    protected static function newFactory()
+    {
+        return CommentFactory::new();
+    }
+}

--- a/tests/src/Models/Post.php
+++ b/tests/src/Models/Post.php
@@ -6,6 +6,7 @@ use Filament\Tests\Database\Factories\PostFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Post extends Model
 {
@@ -21,6 +22,11 @@ class Post extends Model
     public function author(): BelongsTo
     {
         return $this->belongsTo(User::class, 'author_id');
+    }
+
+    public function comments(): HasMany
+    {
+        return $this->hasMany(Comment::class, 'post_id');
     }
 
     protected static function newFactory()

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Filament\Tests\Models\Comment;
 use Filament\Tests\Models\Post;
 use Filament\Tests\Tables\Fixtures\PostsTable;
 use Filament\Tests\Tables\TestCase;
@@ -19,6 +20,19 @@ it('can render text column with relationship', function () {
 
     livewire(PostsTable::class)
         ->assertCanRenderTableColumn('author.name');
+});
+
+it('can render text column with deep relationship', function () {
+    $posts = Post::factory()->count(5)->create();
+
+    foreach ($posts as $post) {
+        $post->comments()->createMany(
+            Comment::factory()->count(10)->make()->toArray()
+        );
+    }
+
+    livewire(PostsTable::class)
+        ->assertCanRenderTableColumn('comments.author.name');
 });
 
 it('can sort records', function () {

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -43,6 +43,8 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
             Tables\Columns\TextColumn::make('with_description')
                 ->description('description below')
                 ->description('description above', 'above'),
+            Tables\Columns\TextColumn::make('comments.author.name')
+                ->ul(),
         ];
     }
 


### PR DESCRIPTION
Allow things like TextColumn::make('dailyLogs.pilots.name') or ('flightLegs.incidents.commander.name').

