### PR TITLE
Add placeholder property to `TextColumn`s and `BadgeColumn`s

### DIFF
--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -166,7 +166,7 @@ TextColumn::make('status')
     ->formatStateUsing(fn (string $state): string => __("statuses.{$state}"))
 ```
 
-## Adding a placeholder
+## Adding a placeholder if the cell is empty
 
 Sometimes you may want to display a placeholder if the cell's value is empty:
 
@@ -176,8 +176,6 @@ use Filament\Tables\Columns\TextColumn;
 TextColumn::make('updated_at')
     ->placeholder('Never')
 ```
-
-> An integer or float equal to `0` will not be considered empty.
 
 ## Customizing the color
 

--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -166,6 +166,19 @@ TextColumn::make('status')
     ->formatStateUsing(fn (string $state): string => __("statuses.{$state}"))
 ```
 
+## Adding a placeholder
+
+Sometimes you may want to display a placeholder if the cell's value is empty:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('updated_at')
+    ->placeholder('Never')
+```
+
+> An integer or float equal to `0` will not be considered empty.
+
 ## Customizing the color
 
 You may set a color for the text, either `primary`, `secondary`, `success`, `warning` or `danger`:

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -117,7 +117,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function placeholder(string | Closure $placeholder): static
+    public function placeholder(string | Closure | null $placeholder): static
     {
         $this->placeholder = $placeholder;
 
@@ -175,7 +175,7 @@ trait CanFormatState
             $state = $state . $this->evaluate($this->suffix);
         }
 
-        if (empty($state) && ! is_numeric($state)) {
+        if (blank($state)) {
             $state = $this->evaluate($this->placeholder);
         }
 

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -21,6 +21,8 @@ trait CanFormatState
 
     protected string | Closure | null $suffix = null;
 
+    protected string | Closure | null $placeholder = null;
+
     protected string | Closure | null $timezone = null;
 
     public function date(?string $format = null, ?string $timezone = null): static
@@ -115,6 +117,13 @@ trait CanFormatState
         return $this;
     }
 
+    public function placeholder(string | Closure $placeholder): static
+    {
+        $this->placeholder = $placeholder;
+
+        return $this;
+    }
+
     public function html(): static
     {
         return $this->formatStateUsing(static fn ($state): HtmlString => $state instanceof HtmlString ? $state : Str::of($state)->sanitizeHtml()->toHtmlString());
@@ -164,6 +173,10 @@ trait CanFormatState
 
         if ($this->suffix) {
             $state = $state . $this->evaluate($this->suffix);
+        }
+
+        if (empty($state) && ! is_numeric($state)) {
+            $state = $this->evaluate($this->placeholder);
         }
 
         return $state;


### PR DESCRIPTION
Sometimes, a placeholder value such as '–', 'None', 'Never', etc., is preferable to an otherwise empty table cell.

This PR allows text-based table columns whose state is empty (and not numeric) to use a placeholder string upon being formatted.

The reason for checking for a non-numeric state is so that `0` and `0.0` are not considered worthy of falling back to a placeholder, given that a zero in the context of other numbers (such as an aggregate column) should likely remain a 0.