### PR TITLE
Feature/add dusk selector to filament form select

### DIFF
--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -68,6 +68,7 @@
                 </select>
             @else
                 <div
+                    dusk="filament.forms.{{ $getStatePath() }}"
                     x-data="selectFormComponent({
                         isHtmlAllowed: @js($isHtmlAllowed()),
                         getOptionLabelUsing: async () => {

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -11,6 +11,7 @@
 
         init: function () {
             this.step = this.getSteps()[{{ $getStartStep() }} - 1]
+            this.updateQuerystring()
         },
 
         nextStep: function () {
@@ -67,7 +68,17 @@
             return @js($isSkippable()) || (this.getStepIndex(step) > index)
         },
 
+        updateQuerystring: function() {
+            if(@js($isStepAsQuerystring())) {
+                const url = new URL(window.location.href);
+                url.searchParams.set('step', this.step);
+                history.pushState(null, document.title, url.toString());
+            }
+        },
     }"
+    x-init="$watch('step', (value) => {
+        updateQuerystring()
+    })"
     x-on:next-wizard-step.window="if ($event.detail.statePath === '{{ $getStatePath() }}') nextStep()"
     x-cloak
     {!! $getId() ? "id=\"{$getId()}\"" : null !!}

--- a/packages/forms/src/Components/Wizard.php
+++ b/packages/forms/src/Components/Wizard.php
@@ -16,9 +16,13 @@ class Wizard extends Component
 
     protected bool | Closure $skippable = false;
 
+    protected bool | Closure $stepAsQuerystring = false;
+
     protected string | Htmlable | null $submitAction = null;
 
     public int | Closure $startStep = 1;
+
+    public ?int $currentStep = null;
 
     protected string $view = 'forms::components.wizard';
 
@@ -100,6 +104,13 @@ class Wizard extends Component
         return $this;
     }
 
+    public function setStepAsQuerystring(bool | Closure $condition = true): static
+    {
+        $this->stepAsQuerystring = $condition;
+
+        return $this;
+    }
+
     public function getCancelAction(): string | Htmlable | null
     {
         return $this->cancelAction;
@@ -118,5 +129,10 @@ class Wizard extends Component
     public function isSkippable(): bool
     {
         return $this->evaluate($this->skippable);
+    }
+
+    public function isStepAsQuerystring(): bool
+    {
+        return $this->evaluate($this->stepAsQuerystring);
     }
 }


### PR DESCRIPTION
## Summary

This PR adds a dusk selector attribute to the filament forms select component. This attributes allows Laravel Dusk to select precise elements without the need for css selectors or xPath queries. 