### PR TITLE
Table action hide disabled label

### DIFF
--- a/packages/tables/resources/views/actions/link-action.blade.php
+++ b/packages/tables/resources/views/actions/link-action.blade.php
@@ -4,5 +4,9 @@
     :icon-position="$getIconPosition()"
     class="filament-tables-link-action"
 >
-    {{ $getLabel() }}
+    <span @class([
+        'sr-only' => $isLabelHidden(),
+    ])>
+        {{ $getLabel() }}
+    </span>
 </x-tables::actions.action>


### PR DESCRIPTION
This is the easiest change to allow for edit table action to disable label.
```php
\Filament\Tables\Actions\EditAction::make()
    ->disableLabel()
```

Not sure if it also needs to be added to the other table actions.