### PR TITLE
fix: resolves error regarding canvas already being used when updating

### DIFF
--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -72,7 +72,7 @@
                 init: function () {
                     chart = Chart.getChart(this.$refs.canvas);
 
-                    chart !== undefined
+                    (chart !== undefined)
                         ? this.updateChart()
                         : this.initChart()
                 },

--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -66,17 +66,19 @@
         <div
             x-title="filament-stats-card-chart"
             x-data="{
-                chart: null,
-
                 labels: {{ json_encode(array_keys($chart)) }},
                 values: {{ json_encode(array_values($chart)) }},
 
                 init: function () {
-                    this.chart ? this.updateChart() : this.initChart()
+                    chart = Chart.getChart(this.$refs.canvas);
+
+                    chart !== undefined
+                        ? this.updateChart()
+                        : this.initChart()
                 },
 
                 initChart: function () {
-                    return this.chart = new Chart(this.$refs.canvas, {
+                    return chart = new Chart(this.$refs.canvas, {
                         type: 'line',
                         data: {
                             labels: this.labels,
@@ -117,9 +119,9 @@
                 },
 
                 updateChart: function () {
-                    this.chart.data.labels = this.labels
-                    this.chart.data.datasets[0].data = this.values
-                    this.chart.update()
+                    chart.data.labels = this.labels
+                    chart.data.datasets[0].data = this.values
+                    chart.update()
                 },
             }"
             x-on:dark-mode-toggled.window="


### PR DESCRIPTION
Resolves the following error:

Uncaught Error: Canvas is already in use. Chart with ID '0' must be destroyed before the canvas with ID '' can be reused.

Somehow the chart instance was not being kept correctly in `this.chart`.

I think this was being mentioned in https://github.com/filamentphp/filament/discussions/2552#discussioncomment-3559218 but hasn't been fixed.