### PR TITLE
Fix: Set component inside getAction for repeatable fields

### DIFF
--- a/packages/forms/src/Components/Concerns/HasActions.php
+++ b/packages/forms/src/Components/Concerns/HasActions.php
@@ -22,7 +22,7 @@ trait HasActions
 
     public function getAction(string $name): ?Action
     {
-        return $this->getActions()[$name] ?? null;
+        return ($this->getActions()[$name] ?? null)?->component($this);
     }
 
     public function getActions(): array


### PR DESCRIPTION
Updates HasActions trait in forms package to set the component at the action level to fix a bug in repeatable fields where the form component action was returning with the incorrect state path.