### PR TITLE
fix: Diffing issues when toggling columns (TextInputColumn)

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -782,6 +782,7 @@
 
                                     <x-tables::cell
                                         :class="$getHiddenClasses($column)"
+                                        wire:key="{{ $this->id }}.table.record.{{ $recordKey }}.column.{{ $column->getName() }}"
                                         wire:loading.remove.delay
                                         wire:target="{{ implode(',', \Filament\Tables\Table::LOADING_TARGETS) }}"
                                     >


### PR DESCRIPTION
When toggling columns I get an Alpine issue with TextInputColumns. The issue appears every second time I remove the column before the TextInputColumn. Since I want to base the column state on Alpine with the other PR this should be resolved.

```
Alpine Expression Error: error is not defined

Expression: "{
            'border-gray-300': ! error,
            'dark:border-gray-600': (! error) && false,
            'border-danger-600 ring-1 ring-inset ring-danger-600': error,
        }"
```

https://user-images.githubusercontent.com/22632550/202922914-3638b388-e271-4f37-ab99-5a58c069428a.mov

I applied this to all table cells in case there are diffing issues with other components. We could also target this to the outer element of `TextInputColumn`, too.

