### PR TITLE
AttachAction - use the specified related key names

### DIFF
--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -67,7 +67,7 @@ class AttachAction extends Action
                 /** @var BelongsToMany $relationship */
                 $relationship = $this->getRelationship();
 
-                $record = $relationship->getRelated()->query()->find($data['recordId']);
+                $record = $relationship->getRelated()->query()->where($relationship->getRelatedKeyName(), $data['recordId'])->first();
 
                 $relationship->attach(
                     $record,

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -67,7 +67,7 @@ class AttachAction extends Action
                 /** @var BelongsToMany $relationship */
                 $relationship = $this->getRelationship();
 
-                $record = $relationship->getRelated()->query()->where($relationship->getRelatedKeyName(), $data['recordId'])->first();
+                $record = $relationship->getRelated()->query()->where($relationship->getQualifiedRelatedKeyName(), $data['recordId'])->first();
 
                 $relationship->attach(
                     $record,


### PR DESCRIPTION
When using `BelongsToMany` relationships that have custom keys, the `AttachAction` needs to load the record using the `relatedKey` instead of the primary key of the record, because the id passed by the search query itself is the `relatedKey`, not the `primaryKey` of that record