### PR TITLE
✨ Make a `CreateRecord` specific stub

### DIFF
--- a/packages/admin/src/Commands/MakeResourceCommand.php
+++ b/packages/admin/src/Commands/MakeResourceCommand.php
@@ -184,9 +184,7 @@ class MakeResourceCommand extends Command
                 'resourcePageClass' => $listResourcePageClass,
             ]);
 
-            $this->copyStubToApp('ResourcePage', $createResourcePagePath, [
-                'baseResourcePage' => 'Filament\\Resources\\Pages\\CreateRecord',
-                'baseResourcePageClass' => 'CreateRecord',
+            $this->copyStubToApp('ResourceCreatePage', $createResourcePagePath, [
                 'namespace' => "{$namespace}\\{$resourceClass}\\Pages",
                 'resource' => "{$namespace}\\{$resourceClass}",
                 'resourceClass' => $resourceClass,

--- a/packages/admin/stubs/ResourceCreatePage.stub
+++ b/packages/admin/stubs/ResourceCreatePage.stub
@@ -1,0 +1,12 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ resource }};
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class {{ resourcePageClass }} extends CreateRecord
+{
+    protected static string $resource = {{ resourceClass }}::class;
+}


### PR DESCRIPTION
This PR aims to add a separate stub for `CreateRecord` generated by the `make:filament-resource` command.

Introducing a separate stub for `CreateRecord` allows us to customize the generated file without conflicting what the `make:filament-page --resource` command would generate.