### PR TITLE
standardize single quotes escapes in translations

### DIFF
--- a/packages/forms/resources/lang/ca/components.php
+++ b/packages/forms/resources/lang/ca/components.php
@@ -10,7 +10,7 @@ return [
 
                 'buttons' => [
                     'link' => 'Enllaç',
-                    'unlink' => 'Elimina l\'enllaç',
+                    'unlink' => "Elimina l'enllaç",
                 ],
 
                 'label' => 'URL',
@@ -41,7 +41,7 @@ return [
     ],
 
     'select' => [
-        'no_search_results_message' => 'No s\'ha trobat cap opció que coincideixi amb la vostra cerca',
+        'no_search_results_message' => "No s'ha trobat cap opció que coincideixi amb la vostra cerca",
         'placeholder' => 'Trieu una opció',
         'search_prompt' => 'Comenceu a escriure per cercar...',
     ],

--- a/packages/forms/resources/lang/it/components.php
+++ b/packages/forms/resources/lang/it/components.php
@@ -206,7 +206,7 @@ return [
 
         'no_search_results_message' => 'Nessuna opzione trovata per la ricerca.',
 
-        'placeholder' => 'Seleziona un\'opzione',
+        'placeholder' => "Seleziona un'opzione",
 
         'searching_message' => 'Ricerca...',
 

--- a/packages/tables/resources/lang/fr/table.php
+++ b/packages/tables/resources/lang/fr/table.php
@@ -139,7 +139,7 @@ return [
 
     ],
 
-    'reorder_indicator' => 'Faites glisser et déposez les enregistrements dans l\'ordre.',
+    'reorder_indicator' => "Faites glisser et déposez les enregistrements dans l'ordre.",
 
     'selection_indicator' => [
 


### PR DESCRIPTION
single quotes + `\`-escaping to double quotes in translation files