### PR TITLE
Fix showing table header children and spacing

### DIFF
--- a/packages/tables/resources/views/components/header/index.blade.php
+++ b/packages/tables/resources/views/components/header/index.blade.php
@@ -6,43 +6,45 @@
     'actions' => [],
     'actionsPosition' => ActionsPosition::End,
     'description' => null,
-    'heading',
+    'heading' => null,
 ])
 
 <div {{ $attributes->class(['filament-tables-header px-4 py-2']) }}>
-    <div class="flex flex-col gap-4 md:justify-between md:items-start md:flex-row">
-        <div>
-            @if ($heading)
-                <x-filament-tables::header.heading>
-                    {{ $heading }}
-                </x-filament-tables::header.heading>
-            @endif
+    <div class="flex flex-col gap-4 md:flex-row md:items-start">
+        @if ($heading || $description || $actionsPosition === ActionsPosition::Start)
+            <div>
+                @if ($heading)
+                    <x-filament-tables::header.heading>
+                        {{ $heading }}
+                    </x-filament-tables::header.heading>
+                @endif
 
-            @if ($description)
-                <x-filament-tables::header.description>
-                    {{ $description }}
-                </x-filament-tables::header.description>
-            @endif
+                @if ($description)
+                    <x-filament-tables::header.description>
+                        {{ $description }}
+                    </x-filament-tables::header.description>
+                @endif
 
-            @if ($actionsPosition === ActionsPosition::Start)
-                <x-filament-tables::actions
-                    :actions="$actions"
-                    alignment="start"
-                    wrap
-                    @class([
-                        'md:-ml-2' => ! ($heading || $description),
-                        'mt-2' => $heading || $description,
-                    ])
-                />
-            @endif
-        </div>
+                @if ($actionsPosition === ActionsPosition::Start)
+                    <x-filament-tables::actions
+                        :actions="$actions"
+                        alignment="start"
+                        wrap
+                        @class([
+                            'md:-ml-2' => ! ($heading || $description),
+                            'mt-2' => $heading || $description,
+                        ])
+                    />
+                @endif
+            </div>
+        @endif
 
         @if ($actionsPosition === ActionsPosition::End)
             <x-filament-tables::actions
                 :actions="$actions"
                 alignment="end"
                 wrap
-                class="shrink-0 md:-mr-2"
+                class="ml-auto shrink-0 md:-mr-2"
             />
         @endif
     </div>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -200,28 +200,27 @@
     <x-filament-tables::container>
         <div
             class="filament-tables-header-container"
-            x-show="hasHeader = (@js($renderHeader = ($header || $heading || ($headerActions && (! $isReordering)) || $isReorderable || count($groups) || $isGlobalSearchVisible || $hasFilters || $isColumnToggleFormVisible)) || (selectedRecords.length && @js(count($groupedBulkActions))))"
+            x-show="hasHeader = (@js($renderHeader = ($header || $heading || $description || ($headerActions && (! $isReordering)) || $isReorderable || count($groups) || $isGlobalSearchVisible || $hasFilters || $isColumnToggleFormVisible)) || (selectedRecords.length && @js(count($groupedBulkActions))))"
             @if (! $renderHeader) x-cloak @endif
         >
             @if ($header)
                 {{ $header }}
-            @elseif ($heading || $headerActions)
+            @elseif ($heading || $description || $headerActions)
                 <div @class([
                     'px-2 pt-2',
-                    'hidden' => ! $heading && $isReordering,
+                    'hidden' => ! ($heading || $description) && $isReordering,
                 ])>
-                    <x-filament-tables::header :actions="$isReordering ? [] : $headerActions" :actions-position="$headerActionsPosition" class="mb-2">
-                        <x-slot name="heading">
-                            {{ $heading }}
-                        </x-slot>
-
-                        <x-slot name="description">
-                            {{ $description }}
-                        </x-slot>
-                    </x-filament-tables::header>
+                    <x-filament-tables::header
+                        :actions="$isReordering ? [] : $headerActions"
+                        :actions-position="$headerActionsPosition"
+                        class="mb-2"
+                        :heading="$heading"
+                        :description="$description"
+                    />
 
                     <x-filament::hr
-                        :x-show="\Illuminate\Support\Js::from($isReorderable || count($groups) || $isGlobalSearchVisible || $hasFilters || $isColumnToggleFormVisible) . ' || (selectedRecords.length && ' . \Illuminate\Support\Js::from(count($groupedBulkActions)) . ')'"/>
+                        :x-show="\Illuminate\Support\Js::from($isReorderable || count($groups) || $isGlobalSearchVisible || $hasFilters || $isColumnToggleFormVisible) . ' || (selectedRecords.length && ' . \Illuminate\Support\Js::from(count($groupedBulkActions)) . ')'"
+                    />
                 </div>
             @endif
 


### PR DESCRIPTION
- Fixes showing description without heading.
- Fixes spacing when passing actions without heading/description by correctly hiding heading/description when empty.