### PR TITLE
Fix table header sort icon direction

### DIFF
--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -35,7 +35,7 @@
         @if ($sortable)
             <x-filament::icon
                 :name="$activelySorted && $sortDirection === 'asc' ? 'heroicon-m-chevron-up' : 'heroicon-m-chevron-down'"
-                alias="filament-tables::header-cell.sort"
+                alias="$activelySorted && $sortDirection === 'asc' ? 'filament-tables::header-cell.sort-asc' : 'filament-tables::header-cell.sort-desc'"
                 color="dark:text-gray-300"
                 size="h-5 w-5"
                 :class="[


### PR DESCRIPTION
We need a different alias for `asc` and `desc`.