### PR TITLE
Adding CanWrapHeader trait for columns

### DIFF
--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -4,6 +4,7 @@
     'sortable' => false,
     'sortDirection',
     'alignment' => null,
+    'wrap' => false,
 ])
 
 <th {{ $attributes->class(['filament-tables-header-cell p-0']) }}>
@@ -13,8 +14,10 @@
         @endif
         type="button"
         @class([
-            'flex items-center w-full px-4 py-2 whitespace-nowrap space-x-1 rtl:space-x-reverse font-medium text-sm text-gray-600 dark:text-gray-300',
+            'flex items-center w-full px-4 py-2 space-x-1 rtl:space-x-reverse font-medium text-sm text-gray-600 dark:text-gray-300',
             'cursor-default' => ! $sortable,
+            'whitespace-nowrap' => ! $wrap,
+            'whitespace-normal' => $wrap,
             match ($alignment) {
                 'start' => 'justify-start',
                 'center' => 'justify-center',

--- a/packages/tables/resources/views/components/summary/index.blade.php
+++ b/packages/tables/resources/views/components/summary/index.blade.php
@@ -39,11 +39,10 @@
         @foreach ($columns as $column)
             @if ($placeholderColumns || $column->hasSummary())
                 <td @class([
-                        'px-4 py-2 font-medium text-sm text-gray-600 dark:text-gray-300',
-                        'whitespace-nowrap' => ! $column->isHeaderWrapped(),
-                        'whitespace-normal' => $column->isHeaderWrapped()
-                    ])
-                >
+                    'px-4 py-2 font-medium text-sm text-gray-600 dark:text-gray-300',
+                    'whitespace-nowrap' => ! $column->isHeaderWrapped(),
+                    'whitespace-normal' => $column->isHeaderWrapped()
+                ])>
                     @if ($loop->first && (! $extraHeadingColumn))
                         <span class="text-base">
                             {{ __('filament-tables::table.summary.heading', ['label' => $pluralModelLabel]) }}

--- a/packages/tables/resources/views/components/summary/index.blade.php
+++ b/packages/tables/resources/views/components/summary/index.blade.php
@@ -38,7 +38,12 @@
 
         @foreach ($columns as $column)
             @if ($placeholderColumns || $column->hasSummary())
-                <td class="px-4 py-2 whitespace-nowrap font-medium text-sm text-gray-600 dark:text-gray-300">
+                <td @class([
+                        'px-4 py-2 font-medium text-sm text-gray-600 dark:text-gray-300',
+                        'whitespace-nowrap' => ! $column->isHeaderWrapped(),
+                        'whitespace-normal' => $column->isHeaderWrapped()
+                    ])
+                >
                     @if ($loop->first && (! $extraHeadingColumn))
                         <span class="text-base">
                             {{ __('filament-tables::table.summary.heading', ['label' => $pluralModelLabel]) }}

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -718,6 +718,7 @@
                                 :sort-direction="$getSortDirection()"
                                 :class="$getHiddenClasses($column)"
                                 :attributes="$column->getExtraHeaderAttributeBag()"
+                                :wrap="$column->isHeaderWrapped()"
                             >
                                 {{ $column->getLabel() }}
                             </x-filament-tables::header-cell>

--- a/packages/tables/src/Columns/Column.php
+++ b/packages/tables/src/Columns/Column.php
@@ -23,6 +23,7 @@ class Column extends ViewComponent
     use Concerns\CanGrow;
     use Concerns\CanOpenUrl;
     use Concerns\CanSpanColumns;
+    use Concerns\CanWrapHeader;
     use Concerns\HasAlignment;
     use Concerns\HasExtraHeaderAttributes;
     use Concerns\HasLabel;

--- a/packages/tables/src/Columns/Concerns/CanWrapHeader.php
+++ b/packages/tables/src/Columns/Concerns/CanWrapHeader.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Filament\Tables\Columns\Concerns;
+
+use Closure;
+
+trait CanWrapHeader
+{
+    protected bool | Closure $isHeaderWrapped = false;
+
+    public function wrapHeader(bool | Closure $condition = true): static
+    {
+        $this->isHeaderWrapped = $condition;
+
+        return $this;
+    }
+
+    public function isHeaderWrapped(): bool
+    {
+        return (bool) $this->evaluate($this->isHeaderWrapped);
+    }
+}


### PR DESCRIPTION
Yes, wrapped headers are fugly, but sometimes we have no choice.

<img width="884" alt="2022-11-30_08-18-26" src="https://user-images.githubusercontent.com/934456/204819708-b47be970-a5da-4396-99ac-52e48692e2aa.png">

... vs ...

<img width="847" alt="2022-11-30_08-13-29" src="https://user-images.githubusercontent.com/934456/204819739-ec834a3a-7310-49f1-a154-e55e63d53a77.png">
