### PR TITLE
Fix pre-collapsed nav group feature

### DIFF
--- a/packages/admin/resources/js/app.js
+++ b/packages/admin/resources/js/app.js
@@ -19,7 +19,7 @@ Alpine.plugin(Tooltip)
 Alpine.store('sidebar', {
     isOpen: Alpine.$persist(true).as('isOpen'),
 
-    collapsedGroups: Alpine.$persist([]).as('collapsedGroups'),
+    collapsedGroups: Alpine.$persist(null).as('collapsedGroups'),
 
     groupIsCollapsed: function (group) {
         return this.collapsedGroups.includes(group)

--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -87,7 +87,7 @@
         @endphp
 
         <script>
-            if (localStorage.getItem('collapsedGroups') === null) {
+            if (JSON.parse(localStorage.getItem('collapsedGroups')) === null) {
                 localStorage.setItem('collapsedGroups', JSON.stringify(@js($collapsedNavigationGroupLabels)))
             }
         </script>


### PR DESCRIPTION
This PR fixes the `->collapsed()` feature on nav groups. 

The filament JS runs on the login page which will initialize the persisted `collapsedGroups` setting as an empty array causing `if (localStorage.getItem('collapsedGroups') === null)` to always come out as false.