### PR TITLE
Add loading feedback to repeater/builder controls

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -163,6 +163,7 @@
                                                     title="{{ __('forms::components.builder.buttons.move_item_up.label') }}"
                                                     type="button"
                                                     wire:click.stop="dispatchFormEvent('builder::moveItemUp', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                    wire:loading.attr="disabled"
                                                     @class([
                                                         'flex items-center justify-center flex-none w-10 h-10 text-gray-400 transition hover:text-gray-500',
                                                         'dark:border-gray-700' => config('forms.dark_mode'),
@@ -172,7 +173,18 @@
                                                         {{ __('forms::components.builder.buttons.move_item_up.label') }}
                                                     </span>
 
-                                                    <x-heroicon-s-chevron-up class="w-4 h-4" />
+                                                    <x-heroicon-s-chevron-up
+                                                        class="w-4 h-4"
+                                                        wire:loading.remove.delay
+                                                        wire:target="dispatchFormEvent('builder::moveItemUp', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                    />
+
+                                                    <x-filament-support::loading-indicator
+                                                        class="w-4 h-4 text-primary-500"
+                                                        wire:loading.delay
+                                                        wire:target="dispatchFormEvent('builder::moveItemUp', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                        x-cloak
+                                                    />
                                                 </button>
                                             </li>
                                         @endunless
@@ -183,6 +195,7 @@
                                                     title="{{ __('forms::components.builder.buttons.move_item_down.label') }}"
                                                     type="button"
                                                     wire:click.stop="dispatchFormEvent('builder::moveItemDown', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                    wire:loading.attr="disabled"
                                                     @class([
                                                         'flex items-center justify-center flex-none w-10 h-10 text-gray-400 transition hover:text-gray-500',
                                                         'dark:border-gray-700' => config('forms.dark_mode'),
@@ -192,7 +205,18 @@
                                                         {{ __('forms::components.builder.buttons.move_item_down.label') }}
                                                     </span>
 
-                                                    <x-heroicon-s-chevron-down class="w-4 h-4" />
+                                                    <x-heroicon-s-chevron-down
+                                                        class="w-4 h-4"
+                                                        wire:loading.remove.delay
+                                                        wire:target="dispatchFormEvent('builder::moveItemDown', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                    />
+
+                                                    <x-filament-support::loading-indicator
+                                                        class="w-4 h-4 text-primary-500"
+                                                        wire:loading.delay
+                                                        wire:target="dispatchFormEvent('builder::moveItemDown', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                        x-cloak
+                                                    />
                                                 </button>
                                             </li>
                                         @endunless
@@ -203,6 +227,7 @@
                                             <button
                                                 title="{{ __('forms::components.builder.buttons.clone_item.label') }}"
                                                 wire:click.stop="dispatchFormEvent('builder::cloneItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                wire:loading.attr="disabled"
                                                 type="button"
                                                 @class([
                                                     'flex items-center justify-center flex-none w-10 h-10 text-gray-400 transition hover:text-gray-500',
@@ -213,7 +238,18 @@
                                                     {{ __('forms::components.builder.buttons.clone_item.label') }}
                                                 </span>
 
-                                                <x-heroicon-s-duplicate class="w-4 h-4"/>
+                                                <x-heroicon-s-duplicate
+                                                    class="w-4 h-4"
+                                                    wire:loading.remove.delay
+                                                    wire:target="dispatchFormEvent('builder::cloneItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                />
+
+                                                <x-filament-support::loading-indicator
+                                                    class="w-4 h-4 text-primary-500"
+                                                    wire:loading.delay
+                                                    wire:target="dispatchFormEvent('builder::cloneItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                    x-cloak
+                                                />
                                             </button>
                                         </li>
                                     @endif
@@ -223,6 +259,7 @@
                                             <button
                                                 title="{{ __('forms::components.builder.buttons.delete_item.label') }}"
                                                 wire:click.stop="dispatchFormEvent('builder::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                wire:loading.attr="disabled"
                                                 type="button"
                                                 @class([
                                                     'flex items-center justify-center flex-none w-10 h-10 text-danger-600 transition hover:text-danger-500',
@@ -233,7 +270,18 @@
                                                     {{ __('forms::components.builder.buttons.delete_item.label') }}
                                                 </span>
 
-                                                <x-heroicon-s-trash class="w-4 h-4"/>
+                                                <x-heroicon-s-trash
+                                                    class="w-4 h-4"
+                                                    wire:loading.remove.delay
+                                                    wire:target="dispatchFormEvent('builder::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                />
+
+                                                <x-filament-support::loading-indicator
+                                                    class="w-4 h-4 text-primary-500"
+                                                    wire:loading.delay
+                                                    wire:target="dispatchFormEvent('builder::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                    x-cloak
+                                                />
                                             </button>
                                         </li>
                                     @endunless

--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -142,6 +142,7 @@
                                                         title="{{ __('forms::components.repeater.buttons.move_item_up.label') }}"
                                                         type="button"
                                                         wire:click.stop="dispatchFormEvent('repeater::moveItemUp', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                        wire:loading.attr="disabled"
                                                         @class([
                                                             'flex items-center justify-center flex-none w-10 h-10 text-gray-400 transition hover:text-gray-500',
                                                             'dark:border-gray-700' => config('forms.dark_mode'),
@@ -151,7 +152,18 @@
                                                             {{ __('forms::components.repeater.buttons.move_item_up.label') }}
                                                         </span>
 
-                                                        <x-heroicon-s-chevron-up class="w-4 h-4" />
+                                                        <x-heroicon-s-chevron-up
+                                                            class="w-4 h-4"
+                                                            wire:loading.remove.delay
+                                                            wire:target="dispatchFormEvent('repeater::moveItemUp', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                        />
+
+                                                        <x-filament-support::loading-indicator
+                                                            class="w-4 h-4 text-primary-500"
+                                                            wire:loading.delay
+                                                            wire:target="dispatchFormEvent('repeater::moveItemUp', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                            x-cloak
+                                                        />
                                                     </button>
                                                 </li>
                                             @endunless
@@ -162,6 +174,7 @@
                                                         title="{{ __('forms::components.repeater.buttons.move_item_down.label') }}"
                                                         type="button"
                                                         wire:click.stop="dispatchFormEvent('repeater::moveItemDown', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                        wire:loading.attr="disabled"
                                                         @class([
                                                             'flex items-center justify-center flex-none w-10 h-10 text-gray-400 transition hover:text-gray-500',
                                                             'dark:border-gray-700' => config('forms.dark_mode'),
@@ -171,7 +184,18 @@
                                                             {{ __('forms::components.repeater.buttons.move_item_down.label') }}
                                                         </span>
 
-                                                        <x-heroicon-s-chevron-down class="w-4 h-4" />
+                                                        <x-heroicon-s-chevron-down
+                                                            class="w-4 h-4"
+                                                            wire:loading.remove.delay
+                                                            wire:target="dispatchFormEvent('repeater::moveItemDown', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                        />
+
+                                                        <x-filament-support::loading-indicator
+                                                            class="w-4 h-4 text-primary-500"
+                                                            wire:loading.delay
+                                                            wire:target="dispatchFormEvent('repeater::moveItemDown', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                            x-cloak
+                                                        />
                                                     </button>
                                                 </li>
                                             @endunless
@@ -182,6 +206,7 @@
                                                 <button
                                                     title="{{ __('forms::components.repeater.buttons.clone_item.label') }}"
                                                     wire:click.stop="dispatchFormEvent('repeater::cloneItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                    wire:loading.attr="disabled"
                                                     type="button"
                                                     @class([
                                                         'flex items-center justify-center flex-none w-10 h-10 text-gray-400 transition hover:text-gray-500',
@@ -192,7 +217,18 @@
                                                         {{ __('forms::components.repeater.buttons.clone_item.label') }}
                                                     </span>
 
-                                                    <x-heroicon-s-duplicate class="w-4 h-4"/>
+                                                    <x-heroicon-s-duplicate
+                                                        class="w-4 h-4"
+                                                        wire:loading.remove.delay
+                                                        wire:target="dispatchFormEvent('repeater::cloneItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                    />
+
+                                                    <x-filament-support::loading-indicator
+                                                        class="w-4 h-4 text-primary-500"
+                                                        wire:loading.delay
+                                                        wire:target="dispatchFormEvent('repeater::cloneItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                        x-cloak
+                                                    />
                                                 </button>
                                             </li>
                                         @endunless
@@ -202,6 +238,7 @@
                                                 <button
                                                     title="{{ __('forms::components.repeater.buttons.delete_item.label') }}"
                                                     wire:click.stop="dispatchFormEvent('repeater::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                    wire:loading.attr="disabled"
                                                     type="button"
                                                     @class([
                                                         'flex items-center justify-center flex-none w-10 h-10 text-danger-600 transition hover:text-danger-500',
@@ -212,7 +249,17 @@
                                                         {{ __('forms::components.repeater.buttons.delete_item.label') }}
                                                     </span>
 
-                                                    <x-heroicon-s-trash class="w-4 h-4"/>
+                                                    <x-heroicon-s-trash class="w-4 h-4"
+                                                        wire:loading.remove.delay
+                                                        wire:target="dispatchFormEvent('repeater::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                    />
+
+                                                    <x-filament-support::loading-indicator
+                                                        class="w-4 h-4 text-primary-500"
+                                                        wire:loading.delay
+                                                        wire:target="dispatchFormEvent('repeater::deleteItem', '{{ $getStatePath() }}', '{{ $uuid }}')"
+                                                        x-cloak
+                                                    />
                                                 </button>
                                             </li>
                                         @endunless


### PR DESCRIPTION
If the connection is slow provide instant feedback that action is being performed. 

Disable button from being clicked multiple times.