### PR TITLE
Copy Value Correction

### DIFF
--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -61,7 +61,7 @@
         <span
             @if ($isCopyable)
                 x-on:click="
-                    window.navigator.clipboard.writeText(@js($state))
+                    window.navigator.clipboard.writeText(@js($getState()))
                     $tooltip(@js($getCopyMessage()), { timeout: @js($getCopyMessageDuration()) })
                 "
             @endif


### PR DESCRIPTION
The variable `$state`, returns the formatted value of the component, which when using the `limit()`, for example, it copies the limited value, not copying the actual value of the component.

With this correction, the copy action copies the actual value of the component, without any formatting.