### PR TITLE
Add trigger db notifications sent event to notification class

### DIFF
--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -12,6 +12,7 @@ use Filament\Notifications\Concerns\HasDuration;
 use Filament\Notifications\Concerns\HasIcon;
 use Filament\Notifications\Concerns\HasId;
 use Filament\Notifications\Concerns\HasTitle;
+use Filament\Notifications\Events\DatabaseNotificationsSent;
 use Filament\Support\Components\ViewComponent;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Support\Arrayable;

--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -109,7 +109,7 @@ class Notification extends ViewComponent implements Arrayable
         return $this;
     }
 
-    public function sendToDatabase(Model | Authenticatable | Collection | array $users): static
+    public function sendToDatabase(Model | Authenticatable | Collection | array $users, bool isEventDispatched = false): static
     {
         if (! is_iterable($users)) {
             $users = [$users];
@@ -117,17 +117,10 @@ class Notification extends ViewComponent implements Arrayable
 
         foreach ($users as $user) {
             $user->notify($this->toDatabase());
-        }
-
-        return $this;
-    }
-
-    public function triggerDatabaseNotificationsSentEvent(Model | Authenticatable | Collection | array $users)
-    {
-        $users = Arr::wrap($users);
-
-        foreach ($users as $user) {
-            DatabaseNotificationsSent::dispatch($user);
+            
+            if ($isEventDispatched) {
+                DatabaseNotificationsSent::dispatch($user);
+            }
         }
 
         return $this;

--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -109,7 +109,7 @@ class Notification extends ViewComponent implements Arrayable
         return $this;
     }
 
-    public function sendToDatabase(Model | Authenticatable | Collection | array $users, bool isEventDispatched = false): static
+    public function sendToDatabase(Model | Authenticatable | Collection | array $users, bool $isEventDispatched = false): static
     {
         if (! is_iterable($users)) {
             $users = [$users];

--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -121,6 +121,17 @@ class Notification extends ViewComponent implements Arrayable
         return $this;
     }
 
+    public function triggerDatabaseNotificationsSentEvent(Model | Authenticatable | Collection | array $users)
+    {
+        $users = Arr::wrap($users);
+
+        foreach ($users as $user) {
+            DatabaseNotificationsSent::dispatch($user);
+        }
+
+        return $this;
+    }
+
     public function toBroadcast(): BroadcastNotification
     {
         $data = $this->toArray();


### PR DESCRIPTION
The bot close this PR automatically just now because I 1st created it as draft PR

For PR Details see https://github.com/filamentphp/filament/pull/5188:

Currently if you use laravel echo, sending notifications is 2 step

Example

```php
$recipients = User::where('created_at', '<', now()->subMonth())->get();

Notification::make()
    ->title('Saved successfully')
    ->sendToDatabase($recipients);
 
foreach ($recipients as $recipient) {
    DatabaseNotificationsSent::dispatch($recipient));
}
```

This extra function make it 1 step

```php
$recipients = User::where('created_at', '<', now()->subMonth())->get();

Notification::make()
    ->title('Saved successfully')
    ->sendToDatabase($recipients)
    ->triggerDatabaseNotificationsSentEvent($recipients);
```