### PR TITLE
Add ability to merge extra (alpine/input/trigger/img/header) attributes instead of overwriting them

### DIFF
--- a/packages/forms/src/Components/Concerns/HasExtraInputAttributes.php
+++ b/packages/forms/src/Components/Concerns/HasExtraInputAttributes.php
@@ -12,7 +12,7 @@ trait HasExtraInputAttributes
     public function extraInputAttributes(array | Closure $attributes, bool $merge = false): static
     {
         if ($merge) {
-            $attributes = array_merge($this->getExtraInputAttributes(), $attributes);
+            $attributes = $this->getExtraInputAttributeBag()->merge($this->evaluate($attributes))->getAttributes();
         }
 
         $this->extraInputAttributes = $attributes;

--- a/packages/forms/src/Components/Concerns/HasExtraInputAttributes.php
+++ b/packages/forms/src/Components/Concerns/HasExtraInputAttributes.php
@@ -9,7 +9,7 @@ trait HasExtraInputAttributes
 {
     protected array $extraInputAttributes = [];
 
-    public function extraInputAttributes(array|Closure $attributes, bool $merge = false): static
+    public function extraInputAttributes(array | Closure $attributes, bool $merge = false): static
     {
         if ($merge) {
             $this->extraInputAttributes[] = $attributes;

--- a/packages/forms/src/Components/Concerns/HasExtraInputAttributes.php
+++ b/packages/forms/src/Components/Concerns/HasExtraInputAttributes.php
@@ -9,8 +9,12 @@ trait HasExtraInputAttributes
 {
     protected array | Closure $extraInputAttributes = [];
 
-    public function extraInputAttributes(array | Closure $attributes): static
+    public function extraInputAttributes(array | Closure $attributes, bool $merge = false): static
     {
+        if ($merge) {
+            $attributes = array_merge($this->getExtraInputAttributes(), $attributes);
+        }
+
         $this->extraInputAttributes = $attributes;
 
         return $this;

--- a/packages/forms/src/Components/Concerns/HasExtraInputAttributes.php
+++ b/packages/forms/src/Components/Concerns/HasExtraInputAttributes.php
@@ -7,22 +7,28 @@ use Illuminate\View\ComponentAttributeBag;
 
 trait HasExtraInputAttributes
 {
-    protected array | Closure $extraInputAttributes = [];
+    protected array $extraInputAttributes = [];
 
-    public function extraInputAttributes(array | Closure $attributes, bool $merge = false): static
+    public function extraInputAttributes(array|Closure $attributes, bool $merge = false): static
     {
         if ($merge) {
-            $attributes = $this->getExtraInputAttributeBag()->merge($this->evaluate($attributes))->getAttributes();
+            $this->extraInputAttributes[] = $attributes;
+        } else {
+            $this->extraInputAttributes = [$attributes];
         }
-
-        $this->extraInputAttributes = $attributes;
 
         return $this;
     }
 
     public function getExtraInputAttributes(): array
     {
-        return $this->evaluate($this->extraInputAttributes);
+        $temporaryAttributeBag = new ComponentAttributeBag();
+
+        foreach ($this->extraInputAttributes as $extraInputAttributes) {
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraInputAttributes));
+        }
+
+        return $temporaryAttributeBag->getAttributes();
     }
 
     public function getExtraInputAttributeBag(): ComponentAttributeBag

--- a/packages/forms/src/Components/DateTimePicker.php
+++ b/packages/forms/src/Components/DateTimePicker.php
@@ -18,7 +18,7 @@ class DateTimePicker extends Field
 
     protected string | Closure | null $displayFormat = null;
 
-    protected array | Closure $extraTriggerAttributes = [];
+    protected array $extraTriggerAttributes = [];
 
     protected int | null $firstDayOfWeek = null;
 
@@ -96,13 +96,13 @@ class DateTimePicker extends Field
         return $this;
     }
 
-    public function extraTriggerAttributes(array | Closure $attributes, bool $merge = false): static
+    public function extraTriggerAttributes(array|Closure $attributes, bool $merge = false): static
     {
         if ($merge) {
-            $attributes = $this->getExtraTriggerAttributeBag()->merge($this->evaluate($attributes))->getAttributes();
+            $this->extraAttributes[] = $attributes;
+        } else {
+            $this->extraAttributes = [$attributes];
         }
-
-        $this->extraTriggerAttributes = $attributes;
 
         return $this;
     }
@@ -256,7 +256,13 @@ class DateTimePicker extends Field
 
     public function getExtraTriggerAttributes(): array
     {
-        return $this->evaluate($this->extraTriggerAttributes);
+        $temporaryAttributeBag = new ComponentAttributeBag();
+
+        foreach ($this->extraTriggerAttributes as $extraTriggerAttributes) {
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraTriggerAttributes));
+        }
+
+        return $temporaryAttributeBag->getAttributes();
     }
 
     public function getExtraTriggerAttributeBag(): ComponentAttributeBag

--- a/packages/forms/src/Components/DateTimePicker.php
+++ b/packages/forms/src/Components/DateTimePicker.php
@@ -96,8 +96,12 @@ class DateTimePicker extends Field
         return $this;
     }
 
-    public function extraTriggerAttributes(array | Closure $attributes): static
+    public function extraTriggerAttributes(array | Closure $attributes, bool $merge = false): static
     {
+        if ($merge) {
+            $attributes = array_merge($this->getExtraTriggerAttributes(), $attributes);
+        }
+
         $this->extraTriggerAttributes = $attributes;
 
         return $this;

--- a/packages/forms/src/Components/DateTimePicker.php
+++ b/packages/forms/src/Components/DateTimePicker.php
@@ -96,7 +96,7 @@ class DateTimePicker extends Field
         return $this;
     }
 
-    public function extraTriggerAttributes(array|Closure $attributes, bool $merge = false): static
+    public function extraTriggerAttributes(array | Closure $attributes, bool $merge = false): static
     {
         if ($merge) {
             $this->extraAttributes[] = $attributes;

--- a/packages/forms/src/Components/DateTimePicker.php
+++ b/packages/forms/src/Components/DateTimePicker.php
@@ -99,7 +99,7 @@ class DateTimePicker extends Field
     public function extraTriggerAttributes(array | Closure $attributes, bool $merge = false): static
     {
         if ($merge) {
-            $attributes = array_merge($this->getExtraTriggerAttributes(), $attributes);
+            $attributes = $this->getExtraTriggerAttributeBag()->merge($this->evaluate($attributes))->getAttributes();
         }
 
         $this->extraTriggerAttributes = $attributes;

--- a/packages/support/src/Concerns/HasExtraAlpineAttributes.php
+++ b/packages/support/src/Concerns/HasExtraAlpineAttributes.php
@@ -7,22 +7,28 @@ use Illuminate\View\ComponentAttributeBag;
 
 trait HasExtraAlpineAttributes
 {
-    protected array | Closure $extraAlpineAttributes = [];
+    protected array $extraAlpineAttributes = [];
 
     public function extraAlpineAttributes(array | Closure $attributes, bool $merge = false): static
     {
-        if ($merge) {
-            $attributes = $this->getExtraAlpineAttributeBag()->merge($this->evaluate($attributes))->getAttributes();
-        }
-
-        $this->extraAlpineAttributes = $attributes;
+		if ($merge) {
+			$this->extraAlpineAttributes[] = $attributes;
+		} else {
+			$this->extraAlpineAttributes = [$attributes];
+		}
 
         return $this;
     }
 
     public function getExtraAlpineAttributes(): array
     {
-        return $this->evaluate($this->extraAlpineAttributes);
+	    $temporaryAttributeBag = new ComponentAttributeBag();
+	
+	    foreach ($this->extraAlpineAttributes as $extraAlpineAttributes) {
+		    $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraAlpineAttributes));
+	    }
+	
+	    return $temporaryAttributeBag->getAttributes();
     }
 
     public function getExtraAlpineAttributeBag(): ComponentAttributeBag

--- a/packages/support/src/Concerns/HasExtraAlpineAttributes.php
+++ b/packages/support/src/Concerns/HasExtraAlpineAttributes.php
@@ -12,7 +12,7 @@ trait HasExtraAlpineAttributes
     public function extraAlpineAttributes(array | Closure $attributes, bool $merge = false): static
     {
         if ($merge) {
-            $attributes = array_merge($this->getExtraAlpineAttributes(), $attributes);
+            $attributes = $this->getExtraAlpineAttributeBag()->merge($this->evaluate($attributes))->getAttributes();
         }
 
         $this->extraAlpineAttributes = $attributes;

--- a/packages/support/src/Concerns/HasExtraAlpineAttributes.php
+++ b/packages/support/src/Concerns/HasExtraAlpineAttributes.php
@@ -11,24 +11,24 @@ trait HasExtraAlpineAttributes
 
     public function extraAlpineAttributes(array | Closure $attributes, bool $merge = false): static
     {
-		if ($merge) {
-			$this->extraAlpineAttributes[] = $attributes;
-		} else {
-			$this->extraAlpineAttributes = [$attributes];
-		}
+        if ($merge) {
+            $this->extraAlpineAttributes[] = $attributes;
+        } else {
+            $this->extraAlpineAttributes = [$attributes];
+        }
 
         return $this;
     }
 
     public function getExtraAlpineAttributes(): array
     {
-	    $temporaryAttributeBag = new ComponentAttributeBag();
-	
-	    foreach ($this->extraAlpineAttributes as $extraAlpineAttributes) {
-		    $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraAlpineAttributes));
-	    }
-	
-	    return $temporaryAttributeBag->getAttributes();
+        $temporaryAttributeBag = new ComponentAttributeBag();
+
+        foreach ($this->extraAlpineAttributes as $extraAlpineAttributes) {
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraAlpineAttributes));
+        }
+
+        return $temporaryAttributeBag->getAttributes();
     }
 
     public function getExtraAlpineAttributeBag(): ComponentAttributeBag

--- a/packages/support/src/Concerns/HasExtraAlpineAttributes.php
+++ b/packages/support/src/Concerns/HasExtraAlpineAttributes.php
@@ -9,8 +9,12 @@ trait HasExtraAlpineAttributes
 {
     protected array | Closure $extraAlpineAttributes = [];
 
-    public function extraAlpineAttributes(array | Closure $attributes): static
+    public function extraAlpineAttributes(array | Closure $attributes, bool $merge = false): static
     {
+        if ($merge) {
+            $attributes = array_merge($this->getExtraAlpineAttributes(), $attributes);
+        }
+
         $this->extraAlpineAttributes = $attributes;
 
         return $this;

--- a/packages/support/src/Concerns/HasExtraAttributes.php
+++ b/packages/support/src/Concerns/HasExtraAttributes.php
@@ -7,22 +7,28 @@ use Illuminate\View\ComponentAttributeBag;
 
 trait HasExtraAttributes
 {
-    protected array | Closure $extraAttributes = [];
+    protected array $extraAttributes = [];
 
-    public function extraAttributes(array | Closure $attributes, bool $merge = false): static
+    public function extraAttributes(array|Closure $attributes, bool $merge = false): static
     {
-        if ($merge) {
-            $attributes = $this->getExtraAttributeBag()->merge($this->evaluate($attributes))->getAttributes();
+        if ( $merge ) {
+            $this->extraAttributes[] = $attributes;
+        } else {
+            $this->extraAttributes = [$attributes];
         }
-
-        $this->extraAttributes = $attributes;
 
         return $this;
     }
 
     public function getExtraAttributes(): array
     {
-        return $this->evaluate($this->extraAttributes);
+        $temporaryAttributeBag = new ComponentAttributeBag();
+
+        foreach ($this->extraAttributes as $extraAttributes) {
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraAttributes));
+        }
+
+        return $temporaryAttributeBag->getAttributes();
     }
 
     public function getExtraAttributeBag(): ComponentAttributeBag

--- a/packages/support/src/Concerns/HasExtraAttributes.php
+++ b/packages/support/src/Concerns/HasExtraAttributes.php
@@ -9,9 +9,9 @@ trait HasExtraAttributes
 {
     protected array $extraAttributes = [];
 
-    public function extraAttributes(array|Closure $attributes, bool $merge = false): static
+    public function extraAttributes(array | Closure $attributes, bool $merge = false): static
     {
-        if ( $merge ) {
+        if ($merge) {
             $this->extraAttributes[] = $attributes;
         } else {
             $this->extraAttributes = [$attributes];

--- a/packages/support/src/Concerns/HasExtraAttributes.php
+++ b/packages/support/src/Concerns/HasExtraAttributes.php
@@ -9,8 +9,12 @@ trait HasExtraAttributes
 {
     protected array | Closure $extraAttributes = [];
 
-    public function extraAttributes(array | Closure $attributes): static
+    public function extraAttributes(array | Closure $attributes, bool $merge = false): static
     {
+        if ($merge) {
+            $attributes = array_merge($this->getExtraAttributes(), $attributes);
+        }
+
         $this->extraAttributes = $attributes;
 
         return $this;

--- a/packages/support/src/Concerns/HasExtraAttributes.php
+++ b/packages/support/src/Concerns/HasExtraAttributes.php
@@ -12,7 +12,7 @@ trait HasExtraAttributes
     public function extraAttributes(array | Closure $attributes, bool $merge = false): static
     {
         if ($merge) {
-            $attributes = array_merge($this->getExtraAttributes(), $attributes);
+            $attributes = $this->getExtraAttributeBag()->merge($this->evaluate($attributes))->getAttributes();
         }
 
         $this->extraAttributes = $attributes;

--- a/packages/tables/src/Columns/Concerns/HasExtraHeaderAttributes.php
+++ b/packages/tables/src/Columns/Concerns/HasExtraHeaderAttributes.php
@@ -3,6 +3,7 @@
 namespace Filament\Tables\Columns\Concerns;
 
 use Closure;
+use Illuminate\View\ComponentAttributeBag;
 
 trait HasExtraHeaderAttributes
 {
@@ -11,7 +12,7 @@ trait HasExtraHeaderAttributes
     public function extraHeaderAttributes(array | Closure $attributes, bool $merge = false): static
     {
         if ($merge) {
-            $attributes = array_merge($this->getExtraHeaderAttributes(), $attributes);
+            $attributes = $this->getExtraHeaderAttributeBag()->merge($this->evaluate($attributes))->getAttributes();
         }
 
         $this->extraHeaderAttributes = $attributes;
@@ -22,5 +23,10 @@ trait HasExtraHeaderAttributes
     public function getExtraHeaderAttributes(): array
     {
         return $this->evaluate($this->extraHeaderAttributes);
+    }
+
+    public function getExtraHeaderAttributeBag(): ComponentAttributeBag
+    {
+        return new ComponentAttributeBag($this->getExtraHeaderAttributes());
     }
 }

--- a/packages/tables/src/Columns/Concerns/HasExtraHeaderAttributes.php
+++ b/packages/tables/src/Columns/Concerns/HasExtraHeaderAttributes.php
@@ -7,22 +7,28 @@ use Illuminate\View\ComponentAttributeBag;
 
 trait HasExtraHeaderAttributes
 {
-    protected array | Closure $extraHeaderAttributes = [];
+    protected array $extraHeaderAttributes = [];
 
     public function extraHeaderAttributes(array | Closure $attributes, bool $merge = false): static
     {
-        if ($merge) {
-            $attributes = $this->getExtraHeaderAttributeBag()->merge($this->evaluate($attributes))->getAttributes();
-        }
-
-        $this->extraHeaderAttributes = $attributes;
+		if ($merge) {
+			$this->extraHeaderAttributes[] = $attributes;
+		} else {
+	        $this->extraHeaderAttributes = [$attributes];
+		}
 
         return $this;
     }
 
     public function getExtraHeaderAttributes(): array
     {
-        return $this->evaluate($this->extraHeaderAttributes);
+	    $temporaryAttributeBag = new ComponentAttributeBag();
+	
+	    foreach ($this->extraHeaderAttributes as $extraHeaderAttributes) {
+		    $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraHeaderAttributes));
+	    }
+	
+	    return $temporaryAttributeBag->getAttributes();
     }
 
     public function getExtraHeaderAttributeBag(): ComponentAttributeBag

--- a/packages/tables/src/Columns/Concerns/HasExtraHeaderAttributes.php
+++ b/packages/tables/src/Columns/Concerns/HasExtraHeaderAttributes.php
@@ -11,24 +11,24 @@ trait HasExtraHeaderAttributes
 
     public function extraHeaderAttributes(array | Closure $attributes, bool $merge = false): static
     {
-		if ($merge) {
-			$this->extraHeaderAttributes[] = $attributes;
-		} else {
-	        $this->extraHeaderAttributes = [$attributes];
-		}
+        if ($merge) {
+            $this->extraHeaderAttributes[] = $attributes;
+        } else {
+            $this->extraHeaderAttributes = [$attributes];
+        }
 
         return $this;
     }
 
     public function getExtraHeaderAttributes(): array
     {
-	    $temporaryAttributeBag = new ComponentAttributeBag();
-	
-	    foreach ($this->extraHeaderAttributes as $extraHeaderAttributes) {
-		    $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraHeaderAttributes));
-	    }
-	
-	    return $temporaryAttributeBag->getAttributes();
+        $temporaryAttributeBag = new ComponentAttributeBag();
+
+        foreach ($this->extraHeaderAttributes as $extraHeaderAttributes) {
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraHeaderAttributes));
+        }
+
+        return $temporaryAttributeBag->getAttributes();
     }
 
     public function getExtraHeaderAttributeBag(): ComponentAttributeBag

--- a/packages/tables/src/Columns/Concerns/HasExtraHeaderAttributes.php
+++ b/packages/tables/src/Columns/Concerns/HasExtraHeaderAttributes.php
@@ -8,8 +8,12 @@ trait HasExtraHeaderAttributes
 {
     protected array | Closure $extraHeaderAttributes = [];
 
-    public function extraHeaderAttributes(array | Closure $attributes): static
+    public function extraHeaderAttributes(array | Closure $attributes, bool $merge = false): static
     {
+        if ($merge) {
+            $attributes = array_merge($this->getExtraHeaderAttributes(), $attributes);
+        }
+
         $this->extraHeaderAttributes = $attributes;
 
         return $this;

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -190,24 +190,24 @@ class ImageColumn extends Column
 
     public function extraImgAttributes(array | Closure $attributes, bool $merge = false): static
     {
-		if ($merge) {
-			$this->extraImgAttributes[] = $attributes;
-		} else {
-			$this->extraImgAttributes = [$attributes];
-		}
+        if ($merge) {
+            $this->extraImgAttributes[] = $attributes;
+        } else {
+            $this->extraImgAttributes = [$attributes];
+        }
 
         return $this;
     }
 
     public function getExtraImgAttributes(): array
     {
-	    $temporaryAttributeBag = new ComponentAttributeBag();
-	
-	    foreach ($this->extraImgAttributes as $extraImgAttributes) {
-		    $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraImgAttributes));
-	    }
-	
-	    return $temporaryAttributeBag->getAttributes();
+        $temporaryAttributeBag = new ComponentAttributeBag();
+
+        foreach ($this->extraImgAttributes as $extraImgAttributes) {
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraImgAttributes));
+        }
+
+        return $temporaryAttributeBag->getAttributes();
     }
 
     public function getExtraImgAttributeBag(): ComponentAttributeBag

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -188,8 +188,12 @@ class ImageColumn extends Column
         return $this->evaluate($this->isSquare);
     }
 
-    public function extraImgAttributes(array | Closure $attributes): static
+    public function extraImgAttributes(array | Closure $attributes, bool $merge = false): static
     {
+        if ($merge) {
+            $attributes = array_merge($this->getExtraImgAttributes(), $merge);
+        }
+
         $this->extraImgAttributes = $attributes;
 
         return $this;

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -191,7 +191,7 @@ class ImageColumn extends Column
     public function extraImgAttributes(array | Closure $attributes, bool $merge = false): static
     {
         if ($merge) {
-            $attributes = array_merge($this->getExtraImgAttributes(), $merge);
+            $attributes = $this->getExtraImgAttributeBag()->merge($this->evaluate($attributes))->getAttributes();
         }
 
         $this->extraImgAttributes = $attributes;

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -25,7 +25,7 @@ class ImageColumn extends Column
 
     protected int | string | Closure | null $width = null;
 
-    protected array | Closure $extraImgAttributes = [];
+    protected array $extraImgAttributes = [];
 
     protected function setUp(): void
     {
@@ -190,18 +190,24 @@ class ImageColumn extends Column
 
     public function extraImgAttributes(array | Closure $attributes, bool $merge = false): static
     {
-        if ($merge) {
-            $attributes = $this->getExtraImgAttributeBag()->merge($this->evaluate($attributes))->getAttributes();
-        }
-
-        $this->extraImgAttributes = $attributes;
+		if ($merge) {
+			$this->extraImgAttributes[] = $attributes;
+		} else {
+			$this->extraImgAttributes = [$attributes];
+		}
 
         return $this;
     }
 
     public function getExtraImgAttributes(): array
     {
-        return $this->evaluate($this->extraImgAttributes);
+	    $temporaryAttributeBag = new ComponentAttributeBag();
+	
+	    foreach ($this->extraImgAttributes as $extraImgAttributes) {
+		    $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraImgAttributes));
+	    }
+	
+	    return $temporaryAttributeBag->getAttributes();
     }
 
     public function getExtraImgAttributeBag(): ComponentAttributeBag


### PR DESCRIPTION
I noticed that when I used the `->extraAttributes()` function twice on a component (for example indirectly inside a macro or function + directly using it when defining the component), that the old values would be overwritten. I didn't really expected this and I looked for a way to allow merging those attributes.

This PR introduces a second optional parameter that allows the developer to state that new attributes should be merged with the existing attributes. The merge is done using the `ComponentAttributeBag`, so that we mirror the default Laravel behaviour when merging attributes (e.g. merge classes, but overwrite `type` attribute).

I set this `$merge = false` parameter to false by default, since it would theoretically be a breaking change. Personally I'd like the parameter to be `true` by default, but that might be an idea for V3. :)

The only caveat is when using merging with existing attributes that are determined by a closure. I know directly evaluated those closures to merge the contents. There might also be a way around it, by constructing a custom Closure that evaluates the already existing attributes later, but that would probably quite increase the complexity of the code.

Thanks!