### PR TITLE
Add 'empty.buttons.reset_column_searches.label' table.php

### DIFF
--- a/packages/tables/resources/lang/nl/table.php
+++ b/packages/tables/resources/lang/nl/table.php
@@ -95,6 +95,15 @@ return [
 
     'empty' => [
         'heading' => 'Geen records gevonden',
+
+        'buttons' => [
+
+            'reset_column_searches' => [
+                'label' => 'Kolom zoekopdracht wissen',
+            ],
+
+        ],
+
     ],
 
     'filters' => [


### PR DESCRIPTION
Adds translation for empty column search label. When searching in a specific column this label is shown, this seemed like the best Dutch translation