### PR TITLE
fix: Lowercase search column to allow searches inside json columns when attaching

### DIFF
--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -265,6 +265,8 @@ class Resource
 
     public static function getGlobalSearchResults(string $searchQuery): Collection
     {
+        $searchQuery = strtolower($searchQuery);
+
         $query = static::getGlobalSearchEloquentQuery();
 
         foreach (explode(' ', $searchQuery) as $searchQueryWord) {
@@ -451,7 +453,7 @@ class Resource
                     };
 
                     return $query->{"{$whereClause}Raw"}(
-                        "lower({$searchColumn}) {$searchOperator} lower(?)",
+                        "lower({$searchColumn}) {$searchOperator} ?",
                         "%{$searchQuery}%",
                     );
                 },

--- a/packages/tables/src/Actions/AssociateAction.php
+++ b/packages/tables/src/Actions/AssociateAction.php
@@ -193,9 +193,8 @@ class AssociateAction extends Action
                     foreach ($searchColumns as $searchColumnName) {
                         $whereClause = $isFirst ? 'where' : 'orWhere';
 
-                        $query->{$whereClause}(
-                            $searchColumnName,
-                            $searchOperator,
+                        $query->{"{$whereClause}Raw"}(
+                            "lower({$searchColumnName}) {$searchOperator} ?",
                             "%{$search}%",
                         );
 

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -193,9 +193,8 @@ class AttachAction extends Action
                     foreach ($searchColumns as $searchColumnName) {
                         $whereClause = $isFirst ? 'where' : 'orWhere';
 
-                        $query->{$whereClause}(
-                            DB::raw("LOWER($searchColumnName)"),
-                            $searchOperator,
+                        $query->{"{$whereClause}Raw"}(
+                            "lower({$searchColumnName}) {$searchOperator} ?",
                             "%{$search}%",
                         );
 

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -12,7 +12,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\DB;
 
 class AttachAction extends Action
 {

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
 
 class AttachAction extends Action
 {
@@ -193,7 +194,7 @@ class AttachAction extends Action
                         $whereClause = $isFirst ? 'where' : 'orWhere';
 
                         $query->{$whereClause}(
-                            $searchColumnName,
+                            DB::raw("LOWER($searchColumnName)"),
                             $searchOperator,
                             "%{$search}%",
                         );


### PR DESCRIPTION
When you search on attach modal for a column of type json even if using `*_ci` collation it does not find any values. To fix that I `LOWER($searchColumnName)` to first lowercase data inside json column.