### PR TITLE
3.x Docs: Add missing indentation

### DIFF
--- a/packages/tables/docs/08-adding-a-table-to-a-livewire-component.md
+++ b/packages/tables/docs/08-adding-a-table-to-a-livewire-component.md
@@ -39,7 +39,8 @@ There are 3 tasks when adding a table to a Livewire component class:
 namespace App\Http\Livewire;
 
 use App\Models\Post;
-use App\Models\Shop\Product;use Filament\Tables\Columns\TextColumn;
+use App\Models\Shop\Product;
+use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;


### PR DESCRIPTION
I noticed that there was a missed indentation so I've corrected it