### PR TITLE
fix: s3 bucket where file missing

### DIFF
--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
+use League\Flysystem\UnableToCheckFileExistence;
 use Livewire\TemporaryUploadedFile;
 use Throwable;
 
@@ -69,13 +70,13 @@ class BaseFileUpload extends Field
             }
 
             $files = collect(Arr::wrap($state))
-            ->filter(static function (string $file) use ($component): bool {
-                try {
-                    return blank($file) || $component->getDisk()->exists($file);
-                } catch(\League\Flysystem\UnableToCheckFileExistence $exception) {
-                    return false;
-                }
-            })
+                ->filter(static function (string $file) use ($component): bool {
+                    try {
+                        return blank($file) || $component->getDisk()->exists($file);
+                    } catch (UnableToCheckFileExistence $exception) {
+                        return false;
+                    }
+                })
                 ->mapWithKeys(static fn (string $file): array => [((string) Str::uuid()) => $file])
                 ->all();
 
@@ -120,7 +121,7 @@ class BaseFileUpload extends Field
                 if (! $storage->exists($file)) {
                     return null;
                 }
-            } catch(\League\Flysystem\UnableToCheckFileExistence $exception) {
+            } catch (UnableToCheckFileExistence $exception) {
                 return null;
             }
 
@@ -147,8 +148,8 @@ class BaseFileUpload extends Field
                 if (! $file->exists()) {
                     return null;
                 }
-            } catch(\League\Flysystem\UnableToCheckFileExistence $exception) {
-                return false;
+            } catch (UnableToCheckFileExistence $exception) {
+                return null;
             }
 
             /** @phpstan-ignore-next-line */

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -72,7 +72,7 @@ class BaseFileUpload extends Field
             ->filter(static function (string $file) use ($component): bool {
                 try {
                     return blank($file) || $component->getDisk()->exists($file);
-                }catch(\League\Flysystem\UnableToCheckFileExistence $exception){
+                } catch(\League\Flysystem\UnableToCheckFileExistence $exception) {
                     return false;
                 }
             })
@@ -120,7 +120,7 @@ class BaseFileUpload extends Field
                 if (! $storage->exists($file)) {
                     return null;
                 }
-            }catch(\League\Flysystem\UnableToCheckFileExistence $exception){
+            } catch(\League\Flysystem\UnableToCheckFileExistence $exception) {
                 return null;
             }
 
@@ -143,12 +143,11 @@ class BaseFileUpload extends Field
         });
 
         $this->saveUploadedFileUsing(static function (BaseFileUpload $component, TemporaryUploadedFile $file): ?string {
-
             try {
                 if (! $file->exists()) {
                     return null;
                 }
-            }catch(\League\Flysystem\UnableToCheckFileExistence $exception){
+            } catch(\League\Flysystem\UnableToCheckFileExistence $exception) {
                 return false;
             }
 

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -143,8 +143,13 @@ class BaseFileUpload extends Field
         });
 
         $this->saveUploadedFileUsing(static function (BaseFileUpload $component, TemporaryUploadedFile $file): ?string {
-            if (! $file->exists()) {
-                return null;
+
+            try {
+                if (! $file->exists()) {
+                    return null;
+                }
+            }catch(\League\Flysystem\UnableToCheckFileExistence $exception){
+                return false;
             }
 
             /** @phpstan-ignore-next-line */

--- a/packages/forms/src/Components/Concerns/HasFileAttachments.php
+++ b/packages/forms/src/Components/Concerns/HasFileAttachments.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Facades\Storage;
+use League\Flysystem\UnableToCheckFileExistence;
 use Livewire\TemporaryUploadedFile;
 use Throwable;
 
@@ -107,7 +108,11 @@ trait HasFileAttachments
         /** @var FilesystemAdapter $storage */
         $storage = $this->getFileAttachmentsDisk();
 
-        if (! $storage->exists($file)) {
+        try {
+            if (! $storage->exists($file)) {
+                return null;
+            }
+        } catch (UnableToCheckFileExistence $exception) {
             return null;
         }
 

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -5,6 +5,7 @@ namespace Filament\Forms\Components;
 use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use League\Flysystem\UnableToCheckFileExistence;
 use Livewire\TemporaryUploadedFile;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\MediaCollections\FileAdder;
@@ -98,7 +99,11 @@ class SpatieMediaLibraryFileUpload extends FileUpload
                 return $file;
             }
 
-            if (! $file->exists()) {
+            try {
+                if (! $file->exists()) {
+                    return null;
+                }
+            } catch (UnableToCheckFileExistence $exception) {
                 return null;
             }
 

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\View\ComponentAttributeBag;
+use League\Flysystem\UnableToCheckFileExistence;
 use Throwable;
 
 class ImageColumn extends Column
@@ -132,7 +133,11 @@ class ImageColumn extends Column
         /** @var FilesystemAdapter $storage */
         $storage = $this->getDisk();
 
-        if (! $storage->exists($state)) {
+        try {
+            if (! $storage->exists($state)) {
+                return null;
+            }
+        } catch (UnableToCheckFileExistence $exception) {
             return null;
         }
 


### PR DESCRIPTION
if an image is missing from s3 bucket, the storage->exists() throws a `League\Flysystem\UnableToCheckFileExistence` exception, which prevents fixing the uploaded file etc.

this patch will allow that to return false/null where needed 