### PR TITLE
Fix: Table TextColumn rowIndex pagination support

### DIFF
--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -140,33 +140,18 @@ You may want a column to contain the number of the current row in the table:
 ```php
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Contracts\HasTable;
-use Filament\Tables\TableComponent;
 
 TextColumn::make('index')->getStateUsing(
     static function (stdClass $rowLoop, HasTable $livewire): string {
-        /** @var TableComponent $livewire */
-        return (string) ($rowLoop->iteration + ($livewire->tableRecordsPerPage * ($livewire->page - 1)));
+        return (string) (
+            $rowLoop->iteration +
+            ($livewire->getTableRecordsPerPage() * ($livewire->page - 1))
+        );
     }
 ),
 ```
 
 As `$rowLoop` is Laravel's Blade `$loop` object, you can reference all other `$loop` properties.
-
-As a shortcut, you may use the `rowIndex()` method:
-
-```php
-use Filament\Tables\Columns\TextColumn;
-
-TextColumn::make('index')->rowIndex()
-```
-
-To start counting from 0 instead of 1, use `isFromZero: true`:
-
-```php
-use Filament\Tables\Columns\TextColumn;
-
-TextColumn::make('index')->rowIndex(isFromZero: true)
-```
 
 ## Custom formatting
 

--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -140,9 +140,11 @@ You may want a column to contain the number of the current row in the table:
 ```php
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\TableComponent;
 
 TextColumn::make('index')->getStateUsing(
     static function (stdClass $rowLoop, HasTable $livewire): string {
+        /** @var TableComponent $livewire */
         return (string) ($rowLoop->iteration + ($livewire->tableRecordsPerPage * ($livewire->page - 1)));
     }
 ),

--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -139,10 +139,13 @@ You may want a column to contain the number of the current row in the table:
 
 ```php
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Contracts\HasTable;
 
-TextColumn::make('index')->getStateUsing(static function (stdClass $rowLoop): string {
-    return (string) $rowLoop->iteration;
-});
+TextColumn::make('index')->getStateUsing(
+    static function (stdClass $rowLoop, HasTable $livewire): string {
+        return (string) ($rowLoop->iteration + ($livewire->tableRecordsPerPage * ($livewire->page - 1)));
+    }
+),
 ```
 
 As `$rowLoop` is Laravel's Blade `$loop` object, you can reference all other `$loop` properties.

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -3,6 +3,7 @@
 namespace Filament\Tables\Columns;
 
 use Closure;
+use Filament\Tables\Contracts\HasTable;
 use stdClass;
 
 class TextColumn extends Column
@@ -22,8 +23,10 @@ class TextColumn extends Column
 
     public function rowIndex(bool $isFromZero = false): static
     {
-        $this->getStateUsing(static function (stdClass $rowLoop) use ($isFromZero): string {
-            return (string) $rowLoop->{$isFromZero ? 'index' : 'iteration'};
+        $this->getStateUsing(static function (stdClass $rowLoop, HasTable $livewire) use ($isFromZero): string {
+            $rowIndex = $rowLoop->{$isFromZero ? 'index' : 'iteration'};
+
+            return (string) ($rowIndex + ($livewire->tableRecordsPerPage * ($livewire->page - 1)));
         });
 
         return $this;

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -24,11 +24,8 @@ class TextColumn extends Column
 
     public function rowIndex(bool $isFromZero = false): static
     {
-        $this->getStateUsing(static function (stdClass $rowLoop, HasTable $livewire) use ($isFromZero): string {
-            /** @var TableComponent $livewire */
-            $rowIndex = $rowLoop->{$isFromZero ? 'index' : 'iteration'};
-
-            return (string) ($rowIndex + ($livewire->tableRecordsPerPage * ($livewire->page - 1)));
+        $this->getStateUsing(static function (stdClass $rowLoop) use ($isFromZero): string {
+             return (string) $rowLoop->{$isFromZero ? 'index' : 'iteration'};
         });
 
         return $this;

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Columns;
 
 use Closure;
 use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\TableComponent;
 use stdClass;
 
 class TextColumn extends Column
@@ -24,6 +25,7 @@ class TextColumn extends Column
     public function rowIndex(bool $isFromZero = false): static
     {
         $this->getStateUsing(static function (stdClass $rowLoop, HasTable $livewire) use ($isFromZero): string {
+            /** @var TableComponent $livewire */
             $rowIndex = $rowLoop->{$isFromZero ? 'index' : 'iteration'};
 
             return (string) ($rowIndex + ($livewire->tableRecordsPerPage * ($livewire->page - 1)));

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -3,8 +3,6 @@
 namespace Filament\Tables\Columns;
 
 use Closure;
-use Filament\Tables\Contracts\HasTable;
-use Filament\Tables\TableComponent;
 use stdClass;
 
 class TextColumn extends Column
@@ -25,7 +23,7 @@ class TextColumn extends Column
     public function rowIndex(bool $isFromZero = false): static
     {
         $this->getStateUsing(static function (stdClass $rowLoop) use ($isFromZero): string {
-             return (string) $rowLoop->{$isFromZero ? 'index' : 'iteration'};
+            return (string) $rowLoop->{$isFromZero ? 'index' : 'iteration'};
         });
 
         return $this;


### PR DESCRIPTION
Current implementation of `->rowIndex()` on Table TextColumn does not take pagination into consideration.