### PR TITLE
Fix Repeater clone button hit collapsible event (bubbling effect from header)

### DIFF
--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -138,7 +138,7 @@
                                             <li>
                                                 <button
                                                     title="{{ __('forms::components.repeater.buttons.clone_item.label') }}"
-                                                    wire:click="dispatchFormEvent('repeater::cloneItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                    wire:click.stop="dispatchFormEvent('repeater::cloneItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
                                                     type="button"
                                                     @class([
                                                         'flex items-center justify-center flex-none w-10 h-10 text-gray-400 transition hover:text-gray-500',


### PR DESCRIPTION
This PR fixes bug on Repeater clone button that still hit header event on collapsible
![image](https://user-images.githubusercontent.com/62993054/208884233-4a03efe7-73a0-427c-bcf3-ea2a161d4bf3.png)
