### PR TITLE
Wrong behavior on removeTableFilters when state is false

### DIFF
--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -103,6 +103,7 @@ trait HasFilters
             $field->state(match (true) {
                 is_array($state) => [],
                 $state === true => false,
+                $state === false => false,
                 default => null,
             });
         }

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -102,8 +102,7 @@ trait HasFilters
 
             $field->state(match (true) {
                 is_array($state) => [],
-                $state === true => false,
-                $state === false => false,
+                is_bool($state) => false,
                 default => null,
             });
         }


### PR DESCRIPTION
Hello,

This PR fixes a bug that happens when you delete all activated filters with the "remove_all" button.

It behaves wrongly on the desactivated filters, which the isActive state is false, and ends up with a null value.

In the `InteractsWithTableQuery`trait and the `apply` method, if the state is null, it consider it true, and apply the filter to the query. Which is not the expected behavior.

@see : [The line in question](https://github.com/filamentphp/filament/blob/30ab1c3bcf4bd718e9af03e46944ac8e728e4507/packages/tables/src/Filters/Concerns/InteractsWithTableQuery.php#L22)