### PR TITLE
Feature/persist sort in session

### DIFF
--- a/packages/tables/docs/03-columns/01-getting-started.md
+++ b/packages/tables/docs/03-columns/01-getting-started.md
@@ -123,6 +123,17 @@ protected function getDefaultTableSortDirection(): ?string
 }
 ```
 
+### Persist search in session
+
+To persist the sort in the user's session, override the `shouldPersistTableSortInSession()` method on the Livewire component:
+
+```php
+protected function shouldPersistTableSortInSession(): bool
+{
+    return true;
+}
+```
+
 ## Searching
 
 Columns may be searchable, by using the text input in the top right of the table. To make a column searchable, you must use the `searchable()` method:

--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -54,8 +54,8 @@ trait CanSortRecords
             session()->put(
                 $this->getTableSortSessionKey(),
                 [
-                    'sortColumn' => $this->tableSortColumn,
-                    'sortDirection' => $this->tableSortDirection,
+                    'column' => $this->tableSortColumn,
+                    'direction' => $this->tableSortDirection,
                 ],
             );
         }

--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -50,6 +50,16 @@ trait CanSortRecords
 
     public function updatedTableSort(): void
     {
+        if ($this->shouldPersistTableSortInSession()) {
+            session()->put(
+                $this->getTableSortSessionKey(),
+                [
+                    'sortColumn' => $this->tableSortColumn,
+                    'sortDirection' => $this->tableSortDirection,
+                ],
+            );
+        }
+
         $this->resetPage();
     }
 
@@ -80,5 +90,17 @@ trait CanSortRecords
         }
 
         return $query;
+    }
+
+    public function getTableSortSessionKey(): string
+    {
+        $table = class_basename($this::class);
+
+        return "tables.{$table}_sort";
+    }
+
+    protected function shouldPersistTableSortInSession(): bool
+    {
+        return false;
     }
 }

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -100,6 +100,13 @@ trait InteractsWithTable
             $this->tableColumnSearchQueries ?? [],
         );
 
+        $sortSessionKey = $this->getTableSortSessionKey();
+
+        if (($this->tableSortColumn === null || $this->tableSortDirection === null) && $this->shouldPersistTableSortInSession() && session()->has($sortSessionKey)) {
+            $this->tableSortColumn = session()->get($sortSessionKey)['sortColumn'];
+            $this->tableSortDirection = session()->get($sortSessionKey)['sortDirection'];
+        }
+
         $this->hasMounted = true;
     }
 

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -102,9 +102,11 @@ trait InteractsWithTable
 
         $sortSessionKey = $this->getTableSortSessionKey();
 
-        if (($this->tableSortColumn === null || $this->tableSortDirection === null) && $this->shouldPersistTableSortInSession() && session()->has($sortSessionKey)) {
-            $this->tableSortColumn = session()->get($sortSessionKey)['sortColumn'];
-            $this->tableSortDirection = session()->get($sortSessionKey)['sortDirection'];
+        if (blank($this->tableSortColumn) && $this->shouldPersistTableSortInSession() && session()->has($sortSessionKey)) {
+            $sort = session()->get($sortSessionKey);
+        
+            $this->tableSortColumn = $sort['column'] ?? null;
+            $this->tableSortDirection = $sort['direction'] ?? null;
         }
 
         $this->hasMounted = true;


### PR DESCRIPTION
This PR adds persisting the sort in a user session. 

I also have a question regarding this PR, how should we handle `defaultTableSortColumn` and `defaultTableSortDirection`?

Right now they get set in the `mountInteractsWithTable` so they overwrite the `sortColumn` and `sortDirection` from the session.
I was thinking to move this:
```
        $this->tableSortColumn ??= $this->getDefaultTableSortColumn();
        $this->tableSortDirection ??= $this->getDefaultTableSortDirection();
```

Out of the `mountInteractsWithTable()` and put it in the `bootedInteractsWithTable()` above the part where the sort gets set by the session so the session can overwrite the default `sortColumn` and `sortDirection`. 