### PR TITLE
Default group behavior

### DIFF
--- a/packages/tables/resources/views/components/groups.blade.php
+++ b/packages/tables/resources/views/components/groups.blade.php
@@ -22,7 +22,7 @@
             </span>
 
             <x-filament::input.select wire:model="tableGrouping" class="w-full">
-                <option>-</option>
+                <option value="">-</option>
                 @foreach ($groups as $group)
                     <option value="{{ $group->getId() }}">{{ $group->getLabel() }}</option>
                 @endforeach
@@ -37,7 +37,7 @@
     </span>
 
     <x-filament::input.select wire:model="tableGrouping" size="sm" class="text-sm">
-        <option>{{ __('filament-tables::table.fields.grouping.placeholder') }}</option>
+        <option value="">{{ __('filament-tables::table.fields.grouping.placeholder') }}</option>
         @foreach ($groups as $group)
             <option value="{{ $group->getId() }}">{{ $group->getLabel() }}</option>
         @endforeach

--- a/packages/tables/src/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Concerns/CanGroupRecords.php
@@ -12,7 +12,7 @@ trait CanGroupRecords
     public function getTableGrouping(): ?Group
     {
         if (blank($this->tableGrouping)) {
-            return $this->getTable()->getDefaultGroup();
+            return $this->getTable()->hasGroups() ? null : $this->getTable()->getDefaultGroup();
         }
 
         return $this->getTable()->getGroup($this->tableGrouping) ?? $this->getTable()->getDefaultGroup();

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -104,10 +104,8 @@ trait InteractsWithTable
             $this->tableRecordsPerPage = $this->getDefaultTableRecordsPerPageSelectOption();
         }
 
-        if ($this->getTable()->hasGroups() && $this->getTable()->getDefaultGroup())
-        {
-            if (array_key_exists($this->getTable()->getDefaultGroup()->getId(), $this->getTable()->getGroups()))
-            {
+        if ($this->getTable()->hasGroups() && $this->getTable()->getDefaultGroup()) {
+            if (array_key_exists($this->getTable()->getDefaultGroup()->getId(), $this->getTable()->getGroups())) {
                 $this->tableGrouping = $this->getTable()->getDefaultGroup()->getId();
             }
         }

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -103,6 +103,14 @@ trait InteractsWithTable
         if ($this->getTable()->isPaginated()) {
             $this->tableRecordsPerPage = $this->getDefaultTableRecordsPerPageSelectOption();
         }
+
+        if ($this->getTable()->hasGroups() && $this->getTable()->getDefaultGroup())
+        {
+            if (array_key_exists($this->getTable()->getDefaultGroup()->getId(), $this->getTable()->getGroups()))
+            {
+                $this->tableGrouping = $this->getTable()->getDefaultGroup()->getId();
+            }
+        }
     }
 
     public function mountInteractsWithTable(): void

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -966,6 +966,11 @@ class Table extends ViewComponent
         return $this->getGroups()[$id] ?? null;
     }
 
+    public function hasGroups(): bool
+    {
+        return count($this->getGroups()) > 0;
+    }
+
     public function getGrouping(): ?Group
     {
         return $this->getLivewire()->getTableGrouping();


### PR DESCRIPTION
Fixes an issue where if you specify groups (so there's a dropdown grouping menu) and a default group, the page loads grouped by the default group (as one would expect) but it isn't selected on the dropdown, and you can't ever "ungroup" (by selecting the not-a-group "Group By" option).

This PR makes sure on boot that if the default group is also in the groups dropdown options, it gets selected.  And unselecting from the Group By dropdown will ungroup.

However ... I think there is a need for another option, like groupingRequired(), or perhaps a second bool arg to defaultGroup($groupId, $required), which forces the table to always be grouped.  So if not grouping required there's a "None" option on the dropdown, if required there isn't.

There is also a case to be made for adding the default group to groups, if groups are specified and default group isn't in them.

Thoughts?