### PR TITLE
fix: Brand name wrapping when expanding sidebar

### DIFF
--- a/packages/admin/resources/views/components/brand.blade.php
+++ b/packages/admin/resources/views/components/brand.blade.php
@@ -1,6 +1,6 @@
 @if (filled($brand = config('filament.brand')))
     <div @class([
-        'filament-brand text-xl font-bold tracking-tight whitespace-nowrap',
+        'filament-brand text-xl font-bold tracking-tight',
         'dark:text-white' => config('filament.dark_mode'),
     ])>
         {{ $brand }}

--- a/packages/admin/resources/views/components/brand.blade.php
+++ b/packages/admin/resources/views/components/brand.blade.php
@@ -1,6 +1,6 @@
 @if (filled($brand = config('filament.brand')))
     <div @class([
-        'filament-brand text-xl font-bold tracking-tight whitespace-nowrap',
+        'filament-brand whitespace-nowrap text-xl font-bold tracking-tight',
         'dark:text-white' => config('filament.dark_mode'),
     ])>
         {{ $brand }}

--- a/packages/admin/resources/views/components/brand.blade.php
+++ b/packages/admin/resources/views/components/brand.blade.php
@@ -1,6 +1,6 @@
 @if (filled($brand = config('filament.brand')))
     <div @class([
-        'filament-brand text-xl font-bold tracking-tight',
+        'filament-brand text-xl font-bold tracking-tight whitespace-nowrap',
         'dark:text-white' => config('filament.dark_mode'),
     ])>
         {{ $brand }}

--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -23,6 +23,9 @@
                 'lg:px-4' => config('filament.layout.sidebar.is_collapsible_on_desktop') && (config('filament.layout.sidebar.collapsed_width') !== 0),
             ])
             x-show="$store.sidebar.isOpen || @js(! config('filament.layout.sidebar.is_collapsible_on_desktop')) || @js(config('filament.layout.sidebar.collapsed_width') === 0)"
+            x-transition:enter="lg:transition delay-100"
+            x-transition:enter-start="opacity-0"
+            x-transition:enter-end="opacity-100"
         >
             @if (config('filament.layout.sidebar.is_collapsible_on_desktop') && (config('filament.layout.sidebar.collapsed_width') !== 0))
                 <button


### PR DESCRIPTION
I think the refactoring of the sidebar reintroduced this animation papercut:

https://user-images.githubusercontent.com/22632550/205878498-ca917015-6797-4ac5-9658-8da92c54cb87.mov

