### PR TITLE
docs: Fix missing semicolon

### DIFF
--- a/packages/notifications/docs/06-testing.md
+++ b/packages/notifications/docs/06-testing.md
@@ -18,7 +18,7 @@ it('sends a notification', function () {
 ```
 
 ```php
-use Filament\Notifications\Notification
+use Filament\Notifications\Notification;
 
 it('sends a notification', function () {
     Notification::assertNotified();


### PR DESCRIPTION
Hi Filament Teams !

I was coming across the filament notification docs and found out the syntax highlighting was broken so i am here to fix the missing semicolon to help Torchlight a little bit ;)

I want to take this opportunity to say thanks to yall too! Good Job on maintaining Filament and i cant wait for v3 to come out officially ! 👍 