### PR TITLE
Call configure on ActionGroup after making it.

### DIFF
--- a/packages/support/src/Actions/ActionGroup.php
+++ b/packages/support/src/Actions/ActionGroup.php
@@ -32,7 +32,10 @@ class ActionGroup extends ViewComponent
 
     public static function make(array $actions): static
     {
-        return app(static::class, ['actions' => $actions]);
+        $static = app(static::class, ['actions' => $actions]);
+        $static->configure();
+
+        return $static;
     }
 
     public function getLabel(): ?string


### PR DESCRIPTION
The `ActionGroup::make()` method was missing the call to `->configure()` inside the make method. This PR adds it.