### PR TITLE
Refactor `Filament\locale_has_pluralization` to `Filament\Support\locale_has_pluralization`

### DIFF
--- a/packages/admin/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/admin/src/Resources/RelationManagers/RelationManager.php
@@ -5,7 +5,7 @@ namespace Filament\Resources\RelationManagers;
 use Closure;
 use Filament\Facades\Filament;
 use Filament\Http\Livewire\Concerns\CanNotify;
-use function Filament\locale_has_pluralization;
+use function Filament\Support\locale_has_pluralization;
 use Filament\Resources\Form;
 use Filament\Resources\Table;
 use Filament\Tables;

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -5,7 +5,7 @@ namespace Filament\Resources;
 use Closure;
 use Filament\Facades\Filament;
 use Filament\GlobalSearch\GlobalSearchResult;
-use function Filament\locale_has_pluralization;
+use function Filament\Support\locale_has_pluralization;
 use Filament\Navigation\NavigationItem;
 use function Filament\Support\get_model_label;
 use Illuminate\Database\Connection;

--- a/packages/admin/src/helpers.php
+++ b/packages/admin/src/helpers.php
@@ -3,7 +3,6 @@
 namespace Filament;
 
 use Illuminate\Support\Str;
-use Illuminate\Translation\MessageSelector;
 
 if (! function_exists('Filament\get_asset_id')) {
     function get_asset_id(string $file, string $manifestPath = null): ?string
@@ -29,12 +28,5 @@ if (! function_exists('Filament\get_asset_id')) {
         }
 
         return (string) Str::of($file)->after('id=');
-    }
-}
-
-if (! function_exists('Filament\locale_has_pluralization')) {
-    function locale_has_pluralization(): bool
-    {
-        return (new MessageSelector())->getPluralIndex(app()->getLocale(), 10) > 0;
     }
 }

--- a/packages/support/src/Actions/Concerns/InteractsWithRecord.php
+++ b/packages/support/src/Actions/Concerns/InteractsWithRecord.php
@@ -3,7 +3,7 @@
 namespace Filament\Support\Actions\Concerns;
 
 use Closure;
-use function Filament\locale_has_pluralization;
+use function Filament\Support\locale_has_pluralization;
 use function Filament\Support\get_model_label;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -15,6 +15,13 @@ if (! function_exists('Filament\Support\get_model_label')) {
     }
 }
 
+if (! function_exists('Filament\Support\locale_has_pluralization')) {
+    function locale_has_pluralization(): bool
+    {
+        return (new MessageSelector())->getPluralIndex(app()->getLocale(), 10) > 0;
+    }
+}
+
 if (! function_exists('Filament\Support\prepare_inherited_attributes')) {
     function prepare_inherited_attributes(ComponentAttributeBag $attributes): ComponentAttributeBag
     {
@@ -29,12 +36,5 @@ if (! function_exists('Filament\Support\prepare_inherited_attributes')) {
         );
 
         return $attributes;
-    }
-}
-
-if (! function_exists('Filament\Support\locale_has_pluralization')) {
-    function locale_has_pluralization(): bool
-    {
-        return (new MessageSelector())->getPluralIndex(app()->getLocale(), 10) > 0;
     }
 }

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -4,6 +4,7 @@ namespace Filament\Support;
 
 use Illuminate\Support\Str;
 use Illuminate\View\ComponentAttributeBag;
+use Illuminate\Translation\MessageSelector;
 
 if (! function_exists('Filament\Support\get_model_label')) {
     function get_model_label(string $model): string
@@ -28,5 +29,12 @@ if (! function_exists('Filament\Support\prepare_inherited_attributes')) {
         );
 
         return $attributes;
+    }
+}
+
+if (! function_exists('Filament\Support\locale_has_pluralization')) {
+    function locale_has_pluralization(): bool
+    {
+        return (new MessageSelector())->getPluralIndex(app()->getLocale(), 10) > 0;
     }
 }

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -2,7 +2,7 @@
 
 namespace Filament\Tables\Concerns;
 
-use function Filament\locale_has_pluralization;
+use function Filament\Support\locale_has_pluralization;
 use function Filament\Support\get_model_label;
 use Filament\Tables\Contracts\HasRelationshipTable;
 use Illuminate\Contracts\Pagination\Paginator;


### PR DESCRIPTION
I used `filament/tables` separately and faced an issue while trying to use `DeleteBulkAction`. 😟

Here is the error message:

![image](https://user-images.githubusercontent.com/51883557/226549452-30cdc795-e2e4-4dc4-95ad-2a4f6da94baf.png)

I've used the admin panel and there were no such issues.
I found that the function was inside `filament/filament` package and to fix the function was needed to move under `Filament\Support` namespace.

What I did?
- Moved the function from `Filament\locale_has_pluralization` to `Filament\Support\locale_has_pluralization`
- Update all the references

Everything is working fine now ✅