### PR TITLE
add method to add unauthenticated tenant routes to context

### DIFF
--- a/packages/app/routes/web.php
+++ b/packages/app/routes/web.php
@@ -111,6 +111,18 @@ Route::name('filament.')
                             }
                         });
 
+                    Route::group([], function () use ($context): void {
+                        $hasRoutableTenancy = $context->hasRoutableTenancy();
+                        $tenantSlugAttribute = $context->getTenantSlugAttribute();
+
+                        Route::prefix($hasRoutableTenancy ? ('{tenant' . (($tenantSlugAttribute) ? ":{$tenantSlugAttribute}" : '') . '}') : '')
+                            ->group(function () use ($context): void {
+                                if ($routes = $context->getTenantRoutes()) {
+                                    $routes($context);
+                                }
+                            });
+                    });
+
                     if ($routes = $context->getRoutes()) {
                         $routes($context);
                     }

--- a/packages/app/src/Context/Concerns/HasRoutes.php
+++ b/packages/app/src/Context/Concerns/HasRoutes.php
@@ -13,6 +13,8 @@ trait HasRoutes
 
     protected ?Closure $authenticatedRoutes = null;
 
+    protected ?Closure $tenantRoutes = null;
+
     protected ?Closure $authenticatedTenantRoutes = null;
 
     protected string $homeUrl = '';
@@ -56,6 +58,13 @@ trait HasRoutes
         return $this;
     }
 
+    public function tenantRoutes(?Closure $routes): static
+    {
+        $this->tenantRoutes = $routes;
+
+        return $this;
+    }
+
     public function authenticatedTenantRoutes(?Closure $routes): static
     {
         $this->authenticatedTenantRoutes = $routes;
@@ -71,6 +80,11 @@ trait HasRoutes
     public function getAuthenticatedRoutes(): ?Closure
     {
         return $this->authenticatedRoutes;
+    }
+
+    public function getTenantRoutes(): ?Closure
+    {
+        return $this->tenantRoutes;
     }
 
     public function getAuthenticatedTenantRoutes(): ?Closure


### PR DESCRIPTION
With tenancy enabled, the routes that are added to a context using ->routes() don't work (and probably shouldn't), but there might be cases where one wants to add custom unauthenticated routes to a tenant routes (e.g. a function to invite new users to a tenant). This PR adds that ability.