### PR TITLE
Fix "Illegal offset type" when query in mongodb

### DIFF
--- a/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
@@ -87,6 +87,10 @@ trait InteractsWithTableQuery
 
         foreach ($this->getSearchColumns() as $searchColumnName) {
             $whereClause = $isFirst ? 'where' : 'orWhere';
+            $searchColumnName = match ($databaseConnection->getDriverName()) {
+                'mongodb' => (string)$searchColumnName,
+                default => $searchColumnName,
+            };
 
             $query->when(
                 method_exists($model, 'isTranslatableAttribute') && $model->isTranslatableAttribute($searchColumnName),


### PR DESCRIPTION
this error should be handled when the query of [laravel mongodb](https://github.com/jenssegers/laravel-mongodb/blob/master/src/Query/Builder.php#L1033) package sets default query type as string