### PR TITLE
Dispatch events during the table reorder operations

### DIFF
--- a/packages/tables/src/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Concerns/CanReorderRecords.php
@@ -17,7 +17,7 @@ trait CanReorderRecords
             return;
         }
 
-        event(new TableSorting($this->ownerRecord));
+        event(new TableSorting($this->getOwnerRecord()));
 
         $orderColumn = $this->getTableReorderColumn();
 
@@ -32,7 +32,7 @@ trait CanReorderRecords
                 ]);
             }
 
-            event(new TableSorted($this->ownerRecord));
+            event(new TableSorted($this->getOwnerRecord()));
 
             return;
         }

--- a/packages/tables/src/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Concerns/CanReorderRecords.php
@@ -3,6 +3,8 @@
 namespace Filament\Tables\Concerns;
 
 use Filament\Tables\Contracts\HasRelationshipTable;
+use Filament\Tables\Events\TableSorted;
+use Filament\Tables\Events\TableSorting;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 trait CanReorderRecords
@@ -14,6 +16,8 @@ trait CanReorderRecords
         if (! $this->isTableReorderable()) {
             return;
         }
+
+        event(new TableSorting($this->ownerRecord));
 
         $orderColumn = $this->getTableReorderColumn();
 
@@ -28,6 +32,8 @@ trait CanReorderRecords
                 ]);
             }
 
+            event(new TableSorted($this->ownerRecord));
+
             return;
         }
 
@@ -36,6 +42,8 @@ trait CanReorderRecords
                 $orderColumn => $index + 1,
             ]);
         }
+
+        event(new TableSorted($this->ownerRecord));
     }
 
     public function toggleTableReordering(): void

--- a/packages/tables/src/Events/TableSorted.php
+++ b/packages/tables/src/Events/TableSorted.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Filament\Tables\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class TableSorted
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public Model $model)
+    {
+    }
+}

--- a/packages/tables/src/Events/TableSorting.php
+++ b/packages/tables/src/Events/TableSorting.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Filament\Tables\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class TableSorting
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public Model $model)
+    {
+    }
+}


### PR DESCRIPTION
We need to be able to run operations either before or after the table reordering operations run. This PR adds a before and after event to `Filament\Tables\Concerns\CanReorderRecords::reorderTable()` and passes the owning record as part of the event.

This mirrors a similar PR submitted against [spatie/eloquent-sortable](https://github.com/spatie/eloquent-sortable/pull/135) (in case that context is important for this PR).