### PR TITLE
SelectColumn class doesn't exist

### DIFF
--- a/packages/tables/docs/03-columns/08-select.md
+++ b/packages/tables/docs/03-columns/08-select.md
@@ -7,9 +7,9 @@ The select column allows you to render a select field inside the table, which ca
 You must pass options to the column:
 
 ```php
-use Filament\Tables\Columns\SelectColumn;
+use Filament\Tables\Columns\Select;
 
-SelectColumn::make('status')
+Select::make('status')
     ->options([
         'draft' => 'Draft',
         'reviewing' => 'Reviewing',
@@ -22,9 +22,9 @@ SelectColumn::make('status')
 You can validate the input by passing any [Laravel validation rules](https://laravel.com/docs/validation#available-validation-rules) in an array:
 
 ```php
-use Filament\Tables\Columns\SelectColumn;
+use Filament\Tables\Columns\Select;
 
-SelectColumn::make('status')
+Select::make('status')
     ->options([
         'draft' => 'Draft',
         'reviewing' => 'Reviewing',
@@ -38,9 +38,9 @@ SelectColumn::make('status')
 You can prevent the placeholder from being selected using the `disablePlaceholderSelection()` method:
 
 ```php
-use Filament\Tables\Columns\SelectColumn;
+use Filament\Tables\Columns\Select;
 
-SelectColumn::make('status')
+Select::make('status')
     ->options([
         'draft' => 'Draft',
         'reviewing' => 'Reviewing',


### PR DESCRIPTION
I faced a problem following this doc. 
the "SelectColumn" class doesn't exist, instead, it's named "Select". you can clearly see that in the dir : "vendor\filament\forms\src\Components" after you install Filament