### PR TITLE
Update 10-testing.md

### DIFF
--- a/packages/admin/docs/10-testing.md
+++ b/packages/admin/docs/10-testing.md
@@ -172,7 +172,7 @@ it('can save', function () {
         ->assertHasNoFormErrors();
 
     expect($post->refresh())
-        ->author->toBeSameModel($newData->author)
+        ->author_id->toBe($newData->author->getKey())
         ->content->toBe($newData->content)
         ->tags->toBe($newData->tags)
         ->title->toBe($newData->title);


### PR DESCRIPTION
This PR updates the FilamentPHP documentation example to replace the `toBeSameModel` method with the `toBe` method and `getKey`. The `toBeSameModel` method was not a valid PestPHP method, confusing users following the example. By making this change, the example now aligns with the current functionality of PestPHP, making it clearer and more accurate for users.

Didn't prefer using the `toBe` method that compares if two variables reference the same object. In this case, `post` and `author` are not referencing the same object. This change ensures that the test case behaves as intended, resulting in more accurate and reliable tests for the FilamentPHP project.

it could be like the code piece below but using `toEqual` felt shorter. 

`
    expect($post->refresh())
        ->author_id->toBe($newData->author->getKey())
        ->content->toBe($newData->content)
        ->tags->toBe($newData->tags)
        ->title->toBe($newData->title);
`