### PR TITLE
Add inlineLabel() method explenation

### DIFF
--- a/packages/forms/docs/04-layout.md
+++ b/packages/forms/docs/04-layout.md
@@ -524,6 +524,17 @@ Card::make()
     ->columns(2)
 ```
 
+You may use the `inlineLabel()` method to inline the form labels. This method works on all layout components.
+
+```php
+use Filament\Forms\Components\Card;
+
+Card::make()
+    ->schema([
+        // ...
+    ])->inlineLabel()
+```
+
 ## View
 
 Aside from [building custom layout components](#building-custom-layout-components), you may create "view" components which allow you to create custom layouts without extra PHP classes.

--- a/packages/forms/docs/04-layout.md
+++ b/packages/forms/docs/04-layout.md
@@ -532,7 +532,8 @@ use Filament\Forms\Components\Card;
 Card::make()
     ->schema([
         // ...
-    ])->inlineLabel()
+    ])
+    ->inlineLabel()
 ```
 
 ## View

--- a/packages/forms/docs/04-layout.md
+++ b/packages/forms/docs/04-layout.md
@@ -524,7 +524,9 @@ Card::make()
     ->columns(2)
 ```
 
-You may use the `inlineLabel()` method to inline the form labels. This method works on all layout components.
+## Inline labels
+
+You may use the `inlineLabel()` method to make the form labels and fields in separate columns, inline with each other. It works on all layout components, each field inside will have an inline label.
 
 ```php
 use Filament\Forms\Components\Card;


### PR DESCRIPTION
There was missing information about `inlineLabel()` on the Layout components documentation page. This adds a little snippet to explain it.