### PR TITLE
feat: formatStateUsing alias for form fields.

### DIFF
--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -94,6 +94,13 @@ trait HasState
         return $this;
     }
 
+    public function formatStateUsing(?Closure $callback): static
+    {
+        $this->afterStateHydrated(fn ($component) => $component->state($component->evaluate($callback)));
+
+        return $this;
+    }
+
     public function getStateToDehydrate(): array
     {
         if ($callback = $this->dehydrateStateUsing) {

--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -96,7 +96,7 @@ trait HasState
 
     public function formatStateUsing(?Closure $callback): static
     {
-        $this->afterStateHydrated(fn ($component) => $component->state($component->evaluate($callback)));
+        $this->afterStateHydrated(fn (Component $component) => $component->state($component->evaluate($callback)));
 
         return $this;
     }


### PR DESCRIPTION
People are used the convenience of `->formatStateUsing()` for table columns and often missing it on form fields. Although it's possible via `->afterStateHydrated()` that name isn't usually what you search for. 

This PR adds a `->formatStateUsing()` alias that uses `->afterStateHydrated()` under the hood on form fields.