### PR TITLE
Preserve table sort while reordering

### DIFF
--- a/packages/tables/docs/02-getting-started.md
+++ b/packages/tables/docs/02-getting-started.md
@@ -479,6 +479,17 @@ protected function isTablePaginationEnabledWhileReordering(): bool
 }
 ```
 
+### Preserve order sort direction while reordering
+
+To sort always in ascending while reordering you can use:
+
+```php
+protected function preserveTableOrderWhileReordering(): bool
+{
+    return false;
+}
+```
+
 ## Polling content
 
 You may poll table content so that it refreshes at a set interval, using the `getTablePollingInterval()` method:

--- a/packages/tables/src/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Concerns/CanReorderRecords.php
@@ -11,7 +11,7 @@ trait CanReorderRecords
 
     public function reorderTable(array $order): void
     {
-        if (!$this->isTableReorderable()) {
+        if (! $this->isTableReorderable()) {
             return;
         }
 

--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -55,7 +55,7 @@ trait CanSortRecords
 
     protected function applySortingToTableQuery(Builder $query): Builder
     {
-        if ($this->isTableReordering()) {
+        if ($this->isTableReordering() && !$this->preserveTableOrderWhileReordering()) {
             return $query->orderBy($this->getTableReorderColumn());
         }
 

--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -55,7 +55,7 @@ trait CanSortRecords
 
     protected function applySortingToTableQuery(Builder $query): Builder
     {
-        if ($this->isTableReordering() && !$this->preserveTableOrderWhileReordering()) {
+        if ($this->isTableReordering() && ! $this->preserveTableOrderWhileReordering()) {
             return $query->orderBy($this->getTableReorderColumn());
         }
 


### PR DESCRIPTION
Hi,
this is my first ever contribution to a github project so i hope i'm doing all correct.

I'm using in my websites your really good package and i found out that when reordering default sorting back always to ascending.
I really appreciate if this code i've changed can be accepted or improved for making my projects easier.
I tested in a simple situation ->defaultSort('position', 'desc') and isTablePaginationEnabledWhileReordering() = true

Let me know
Thanks!

PS. i made a private function to retrive the new position two time in the code
but i don't know if it's a good practice or the right spot for packages code