### PR TITLE
Ensuring that notification actions from Notifications have full event information

### DIFF
--- a/packages/notifications/src/Actions/Action.php
+++ b/packages/notifications/src/Actions/Action.php
@@ -28,6 +28,8 @@ class Action extends BaseAction implements Arrayable
             'color' => $this->getColor(),
             'event' => $this->getEvent(),
             'eventData' => $this->getEventData(),
+            'emitDirection' => $this->getEmitDirection(),
+            'emitToComponent' => $this->getEmitToComponent(),
             'extraAttributes' => $this->getExtraAttributes(),
             'icon' => $this->getIcon(),
             'iconPosition' => $this->getIconPosition(),

--- a/packages/support/src/Actions/Concerns/CanEmitEvent.php
+++ b/packages/support/src/Actions/Concerns/CanEmitEvent.php
@@ -76,7 +76,7 @@ trait CanEmitEvent
         return $this->evaluate($this->eventData);
     }
 
-    public function getEmitDirection(): bool|string
+    public function getEmitDirection(): bool | string
     {
         return $this->emitDirection;
     }

--- a/packages/support/src/Actions/Concerns/CanEmitEvent.php
+++ b/packages/support/src/Actions/Concerns/CanEmitEvent.php
@@ -76,6 +76,16 @@ trait CanEmitEvent
         return $this->evaluate($this->eventData);
     }
 
+    public function getEmitDirection(): bool|string
+    {
+        return $this->emitDirection;
+    }
+
+    public function getEmitToComponent(): ?string
+    {
+        return $this->emitToComponent;
+    }
+
     public function getLivewireMountAction(): ?string
     {
         $event = $this->getEvent();

--- a/tests/src/Notifications/NotificationTest.php
+++ b/tests/src/Notifications/NotificationTest.php
@@ -161,44 +161,69 @@ it('can close notifications', function () {
         ->toHaveCount(0);
 });
 
-it('can confirm a notification was sent', function () {
-    $notification = Notification::make()
-        ->success()
-        ->title('This is a notification')
-        ->body('Are you sure?')
-        ->send();
+function getLastNotificationAction()
+{
+    $notificationsLivewireComponent = new Notifications();
+    $notificationsLivewireComponent->mount();
+    $notifications = $notificationsLivewireComponent->notifications;
 
-    Notification::assertNotified($notification);
-});
+    return $notifications->first()->getActions()[0];
+}
 
 it('can emit an event', function () {
     $action = Action::make('action')->emit('an_event');
     expect($action->getLivewireMountAction())->toBe("\$emit('an_event')");
 
+    $notification = Notification::make()->actions([$action])->send();
+    expect(getLastNotificationAction()->getLivewireMountAction())->toBe("\$emit('an_event')");
+
     $action = Action::make('action')->emit('an_event', ['data']);
     expect($action->getLivewireMountAction())->toBe("\$emit('an_event', 'data')");
+
+    $notification = Notification::make()->actions([$action])->send();
+    expect(getLastNotificationAction()->getLivewireMountAction())->toBe("\$emit('an_event', 'data')");
+
 });
 
 it('can emit an event to itself', function () {
     $action = Action::make('action')->emitSelf('an_event');
     expect($action->getLivewireMountAction())->toBe("\$emitSelf('an_event')");
 
+    $notification = Notification::make()->actions([$action])->send();
+    expect(getLastNotificationAction()->getLivewireMountAction())->toBe("\$emitSelf('an_event')");
+
     $action = Action::make('action')->emitSelf('an_event', ['data']);
     expect($action->getLivewireMountAction())->toBe("\$emitSelf('an_event', 'data')");
+
+    $notification = Notification::make()->actions([$action])->send();
+    expect(getLastNotificationAction()->getLivewireMountAction())->toBe("\$emitSelf('an_event', 'data')");
 });
 
 it('can emit an event up', function () {
     $action = Action::make('action')->emitUp('an_event');
     expect($action->getLivewireMountAction())->toBe("\$emitUp('an_event')");
 
+    $notification = Notification::make()->actions([$action])->send();
+    expect(getLastNotificationAction()->getLivewireMountAction())->toBe("\$emitUp('an_event')");
+
     $action = Action::make('action')->emitUp('an_event', ['data']);
     expect($action->getLivewireMountAction())->toBe("\$emitUp('an_event', 'data')");
+
+    $notification = Notification::make()->actions([$action])->send();
+    expect(getLastNotificationAction()->getLivewireMountAction())->toBe("\$emitUp('an_event', 'data')");
 });
 
 it('can emit an event to a component', function () {
     $action = Action::make('action')->emitTo('a_component', 'an_event');
     expect($action->getLivewireMountAction())->toBe("\$emitTo('a_component', 'an_event')");
 
-    $action = Action::make('action')->emitTo('a_component', 'an_event', ['data']);
+    $notification = Notification::make()->actions([$action])->send();
+    expect(getLastNotificationAction()->getLivewireMountAction())->toBe("\$emitTo('a_component', 'an_event')");
+
+    $action = Action::make('action')->emitTo('a_component', 'an_event', ['data'], );
     expect($action->getLivewireMountAction())->toBe("\$emitTo('a_component', 'an_event', 'data')");
+
+    $notification = Notification::make()->actions([$action])->send();
+    expect(getLastNotificationAction()->getLivewireMountAction())->toBe("\$emitTo('a_component', 'an_event', 'data')");
 });
+

--- a/tests/src/Notifications/NotificationTest.php
+++ b/tests/src/Notifications/NotificationTest.php
@@ -182,7 +182,6 @@ it('can emit an event', function () {
 
     $notification = Notification::make()->actions([$action])->send();
     expect(getLastNotificationAction()->getLivewireMountAction())->toBe("\$emit('an_event', 'data')");
-
 });
 
 it('can emit an event to itself', function () {
@@ -220,10 +219,9 @@ it('can emit an event to a component', function () {
     $notification = Notification::make()->actions([$action])->send();
     expect(getLastNotificationAction()->getLivewireMountAction())->toBe("\$emitTo('a_component', 'an_event')");
 
-    $action = Action::make('action')->emitTo('a_component', 'an_event', ['data'], );
+    $action = Action::make('action')->emitTo('a_component', 'an_event', ['data']);
     expect($action->getLivewireMountAction())->toBe("\$emitTo('a_component', 'an_event', 'data')");
 
     $notification = Notification::make()->actions([$action])->send();
     expect(getLastNotificationAction()->getLivewireMountAction())->toBe("\$emitTo('a_component', 'an_event', 'data')");
 });
-


### PR DESCRIPTION
This is a follow up on #5732. The original tests verified that `Action` was correctly parsing the event information (event name, data and it's direction) and generating the correct `wire:click` attribute for use in the HTML through `getLivewireMountAction`. What I missed was that when used with `Notifications`, the actions are serialized. I had put code in to unserialize the data into the array but not to put it in the array! My bad! Apologies. This PR should fix that issue and have added further tests to verify that the correct `emit` call is rendered and will be pulled out of `Notifications` correctly.

I kept the original tests in because if the `toArray` method in `Action` changes, this would trigger test failures.