### PR TITLE
Adding ability to `emitSelf`, `emitUp` and `emitTo` for `CanEmitEvent` trait

### DIFF
--- a/packages/notifications/dist/module.esm.js
+++ b/packages/notifications/dist/module.esm.js
@@ -469,6 +469,30 @@ var Action = class {
     this.eventData(data);
     return this;
   }
+  emitSelf(event, data) {
+    this.emit(event, data);
+    this.emitDirection = "self";
+    return this;
+  }
+  emitTo(to, event, data) {
+    this.emit(event, data);
+    this.emitDirection = "to";
+    this.emitToTarget = to;
+    return this;
+  }
+  emitUp(event, data) {
+    this.emit(event, data);
+    this.emitDirection = "up";
+    return this;
+  }
+  emitDirection(emitDirection) {
+    this.emitDirection = emitDirection;
+    return this;
+  }
+  emitToTarget(emitToTarget) {
+    this.emitToTarget = emitToTarget;
+    return this;
+  }
   event(event) {
     this.event = event;
     return this;

--- a/packages/notifications/docs/02-sending-notifications.md
+++ b/packages/notifications/docs/02-sending-notifications.md
@@ -296,6 +296,22 @@ Notification::make()
     ->send();
 ```
 
+You can also `emitSelf`, `emitUp` and `emitTo`:
+
+```php
+Action::make('undo')
+    ->color('secondary')
+    ->emitSelf('undoEditingPost', [$post->id]) // [tl! focus]
+    
+Action::make('undo')
+    ->color('secondary')
+    ->emitUp('undoEditingPost', [$post->id]) // [tl! focus]
+    
+Action::make('undo')
+    ->color('secondary')
+    ->emitTo('another_component', 'undoEditingPost', [$post->id]) // [tl! focus]
+```
+
 Or with JavaScript:
 
 ```js
@@ -315,6 +331,21 @@ new Notification()
     .send()
 ```
 
+Similarly, `emitSelf`, `emitUp` and `emitTo` are also available:
+
+```js
+new NotificationAction('undo')
+    .color('secondary')
+    .emitSelf('undoEditingPost') // [tl! focus]
+
+new NotificationAction('undo')
+    .color('secondary')
+    .emitUp('undoEditingPost') // [tl! focus]
+
+new NotificationAction('undo')
+    .color('secondary')
+    .emitTo('another_component', 'undoEditingPost') // [tl! focus]
+```
 ### Closing notifications
 
 After opening a URL or emitting an event from your action, you may want to close the notification right away:

--- a/packages/notifications/resources/js/Notification.js
+++ b/packages/notifications/resources/js/Notification.js
@@ -136,6 +136,40 @@ class Action {
         return this
     }
 
+    emitSelf(event, data) {
+        this.emit(event, data)
+        this.emitDirection = 'self'
+
+        return this
+    }
+
+    emitTo(to, event, data) {
+        this.emit(event, data)
+        this.emitDirection = 'to'
+        this.emitToTarget = to
+
+        return this
+    }
+
+    emitUp(event, data) {
+        this.emit(event, data)
+        this.emitDirection = 'up'
+
+        return this
+    }
+
+    emitDirection(emitDirection) {
+        this.emitDirection = emitDirection
+
+        return this
+    }
+
+    emitToTarget(emitToTarget) {
+        this.emitToTarget = emitToTarget
+
+        return this
+    }
+
     event(event) {
         this.event = event
 

--- a/packages/notifications/resources/views/components/actions/action.blade.php
+++ b/packages/notifications/resources/views/components/actions/action.blade.php
@@ -3,25 +3,12 @@
     'component',
 ])
 
-@php
-    $wireClickAction = null;
-
-    if ($action->getEvent()) {
-        $emitArguments = collect([$action->getEvent()])
-            ->merge($action->getEventData())
-            ->map(fn (mixed $value) => \Illuminate\Support\Js::from($value)->toHtml())
-            ->implode(', ');
-
-        $wireClickAction = "\$emit($emitArguments)";
-    }
-@endphp
-
 <x-dynamic-component
     :component="$component"
     :dark-mode="config('notifications.dark_mode')"
     :attributes="\Filament\Support\prepare_inherited_attributes($attributes)->merge($action->getExtraAttributes())"
     :tag="$action->getUrl() ? 'a' : 'button'"
-    :wire:click="$action->isEnabled() ? $wireClickAction : null"
+    :wire:click="$action->isEnabled() ? $action->getWireClickAction() : null"
     :x-on:click="$action->isEnabled() && $action->shouldCloseNotification() ? 'close' : null"
     :href="$action->isEnabled() ? $action->getUrl() : null"
     :target="$action->shouldOpenUrlInNewTab() ? '_blank' : null"

--- a/packages/notifications/src/Actions/Action.php
+++ b/packages/notifications/src/Actions/Action.php
@@ -56,7 +56,7 @@ class Action extends BaseAction implements Arrayable
         $static->color($data['color'] ?? null);
         $static->disabled($data['isDisabled'] ?? false);
 
-        match($data['emitDirection'] ?? '') {
+        match ($data['emitDirection'] ?? '') {
             'self' => $static->emitSelf($data['event'] ?? null, $data['eventData'] ?? []),
             'up' => $static->emitUp($data['event'] ?? null, $data['eventData'] ?? []),
             'to' => $static->emitTo($data['emitToTarget'] ?? null, $data['event'] ?? null, $data['eventData'] ?? []),

--- a/packages/notifications/src/Actions/Action.php
+++ b/packages/notifications/src/Actions/Action.php
@@ -55,7 +55,14 @@ class Action extends BaseAction implements Arrayable
         $static->close($data['shouldCloseNotification'] ?? false);
         $static->color($data['color'] ?? null);
         $static->disabled($data['isDisabled'] ?? false);
-        $static->emit($data['event'] ?? null, $data['eventData'] ?? []);
+
+        match($data['emitDirection'] ?? '') {
+            'self' => $static->emitSelf($data['event'] ?? null, $data['eventData'] ?? []),
+            'up' => $static->emitUp($data['event'] ?? null, $data['eventData'] ?? []),
+            'to' => $static->emitTo($data['emitToTarget'] ?? null, $data['event'] ?? null, $data['eventData'] ?? []),
+            default => $static->emit($data['event'] ?? null, $data['eventData'] ?? [])
+        };
+
         $static->extraAttributes($data['extraAttributes'] ?? []);
         $static->icon($data['icon'] ?? null);
         $static->iconPosition($data['iconPosition'] ?? null);

--- a/packages/support/src/Actions/Concerns/CanEmitEvent.php
+++ b/packages/support/src/Actions/Concerns/CanEmitEvent.php
@@ -3,6 +3,7 @@
 namespace Filament\Support\Actions\Concerns;
 
 use Closure;
+use Illuminate\Support\Collection;
 
 trait CanEmitEvent
 {
@@ -81,8 +82,8 @@ trait CanEmitEvent
         if ($this->getEvent()) {
             $emitArguments = collect([$this->getEvent()])
                 ->merge($this->getEventData())
-                ->when($this->emitToTarget, fn ($collection, string $target) => $collection->prepend($target))
-                ->map(fn (mixed $value) => \Illuminate\Support\Js::from($value)->toHtml())
+                ->when($this->emitToTarget, fn (Collection $collection, string $target) => $collection->prepend($target))
+                ->map(fn (mixed $value): string => \Illuminate\Support\Js::from($value)->toHtml())
                 ->implode(', ');
 
             $wireClickAction = match ($this->emitDirection) {

--- a/packages/support/src/Actions/Concerns/CanEmitEvent.php
+++ b/packages/support/src/Actions/Concerns/CanEmitEvent.php
@@ -81,11 +81,11 @@ trait CanEmitEvent
         if ($this->getEvent()) {
             $emitArguments = collect([$this->getEvent()])
                 ->merge($this->getEventData())
-                ->when($this->emitToTarget, fn($collection, string $target) => $collection->prepend($target))
+                ->when($this->emitToTarget, fn ($collection, string $target) => $collection->prepend($target))
                 ->map(fn (mixed $value) => \Illuminate\Support\Js::from($value)->toHtml())
                 ->implode(', ');
 
-            $wireClickAction = match($this->emitDirection) {
+            $wireClickAction = match ($this->emitDirection) {
                 'self' => "\$emitSelf($emitArguments)",
                 'up' => "\$emitUp($emitArguments)",
                 'to' => "\$emitTo($emitArguments)",

--- a/packages/support/src/Actions/Concerns/CanEmitEvent.php
+++ b/packages/support/src/Actions/Concerns/CanEmitEvent.php
@@ -10,12 +10,49 @@ trait CanEmitEvent
 
     protected array | Closure $eventData = [];
 
+    protected string | bool $emitDirection = false;
+
+    protected string $emitToTarget = '';
+
     public function emit(
         string | Closure | null $event,
-        array | Closure $data = [],
+        array | Closure $data = []
     ): static {
         $this->event = $event;
         $this->eventData = $data;
+        $this->emitDirection = false;
+
+        return $this;
+    }
+
+    public function emitSelf(
+        string | Closure | null $event,
+        array | Closure $data = []
+    ): static {
+        $this->emit($event, $data);
+        $this->emitDirection = 'self';
+
+        return $this;
+    }
+
+    public function emitTo(
+        string $to,
+        string | Closure | null $event,
+        array | Closure $data = [],
+    ): static {
+        $this->emit($event, $data);
+        $this->emitDirection = 'to';
+        $this->emitToTarget = $to;
+
+        return $this;
+    }
+
+    public function emitUp(
+        string | Closure | null $event,
+        array | Closure $data = []
+    ): static {
+        $this->emit($event, $data);
+        $this->emitDirection = 'up';
 
         return $this;
     }
@@ -35,5 +72,27 @@ trait CanEmitEvent
     public function getEventData(): array
     {
         return $this->evaluate($this->eventData);
+    }
+
+    public function getWireClickAction(): ?string
+    {
+        $wireClickAction = null;
+
+        if ($this->getEvent()) {
+            $emitArguments = collect([$this->getEvent()])
+                ->merge($this->getEventData())
+                ->when($this->emitToTarget, fn($collection, string $target) => $collection->prepend($target))
+                ->map(fn (mixed $value) => \Illuminate\Support\Js::from($value)->toHtml())
+                ->implode(', ');
+
+            $wireClickAction = match($this->emitDirection) {
+                'self' => "\$emitSelf($emitArguments)",
+                'up' => "\$emitUp($emitArguments)",
+                'to' => "\$emitTo($emitArguments)",
+                default => "\$emit($emitArguments)"
+            };
+        }
+
+        return $wireClickAction;
     }
 }

--- a/tests/src/Notifications/NotificationTest.php
+++ b/tests/src/Notifications/NotificationTest.php
@@ -160,3 +160,39 @@ it('can close notifications', function () {
         ->toBeInstanceOf(Collection::class)
         ->toHaveCount(0);
 });
+
+it('can emit an event', function () {
+
+    $action = Action::make('action')->emit('an_event');
+    expect($action->getWireClickAction())->toBe("\$emit('an_event')");
+
+    $action = Action::make('action')->emit('an_event', ['data']);
+    expect($action->getWireClickAction())->toBe("\$emit('an_event', 'data')");
+
+});
+
+it('can emit an event to itself', function () {
+
+    $action = Action::make('action')->emitSelf('an_event');
+    expect($action->getWireClickAction())->toBe("\$emitSelf('an_event')");
+
+    $action = Action::make('action')->emitSelf('an_event', ['data']);
+    expect($action->getWireClickAction())->toBe("\$emitSelf('an_event', 'data')");
+});
+
+it('can emit an event up', function () {
+    $action = Action::make('action')->emitUp('an_event');
+    expect($action->getWireClickAction())->toBe("\$emitUp('an_event')");
+
+    $action = Action::make('action')->emitUp('an_event', ['data']);
+    expect($action->getWireClickAction())->toBe("\$emitUp('an_event', 'data')");
+});
+
+it('can emit an event to a component', function () {
+    $action = Action::make('action')->emitTo('a_component', 'an_event');
+    expect($action->getWireClickAction())->toBe("\$emitTo('a_component', 'an_event')");
+
+    $action = Action::make('action')->emitTo('a_component', 'an_event', ['data'], );
+    expect($action->getWireClickAction())->toBe("\$emitTo('a_component', 'an_event', 'data')");
+});
+

--- a/tests/src/Notifications/NotificationTest.php
+++ b/tests/src/Notifications/NotificationTest.php
@@ -162,17 +162,14 @@ it('can close notifications', function () {
 });
 
 it('can emit an event', function () {
-
     $action = Action::make('action')->emit('an_event');
     expect($action->getWireClickAction())->toBe("\$emit('an_event')");
 
     $action = Action::make('action')->emit('an_event', ['data']);
     expect($action->getWireClickAction())->toBe("\$emit('an_event', 'data')");
-
 });
 
 it('can emit an event to itself', function () {
-
     $action = Action::make('action')->emitSelf('an_event');
     expect($action->getWireClickAction())->toBe("\$emitSelf('an_event')");
 
@@ -192,7 +189,6 @@ it('can emit an event to a component', function () {
     $action = Action::make('action')->emitTo('a_component', 'an_event');
     expect($action->getWireClickAction())->toBe("\$emitTo('a_component', 'an_event')");
 
-    $action = Action::make('action')->emitTo('a_component', 'an_event', ['data'], );
+    $action = Action::make('action')->emitTo('a_component', 'an_event', ['data']);
     expect($action->getWireClickAction())->toBe("\$emitTo('a_component', 'an_event', 'data')");
 });
-


### PR DESCRIPTION
PR to allow emitting to self, up and to from Notification Actions. Docs also updated.

I have also included this for the JS side of things. I could only test this anecdotally. Is there a test suite for JS in Filament?