### PR TITLE
Move callAfter hook outside of create another

### DIFF
--- a/packages/admin/src/Pages/Actions/CreateAction.php
+++ b/packages/admin/src/Pages/Actions/CreateAction.php
@@ -49,8 +49,9 @@ class CreateAction extends Action
             $this->record($record);
             $form->model($record)->saveRelationships();
 
+            $this->callAfter();
+            
             if ($arguments['another'] ?? false) {
-                $this->callAfter();
                 $this->sendSuccessNotification();
 
                 $this->record(null);

--- a/packages/admin/src/Pages/Actions/CreateAction.php
+++ b/packages/admin/src/Pages/Actions/CreateAction.php
@@ -50,7 +50,7 @@ class CreateAction extends Action
             $form->model($record)->saveRelationships();
 
             $this->callAfter();
-            
+
             if ($arguments['another'] ?? false) {
                 $this->sendSuccessNotification();
 

--- a/packages/admin/src/Pages/Actions/CreateAction.php
+++ b/packages/admin/src/Pages/Actions/CreateAction.php
@@ -49,8 +49,9 @@ class CreateAction extends Action
             $this->record($record);
             $form->model($record)->saveRelationships();
 
+            $this->callAfter();
+
             if ($arguments['another'] ?? false) {
-                $this->callAfter();
                 $this->sendSuccessNotification();
 
                 $this->record(null);

--- a/packages/tables/src/Actions/AssociateAction.php
+++ b/packages/tables/src/Actions/AssociateAction.php
@@ -77,8 +77,9 @@ class AssociateAction extends Action
                 $record->save();
             });
 
+            $this->callAfter();
+
             if ($arguments['another'] ?? false) {
-                $this->callAfter();
                 $this->sendSuccessNotification();
 
                 $form->fill();

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -75,8 +75,9 @@ class AttachAction extends Action
                 );
             });
 
+            $this->callAfter();
+
             if ($arguments['another'] ?? false) {
-                $this->callAfter();
                 $this->sendSuccessNotification();
 
                 $form->fill();

--- a/packages/tables/src/Actions/CreateAction.php
+++ b/packages/tables/src/Actions/CreateAction.php
@@ -70,8 +70,9 @@ class CreateAction extends Action
 
             $livewire->mountedTableActionRecord($record->getKey());
 
+            $this->callAfter();
+
             if ($arguments['another'] ?? false) {
-                $this->callAfter();
                 $this->sendSuccessNotification();
 
                 $this->record(null);


### PR DESCRIPTION
After event was only being called if you clicked 'Create & create another'