### PR TITLE
Fix heroicon title attribute

### DIFF
--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -149,7 +149,7 @@
                     >
                         <x-heroicon-s-x
                             class="filament-modal-close-button h-4 w-4 cursor-pointer text-gray-400"
-                            title="__('filament-support::components/modal.actions.close.label')"
+                            :title="__('filament-support::components/modal.actions.close.label')"
                             tabindex="-1"
                         />
 


### PR DESCRIPTION
The value is being rendered as a literal string instead of compiling the php due to missing column

<img width="566" alt="Screenshot 2023-02-25 at 12 10 02" src="https://user-images.githubusercontent.com/3823354/221353657-65a176b3-6c4a-4641-906e-e8d49f4439ef.png">
