### PR TITLE
Fix Italian localization of dashboard title

### DIFF
--- a/packages/admin/resources/lang/it/pages/dashboard.php
+++ b/packages/admin/resources/lang/it/pages/dashboard.php
@@ -2,6 +2,6 @@
 
 return [
 
-    'title' => 'Cruscotto',
+    'title' => 'Pannello',
 
 ];


### PR DESCRIPTION
In Italy, "Cruscotto" is used only for vehicles