### PR TITLE
Fixing `assertNotified` to remove false positives and usage of `id` in equality

### DIFF
--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -210,12 +210,12 @@ class Notification extends ViewComponent implements Arrayable
 
         Assert::assertIsArray($notifications->toArray());
 
-        if(is_string($notification)) {
-            $expectedNotification = $notifications->first(fn($n) => $n->title == $notification);
-        };
+        if (is_string($notification)) {
+            $expectedNotification = $notifications->first(fn ($n) => $n->title == $notification);
+        }
 
         if ($notification instanceof Notification) {
-            $expectedNotification = $notifications->first(fn($n, $key) => $n->id == $key);
+            $expectedNotification = $notifications->first(fn ($n, $key) => $n->id == $key);
         }
 
         if (blank($notification)) {

--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -211,11 +211,11 @@ class Notification extends ViewComponent implements Arrayable
         Assert::assertIsArray($notifications->toArray());
 
         if (is_string($notification)) {
-            $expectedNotification = $notifications->first(fn ($n) => $n->title == $notification);
+            $expectedNotification = $notifications->first(fn (Notification $notification): bool => $notification->title === $notification);
         }
 
         if ($notification instanceof Notification) {
-            $expectedNotification = $notifications->first(fn ($n, $key) => $n->id == $key);
+            $expectedNotification = $notifications->first(fn (Notification $notification, string $key): bool => $notification->id === $key);
         }
 
         if (blank($notification)) {

--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -206,7 +206,8 @@ class Notification extends ViewComponent implements Arrayable
 
         Assert::assertIsArray($notifications);
 
-        $expectedNotification = Arr::last($notifications);
+        $expectedNotification = array_pop($notifications);
+        session()->put('filament.notifications', $notifications);
 
         Assert::assertIsArray($expectedNotification);
 
@@ -215,7 +216,10 @@ class Notification extends ViewComponent implements Arrayable
         }
 
         if ($notification instanceof Notification) {
-            Assert::assertSame($expectedNotification, $notification->toArray());
+            Assert::assertSame(
+                collect($expectedNotification)->except(['id'])->toArray(),
+                collect($notification->toArray())->except(['id'])->toArray()
+            );
 
             return;
         }

--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -211,11 +211,11 @@ class Notification extends ViewComponent implements Arrayable
         Assert::assertIsArray($notifications->toArray());
 
         if (is_string($notification)) {
-            $expectedNotification = $notifications->first(fn (Notification $notification): bool => $notification->title === $notification);
+            $expectedNotification = $notifications->first(fn (Notification $mountedNotification): bool => $mountedNotification->title === $notification);
         }
 
         if ($notification instanceof Notification) {
-            $expectedNotification = $notifications->first(fn (Notification $notification, string $key): bool => $notification->id === $key);
+            $expectedNotification = $notifications->first(fn (Notification $mountedNotification, string $key): bool => $mountedNotification->id === $key);
         }
 
         if (blank($notification)) {

--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -19,7 +19,6 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\DatabaseNotification as DatabaseNotificationModel;
 use Illuminate\Notifications\Messages\BroadcastMessage;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\Assert;

--- a/tests/src/Admin/Fixtures/Pages/PageActions.php
+++ b/tests/src/Admin/Fixtures/Pages/PageActions.php
@@ -74,7 +74,7 @@ class PageActions extends Page
                         ->send();
                 }),
             Action::make('two_notifications')
-                ->action(function() {
+                ->action(function () {
                     Notification::make('first_notification')
                         ->title('First notification')
                         ->success()
@@ -83,7 +83,7 @@ class PageActions extends Page
                         ->title('Second notification')
                         ->success()
                         ->send();
-                })
+                }),
         ];
     }
 }

--- a/tests/src/Admin/Fixtures/Pages/PageActions.php
+++ b/tests/src/Admin/Fixtures/Pages/PageActions.php
@@ -59,7 +59,7 @@ class PageActions extends Page
             Action::make('url_not_in_new_tab')
                 ->url('https://filamentphp.com', false),
             Action::make('shows_notification')
-                ->action(function() {
+                ->action(function () {
                     Notification::make()
                         ->title('A notification')
                         ->success()
@@ -67,7 +67,7 @@ class PageActions extends Page
                 }),
             Action::make('does_not_show_notification'),
             Action::make('shows_notification_with_id')
-                ->action(function() {
+                ->action(function () {
                     Notification::make('notification_with_id')
                         ->title('A notification')
                         ->success()

--- a/tests/src/Admin/Fixtures/Pages/PageActions.php
+++ b/tests/src/Admin/Fixtures/Pages/PageActions.php
@@ -4,6 +4,7 @@ namespace Filament\Tests\Admin\Fixtures\Pages;
 
 use Filament\Forms\ComponentContainer;
 use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
 use Filament\Pages\Actions\Action;
 use Filament\Pages\Page;
 
@@ -57,6 +58,21 @@ class PageActions extends Page
                 ->url('https://filamentphp.com', true),
             Action::make('url_not_in_new_tab')
                 ->url('https://filamentphp.com', false),
+            Action::make('shows_notification')
+                ->action(function() {
+                    Notification::make()
+                        ->title('A notification')
+                        ->success()
+                        ->send();
+                }),
+            Action::make('does_not_show_notification'),
+            Action::make('shows_notification_with_id')
+                ->action(function() {
+                    Notification::make('notification_with_id')
+                        ->title('A notification')
+                        ->success()
+                        ->send();
+                }),
         ];
     }
 }

--- a/tests/src/Admin/Fixtures/Pages/PageActions.php
+++ b/tests/src/Admin/Fixtures/Pages/PageActions.php
@@ -73,6 +73,17 @@ class PageActions extends Page
                         ->success()
                         ->send();
                 }),
+            Action::make('two_notifications')
+                ->action(function() {
+                    Notification::make('first_notification')
+                        ->title('First notification')
+                        ->success()
+                        ->send();
+                    Notification::make('second_notification')
+                        ->title('Second notification')
+                        ->success()
+                        ->send();
+                })
         ];
     }
 }

--- a/tests/src/Admin/Pages/ActionTest.php
+++ b/tests/src/Admin/Pages/ActionTest.php
@@ -108,7 +108,6 @@ it('can state whether a page action exists', function () {
 });
 
 it('can show a notification', function () {
-
     livewire(PageActions::class)
         ->callPageAction('shows_notification')
         ->assertNotified();
@@ -127,7 +126,6 @@ it('can show a notification', function () {
 });
 
 it('will raise an exception if a notification was not sent checking notification object', function () {
-
     $this->expectException('PHPUnit\Framework\ExpectationFailedException');
 
     livewire(PageActions::class)
@@ -140,7 +138,6 @@ it('will raise an exception if a notification was not sent checking notification
 });
 
 it('will raise an exception if a notification was not sent checking notification title', function () {
-
     $this->expectException('PHPUnit\Framework\ExpectationFailedException');
 
     livewire(PageActions::class)
@@ -149,7 +146,6 @@ it('will raise an exception if a notification was not sent checking notification
 });
 
 it('can show a notification with id', function () {
-
     livewire(PageActions::class)
         ->callPageAction('shows_notification_with_id')
         ->assertNotified();
@@ -168,7 +164,6 @@ it('can show a notification with id', function () {
 });
 
 it('will raise an exception if a notification was sent checking with a different notification title', function () {
-
     $this->expectException('PHPUnit\Framework\ExpectationFailedException');
 
     livewire(PageActions::class)
@@ -181,7 +176,6 @@ it('will raise an exception if a notification was sent checking with a different
 });
 
 test('assertNotified will remove notifications from the session', function () {
-
     livewire(PageActions::class)
         ->callPageAction('shows_notification_with_id')
         ->assertNotified(

--- a/tests/src/Admin/Pages/ActionTest.php
+++ b/tests/src/Admin/Pages/ActionTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Filament\Notifications\Notification;
 use Filament\Tests\Admin\Fixtures\Pages\PageActions;
 use Filament\Tests\Admin\Pages\TestCase;
 use Illuminate\Support\Str;
@@ -104,4 +105,98 @@ it('can state whether a page action exists', function () {
     livewire(PageActions::class)
         ->assertPageActionExists('exists')
         ->assertPageActionDoesNotExist('does_not_exist');
+});
+
+it('can show a notification', function () {
+
+    livewire(PageActions::class)
+        ->callPageAction('shows_notification')
+        ->assertNotified();
+
+    livewire(PageActions::class)
+        ->callPageAction('shows_notification')
+        ->assertNotified('A notification');
+
+    livewire(PageActions::class)
+        ->callPageAction('shows_notification')
+        ->assertNotified(
+            Notification::make()
+                ->title('A notification')
+                ->success()
+        );
+});
+
+it('will raise an exception if a notification was not sent checking notification object', function () {
+
+    $this->expectException('PHPUnit\Framework\ExpectationFailedException');
+
+    livewire(PageActions::class)
+        ->callPageAction('does_not_show_notification')
+        ->assertNotified(
+            Notification::make()
+                ->title('A notification')
+                ->success()
+        );
+});
+
+it('will raise an exception if a notification was not sent checking notification title', function () {
+
+    $this->expectException('PHPUnit\Framework\ExpectationFailedException');
+
+    livewire(PageActions::class)
+        ->callPageAction('does_not_show_notification')
+        ->assertNotified('A notification');
+});
+
+it('can show a notification with id', function () {
+
+    livewire(PageActions::class)
+        ->callPageAction('shows_notification_with_id')
+        ->assertNotified();
+
+    livewire(PageActions::class)
+        ->callPageAction('shows_notification_with_id')
+        ->assertNotified('A notification');
+
+    livewire(PageActions::class)
+        ->callPageAction('shows_notification_with_id')
+        ->assertNotified(
+            Notification::make('notification_with_id')
+                ->title('A notification')
+                ->success()
+        );
+});
+
+it('will raise an exception if a notification was sent checking with a different notification title', function () {
+
+    $this->expectException('PHPUnit\Framework\ExpectationFailedException');
+
+    livewire(PageActions::class)
+        ->callPageAction('shows_notification_with_id')
+        ->assertNotified(
+            Notification::make()
+                ->title('A different title')
+                ->success()
+        );
+});
+
+test('assertNotified will remove notifications from the session', function () {
+
+    livewire(PageActions::class)
+        ->callPageAction('shows_notification_with_id')
+        ->assertNotified(
+            Notification::make()
+                ->title('A notification')
+                ->success()
+        );
+
+    $this->expectException('PHPUnit\Framework\ExpectationFailedException');
+
+    livewire(PageActions::class)
+        ->callPageAction('does_not_show_notification')
+        ->assertNotified(
+            Notification::make()
+                ->title('A notification')
+                ->success()
+        );
 });

--- a/tests/src/Admin/Pages/ActionTest.php
+++ b/tests/src/Admin/Pages/ActionTest.php
@@ -218,7 +218,6 @@ it('will raise an exception if a notification is not sent but a previous notific
 });
 
 test('can assert that notifications are sent in any order', function () {
-
     livewire(PageActions::class)
         ->callPageAction('two_notifications')
         ->assertNotified('Second notification');

--- a/tests/src/Admin/Pages/ActionTest.php
+++ b/tests/src/Admin/Pages/ActionTest.php
@@ -127,6 +127,7 @@ it('can show a notification', function () {
 
 it('will raise an exception if a notification was not sent checking notification object', function () {
     $this->expectException('PHPUnit\Framework\ExpectationFailedException');
+    $this->expectExceptionMessage('A notification was not sent');
 
     livewire(PageActions::class)
         ->callPageAction('does_not_show_notification')
@@ -139,13 +140,32 @@ it('will raise an exception if a notification was not sent checking notification
 
 it('will raise an exception if a notification was not sent checking notification title', function () {
     $this->expectException('PHPUnit\Framework\ExpectationFailedException');
+    $this->expectExceptionMessage('A notification was not sent');
 
     livewire(PageActions::class)
         ->callPageAction('does_not_show_notification')
         ->assertNotified('A notification');
 });
 
-it('can show a notification with id', function () {
+it('can assert that a notification without an id was sent', function () {
+    livewire(PageActions::class)
+        ->callPageAction('shows_notification')
+        ->assertNotified();
+
+    livewire(PageActions::class)
+        ->callPageAction('shows_notification')
+        ->assertNotified('A notification');
+
+    livewire(PageActions::class)
+        ->callPageAction('shows_notification')
+        ->assertNotified(
+            Notification::make()
+                ->title('A notification')
+                ->success()
+        );
+});
+
+it('can assert that a notification with an id was sent', function () {
     livewire(PageActions::class)
         ->callPageAction('shows_notification_with_id')
         ->assertNotified();
@@ -165,6 +185,7 @@ it('can show a notification with id', function () {
 
 it('will raise an exception if a notification was sent checking with a different notification title', function () {
     $this->expectException('PHPUnit\Framework\ExpectationFailedException');
+    $this->expectExceptionMessage('Failed asserting that two arrays are identical.');
 
     livewire(PageActions::class)
         ->callPageAction('shows_notification_with_id')
@@ -175,7 +196,7 @@ it('will raise an exception if a notification was sent checking with a different
         );
 });
 
-test('assertNotified will remove notifications from the session', function () {
+it('will raise an exception if a notification is not sent but a previous notification was sent', function () {
     livewire(PageActions::class)
         ->callPageAction('shows_notification_with_id')
         ->assertNotified(
@@ -185,6 +206,7 @@ test('assertNotified will remove notifications from the session', function () {
         );
 
     $this->expectException('PHPUnit\Framework\ExpectationFailedException');
+    $this->expectExceptionMessage('A notification was not sent');
 
     livewire(PageActions::class)
         ->callPageAction('does_not_show_notification')
@@ -193,4 +215,22 @@ test('assertNotified will remove notifications from the session', function () {
                 ->title('A notification')
                 ->success()
         );
+});
+
+test('can assert that notifications are sent in any order', function () {
+
+    livewire(PageActions::class)
+        ->callPageAction('two_notifications')
+        ->assertNotified('Second notification');
+
+    livewire(PageActions::class)
+        ->callPageAction('two_notifications')
+        ->assertNotified('First notification');
+
+    $this->expectException('PHPUnit\Framework\ExpectationFailedException');
+    $this->expectExceptionMessage('A notification was not sent');
+
+    livewire(PageActions::class)
+        ->callPageAction('two_notifications')
+        ->assertNotified('Third notification');
 });

--- a/tests/src/Admin/Pages/ActionTest.php
+++ b/tests/src/Admin/Pages/ActionTest.php
@@ -147,7 +147,7 @@ it('will raise an exception if a notification was not sent checking notification
         ->assertNotified('A notification');
 });
 
-it('can assert that a notification without an id was sent', function () {
+it('can assert that a notification without an ID was sent', function () {
     livewire(PageActions::class)
         ->callPageAction('shows_notification')
         ->assertNotified();
@@ -165,7 +165,7 @@ it('can assert that a notification without an id was sent', function () {
         );
 });
 
-it('can assert that a notification with an id was sent', function () {
+it('can assert that a notification with an ID was sent', function () {
     livewire(PageActions::class)
         ->callPageAction('shows_notification_with_id')
         ->assertNotified();

--- a/tests/src/Notifications/NotificationTest.php
+++ b/tests/src/Notifications/NotificationTest.php
@@ -160,3 +160,12 @@ it('can close notifications', function () {
         ->toBeInstanceOf(Collection::class)
         ->toHaveCount(0);
 });
+
+it('can confirm a notification was sent', function() {
+    ($notification = Notification::make()
+        ->success()
+        ->title('This is a notification')
+        ->body('are you sure'))->send();
+
+    Notification::assertNotified($notification);
+});

--- a/tests/src/Notifications/NotificationTest.php
+++ b/tests/src/Notifications/NotificationTest.php
@@ -161,7 +161,6 @@ it('can close notifications', function () {
         ->toHaveCount(0);
 });
 
-
 it('can confirm a notification was sent', function () {
     $notification = Notification::make()
         ->success()
@@ -171,7 +170,7 @@ it('can confirm a notification was sent', function () {
 
     Notification::assertNotified($notification);
 });
-    
+
 it('can emit an event', function () {
     $action = Action::make('action')->emit('an_event');
     expect($action->getWireClickAction())->toBe("\$emit('an_event')");

--- a/tests/src/Notifications/NotificationTest.php
+++ b/tests/src/Notifications/NotificationTest.php
@@ -161,7 +161,7 @@ it('can close notifications', function () {
         ->toHaveCount(0);
 });
 
-it('can confirm a notification was sent', function() {
+it('can confirm a notification was sent', function () {
     ($notification = Notification::make()
         ->success()
         ->title('This is a notification')


### PR DESCRIPTION
Fixes #5717.

Two main things I found when digging into this. My tests are perhaps overkill but just wanted to be sure. Please trim if necessary! 

1. One of the issues that when comparing notifications, the `id` is used in that comparison. If an `id` is missing when an notification is created, then one is randomly generated, This happens when the notification is stored and retreived. As a result, the comparison invariably fails as most people won't set an `id` or don't even realise that an `id` can be set. The solution here was to just remove `id` when testing for equality between the arrays.

2. `assertNotified` doesn't mimic the removal of notifications when they are dispatched. So false positives can arise. Given the example:

```
Action::make('does_not_show_notification'),
Action::make('shows_notification_with_id')
    ->action(function() {
        Notification::make('notification_with_id')
            ->title('A notification')
            ->success()
            ->send();

...

it('should fail', function () {

    //this passes correctly
    livewire(PageActions::class)
        ->callPageAction('shows_notification_with_id')
        ->assertNotified(
            Notification::make('notification_with_id')
                ->title('A notification')
                ->success()
        );

    //this should fail
    livewire(PageActions::class)
        ->callPageAction('does_not_show_notification')
        ->assertNotified(
            Notification::make('notification_with_id')
                ->title('A notification')
                ->success()
        );
});
```
This test passes as the first assertion does not remove the notification from the session. The second assertion test just pulls the last notification from the session and uses that to test. I've added in a small amendment to remove the tested notification and write back to the session so that it is sync with the test.