### PR TITLE
Fixes header cell sort icon spacing

### DIFF
--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -14,7 +14,7 @@
         @endif
         type="button"
         @class([
-            'flex items-center w-full px-4 py-2 whitespace-nowrap space-x-1 rtl:space-x-reverse font-medium text-sm text-gray-600',
+            'flex items-center w-full px-4 py-2 whitespace-nowrap font-medium text-sm text-gray-600',
             'dark:text-gray-300' => config('tables.dark_mode'),
             'cursor-default' => ! $sortable,
             match ($alignment) {
@@ -48,7 +48,7 @@
             <x-dynamic-component
                 :component="$isSortColumn && $sortDirection === 'asc' ? 'heroicon-s-chevron-up' : 'heroicon-s-chevron-down'"
                 :class="\Illuminate\Support\Arr::toCssClasses([
-                    'filament-tables-header-cell-sort-icon h-3 w-3',
+                    'filament-tables-header-cell-sort-icon h-3 w-3 ml-1 rtl:ml-0 rtl:mr-1',
                     'dark:text-gray-300' => config('tables.dark_mode'),
                     'opacity-25' => ! $isSortColumn,
                 ])"


### PR DESCRIPTION
This fixes the extra margin-left spacing that was added in #5648 due to the additional sr-only span classes. 

With the addition of the spans, `space-x-1` is no longer viable. This removes the `space-x-1` and adds `ml-1` to the icon (and adjusts for RTL). 