### PR TITLE
Use attributesToArray() in getStateFromRecord()

### DIFF
--- a/packages/infolists/src/Components/Concerns/HasState.php
+++ b/packages/infolists/src/Components/Concerns/HasState.php
@@ -151,7 +151,7 @@ trait HasState
         $relationshipAttribute = $this->getRelationshipAttribute();
 
         $state = collect($this->getRelationshipResults($record))
-            ->filter(fn (Model $record): bool => array_key_exists($relationshipAttribute, $record->getAttributes()))
+            ->filter(fn (Model $record): bool => array_key_exists($relationshipAttribute, $record->attributesToArray()))
             ->pluck($relationshipAttribute)
             ->when($this->isDistinctList(), fn (Collection $state) => $state->unique())
             ->values();

--- a/packages/tables/src/Columns/Concerns/HasState.php
+++ b/packages/tables/src/Columns/Concerns/HasState.php
@@ -95,7 +95,7 @@ trait HasState
         $relationshipAttribute = $this->getRelationshipAttribute();
 
         $state = collect($this->getRelationshipResults($record))
-            ->filter(fn (Model $record): bool => array_key_exists($relationshipAttribute, $record->getAttributes()))
+            ->filter(fn (Model $record): bool => array_key_exists($relationshipAttribute, $record->attributesToArray()))
             ->pluck($relationshipAttribute)
             ->when($this->isDistinctList(), fn (Collection $state) => $state->unique())
             ->values();


### PR DESCRIPTION
Using getAttributes() doesn't pick up computed properties / accessors on the model record, so changed it to use attributesToArray().