### PR TITLE
Fix spelling mistake in docs

### DIFF
--- a/packages/notifications/docs/06-testing.md
+++ b/packages/notifications/docs/06-testing.md
@@ -26,7 +26,7 @@ it('sends a notification', function () {
 ```
 
 ```php
-use function Filament\Notifications\Testing\assetNotified;
+use function Filament\Notifications\Testing\assertNotified;
 
 it('sends a notification', function () {
     assertNotified();


### PR DESCRIPTION
Was testing notifications this morning and noticed the use function clause had a spelling mistake in it,

Cheers and have a fantastic weekend!