### PR TITLE
stats overview card: add description icon position

### DIFF
--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -48,13 +48,13 @@
                     default => 'text-gray-600',
                 },
             ])>
-                @if ($descriptionIcon && $descriptionIconPosition == 'before')
+                @if ($descriptionIcon && ($descriptionIconPosition === 'before'))
                     <x-dynamic-component :component="$descriptionIcon" class="w-4 h-4" />
                 @endif
 
                 <span>{{ $description }}</span>
 
-                @if ($descriptionIcon && $descriptionIconPosition != 'before')
+                @if ($descriptionIcon && ($descriptionIconPosition !== 'before'))
                     <x-dynamic-component :component="$descriptionIcon" class="w-4 h-4" />
                 @endif
             </div>

--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -48,9 +48,13 @@
                     default => 'text-gray-600',
                 },
             ])>
+                @if ($descriptionIcon && $descriptionIconPosition == 'before')
+                    <x-dynamic-component :component="$descriptionIcon" class="w-4 h-4" />
+                @endif
+
                 <span>{{ $description }}</span>
 
-                @if ($descriptionIcon)
+                @if ($descriptionIcon && $descriptionIconPosition != 'before')
                     <x-dynamic-component :component="$descriptionIcon" class="w-4 h-4" />
                 @endif
             </div>

--- a/packages/admin/resources/views/widgets/stats-overview-widget/card.blade.php
+++ b/packages/admin/resources/views/widgets/stats-overview-widget/card.blade.php
@@ -11,6 +11,7 @@
     :description="$getDescription()"
     :description-color="$getDescriptionColor()"
     :description-icon="$getDescriptionIcon()"
+    :description-icon-position="$getDescriptionIconPosition()"
     :href="$url"
     :target="$shouldOpenUrlInNewTab() ? '_blank' : null"
     :label="$getLabel()"

--- a/packages/admin/src/Widgets/StatsOverviewWidget/Card.php
+++ b/packages/admin/src/Widgets/StatsOverviewWidget/Card.php
@@ -21,6 +21,8 @@ class Card extends Component implements Htmlable
 
     protected ?string $descriptionIcon = null;
 
+    protected ?string $descriptionIconPosition = null;
+
     protected ?string $descriptionColor = null;
 
     protected array $extraAttributes = [];
@@ -81,9 +83,10 @@ class Card extends Component implements Htmlable
         return $this;
     }
 
-    public function descriptionIcon(?string $icon): static
+    public function descriptionIcon(?string $icon, ?string $position = null): static
     {
         $this->descriptionIcon = $icon;
+        $this->descriptionIconPosition = $position;
 
         return $this;
     }
@@ -171,6 +174,11 @@ class Card extends Component implements Htmlable
     public function getDescriptionIcon(): ?string
     {
         return $this->descriptionIcon;
+    }
+
+    public function getDescriptionIconPosition(): ?string
+    {
+        return $this->descriptionIconPosition;
     }
 
     public function getExtraAttributes(): array


### PR DESCRIPTION
I want to place description icon before description text in StatsOverviewWidget.

Screenshot:
![1](https://user-images.githubusercontent.com/37311362/207198832-87c49669-a27a-47c6-b80f-643acef21f8c.png)

I extended description icon setter:
`descriptionIcon(?string $icon, ?string $position = null)`

Is it acceptable, or should it be like this?
`descriptionIcon(?string $icon)`
`descriptionIconPosition(?string $position)`

I am also not sure what to do about duplicated dynamic component.