### PR TITLE
Handle JSON columns in form select component relationships (updated)

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -432,8 +432,11 @@ class Select extends Field implements Contracts\HasNestedRecursiveValidationRule
                     ->toArray();
             }
 
+            $relationshipTitleColumnName = $component->getRelationshipTitleColumnName();
+            if (str_contains($relationshipTitleColumnName, '->') && !str_contains($relationshipTitleColumnName, ' as ')) $relationshipTitleColumnName .= ' as ' . $relationshipTitleColumnName;
+
             return $relationshipQuery
-                ->pluck($component->getRelationshipTitleColumnName(), $keyName)
+                ->pluck($relationshipTitleColumnName, $keyName)
                 ->toArray();
         });
 
@@ -471,8 +474,11 @@ class Select extends Field implements Contracts\HasNestedRecursiveValidationRule
                     ->toArray();
             }
 
+            $relationshipTitleColumnName = $component->getRelationshipTitleColumnName();
+            if (str_contains($relationshipTitleColumnName, '->') && !str_contains($relationshipTitleColumnName, ' as ')) $relationshipTitleColumnName .= ' as ' . $relationshipTitleColumnName;
+
             return $relationshipQuery
-                ->pluck($component->getRelationshipTitleColumnName(), $keyName)
+                ->pluck($relationshipTitleColumnName, $keyName)
                 ->toArray();
         });
 
@@ -560,8 +566,11 @@ class Select extends Field implements Contracts\HasNestedRecursiveValidationRule
                     ->toArray();
             }
 
+            $relationshipTitleColumnName = $component->getRelationshipTitleColumnName();
+            if (str_contains($relationshipTitleColumnName, '->') && !str_contains($relationshipTitleColumnName, ' as ')) $relationshipTitleColumnName .= ' as ' . $relationshipTitleColumnName;
+
             return $relationshipQuery
-                ->pluck($component->getRelationshipTitleColumnName(), $relatedKeyName)
+                ->pluck($relationshipTitleColumnName, $relatedKeyName)
                 ->toArray();
         });
 

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -433,7 +433,13 @@ class Select extends Field implements Contracts\HasNestedRecursiveValidationRule
             }
 
             $relationshipTitleColumnName = $component->getRelationshipTitleColumnName();
-            if (str_contains($relationshipTitleColumnName, '->') && !str_contains($relationshipTitleColumnName, ' as ')) $relationshipTitleColumnName .= ' as ' . $relationshipTitleColumnName;
+            
+            if (
+                str_contains($relationshipTitleColumnName, '->') &&
+                (! str_contains($relationshipTitleColumnName, ' as '))
+            ) {
+                $relationshipTitleColumnName .= " as {$relationshipTitleColumnName}";
+            }
 
             return $relationshipQuery
                 ->pluck($relationshipTitleColumnName, $keyName)
@@ -475,7 +481,13 @@ class Select extends Field implements Contracts\HasNestedRecursiveValidationRule
             }
 
             $relationshipTitleColumnName = $component->getRelationshipTitleColumnName();
-            if (str_contains($relationshipTitleColumnName, '->') && !str_contains($relationshipTitleColumnName, ' as ')) $relationshipTitleColumnName .= ' as ' . $relationshipTitleColumnName;
+            
+            if (
+                str_contains($relationshipTitleColumnName, '->') &&
+                (! str_contains($relationshipTitleColumnName, ' as '))
+            ) {
+                $relationshipTitleColumnName .= " as {$relationshipTitleColumnName}";
+            }
 
             return $relationshipQuery
                 ->pluck($relationshipTitleColumnName, $keyName)
@@ -567,7 +579,13 @@ class Select extends Field implements Contracts\HasNestedRecursiveValidationRule
             }
 
             $relationshipTitleColumnName = $component->getRelationshipTitleColumnName();
-            if (str_contains($relationshipTitleColumnName, '->') && !str_contains($relationshipTitleColumnName, ' as ')) $relationshipTitleColumnName .= ' as ' . $relationshipTitleColumnName;
+            
+            if (
+                str_contains($relationshipTitleColumnName, '->') &&
+                (! str_contains($relationshipTitleColumnName, ' as '))
+            ) {
+                $relationshipTitleColumnName .= " as {$relationshipTitleColumnName}";
+            }
 
             return $relationshipQuery
                 ->pluck($relationshipTitleColumnName, $relatedKeyName)


### PR DESCRIPTION
This time an alias is added to pluck() only if the titleColumnName contains '->' and doesn't contain ' as '