### PR TITLE
make required-asterisk stick to label

### DIFF
--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -15,13 +15,12 @@
         'text-danger-700' => $error,
         'dark:text-danger-400' => $error && config('forms.dark_mode'),
     ])>
-        {{ $slot }}
-
-        @if ($required)
-            <sup @class([
-                'font-medium text-danger-700',
-                'dark:text-danger-400' => config('forms.dark_mode'),
-            ])>*</sup>
+        {{ $slot }}@if ($required)<span class="whitespace-nowrap">
+                <sup @class([
+                    'font-medium text-danger-700',
+                    'dark:text-danger-400' => config('forms.dark_mode'),
+                ])>*</sup>
+            </span>
         @endif
     </span>
 

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -15,6 +15,7 @@
         'text-danger-700' => $error,
         'dark:text-danger-400' => $error && config('forms.dark_mode'),
     ])>
+        {{-- Deliberately poor formatting to ensure that the asterisk sticks to the final word in the label. --}}
         {{ $slot }}@if ($required)<span class="whitespace-nowrap">
                 <sup @class([
                     'font-medium text-danger-700',


### PR DESCRIPTION
Problem: When using inline-labels, it might occur that the asterisk denoting required fields wraps to a newline after the label. This does't look great:
![image](https://user-images.githubusercontent.com/4368880/226076067-a5a21ff8-6895-405d-b275-2b2b17d2621f.png)
![Screenshot_20230318_022454](https://user-images.githubusercontent.com/4368880/226076089-559560ae-ebe5-4bb4-9936-961129f5c050.png)

Putting `whitespace-nowrap` into the label classes is not a solutin imo as it leads to long labels not wrapping at all:
![Screenshot_20230318_022555](https://user-images.githubusercontent.com/4368880/226076120-df118290-da8e-49da-a0a1-f23aa2730e39.png)
![Screenshot_20230318_022618](https://user-images.githubusercontent.com/4368880/226076126-400967e0-d506-4167-84d2-a4dddf862167.png)

So I wrapped the `sup` tag with the asterisk inside a `span` with `whitespace-nowrap` and moved it directly behind the label text. It doesn't look pretty in the blade file, but it works and results in the asterisk sticking to the last label word without wrapping into its own line:
![Screenshot_20230318_022740](https://user-images.githubusercontent.com/4368880/226076176-44c6563c-a987-49c1-9b84-65d51b40590f.png)


Aside:
long words or too much label text are still not great, but I don't think there's much we can do
![image](https://user-images.githubusercontent.com/4368880/226076227-6e9d8b98-8f5c-433f-a5fb-78d881573cad.png)
![Screenshot_20230318_022358](https://user-images.githubusercontent.com/4368880/226076232-9b24d17a-a9a7-4c0b-a694-688d7b1e54f3.png)