### PR TITLE
Move uploaded file if disk remote matches

### DIFF
--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -110,7 +110,7 @@ class BaseFileUpload extends Field
             /** @var FilesystemAdapter $storage */
             $storage = $component->getDisk();
 
-            if (! $storage->exists($file)) {
+            if (!$storage->exists($file)) {
                 return null;
             }
 
@@ -133,7 +133,7 @@ class BaseFileUpload extends Field
         });
 
         $this->saveUploadedFileUsing(static function (BaseFileUpload $component, TemporaryUploadedFile $file): ?string {
-            if (! $file->exists()) {
+            if (!$file->exists()) {
                 return null;
             }
 
@@ -219,7 +219,7 @@ class BaseFileUpload extends Field
 
     public function disablePreview(bool | Closure $condition = true): static
     {
-        $this->canPreview = fn (BaseFileUpload $component): bool => ! $component->evaluate($condition);
+        $this->canPreview = fn (BaseFileUpload $component): bool => !$component->evaluate($condition);
 
         return $this;
     }
@@ -238,7 +238,7 @@ class BaseFileUpload extends Field
         return $this;
     }
 
-    public function moveFile(bool | Closure $condition = false): static
+    public function moveFile(bool | Closure $condition = true): static
     {
         $this->shouldMoveFile = $condition;
 
@@ -400,7 +400,7 @@ class BaseFileUpload extends Field
 
     public function getFileNamesStatePath(): ?string
     {
-        if (! $this->fileNamesStatePath) {
+        if (!$this->fileNamesStatePath) {
             return null;
         }
 
@@ -433,7 +433,7 @@ class BaseFileUpload extends Field
                 customAttributes: ["{$name}.*" => $this->getValidationAttribute()],
             );
 
-            if (! $validator->fails()) {
+            if (!$validator->fails()) {
                 return;
             }
 
@@ -453,7 +453,7 @@ class BaseFileUpload extends Field
 
         $callback = $this->deleteUploadedFileUsing;
 
-        if (! $callback) {
+        if (!$callback) {
             return $this;
         }
 
@@ -469,7 +469,7 @@ class BaseFileUpload extends Field
         $files = $this->getState();
         $file = $files[$fileKey] ?? null;
 
-        if (! $file) {
+        if (!$file) {
             return null;
         }
 
@@ -495,7 +495,7 @@ class BaseFileUpload extends Field
         }
 
         $this->evaluate(function (BaseFileUpload $component, Closure $get, Closure $set) use ($file, $statePath) {
-            if (! $component->isMultiple()) {
+            if (!$component->isMultiple()) {
                 $set($statePath, null);
 
                 return;
@@ -513,7 +513,7 @@ class BaseFileUpload extends Field
 
     public function reorderUploadedFiles(array $fileKeys): void
     {
-        if (! $this->canReorder) {
+        if (!$this->canReorder) {
             return;
         }
 
@@ -539,7 +539,7 @@ class BaseFileUpload extends Field
 
             $callback = $this->getUploadedFileUrlUsing;
 
-            if (! $callback) {
+            if (!$callback) {
                 return [$fileKey => null];
             }
 
@@ -560,13 +560,13 @@ class BaseFileUpload extends Field
         }
 
         $state = array_filter(array_map(function (TemporaryUploadedFile | string $file) {
-            if (! $file instanceof TemporaryUploadedFile) {
+            if (!$file instanceof TemporaryUploadedFile) {
                 return $file;
             }
 
             $callback = $this->saveUploadedFileUsing;
 
-            if (! $callback) {
+            if (!$callback) {
                 $file->delete();
 
                 return $file;
@@ -605,7 +605,7 @@ class BaseFileUpload extends Field
         }
 
         $this->evaluate(function (BaseFileUpload $component, Closure $get, Closure $set) use ($file, $fileName, $statePath) {
-            if (! $component->isMultiple()) {
+            if (!$component->isMultiple()) {
                 $set($statePath, $fileName);
 
                 return;

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -41,6 +41,8 @@ class BaseFileUpload extends Field
 
     protected bool | Closure $shouldPreserveFilenames = false;
 
+    protected bool | Closure $shouldMoveFile = false;
+
     protected string | Closure | null $fileNamesStatePath = null;
 
     protected string | Closure $visibility = 'public';
@@ -136,7 +138,7 @@ class BaseFileUpload extends Field
             }
 
             /** @phpstan-ignore-next-line */
-            if ($component->getDiskName() == $file->disk) {
+            if ($component->shouldMoveFile() && $component->getDiskName() == $file->disk) {
                 $newPath = trim($component->getDirectory() . '/' . $component->getUploadedFileNameForStorage($file), '/');
 
                 $component->getDisk()->move($file->path(), $newPath);
@@ -232,6 +234,13 @@ class BaseFileUpload extends Field
     public function preserveFilenames(bool | Closure $condition = true): static
     {
         $this->shouldPreserveFilenames = $condition;
+
+        return $this;
+    }
+
+    public function moveFile(bool | Closure $condition = false): static
+    {
+        $this->shouldMoveFile = $condition;
 
         return $this;
     }
@@ -382,6 +391,11 @@ class BaseFileUpload extends Field
     public function shouldPreserveFilenames(): bool
     {
         return $this->evaluate($this->shouldPreserveFilenames);
+    }
+
+    public function shouldMoveFile(): bool
+    {
+        return $this->evaluate($this->shouldMoveFile);
     }
 
     public function getFileNamesStatePath(): ?string

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -110,7 +110,7 @@ class BaseFileUpload extends Field
             /** @var FilesystemAdapter $storage */
             $storage = $component->getDisk();
 
-            if (!$storage->exists($file)) {
+            if (! $storage->exists($file)) {
                 return null;
             }
 
@@ -133,7 +133,7 @@ class BaseFileUpload extends Field
         });
 
         $this->saveUploadedFileUsing(static function (BaseFileUpload $component, TemporaryUploadedFile $file): ?string {
-            if (!$file->exists()) {
+            if (! $file->exists()) {
                 return null;
             }
 
@@ -219,7 +219,7 @@ class BaseFileUpload extends Field
 
     public function disablePreview(bool | Closure $condition = true): static
     {
-        $this->canPreview = fn (BaseFileUpload $component): bool => !$component->evaluate($condition);
+        $this->canPreview = fn (BaseFileUpload $component): bool => ! $component->evaluate($condition);
 
         return $this;
     }
@@ -400,7 +400,7 @@ class BaseFileUpload extends Field
 
     public function getFileNamesStatePath(): ?string
     {
-        if (!$this->fileNamesStatePath) {
+        if (! $this->fileNamesStatePath) {
             return null;
         }
 
@@ -433,7 +433,7 @@ class BaseFileUpload extends Field
                 customAttributes: ["{$name}.*" => $this->getValidationAttribute()],
             );
 
-            if (!$validator->fails()) {
+            if (! $validator->fails()) {
                 return;
             }
 
@@ -453,7 +453,7 @@ class BaseFileUpload extends Field
 
         $callback = $this->deleteUploadedFileUsing;
 
-        if (!$callback) {
+        if (! $callback) {
             return $this;
         }
 
@@ -469,7 +469,7 @@ class BaseFileUpload extends Field
         $files = $this->getState();
         $file = $files[$fileKey] ?? null;
 
-        if (!$file) {
+        if (! $file) {
             return null;
         }
 
@@ -495,7 +495,7 @@ class BaseFileUpload extends Field
         }
 
         $this->evaluate(function (BaseFileUpload $component, Closure $get, Closure $set) use ($file, $statePath) {
-            if (!$component->isMultiple()) {
+            if (! $component->isMultiple()) {
                 $set($statePath, null);
 
                 return;
@@ -513,7 +513,7 @@ class BaseFileUpload extends Field
 
     public function reorderUploadedFiles(array $fileKeys): void
     {
-        if (!$this->canReorder) {
+        if (! $this->canReorder) {
             return;
         }
 
@@ -539,7 +539,7 @@ class BaseFileUpload extends Field
 
             $callback = $this->getUploadedFileUrlUsing;
 
-            if (!$callback) {
+            if (! $callback) {
                 return [$fileKey => null];
             }
 
@@ -560,13 +560,13 @@ class BaseFileUpload extends Field
         }
 
         $state = array_filter(array_map(function (TemporaryUploadedFile | string $file) {
-            if (!$file instanceof TemporaryUploadedFile) {
+            if (! $file instanceof TemporaryUploadedFile) {
                 return $file;
             }
 
             $callback = $this->saveUploadedFileUsing;
 
-            if (!$callback) {
+            if (! $callback) {
                 $file->delete();
 
                 return $file;
@@ -605,7 +605,7 @@ class BaseFileUpload extends Field
         }
 
         $this->evaluate(function (BaseFileUpload $component, Closure $get, Closure $set) use ($file, $fileName, $statePath) {
-            if (!$component->isMultiple()) {
+            if (! $component->isMultiple()) {
                 $set($statePath, $fileName);
 
                 return;

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -131,11 +131,20 @@ class BaseFileUpload extends Field
         });
 
         $this->saveUploadedFileUsing(static function (BaseFileUpload $component, TemporaryUploadedFile $file): ?string {
-            $storeMethod = $component->getVisibility() === 'public' ? 'storePubliclyAs' : 'storeAs';
-
             if (! $file->exists()) {
                 return null;
             }
+
+            /** @phpstan-ignore-next-line */
+            if ($component->getDiskName() == $file->disk) {
+                $newPath = trim($component->getDirectory() . '/' . $component->getUploadedFileNameForStorage($file), '/');
+
+                $component->getDisk()->move($file->path(), $newPath);
+
+                return $newPath;
+            }
+
+            $storeMethod = $component->getVisibility() === 'public' ? 'storePubliclyAs' : 'storeAs';
 
             return $file->{$storeMethod}(
                 $component->getDirectory(),


### PR DESCRIPTION
This PR adds the ability for the user to have a uploaded file "moved" on save instead of read and written to its destination.

This significantly improves the performance of large file uploads to a remote S3 server since the files do not need to be downloaded and re-uploaded by the laravel application