### PR TITLE
Fixed the collapsedGroups value check adding support for the json representation of the null value

### DIFF
--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -87,7 +87,10 @@
         @endphp
 
         <script>
-            if (JSON.parse(localStorage.getItem('collapsedGroups')) === null || JSON.parse(localStorage.getItem('collapsedGroups')) === 'null') {
+            if (
+                (JSON.parse(localStorage.getItem('collapsedGroups')) === null) ||
+                (JSON.parse(localStorage.getItem('collapsedGroups')) === 'null')
+            ) {
                 localStorage.setItem('collapsedGroups', JSON.stringify(@js($collapsedNavigationGroupLabels)))
             }
         </script>

--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -87,7 +87,7 @@
         @endphp
 
         <script>
-            if (JSON.parse(localStorage.getItem('collapsedGroups')) === null) {
+            if (JSON.parse(localStorage.getItem('collapsedGroups')) === null || JSON.parse(localStorage.getItem('collapsedGroups')) === 'null') {
                 localStorage.setItem('collapsedGroups', JSON.stringify(@js($collapsedNavigationGroupLabels)))
             }
         </script>


### PR DESCRIPTION
In some cases the collapsedGroups value is the json stringified version of the null value, the string "null".

It seems related to discussion #5457