### PR TITLE
Add support for relationships to Infolists

### DIFF
--- a/packages/infolists/src/Components/Concerns/CanGetStateFromRelationships.php
+++ b/packages/infolists/src/Components/Concerns/CanGetStateFromRelationships.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
 
-trait InteractsWithTableQuery
+trait CanGetStateFromRelationships
 {
     public function queriesRelationships(Model $record): bool
     {

--- a/packages/infolists/src/Components/Concerns/CanGetStateFromRelationships.php
+++ b/packages/infolists/src/Components/Concerns/CanGetStateFromRelationships.php
@@ -13,15 +13,15 @@ trait CanGetStateFromRelationships
         return $this->getRelationship($record) !== null;
     }
 
-    public function getRelationship(Model $record, ?string $name = null): ?Relation
+    public function getRelationship(Model $record, ?string $statePath = null): ?Relation
     {
-        if (blank($name) && (! str($this->getName())->contains('.'))) {
+        if (blank($statePath) && (! str($this->getStatePath())->contains('.'))) {
             return null;
         }
 
         $relationship = null;
 
-        foreach (explode('.', $name ?? $this->getRelationshipName()) as $nestedRelationshipName) {
+        foreach (explode('.', $statePath ?? $this->getRelationshipName()) as $nestedRelationshipName) {
             if (! $record->isRelation($nestedRelationshipName)) {
                 $relationship = null;
 
@@ -86,25 +86,25 @@ trait CanGetStateFromRelationships
         return $results;
     }
 
-    public function getRelationshipAttribute(?string $name = null): string
+    public function getRelationshipAttribute(?string $statePath = null): string
     {
-        $name ??= $this->getName();
+        $statePath ??= $this->getStatePath();
 
-        if (! str($name)->contains('.')) {
-            return $name;
+        if (! str($statePath)->contains('.')) {
+            return $statePath;
         }
 
-        return (string) str($name)->afterLast('.');
+        return (string) str($statePath)->afterLast('.');
     }
 
-    public function getRelationshipName(?string $name = null): ?string
+    public function getRelationshipName(?string $statePath = null): ?string
     {
-        $name ??= $this->getName();
+        $statePath ??= $this->getStatePath();
 
-        if (! str($name)->contains('.')) {
+        if (! str($statePath)->contains('.')) {
             return null;
         }
 
-        return (string) str($name)->beforeLast('.');
+        return (string) str($statePath)->beforeLast('.');
     }
 }

--- a/packages/infolists/src/Components/Concerns/CanGetStateFromRelationships.php
+++ b/packages/infolists/src/Components/Concerns/CanGetStateFromRelationships.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Collection;
 
 trait CanGetStateFromRelationships
 {
-    public function queriesRelationships(Model $record): bool
+    public function hasRelationship(Model $record): bool
     {
         return $this->getRelationship($record) !== null;
     }

--- a/packages/infolists/src/Components/Concerns/HasState.php
+++ b/packages/infolists/src/Components/Concerns/HasState.php
@@ -125,11 +125,6 @@ trait HasState
         return implode('.', $pathComponents);
     }
 
-    public function getName(): string
-    {
-        return $this->getStatePath();
-    }
-
     public function getStateFromRecord(Model $record): mixed
     {
         $state = data_get($record, $this->getStatePath());

--- a/packages/infolists/src/Components/Concerns/HasState.php
+++ b/packages/infolists/src/Components/Concerns/HasState.php
@@ -4,7 +4,6 @@ namespace Filament\Infolists\Components\Concerns;
 
 use BackedEnum;
 use Closure;
-use Filament\Tables\Columns\Concerns\InteractsWithTableQuery;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 

--- a/packages/infolists/src/Components/Concerns/HasState.php
+++ b/packages/infolists/src/Components/Concerns/HasState.php
@@ -138,7 +138,7 @@ trait HasState
             return $state;
         }
 
-        if (! $this->queriesRelationships($record)) {
+        if (! $this->hasRelationship($record)) {
             return null;
         }
 

--- a/packages/infolists/src/Components/Concerns/HasState.php
+++ b/packages/infolists/src/Components/Concerns/HasState.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Collection;
 
 trait HasState
 {
-    use InteractsWithTableQuery;
+    use CanGetStateFromRelationships;
 
     protected mixed $defaultState = null;
 

--- a/packages/infolists/src/Components/Concerns/HasState.php
+++ b/packages/infolists/src/Components/Concerns/HasState.php
@@ -6,7 +6,6 @@ use BackedEnum;
 use Closure;
 use Filament\Tables\Columns\Concerns\InteractsWithTableQuery;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
 trait HasState
@@ -131,6 +130,7 @@ trait HasState
     {
         return $this->getStatePath();
     }
+
     public function getStateFromRecord(Model $record): mixed
     {
         $state = data_get($record, $this->getStatePath());

--- a/packages/infolists/src/Components/Concerns/HasState.php
+++ b/packages/infolists/src/Components/Concerns/HasState.php
@@ -54,10 +54,15 @@ trait HasState
 
     public function getState(): mixed
     {
-        $state = $this->getStateUsing ? $this->evaluate(
-            $this->getStateUsing,
-            exceptParameters: ['state'],
-        ) : $this->getStateFromRecord($this->getContainer()->getState());
+        if ($this->getStateUsing) {
+            $state = $this->evaluate($this->getStateUsing, exceptParameters: ['state']);
+        } else {
+            $containerState = $this->getContainer()->getState();
+
+            $state = $containerState instanceof Model ?
+                $this->getStateFromRecord($containerState) :
+                data_get($containerState, $this->getStatePath());
+        }
 
         if (
             interface_exists(BackedEnum::class) &&

--- a/packages/infolists/src/Components/Concerns/InteractsWithTableQuery.php
+++ b/packages/infolists/src/Components/Concerns/InteractsWithTableQuery.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Filament\Infolists\Components\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Collection;
+
+trait InteractsWithTableQuery
+{
+    public function queriesRelationships(Model $record): bool
+    {
+        return $this->getRelationship($record) !== null;
+    }
+
+    public function getRelationship(Model $record, ?string $name = null): ?Relation
+    {
+        if (blank($name) && (! str($this->getName())->contains('.'))) {
+            return null;
+        }
+
+        $relationship = null;
+
+        foreach (explode('.', $name ?? $this->getRelationshipName()) as $nestedRelationshipName) {
+            if (! $record->isRelation($nestedRelationshipName)) {
+                $relationship = null;
+
+                break;
+            }
+
+            $relationship = $record->{$nestedRelationshipName}();
+            $record = $relationship->getRelated();
+        }
+
+        return $relationship;
+    }
+
+    /**
+     * @param  array<string> | null  $relationships
+     * @return array<Model>
+     */
+    public function getRelationshipResults(Model $record, ?array $relationships = null): array
+    {
+        $results = [];
+
+        $relationships ??= explode('.', $this->getRelationshipName());
+
+        while (count($relationships)) {
+            $currentRelationshipName = array_shift($relationships);
+
+            $currentRelationshipValue = $record->getRelationValue($currentRelationshipName);
+
+            if ($currentRelationshipValue instanceof Collection) {
+                if (! count($relationships)) {
+                    $results = array_merge($results, $currentRelationshipValue->all());
+
+                    continue;
+                }
+
+                foreach ($currentRelationshipValue as $valueRecord) {
+                    $results = array_merge(
+                        $results,
+                        $this->getRelationshipResults(
+                            $valueRecord,
+                            $relationships,
+                        ),
+                    );
+                }
+
+                break;
+            }
+
+            if (! $currentRelationshipValue instanceof Model) {
+                break;
+            }
+
+            if (! count($relationships)) {
+                $results[] = $currentRelationshipValue;
+
+                break;
+            }
+
+            $record = $currentRelationshipValue;
+        }
+
+        return $results;
+    }
+
+    public function getRelationshipAttribute(?string $name = null): string
+    {
+        $name ??= $this->getName();
+
+        if (! str($name)->contains('.')) {
+            return $name;
+        }
+
+        return (string) str($name)->afterLast('.');
+    }
+
+    public function getRelationshipName(?string $name = null): ?string
+    {
+        $name ??= $this->getName();
+
+        if (! str($name)->contains('.')) {
+            return null;
+        }
+
+        return (string) str($name)->beforeLast('.');
+    }
+}


### PR DESCRIPTION
Adds support for arbitrary depth relationships to Infolists, so they work like table columns, like ...

```
                    TextEntry::make('flightLegs.dailyLog.aircraft.n_number')
                        ->label('Aircraft Flown')
                        ->distinctList()
                        ->listWithLineBreaks(),
```

