### PR TITLE
Clarify documentation on MarkdownEditor file upload functionality

### DIFF
--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -1393,7 +1393,7 @@ RichEditor::make('content')
 
 ## Markdown editor
 
-The markdown editor allows you to edit and preview markdown content, as well as upload images using drang and drop.
+The markdown editor allows you to edit and preview markdown content, as well as upload images using drag and drop.
 
 ```php
 use Filament\Forms\Components\MarkdownEditor;

--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -1393,7 +1393,7 @@ RichEditor::make('content')
 
 ## Markdown editor
 
-The markdown editor allows you to edit and preview markdown content, as well as upload images.
+The markdown editor allows you to edit and preview markdown content, as well as upload images using drang and drop.
 
 ```php
 use Filament\Forms\Components\MarkdownEditor;


### PR DESCRIPTION
When reading the documentation it is not obvious how the file upload functionality of the MarkdownEditor is supposed to work. This PR adds the information on how the feature is working to the description of the MarkdownEditor field.