### PR TITLE
Revert "Fix `support::button` loading indicator when using action params"

### DIFF
--- a/packages/support/resources/views/components/button.blade.php
+++ b/packages/support/resources/views/components/button.blade.php
@@ -63,7 +63,7 @@
     $hasLoadingIndicator = filled($attributes->get('wire:target')) || filled($attributes->get('wire:click')) || (($type === 'submit') && filled($form));
 
     if ($hasLoadingIndicator) {
-        $loadingIndicatorTarget = \Illuminate\Support\Str::before(html_entity_decode($attributes->get('wire:target', $attributes->get('wire:click', $form)), ENT_QUOTES), '(');
+        $loadingIndicatorTarget = html_entity_decode($attributes->get('wire:target', $attributes->get('wire:click', $form)), ENT_QUOTES);
     }
 @endphp
 


### PR DESCRIPTION
Reverts filamentphp/filament#5526 — further context below:

The original PR mentioned:

> if the action includes parameters (`wire:click="refresh(123)"`) the automatic `wire:target` breaks as that should just be the action name without the brackets and parameters

From what I understand [in the Livewire docs](https://laravel-livewire.com/docs/2.x/loading-states#targeting-actions), that's not the case — `wire:target` is still meant to work with brackets and parameters.

This change causes issues on pages with multiple action buttons, as they lose their loading target specificity. When using `getActions()` to define several buttons, the value of `$loadingIndicatorTarget` gets set to `mountAction('action-x')`, `mountAction('action-y')`, `mountAction('action-z')` etc. — so this change causes unrelated loading indicators to spin when several actions are on the same page.