### PR TITLE
Fix test examples to use getRouteKey() for custom route key names in documentation

### DIFF
--- a/packages/admin/docs/10-testing.md
+++ b/packages/admin/docs/10-testing.md
@@ -191,7 +191,7 @@ it('can validate input', function () {
     $newData = Post::factory()->make();
 
     livewire(PostResource\Pages\EditPost::class, [
-        'record' => $post->getKey(),
+        'record' => $post->getRouteKey(),
     ])
         ->fillForm([
             'title' => null,

--- a/packages/admin/docs/10-testing.md
+++ b/packages/admin/docs/10-testing.md
@@ -137,7 +137,7 @@ it('can retrieve data', function () {
     $post = Post::factory()->create();
 
     livewire(PostResource\Pages\EditPost::class, [
-        'record' => $post->getKey(),
+        'record' => $post->getRouteKey(),
     ])
         ->assertFormSet([
             'author_id' => $post->author->getKey(),
@@ -160,7 +160,7 @@ it('can save', function () {
     $newData = Post::factory()->make();
 
     livewire(PostResource\Pages\EditPost::class, [
-        'record' => $post->getKey(),
+        'record' => $post->getRouteKey(),
     ])
         ->fillForm([
             'author_id' => $newData->author->getKey(),
@@ -213,7 +213,7 @@ it('can delete', function () {
     $post = Post::factory()->create();
 
     livewire(PostResource\Pages\EditPost::class, [
-        'record' => $post->getKey(),
+        'record' => $post->getRouteKey(),
     ])
         ->callPageAction(DeleteAction::class);
 
@@ -231,7 +231,7 @@ it('can not delete', function () {
     $post = Post::factory()->create();
 
     livewire(PostResource\Pages\EditPost::class, [
-        'record' => $post->getKey(),
+        'record' => $post->getRouteKey(),
     ])
         ->assertPageActionHidden(DeleteAction::class);
 });
@@ -262,7 +262,7 @@ it('can retrieve data', function () {
     $post = Post::factory()->create();
 
     livewire(PostResource\Pages\ViewPost::class, [
-        'record' => $post->getKey(),
+        'record' => $post->getRouteKey(),
     ])
         ->assertFormSet([
             'author_id' => $post->author->getKey(),


### PR DESCRIPTION
This pull request addresses a bug in the test examples where the usage of **getKey()** would cause test failures when a custom route key name is specified in the model by overriding the **getRouteKeyName()** method. The **getKey()** method returns the primary key of the model, but in some cases, a custom field like a slug might be used as the route key name.

Changes include:

Replacing **getKey()** with **getRouteKey()** in the test examples to ensure compatibility with custom route key names in models, such as when using a slug or another field instead of the primary key.
Updating the testing documentation to reflect these changes and provide accurate guidance for users with custom route key names, explaining the difference between **getKey()** and **getRouteKey()**.
These changes will help users with custom route key names avoid test failures and improve the overall testing experience.