### PR TITLE
[3.X] user-menu hover bg-color issue fixed

### DIFF
--- a/packages/app/resources/views/components/user-menu.blade.php
+++ b/packages/app/resources/views/components/user-menu.blade.php
@@ -90,7 +90,7 @@
 
         @foreach ($items as $key => $item)
             <x-filament::dropdown.list.item
-                :color="$item->getColor() ?? 'gray'"
+                :color="$item->getColor() ?? 'primary'"
                 :icon="$item->getIcon()"
                 :href="$item->getUrl()"
                 tag="a"
@@ -100,7 +100,7 @@
         @endforeach
 
         <x-filament::dropdown.list.item
-            :color="$logoutItem?->getColor() ?? 'gray'"
+            :color="$logoutItem?->getColor() ?? 'primary'"
             :icon="$logoutItem?->getIcon() ?? 'heroicon-m-arrow-left-on-rectangle'"
             :action="$logoutItem?->getUrl() ?? filament()->getLogoutUrl()"
             method="post"


### PR DESCRIPTION
Before
<img width="1504" alt="Screenshot 2023-01-23 at 9 50 14 PM" src="https://user-images.githubusercontent.com/21066418/214084533-7ecd49d2-5055-4674-99bc-f75b93694d59.png">

After
<img width="1509" alt="Screenshot 2023-01-23 at 9 51 13 PM" src="https://user-images.githubusercontent.com/21066418/214084735-23d04d00-61a3-4406-86d0-4e987cd4279f.png">

