### PR TITLE
Fix outline-color transition

### DIFF
--- a/packages/admin/resources/css/app.css
+++ b/packages/admin/resources/css/app.css
@@ -24,6 +24,10 @@
 }
 
 @layer components {
+    .transition {
+        transition-property: color,background-color,border-color,text-decoration-color,fill,stroke,opacity,box-shadow,transform,filter,backdrop-filter,-webkit-backdrop-filter !important
+    }
+
     .filament-login-page {
         @apply relative bg-no-repeat;
         background-image: radial-gradient(


### PR DESCRIPTION
This fixes the outline-color transition issue on inputs as a result of tailwind's 3.2.5 release when themeing Filament.

It applies the transition settings pre 3.2.5 which didn't include outline-color.

See issue #5675 

There may be a better way to solve this, like actually working with the outline-color instead of overwriting it, but I wanted to at least propose this as a solution.  