### PR TITLE
Update 10-text-input.md

### DIFF
--- a/packages/tables/docs/03-columns/10-text-input.md
+++ b/packages/tables/docs/03-columns/10-text-input.md
@@ -21,6 +21,8 @@ TextInputColumn::make('name')
     ->rules(['required', 'max:255'])
 ```
 
+> Filament uses tooltips to display validation errors. If you want to use tooltips outside of the admin panel to display validation errors, make sure you have [`@ryangjchandler/alpine-tooltip` installed](https://github.com/ryangjchandler/alpine-tooltip#installation) in your app.
+
 ## Customizing the HTML input type
 
 You may use the `type()` method to pass a custom [HTML input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types):


### PR DESCRIPTION
Adding verbiage to clarify that validation errors won't display on standalone tables unless alpine-tooltip is installed. 

I did not include the additional verbiage found [here](https://filamentphp.com/docs/2.x/tables/columns/getting-started#tooltips) regarding Tippy, since Tippy is a dependency of ryangjchandler/alpine-tooltip