### PR TITLE
TextInputColumn. Debounce numeric input

### DIFF
--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -13,6 +13,13 @@
         error: undefined,
         state: @js($state),
         isLoading: false,
+        update: async function(value) {
+            this.isLoading = true
+            this.response = await $wire.updateTableColumnState(@js($getName()), @js($recordKey), value)
+            this.error = response?.error ?? undefined
+            if (! this.error) this.state = response
+            this.isLoading = false
+        }
     }"
     x-init="
         Livewire.hook('message.processed', (component) => {
@@ -46,13 +53,8 @@
         {!! ($inputMode = $getInputMode()) ? "inputmode=\"{$inputMode}\"" : null !!}
         {!! ($placeholder = $getPlaceholder()) ? "placeholder=\"{$placeholder}\"" : null !!}
         {!! ($interval = $getStep()) ? "step=\"{$interval}\"" : null !!}
-        x-on:change="
-            isLoading = true
-            response = await $wire.updateTableColumnState(@js($getName()), @js($recordKey), $event.target.value)
-            error = response?.error ?? undefined
-            if (! error) state = response
-            isLoading = false
-        "
+        x-on:change{{ $getType() === 'number' ? '.debounce.750ms' : null }}="update($event.target.value)"
+        x-on:keydown.enter="update($event.target.value)"
         :readonly="isLoading"
         x-tooltip="error"
         {{ $attributes->merge($getExtraInputAttributes())->merge($getExtraAttributes())->class([

--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -54,7 +54,6 @@
         {!! ($placeholder = $getPlaceholder()) ? "placeholder=\"{$placeholder}\"" : null !!}
         {!! ($interval = $getStep()) ? "step=\"{$interval}\"" : null !!}
         x-on:change{{ $getType() === 'number' ? '.debounce.750ms' : null }}="update($event.target.value)"
-        x-on:keydown.enter="update($event.target.value)"
         :readonly="isLoading"
         x-tooltip="error"
         {{ $attributes->merge($getExtraInputAttributes())->merge($getExtraAttributes())->class([

--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -13,13 +13,6 @@
         error: undefined,
         state: @js($state),
         isLoading: false,
-        update: async function(value) {
-            this.isLoading = true
-            this.response = await $wire.updateTableColumnState(@js($getName()), @js($recordKey), value)
-            this.error = response?.error ?? undefined
-            if (! this.error) this.state = response
-            this.isLoading = false
-        }
     }"
     x-init="
         Livewire.hook('message.processed', (component) => {
@@ -53,7 +46,13 @@
         {!! ($inputMode = $getInputMode()) ? "inputmode=\"{$inputMode}\"" : null !!}
         {!! ($placeholder = $getPlaceholder()) ? "placeholder=\"{$placeholder}\"" : null !!}
         {!! ($interval = $getStep()) ? "step=\"{$interval}\"" : null !!}
-        x-on:change{{ $getType() === 'number' ? '.debounce.750ms' : null }}="update($event.target.value)"
+        x-on:change{{ $getType() === 'number' ? '.debounce.1s' : null }}="
+            isLoading = true
+            response = await $wire.updateTableColumnState(@js($getName()), @js($recordKey), $event.target.value)
+            error = response?.error ?? undefined
+            if (! error) state = response
+            isLoading = false
+        "
         :readonly="isLoading"
         x-tooltip="error"
         {{ $attributes->merge($getExtraInputAttributes())->merge($getExtraAttributes())->class([


### PR DESCRIPTION
Debounce input where type = number

If you have a numeric input and the value is changed via the inputs "arrow buttons" or the keyboard arrow up/down.
A network request is generated for every click/keystroke.

This PR tries to prevent that.