### PR TITLE
Fix: Copy paste image in Markdown Editor

### DIFF
--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -186,7 +186,7 @@
                         dusk="filament.forms.{{ $getStatePath() }}"
                         x-on:keyup.enter="checkForAutoInsertion"
                         x-on:file-attachment-accepted.window="
-                            if ($event.explicitOriginalTarget.id === '{{ $getId() }}') {
+                            if ($event?.srcElement.querySelector('textarea')?.id === '{{ $getId() }}') {
                                 attachment = $event.detail?.attachments?.[0]
 
                                 if (! attachment || ! attachment.file) return


### PR DESCRIPTION
Fixes browser inconsistency with attributes provided by the browser's event object. 

Resolves #5764 