### PR TITLE
add triggerDatabaseNotificationsSentEvent function

### DIFF
--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -121,6 +121,17 @@ class Notification extends ViewComponent implements Arrayable
         return $this;
     }
 
+    public function triggerDatabaseNotificationsSentEvent(Model | Authenticatable | Collection | array $users)
+    {
+        $users = Arr::wrap($users);
+
+        foreach ($users as $user) {
+            DatabaseNotificationsSent::dispatch($user);
+        }
+
+        return $this;
+    }
+
     public function toBroadcast(): BroadcastNotification
     {
         $data = $this->toArray();


### PR DESCRIPTION
Currently if you use laravel echo, sending notifications is 2 step

Example

```php
$recipients = User::where('created_at', '<', now()->subMonth())->get();

Notification::make()
    ->title('Saved successfully')
    ->sendToDatabase($recipients);
 
foreach ($recipients as $recipient) {
    DatabaseNotificationsSent::dispatch($recipient));
}
```

This extra function make it 1 step

```php
$recipients = User::where('created_at', '<', now()->subMonth())->get();

Notification::make()
    ->title('Saved successfully')
    ->sendToDatabase($recipients)
    ->triggerDatabaseNotificationsSentEvent($recipients);
```