### PR TITLE
Prevents duplicate queries using the SelectFilter

### DIFF
--- a/packages/tables/src/Filters/Concerns/HasOptions.php
+++ b/packages/tables/src/Filters/Concerns/HasOptions.php
@@ -32,6 +32,8 @@ trait HasOptions
             $options = $options->toArray();
         }
 
+        $this->options = $options;
+
         return $options;
     }
 }


### PR DESCRIPTION
Hi, dears!

Using the `SelectFilter` component and applying a filter, it executes the query two times in the same request.

The PR adds the ability to execute the query only once, caching the results in the `$this->options` property for subsequent usages.