### PR TITLE
fix: only try to render active manager if visible

### DIFF
--- a/packages/admin/resources/views/components/resources/relation-managers/index.blade.php
+++ b/packages/admin/resources/views/components/resources/relation-managers/index.blade.php
@@ -51,7 +51,7 @@
         </div>
     @endif
 
-    @if (filled($activeManager))
+    @if (filled($activeManager) && isset($managers[$activeManager]))
         <div
             @if (count($managers) > 1)
                 id="relationManager{{ ucfirst($activeManager) }}"


### PR DESCRIPTION
Came across this issue on an app where relation managers are conditionally visible. If the active relation manager is hidden / visible(false) after a Livewire request, the pages errors because it's trying to render the active one still.

![CleanShot 2022-12-20 at 16 06 09@2x](https://user-images.githubusercontent.com/41837763/208712132-68023442-8898-459a-a531-146df4d65254.png)
