### PR TITLE
Add row layout to checkbox list

### DIFF
--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -110,11 +110,11 @@
             :lg="$getColumns('lg')"
             :xl="$getColumns('xl')"
             :two-xl="$getColumns('2xl')"
-            :direction="$getDirection()"
+            :direction="$getGridDirection() ?? 'column'"
             :x-show="$isSearchable() ? 'visibleCheckboxListOptions.length' : null"
             :attributes="$attributes->class([
                 'filament-forms-checkbox-list-component gap-1',
-                'space-y-2' => $getDirection() == 'column'
+                'space-y-2' => $getGridDirection() !== 'row'
                 ])"
         >
             @forelse ($getOptions() as $optionValue => $optionLabel)

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -112,10 +112,7 @@
             :two-xl="$getColumns('2xl')"
             :direction="$getGridDirection() ?? 'column'"
             :x-show="$isSearchable() ? 'visibleCheckboxListOptions.length' : null"
-            :attributes="$attributes->class([
-                'filament-forms-checkbox-list-component gap-1',
-                'space-y-2' => $getGridDirection() !== 'row'
-                ])"
+            :attributes="$attributes->class(['filament-forms-checkbox-list-component gap-1'])"
         >
             @forelse ($getOptions() as $optionValue => $optionLabel)
                 <div wire:key="{{ $this->id }}.{{ $getStatePath() }}.{{ $field::class }}.options.{{ $optionValue }}">

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -110,9 +110,12 @@
             :lg="$getColumns('lg')"
             :xl="$getColumns('xl')"
             :two-xl="$getColumns('2xl')"
-            direction="column"
+            :direction="$getDirection()"
             :x-show="$isSearchable() ? 'visibleCheckboxListOptions.length' : null"
-            :attributes="$attributes->class(['filament-forms-checkbox-list-component gap-1 space-y-2'])"
+            :attributes="$attributes->class([
+                'filament-forms-checkbox-list-component gap-1',
+                'space-y-2' => $getDirection() == 'column'
+                ])"
         >
             @forelse ($getOptions() as $optionValue => $optionLabel)
                 <div wire:key="{{ $this->id }}.{{ $getStatePath() }}.{{ $field::class }}.options.{{ $optionValue }}">

--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -13,6 +13,7 @@ class CheckboxList extends Field implements Contracts\HasNestedRecursiveValidati
     use Concerns\CanBeSearchable;
     use Concerns\HasNestedRecursiveValidationRules;
     use Concerns\HasOptions;
+    use Concerns\HasDirection;
 
     protected string $view = 'forms::components.checkbox-list';
 

--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -11,9 +11,9 @@ use Illuminate\Support\Str;
 class CheckboxList extends Field implements Contracts\HasNestedRecursiveValidationRules
 {
     use Concerns\CanBeSearchable;
+    use Concerns\HasGridDirection;
     use Concerns\HasNestedRecursiveValidationRules;
     use Concerns\HasOptions;
-    use Concerns\HasDirection;
 
     protected string $view = 'forms::components.checkbox-list';
 

--- a/packages/forms/src/Components/Concerns/HasDirection.php
+++ b/packages/forms/src/Components/Concerns/HasDirection.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Filament\Forms\Components\Concerns;
+
+use Closure;
+
+trait HasDirection
+{
+    protected bool | Closure | null $isRow = null;
+
+    protected array | int | null $rowColumns = null;
+
+    public function row(bool | Closure $condition = true, array | int | null $columns = 2): static
+    {
+        $this->isRow = fn () => $condition;
+
+        $this->rowColumns = $columns;
+
+        return $this;
+    }
+
+    public function isRow(): bool
+    {
+        return (bool) $this->evaluate($this->isRow);
+    }
+
+    public function getDirection(): string
+    {
+        if ($this->isRow()) {
+            $this->columns($this->rowColumns);
+
+            return 'row';
+        }
+
+        return 'column';
+    }
+}

--- a/packages/forms/src/Components/Concerns/HasDirection.php
+++ b/packages/forms/src/Components/Concerns/HasDirection.php
@@ -6,32 +6,17 @@ use Closure;
 
 trait HasDirection
 {
-    protected bool | Closure | null $isRow = null;
+    protected string | Closure | null $gridDirection = null;
 
-    protected array | int | null $rowColumns = null;
-
-    public function row(bool | Closure $condition = true, array | int | null $columns = 2): static
+    public function gridDirection(string | Closure | null $gridDirection = null): static
     {
-        $this->isRow = fn () => $condition;
-
-        $this->rowColumns = $columns;
+        $this->gridDirection = $gridDirection;
 
         return $this;
     }
 
-    public function isRow(): bool
+    public function getGridDirection(): ?string
     {
-        return (bool) $this->evaluate($this->isRow);
-    }
-
-    public function getDirection(): string
-    {
-        if ($this->isRow()) {
-            $this->columns($this->rowColumns);
-
-            return 'row';
-        }
-
-        return 'column';
+        return $this->evaluate($this->gridDirection);
     }
 }

--- a/packages/forms/src/Components/Concerns/HasGridDirection.php
+++ b/packages/forms/src/Components/Concerns/HasGridDirection.php
@@ -4,11 +4,11 @@ namespace Filament\Forms\Components\Concerns;
 
 use Closure;
 
-trait HasDirection
+trait HasGridDirection
 {
     protected string | Closure | null $gridDirection = null;
 
-    public function gridDirection(string | Closure | null $gridDirection = null): static
+    public function gridDirection(string | Closure | null $gridDirection): static
     {
         $this->gridDirection = $gridDirection;
 


### PR DESCRIPTION
while current CheckboxList can configure the columns with `->columns([..])`, the direction is always vertical, and this may not be ideal

![image](https://user-images.githubusercontent.com/67364036/222352961-0d6394d9-a26a-43fa-a820-8f3ae1327efe.png)

this is introduced by https://github.com/filamentphp/filament/pull/3984 where the grid direction is set to be always `column`

and in the doc screenshot shows the `row` behaviour
![image](https://user-images.githubusercontent.com/67364036/222353936-7a7f43b4-5c41-472b-b090-4ed96bda364b.png)


This PR looks to introduce a `row()` method to configure it into a row direction

![image](https://user-images.githubusercontent.com/67364036/222354588-60df20cf-9023-46db-84b1-c06ade78fea3.png)
```php
Forms\Components\CheckboxList::make('workdays')
                        ->options(Carbon::getDays())
                        ->columns([
                            'default' => 2,
                            'lg' => 3,
                            'xl' => 4,
                        ])
                        ->row() // <- new method
```

- Radio component does not need this change as it can use `inline()`