### PR TITLE
Fix sidebar group collapse icon size

### DIFF
--- a/packages/app/resources/views/components/layouts/app/sidebar/group.blade.php
+++ b/packages/app/resources/views/components/layouts/app/sidebar/group.blade.php
@@ -43,7 +43,7 @@
                 <x-filament::icon
                     name="heroicon-m-chevron-down"
                     alias="app::sidebar.group.collapse"
-                    size="h-3 w-3"
+                    size="h-5 w-5"
                     class="text-gray-600 transition dark:text-gray-300"
                     x-bind:class="$store.sidebar.groupIsCollapsed(label) || '-rotate-180'"
                     x-cloak=""


### PR DESCRIPTION
Makes it match other uses of the icon.