### PR TITLE
Fix composer.json formatting after install command

### DIFF
--- a/packages/support/src/Commands/InstallCommand.php
+++ b/packages/support/src/Commands/InstallCommand.php
@@ -170,7 +170,11 @@ class InstallCommand extends Command
 
         file_put_contents(
             $path,
-            json_encode($configuration, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) . PHP_EOL,
+            str_replace(
+                search: "    \"keywords\": [\n        \"framework\",\n        \"laravel\"\n    ],",
+                replace: '    "keywords": ["framework", "laravel"],',
+                subject: json_encode($configuration, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL,
+            ),
         );
     }
 }


### PR DESCRIPTION
`JSON_PRETTY_PRINT` introduced additional changes as the formatting of the keywords was different from a standard Laravel project. This PR fixes this by manually reverting that change.