### PR TITLE
Update MakeUserCommand to make it inline fillable

### DIFF
--- a/packages/admin/src/Commands/MakeUserCommand.php
+++ b/packages/admin/src/Commands/MakeUserCommand.php
@@ -27,9 +27,9 @@ class MakeUserCommand extends Command
     protected function getUserData(): array
     {
         return [
-            'name' => $this->validateInput(fn () => $this->options['name'] ?? $this->ask('Name'), 'name', ['required'], fn () => unset($this->options['name'])),
-            'email' => $this->validateInput(fn () => $this->options['email'] ?? $this->ask('Email address'), 'email', ['required', 'email', 'unique:' . $this->getUserModel()], fn () => unset($this->options['email'])),
-            'password' => Hash::make($this->validateInput(fn () => $this->options['password'] ?? $this->secret('Password'), 'password', ['required', 'min:8'], fn () => unset($this->options['password']))),
+            'name' => $this->validateInput(fn () => $this->options['name'] ?? $this->ask('Name'), 'name', ['required'], fn () => $this->options['name'] = null),
+            'email' => $this->validateInput(fn () => $this->options['email'] ?? $this->ask('Email address'), 'email', ['required', 'email', 'unique:' . $this->getUserModel()], fn () => $this->options['email'] = null),
+            'password' => Hash::make($this->validateInput(fn () => $this->options['password'] ?? $this->secret('Password'), 'password', ['required', 'min:8'], fn () => $this->options['password'] = null)),
         ];
     }
 

--- a/packages/admin/src/Commands/MakeUserCommand.php
+++ b/packages/admin/src/Commands/MakeUserCommand.php
@@ -10,7 +10,6 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Facades\Validator;
 
 class MakeUserCommand extends Command
 {

--- a/packages/admin/src/Commands/MakeUserCommand.php
+++ b/packages/admin/src/Commands/MakeUserCommand.php
@@ -19,9 +19,7 @@ class MakeUserCommand extends Command
 
     protected $signature = 'make:filament-user {--name= : The name of the user} {--email= : A valid and unique email address} {--password= : The password for the user (min. 8 characters)}';
 
-    protected $options;
-
-
+    protected array $options;
 
     protected function getUserData(): array
     {
@@ -77,7 +75,6 @@ class MakeUserCommand extends Command
 
     public function handle(): int
     {
-
         $this->options = $this->options();
 
         $user = $this->createUser();

--- a/packages/admin/src/Commands/MakeUserCommand.php
+++ b/packages/admin/src/Commands/MakeUserCommand.php
@@ -26,9 +26,9 @@ class MakeUserCommand extends Command
     protected function getUserData(): array
     {
         return [
-            'name' => $this->validateInput(fn () => $this->options['name']??$this->ask('Name'), 'name', ['required'], function () { unset($this->options['name']);}),
-            'email' => $this->validateInput(fn () => $this->options['email']??$this->ask('Email address'), 'email', ['required', 'email', 'unique:' . $this->getUserModel()], function () { unset($this->options['email']);}),
-            'password' => Hash::make($this->validateInput(fn () => $this->options['password']??$this->secret('Password'), 'password', ['required', 'min:8'], function () { unset($this->options['password']);})),
+            'name' => $this->validateInput(fn () => $this->options['name'] ?? $this->ask('Name'), 'name', ['required'], fn () => unset($this->options['name'])),
+            'email' => $this->validateInput(fn () => $this->options['email'] ?? $this->ask('Email address'), 'email', ['required', 'email', 'unique:' . $this->getUserModel()], fn () => unset($this->options['email'])),
+            'password' => Hash::make($this->validateInput(fn () => $this->options['password'] ?? $this->secret('Password'), 'password', ['required', 'min:8'], fn () => unset($this->options['password']))),
         ];
     }
 

--- a/packages/admin/src/Commands/MakeUserCommand.php
+++ b/packages/admin/src/Commands/MakeUserCommand.php
@@ -17,7 +17,10 @@ class MakeUserCommand extends Command
 
     protected $description = 'Creates a Filament user.';
 
-    protected $signature = 'make:filament-user {--name= : The name of the user} {--email= : A valid and unique email address} {--password= : The password for the user (min. 8 characters)}';
+    protected $signature = 'make:filament-user
+                            {--name= : The name of the user}
+                            {--email= : A valid and unique email address}
+                            {--password= : The password for the user (min. 8 characters)}';
 
     protected array $options;
 

--- a/packages/admin/src/Commands/MakeUserCommand.php
+++ b/packages/admin/src/Commands/MakeUserCommand.php
@@ -17,14 +17,14 @@ class MakeUserCommand extends Command
 
     protected $description = 'Creates a Filament user.';
 
-    protected $signature = 'make:filament-user';
+    protected $signature = 'make:filament-user {--name= : The name of the user} {--email= : A valid and unique email address} {--password= : The password for the user (min. 8 characters)}';
 
     protected function getUserData(): array
     {
         return [
-            'name' => $this->validateInput(fn () => $this->ask('Name'), 'name', ['required']),
-            'email' => $this->validateInput(fn () => $this->ask('Email address'), 'email', ['required', 'email', 'unique:' . $this->getUserModel()]),
-            'password' => Hash::make($this->validateInput(fn () => $this->secret('Password'), 'password', ['required', 'min:8'])),
+            'name' => $this->validateInput(fn () => $this->option('name')??$this->ask('Name'), 'name', ['required']),
+            'email' => $this->validateInput(fn () => $this->option('email')??$this->ask('Email address'), 'email', ['required', 'email', 'unique:' . $this->getUserModel()]),
+            'password' => Hash::make($this->validateInput(fn () => $this->option('password')??$this->secret('Password'), 'password', ['required', 'min:8'])),
         ];
     }
 

--- a/packages/admin/src/Commands/MakeUserCommand.php
+++ b/packages/admin/src/Commands/MakeUserCommand.php
@@ -80,23 +80,6 @@ class MakeUserCommand extends Command
 
         $this->options = $this->options();
 
-        $validation = Validator::make($this->options, [
-            'name'=>'required',
-            'email'=>'required:email:unique:' . $this->getUserModel(),
-            'password'=>'required:min:8',
-        ]);
-
-        $validation->validate();
-
-        if($validation->fails())
-        {
-            dd($validation->failed);
-        }
-
-
-
-
-
         $user = $this->createUser();
 
         $this->sendSuccessMessage($user);

--- a/packages/support/src/Commands/Concerns/CanValidateInput.php
+++ b/packages/support/src/Commands/Concerns/CanValidateInput.php
@@ -12,7 +12,7 @@ trait CanValidateInput
         return $this->validateInput(fn () => $this->ask($question, $default), $field, ['required']);
     }
 
-    protected function validateInput(Closure $callback, string $field, array $rules): string
+    protected function validateInput(Closure $callback, string $field, array $rules, ?Closure $fallback = null): string
     {
         $input = $callback();
 
@@ -23,6 +23,10 @@ trait CanValidateInput
 
         if ($validator->fails()) {
             $this->error($validator->errors()->first());
+            if($fallback !== null)
+            {
+                $fallback();
+            }
 
             $input = $this->validateInput($callback, $field, $rules);
         }

--- a/packages/support/src/Commands/Concerns/CanValidateInput.php
+++ b/packages/support/src/Commands/Concerns/CanValidateInput.php
@@ -12,7 +12,7 @@ trait CanValidateInput
         return $this->validateInput(fn () => $this->ask($question, $default), $field, ['required']);
     }
 
-    protected function validateInput(Closure $callback, string $field, array $rules, ?Closure $fallback = null): string
+    protected function validateInput(Closure $callback, string $field, array $rules, ?Closure $onError = null): string
     {
         $input = $callback();
 
@@ -23,9 +23,9 @@ trait CanValidateInput
 
         if ($validator->fails()) {
             $this->error($validator->errors()->first());
-            if($fallback !== null)
-            {
-                $fallback();
+            
+            if ($onError) {
+                $onError($validator);
             }
 
             $input = $this->validateInput($callback, $field, $rules);


### PR DESCRIPTION
This makes the artisan command make:filament-user inline fillable by using

<img width="575" alt="Captura de pantalla 2022-11-30 a la(s) 4 49 00 p m" src="https://user-images.githubusercontent.com/47951932/204915342-d897bd3d-f775-4afb-96a5-66bfcc183b70.png">

The PR also includes the --help options description and the options can be non-used inline: in that case, each option not used there will be prompted.
