### PR TITLE
Fix `support::button` loading indicator when using action params

### DIFF
--- a/packages/support/resources/views/components/button.blade.php
+++ b/packages/support/resources/views/components/button.blade.php
@@ -63,7 +63,7 @@
     $hasLoadingIndicator = filled($attributes->get('wire:target')) || filled($attributes->get('wire:click')) || (($type === 'submit') && filled($form));
 
     if ($hasLoadingIndicator) {
-        $loadingIndicatorTarget = html_entity_decode($attributes->get('wire:target', $attributes->get('wire:click', $form)), ENT_QUOTES);
+        $loadingIndicatorTarget = \Illuminate\Support\Str::before(html_entity_decode($attributes->get('wire:target', $attributes->get('wire:click', $form)), ENT_QUOTES), '(');
     }
 @endphp
 


### PR DESCRIPTION
The `<x-filament-support::button>` component adds a loading indicator if you're using `wire:click`, with the action copied over to `wire:target`. However if the action includes parameters (`wire:click="refresh(123)"`) the automatic `wire:target` breaks as that should just be the action name without the brackets and parameters.

This PR fixes that by setting `$loadingIndicatorTarget` to the value only up to the end of the action name.