### PR TITLE
Get resource class from service container

### DIFF
--- a/packages/admin/src/Resources/Pages/Page.php
+++ b/packages/admin/src/Resources/Pages/Page.php
@@ -47,7 +47,7 @@ class Page extends BasePage
 
     public static function getResource(): string
     {
-        return static::$resource;
+        return app()->getAlias(static::$resource);
     }
 
     protected function callHook(string $hook): void


### PR DESCRIPTION
This allows for overwriting a resource registered in another package. E.g 
```php
$this->app->alias(\App\Filament\Resources\NavigationResource::class, \RyanChandler\FilamentNavigation\Filament\Resources\NavigationResource::class);
```