### PR TITLE
Add isReactive method

### DIFF
--- a/packages/forms/src/Concerns/HasStateBindingModifiers.php
+++ b/packages/forms/src/Concerns/HasStateBindingModifiers.php
@@ -71,6 +71,11 @@ trait HasStateBindingModifiers
         return ['defer'];
     }
 
+    public function isReactive(): bool
+    {
+        return empty($this->getStateBindingModifiers());
+    }
+
     public function isLazy(): bool
     {
         return in_array('lazy', $this->getStateBindingModifiers());


### PR DESCRIPTION
I recently had to test specific configuration of a field including it's state bindings.
This would be helpful in combination with #6040:

```php
it('title field is reactive', function () {
    livewire(CreatePost::class)
        ->assertFormFieldExists('title', function (TextInput $input) {
            return $input->isReactive();
        });
});
```