### PR TITLE
Add isViewSafe() to notification class

### DIFF
--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -62,12 +62,20 @@ class Notification extends ViewComponent implements Arrayable
             'icon' => $this->getIcon(),
             'iconColor' => $this->getIconColor(),
             'title' => $this->getTitle(),
+            'view' => $this->getView(),
         ];
     }
 
     public static function fromArray(array $data): static
     {
         $static = static::make($data['id'] ?? Str::random());
+
+        $view = $data['view'] ?? null;
+
+        if (filled($view) && ($static->getView() !== $view) && static::isViewSafe()) {
+            $static->view($data['view']);
+        }
+
         $static->actions(
             array_map(
                 fn (array $action): Action | ActionGroup => match (array_key_exists('actions', $action)) {
@@ -84,6 +92,11 @@ class Notification extends ViewComponent implements Arrayable
         $static->title($data['title'] ?? null);
 
         return $static;
+    }
+
+    protected static function isViewSafe(): bool
+    {
+        return false;
     }
 
     public function send(): static


### PR DESCRIPTION
Add isViewSafe method to Notification class. So that when extends from base Notification class , you can override isViewSafe to use the view() method to add your own view to notification

https://discord.com/channels/883083792112300104/1001249817961451540/1050016360316555274