### PR TITLE
Fixes alpine error with deferred loading and selection indicator

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -270,7 +270,7 @@
                     'dark:border-gray-700' => config('tables.dark_mode'),
                 ])"
             />
-        @elseif ($isSelectionEnabled)
+        @elseif ($isSelectionEnabled && $isLoaded)
             <x-tables::selection-indicator
                 :all-records-count="$allRecordsCount"
                 :colspan="$columnsCount"


### PR DESCRIPTION
When using the new deferLoading() method when tables are initially loaded `$allRecordsCount` is null which causes an alpine error in the `selection-indicator` component. This PR fixes the bug by only loading the `selection-indicator` after the data is loaded.

If you prefer you could also use `&& $allRecordsCount` instead of `&& $isLoaded`.