### PR TITLE
Support route parameters on resource slug

### DIFF
--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use Route;
 
 class Resource
 {
@@ -433,7 +434,7 @@ class Resource
     {
         $routeBaseName = static::getRouteBaseName();
 
-        return route("{$routeBaseName}.{$name}", $params, $isAbsolute);
+        return route("{$routeBaseName}.{$name}", Route::current()->parameters() + $params, $isAbsolute);
     }
 
     public static function hasPage($page): bool

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -17,7 +17,6 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
-use Route;
 
 class Resource
 {


### PR DESCRIPTION
This small adjustment allows to build resource URLs with multiple named parameters, otherwise it results in a missing required parameter error when user navigates to the resource with route parameters defined in the slug.

```php
    public static function table(Table $table): Table
    {
        return $table
            ->columns([
                Tables\Columns\TextColumn::make('title'),
            ])
            ->actions([
                Tables\Actions\Action::make('categories')
                    ->url(fn (Menu $record) => CategoryResource::getUrl('index', ['menu' => $record->id]))
                    ->icon('heroicon-o-tag')
                    ->color('success'),
            ]);
    }
```

```php
class CategoryResource extends Resource
{
    protected static ?string $model = Category::class;

    protected static ?string $slug = 'menus/{menu}/categories';

    protected static bool $shouldRegisterNavigation = false;

    .........

    public static function getPages(): array
    {
        return [
            'index' => Pages\ListCategories::route('/'),
            'create' => Pages\CreateCategory::route('/create'),
            'edit' => Pages\EditCategory::route('/{record}/edit'),
        ];
    }
````