### PR TITLE
fix/hide extra element in table when empty

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -312,9 +312,17 @@
         >
             @if (($content || $hasColumnsLayout) && ($records !== null) && count($records))
                 @if (($content || $hasColumnsLayout) && (! $isReordering))
+                    @php
+                        $sortableColumns = array_filter(
+                            $columns,
+                            fn (\Filament\Tables\Columns\Column $column): bool => $column->isSortable(),
+                        );
+                    @endphp
+                    
                     <div @class([
                         'bg-gray-500/5 flex items-center gap-4 px-4 border-b',
                         'dark:border-gray-700' => config('tables.dark_mode'),
+                        'hidden' => !$isSelectionEnabled && !count($sortableColumns),
                     ])>
                         @if ($isSelectionEnabled)
                             <x-tables::checkbox
@@ -338,13 +346,6 @@
                                 ])"
                             />
                         @endif
-
-                        @php
-                            $sortableColumns = array_filter(
-                                $columns,
-                                fn (\Filament\Tables\Columns\Column $column): bool => $column->isSortable(),
-                            );
-                        @endphp
 
                         @if (count($sortableColumns))
                             <div

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -322,7 +322,7 @@
                     <div @class([
                         'bg-gray-500/5 flex items-center gap-4 px-4 border-b',
                         'dark:border-gray-700' => config('tables.dark_mode'),
-                        'hidden' => !$isSelectionEnabled && !count($sortableColumns),
+                        'hidden' => (! $isSelectionEnabled) && (! count($sortableColumns)),
                     ])>
                         @if ($isSelectionEnabled)
                             <x-tables::checkbox


### PR DESCRIPTION
currently when using column layout but without sortable columns, there is an extra element with `border-b`

![image](https://user-images.githubusercontent.com/67364036/226333722-4164bfc8-e85c-4aa5-9443-e51f3888fe59.png)


**before**
![image](https://user-images.githubusercontent.com/67364036/226332112-520ca474-92dc-4ab2-9334-c19b7fb3a1da.png)

**after**
![image](https://user-images.githubusercontent.com/67364036/226332046-7579b345-4928-4676-a170-887a032d5ebb.png)

example
```php
Tables\Columns\Layout\Stack::make([
    Tables\Columns\TextColumn::make('name')
])
```