### PR TITLE
fix dateComparisonRule logical problem

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -542,7 +542,7 @@ trait CanBeValidated
         $this->rule(static function (Field $component) use ($date, $isStatePathAbsolute, $rule): string {
             $date = $component->evaluate($date);
 
-            if (! (strtotime($date) && $isStatePathAbsolute)) {
+            if (! (strtotime($date) || $isStatePathAbsolute)) {
                 $containerStatePath = $component->getContainer()->getStatePath();
 
                 if ($containerStatePath) {


### PR DESCRIPTION
According to the doc the dateComparisonRules such as `before` or `after`, etc should handle both date and another field comparison but right now it's not supporting date comparison unless you pass `true` as the second argument of these methods.

