### PR TITLE
Allow for easier integration with Bouncer

### DIFF
--- a/packages/admin/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/admin/src/Resources/RelationManagers/RelationManager.php
@@ -6,6 +6,7 @@ use Closure;
 use Filament\Facades\Filament;
 use Filament\Http\Livewire\Concerns\CanNotify;
 use Filament\Resources\Form;
+use Filament\Resources\Resource;
 use Filament\Resources\Table;
 use function Filament\Support\locale_has_pluralization;
 use Filament\Tables;
@@ -51,6 +52,8 @@ class RelationManager extends Component implements Tables\Contracts\HasRelations
     protected static ?string $pluralModelLabel = null;
 
     protected static ?string $title = null;
+
+    protected static bool $shouldAuthorizeWithGate = false;
 
     protected static bool $shouldIgnorePolicies = false;
 
@@ -233,12 +236,18 @@ class RelationManager extends Component implements Tables\Contracts\HasRelations
 
     protected function can(string $action, ?Model $record = null): bool
     {
+        $user = Filament::auth()->user();
+        $model = $this->getRelatedModel();
+
+        if (static::shouldAuthorizeWithGate()) {
+            return Gate::forUser($user)->check($action, $record ?? $model);
+        }
+
         if (static::shouldIgnorePolicies()) {
             return true;
         }
 
-        $policy = Gate::getPolicyFor($model = $this->getRelatedModel());
-        $user = Filament::auth()->user();
+        $policy = Gate::getPolicyFor($model);
 
         if ($policy === null) {
             return true;
@@ -251,9 +260,19 @@ class RelationManager extends Component implements Tables\Contracts\HasRelations
         return Gate::forUser($user)->check($action, $record ?? $model);
     }
 
+    public static function authorizeWithGate(bool $condition = true): void
+    {
+        static::$shouldAuthorizeWithGate = $condition;
+    }
+
     public static function ignorePolicies(bool $condition = true): void
     {
         static::$shouldIgnorePolicies = $condition;
+    }
+
+    public static function shouldAuthorizeWithGate(): bool
+    {
+        return static::$shouldAuthorizeWithGate;
     }
 
     public static function shouldIgnorePolicies(): bool

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -66,6 +66,8 @@ class Resource
 
     protected static int $globalSearchResultsLimit = 50;
 
+    protected static bool $shouldAlwaysCheckGate = false;
+
     protected static bool $shouldIgnorePolicies = false;
 
     public static function form(Form $form): Form
@@ -116,6 +118,10 @@ class Resource
 
     public static function can(string $action, ?Model $record = null): bool
     {
+        if (static::shouldAlwaysCheckGate()) {
+            return Gate::forUser(Filament::auth()->user())->check($action, $record ?? static::getModel());
+        }
+
         if (static::shouldIgnorePolicies()) {
             return true;
         }
@@ -134,9 +140,19 @@ class Resource
         return Gate::forUser($user)->check($action, $record ?? $model);
     }
 
+    public static function alwaysCheckGate(bool $condition = true): void
+    {
+        static::$shouldAlwaysCheckGate = $condition;
+    }
+
     public static function ignorePolicies(bool $condition = true): void
     {
         static::$shouldIgnorePolicies = $condition;
+    }
+
+    public static function shouldAlwaysCheckGate(): bool
+    {
+        return static::$shouldAlwaysCheckGate;
     }
 
     public static function shouldIgnorePolicies(): bool

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -66,7 +66,7 @@ class Resource
 
     protected static int $globalSearchResultsLimit = 50;
 
-    protected static bool $shouldAlwaysCheckGate = false;
+    protected static bool $shouldAuthorizeWithGate = false;
 
     protected static bool $shouldIgnorePolicies = false;
 
@@ -118,17 +118,18 @@ class Resource
 
     public static function can(string $action, ?Model $record = null): bool
     {
-        if (static::shouldAlwaysCheckGate()) {
-            return Gate::forUser(Filament::auth()->user())->check($action, $record ?? static::getModel());
+        $user = Filament::auth()->user();
+        $model = static::getModel();
+
+        if (static::shouldAuthorizeWithGate()) {
+            return Gate::forUser($user)->check($action, $record ?? $model);
         }
 
         if (static::shouldIgnorePolicies()) {
             return true;
         }
 
-        $policy = Gate::getPolicyFor($model = static::getModel());
-        $user = Filament::auth()->user();
-
+        $policy = Gate::getPolicyFor($model);
         if ($policy === null) {
             return true;
         }
@@ -140,9 +141,9 @@ class Resource
         return Gate::forUser($user)->check($action, $record ?? $model);
     }
 
-    public static function alwaysCheckGate(bool $condition = true): void
+    public static function authorizeWithGate(bool $condition = true): void
     {
-        static::$shouldAlwaysCheckGate = $condition;
+        static::$shouldAuthorizeWithGate = $condition;
     }
 
     public static function ignorePolicies(bool $condition = true): void
@@ -150,9 +151,9 @@ class Resource
         static::$shouldIgnorePolicies = $condition;
     }
 
-    public static function shouldAlwaysCheckGate(): bool
+    public static function shouldAuthorizeWithGate(): bool
     {
-        return static::$shouldAlwaysCheckGate;
+        return static::$shouldAuthorizeWithGate;
     }
 
     public static function shouldIgnorePolicies(): bool


### PR DESCRIPTION
I'm currently integrating [Bouncer](https://github.com/JosephSilber/bouncer) into filament and I came across an obstacle with the fact that the existance of a policy and corresponding method is required for the ability to be checked at the gate.

This is confliting with how Bouncer works by default: the ability is checked even when the policy does not exist - this allows for super simple implementation of permissions just by granting the abilities and not having to worry about policies until you need them. Having to create policies in order to integrate with Filament breaks the DX.

My solution is to add a `Resource::alwaysCheckGate()` toggle which bypasses policies completely and checks everything at the gate when enabled. This can be then simply called inside a service provider by the user.