### PR TITLE
Fixes error display of nestedRecurrsiveValidationRules

### DIFF
--- a/packages/forms/resources/views/components/field-wrapper/index.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/index.blade.php
@@ -52,7 +52,7 @@
 
             @if ($errors->has($statePath) || ($hasNestedRecursiveValidationRules && $errors->has("{$statePath}.*")))
                 <x-forms::field-wrapper.error-message>
-                    {{ $errors->first($statePath) ? $errors->first($statePath) : ($hasNestedRecursiveValidationRules ? $errors->first("{$statePath}.*") : null) }}
+                    {{ $errors->has($statePath) ? $errors->first($statePath) : ($hasNestedRecursiveValidationRules ? $errors->first("{$statePath}.*") : null) }}
                 </x-forms::field-wrapper.error-message>
             @endif
 

--- a/packages/forms/resources/views/components/field-wrapper/index.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/index.blade.php
@@ -52,7 +52,7 @@
 
             @if ($errors->has($statePath) || ($hasNestedRecursiveValidationRules && $errors->has("{$statePath}.*")))
                 <x-forms::field-wrapper.error-message>
-                    {{ $errors->has($statePath) ? $errors->first($statePath) : ($hasNestedRecursiveValidationRules ? $errors->first("{$statePath}.*") : null) }}
+                    {{ $errors->first($statePath) ?: ($hasNestedRecursiveValidationRules ? $errors->first("{$statePath}.*") : null) }}
                 </x-forms::field-wrapper.error-message>
             @endif
 

--- a/packages/forms/resources/views/components/field-wrapper/index.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/index.blade.php
@@ -52,7 +52,7 @@
 
             @if ($errors->has($statePath) || ($hasNestedRecursiveValidationRules && $errors->has("{$statePath}.*")))
                 <x-forms::field-wrapper.error-message>
-                    {{ $errors->first($statePath) ?? ($hasNestedRecursiveValidationRules ? $errors->first("{$statePath}.*") : null) }}
+                    {{ $errors->first($statePath) ? $errors->first($statePath) : ($hasNestedRecursiveValidationRules ? $errors->first("{$statePath}.*") : null) }}
                 </x-forms::field-wrapper.error-message>
             @endif
 


### PR DESCRIPTION
Currently, nested recurrsive validation rule errors never display since the logic to show them is using the null coalescing operator. Since the `$errors->first($statePath)` is always set (but evaluates to false) it never shows the nested rules. 

This fixes it by changing to the ternary operator. 