### PR TITLE
Add icon to section class and template

### DIFF
--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -57,9 +57,19 @@
             'cursor-pointer' => $isCollapsible,
         ])>
             <h3 @class([
-                'font-bold tracking-tight pointer-events-none',
-                'text-xl font-bold' => ! $isCompact,
+                'font-bold tracking-tight pointer-events-none flex flex-row items-center',
+                'text-xl' => ! $isCompact,
             ])>
+                @if ($icon = $getIcon())
+                    <x-dynamic-component
+                        :component="$icon"
+                        @class([
+                            'mr-1',
+                            'h-4 w-4' => $isCompact,
+                            'h-6 w-6' => ! $isCompact,
+                        ]) />
+                @endif
+
                 {{ $getHeading() }}
             </h3>
 

--- a/packages/forms/src/Components/Section.php
+++ b/packages/forms/src/Components/Section.php
@@ -22,6 +22,8 @@ class Section extends Component implements Contracts\CanConcealComponents, Contr
 
     protected bool | Closure | null $isAside = null;
 
+    protected string | Closure | null $icon = null;
+
     final public function __construct(string | Htmlable | Closure $heading)
     {
         $this->heading($heading);
@@ -96,5 +98,17 @@ class Section extends Component implements Contracts\CanConcealComponents, Contr
     public function isAside(): bool
     {
         return (bool) ($this->evaluate($this->isAside) ?? false);
+    }
+
+    public function icon(string | Closure | null $icon): static
+    {
+        $this->icon = $icon;
+
+        return $this;
+    }
+
+    public function getIcon(): ?string
+    {
+        return $this->evaluate($this->icon);
     }
 }


### PR DESCRIPTION
Add ability to add an icon to the section header using the `icon()` method as with e.g. tabs.
Looks like this (compact and non-compact):

![image](https://user-images.githubusercontent.com/4368880/225176562-f743a3a7-b655-43d3-8659-d60dcc585502.png)

I thought about adding an `iconSize()` method as well but decided against it and chose default size values that I think work well.

While at it, I also removed the superfluous `font-bold` from the heading classes.