### PR TITLE
Fix: RichEditor debounce() not implemented

### DIFF
--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -15,7 +15,11 @@
         x-data="richEditorFormComponent({
             state: $wire.{{ $applyStateBindingModifiers('entangle(\'' . $getStatePath() . '\')') }},
         })"
-        x-on:trix-change="state = $event.target.value"
+        {!!
+            $isDebounced()
+                ? "x-on:trix-change.debounce.{$getDebounce()}=\"state = \$event.target.value\""
+                : 'x-on:trix-change="state = $event.target.value"'
+        !!}
         x-on:trix-attachment-add="
             if (! $event.attachment.file) return
 


### PR DESCRIPTION
As a `Field`, the `debounce()` method can be called on the `RichEditor` field. 

However, no debounce was actually implemented anywhere in the blade view.

This PR adds debounce functionality to the `RichEditor` component. The implementation is similar to the `TextInput` one, but it listens to the `trix-change` event instead of `input` and sets the entangled `state` variable instead.

I tried to fix it using `$lazilyEntangledModifiers` of `$applyStateBindingModifiers()` too, but could not get it to work that way.

```php
// New debounce implementation
{!!
	$isDebounced()
		? "x-on:trix-change.debounce.{$getDebounce()}=\"state = \$event.target.value\""
		: 'x-on:trix-change="state = $event.target.value"'
!!}
```