### PR TITLE
Adding option for adding default collapsed/expanded for Panel Layout.

### DIFF
--- a/packages/tables/docs/06-layout.md
+++ b/packages/tables/docs/06-layout.md
@@ -256,6 +256,31 @@ use Filament\Tables\Columns\TextColumn;
 ]
 ```
 
+Also default collapse mode can be set for `Panel` Layout using `collapsed` method.
+
+```php
+use Filament\Tables\Columns\Layout\Panel;
+use Filament\Tables\Columns\TextColumn;
+
+[
+    Panel::make([
+        Stack::make([
+            TextColumn::make('email'),
+            TextColumn::make('phone'),
+        ]),
+    ])->collapsed(function($record){
+         return false;
+    }),
+    
+    Panel::make([
+        Stack::make([
+            TextColumn::make('address'),
+            TextColumn::make('addressline'),
+        ]),
+    ])->collapsed(false),
+    
+]
+```
 ![Collapsible content](https://user-images.githubusercontent.com/41773797/191834045-e423afd4-1ad3-4636-8635-fe9453423555.png)
 
 ### Adding a collapse animation

--- a/packages/tables/docs/06-layout.md
+++ b/packages/tables/docs/06-layout.md
@@ -256,7 +256,7 @@ use Filament\Tables\Columns\TextColumn;
 ]
 ```
 
-Also default collapse mode can be set for `Panel` Layout using `collapsed` method.
+You can collapse a panel by default using the `collapsed()` method:
 
 ```php
 use Filament\Tables\Columns\Layout\Panel;

--- a/packages/tables/docs/06-layout.md
+++ b/packages/tables/docs/06-layout.md
@@ -256,7 +256,7 @@ use Filament\Tables\Columns\TextColumn;
 ]
 ```
 
-You can collapse a panel by default using the `collapsed()` method:
+Also default collapse mode can be set for `Panel` Layout using `collapsed` method.
 
 ```php
 use Filament\Tables\Columns\Layout\Panel;
@@ -268,17 +268,7 @@ use Filament\Tables\Columns\TextColumn;
             TextColumn::make('email'),
             TextColumn::make('phone'),
         ]),
-    ])->collapsed(function($record){
-         return false;
-    }),
-    
-    Panel::make([
-        Stack::make([
-            TextColumn::make('address'),
-            TextColumn::make('addressline'),
-        ]),
-    ])->collapsed(false),
-    
+    ])->collapsed(false), 
 ]
 ```
 ![Collapsible content](https://user-images.githubusercontent.com/41773797/191834045-e423afd4-1ad3-4636-8635-fe9453423555.png)

--- a/packages/tables/docs/06-layout.md
+++ b/packages/tables/docs/06-layout.md
@@ -267,9 +267,7 @@ Panel::make([
         TextColumn::make('email'),
         TextColumn::make('phone'),
     ]),
-])
-    ->collapsible()
-    ->collapsed(false)
+])->collapsed(false)
 ```
 
 ![Collapsible content](https://user-images.githubusercontent.com/41773797/191834045-e423afd4-1ad3-4636-8635-fe9453423555.png)

--- a/packages/tables/docs/06-layout.md
+++ b/packages/tables/docs/06-layout.md
@@ -256,21 +256,22 @@ use Filament\Tables\Columns\TextColumn;
 ]
 ```
 
-You can collapse a panel by default using the `collapsed()` method:
+You can expand a panel by default using the `collapsed(false)` method:
 
 ```php
 use Filament\Tables\Columns\Layout\Panel;
 use Filament\Tables\Columns\TextColumn;
 
-[
-    Panel::make([
-        Stack::make([
-            TextColumn::make('email'),
-            TextColumn::make('phone'),
-        ]),
-    ])->collapsed(false), 
-]
+Panel::make([
+    Stack::make([
+        TextColumn::make('email'),
+        TextColumn::make('phone'),
+    ]),
+])
+    ->collapsible()
+    ->collapsed(false)
 ```
+
 ![Collapsible content](https://user-images.githubusercontent.com/41773797/191834045-e423afd4-1ad3-4636-8635-fe9453423555.png)
 
 ### Adding a collapse animation

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -430,11 +430,12 @@
 
                                 $collapsibleColumnsLayout?->record($record);
                                 $hasCollapsibleColumnsLayout = $collapsibleColumnsLayout && (! $collapsibleColumnsLayout->isHidden());
+                                $isCollapsed = ($collapsibleColumnsLayout instanceof \Filament\Tables\Columns\Layout\Panel)? $collapsibleColumnsLayout->isCollapsed():true;
                             @endphp
 
                             <div
                                 @if ($hasCollapsibleColumnsLayout)
-                                    x-data="{ isCollapsed: true }"
+                                    x-data="{ isCollapsed: {{$isCollapsed?'true':'false'}} }"
                                     x-init="$dispatch('collapsible-table-row-initialized')"
                                     x-on:expand-all-table-rows.window="isCollapsed = false"
                                     x-on:collapse-all-table-rows.window="isCollapsed = true"

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -435,7 +435,7 @@
 
                             <div
                                 @if ($hasCollapsibleColumnsLayout)
-                                    x-data="{ isCollapsed: {{$isCollapsed?'true':'false'}} }"
+                                    x-data="{ isCollapsed: @js($isCollapsed) }"
                                     x-init="$dispatch('collapsible-table-row-initialized')"
                                     x-on:expand-all-table-rows.window="isCollapsed = false"
                                     x-on:collapse-all-table-rows.window="isCollapsed = true"

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -434,7 +434,7 @@
 
                             <div
                                 @if ($hasCollapsibleColumnsLayout)
-                                    x-data="{ isCollapsed: @js($isCollapsed) }"
+                                    x-data="{ isCollapsed: @js($collapsibleColumnsLayout->isCollapsed()) }"
                                     x-init="$dispatch('collapsible-table-row-initialized')"
                                     x-on:expand-all-table-rows.window="isCollapsed = false"
                                     x-on:collapse-all-table-rows.window="isCollapsed = true"

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -430,7 +430,6 @@
 
                                 $collapsibleColumnsLayout?->record($record);
                                 $hasCollapsibleColumnsLayout = $collapsibleColumnsLayout && (! $collapsibleColumnsLayout->isHidden());
-                                $isCollapsed = ($collapsibleColumnsLayout instanceof \Filament\Tables\Columns\Layout\Panel)? $collapsibleColumnsLayout->isCollapsed():true;
                             @endphp
 
                             <div

--- a/packages/tables/src/Columns/Layout/Component.php
+++ b/packages/tables/src/Columns/Layout/Component.php
@@ -35,6 +35,8 @@ class Component extends ViewComponent
 
     protected bool $isCollapsible = false;
 
+    protected bool | Closure $isCollapsed = true;
+
     public function schema(array | Closure $schema): static
     {
         $this->components($schema);
@@ -54,6 +56,19 @@ class Component extends ViewComponent
         $this->isCollapsible = $condition;
 
         return $this;
+    }
+
+    public function collapsed(bool | Closure $condition = true): static
+    {
+        $this->collapsible();
+        $this->isCollapsed = $condition;
+
+        return $this;
+    }
+
+    public function isCollapsed(): bool
+    {
+        return (bool) $this->evaluate($this->isCollapsed);
     }
 
     public function getColumns(): array

--- a/packages/tables/src/Columns/Layout/Panel.php
+++ b/packages/tables/src/Columns/Layout/Panel.php
@@ -32,6 +32,6 @@ class Panel extends Component
 
     public function isCollapsed()
     {
-        return $this->evaluate($this->collapsed);
+        return (bool) $this->evaluate($this->isCollapsed);
     }
 }

--- a/packages/tables/src/Columns/Layout/Panel.php
+++ b/packages/tables/src/Columns/Layout/Panel.php
@@ -8,8 +8,6 @@ class Panel extends Component
 {
     protected string $view = 'tables::columns.layout.panel';
 
-    protected bool | Closure $isCollapsed = true;
-
     final public function __construct(array | Closure $schema)
     {
         $this->schema($schema);
@@ -21,18 +19,5 @@ class Panel extends Component
         $static->configure();
 
         return $static;
-    }
-
-    public function collapsed(bool | Closure $condition = true): static
-    {
-        $this->collapsible();
-        $this->isCollapsed = $condition;
-
-        return $this;
-    }
-
-    public function isCollapsed(): bool
-    {
-        return (bool) $this->evaluate($this->isCollapsed);
     }
 }

--- a/packages/tables/src/Columns/Layout/Panel.php
+++ b/packages/tables/src/Columns/Layout/Panel.php
@@ -25,6 +25,7 @@ class Panel extends Component
 
     public function collapsed(bool | Closure $condition = true): static
     {
+        $this->collapsible();
         $this->isCollapsed = $condition;
 
         return $this;

--- a/packages/tables/src/Columns/Layout/Panel.php
+++ b/packages/tables/src/Columns/Layout/Panel.php
@@ -8,6 +8,8 @@ class Panel extends Component
 {
     protected string $view = 'tables::columns.layout.panel';
 
+    protected Closure | bool $collapsed = true;
+
     final public function __construct(array | Closure $schema)
     {
         $this->schema($schema);
@@ -19,5 +21,17 @@ class Panel extends Component
         $static->configure();
 
         return $static;
+    }
+
+    public function collapsed(Closure | bool $collapsed = true)
+    {
+        $this->collapsed = $collapsed;
+
+        return $this;
+    }
+
+    public function isCollapsed()
+    {
+        return $this->evaluate($this->collapsed);
     }
 }

--- a/packages/tables/src/Columns/Layout/Panel.php
+++ b/packages/tables/src/Columns/Layout/Panel.php
@@ -23,7 +23,7 @@ class Panel extends Component
         return $static;
     }
 
-    public function collapsed(bool | Closure $condition = true)
+    public function collapsed(bool | Closure $condition = true): static
     {
         $this->isCollapsed = $condition;
 

--- a/packages/tables/src/Columns/Layout/Panel.php
+++ b/packages/tables/src/Columns/Layout/Panel.php
@@ -25,7 +25,7 @@ class Panel extends Component
 
     public function collapsed(Closure | bool $collapsed = true)
     {
-        $this->isCollapsed = $collapsed;
+        $this->isCollapsed = $condition;
 
         return $this;
     }

--- a/packages/tables/src/Columns/Layout/Panel.php
+++ b/packages/tables/src/Columns/Layout/Panel.php
@@ -30,7 +30,7 @@ class Panel extends Component
         return $this;
     }
 
-    public function isCollapsed()
+    public function isCollapsed(): bool
     {
         return (bool) $this->evaluate($this->isCollapsed);
     }

--- a/packages/tables/src/Columns/Layout/Panel.php
+++ b/packages/tables/src/Columns/Layout/Panel.php
@@ -23,7 +23,7 @@ class Panel extends Component
         return $static;
     }
 
-    public function collapsed(Closure | bool $collapsed = true)
+    public function collapsed(bool | Closure $condition = true)
     {
         $this->isCollapsed = $condition;
 

--- a/packages/tables/src/Columns/Layout/Panel.php
+++ b/packages/tables/src/Columns/Layout/Panel.php
@@ -8,7 +8,7 @@ class Panel extends Component
 {
     protected string $view = 'tables::columns.layout.panel';
 
-    protected Closure | bool $collapsed = true;
+    protected bool | Closure $isCollapsed = true;
 
     final public function __construct(array | Closure $schema)
     {
@@ -25,7 +25,7 @@ class Panel extends Component
 
     public function collapsed(Closure | bool $collapsed = true)
     {
-        $this->collapsed = $collapsed;
+        $this->isCollapsed = $collapsed;
 
         return $this;
     }


### PR DESCRIPTION
Some time we may want to keep a panel expanded. This Pr allow us to do so for  \Filament\Tables\Columns\Layout\Panel Layout