### PR TITLE
Allow testing fields via callbacks

### DIFF
--- a/packages/forms/.stubs.php
+++ b/packages/forms/.stubs.php
@@ -13,7 +13,7 @@ namespace Livewire\Testing {
 
         public function assertFormExists(string $name = 'form'): static {}
 
-        public function assertFormFieldExists(string $fieldName, string $formName = 'form'): static {}
+        public function assertFormFieldExists(string $fieldName, string|callable $formName = 'form', callable $callback = null): static {}
 
         public function assertFormFieldIsDisabled(string $fieldName, string $formName = 'form'): static {}
 

--- a/packages/forms/.stubs.php
+++ b/packages/forms/.stubs.php
@@ -1,5 +1,7 @@
 <?php
 
+use Closure'
+
 namespace Livewire\Testing {
 
     class TestableLivewire {
@@ -13,7 +15,7 @@ namespace Livewire\Testing {
 
         public function assertFormExists(string $name = 'form'): static {}
 
-        public function assertFormFieldExists(string $fieldName, string|callable $formName = 'form', callable $callback = null): static {}
+        public function assertFormFieldExists(string $fieldName, string | Closure $formName = 'form', ?Closure $callback = null): static {}
 
         public function assertFormFieldIsDisabled(string $fieldName, string $formName = 'form'): static {}
 

--- a/packages/forms/.stubs.php
+++ b/packages/forms/.stubs.php
@@ -1,6 +1,6 @@
 <?php
 
-use Closure'
+use Closure;
 
 namespace Livewire\Testing {
 

--- a/packages/forms/docs/07-testing.md
+++ b/packages/forms/docs/07-testing.md
@@ -103,20 +103,20 @@ it('has a title field', function () {
 });
 ```
 
-You may pass a closure as a second argument in order to assert that a field passes a given "truth test". This is useful for asserting that a field has a specific configuration:
+You may pass a function as an additional argument in order to assert that a field passes a given "truth test". This is useful for asserting that a field has a specific configuration:
 
 ```php
 use function Pest\Livewire\livewire;
 
 it('has a title field', function () {
     livewire(CreatePost::class)
-        ->assertFormFieldExists('title', function (TextInput $input) {
+        ->assertFormFieldExists('title', function (TextInput $field): bool {
             return $input->isDisabled();
         });
 });
 ```
 
-> Note that if you have multiple forms on a Livewire component, you can specify which form you want to check for the existence of the field like `assertFormFieldExists('title', 'createPostForm')`. In this case, you can also pass a closure as the third argument like `assertFormFieldExists('title', 'createPostForm', function (TextInput $input) { ... })`.
+> Note that if you have multiple forms on a Livewire component, you can specify which form you want to check for the existence of the field like `assertFormFieldExists('title', 'createPostForm')`.
 
 ### Hidden fields
 

--- a/packages/forms/docs/07-testing.md
+++ b/packages/forms/docs/07-testing.md
@@ -103,7 +103,20 @@ it('has a title field', function () {
 });
 ```
 
-> Note that if you have multiple forms on a Livewire component, you can specify which form you want to check for the existence of the field like `assertFormFieldExists('title', 'createPostForm')`.
+You may pass a closure as a second argument in order to assert that a field passes a given "truth test". This is useful for asserting that a field has a specific configuration:
+
+```php
+use function Pest\Livewire\livewire;
+
+it('has a title field', function () {
+    livewire(CreatePost::class)
+        ->assertFormFieldExists('title', function (TextInput $input) {
+            return $input->isDisabled();
+        });
+});
+```
+
+> Note that if you have multiple forms on a Livewire component, you can specify which form you want to check for the existence of the field like `assertFormFieldExists('title', 'createPostForm')`. In this case, you can also pass a closure as the third argument like `assertFormFieldExists('title', 'createPostForm', function (TextInput $input) { ... })`.
 
 ### Hidden fields
 

--- a/packages/forms/src/Testing/TestsForms.php
+++ b/packages/forms/src/Testing/TestsForms.php
@@ -137,7 +137,12 @@ class TestsForms
 
     public function assertFormFieldExists(): Closure
     {
-        return function (string $fieldName, string $formName = 'form'): static {
+        return function (string $fieldName, string|callable $formName = 'form', callable $callback = null): static {
+            if (is_callable($formName)) {
+                $callback = $formName;
+                $formName = 'form';
+            }
+        
             /** @phpstan-ignore-next-line  */
             $this->assertFormExists($formName);
 
@@ -156,6 +161,13 @@ class TestsForms
                 "Failed asserting that a field with the name [{$fieldName}] exists on the form with the name [{$formName}] on the [{$livewireClass}] component."
             );
 
+            if (is_callable($callback)) {
+                Assert::assertTrue(
+                    $callback($field),
+                    "Failed asserting that a field with the name [{$fieldName}] and given configuration exists on the form with the name [{$formName}] on the [{$livewireClass}] component."
+                );
+            }
+
             return $this;
         };
     }
@@ -163,22 +175,18 @@ class TestsForms
     public function assertFormFieldIsDisabled(): Closure
     {
         return function (string $fieldName, string $formName = 'form'): static {
-            /** @phpstan-ignore-next-line  */
-            $this->assertFormFieldExists($fieldName, $formName);
-
             $livewire = $this->instance();
             $livewireClass = $livewire::class;
 
-            /** @var ComponentContainer $form */
-            $form = $livewire->{$formName};
+            /** @phpstan-ignore-next-line  */
+            $this->assertFormFieldExists($fieldName, $formName, function (Field $field) use ($fieldName, $formName, $livewireClass) {
+                Assert::assertTrue(
+                    $field->isDisabled(),
+                    "Failed asserting that a field with the name [{$fieldName}] is disabled on the form named [{$formName}] on the [{$livewireClass}] component."
+                );
 
-            /** @var Field $field */
-            $field = $form->getFlatFields(withHidden: true)[$fieldName];
-
-            Assert::assertTrue(
-                $field->isDisabled(),
-                "Failed asserting that a field with the name [{$fieldName}] is disabled on the form named [{$formName}] on the [{$livewireClass}] component."
-            );
+                return true;
+            });
 
             return $this;
         };
@@ -187,23 +195,19 @@ class TestsForms
     public function assertFormFieldIsEnabled(): Closure
     {
         return function (string $fieldName, string $formName = 'form'): static {
-            /** @phpstan-ignore-next-line  */
-            $this->assertFormFieldExists($fieldName, $formName);
-
             $livewire = $this->instance();
             $livewireClass = $livewire::class;
 
-            /** @var ComponentContainer $form */
-            $form = $livewire->{$formName};
-
-            /** @var Field $field */
-            $field = $form->getFlatFields(withHidden: true)[$fieldName];
-
-            Assert::assertFalse(
-                $field->isDisabled(),
-                "Failed asserting that a field with the name [{$fieldName}] is enabled on the form named [{$formName}] on the [{$livewireClass}] component."
-            );
-
+            /** @phpstan-ignore-next-line  */
+            $this->assertFormFieldExists($fieldName, $formName, function (Field $field) use ($fieldName, $formName, $livewireClass) {
+                Assert::assertFalse(
+                    $field->isDisabled(),
+                    "Failed asserting that a field with the name [{$fieldName}] is enabled on the form named [{$formName}] on the [{$livewireClass}] component."
+                );
+                
+                return true;
+            });
+            
             return $this;
         };
     }

--- a/packages/forms/src/Testing/TestsForms.php
+++ b/packages/forms/src/Testing/TestsForms.php
@@ -179,7 +179,7 @@ class TestsForms
             $livewireClass = $livewire::class;
 
             /** @phpstan-ignore-next-line  */
-            $this->assertFormFieldExists($fieldName, $formName, function (Field $field) use ($fieldName, $formName, $livewireClass) {
+            $this->assertFormFieldExists($fieldName, $formName, function (Field $field) use ($fieldName, $formName, $livewireClass): bool {
                 Assert::assertTrue(
                     $field->isDisabled(),
                     "Failed asserting that a field with the name [{$fieldName}] is disabled on the form named [{$formName}] on the [{$livewireClass}] component."
@@ -199,7 +199,7 @@ class TestsForms
             $livewireClass = $livewire::class;
 
             /** @phpstan-ignore-next-line  */
-            $this->assertFormFieldExists($fieldName, $formName, function (Field $field) use ($fieldName, $formName, $livewireClass) {
+            $this->assertFormFieldExists($fieldName, $formName, function (Field $field) use ($fieldName, $formName, $livewireClass): bool {
                 Assert::assertFalse(
                     $field->isDisabled(),
                     "Failed asserting that a field with the name [{$fieldName}] is enabled on the form named [{$formName}] on the [{$livewireClass}] component."

--- a/packages/forms/src/Testing/TestsForms.php
+++ b/packages/forms/src/Testing/TestsForms.php
@@ -137,8 +137,8 @@ class TestsForms
 
     public function assertFormFieldExists(): Closure
     {
-        return function (string $fieldName, string|callable $formName = 'form', callable $callback = null): static {
-            if (is_callable($formName)) {
+        return function (string $fieldName, string | Closure $formName = 'form', ?Closure $callback = null): static {
+            if ($formName instanceof Closure) {
                 $callback = $formName;
                 $formName = 'form';
             }
@@ -161,10 +161,10 @@ class TestsForms
                 "Failed asserting that a field with the name [{$fieldName}] exists on the form with the name [{$formName}] on the [{$livewireClass}] component."
             );
 
-            if (is_callable($callback)) {
+            if ($callback) {
                 Assert::assertTrue(
                     $callback($field),
-                    "Failed asserting that a field with the name [{$fieldName}] and given configuration exists on the form with the name [{$formName}] on the [{$livewireClass}] component."
+                    "Failed asserting that a field with the name [{$fieldName}] and provided configuration exists on the form with the name [{$formName}] on the [{$livewireClass}] component."
                 );
             }
 

--- a/tests/src/Forms/FormsTest.php
+++ b/tests/src/Forms/FormsTest.php
@@ -22,13 +22,19 @@ it('can have forms with non-default names', function () {
 it('has fields', function () {
     livewire(TestComponentWithForm::class)
         ->assertFormFieldExists('title')
-        ->assertFormFieldExists('nested.input');
+        ->assertFormFieldExists('nested.input')
+        ->assertFormFieldExists('disabled', function (TextInput $field) {
+            return $field->isDisabled();
+        });
 });
 
 it('has fields on multiple forms', function () {
     livewire(TestComponentWithMultipleForms::class)
         ->assertFormFieldExists('title', 'fooForm')
-        ->assertFormFieldExists('title', 'barForm');
+        ->assertFormFieldExists('title', 'barForm')
+        ->assertFormFieldExists('disabled', 'barForm', function (TextInput $field) {
+            return $field->isDisabled();
+        });
 });
 
 it('can fill fields on multiple forms', function () {

--- a/tests/src/Forms/FormsTest.php
+++ b/tests/src/Forms/FormsTest.php
@@ -23,7 +23,7 @@ it('has fields', function () {
     livewire(TestComponentWithForm::class)
         ->assertFormFieldExists('title')
         ->assertFormFieldExists('nested.input')
-        ->assertFormFieldExists('disabled', function (TextInput $field) {
+        ->assertFormFieldExists('disabled', function (TextInput $field): bool {
             return $field->isDisabled();
         });
 });
@@ -32,7 +32,7 @@ it('has fields on multiple forms', function () {
     livewire(TestComponentWithMultipleForms::class)
         ->assertFormFieldExists('title', 'fooForm')
         ->assertFormFieldExists('title', 'barForm')
-        ->assertFormFieldExists('disabled', 'barForm', function (TextInput $field) {
+        ->assertFormFieldExists('disabled', 'barForm', function (TextInput $field): bool {
             return $field->isDisabled();
         });
 });


### PR DESCRIPTION
This PR adds the ability to test fields using callbacks like:

```php
it('has a title field', function () {
    livewire(CreatePost::class)
        ->assertFormFieldExists('title', function (TextInput $input) {
            return $input->isDisabled();
        });
});
```

This is inspired by Laravel testing helpers, eg:

```php
Mail::assertSent(OrderShipped::class, function (OrderShipped $mail) use ($user) {
    return $mail->hasTo($user->email);
});
```

The functionality is backwards compatible with the current testing helper where form can be passed in as second argument. In that case the callback needs to be passed in as thrid argument.

I also refactored `assertFormFieldIsDisabled` and `assertFormFieldIsEnabled` to use the new api