### PR TITLE
Always Show Pagination Overview

### DIFF
--- a/packages/tables/resources/lang/en/table.php
+++ b/packages/tables/resources/lang/en/table.php
@@ -27,7 +27,7 @@ return [
 
         'label' => 'Pagination Navigation',
 
-        'overview' => 'Showing :first to :last of :total results',
+        'overview' => '{1} Showing 1 result|[2,*] Showing :first to :last of :total results',
 
         'fields' => [
 

--- a/packages/tables/resources/lang/nl/table.php
+++ b/packages/tables/resources/lang/nl/table.php
@@ -27,7 +27,7 @@ return [
 
         'label' => 'Paginering navigatie',
 
-        'overview' => 'Toont :first tot :last van :total resultaten',
+        'overview' => '{1} Toont 1 resultaat|[2,*] Toont :first tot :last van :total resultaten',
 
         'fields' => [
 

--- a/packages/tables/resources/views/components/pagination/index.blade.php
+++ b/packages/tables/resources/views/components/pagination/index.blade.php
@@ -62,11 +62,15 @@
                     'pl-2 text-sm font-medium',
                     'dark:text-white' => config('tables.dark_mode'),
                 ])>
-                    {{ __('tables::table.pagination.overview', [
-                        'first' => $paginator->firstItem(),
-                        'last' => $paginator->lastItem(),
-                        'total' => $paginator->total(),
-                    ]) }}
+                    {{ trans_choice(
+                        'tables::table.pagination.overview',
+                        $paginator->total(),
+                        [
+                            'first' => $paginator->firstItem(),
+                            'last' => $paginator->lastItem(),
+                            'total' => $paginator->total(),
+                        ],
+                    ) }}
                 </div>
             @endif
         </div>

--- a/packages/tables/resources/views/components/pagination/index.blade.php
+++ b/packages/tables/resources/views/components/pagination/index.blade.php
@@ -62,13 +62,11 @@
                     'pl-2 text-sm font-medium',
                     'dark:text-white' => config('tables.dark_mode'),
                 ])>
-                    @if ($paginator->total() > 1)
-                        {{ __('tables::table.pagination.overview', [
-                            'first' => $paginator->firstItem(),
-                            'last' => $paginator->lastItem(),
-                            'total' => $paginator->total(),
-                        ]) }}
-                    @endif
+                    {{ __('tables::table.pagination.overview', [
+                        'first' => $paginator->firstItem(),
+                        'last' => $paginator->lastItem(),
+                        'total' => $paginator->total(),
+                    ]) }}
                 </div>
             @endif
         </div>


### PR DESCRIPTION
When a resource has only one result, the pagination overview text (`Showing X to Y of Z results`)  is not shown. While it's obviously pretty easy to see that there is only one record, I find that the change in the UI is jarring. There really isn't a great reason not to show it IMO.

This PR shows the pagination overview regardless of how many results there are.