### PR TITLE
[FIX]: fix apply callback order to relationship query

### DIFF
--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -44,12 +44,16 @@ class CheckboxList extends Field
         $this->options(static function (CheckboxList $component) use ($callback): array {
             $relationship = $component->getRelationship();
 
-            $relationshipQuery = $relationship->getRelated()->query()->orderBy($component->getRelationshipTitleColumnName());
+            $relationshipQuery = $relationship->getRelated()->query();
 
             if ($callback) {
                 $relationshipQuery = $component->evaluate($callback, [
                     'query' => $relationshipQuery,
                 ]) ?? $relationshipQuery;
+            }
+
+            if (empty($relationshipQuery->getQuery()->orders)) {
+                $relationshipQuery->orderBy($component->getRelationshipTitleColumnName());
             }
 
             if ($component->hasOptionLabelFromRecordUsingCallback()) {

--- a/packages/tables/src/Filters/Concerns/HasRelationship.php
+++ b/packages/tables/src/Filters/Concerns/HasRelationship.php
@@ -55,7 +55,7 @@ trait HasRelationship
             ]) ?? $relationshipQuery;
         }
 
-        if(empty($relationshipQuery->getQuery()->orders)) {
+        if (empty($relationshipQuery->getQuery()->orders)) {
             $relationshipQuery->orderBy($titleColumnName);
         }
 

--- a/packages/tables/src/Filters/Concerns/HasRelationship.php
+++ b/packages/tables/src/Filters/Concerns/HasRelationship.php
@@ -47,12 +47,16 @@ trait HasRelationship
 
         $titleColumnName = $this->getRelationshipTitleColumnName();
 
-        $relationshipQuery = $relationship->getRelated()->query()->orderBy($titleColumnName);
+        $relationshipQuery = $relationship->getRelated()->query();
 
         if ($this->modifyRelationshipQueryUsing) {
             $relationshipQuery = $this->evaluate($this->modifyRelationshipQueryUsing, [
                 'query' => $relationshipQuery,
             ]) ?? $relationshipQuery;
+        }
+
+        if(empty($relationshipQuery->getQuery()->orders)) {
+            $relationshipQuery->orderBy($titleColumnName);
         }
 
         return $relationshipQuery


### PR DESCRIPTION
this pull request apply order query if user order query to relationship callback query:

1- CheckboxList:
```php
CheckboxList::make('sites')->relationship('sites', 'name', fn (Builder $query) => $query->oldest('id'));
```

2- SelectFilter:
```php
SelectFilter::make('site')->relationship('sites', 'name', fn (Builder $query) => $query->oldest('id'));
```