### PR TITLE
Fix bug when saving a reorderable field w/ custom table name

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -134,7 +134,9 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             $uuids = array_filter(array_values($state));
             $mappedIds = Media::query()->whereIn('uuid', $uuids)->pluck('id', 'uuid')->toArray();
 
-            Media::setNewOrder(array_merge(array_flip($uuids), $mappedIds));
+            $mediaClass = config('media-library.media_model', Media::class);
+
+            $mediaClass::setNewOrder(array_merge(array_flip($uuids), $mappedIds));
 
             return $state;
         });


### PR DESCRIPTION
When saving with a reorderable media library file field AND a custom table name for the Media class, it crashes because the fixed code does not take into account the custom media model from the config.