### PR TITLE
Make TenantSet event properties accessible

### DIFF
--- a/packages/app/src/Events/TenantSet.php
+++ b/packages/app/src/Events/TenantSet.php
@@ -17,18 +17,12 @@ class TenantSet
     ) {
     }
 
-    /**
-     * @return Model
-     */
     public function getTenant(): Model
     {
         return $this->tenant;
     }
 
-    /**
-     * @return HasTenants | Authenticatable | Model
-     */
-    public function getUser(): Model | HasTenants | Authenticatable
+    public function getUser(): Model | Authenticatable | HasTenants
     {
         return $this->user;
     }

--- a/packages/app/src/Events/TenantSet.php
+++ b/packages/app/src/Events/TenantSet.php
@@ -12,8 +12,8 @@ class TenantSet
     use Dispatchable;
 
     public function __construct(
-        public readonly Model $tenant,
-        public readonly Model | Authenticatable | HasTenants $user,
+        public Model $tenant,
+        public Model | Authenticatable | HasTenants $user,
     ) {
     }
 }

--- a/packages/app/src/Events/TenantSet.php
+++ b/packages/app/src/Events/TenantSet.php
@@ -12,8 +12,24 @@ class TenantSet
     use Dispatchable;
 
     public function __construct(
-        public Model $tenant,
-        public Model | Authenticatable | HasTenants $user,
+        protected Model $tenant,
+        protected Model | Authenticatable | HasTenants $user,
     ) {
+    }
+
+    /**
+     * @return Model
+     */
+    public function getTenant(): Model
+    {
+        return $this->tenant;
+    }
+
+    /**
+     * @return HasTenants | Authenticatable | Model
+     */
+    public function getUser(): Model | HasTenants | Authenticatable
+    {
+        return $this->user;
     }
 }

--- a/packages/app/src/Events/TenantSet.php
+++ b/packages/app/src/Events/TenantSet.php
@@ -12,8 +12,8 @@ class TenantSet
     use Dispatchable;
 
     public function __construct(
-        protected Model $tenant,
-        protected Model | Authenticatable | HasTenants $user,
+        public readonly Model $tenant,
+        public readonly Model | Authenticatable | HasTenants $user,
     ) {
     }
 }


### PR DESCRIPTION
Properties $tenant and $user are currently declared protected in the TenantSet event which prevents them from being accessed in listeners. This PR sets them as public (and readonly). I hope I'm not missing some reason for making them protected. If that's the case, let me know and delete this PR.