### PR TITLE
Enable Customizing imageResizeUpscale

### DIFF
--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -40,6 +40,7 @@ export default (Alpine) => {
             imageResizeMode,
             imageResizeTargetHeight,
             imageResizeTargetWidth,
+            imageResizeUpscale,
             isAvatar,
             loadingIndicatorPosition,
             locale,
@@ -89,6 +90,7 @@ export default (Alpine) => {
                         imageResizeTargetHeight,
                         imageResizeTargetWidth,
                         imageResizeMode,
+                        imageResizeUpscale,
                         itemInsertLocation: shouldAppendFiles
                             ? 'after'
                             : 'before',

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -16,6 +16,7 @@
         $imageResizeTargetHeight = $getImageResizeTargetHeight();
         $imageResizeTargetWidth = $getImageResizeTargetWidth();
         $imageResizeMode = $getImageResizeMode();
+        $imageResizeUpscale = $getImageResizeUpscale();
         $shouldTransformImage = $imageCropAspectRatio || $imageResizeTargetHeight || $imageResizeTargetWidth;
     @endphp
     <div
@@ -36,6 +37,7 @@
             imageResizeMode: {{ $imageResizeMode ? "'{$imageResizeMode}'" : 'null' }},
             imageResizeTargetHeight: {{ $imageResizeTargetHeight ? "'{$imageResizeTargetHeight}'" : 'null' }},
             imageResizeTargetWidth: {{ $imageResizeTargetWidth ? "'{$imageResizeTargetWidth}'" : 'null' }},
+            imageResizeUpscale: {{ $imageResizeUpscale ? "'{$imageResizeUpscale}'" : 'null' }}
             isAvatar: {{ $isAvatar() ? 'true' : 'false' }},
             loadingIndicatorPosition: '{{ $getLoadingIndicatorPosition() }}',
             locale: @js(app()->getLocale()),

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -37,7 +37,7 @@
             imageResizeMode: {{ $imageResizeMode ? "'{$imageResizeMode}'" : 'null' }},
             imageResizeTargetHeight: {{ $imageResizeTargetHeight ? "'{$imageResizeTargetHeight}'" : 'null' }},
             imageResizeTargetWidth: {{ $imageResizeTargetWidth ? "'{$imageResizeTargetWidth}'" : 'null' }},
-            imageResizeUpscale: {{ $imageResizeUpscale ? "'{$imageResizeUpscale}'" : 'null' }}
+            imageResizeUpscale: {{ $imageResizeUpscale ? 'true' : 'false' }},
             isAvatar: {{ $isAvatar() ? 'true' : 'false' }},
             loadingIndicatorPosition: '{{ $getLoadingIndicatorPosition() }}',
             locale: @js(app()->getLocale()),

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -193,7 +193,7 @@ class FileUpload extends BaseFileUpload
         return $this->evaluate($this->imageResizeMode);
     }
 
-    public function getImageResizeUpscale(): ?bool
+    public function getImageResizeUpscale(): bool
     {
         return $this->evaluate($this->imageResizeUpscale);
     }

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -195,7 +195,7 @@ class FileUpload extends BaseFileUpload
 
     public function getImageResizeUpscale(): ?string
     {
-      return $this->evaluate($this->imageResizeUpscale);
+        return $this->evaluate($this->imageResizeUpscale);
     }
 
     public function getLoadingIndicatorPosition(): string

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -23,6 +23,8 @@ class FileUpload extends BaseFileUpload
 
     protected string | Closure | null $imageResizeMode = null;
 
+    protected string | Closure | null $imageResizeUpscale = null;
+
     protected bool | Closure $isAvatar = false;
 
     protected string | Closure $loadingIndicatorPosition = 'right';

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -193,7 +193,7 @@ class FileUpload extends BaseFileUpload
         return $this->evaluate($this->imageResizeMode);
     }
 
-    public function getImageResizeUpscale(): ?string
+    public function getImageResizeUpscale(): ?bool
     {
         return $this->evaluate($this->imageResizeUpscale);
     }

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -23,7 +23,7 @@ class FileUpload extends BaseFileUpload
 
     protected string | Closure | null $imageResizeMode = null;
 
-    protected bool | Closure | null $imageResizeUpscale = true;
+    protected bool | Closure $imageResizeUpscale = true;
 
     protected bool | Closure $isAvatar = false;
 
@@ -119,9 +119,9 @@ class FileUpload extends BaseFileUpload
         return $this;
     }
 
-    public function imageResizeUpscale(bool | Closure | null $bool): static
+    public function imageResizeUpscale(bool | Closure $condition = true): static
     {
-        $this->imageResizeUpscale = $bool;
+        $this->imageResizeUpscale = $condition;
 
         return $this;
     }

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -117,6 +117,13 @@ class FileUpload extends BaseFileUpload
         return $this;
     }
 
+    public function imageResizeUpscale(string | Closure | null $mode): static
+    {
+        $this->imageResizeUpscale = $mode;
+
+        return $this;
+    }
+
     public function loadingIndicatorPosition(string | Closure | null $position): static
     {
         $this->loadingIndicatorPosition = $position;
@@ -182,6 +189,11 @@ class FileUpload extends BaseFileUpload
     public function getImageResizeMode(): ?string
     {
         return $this->evaluate($this->imageResizeMode);
+    }
+
+    public function getImageResizeUpscale(): ?string
+    {
+      return $this->evaluate($this->imageResizeUpscale);
     }
 
     public function getLoadingIndicatorPosition(): string

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -23,7 +23,7 @@ class FileUpload extends BaseFileUpload
 
     protected string | Closure | null $imageResizeMode = null;
 
-    protected string | Closure | null $imageResizeUpscale = null;
+    protected bool | Closure | null $imageResizeUpscale = true;
 
     protected bool | Closure $isAvatar = false;
 
@@ -119,9 +119,9 @@ class FileUpload extends BaseFileUpload
         return $this;
     }
 
-    public function imageResizeUpscale(string | Closure | null $mode): static
+    public function imageResizeUpscale(bool | Closure | null $bool): static
     {
-        $this->imageResizeUpscale = $mode;
+        $this->imageResizeUpscale = $bool;
 
         return $this;
     }


### PR DESCRIPTION
This will allow devs to disable image upscaling when using the FilePond ImageResize Feature.

I need this because I was literally lost on why users uploading 3MB image are getting errors saying that the image they uploaded exceeds 10MB, and after 500 years (2 hours) of debugging I found out it's because of this.

Please accept this 😭 

Should I create tests for this be accepted?