### PR TITLE
Create new filter layout: AboveContentCollapsable

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -30,7 +30,8 @@
     $isLoaded = $isLoaded();
     $hasFilters = $isFilterable();
     $hasFiltersPopover = $hasFilters && ($getFiltersLayout() === FiltersLayout::Popover);
-    $hasFiltersAboveContent = $hasFilters && ($getFiltersLayout() === FiltersLayout::AboveContent);
+    $hasFiltersAboveContent = $hasFilters && ($getFiltersLayout() === FiltersLayout::AboveContent || FiltersLayout::AboveContentColapsable);
+    $hasFiltersAboveContentColapsable = $hasFilters && ($getFiltersLayout() === FiltersLayout::AboveContentColapsable);
     $hasFiltersAfterContent = $hasFilters && ($getFiltersLayout() === FiltersLayout::BelowContent);
     $isColumnToggleFormVisible = $hasToggleableColumns();
     $records = $isLoaded ? $getRecords() : null;
@@ -193,8 +194,14 @@
             @endif
 
             @if ($hasFiltersAboveContent)
-                <div class="px-2 pt-2">
-                    <div class="p-4 mb-2">
+                <div class="px-2 pt-2" x-data="{ hasFilterAboveContentOpen: @js(!$hasFiltersAboveContentColapsable) }">
+                    @if($hasFiltersAboveContentColapsable)
+                        <div class="flex w-full justify-end">
+                            <x-tables::filters.trigger @click="hasFilterAboveContentOpen=!hasFilterAboveContentOpen" />
+                        </div>
+                    @endif
+
+                    <div class="p-4 mb-2" x-show="hasFilterAboveContentOpen">
                         <x-tables::filters :form="$getFiltersForm()" />
                     </div>
 

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -30,8 +30,8 @@
     $isLoaded = $isLoaded();
     $hasFilters = $isFilterable();
     $hasFiltersPopover = $hasFilters && ($getFiltersLayout() === FiltersLayout::Popover);
-    $hasFiltersAboveContent = $hasFilters && ($getFiltersLayout() === FiltersLayout::AboveContent || $getFiltersLayout() === FiltersLayout::AboveContentColapsable);
-    $hasFiltersAboveContentColapsable = $hasFilters && ($getFiltersLayout() === FiltersLayout::AboveContentColapsable);
+    $hasFiltersAboveContent = $hasFilters && ($getFiltersLayout() === FiltersLayout::AboveContent || $getFiltersLayout() === FiltersLayout::AboveContentCollapsable);
+    $hasFiltersAboveContentCollapsable = $hasFilters && ($getFiltersLayout() === FiltersLayout::AboveContentCollapsable);
     $hasFiltersAfterContent = $hasFilters && ($getFiltersLayout() === FiltersLayout::BelowContent);
     $isColumnToggleFormVisible = $hasToggleableColumns();
     $records = $isLoaded ? $getRecords() : null;
@@ -194,8 +194,8 @@
             @endif
 
             @if ($hasFiltersAboveContent)
-                <div class="px-2 pt-2" x-data="{ hasFilterAboveContentOpen: @js(!$hasFiltersAboveContentColapsable) }">
-                    @if($hasFiltersAboveContentColapsable)
+                <div class="px-2 pt-2" x-data="{ hasFilterAboveContentOpen: @js(!$hasFiltersAboveContentCollapsable) }">
+                    @if($hasFiltersAboveContentCollapsable)
                         <div class="flex w-full justify-end">
                             <x-tables::filters.trigger @click="hasFilterAboveContentOpen=!hasFilterAboveContentOpen" />
                         </div>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -29,10 +29,11 @@
     $isStriped = $isStriped();
     $isLoaded = $isLoaded();
     $hasFilters = $isFilterable();
-    $hasFiltersPopover = $hasFilters && ($getFiltersLayout() === FiltersLayout::Popover);
-    $hasFiltersAboveContent = $hasFilters && ($getFiltersLayout() === FiltersLayout::AboveContent || $getFiltersLayout() === FiltersLayout::AboveContentCollapsable);
-    $hasFiltersAboveContentCollapsable = $hasFilters && ($getFiltersLayout() === FiltersLayout::AboveContentCollapsable);
-    $hasFiltersAfterContent = $hasFilters && ($getFiltersLayout() === FiltersLayout::BelowContent);
+    $filtersLayout = $getFiltersLayout();
+    $hasFiltersPopover = $hasFilters && ($filtersLayout === FiltersLayout::Popover);
+    $hasFiltersAboveContent = $hasFilters && in_array($filtersLayout, [FiltersLayout::AboveContent, FiltersLayout::AboveContentCollapsible]);
+    $hasFiltersAboveContentCollapsible = $hasFilters && ($filtersLayout === FiltersLayout::AboveContentCollapsible);
+    $hasFiltersAfterContent = $hasFilters && ($filtersLayout === FiltersLayout::BelowContent);
     $isColumnToggleFormVisible = $hasToggleableColumns();
     $records = $isLoaded ? $getRecords() : null;
     $allRecordsCount = $isLoaded ? $getAllRecordsCount() : null;
@@ -194,8 +195,8 @@
             @endif
 
             @if ($hasFiltersAboveContent)
-                <div class="px-2 pt-2" x-data="{ hasFilterAboveContentOpen: @js(!$hasFiltersAboveContentCollapsable) }">
-                    @if($hasFiltersAboveContentCollapsable)
+                <div class="px-2 pt-2" x-data="{ hasFilterAboveContentOpen: @js(! $hasFiltersAboveContentCollapsible) }">
+                    @if ($hasFiltersAboveContentCollapsible)
                         <div class="flex w-full justify-end">
                             <x-tables::filters.trigger @click="hasFilterAboveContentOpen=!hasFilterAboveContentOpen" />
                         </div>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -30,7 +30,7 @@
     $isLoaded = $isLoaded();
     $hasFilters = $isFilterable();
     $hasFiltersPopover = $hasFilters && ($getFiltersLayout() === FiltersLayout::Popover);
-    $hasFiltersAboveContent = $hasFilters && ($getFiltersLayout() === FiltersLayout::AboveContent || FiltersLayout::AboveContentColapsable);
+    $hasFiltersAboveContent = $hasFilters && ($getFiltersLayout() === FiltersLayout::AboveContent || $getFiltersLayout() === FiltersLayout::AboveContentColapsable);
     $hasFiltersAboveContentColapsable = $hasFilters && ($getFiltersLayout() === FiltersLayout::AboveContentColapsable);
     $hasFiltersAfterContent = $hasFilters && ($getFiltersLayout() === FiltersLayout::BelowContent);
     $isColumnToggleFormVisible = $hasToggleableColumns();

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -195,14 +195,14 @@
             @endif
 
             @if ($hasFiltersAboveContent)
-                <div class="px-2 pt-2" x-data="{ hasFilterAboveContentOpen: @js(! $hasFiltersAboveContentCollapsible) }">
+                <div class="px-2 pt-2" x-data="{ areFiltersOpen: @js(! $hasFiltersAboveContentCollapsible) }">
                     @if ($hasFiltersAboveContentCollapsible)
                         <div class="flex w-full justify-end">
-                            <x-tables::filters.trigger @click="hasFilterAboveContentOpen=!hasFilterAboveContentOpen" />
+                            <x-tables::filters.trigger x-on:click="areFiltersOpen = ! areFiltersOpen" />
                         </div>
                     @endif
 
-                    <div class="p-4 mb-2" x-show="hasFilterAboveContentOpen">
+                    <div class="p-4 mb-2" x-show="areFiltersOpen">
                         <x-tables::filters :form="$getFiltersForm()" />
                     </div>
 

--- a/packages/tables/src/Filters/Layout.php
+++ b/packages/tables/src/Filters/Layout.php
@@ -6,7 +6,7 @@ class Layout
 {
     public const AboveContent = 'above_content';
 
-    public const AboveContentColapsable = 'above_content_collapsable';
+    public const AboveContentCollapsable = 'above_content_collapsable';
 
     public const BelowContent = 'below_content';
 

--- a/packages/tables/src/Filters/Layout.php
+++ b/packages/tables/src/Filters/Layout.php
@@ -6,6 +6,8 @@ class Layout
 {
     public const AboveContent = 'above_content';
 
+    public const AboveContentColapsable = 'above_content_collapsable';
+
     public const BelowContent = 'below_content';
 
     public const Popover = 'in_popover';

--- a/packages/tables/src/Filters/Layout.php
+++ b/packages/tables/src/Filters/Layout.php
@@ -6,7 +6,7 @@ class Layout
 {
     public const AboveContent = 'above_content';
 
-    public const AboveContentCollapsable = 'above_content_collapsable';
+    public const AboveContentCollapsible = 'above_content_collapsible';
 
     public const BelowContent = 'below_content';
 


### PR DESCRIPTION
Hey everyone! 👋🏼 

This PR creates a new layout for the filter table called `AboveContentCollapsable` to allow us to have the behavior below:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/4853801/221185748-948b5fe6-0b9c-4f55-97d7-8a87fb1050d3.gif)

Sometimes we have too many fields to be displayed above content immediately so it would be nice to the possibility to have a button to collapse it. 😄

I would love to have this appreciated. What do you think?
