### PR TITLE
Qualify the field name for sorting.

### DIFF
--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -224,7 +224,7 @@ class Group
             [];
 
         if (! count($relationships)) {
-            return $lastRelationship ? $lastRelationship->getModel()->qualifyColumn($sortColumn) : $sortColumn;
+            return $lastRelationship ? $lastRelationship->getQuery()->getModel()->qualifyColumn($sortColumn) : $sortColumn;
         }
 
         $currentRelationshipName = array_shift($relationships);

--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -217,14 +217,14 @@ class Group
     /**
      * @param  array<string> | null  $relationships
      */
-    protected function getSortColumnForQuery(EloquentBuilder $query, string $sortColumn, ?array $relationships = null): string | Builder
+    protected function getSortColumnForQuery(EloquentBuilder $query, string $sortColumn, ?array $relationships = null, ?Relation $lastRelationship = null): string|Builder
     {
         $relationships ??= ($relationshipName = $this->getRelationshipName()) ?
             explode('.', $relationshipName) :
             [];
 
         if (! count($relationships)) {
-            return $sortColumn;
+            return $lastRelationship ? $lastRelationship->getModel()->qualifyColumn($sortColumn) : $sortColumn;
         }
 
         $currentRelationshipName = array_shift($relationships);
@@ -241,6 +241,7 @@ class Group
                     $relatedQuery,
                     $sortColumn,
                     $relationships,
+                    $relationship,
                 )],
             )
             ->applyScopes()

--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -217,7 +217,7 @@ class Group
     /**
      * @param  array<string> | null  $relationships
      */
-    protected function getSortColumnForQuery(EloquentBuilder $query, string $sortColumn, ?array $relationships = null, ?Relation $lastRelationship = null): string|Builder
+    protected function getSortColumnForQuery(EloquentBuilder $query, string $sortColumn, ?array $relationships = null, ?Relation $lastRelationship = null): string | Builder
     {
         $relationships ??= ($relationshipName = $this->getRelationshipName()) ?
             explode('.', $relationshipName) :


### PR DESCRIPTION
Protects against "ambiguous" errors when more than one table in the relationship chain has the same field name.

Not sure if my change is the most efficient way of doing this, but it's the only way I could figure out to do it.  Happy to change the code if anyone has a better way.