### PR TITLE
Fix bug when saving a reorderable field w/ custom table name

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -132,9 +132,10 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
         $this->reorderUploadedFilesUsing(static function (SpatieMediaLibraryFileUpload $component, array $state): array {
             $uuids = array_filter(array_values($state));
-            $mappedIds = Media::query()->whereIn('uuid', $uuids)->pluck('id', 'uuid')->toArray();
 
             $mediaClass = config('media-library.media_model', Media::class);
+
+            $mappedIds = $mediaClass::query()->whereIn('uuid', $uuids)->pluck('id', 'uuid')->toArray();
 
             $mediaClass::setNewOrder(array_merge(array_flip($uuids), $mappedIds));
 


### PR DESCRIPTION
Another bug where custom table name is ignore when saving a reordarable spatie file field