### PR TITLE
Fixes has many deep relationship with textColumn

### DIFF
--- a/packages/tables/src/Columns/Concerns/HasState.php
+++ b/packages/tables/src/Columns/Concerns/HasState.php
@@ -85,7 +85,8 @@ trait HasState
             $relationship instanceof HasMany ||
             $relationship instanceof BelongsToMany ||
             $relationship instanceof MorphMany ||
-            $relationship instanceof \Staudenmeir\EloquentHasManyDeep\HasManyDeep
+            ($relationship instanceof \Staudenmeir\EloquentHasManyDeep\HasManyDeep &&
+            ! $relationship instanceof \Staudenmeir\EloquentHasManyDeep\HasOneDeep)
         )) {
             return null;
         }

--- a/packages/tables/src/Columns/Concerns/HasState.php
+++ b/packages/tables/src/Columns/Concerns/HasState.php
@@ -85,8 +85,7 @@ trait HasState
             $relationship instanceof HasMany ||
             $relationship instanceof BelongsToMany ||
             $relationship instanceof MorphMany ||
-            ($relationship instanceof \Staudenmeir\EloquentHasManyDeep\HasManyDeep &&
-            ! $relationship instanceof \Staudenmeir\EloquentHasManyDeep\HasOneDeep)
+            ($relationship instanceof \Staudenmeir\EloquentHasManyDeep\HasManyDeep && (! $relationship instanceof \Staudenmeir\EloquentHasManyDeep\HasOneDeep))
         )) {
             return null;
         }


### PR DESCRIPTION
Implementing PR #5992 breaks `textColumns` that are using `\Staudenmeir\EloquentHasManyDeep\HasOneDeep` if the relationship doesn't exist since the `HasOneDeep` class extends `HasManyDeep` and therefore gets through the conditional. This throws a `Call to a member function pluck() on null` error. 

This PR fixes it by adding another conditional to exclude HasOneDeep. 

It can also be written as `get_class($relationship) === 'Staudenmeir\EloquentHasManyDeep\HasManyDeep'` if you prefer. 