### PR TITLE
Describe filepond domain and cors headers

### DIFF
--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -1174,6 +1174,8 @@ FileUpload::make('attachment')
 
 By default, files will be uploaded publicly to your default storage disk.
 
+> Please note, to correctly display images and other files filepond requires files to be served from the same domain as the admin panel or cors headers to be present. Set the `APP_URL` env variable or modify the [filesystem](https://laravel.com/docs/10.x/filesystem) driver to set the correct url or ensure cors headers are present when serving files from an external (s3) filesystem.
+
 To change the disk and directory that files are saved in, and their visibility, use the `disk()`, `directory()` and `visibility` methods:
 
 ```php

--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -1174,7 +1174,7 @@ FileUpload::make('attachment')
 
 By default, files will be uploaded publicly to your default storage disk.
 
-> Please note, to correctly display images and other files filepond requires files to be served from the same domain as the admin panel or cors headers to be present. Set the `APP_URL` env variable or modify the [filesystem](https://laravel.com/docs/10.x/filesystem) driver to set the correct url or ensure cors headers are present when serving files from an external (s3) filesystem.
+> Please note, to correctly preview images and other files, FilePond requires files to be served from the same domain as the app, or the appropriate CORS headers need to be present. Ensure that the `APP_URL` environment variable is correct, or modify the [filesystem](https://laravel.com/docs/10.x/filesystem) driver to set the correct URL. If you're hosting files on a separate domain like S3, ensure that CORS headers are set up.
 
 To change the disk and directory that files are saved in, and their visibility, use the `disk()`, `directory()` and `visibility` methods:
 


### PR DESCRIPTION
Describe the filepond domain and cors headers with the [file-upload documentation](https://filamentphp.com/docs/2.x/forms/fields#file-upload).

As quickly discussed here: https://github.com/filamentphp/filament/discussions/5485#discussioncomment-5427539 