### PR TITLE
Add decimalSeparator to money mask

### DIFF
--- a/packages/forms/src/Components/TextInput/Mask.php
+++ b/packages/forms/src/Components/TextInput/Mask.php
@@ -141,14 +141,14 @@ class Mask implements Jsonable
         return $this;
     }
 
-    public function money(string $prefix = '$', string $thousandsSeparator = ',', int $decimalPlaces = 2, bool $isSigned = true, string $decimalSeperator = '.'): static
+    public function money(string $prefix = '$', string $thousandsSeparator = ',', int $decimalPlaces = 2, bool $isSigned = true, string $decimalSeparator = '.'): static
     {
         $this
             ->patternBlocks([
                 'money' => fn (Mask $mask) => $mask
                     ->numeric()
                     ->thousandsSeparator($thousandsSeparator)
-                    ->decimalSeparator($decimalSeperator)
+                    ->decimalSeparator($decimalSeparator)
                     ->decimalPlaces($decimalPlaces)
                     ->signed($isSigned)
                     ->padFractionalZeros()

--- a/packages/forms/src/Components/TextInput/Mask.php
+++ b/packages/forms/src/Components/TextInput/Mask.php
@@ -141,13 +141,14 @@ class Mask implements Jsonable
         return $this;
     }
 
-    public function money(string $prefix = '$', string $thousandsSeparator = ',', int $decimalPlaces = 2, bool $isSigned = true): static
+    public function money(string $prefix = '$', string $thousandsSeparator = ',', int $decimalPlaces = 2, bool $isSigned = true, string $decimalSeperator = '.'): static
     {
         $this
             ->patternBlocks([
                 'money' => fn (Mask $mask) => $mask
                     ->numeric()
                     ->thousandsSeparator($thousandsSeparator)
+                    ->decimalSeparator($decimalSeperator)
                     ->decimalPlaces($decimalPlaces)
                     ->signed($isSigned)
                     ->padFractionalZeros()


### PR DESCRIPTION
Zep suggested we could add the decimalseparator in the function as a parameter at the end, so it won't be a breaking change.

For v3, any chance we could change the order?
```php
public function money(string $prefix = '$', string $thousandsSeparator = ',', string $decimalSeparator = '.', int $decimalPlaces = 2, bool $isSigned = true): static
    {

    }
```