### PR TITLE
Pass item component to isCollapsed

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -67,7 +67,7 @@
                     <li
                         x-data="{
                             isCreateButtonVisible: false,
-                            isCollapsed: @js($isCollapsed()),
+                            isCollapsed: @js($isCollapsed($item)),
                         }"
                         x-on:builder-collapse.window="$event.detail === '{{ $getStatePath() }}' && (isCollapsed = true)"
                         x-on:builder-expand.window="$event.detail === '{{ $getStatePath() }}' && (isCollapsed = false)"

--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -66,7 +66,7 @@
                     @foreach ($containers as $uuid => $item)
                         <li
                             x-data="{
-                                isCollapsed: @js($isCollapsed()),
+                                isCollapsed: @js($isCollapsed($item)),
                             }"
                             x-on:repeater-collapse.window="$event.detail === '{{ $getStatePath() }}' && (isCollapsed = true)"
                             x-on:repeater-expand.window="$event.detail === '{{ $getStatePath() }}' && (isCollapsed = false)"

--- a/packages/forms/src/Components/Concerns/CanBeCollapsed.php
+++ b/packages/forms/src/Components/Concerns/CanBeCollapsed.php
@@ -22,7 +22,7 @@ trait CanBeCollapsed
         return $this;
     }
 
-    public function isCollapsed(null | ComponentContainer $item = null): bool
+    public function isCollapsed(?ComponentContainer $item = null): bool
     {
         return (bool) $this->evaluate($this->isCollapsed, ['item' => $item]);
     }

--- a/packages/forms/src/Components/Concerns/CanBeCollapsed.php
+++ b/packages/forms/src/Components/Concerns/CanBeCollapsed.php
@@ -3,6 +3,7 @@
 namespace Filament\Forms\Components\Concerns;
 
 use Closure;
+use Filament\Forms\ComponentContainer;
 
 trait CanBeCollapsed
 {
@@ -21,9 +22,9 @@ trait CanBeCollapsed
         return $this;
     }
 
-    public function isCollapsed(): bool
+    public function isCollapsed(null | ComponentContainer $item = null): bool
     {
-        return (bool) $this->evaluate($this->isCollapsed);
+        return (bool) $this->evaluate($this->isCollapsed, ['item' => $item]);
     }
 
     public function collapsible(bool | Closure | null $condition = true): static


### PR DESCRIPTION
Control which items are collapsed using `getRawState`
```php
Forms\Components\Repeater::make('test')
    ->collapsed(function (Forms\ComponentContainer $item): bool {
        $data = $item->getRawState();
        return $data['default'] ?? true;
    })
```