### PR TITLE
Add tooltip documentation to `TextColumn` field

### DIFF
--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -264,3 +264,5 @@ TextColumn::make('email')
     ->copyMessage('Email address copied')
     ->copyMessageDuration(1500)
 ```
+
+> Filament uses tooltips to display validation errors. If you want to use tooltips outside of the admin panel to display validation errors, make sure you have [`@ryangjchandler/alpine-tooltip` installed](https://github.com/ryangjchandler/alpine-tooltip#installation) in your app.

--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -265,4 +265,4 @@ TextColumn::make('email')
     ->copyMessageDuration(1500)
 ```
 
-> Filament uses tooltips to display validation errors. If you want to use tooltips outside of the admin panel to display validation errors, make sure you have [`@ryangjchandler/alpine-tooltip` installed](https://github.com/ryangjchandler/alpine-tooltip#installation) in your app.
+> Filament uses tooltips to display the copy message in the admin panel. If you want to use the copyable feature outside of the admin panel, make sure you have [`@ryangjchandler/alpine-tooltip` installed](https://github.com/ryangjchandler/alpine-tooltip#installation) in your app.


### PR DESCRIPTION
The documentation for `TextInputColumn` contains the snippet about requiring the `@ryangjchandler/alpine-tooltip` package, but the `TextColumn` has the `copyable()` method, which also requires this package. Thus the same snippet should be referenced on the docs for that column as well.