### PR TITLE
Adds note on testing with deferLoading()

### DIFF
--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -125,8 +125,6 @@ namespace Livewire\Testing {
 
         public function assertSelectColumnDoesNotHaveOptions(string $name, array $options, $record): static {}
 
-        public function loadTable(): static {}
-
         public function sortTable(?string $name = null, ?string $direction = null): static {}
 
         public function searchTable(?string $search = null): static {}
@@ -138,6 +136,8 @@ namespace Livewire\Testing {
         public function removeTableFilter(string $filter, ?string $field = null): static {}
 
         public function removeTableFilters(): static {}
+
+        public function loadTable(): static {}
 
         public function assertCanSeeTableRecords(array | Collection $records, bool $inOrder = false): static {}
 

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -137,13 +137,13 @@ namespace Livewire\Testing {
 
         public function removeTableFilters(): static {}
 
-        public function loadTable(): static {}
-
         public function assertCanSeeTableRecords(array | Collection $records, bool $inOrder = false): static {}
 
         public function assertCanNotSeeTableRecords(array | Collection $records): static {}
 
         public function assertCountTableRecords(int $count): static {}
+
+        public function loadTable(): static {}
     }
 
 }

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -125,6 +125,8 @@ namespace Livewire\Testing {
 
         public function assertSelectColumnDoesNotHaveOptions(string $name, array $options, $record): static {}
 
+        public function loadTable(): static {}
+
         public function sortTable(?string $name = null, ?string $direction = null): static {}
 
         public function searchTable(?string $search = null): static {}
@@ -136,8 +138,6 @@ namespace Livewire\Testing {
         public function removeTableFilter(string $filter, ?string $field = null): static {}
 
         public function removeTableFilters(): static {}
-
-        public function loadTable(): static {}
 
         public function assertCanSeeTableRecords(array | Collection $records, bool $inOrder = false): static {}
 

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -137,6 +137,8 @@ namespace Livewire\Testing {
 
         public function removeTableFilters(): static {}
 
+        public function loadTable(): static {}
+
         public function assertCanSeeTableRecords(array | Collection $records, bool $inOrder = false): static {}
 
         public function assertCanNotSeeTableRecords(array | Collection $records): static {}

--- a/packages/tables/docs/07-testing.md
+++ b/packages/tables/docs/07-testing.md
@@ -33,7 +33,7 @@ it('can list posts', function () {
 
 > Note that if your table uses pagination, `assertCanSeeTableRecords()` will only check for records on the first page. To switch page, call `set('page', 2)`.
 
-> Note that if your table uses deferLoading(), you must call `set('isTableLoaded', true)` before `assertCanSeeTableRecords()` to force the the component to render the records.
+> Note that if your table uses `deferLoading()`, you should call `set('isTableLoaded', true)` before `assertCanSeeTableRecords()` to render the table records directly.
 
 ## Columns
 

--- a/packages/tables/docs/07-testing.md
+++ b/packages/tables/docs/07-testing.md
@@ -33,6 +33,8 @@ it('can list posts', function () {
 
 > Note that if your table uses pagination, `assertCanSeeTableRecords()` will only check for records on the first page. To switch page, call `set('page', 2)`.
 
+> Note that if your table uses deferLoading(), you must call `set('isTableLoaded', true)` before `assertCanSeeTableRecords()` to force the the component to render the records.
+
 ## Columns
 
 To ensure that a certain column is rendered, pass the column name to `assertCanRenderTableColumn()`:

--- a/packages/tables/docs/07-testing.md
+++ b/packages/tables/docs/07-testing.md
@@ -33,7 +33,7 @@ it('can list posts', function () {
 
 > Note that if your table uses pagination, `assertCanSeeTableRecords()` will only check for records on the first page. To switch page, call `set('page', 2)`.
 
-> Note that if your table uses `deferLoading()`, you should call `loadTable()` before `assertCanSeeTableRecords()` to render the table records directly.
+> Note that if your table uses `deferLoading()`, you should call `loadTable()` before `assertCanSeeTableRecords()`.
 
 ## Columns
 

--- a/packages/tables/docs/07-testing.md
+++ b/packages/tables/docs/07-testing.md
@@ -33,7 +33,7 @@ it('can list posts', function () {
 
 > Note that if your table uses pagination, `assertCanSeeTableRecords()` will only check for records on the first page. To switch page, call `set('page', 2)`.
 
-> Note that if your table uses `deferLoading()`, you should call `set('isTableLoaded', true)` before `assertCanSeeTableRecords()` to render the table records directly.
+> Note that if your table uses `deferLoading()`, you should call `loadTable()` before `assertCanSeeTableRecords()` to render the table records directly.
 
 ## Columns
 

--- a/packages/tables/src/Testing/TestsRecords.php
+++ b/packages/tables/src/Testing/TestsRecords.php
@@ -78,4 +78,13 @@ class TestsRecords
             return $this;
         };
     }
+
+    public function loadTable(): Closure
+    {
+        return function (): static {
+            $this->call('loadTable');
+
+            return $this;
+        };
+    }
 }


### PR DESCRIPTION
Resource list tests will fail if you are using deferLoading() as the livewire component hasnt loaded the records yet. To fix you need to call `->set('isTableLoaded', true)` before calling `assertCanSeeTableRecords()`. 

This PR adds a note to the documentation about this. 