### PR TITLE
revert: PR #2518 triggering loading indicators when closing modals.

### DIFF
--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -27,7 +27,7 @@ class Table extends ViewComponent
 
     protected string $viewIdentifier = 'table';
 
-    public const LOADING_TARGETS = ['previousPage', 'nextPage', 'gotoPage', 'sortTable', 'tableFilters', 'resetTableFiltersForm', 'tableSearchQuery', 'tableColumnSearchQueries', 'tableRecordsPerPage', '$set'];
+    public const LOADING_TARGETS = ['previousPage', 'nextPage', 'gotoPage', 'sortTable', 'tableFilters', 'resetTableFiltersForm', 'tableSearchQuery', 'tableColumnSearchQueries', 'tableRecordsPerPage'];
 
     final public function __construct(HasTable $livewire)
     {


### PR DESCRIPTION
PR #2518 added loading indicators when changing filter values, but this had the side effect that now close action on modals also triggers loading indicators on the table, even when there is no data that needs to be updated..