### PR TITLE
Callback support for NavigationItem badge

### DIFF
--- a/packages/admin/src/Navigation/NavigationItem.php
+++ b/packages/admin/src/Navigation/NavigationItem.php
@@ -3,7 +3,6 @@
 namespace Filament\Navigation;
 
 use Closure;
-use function PHPUnit\Framework\isInstanceOf;
 
 class NavigationItem
 {
@@ -104,7 +103,7 @@ class NavigationItem
         return $this;
     }
 
-    public function setBadge(string|Closure $callback): static
+    public function setBadge(string | Closure $callback): static
     {
         $this->badge = $callback instanceof Closure
             ? $callback()
@@ -118,7 +117,7 @@ class NavigationItem
         return $this->badge;
     }
 
-    public function setBadgeColor(string|Closure $callback): static
+    public function setBadgeColor(string | Closure $callback): static
     {
         $this->badgeColor = $callback instanceof Closure
             ? $callback()

--- a/packages/admin/src/Navigation/NavigationItem.php
+++ b/packages/admin/src/Navigation/NavigationItem.php
@@ -3,6 +3,7 @@
 namespace Filament\Navigation;
 
 use Closure;
+use function PHPUnit\Framework\isInstanceOf;
 
 class NavigationItem
 {
@@ -103,9 +104,27 @@ class NavigationItem
         return $this;
     }
 
+    public function setBadge(string|Closure $callback): static
+    {
+        $this->badge = $callback instanceof Closure
+            ? $callback()
+            : $callback;
+
+        return $this;
+    }
+
     public function getBadge(): ?string
     {
         return $this->badge;
+    }
+
+    public function setBadgeColor(string|Closure $callback): static
+    {
+        $this->badgeColor = $callback instanceof Closure
+            ? $callback()
+            : $callback;
+
+        return $this;
     }
 
     public function getBadgeColor(): ?string


### PR DESCRIPTION
I needed callback for MenuItems defined via AppServiceProvider. I made a small contribution for this.

Now you can:
```php
NavigationItem::make('Test')
    ->setBadge(fn() => User::query()->count())
    ->setBadgeColor(fn() => User::query()->count() < 10 ? 'danger' : 'success')
    
// OR

NavigationItem::make('Test')
    ->setBadge(5)
    ->setBadgeColor('danger')
```