### PR TITLE
Select column option assertions

### DIFF
--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -121,6 +121,10 @@ namespace Livewire\Testing {
 
         public function assertTableColumnDoesNotHaveDescription(string $name, $description, $record, $position = 'below'): static {}
 
+        public function assertSelectColumnHasOptions(string $name, array $options, $record): static {}
+
+        public function assertSelectColumnDoesNotHaveOptions(string $name, array $options, $record): static {}
+
         public function sortTable(?string $name = null, ?string $direction = null): static {}
 
         public function searchTable(?string $search = null): static {}

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -342,7 +342,7 @@ class TestsColumns
 
     public function assertSelectColumnHasOptions(): Closure
     {
-        return function(string $name, array $options, $record) {
+        return function (string $name, array $options, $record) {
             /** @phpstan-ignore-next-line */
             $this->assertTableColumnExists($name);
 
@@ -370,7 +370,7 @@ class TestsColumns
 
     public function assertSelectColumnDoesNotHaveOptions(): Closure
     {
-        return function(string $name, array $options, $record) {
+        return function (string $name, array $options, $record) {
             /** @phpstan-ignore-next-line */
             $this->assertTableColumnExists($name);
 

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -340,6 +340,62 @@ class TestsColumns
         };
     }
 
+    public function assertSelectColumnHasOptions(): Closure
+    {
+        return function(string $name, array $options, $record) {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableColumnExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $column = $livewire->getCachedTableColumn($name);
+
+            if (! ($record instanceof Model)) {
+                $record = $livewire->getTableRecord($record);
+            }
+
+            $column->record($record);
+
+            $optionsString = print_r($options, true);
+
+            Assert::assertTrue(
+                $column->getOptions() == $options,
+                message: "Failed asserting that a table column with name [{$name}] has options [{$optionsString}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertSelectColumnDoesNotHaveOptions(): Closure
+    {
+        return function(string $name, array $options, $record) {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableColumnExists($name);
+
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $column = $livewire->getCachedTableColumn($name);
+
+            if (! ($record instanceof Model)) {
+                $record = $livewire->getTableRecord($record);
+            }
+
+            $column->record($record);
+
+            $optionsString = print_r($options, true);
+
+            Assert::assertFalse(
+                $column->getOptions() == $options,
+                message: "Failed asserting that a table column with name [{$name}] does not have options [{$optionsString}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
     public function callTableColumnAction(): Closure
     {
         return function (string $name, $record = null): static {

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -120,7 +120,6 @@ it('can state whether a column has a description', function () {
 });
 
 it('can state whether a select column has options', function () {
-
     $post = Post::factory()->create();
 
     livewire(PostsTable::class)

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -118,3 +118,12 @@ it('can state whether a column has a description', function () {
         ->assertTableColumnDoesNotHaveDescription('with_description', 'incorrect description below', $post)
         ->assertTableColumnDoesNotHaveDescription('with_description', 'incorrect description above', $post, 'above');
 });
+
+it('can state whether a select column has options', function () {
+
+    $post = Post::factory()->create();
+
+    livewire(PostsTable::class)
+        ->assertSelectColumnHasOptions('with_options', ['red' => 'Red', 'blue' => 'Blue'], $post)
+        ->assertSelectColumnDoesNotHaveOptions('with_options', ['one' => 'One', 'two' => 'Two'], $post);
+});

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -46,8 +46,8 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
             Tables\Columns\SelectColumn::make('with_options')
                 ->options([
                     'red' => 'Red',
-                    'blue' => 'Blue'
-                ])
+                    'blue' => 'Blue',
+                ]),
         ];
     }
 

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -43,6 +43,11 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
             Tables\Columns\TextColumn::make('with_description')
                 ->description('description below')
                 ->description('description above', 'above'),
+            Tables\Columns\SelectColumn::make('with_options')
+                ->options([
+                    'red' => 'Red',
+                    'blue' => 'Blue'
+                ])
         ];
     }
 


### PR DESCRIPTION
Two assertions to check options against a `SelectColumn`:

```
assertSelectColumnHasOptions(string $name, array $options, $record)
assertSelectColumnDoesNotHaveOptions(string $name, array $options, $record)
```