### PR TITLE
Notification - center notifications vertically

### DIFF
--- a/packages/notifications/resources/views/notification.blade.php
+++ b/packages/notifications/resources/views/notification.blade.php
@@ -13,7 +13,7 @@
             'center' => match (config('notifications.layout.alignment.vertical')) {
                 'top' => '-translate-y-12',
                 'bottom' => 'translate-y-12',
-                'center' => '',
+                'center' => null,
             },
         },
     ])"

--- a/packages/notifications/resources/views/notification.blade.php
+++ b/packages/notifications/resources/views/notification.blade.php
@@ -13,6 +13,7 @@
             'center' => match (config('notifications.layout.alignment.vertical')) {
                 'top' => '-translate-y-12',
                 'bottom' => 'translate-y-12',
+                'center' => '',
             },
         },
     ])"

--- a/packages/notifications/resources/views/notifications.blade.php
+++ b/packages/notifications/resources/views/notifications.blade.php
@@ -1,15 +1,16 @@
 <div>
     <div
         @class([
-            'filament-notifications pointer-events-none fixed inset-4 z-50 mx-auto flex justify-end gap-3',
+            'filament-notifications pointer-events-none fixed inset-4 z-50 mx-auto flex gap-3',
             match (config('notifications.layout.alignment.horizontal')) {
                 'left' => 'items-start',
                 'center' => 'items-center',
                 'right' => 'items-end',
             },
             match (config('notifications.layout.alignment.vertical')) {
-                'top' => 'flex-col-reverse',
-                'bottom' => 'flex-col',
+                'top' => 'flex-col-reverse justify-end',
+                'bottom' => 'flex-col justify-end',
+                'center' => 'flex-col justify-center'
             },
         ])
         role="status"


### PR DESCRIPTION
Hi! This pull request includes a new feature that enables users of Filament to easily center notifications vertically. Previously, this functionality was not available, but now with the addition of 'vertical_alignment' => 'center' in the filament config file, users can easily set their notifications to appear in the center of their screen.