### PR TITLE
Add register listener

### DIFF
--- a/packages/forms/src/Components/Concerns/ListensToEvents.php
+++ b/packages/forms/src/Components/Concerns/ListensToEvents.php
@@ -2,6 +2,8 @@
 
 namespace Filament\Forms\Components\Concerns;
 
+use Closure;
+
 trait ListensToEvents
 {
     protected array $listeners = [];
@@ -11,6 +13,13 @@ trait ListensToEvents
         foreach ($this->getListeners($event) as $callback) {
             $callback($this, ...$parameters);
         }
+
+        return $this;
+    }
+    
+    public function registerListener(string $name, Closure $callback): static
+    {
+        $this->listeners[$name] = [$callback];
 
         return $this;
     }

--- a/packages/forms/src/Components/Concerns/ListensToEvents.php
+++ b/packages/forms/src/Components/Concerns/ListensToEvents.php
@@ -16,7 +16,7 @@ trait ListensToEvents
 
         return $this;
     }
-    
+
     public function registerListener(string $name, Closure $callback): static
     {
         $this->listeners[$name] = [$callback];


### PR DESCRIPTION
Allow for singular listeners to be added and ability to overwrite default listeners

```php
Repeater::make()->registerListener('repeater::createItem', fn () => )
```