### PR TITLE
Visually distinguish disabled options

### DIFF
--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -33,6 +33,9 @@
                 @endphp
 
                 @foreach ($getOptions() as $value => $label)
+                    @php
+                        $shouldOptionBeDisabled = $isDisabled || $isOptionDisabled($value, $label);
+                    @endphp
                     <div @class([
                         'flex items-start',
                         'gap-3' => ! $isInline(),
@@ -54,7 +57,7 @@
                                     'border-danger-600 ring-1 ring-inset ring-danger-600' => $errors->has($getStatePath()),
                                     'dark:border-danger-400 dark:ring-danger-400' => $errors->has($getStatePath()) && config('forms.dark_mode'),
                                 ]) }}
-                                {!! ($isDisabled || $isOptionDisabled($value, $label)) ? 'disabled' : null !!}
+                                {!! $shouldOptionBeDisabled ? 'disabled' : null !!}
                                 wire:loading.attr="disabled"
                             />
                         </div>
@@ -62,8 +65,10 @@
                         <div class="text-sm">
                             <label for="{{ $getId() }}-{{ $value }}" @class([
                                 'font-medium',
-                                'text-gray-700' => ! $errors->has($getStatePath()),
-                                'dark:text-gray-200' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
+                                'text-gray-700' => ! $errors->has($getStatePath()) && ! $shouldOptionBeDisabled,
+                                'dark:text-gray-200' => (! $errors->has($getStatePath()) && ! $shouldOptionBeDisabled) && config('forms.dark_mode'),
+                                'text-gray-400' => ! $errors->has($getStatePath()) && $shouldOptionBeDisabled,
+                                'dark:text-gray-500' => (! $errors->has($getStatePath()) && $shouldOptionBeDisabled) && config('forms.dark_mode'),
                                 'text-danger-600' => $errors->has($getStatePath()),
                                 'dark:text-danger-400' => $errors->has($getStatePath()) && config('forms.dark_mode'),
                             ])>

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -36,6 +36,7 @@
                     @php
                         $shouldOptionBeDisabled = $isDisabled || $isOptionDisabled($value, $label);
                     @endphp
+                    
                     <div @class([
                         'flex items-start',
                         'gap-3' => ! $isInline(),

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -66,11 +66,11 @@
                         <div class="text-sm">
                             <label for="{{ $getId() }}-{{ $value }}" @class([
                                 'font-medium',
-                                'text-gray-700' => ! $errors->has($getStatePath()) && ! $shouldOptionBeDisabled,
-                                'dark:text-gray-200' => (! $errors->has($getStatePath()) && ! $shouldOptionBeDisabled) && config('forms.dark_mode'),
-                                'opacity-50' => ! $errors->has($getStatePath()) && $shouldOptionBeDisabled,
+                                'text-gray-700' => ! $errors->has($getStatePath()),
+                                'dark:text-gray-200' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
                                 'text-danger-600' => $errors->has($getStatePath()),
                                 'dark:text-danger-400' => $errors->has($getStatePath()) && config('forms.dark_mode'),
+                                'opacity-50' => $shouldOptionBeDisabled,
                             ])>
                                 {{ $label }}
                             </label>

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -68,8 +68,7 @@
                                 'font-medium',
                                 'text-gray-700' => ! $errors->has($getStatePath()) && ! $shouldOptionBeDisabled,
                                 'dark:text-gray-200' => (! $errors->has($getStatePath()) && ! $shouldOptionBeDisabled) && config('forms.dark_mode'),
-                                'text-gray-400' => ! $errors->has($getStatePath()) && $shouldOptionBeDisabled,
-                                'dark:text-gray-500' => (! $errors->has($getStatePath()) && $shouldOptionBeDisabled) && config('forms.dark_mode'),
+                                'opacity-50' => ! $errors->has($getStatePath()) && $shouldOptionBeDisabled,
                                 'text-danger-600' => $errors->has($getStatePath()),
                                 'dark:text-danger-400' => $errors->has($getStatePath()) && config('forms.dark_mode'),
                             ])>


### PR DESCRIPTION
Disabled options are really hard to distinguish from non-disabled ones.

Before
![Screenshot 2023-03-20 at 15 15 05](https://user-images.githubusercontent.com/33912290/226367556-15483e9e-18b1-4ca4-a5d2-84f92100ebc8.png)

After
![Screenshot 2023-03-20 at 15 15 22](https://user-images.githubusercontent.com/33912290/226367575-3e29816a-600c-44c5-bec8-aab8adfbe7f9.png)

Before (dark mode)
![Screenshot 2023-03-20 at 15 17 46](https://user-images.githubusercontent.com/33912290/226368018-8397e7e0-025b-448b-b77b-3c26a7b5790f.png)

After (dark mode)
![Screenshot 2023-03-20 at 15 18 01](https://user-images.githubusercontent.com/33912290/226368065-ac707cd0-5027-4cb2-a548-08f7ccbbf927.png)
