### PR TITLE
Remove markup when modal heading is empty

### DIFF
--- a/packages/admin/resources/views/components/page.blade.php
+++ b/packages/admin/resources/views/components/page.blade.php
@@ -70,9 +70,9 @@
             @if ($action)
                 @if ($action->isModalCentered())
                     @if ($heading = $action->getModalHeading())
-                        <x-tables::modal.heading>
-                            {{ $heading }}
-                        </x-tables::modal.heading>
+                        <x-slot name="heading">
+                            {{ $action->getModalHeading() }}
+                        </x-slot>
                     @endif
 
                     @if ($subheading = $action->getModalSubheading())
@@ -83,9 +83,9 @@
                 @else
                     <x-slot name="header">
                         @if ($heading = $action->getModalHeading())
-                            <x-tables::modal.heading>
-                                {{ $heading }}
-                            </x-tables::modal.heading>
+                            <x-filament::modal.heading>
+                                {{ $action->getModalHeading() }}
+                            </x-filament::modal.heading>
                         @endif
 
                         @if ($subheading = $action->getModalSubheading())

--- a/packages/admin/resources/views/components/page.blade.php
+++ b/packages/admin/resources/views/components/page.blade.php
@@ -69,7 +69,7 @@
         >
             @if ($action)
                 @if ($action->isModalCentered())
-                    @if($modalHeading = $action->getModalHeading())
+                    @if ($modalHeading = $action->getModalHeading())
                         <x-tables::modal.heading>
                             {{ $action->getModalHeading() }}
                         </x-tables::modal.heading>

--- a/packages/admin/resources/views/components/page.blade.php
+++ b/packages/admin/resources/views/components/page.blade.php
@@ -69,9 +69,11 @@
         >
             @if ($action)
                 @if ($action->isModalCentered())
-                    <x-slot name="heading">
-                        {{ $action->getModalHeading() }}
-                    </x-slot>
+                    @if($modalHeading = $action->getModalHeading())
+                        <x-tables::modal.heading>
+                            {{ $action->getModalHeading() }}
+                        </x-tables::modal.heading>
+                    @endif
 
                     @if ($subheading = $action->getModalSubheading())
                         <x-slot name="subheading">
@@ -80,9 +82,11 @@
                     @endif
                 @else
                     <x-slot name="header">
-                        <x-filament::modal.heading>
-                            {{ $action->getModalHeading() }}
-                        </x-filament::modal.heading>
+                        @if($modalHeading = $action->getModalHeading())
+                            <x-tables::modal.heading>
+                                {{ $action->getModalHeading() }}
+                            </x-tables::modal.heading>
+                        @endif
 
                         @if ($subheading = $action->getModalSubheading())
                             <x-filament::modal.subheading>

--- a/packages/admin/resources/views/components/page.blade.php
+++ b/packages/admin/resources/views/components/page.blade.php
@@ -71,7 +71,7 @@
                 @if ($action->isModalCentered())
                     @if ($heading = $action->getModalHeading())
                         <x-slot name="heading">
-                            {{ $action->getModalHeading() }}
+                            {{ $heading }}
                         </x-slot>
                     @endif
 
@@ -84,7 +84,7 @@
                     <x-slot name="header">
                         @if ($heading = $action->getModalHeading())
                             <x-filament::modal.heading>
-                                {{ $action->getModalHeading() }}
+                                {{ $heading }}
                             </x-filament::modal.heading>
                         @endif
 

--- a/packages/admin/resources/views/components/page.blade.php
+++ b/packages/admin/resources/views/components/page.blade.php
@@ -69,9 +69,9 @@
         >
             @if ($action)
                 @if ($action->isModalCentered())
-                    @if ($modalHeading = $action->getModalHeading())
+                    @if ($heading = $action->getModalHeading())
                         <x-tables::modal.heading>
-                            {{ $modalHeading }}
+                            {{ $heading }}
                         </x-tables::modal.heading>
                     @endif
 
@@ -82,9 +82,9 @@
                     @endif
                 @else
                     <x-slot name="header">
-                        @if ($modalHeading = $action->getModalHeading())
+                        @if ($heading = $action->getModalHeading())
                             <x-tables::modal.heading>
-                                {{ $modalHeading }}
+                                {{ $heading }}
                             </x-tables::modal.heading>
                         @endif
 

--- a/packages/admin/resources/views/components/page.blade.php
+++ b/packages/admin/resources/views/components/page.blade.php
@@ -82,7 +82,7 @@
                     @endif
                 @else
                     <x-slot name="header">
-                        @if($modalHeading = $action->getModalHeading())
+                        @if ($modalHeading = $action->getModalHeading())
                             <x-tables::modal.heading>
                                 {{ $action->getModalHeading() }}
                             </x-tables::modal.heading>

--- a/packages/admin/resources/views/components/page.blade.php
+++ b/packages/admin/resources/views/components/page.blade.php
@@ -71,7 +71,7 @@
                 @if ($action->isModalCentered())
                     @if ($modalHeading = $action->getModalHeading())
                         <x-tables::modal.heading>
-                            {{ $action->getModalHeading() }}
+                            {{ $modalHeading }}
                         </x-tables::modal.heading>
                     @endif
 

--- a/packages/admin/resources/views/components/page.blade.php
+++ b/packages/admin/resources/views/components/page.blade.php
@@ -84,7 +84,7 @@
                     <x-slot name="header">
                         @if ($modalHeading = $action->getModalHeading())
                             <x-tables::modal.heading>
-                                {{ $action->getModalHeading() }}
+                                {{ $modalHeading }}
                             </x-tables::modal.heading>
                         @endif
 

--- a/packages/forms/resources/views/components/actions/modal/index.blade.php
+++ b/packages/forms/resources/views/components/actions/modal/index.blade.php
@@ -17,7 +17,7 @@
             @if ($action->isModalCentered())
                 @if ($modalHeading = $action->getModalHeading())
                     <x-tables::modal.heading>
-                        {{ $action->getModalHeading() }}
+                        {{ $modalHeading }}
                     </x-tables::modal.heading>
                 @endif
 

--- a/packages/forms/resources/views/components/actions/modal/index.blade.php
+++ b/packages/forms/resources/views/components/actions/modal/index.blade.php
@@ -16,9 +16,9 @@
         @if ($action)
             @if ($action->isModalCentered())
                 @if ($heading = $action->getModalHeading())
-                    <x-tables::modal.heading>
-                        {{ $heading }}
-                    </x-tables::modal.heading>
+                    <x-slot name="heading">
+                        {{ $action->getModalHeading() }}
+                    </x-slot>
                 @endif
 
                 @if ($subheading = $action->getModalSubheading())
@@ -29,9 +29,9 @@
             @else
                 <x-slot name="header">
                     @if ($heading = $action->getModalHeading())
-                        <x-tables::modal.heading>
-                            {{ $heading }}
-                        </x-tables::modal.heading>
+                        <x-forms::modal.heading>
+                            {{ $action->getModalHeading() }}
+                        </x-forms::modal.heading>
                     @endif
 
                     @if ($subheading = $action->getModalSubheading())

--- a/packages/forms/resources/views/components/actions/modal/index.blade.php
+++ b/packages/forms/resources/views/components/actions/modal/index.blade.php
@@ -15,9 +15,11 @@
     >
         @if ($action)
             @if ($action->isModalCentered())
-                <x-slot name="heading">
-                    {{ $action->getModalHeading() }}
-                </x-slot>
+                @if($modalHeading = $action->getModalHeading())
+                    <x-tables::modal.heading>
+                        {{ $action->getModalHeading() }}
+                    </x-tables::modal.heading>
+                @endif
 
                 @if ($subheading = $action->getModalSubheading())
                     <x-slot name="subheading">
@@ -26,9 +28,11 @@
                 @endif
             @else
                 <x-slot name="header">
-                    <x-forms::modal.heading>
-                        {{ $action->getModalHeading() }}
-                    </x-forms::modal.heading>
+                    @if($modalHeading = $action->getModalHeading())
+                        <x-tables::modal.heading>
+                            {{ $action->getModalHeading() }}
+                        </x-tables::modal.heading>
+                    @endif
 
                     @if ($subheading = $action->getModalSubheading())
                         <x-forms::modal.subheading>

--- a/packages/forms/resources/views/components/actions/modal/index.blade.php
+++ b/packages/forms/resources/views/components/actions/modal/index.blade.php
@@ -28,7 +28,7 @@
                 @endif
             @else
                 <x-slot name="header">
-                    @if($modalHeading = $action->getModalHeading())
+                    @if ($modalHeading = $action->getModalHeading())
                         <x-tables::modal.heading>
                             {{ $action->getModalHeading() }}
                         </x-tables::modal.heading>

--- a/packages/forms/resources/views/components/actions/modal/index.blade.php
+++ b/packages/forms/resources/views/components/actions/modal/index.blade.php
@@ -15,9 +15,9 @@
     >
         @if ($action)
             @if ($action->isModalCentered())
-                @if ($modalHeading = $action->getModalHeading())
+                @if ($heading = $action->getModalHeading())
                     <x-tables::modal.heading>
-                        {{ $modalHeading }}
+                        {{ $heading }}
                     </x-tables::modal.heading>
                 @endif
 
@@ -28,9 +28,9 @@
                 @endif
             @else
                 <x-slot name="header">
-                    @if ($modalHeading = $action->getModalHeading())
+                    @if ($heading = $action->getModalHeading())
                         <x-tables::modal.heading>
-                            {{ $modalHeading }}
+                            {{ $heading }}
                         </x-tables::modal.heading>
                     @endif
 

--- a/packages/forms/resources/views/components/actions/modal/index.blade.php
+++ b/packages/forms/resources/views/components/actions/modal/index.blade.php
@@ -17,7 +17,7 @@
             @if ($action->isModalCentered())
                 @if ($heading = $action->getModalHeading())
                     <x-slot name="heading">
-                        {{ $action->getModalHeading() }}
+                        {{ $heading }}
                     </x-slot>
                 @endif
 
@@ -30,7 +30,7 @@
                 <x-slot name="header">
                     @if ($heading = $action->getModalHeading())
                         <x-forms::modal.heading>
-                            {{ $action->getModalHeading() }}
+                            {{ $heading }}
                         </x-forms::modal.heading>
                     @endif
 

--- a/packages/forms/resources/views/components/actions/modal/index.blade.php
+++ b/packages/forms/resources/views/components/actions/modal/index.blade.php
@@ -30,7 +30,7 @@
                 <x-slot name="header">
                     @if ($modalHeading = $action->getModalHeading())
                         <x-tables::modal.heading>
-                            {{ $action->getModalHeading() }}
+                            {{ $modalHeading }}
                         </x-tables::modal.heading>
                     @endif
 

--- a/packages/forms/resources/views/components/actions/modal/index.blade.php
+++ b/packages/forms/resources/views/components/actions/modal/index.blade.php
@@ -15,7 +15,7 @@
     >
         @if ($action)
             @if ($action->isModalCentered())
-                @if($modalHeading = $action->getModalHeading())
+                @if ($modalHeading = $action->getModalHeading())
                     <x-tables::modal.heading>
                         {{ $action->getModalHeading() }}
                     </x-tables::modal.heading>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -902,7 +902,7 @@
                 @if ($action->isModalCentered())
                     @if ($heading = $action->getModalHeading())
                         <x-slot name="heading">
-                            {{ $action->getModalHeading() }}
+                            {{ $heading }}
                         </x-slot>
                     @endif
 
@@ -915,7 +915,7 @@
                     <x-slot name="header">
                         @if ($heading = $action->getModalHeading())
                             <x-tables::modal.heading>
-                                {{ $action->getModalHeading() }}
+                                {{ $heading }}
                             </x-tables::modal.heading>
                         @endif
 
@@ -967,7 +967,7 @@
                 @if ($action->isModalCentered())
                     @if ($heading = $action->getModalHeading())
                         <x-slot name="heading">
-                            {{ $action->getModalHeading() }}
+                            {{ $heading }}
                         </x-slot>
                     @endif
 
@@ -980,7 +980,7 @@
                     <x-slot name="header">
                         @if ($heading = $action->getModalHeading())
                             <x-tables::modal.heading>
-                                {{ $action->getModalHeading() }}
+                                {{ $heading }}
                             </x-tables::modal.heading>
                         @endif
 

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -913,7 +913,7 @@
                     @endif
                 @else
                     <x-slot name="header">
-                        @if($modalHeading = $action->getModalHeading())
+                        @if ($modalHeading = $action->getModalHeading())
                             <x-tables::modal.heading>
                                 {{ $modalHeading }}
                             </x-tables::modal.heading>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -902,7 +902,7 @@
                 @if ($action->isModalCentered())
                     @if($modalHeading = $action->getModalHeading())
                         <x-tables::modal.heading>
-                            {{ $action->getModalHeading() }}
+                            {{ $modalHeading }}
                         </x-tables::modal.heading>
                     @endif
 

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -965,7 +965,7 @@
         >
             @if ($action)
                 @if ($action->isModalCentered())
-                    @if($modalHeading = $action->getModalHeading())
+                    @if ($modalHeading = $action->getModalHeading())
                         <x-tables::modal.heading>
                             {{ $modalHeading }}
                         </x-tables::modal.heading>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -901,9 +901,9 @@
             @if ($action)
                 @if ($action->isModalCentered())
                     @if ($heading = $action->getModalHeading())
-                        <x-tables::modal.heading>
-                            {{ $heading }}
-                        </x-tables::modal.heading>
+                        <x-slot name="heading">
+                            {{ $action->getModalHeading() }}
+                        </x-slot>
                     @endif
 
                     @if ($subheading = $action->getModalSubheading())
@@ -915,7 +915,7 @@
                     <x-slot name="header">
                         @if ($heading = $action->getModalHeading())
                             <x-tables::modal.heading>
-                                {{ $heading }}
+                                {{ $action->getModalHeading() }}
                             </x-tables::modal.heading>
                         @endif
 
@@ -966,9 +966,9 @@
             @if ($action)
                 @if ($action->isModalCentered())
                     @if ($heading = $action->getModalHeading())
-                        <x-tables::modal.heading>
-                            {{ $modalHeading }}
-                        </x-tables::modal.heading>
+                        <x-slot name="heading">
+                            {{ $action->getModalHeading() }}
+                        </x-slot>
                     @endif
 
                     @if ($subheading = $action->getModalSubheading())
@@ -980,7 +980,7 @@
                     <x-slot name="header">
                         @if ($heading = $action->getModalHeading())
                             <x-tables::modal.heading>
-                                {{ $modalHeading }}
+                                {{ $action->getModalHeading() }}
                             </x-tables::modal.heading>
                         @endif
 

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -980,7 +980,7 @@
                     <x-slot name="header">
                         @if ($modalHeading = $action->getModalHeading())
                             <x-tables::modal.heading>
-                                {{ $action->getModalHeading() }}
+                                {{ $modalHeading }}
                             </x-tables::modal.heading>
                         @endif
 

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -967,7 +967,7 @@
                 @if ($action->isModalCentered())
                     @if($modalHeading = $action->getModalHeading())
                         <x-tables::modal.heading>
-                            {{ $action->getModalHeading() }}
+                            {{ $modalHeading }}
                         </x-tables::modal.heading>
                     @endif
 

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -900,9 +900,11 @@
         >
             @if ($action)
                 @if ($action->isModalCentered())
-                    <x-slot name="heading">
-                        {{ $action->getModalHeading() }}
-                    </x-slot>
+                    @if($modalHeading = $action->getModalHeading())
+                        <x-tables::modal.heading>
+                            {{ $action->getModalHeading() }}
+                        </x-tables::modal.heading>
+                    @endif
 
                     @if ($subheading = $action->getModalSubheading())
                         <x-slot name="subheading">
@@ -911,9 +913,11 @@
                     @endif
                 @else
                     <x-slot name="header">
-                        <x-tables::modal.heading>
-                            {{ $action->getModalHeading() }}
-                        </x-tables::modal.heading>
+                        @if($modalHeading = $action->getModalHeading())
+                            <x-tables::modal.heading>
+                                {{ $action->getModalHeading() }}
+                            </x-tables::modal.heading>
+                        @endif
 
                         @if ($subheading = $action->getModalSubheading())
                             <x-tables::modal.subheading>
@@ -961,9 +965,11 @@
         >
             @if ($action)
                 @if ($action->isModalCentered())
-                    <x-slot name="heading">
-                        {{ $action->getModalHeading() }}
-                    </x-slot>
+                    @if($modalHeading = $action->getModalHeading())
+                        <x-tables::modal.heading>
+                            {{ $action->getModalHeading() }}
+                        </x-tables::modal.heading>
+                    @endif
 
                     @if ($subheading = $action->getModalSubheading())
                         <x-slot name="subheading">
@@ -972,9 +978,11 @@
                     @endif
                 @else
                     <x-slot name="header">
-                        <x-tables::modal.heading>
-                            {{ $action->getModalHeading() }}
-                        </x-tables::modal.heading>
+                        @if($modalHeading = $action->getModalHeading())
+                            <x-tables::modal.heading>
+                                {{ $action->getModalHeading() }}
+                            </x-tables::modal.heading>
+                        @endif
 
                         @if ($subheading = $action->getModalSubheading())
                             <x-tables::modal.subheading>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -915,7 +915,7 @@
                     <x-slot name="header">
                         @if($modalHeading = $action->getModalHeading())
                             <x-tables::modal.heading>
-                                {{ $action->getModalHeading() }}
+                                {{ $modalHeading }}
                             </x-tables::modal.heading>
                         @endif
 

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -900,9 +900,9 @@
         >
             @if ($action)
                 @if ($action->isModalCentered())
-                    @if ($modalHeading = $action->getModalHeading())
+                    @if ($heading = $action->getModalHeading())
                         <x-tables::modal.heading>
-                            {{ $modalHeading }}
+                            {{ $heading }}
                         </x-tables::modal.heading>
                     @endif
 
@@ -913,9 +913,9 @@
                     @endif
                 @else
                     <x-slot name="header">
-                        @if ($modalHeading = $action->getModalHeading())
+                        @if ($heading = $action->getModalHeading())
                             <x-tables::modal.heading>
-                                {{ $modalHeading }}
+                                {{ $heading }}
                             </x-tables::modal.heading>
                         @endif
 
@@ -965,7 +965,7 @@
         >
             @if ($action)
                 @if ($action->isModalCentered())
-                    @if ($modalHeading = $action->getModalHeading())
+                    @if ($heading = $action->getModalHeading())
                         <x-tables::modal.heading>
                             {{ $modalHeading }}
                         </x-tables::modal.heading>
@@ -978,7 +978,7 @@
                     @endif
                 @else
                     <x-slot name="header">
-                        @if ($modalHeading = $action->getModalHeading())
+                        @if ($heading = $action->getModalHeading())
                             <x-tables::modal.heading>
                                 {{ $modalHeading }}
                             </x-tables::modal.heading>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -978,7 +978,7 @@
                     @endif
                 @else
                     <x-slot name="header">
-                        @if($modalHeading = $action->getModalHeading())
+                        @if ($modalHeading = $action->getModalHeading())
                             <x-tables::modal.heading>
                                 {{ $action->getModalHeading() }}
                             </x-tables::modal.heading>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -900,7 +900,7 @@
         >
             @if ($action)
                 @if ($action->isModalCentered())
-                    @if($modalHeading = $action->getModalHeading())
+                    @if ($modalHeading = $action->getModalHeading())
                         <x-tables::modal.heading>
                             {{ $modalHeading }}
                         </x-tables::modal.heading>


### PR DESCRIPTION
When setting `modalHeading()` to empty or false to hide it the markup is still rendered (empty H2 tag). This creates a weird gap between the top of the modal and its content (see screenshots).

This PR only renders the heading slot in modals when the modal heading is set.

![Screen Shot 2022-11-19 at 4 13 54 PM](https://user-images.githubusercontent.com/10107779/202841783-f764bed9-b7c4-4c28-bdb8-1a11fe24aed5.png)
![Screen Shot 2022-11-19 at 4 14 14 PM](https://user-images.githubusercontent.com/10107779/202841788-c6cc45c4-134e-41a1-975d-3bf6d7943493.png)
