### PR TITLE
Include aggregated summarized columns in filter query

### DIFF
--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -1,296 +1,153 @@
 <?php
 
 namespace Livewire\Testing {
+
     use Illuminate\Support\Collection;
 
     class TestableLivewire
     {
-        public function mountTableAction(string $name, $record = null): static
-        {
-        }
-
-        public function setTableActionData(array $data): static
-        {
-        }
-
-        public function assertTableActionDataSet(array $data): static
-        {
-        }
-
-        public function callTableAction(string $name, $record = null, array $data = [], array $arguments = []): static
-        {
-        }
-
-        public function callTableColumnAction(string $name, $record = null): static
-        {
-        }
-
-        public function callMountedTableAction(array $arguments = []): static
-        {
-        }
-
-        public function assertTableActionExists(string $name): static
-        {
-        }
-
-        public function assertTableActionDoesNotExist(string $name): static
-        {
-        }
-
-        public function assertTableActionVisible(string $name, $record = null): static
-        {
-        }
-
-        public function assertTableActionHidden(string $name, $record = null): static
-        {
-        }
-
-        public function assertTableActionEnabled(string $name, $record = null): static
-        {
-        }
-
-        public function assertTableActionDisabled(string $name, $record = null): static
-        {
-        }
-
-        public function assertTableActionHalted(string $name): static
-        {
-        }
-
-        public function assertHasTableActionErrors(array $keys = []): static
-        {
-        }
-
-        public function assertHasNoTableActionErrors(array $keys = []): static
-        {
-        }
-
-        public function mountTableBulkAction(string $name, array | Collection $records): static
-        {
-        }
-
-        public function setTableBulkActionData(array $data): static
-        {
-        }
-
-        public function assertTableBulkActionDataSet(array $data): static
-        {
-        }
-
-        public function callTableBulkAction(string $name, array | Collection $records, array $data = [], array $arguments = []): static
-        {
-        }
-
-        public function callMountedTableBulkAction(array $arguments = []): static
-        {
-        }
-
-        public function assertTableBulkActionExists(string $name): static
-        {
-        }
-
-        public function assertTableBulkActionDoesNotExist(string $name): static
-        {
-        }
-
-        public function assertTableBulkActionVisible(string $name): static
-        {
-        }
-
-        public function assertTableBulkActionHidden(string $name): static
-        {
-        }
-
-        public function assertTableBulkActionEnabled(string $name): static
-        {
-        }
-
-        public function assertTableBulkActionDisabled(string $name): static
-        {
-        }
-
-        public function assertTableActionHasIcon(string $name, string $icon): static
-        {
-        }
-
-        public function assertTableActionDoesNotHaveIcon(string $name, string $icon): static
-        {
-        }
-
-        public function assertTableActionHasLabel(string $name, string $label): static
-        {
-        }
-
-        public function assertTableActionHasColor(string $name, string $color): static
-        {
-        }
-
-        public function assertTableActionDoesNotHaveColor(string $name, string $color): static
-        {
-        }
-
-        public function assertTableActionDoesNotHaveLabel(string $name, string $label): static
-        {
-        }
-
-        public function assertTableBulkActionHasIcon(string $name, string $icon): static
-        {
-        }
-
-        public function assertTableBulkActionDoesNotHaveIcon(string $name, string $icon): static
-        {
-        }
-
-        public function assertTableBulkActionHasLabel(string $name, string $label): static
-        {
-        }
-
-        public function assertTableBulkActionDoesNotHaveLabel(string $name, string $label): static
-        {
-        }
-
-        public function assertTableBulkActionHasColor(string $name, string $color): static
-        {
-        }
-
-        public function assertTableBulkActionDoesNotHaveColor(string $name, string $color): static
-        {
-        }
-
-        public function assertTableActionHasUrl(string $name, string $url): static
-        {
-        }
-
-        public function assertTableActionDoesNotHaveUrl(string $name, string $url): static
-        {
-        }
-
-        public function assertTableActionShouldOpenUrlInNewTab(string $name): static
-        {
-        }
-
-        public function assertTableActionShouldNotOpenUrlInNewTab(string $name): static
-        {
-        }
-
-        public function assertTableBulkActionHalted(string $name): static
-        {
-        }
-
-        public function assertHasTableBulkActionErrors(array $keys = []): static
-        {
-        }
-
-        public function assertHasNoTableBulkActionErrors(array $keys = []): static
-        {
-        }
-
-        public function assertCanRenderTableColumn(string $name): static
-        {
-        }
-
-        public function assertCanNotRenderTableColumn(string $name): static
-        {
-        }
-
-        public function assertTableColumnExists(string $name): static
-        {
-        }
-
-        public function assertTableColumnVisible(string $name): static
-        {
-        }
-
-        public function assertTableColumnHidden(string $name): static
-        {
-        }
-
-        public function assertTableColumnStateSet(string $name, $value, $record): static
-        {
-        }
-
-        public function assertTableColumnStateNotSet(string $name, $value, $record): static
-        {
-        }
-
-        public function assertTableColumnSummarizerExists(string $columnName, string $summarizerId): static
-        {
-        }
-
-        public function assertTableColumnSummarySet(string $columnName, string $summarizerId, $state, bool $isCurrentPaginationPageOnly = false): static
-        {
-        }
-
-        public function assertTableColumnSummaryNotSet(string $columnName, string $summarizerId, $state, bool $isCurrentPaginationPageOnly = false): static
-        {
-        }
-
-        public function assertTableColumnFormattedStateSet(string $name, $value, $record): static
-        {
-        }
-
-        public function assertTableColumnFormattedStateNotSet(string $name, $value, $record): static
-        {
-        }
-
-        public function assertTableColumnHasExtraAttributes(string $name, $value, $record): static
-        {
-        }
-
-        public function assertTableColumnDoesNotHaveExtraAttributes(string $name, $value, $record): static
-        {
-        }
-
-        public function assertTableColumnHasDescription(string $name, $description, $record, $position = 'below'): static
-        {
-        }
-
-        public function assertTableColumnDoesNotHaveDescription(string $name, $description, $record, $position = 'below'): static
-        {
-        }
-
-        public function assertTableSelectColumnHasOptions(string $name, array $options, $record): static
-        {
-        }
-
-        public function assertTableSelectColumnDoesNotHaveOptions(string $name, array $options, $record): static
-        {
-        }
-
-        public function sortTable(?string $name = null, ?string $direction = null): static
-        {
-        }
-
-        public function searchTable(?string $search = null): static
-        {
-        }
-
-        public function filterTable(string $name, $data = null): static
-        {
-        }
-
-        public function resetTableFilters(): static
-        {
-        }
-
-        public function removeTableFilter(string $filter, ?string $field = null): static
-        {
-        }
-
-        public function removeTableFilters(): static
-        {
-        }
-
-        public function assertCanSeeTableRecords(array | Collection $records, bool $inOrder = false): static
-        {
-        }
-
-        public function assertCanNotSeeTableRecords(array | Collection $records): static
-        {
-        }
-
-        public function assertCountTableRecords(int $count): static
-        {
-        }
+        public function mountTableAction(string $name, $record = null): static {}
+
+        public function setTableActionData(array $data): static {}
+
+        public function assertTableActionDataSet(array $data): static {}
+
+        public function callTableAction(string $name, $record = null, array $data = [], array $arguments = []): static {}
+
+        public function callTableColumnAction(string $name, $record = null): static {}
+
+        public function callMountedTableAction(array $arguments = []): static {}
+
+        public function assertTableActionExists(string $name): static {}
+
+        public function assertTableActionDoesNotExist(string $name): static {}
+
+        public function assertTableActionVisible(string $name, $record = null): static {}
+
+        public function assertTableActionHidden(string $name, $record = null): static {}
+
+        public function assertTableActionEnabled(string $name, $record = null): static {}
+
+        public function assertTableActionDisabled(string $name, $record = null): static {}
+
+        public function assertTableActionHalted(string $name): static {}
+
+        public function assertHasTableActionErrors(array $keys = []): static {}
+
+        public function assertHasNoTableActionErrors(array $keys = []): static {}
+
+        public function mountTableBulkAction(string $name, array|Collection $records): static {}
+
+        public function setTableBulkActionData(array $data): static {}
+
+        public function assertTableBulkActionDataSet(array $data): static {}
+
+        public function callTableBulkAction(string $name, array|Collection $records, array $data = [], array $arguments = []): static {}
+
+        public function callMountedTableBulkAction(array $arguments = []): static {}
+
+        public function assertTableBulkActionExists(string $name): static {}
+
+        public function assertTableBulkActionDoesNotExist(string $name): static {}
+
+        public function assertTableBulkActionVisible(string $name): static {}
+
+        public function assertTableBulkActionHidden(string $name): static {}
+
+        public function assertTableBulkActionEnabled(string $name): static {}
+
+        public function assertTableBulkActionDisabled(string $name): static {}
+
+        public function assertTableActionHasIcon(string $name, string $icon): static {}
+
+        public function assertTableActionDoesNotHaveIcon(string $name, string $icon): static {}
+
+        public function assertTableActionHasLabel(string $name, string $label): static {}
+
+        public function assertTableActionHasColor(string $name, string $color): static {}
+
+        public function assertTableActionDoesNotHaveColor(string $name, string $color): static {}
+
+        public function assertTableActionDoesNotHaveLabel(string $name, string $label): static {}
+
+        public function assertTableBulkActionHasIcon(string $name, string $icon): static {}
+
+        public function assertTableBulkActionDoesNotHaveIcon(string $name, string $icon): static {}
+
+        public function assertTableBulkActionHasLabel(string $name, string $label): static {}
+
+        public function assertTableBulkActionDoesNotHaveLabel(string $name, string $label): static {}
+
+        public function assertTableBulkActionHasColor(string $name, string $color): static {}
+
+        public function assertTableBulkActionDoesNotHaveColor(string $name, string $color): static {}
+
+        public function assertTableActionHasUrl(string $name, string $url): static {}
+
+        public function assertTableActionDoesNotHaveUrl(string $name, string $url): static {}
+
+        public function assertTableActionShouldOpenUrlInNewTab(string $name): static {}
+
+        public function assertTableActionShouldNotOpenUrlInNewTab(string $name): static {}
+
+        public function assertTableBulkActionHalted(string $name): static {}
+
+        public function assertHasTableBulkActionErrors(array $keys = []): static {}
+
+        public function assertHasNoTableBulkActionErrors(array $keys = []): static {}
+
+        public function assertCanRenderTableColumn(string $name): static {}
+
+        public function assertCanNotRenderTableColumn(string $name): static {}
+
+        public function assertTableColumnExists(string $name): static {}
+
+        public function assertTableColumnVisible(string $name): static {}
+
+        public function assertTableColumnHidden(string $name): static {}
+
+        public function assertTableColumnStateSet(string $name, $value, $record): static {}
+
+        public function assertTableColumnStateNotSet(string $name, $value, $record): static {}
+
+        public function assertTableColumnSummarizerExists(string $columnName, string $summarizerId): static {}
+
+        public function assertTableColumnSummarySet(string $columnName, string $summarizerId, $state, bool $isCurrentPaginationPageOnly = false): static {}
+
+        public function assertTableColumnSummaryNotSet(string $columnName, string $summarizerId, $state, bool $isCurrentPaginationPageOnly = false): static {}
+
+        public function assertTableColumnFormattedStateSet(string $name, $value, $record): static {}
+
+        public function assertTableColumnFormattedStateNotSet(string $name, $value, $record): static {}
+
+        public function assertTableColumnHasExtraAttributes(string $name, $value, $record): static {}
+
+        public function assertTableColumnDoesNotHaveExtraAttributes(string $name, $value, $record): static {}
+
+        public function assertTableColumnHasDescription(string $name, $description, $record, $position = 'below'): static {}
+
+        public function assertTableColumnDoesNotHaveDescription(string $name, $description, $record, $position = 'below'): static {}
+
+        public function assertTableSelectColumnHasOptions(string $name, array $options, $record): static {}
+
+        public function assertTableSelectColumnDoesNotHaveOptions(string $name, array $options, $record): static {}
+
+        public function sortTable(?string $name = null, ?string $direction = null): static {}
+
+        public function searchTable(?string $search = null): static {}
+
+        public function filterTable(string $name, $data = null): static {}
+
+        public function resetTableFilters(): static {}
+
+        public function removeTableFilter(string $filter, ?string $field = null): static {}
+
+        public function removeTableFilters(): static {}
+
+        public function assertCanSeeTableRecords(array|Collection $records, bool $inOrder = false): static {}
+
+        public function assertCanNotSeeTableRecords(array|Collection $records): static {}
+
+        public function assertCountTableRecords(int $count): static {}
     }
 }

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -1,153 +1,296 @@
 <?php
 
 namespace Livewire\Testing {
-
     use Illuminate\Support\Collection;
 
-    class TestableLivewire {
-        public function mountTableAction(string $name, $record = null): static {}
-
-        public function setTableActionData(array $data): static {}
-
-        public function assertTableActionDataSet(array $data): static {}
-
-        public function callTableAction(string $name, $record = null, array $data = [], array $arguments = []): static {}
-
-        public function callTableColumnAction(string $name, $record = null): static {}
-
-        public function callMountedTableAction(array $arguments = []): static {}
-
-        public function assertTableActionExists(string $name): static {}
-
-        public function assertTableActionDoesNotExist(string $name): static {}
-
-        public function assertTableActionVisible(string $name, $record = null): static {}
-
-        public function assertTableActionHidden(string $name, $record = null): static {}
-
-        public function assertTableActionEnabled(string $name, $record = null): static {}
-
-        public function assertTableActionDisabled(string $name, $record = null): static {}
-
-        public function assertTableActionHalted(string $name): static {}
-
-        public function assertHasTableActionErrors(array $keys = []): static {}
-
-        public function assertHasNoTableActionErrors(array $keys = []): static {}
-
-        public function mountTableBulkAction(string $name, array | Collection $records): static {}
-
-        public function setTableBulkActionData(array $data): static {}
-
-        public function assertTableBulkActionDataSet(array $data): static {}
-
-        public function callTableBulkAction(string $name, array | Collection $records, array $data = [], array $arguments = []): static {}
-
-        public function callMountedTableBulkAction(array $arguments = []): static {}
-
-        public function assertTableBulkActionExists(string $name): static {}
-
-        public function assertTableBulkActionDoesNotExist(string $name): static {}
-
-        public function assertTableBulkActionVisible(string $name): static {}
-
-        public function assertTableBulkActionHidden(string $name): static {}
-
-        public function assertTableBulkActionEnabled(string $name): static {}
-
-        public function assertTableBulkActionDisabled(string $name): static {}
-
-        public function assertTableActionHasIcon(string $name, string $icon): static {}
-
-        public function assertTableActionDoesNotHaveIcon(string $name, string $icon): static {}
-
-        public function assertTableActionHasLabel(string $name, string $label): static {}
-
-        public function assertTableActionHasColor(string $name, string $color): static {}
-
-        public function assertTableActionDoesNotHaveColor(string $name, string $color): static {}
-
-        public function assertTableActionDoesNotHaveLabel(string $name, string $label): static {}
-
-        public function assertTableBulkActionHasIcon(string $name, string $icon): static {}
-
-        public function assertTableBulkActionDoesNotHaveIcon(string $name, string $icon): static {}
-
-        public function assertTableBulkActionHasLabel(string $name, string $label): static {}
-
-        public function assertTableBulkActionDoesNotHaveLabel(string $name, string $label): static {}
-
-        public function assertTableBulkActionHasColor(string $name, string $color): static {}
-
-        public function assertTableBulkActionDoesNotHaveColor(string $name, string $color): static {}
-
-        public function assertTableActionHasUrl(string $name, string $url): static {}
-
-        public function assertTableActionDoesNotHaveUrl(string $name, string $url): static {}
-
-        public function assertTableActionShouldOpenUrlInNewTab(string $name): static {}
-
-        public function assertTableActionShouldNotOpenUrlInNewTab(string $name): static {}
-
-        public function assertTableBulkActionHalted(string $name): static {}
-
-        public function assertHasTableBulkActionErrors(array $keys = []): static {}
-
-        public function assertHasNoTableBulkActionErrors(array $keys = []): static {}
-
-        public function assertCanRenderTableColumn(string $name): static {}
-
-        public function assertCanNotRenderTableColumn(string $name): static {}
-
-        public function assertTableColumnExists(string $name): static {}
-
-        public function assertTableColumnVisible(string $name): static {}
-
-        public function assertTableColumnHidden(string $name): static {}
-
-        public function assertTableColumnStateSet(string $name, $value, $record): static {}
-
-        public function assertTableColumnStateNotSet(string $name, $value, $record): static {}
-
-        public function assertTableColumnSummarizerExists(string $columnName, string $summarizerId): static {}
-
-        public function assertTableColumnSummarySet(string $columnName, string $summarizerId, $state, bool $isCurrentPaginationPageOnly = false): static {}
-
-        public function assertTableColumnSummaryNotSet(string $columnName, string $summarizerId, $state, bool $isCurrentPaginationPageOnly = false): static {}
-
-        public function assertTableColumnFormattedStateSet(string $name, $value, $record): static {}
-
-        public function assertTableColumnFormattedStateNotSet(string $name, $value, $record): static {}
-
-        public function assertTableColumnHasExtraAttributes(string $name, $value, $record): static {}
-
-        public function assertTableColumnDoesNotHaveExtraAttributes(string $name, $value, $record): static {}
-
-        public function assertTableColumnHasDescription(string $name, $description, $record, $position = 'below'): static {}
-
-        public function assertTableColumnDoesNotHaveDescription(string $name, $description, $record, $position = 'below'): static {}
-
-        public function assertTableSelectColumnHasOptions(string $name, array $options, $record): static {}
-
-        public function assertTableSelectColumnDoesNotHaveOptions(string $name, array $options, $record): static {}
-
-        public function sortTable(?string $name = null, ?string $direction = null): static {}
-
-        public function searchTable(?string $search = null): static {}
-
-        public function filterTable(string $name, $data = null): static {}
-
-        public function resetTableFilters(): static {}
-
-        public function removeTableFilter(string $filter, ?string $field = null): static {}
-
-        public function removeTableFilters(): static {}
-
-        public function assertCanSeeTableRecords(array | Collection $records, bool $inOrder = false): static {}
-
-        public function assertCanNotSeeTableRecords(array | Collection $records): static {}
-
-        public function assertCountTableRecords(int $count): static {}
+    class TestableLivewire
+    {
+        public function mountTableAction(string $name, $record = null): static
+        {
+        }
+
+        public function setTableActionData(array $data): static
+        {
+        }
+
+        public function assertTableActionDataSet(array $data): static
+        {
+        }
+
+        public function callTableAction(string $name, $record = null, array $data = [], array $arguments = []): static
+        {
+        }
+
+        public function callTableColumnAction(string $name, $record = null): static
+        {
+        }
+
+        public function callMountedTableAction(array $arguments = []): static
+        {
+        }
+
+        public function assertTableActionExists(string $name): static
+        {
+        }
+
+        public function assertTableActionDoesNotExist(string $name): static
+        {
+        }
+
+        public function assertTableActionVisible(string $name, $record = null): static
+        {
+        }
+
+        public function assertTableActionHidden(string $name, $record = null): static
+        {
+        }
+
+        public function assertTableActionEnabled(string $name, $record = null): static
+        {
+        }
+
+        public function assertTableActionDisabled(string $name, $record = null): static
+        {
+        }
+
+        public function assertTableActionHalted(string $name): static
+        {
+        }
+
+        public function assertHasTableActionErrors(array $keys = []): static
+        {
+        }
+
+        public function assertHasNoTableActionErrors(array $keys = []): static
+        {
+        }
+
+        public function mountTableBulkAction(string $name, array | Collection $records): static
+        {
+        }
+
+        public function setTableBulkActionData(array $data): static
+        {
+        }
+
+        public function assertTableBulkActionDataSet(array $data): static
+        {
+        }
+
+        public function callTableBulkAction(string $name, array | Collection $records, array $data = [], array $arguments = []): static
+        {
+        }
+
+        public function callMountedTableBulkAction(array $arguments = []): static
+        {
+        }
+
+        public function assertTableBulkActionExists(string $name): static
+        {
+        }
+
+        public function assertTableBulkActionDoesNotExist(string $name): static
+        {
+        }
+
+        public function assertTableBulkActionVisible(string $name): static
+        {
+        }
+
+        public function assertTableBulkActionHidden(string $name): static
+        {
+        }
+
+        public function assertTableBulkActionEnabled(string $name): static
+        {
+        }
+
+        public function assertTableBulkActionDisabled(string $name): static
+        {
+        }
+
+        public function assertTableActionHasIcon(string $name, string $icon): static
+        {
+        }
+
+        public function assertTableActionDoesNotHaveIcon(string $name, string $icon): static
+        {
+        }
+
+        public function assertTableActionHasLabel(string $name, string $label): static
+        {
+        }
+
+        public function assertTableActionHasColor(string $name, string $color): static
+        {
+        }
+
+        public function assertTableActionDoesNotHaveColor(string $name, string $color): static
+        {
+        }
+
+        public function assertTableActionDoesNotHaveLabel(string $name, string $label): static
+        {
+        }
+
+        public function assertTableBulkActionHasIcon(string $name, string $icon): static
+        {
+        }
+
+        public function assertTableBulkActionDoesNotHaveIcon(string $name, string $icon): static
+        {
+        }
+
+        public function assertTableBulkActionHasLabel(string $name, string $label): static
+        {
+        }
+
+        public function assertTableBulkActionDoesNotHaveLabel(string $name, string $label): static
+        {
+        }
+
+        public function assertTableBulkActionHasColor(string $name, string $color): static
+        {
+        }
+
+        public function assertTableBulkActionDoesNotHaveColor(string $name, string $color): static
+        {
+        }
+
+        public function assertTableActionHasUrl(string $name, string $url): static
+        {
+        }
+
+        public function assertTableActionDoesNotHaveUrl(string $name, string $url): static
+        {
+        }
+
+        public function assertTableActionShouldOpenUrlInNewTab(string $name): static
+        {
+        }
+
+        public function assertTableActionShouldNotOpenUrlInNewTab(string $name): static
+        {
+        }
+
+        public function assertTableBulkActionHalted(string $name): static
+        {
+        }
+
+        public function assertHasTableBulkActionErrors(array $keys = []): static
+        {
+        }
+
+        public function assertHasNoTableBulkActionErrors(array $keys = []): static
+        {
+        }
+
+        public function assertCanRenderTableColumn(string $name): static
+        {
+        }
+
+        public function assertCanNotRenderTableColumn(string $name): static
+        {
+        }
+
+        public function assertTableColumnExists(string $name): static
+        {
+        }
+
+        public function assertTableColumnVisible(string $name): static
+        {
+        }
+
+        public function assertTableColumnHidden(string $name): static
+        {
+        }
+
+        public function assertTableColumnStateSet(string $name, $value, $record): static
+        {
+        }
+
+        public function assertTableColumnStateNotSet(string $name, $value, $record): static
+        {
+        }
+
+        public function assertTableColumnSummarizerExists(string $columnName, string $summarizerId): static
+        {
+        }
+
+        public function assertTableColumnSummarySet(string $columnName, string $summarizerId, $state, bool $isCurrentPaginationPageOnly = false): static
+        {
+        }
+
+        public function assertTableColumnSummaryNotSet(string $columnName, string $summarizerId, $state, bool $isCurrentPaginationPageOnly = false): static
+        {
+        }
+
+        public function assertTableColumnFormattedStateSet(string $name, $value, $record): static
+        {
+        }
+
+        public function assertTableColumnFormattedStateNotSet(string $name, $value, $record): static
+        {
+        }
+
+        public function assertTableColumnHasExtraAttributes(string $name, $value, $record): static
+        {
+        }
+
+        public function assertTableColumnDoesNotHaveExtraAttributes(string $name, $value, $record): static
+        {
+        }
+
+        public function assertTableColumnHasDescription(string $name, $description, $record, $position = 'below'): static
+        {
+        }
+
+        public function assertTableColumnDoesNotHaveDescription(string $name, $description, $record, $position = 'below'): static
+        {
+        }
+
+        public function assertTableSelectColumnHasOptions(string $name, array $options, $record): static
+        {
+        }
+
+        public function assertTableSelectColumnDoesNotHaveOptions(string $name, array $options, $record): static
+        {
+        }
+
+        public function sortTable(?string $name = null, ?string $direction = null): static
+        {
+        }
+
+        public function searchTable(?string $search = null): static
+        {
+        }
+
+        public function filterTable(string $name, $data = null): static
+        {
+        }
+
+        public function resetTableFilters(): static
+        {
+        }
+
+        public function removeTableFilter(string $filter, ?string $field = null): static
+        {
+        }
+
+        public function removeTableFilters(): static
+        {
+        }
+
+        public function assertCanSeeTableRecords(array | Collection $records, bool $inOrder = false): static
+        {
+        }
+
+        public function assertCanNotSeeTableRecords(array | Collection $records): static
+        {
+        }
+
+        public function assertCountTableRecords(int $count): static
+        {
+        }
     }
-
 }

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -4,8 +4,8 @@ namespace Livewire\Testing {
 
     use Illuminate\Support\Collection;
 
-    class TestableLivewire
-    {
+    class TestableLivewire {
+    
         public function mountTableAction(string $name, $record = null): static {}
 
         public function setTableActionData(array $data): static {}
@@ -36,13 +36,13 @@ namespace Livewire\Testing {
 
         public function assertHasNoTableActionErrors(array $keys = []): static {}
 
-        public function mountTableBulkAction(string $name, array|Collection $records): static {}
+        public function mountTableBulkAction(string $name, array | Collection $records): static {}
 
         public function setTableBulkActionData(array $data): static {}
 
         public function assertTableBulkActionDataSet(array $data): static {}
 
-        public function callTableBulkAction(string $name, array|Collection $records, array $data = [], array $arguments = []): static {}
+        public function callTableBulkAction(string $name, array | Collection $records, array $data = [], array $arguments = []): static {}
 
         public function callMountedTableBulkAction(array $arguments = []): static {}
 
@@ -144,10 +144,11 @@ namespace Livewire\Testing {
 
         public function removeTableFilters(): static {}
 
-        public function assertCanSeeTableRecords(array|Collection $records, bool $inOrder = false): static {}
+        public function assertCanSeeTableRecords(array | Collection $records, bool $inOrder = false): static {}
 
-        public function assertCanNotSeeTableRecords(array|Collection $records): static {}
+        public function assertCanNotSeeTableRecords(array | Collection $records): static {}
 
         public function assertCountTableRecords(int $count): static {}
+        
     }
 }

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -5,7 +5,6 @@ namespace Livewire\Testing {
     use Illuminate\Support\Collection;
 
     class TestableLivewire {
-    
         public function mountTableAction(string $name, $record = null): static {}
 
         public function setTableActionData(array $data): static {}
@@ -149,6 +148,6 @@ namespace Livewire\Testing {
         public function assertCanNotSeeTableRecords(array | Collection $records): static {}
 
         public function assertCountTableRecords(int $count): static {}
-        
     }
+    
 }

--- a/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
+++ b/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
@@ -121,4 +121,10 @@ trait CanAggregateRelatedModels
     {
         return $this->evaluate($this->relationshipToSum);
     }
+
+    public function hasAggregate(): bool
+    {
+        return $this->relationshipToCount || $this->relationshipToAvg ||
+            $this->relationshipToMax || $this->relationshipToMin || $this->relationshipToSum;
+    }
 }

--- a/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
+++ b/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
@@ -6,27 +6,27 @@ use Closure;
 
 trait CanAggregateRelatedModels
 {
-    protected string|Closure|null $columnToAvg = null;
+    protected string | Closure | null $columnToAvg = null;
 
-    protected string|Closure|null $relationshipToAvg = null;
+    protected string | Closure | null $relationshipToAvg = null;
 
-    protected string|Closure|null $relationshipToCount = null;
+    protected string | Closure | null $relationshipToCount = null;
 
-    protected string|Closure|null $relationshipToExistenceCheck = null;
+    protected string | Closure | null $relationshipToExistenceCheck = null;
 
-    protected string|Closure|null $columnToMax = null;
+    protected string | Closure | null $columnToMax = null;
 
-    protected string|Closure|null $relationshipToMax = null;
+    protected string | Closure | null $relationshipToMax = null;
 
-    protected string|Closure|null $columnToMin = null;
+    protected string | Closure | null $columnToMin = null;
 
-    protected string|Closure|null $relationshipToMin = null;
+    protected string | Closure | null $relationshipToMin = null;
 
-    protected string|Closure|null $columnToSum = null;
+    protected string | Closure | null $columnToSum = null;
 
-    protected string|Closure|null $relationshipToSum = null;
+    protected string | Closure | null $relationshipToSum = null;
 
-    public function avg(string|Closure|null $relationship, string|Closure|null $column): static
+    public function avg(string | Closure | null $relationship, string | Closure | null $column): static
     {
         $this->columnToAvg = $column;
         $this->relationshipToAvg = $relationship;
@@ -34,21 +34,21 @@ trait CanAggregateRelatedModels
         return $this;
     }
 
-    public function counts(string|Closure|null $relationship): static
+    public function counts(string | Closure | null $relationship): static
     {
         $this->relationshipToCount = $relationship;
 
         return $this;
     }
 
-    public function exists(string|Closure|null $relationship): static
+    public function exists(string | Closure | null $relationship): static
     {
         $this->relationshipToExistenceCheck = $relationship;
 
         return $this;
     }
 
-    public function max(string|Closure|null $relationship, string|Closure|null $column): static
+    public function max(string | Closure | null $relationship, string | Closure | null $column): static
     {
         $this->columnToMax = $column;
         $this->relationshipToMax = $relationship;
@@ -56,7 +56,7 @@ trait CanAggregateRelatedModels
         return $this;
     }
 
-    public function min(string|Closure|null $relationship, string|Closure|null $column): static
+    public function min(string | Closure | null $relationship, string | Closure | null $column): static
     {
         $this->columnToMin = $column;
         $this->relationshipToMin = $relationship;
@@ -64,7 +64,7 @@ trait CanAggregateRelatedModels
         return $this;
     }
 
-    public function sum(string|Closure|null $relationship, string|Closure|null $column): static
+    public function sum(string | Closure | null $relationship, string | Closure | null $column): static
     {
         $this->columnToSum = $column;
         $this->relationshipToSum = $relationship;

--- a/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
+++ b/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
@@ -121,10 +121,4 @@ trait CanAggregateRelatedModels
     {
         return $this->evaluate($this->relationshipToSum);
     }
-
-    public function hasAggregate(): bool
-    {
-        return $this->relationshipToCount || $this->relationshipToAvg ||
-            $this->relationshipToMax || $this->relationshipToMin || $this->relationshipToSum;
-    }
 }

--- a/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
+++ b/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
@@ -6,27 +6,27 @@ use Closure;
 
 trait CanAggregateRelatedModels
 {
-    protected string | Closure | null $columnToAvg = null;
+    protected string|Closure|null $columnToAvg = null;
 
-    protected string | Closure | null $relationshipToAvg = null;
+    protected string|Closure|null $relationshipToAvg = null;
 
-    protected string | Closure | null $relationshipToCount = null;
+    protected string|Closure|null $relationshipToCount = null;
 
-    protected string | Closure | null $relationshipToExistenceCheck = null;
+    protected string|Closure|null $relationshipToExistenceCheck = null;
 
-    protected string | Closure | null $columnToMax = null;
+    protected string|Closure|null $columnToMax = null;
 
-    protected string | Closure | null $relationshipToMax = null;
+    protected string|Closure|null $relationshipToMax = null;
 
-    protected string | Closure | null $columnToMin = null;
+    protected string|Closure|null $columnToMin = null;
 
-    protected string | Closure | null $relationshipToMin = null;
+    protected string|Closure|null $relationshipToMin = null;
 
-    protected string | Closure | null $columnToSum = null;
+    protected string|Closure|null $columnToSum = null;
 
-    protected string | Closure | null $relationshipToSum = null;
+    protected string|Closure|null $relationshipToSum = null;
 
-    public function avg(string | Closure | null $relationship, string | Closure | null $column): static
+    public function avg(string|Closure|null $relationship, string|Closure|null $column): static
     {
         $this->columnToAvg = $column;
         $this->relationshipToAvg = $relationship;
@@ -34,21 +34,21 @@ trait CanAggregateRelatedModels
         return $this;
     }
 
-    public function counts(string | Closure | null $relationship): static
+    public function counts(string|Closure|null $relationship): static
     {
         $this->relationshipToCount = $relationship;
 
         return $this;
     }
 
-    public function exists(string | Closure | null $relationship): static
+    public function exists(string|Closure|null $relationship): static
     {
         $this->relationshipToExistenceCheck = $relationship;
 
         return $this;
     }
 
-    public function max(string | Closure | null $relationship, string | Closure | null $column): static
+    public function max(string|Closure|null $relationship, string|Closure|null $column): static
     {
         $this->columnToMax = $column;
         $this->relationshipToMax = $relationship;
@@ -56,7 +56,7 @@ trait CanAggregateRelatedModels
         return $this;
     }
 
-    public function min(string | Closure | null $relationship, string | Closure | null $column): static
+    public function min(string|Closure|null $relationship, string|Closure|null $column): static
     {
         $this->columnToMin = $column;
         $this->relationshipToMin = $relationship;
@@ -64,7 +64,7 @@ trait CanAggregateRelatedModels
         return $this;
     }
 
-    public function sum(string | Closure | null $relationship, string | Closure | null $column): static
+    public function sum(string|Closure|null $relationship, string|Closure|null $column): static
     {
         $this->columnToSum = $column;
         $this->relationshipToSum = $relationship;

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -53,10 +53,10 @@ trait HasRecords
 
     protected function hydratePivotRelationForTableRecords(Collection|Paginator $records): Collection|Paginator
     {
-        $table        = $this->getTable();
+        $table = $this->getTable();
         $relationship = $table->getRelationship();
 
-        if ($table->getRelationship() instanceof BelongsToMany && !$table->allowsDuplicates()) {
+        if ($table->getRelationship() instanceof BelongsToMany && ! $table->allowsDuplicates()) {
             invade($relationship)->hydratePivotRelation($records->all());
         }
 
@@ -72,8 +72,8 @@ trait HasRecords
         $query = $this->getFilteredSortedTableQuery();
 
         if (
-            (!$this->getTable()->isPaginated()) ||
-            ($this->isTableReordering() && (!$this->getTable()->isPaginatedWhileReordering()))
+            (! $this->getTable()->isPaginated()) ||
+            ($this->isTableReordering() && (! $this->getTable()->isPaginatedWhileReordering()))
         ) {
             return $this->records = $this->hydratePivotRelationForTableRecords($query->get());
         }
@@ -87,14 +87,14 @@ trait HasRecords
             return null;
         }
 
-        if (!($this->getTable()->getRelationship() instanceof BelongsToMany)) {
+        if (! ($this->getTable()->getRelationship() instanceof BelongsToMany)) {
             return $this->getTable()->getQuery()->find($key);
         }
 
         /** @var BelongsToMany $relationship */
         $relationship = $this->getTable()->getRelationship();
 
-        $pivotClass   = $relationship->getPivotClass();
+        $pivotClass = $relationship->getPivotClass();
         $pivotKeyName = app($pivotClass)->getKeyName();
 
         $table = $this->getTable();
@@ -117,14 +117,14 @@ trait HasRecords
     {
         $table = $this->getTable();
 
-        if (!($table->getRelationship() instanceof BelongsToMany && $table->allowsDuplicates())) {
+        if (! ($table->getRelationship() instanceof BelongsToMany && $table->allowsDuplicates())) {
             return $record->getKey();
         }
 
         /** @var BelongsToMany $relationship */
         $relationship = $table->getRelationship();
 
-        $pivotClass   = $relationship->getPivotClass();
+        $pivotClass = $relationship->getPivotClass();
         $pivotKeyName = app($pivotClass)->getKeyName();
 
         return $record->getAttributeValue($pivotKeyName);

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -28,7 +28,9 @@ trait HasRecords
 
         if (! $this->getTable()->isGroupsOnly()) {
             foreach ($this->getTable()->getColumns() as $column) {
-                if ($column->isHidden()) {
+                if ($column->isHidden() ||
+                    ($this->getTable()->isGroupsOnly() && ! ($column->hasSummary() && $column->hasAggregate()))
+                ) {
                     continue;
                 }
 

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -16,7 +16,7 @@ trait HasRecords
      */
     protected bool $allowsDuplicates = false;
 
-    protected Collection|Paginator|null $records = null;
+    protected Collection | Paginator | null $records = null;
 
     public function getFilteredTableQuery(): Builder
     {
@@ -51,7 +51,7 @@ trait HasRecords
         return $query;
     }
 
-    protected function hydratePivotRelationForTableRecords(Collection|Paginator $records): Collection|Paginator
+    protected function hydratePivotRelationForTableRecords(Collection | Paginator $records): Collection | Paginator
     {
         $table = $this->getTable();
         $relationship = $table->getRelationship();
@@ -63,7 +63,7 @@ trait HasRecords
         return $records;
     }
 
-    public function getTableRecords(): Collection|Paginator
+    public function getTableRecords(): Collection | Paginator
     {
         if ($this->records) {
             return $this->records;

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -28,7 +28,7 @@ trait HasRecords
 
         foreach ($this->getTable()->getColumns() as $column) {
             if ($column->isHidden() ||
-                ($this->getTable()->isGroupsOnly() && !($column->hasSummary() && $column->hasAggregate()))
+                ($this->getTable()->isGroupsOnly() && ! ($column->hasSummary() && $column->hasAggregate()))
             ) {
                 continue;
             }

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -16,7 +16,7 @@ trait HasRecords
      */
     protected bool $allowsDuplicates = false;
 
-    protected Collection | Paginator | null $records = null;
+    protected Collection|Paginator|null $records = null;
 
     public function getFilteredTableQuery(): Builder
     {
@@ -26,17 +26,15 @@ trait HasRecords
 
         $this->applySearchToTableQuery($query);
 
-        if (! $this->getTable()->isGroupsOnly()) {
-            foreach ($this->getTable()->getColumns() as $column) {
-                if ($column->isHidden() ||
-                    ($this->getTable()->isGroupsOnly() && ! ($column->hasSummary() && $column->hasAggregate()))
-                ) {
-                    continue;
-                }
-
-                $column->applyEagerLoading($query);
-                $column->applyRelationshipAggregates($query);
+        foreach ($this->getTable()->getColumns() as $column) {
+            if ($column->isHidden() ||
+                ($this->getTable()->isGroupsOnly() && ! ($column->hasSummary() && $column->hasAggregate()))
+            ) {
+                continue;
             }
+
+            $column->applyEagerLoading($query);
+            $column->applyRelationshipAggregates($query);
         }
 
         return $query;
@@ -53,19 +51,19 @@ trait HasRecords
         return $query;
     }
 
-    protected function hydratePivotRelationForTableRecords(Collection | Paginator $records): Collection | Paginator
+    protected function hydratePivotRelationForTableRecords(Collection|Paginator $records): Collection|Paginator
     {
-        $table = $this->getTable();
+        $table        = $this->getTable();
         $relationship = $table->getRelationship();
 
-        if ($table->getRelationship() instanceof BelongsToMany && ! $table->allowsDuplicates()) {
+        if ($table->getRelationship() instanceof BelongsToMany && !$table->allowsDuplicates()) {
             invade($relationship)->hydratePivotRelation($records->all());
         }
 
         return $records;
     }
 
-    public function getTableRecords(): Collection | Paginator
+    public function getTableRecords(): Collection|Paginator
     {
         if ($this->records) {
             return $this->records;
@@ -74,8 +72,8 @@ trait HasRecords
         $query = $this->getFilteredSortedTableQuery();
 
         if (
-            (! $this->getTable()->isPaginated()) ||
-            ($this->isTableReordering() && (! $this->getTable()->isPaginatedWhileReordering()))
+            (!$this->getTable()->isPaginated()) ||
+            ($this->isTableReordering() && (!$this->getTable()->isPaginatedWhileReordering()))
         ) {
             return $this->records = $this->hydratePivotRelationForTableRecords($query->get());
         }
@@ -89,14 +87,14 @@ trait HasRecords
             return null;
         }
 
-        if (! ($this->getTable()->getRelationship() instanceof BelongsToMany)) {
+        if (!($this->getTable()->getRelationship() instanceof BelongsToMany)) {
             return $this->getTable()->getQuery()->find($key);
         }
 
         /** @var BelongsToMany $relationship */
         $relationship = $this->getTable()->getRelationship();
 
-        $pivotClass = $relationship->getPivotClass();
+        $pivotClass   = $relationship->getPivotClass();
         $pivotKeyName = app($pivotClass)->getKeyName();
 
         $table = $this->getTable();
@@ -119,14 +117,14 @@ trait HasRecords
     {
         $table = $this->getTable();
 
-        if (! ($table->getRelationship() instanceof BelongsToMany && $table->allowsDuplicates())) {
+        if (!($table->getRelationship() instanceof BelongsToMany && $table->allowsDuplicates())) {
             return $record->getKey();
         }
 
         /** @var BelongsToMany $relationship */
         $relationship = $table->getRelationship();
 
-        $pivotClass = $relationship->getPivotClass();
+        $pivotClass   = $relationship->getPivotClass();
         $pivotKeyName = app($pivotClass)->getKeyName();
 
         return $record->getAttributeValue($pivotKeyName);

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -28,7 +28,7 @@ trait HasRecords
 
         foreach ($this->getTable()->getColumns() as $column) {
             if ($column->isHidden() ||
-                ($this->getTable()->isGroupsOnly() && ! ($column->hasSummary() && $column->hasAggregate()))
+                ($this->getTable()->isGroupsOnly() && !($column->hasSummary() && $column->hasAggregate()))
             ) {
                 continue;
             }

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -36,7 +36,7 @@ trait HasRecords
             if ($this->getTable()->isGroupsOnly()) {
                 continue;
             }
-            
+
             $column->applyEagerLoading($query);
         }
 

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -27,13 +27,14 @@ trait HasRecords
         $this->applySearchToTableQuery($query);
 
         foreach ($this->getTable()->getColumns() as $column) {
-            if ($column->isHidden() ||
-                ($this->getTable()->isGroupsOnly() && ! ($column->hasSummary() && $column->hasAggregate()))
-            ) {
+            if ($column->isHidden() || ($this->getTable()->isGroupsOnly() && ! $column->hasSummary())) {
                 continue;
             }
 
-            $column->applyEagerLoading($query);
+            if (! $this->getTable()->isGroupsOnly()) {
+                $column->applyEagerLoading($query);
+            }
+
             $column->applyRelationshipAggregates($query);
         }
 

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -27,15 +27,17 @@ trait HasRecords
         $this->applySearchToTableQuery($query);
 
         foreach ($this->getTable()->getColumns() as $column) {
-            if ($column->isHidden() || ($this->getTable()->isGroupsOnly() && ! $column->hasSummary())) {
+            if ($column->isHidden()) {
                 continue;
             }
 
-            if (! $this->getTable()->isGroupsOnly()) {
-                $column->applyEagerLoading($query);
-            }
-
             $column->applyRelationshipAggregates($query);
+
+            if ($this->getTable()->isGroupsOnly()) {
+                continue;
+            }
+            
+            $column->applyEagerLoading($query);
         }
 
         return $query;


### PR DESCRIPTION
In getFilteredTableQuery(), in isGroupsOnly() mode, we need to include any columns that use relationship aggregating functions like sum(), that are also summarized, as these columns are based on computed attributes which won't otherwise get included in the base query, which blows up the summarizer methods.

I don't know what's going on with the formatting, btw.  I even set up a pint file watcher, but somehow it still changes a crapload of code formatting. Although perhaps the existing formatting was different from current project standards.