### PR TITLE
Change escaping of $getState on TextInputColumn

### DIFF
--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -8,7 +8,7 @@
 <div
     x-data="{
         error: undefined,
-        state: '{{ $getState() }}',
+        state: @js($getState()),
         isLoading: false
     }"
     {{ $attributes->merge($getExtraAttributes())->class([


### PR DESCRIPTION
Fixes an issue whereby using an apostrophe (') in the input breaks the component.