### PR TITLE
Add Action suffix to action methods

### DIFF
--- a/packages/actions/docs/05-adding-an-action-to-a-livewire-component.md
+++ b/packages/actions/docs/05-adding-an-action-to-a-livewire-component.md
@@ -36,7 +36,7 @@ class ManagePost extends Component implements HasActions
     
     public Post $post;
     
-    public function delete(): Action
+    public function deleteAction(): Action
     {
         return Action::make('delete')
             ->requiresConfirmation()
@@ -47,11 +47,11 @@ class ManagePost extends Component implements HasActions
 }
 ```
 
-Finally, you need to render the action in your view. To do this, you can use `{{ $this->delete }}`, where you replace `delete` with the name of your action method:
+Finally, you need to render the action in your view. To do this, you can use `{{ $this->deleteAction }}`, where you replace `deleteAction` with the name of your action method:
 
 ```blade
 <div>
-    {{ $this->delete }}
+    {{ $this->deleteAction }}
     
     <x-filament-actions::modals />
 </div>
@@ -81,7 +81,7 @@ Now, you can access the post ID in your action method:
 use App\Models\Post;
 use Filament\Actions\Action;
 
-public function delete(): Action
+public function deleteAction(): Action
 {
     return Action::make('delete')
         ->requiresConfirmation()
@@ -100,9 +100,9 @@ You may group actions together into a dropdown menu by using the `<x-filament-ac
 ```blade
 <div>
     <x-filament-actions::group :actions="[
-        $this->edit,
-        $this->view,
-        $this->delete,
+        $this->editAction,
+        $this->viewAction,
+        $this->deleteAction,
     ]" />
     
     <x-filament-actions::modals />
@@ -115,9 +115,9 @@ You can also pass in a `label`, `icon`, `color`, `size`, `tooltip`, and `dropdow
 <div>
     <x-filament-actions::group
         :actions="[
-            $this->edit,
-            $this->view,
-            $this->delete,
+            $this->editAction,
+            $this->viewAction,
+            $this->deleteAction,
         ]"
         label="Actions"
         icon="heroicon-m-ellipsis-vertical"


### PR DESCRIPTION
This PR renames action methods like `delete` to `deleteAction` for multiple reasons:

- Consistency with forms and tables following the same naming, e.g. `createCommentForm`.
- In forms, you often have a submit action and a separate method that handles the submission. Naming the action method `submit`, would collide with the actual submit method. Having `submitAction` and `submit`, `updateAction` and `update`, or `saveAction` and `save` works better in these cases.