### PR TITLE
Feat: Add action color methods

### DIFF
--- a/packages/support/src/Actions/Concerns/HasColor.php
+++ b/packages/support/src/Actions/Concerns/HasColor.php
@@ -15,6 +15,31 @@ trait HasColor
         return $this;
     }
 
+    public function colorDanger(): static
+    {
+        return $this->color('danger');
+    }
+
+    public function colorPrimary(): static
+    {
+        return $this->color('primary');
+    }
+
+    public function colorSecondary(): static
+    {
+        return $this->color('secondary');
+    }
+
+    public function colorSuccess(): static
+    {
+        return $this->color('success');
+    }
+
+    public function colorWarning(): static
+    {
+        return $this->color('warning');
+    }
+
     public function getColor(): ?string
     {
         return $this->evaluate($this->color);

--- a/packages/support/src/Actions/Concerns/HasColor.php
+++ b/packages/support/src/Actions/Concerns/HasColor.php
@@ -17,27 +17,37 @@ trait HasColor
 
     public function colorDanger(): static
     {
-        return $this->color('danger');
+        $this->color('danger');
+        
+        return $this;
     }
 
     public function colorPrimary(): static
     {
-        return $this->color('primary');
+        $this->color('primary');
+        
+        return $this;
     }
 
     public function colorSecondary(): static
     {
-        return $this->color('secondary');
+        $this->color('secondary');
+        
+        return $this;
     }
 
     public function colorSuccess(): static
     {
-        return $this->color('success');
+        $this->color('success');
+        
+        return $this;
     }
 
     public function colorWarning(): static
     {
-        return $this->color('warning');
+        $this->color('warning');
+        
+        return $this;
     }
 
     public function getColor(): ?string


### PR DESCRIPTION
discussed in: https://github.com/filamentphp/filament/discussions/5119

was orignally going to use `success`, `warning`, `primary`, etc methods. However it turns out `->success()` is already being used in `Action` class

https://github.com/filamentphp/filament/blob/884ab2d7be48ea7d05cba2e81aace75c42a1afae/packages/support/src/Actions/Action.php#L53-L57