### PR TITLE
Handle JSON columns in form select component relationships

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -474,6 +474,7 @@ class Select extends Field implements Contracts\HasNestedRecursiveValidationRule
             }
 
             $relationshipTitleColumnName = $component->getRelationshipTitleColumnName();
+
             return $relationshipQuery
                 ->pluck("{$relationshipTitleColumnName} as {$relationshipTitleColumnName}", $keyName)
                 ->toArray();

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -565,6 +565,7 @@ class Select extends Field implements Contracts\HasNestedRecursiveValidationRule
             }
 
             $relationshipTitleColumnName = $component->getRelationshipTitleColumnName();
+
             return $relationshipQuery
                 ->pluck("{$relationshipTitleColumnName} as {$relationshipTitleColumnName}", $relatedKeyName)
                 ->toArray();

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -433,7 +433,7 @@ class Select extends Field implements Contracts\HasNestedRecursiveValidationRule
             }
 
             return $relationshipQuery
-                ->pluck($component->getRelationshipTitleColumnName(), $keyName)
+                ->pluck($component->getRelationshipTitleColumnName() . ' as ' . $component->getRelationshipTitleColumnName(), $keyName)
                 ->toArray();
         });
 
@@ -472,7 +472,7 @@ class Select extends Field implements Contracts\HasNestedRecursiveValidationRule
             }
 
             return $relationshipQuery
-                ->pluck($component->getRelationshipTitleColumnName(), $keyName)
+                ->pluck($component->getRelationshipTitleColumnName() . ' as ' . $component->getRelationshipTitleColumnName(), $keyName)
                 ->toArray();
         });
 
@@ -561,7 +561,7 @@ class Select extends Field implements Contracts\HasNestedRecursiveValidationRule
             }
 
             return $relationshipQuery
-                ->pluck($component->getRelationshipTitleColumnName(), $relatedKeyName)
+                ->pluck($component->getRelationshipTitleColumnName() . ' as ' . $component->getRelationshipTitleColumnName(), $relatedKeyName)
                 ->toArray();
         });
 

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -433,7 +433,7 @@ class Select extends Field implements Contracts\HasNestedRecursiveValidationRule
             }
 
             return $relationshipQuery
-                ->pluck($component->getRelationshipTitleColumnName() . ' as ' . $component->getRelationshipTitleColumnName(), $keyName)
+                ->pluck("{$component->getRelationshipTitleColumnName()} as {$component->getRelationshipTitleColumnName()}", $keyName)
                 ->toArray();
         });
 

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -472,7 +472,7 @@ class Select extends Field implements Contracts\HasNestedRecursiveValidationRule
             }
 
             return $relationshipQuery
-                ->pluck($component->getRelationshipTitleColumnName() . ' as ' . $component->getRelationshipTitleColumnName(), $keyName)
+                ->pluck("{$component->getRelationshipTitleColumnName()} as {$component->getRelationshipTitleColumnName()}", $keyName)
                 ->toArray();
         });
 
@@ -561,7 +561,7 @@ class Select extends Field implements Contracts\HasNestedRecursiveValidationRule
             }
 
             return $relationshipQuery
-                ->pluck($component->getRelationshipTitleColumnName() . ' as ' . $component->getRelationshipTitleColumnName(), $relatedKeyName)
+                ->pluck("{$component->getRelationshipTitleColumnName()} as {$component->getRelationshipTitleColumnName()}", $relatedKeyName)
                 ->toArray();
         });
 

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -433,6 +433,7 @@ class Select extends Field implements Contracts\HasNestedRecursiveValidationRule
             }
 
             $relationshipTitleColumnName = $component->getRelationshipTitleColumnName();
+
             return $relationshipQuery
                 ->pluck("{$relationshipTitleColumnName} as {$relationshipTitleColumnName}", $keyName)
                 ->toArray();

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -432,8 +432,9 @@ class Select extends Field implements Contracts\HasNestedRecursiveValidationRule
                     ->toArray();
             }
 
+            $relationshipTitleColumnName = $component->getRelationshipTitleColumnName();
             return $relationshipQuery
-                ->pluck("{$component->getRelationshipTitleColumnName()} as {$component->getRelationshipTitleColumnName()}", $keyName)
+                ->pluck("{$relationshipTitleColumnName} as {$relationshipTitleColumnName}", $keyName)
                 ->toArray();
         });
 
@@ -471,8 +472,9 @@ class Select extends Field implements Contracts\HasNestedRecursiveValidationRule
                     ->toArray();
             }
 
+            $relationshipTitleColumnName = $component->getRelationshipTitleColumnName();
             return $relationshipQuery
-                ->pluck("{$component->getRelationshipTitleColumnName()} as {$component->getRelationshipTitleColumnName()}", $keyName)
+                ->pluck("{$relationshipTitleColumnName} as {$relationshipTitleColumnName}", $keyName)
                 ->toArray();
         });
 
@@ -560,8 +562,9 @@ class Select extends Field implements Contracts\HasNestedRecursiveValidationRule
                     ->toArray();
             }
 
+            $relationshipTitleColumnName = $component->getRelationshipTitleColumnName();
             return $relationshipQuery
-                ->pluck("{$component->getRelationshipTitleColumnName()} as {$component->getRelationshipTitleColumnName()}", $relatedKeyName)
+                ->pluck("{$relationshipTitleColumnName} as {$relationshipTitleColumnName}", $relatedKeyName)
                 ->toArray();
         });
 


### PR DESCRIPTION
Adding alias to relationshipTitleColumnName inside pluck fixes the issue of not being able to get fields for json columns.
And won't break for non-json columns also.