### PR TITLE
Switch from json_encode to castAsJson

### DIFF
--- a/tests/src/Admin/Resources/Pages/CreateRecordTest.php
+++ b/tests/src/Admin/Resources/Pages/CreateRecordTest.php
@@ -28,7 +28,7 @@ it('can create', function () {
     $this->assertDatabaseHas(Post::class, [
         'author_id' => $newData->author->getKey(),
         'content' => $newData->content,
-        'tags' => json_encode($newData->tags),
+        'tags' => $this->castAsJson($newData->tags),
         'title' => $newData->title,
         'rating' => $newData->rating,
     ]);


### PR DESCRIPTION
When running the test suite against a MySql database the CreateRecordTest fails due to json encoding the tags. This works when running againast Sqlite, but fails with MySql. 

Using the `castAsJson()` method works for both databases. 