### PR TITLE
Remove doubling up of adding window height

### DIFF
--- a/packages/admin/resources/views/components/form/actions.blade.php
+++ b/packages/admin/resources/views/components/form/actions.blade.php
@@ -13,7 +13,7 @@
                 let documentHeight = document.body.scrollHeight
                 let currentScroll = window.scrollY + window.innerHeight
 
-                this.isSticky = (currentScroll + window.innerHeight) <= documentHeight
+                this.isSticky = currentScroll <= documentHeight
             },
 
         }"


### PR DESCRIPTION
The sticky actions don't work for me due to this adding the window height twice. Removing it fixes.