### PR TITLE
 Default currency in money format

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -135,7 +135,7 @@ trait CanFormatState
             }
 
             if (blank($currency)) {
-                $currency = env('DEFAULT_CURRENCY', 'USD');
+                $currency = config('money.default_currency') ?? 'usd';
             }
 
             return (new Money\Money(


### PR DESCRIPTION
This currently doesn't work in production. When configs are cached then env() method will always return `null` and therefore the default option will always be selected.

https://laravel.com/docs/9.x/deployment#optimizing-configuration-loading

I have notified [akaunting/laravel-money](https://github.com/akaunting/laravel-money/issues/75) and suggested that they add a `default_currency` to their config.