### PR TITLE
fix: table loses its default sort and direction.

### DIFF
--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -22,8 +22,8 @@ trait CanSortRecords
             $direction ??= 'asc';
         }
 
-        $this->tableSortColumn = $direction ? $column : null;
-        $this->tableSortDirection = $direction;
+        $this->tableSortColumn = $direction ? $column : $this->getDefaultTableSortColumn();
+        $this->tableSortDirection = $direction ?? $this->getDefaultTableSortDirection();
 
         $this->updatedTableSort();
     }


### PR DESCRIPTION
The default sorting field and direction are lost when a user clicks on the header several times removing the column sorting. This fix solves the issue.