### PR TITLE
Allow to override component container

### DIFF
--- a/packages/forms/config/forms.php
+++ b/packages/forms/config/forms.php
@@ -1,5 +1,6 @@
 <?php
 
+
 return [
 
     /*
@@ -13,6 +14,7 @@ return [
     */
 
     'components' => [
+        'container' => Filament\Forms\ComponentContainer::class,
 
         'actions' => [
 

--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -336,6 +336,7 @@ trait InteractsWithForms
 
     protected function makeForm(): ComponentContainer
     {
-        return ComponentContainer::make($this);
+        $container = config('forms.components.container', ComponentContainer::class);
+        return $container::make($this);
     }
 }


### PR DESCRIPTION
It would be useful if you could override ComponentContainer in forms with config as it would allow more flexibility to custom `$wire->` commands for custom Fields