### PR TITLE
revert #5132 additional color functions

### DIFF
--- a/packages/support/src/Actions/Concerns/HasColor.php
+++ b/packages/support/src/Actions/Concerns/HasColor.php
@@ -15,41 +15,6 @@ trait HasColor
         return $this;
     }
 
-    public function colorDanger(): static
-    {
-        $this->color('danger');
-
-        return $this;
-    }
-
-    public function colorPrimary(): static
-    {
-        $this->color('primary');
-
-        return $this;
-    }
-
-    public function colorSecondary(): static
-    {
-        $this->color('secondary');
-
-        return $this;
-    }
-
-    public function colorSuccess(): static
-    {
-        $this->color('success');
-
-        return $this;
-    }
-
-    public function colorWarning(): static
-    {
-        $this->color('warning');
-
-        return $this;
-    }
-
     public function getColor(): ?string
     {
         return $this->evaluate($this->color);


### PR DESCRIPTION
@danharrin: @zepfietje and I discussed #5132 on Discord and are not sure whether we need this.

1) For consistency we should have this everywhere where we have `->color()`
2) It adds more classes to autocomplete and makes it harder to find stuff.
3) We would prefer a Color enum that can be type-hinted (v3 will probably arrive around the same time as Laravel 10 and therefore we can go on PHP 8.1)
