### PR TITLE
Add information on creating an action link for a custom page

### DIFF
--- a/packages/admin/docs/02-resources/10-custom-pages.md
+++ b/packages/admin/docs/02-resources/10-custom-pages.md
@@ -29,3 +29,10 @@ To generate a URL for a resource route, you may call the static `getUrl()` metho
 ```php
 UserResource::getUrl('sort');
 ```
+
+To use the new page in an action link in a table call the static `getUrl()` method on the resource class in a callback:
+
+```php
+Tables\Actions\Action::make('sort')
+    ->url(fn (User $record): string => UserResource::getUrl('sort', $record)),
+```


### PR DESCRIPTION
I was reading both the admin and table builder documents on actions, and getting confused with the linking mechanics. The table builder uses the Laravel route() helper in actions and this document uses the resource.

I found the answer here: https://github.com/filamentphp/filament/discussions/2282 as I am not the only one to have missed the difference I figured it might be handy in the docs!