### PR TITLE
Allow empty modal subheading

### DIFF
--- a/packages/support/src/Actions/Concerns/CanOpenModal.php
+++ b/packages/support/src/Actions/Concerns/CanOpenModal.php
@@ -214,7 +214,7 @@ trait CanOpenModal
 
     public function getModalSubheading(): string | Htmlable | null
     {
-        if (filled($this->modalSubheading)) {
+        if ($this->modalSubheading !== null) {
             return $this->evaluate($this->modalSubheading);
         }
 

--- a/packages/support/src/Actions/Concerns/CanOpenModal.php
+++ b/packages/support/src/Actions/Concerns/CanOpenModal.php
@@ -186,15 +186,7 @@ trait CanOpenModal
 
     public function getModalButtonLabel(): string
     {
-        if (filled($this->modalButtonLabel)) {
-            return $this->evaluate($this->modalButtonLabel);
-        }
-
-        if ($this->isConfirmationRequired()) {
-            return __('filament-support::actions/modal.actions.confirm.label');
-        }
-
-        return __('filament-support::actions/modal.actions.submit.label');
+        return $this->evaluate($this->modalButtonLabel) ?? __('filament-support::actions/modal.actions.submit.label');
     }
 
     public function getModalContent(): View | Htmlable | null
@@ -214,41 +206,17 @@ trait CanOpenModal
 
     public function getModalSubheading(): string | Htmlable | null
     {
-        if ($this->modalSubheading !== null) {
-            return $this->evaluate($this->modalSubheading);
-        }
-
-        if ($this->isConfirmationRequired()) {
-            return __('filament-support::actions/modal.confirmation');
-        }
-
-        return null;
+        return $this->evaluate($this->modalSubheading);
     }
 
     public function getModalWidth(): string
     {
-        if (filled($this->modalWidth)) {
-            return $this->evaluate($this->modalWidth);
-        }
-
-        if ($this->isConfirmationRequired()) {
-            return 'sm';
-        }
-
-        return '4xl';
+        return $this->evaluate($this->modalWidth) ?? '4xl';
     }
 
     public function isModalCentered(): bool
     {
-        if ($this->isModalCentered !== null) {
-            return $this->evaluate($this->isModalCentered);
-        }
-
-        if (in_array($this->getModalWidth(), ['xs', 'sm'])) {
-            return true;
-        }
-
-        return $this->isConfirmationRequired();
+        return $this->evaluate($this->isModalCentered) ?? in_array($this->getModalWidth(), ['xs', 'sm']);
     }
 
     public function isModalSlideOver(): bool
@@ -258,7 +226,7 @@ trait CanOpenModal
 
     public function shouldOpenModal(): bool
     {
-        return $this->isConfirmationRequired() || $this->hasFormSchema() || $this->getModalContent() || $this->getModalFooter();
+        return $this->hasFormSchema() || $this->getModalSubheading() || $this->getModalContent() || $this->getModalFooter();
     }
 
     protected function makeExtraModalAction(string $name, ?array $arguments = null): ModalAction

--- a/packages/support/src/Actions/Concerns/CanRequireConfirmation.php
+++ b/packages/support/src/Actions/Concerns/CanRequireConfirmation.php
@@ -3,20 +3,17 @@
 namespace Filament\Support\Actions\Concerns;
 
 use Closure;
+use Filament\Support\Actions\Action;
 
 trait CanRequireConfirmation
 {
-    protected bool | Closure $isConfirmationRequired = false;
-
     public function requiresConfirmation(bool | Closure $condition = true): static
     {
-        $this->isConfirmationRequired = $condition;
+        $this->modalSubheading(fn (Action $action): ?string => $action->evaluate($condition) ? __('filament-support::actions/modal.confirmation') : null);
+        $this->modalButton(fn (Action $action): ?string => $action->evaluate($condition) ? __('filament-support::actions/modal.actions.confirm.label') : null);
+        $this->modalWidth(fn (Action $action): ?string => $action->evaluate($condition) ? 'sm' : null);
+        $this->centerModal($condition);
 
         return $this;
-    }
-
-    public function isConfirmationRequired(): bool
-    {
-        return $this->evaluate($this->isConfirmationRequired);
     }
 }


### PR DESCRIPTION
Currently, when using `->requiresConfirmation()` for an action modal, removing the subheading is impossible.
You either have the `Are you sure you would like to do this?` subheading or define your own.

This PR allows setting the `->modalSubheading()` to an empty string or false to hide it.

The previous/default behavior should not be impacted by this PR.