### PR TITLE
Update default position for descriptionIcon to be after

### DIFF
--- a/packages/widgets/src/StatsOverviewWidget/Card.php
+++ b/packages/widgets/src/StatsOverviewWidget/Card.php
@@ -100,7 +100,7 @@ class Card extends Component implements Htmlable
         return $this;
     }
 
-    public function descriptionIcon(?string $icon, ?string $position = null): static
+    public function descriptionIcon(?string $icon, ?string $position = 'after'): static
     {
         $this->descriptionIcon = $icon;
         $this->descriptionIconPosition = $position;


### PR DESCRIPTION
Currently, the `descriptionIcon` has a default `$position` of `null`. When the `position` is `null`, the `card.blade.php` responsible for rendering the icon has a conditional for showing the icon if the `position` is set to `before` or `after` but does not display at all if the `position` is set to `null`. 

This PR will set it by default to be `after` so that when users set a `descriptionIcon` it will show up even when not setting a second argument.

https://github.com/filamentphp/filament/blob/7269baf95c6d23f64047a2f886e1b0561c3d24d2/packages/widgets/resources/views/stats-overview-widget/card.blade.php#L48-L64