### PR TITLE
Fix assertNotified no longer working with multiple notifications

### DIFF
--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -248,7 +248,7 @@ class Notification extends ViewComponent implements Arrayable
         }
 
         if ($notification instanceof Notification) {
-            $expectedNotification = $notifications->first(fn (Notification $mountedNotification, string $key): bool => $mountedNotification->id === $key);
+            $expectedNotification = $notifications->first(fn (Notification $mountedNotification): bool => $mountedNotification->id === $notification->id);
         }
 
         if (blank($notification)) {


### PR DESCRIPTION
Using`assertNotified` with a notification instance when having multiple notifications did no longer work because it was trying to find notifications by comparing the ID of the mountedNotification against its key in the send notifications array instead of comparing it with the ID of the given notification. 

And because notifications are keyed by ID it would always match on the first notification in the array.