### PR TITLE
Adds dropdown action divider

### DIFF
--- a/packages/admin/resources/views/components/dropdown/list/divider.blade.php
+++ b/packages/admin/resources/views/components/dropdown/list/divider.blade.php
@@ -1,0 +1,1 @@
+<div {{ $attributes->class(['border-t border-gray-100 -mx-1 my-1 dark:border-gray-700']) }}></div>

--- a/packages/support/resources/views/components/actions/group.blade.php
+++ b/packages/support/resources/views/components/actions/group.blade.php
@@ -30,8 +30,14 @@
 
     <x-filament-support::dropdown.list>
         @foreach ($actions as $action)
+            @if ($action->hasDividerBefore())
+                <x-filament-support::dropdown.list.divider />
+            @endif
             @if (! $action->isHidden())
                 {{ $action }}
+            @endif
+            @if ($action->hasDividerAfter())
+                <x-filament-support::dropdown.list.divider />
             @endif
         @endforeach
     </x-filament-support::dropdown.list>

--- a/packages/support/src/Actions/BaseAction.php
+++ b/packages/support/src/Actions/BaseAction.php
@@ -12,6 +12,7 @@ abstract class BaseAction extends ViewComponent
     use Concerns\CanBeDisabled;
     use Concerns\CanBeHidden;
     use Concerns\HasColor;
+    use Concerns\HasDivider;
     use Concerns\HasIcon;
     use Concerns\HasLabel;
     use Concerns\HasName;

--- a/packages/support/src/Actions/Concerns/HasDivider.php
+++ b/packages/support/src/Actions/Concerns/HasDivider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Filament\Support\Actions\Concerns;
+
+use Closure;
+
+trait HasDivider
+{
+    protected bool | Closure $hasDividerBefore = false;
+
+    protected bool | Closure $hasDividerAfter = false;
+
+    public function dividerBefore(bool | Closure $condition = true): static
+    {
+        $this->hasDividerBefore = $condition;
+
+        return $this;
+    }
+
+    public function dividerAfter(bool | Closure $condition = true): static
+    {
+        $this->hasDividerAfter = $condition;
+
+        return $this;
+    }
+
+    public function hasDividerBefore(): bool
+    {
+        return $this->evaluate($this->hasDividerBefore);
+    }
+
+    public function hasDividerAfter(): bool
+    {
+        return $this->evaluate($this->hasDividerAfter);
+    }
+}


### PR DESCRIPTION
Since there's no ETA on Livewire v3 (and thus Filament v3) and also since some people who are currently using Filament v2 might not be able to update to v3 when it's out, I wanted to go ahead and add this feature to allow dropdown actions groups to have dividers. 

This  PR adds the `->dividerBefore()` and `dividerAfter()` methods to the BaseAction class.

Obvisouly, this is NOT the best way to implement this feature. Ideally there would be an entirly new `ListGroup` class or something like that and then the divider could be added through tailwinds `divide-y` class, BUT that would be a breaking change to v2 so this seems like the best way to add this. 

Hopefully v3 will support this natively and more elegantly, but for v2 users hopefully this helps. 