### PR TITLE
Fix: height issues on body with overflow-x-clip and min-h-full

### DIFF
--- a/packages/admin/resources/views/components/layouts/base.blade.php
+++ b/packages/admin/resources/views/components/layouts/base.blade.php
@@ -75,7 +75,7 @@
     </head>
 
     <body @class([
-        'filament-body min-h-full bg-gray-100 text-gray-900',
+        'filament-body h-0 min-h-full bg-gray-100 text-gray-900',
         'dark:text-gray-100 dark:bg-gray-900' => config('filament.dark_mode'),
     ])>
         {{ \Filament\Facades\Filament::renderHook('body.start') }}


### PR DESCRIPTION
This fixes a bug I came across with the min-h-full on the body causing issues when the body content is too short to reach the bottom of the window.

There is no know issues with Filament directly that this solves, but is causing issues with a plugin and could potentially create issues with other plugins.