### PR TITLE
Add "InOrder" Table & Page Action assertions

### DIFF
--- a/packages/admin/.stubs.php
+++ b/packages/admin/.stubs.php
@@ -17,6 +17,8 @@ namespace Livewire\Testing {
 
         public function assertPageActionDoesNotExist(string $name): static {}
 
+        public function assertPageActionsExistInOrder(array $names): static {}
+
         public function assertPageActionVisible(string $name): static {}
 
         public function assertPageActionHidden(string $name): static {}

--- a/packages/admin/docs/10-testing.md
+++ b/packages/admin/docs/10-testing.md
@@ -381,7 +381,7 @@ it('can validate invoice recipient email', function () {
 });
 ```
 
-### Pre-filled Data
+### Pre-filled data
 
 To check if a page action is pre-filled with data, you can use the `assertPageActionDataSet()` method:
 

--- a/packages/admin/docs/10-testing.md
+++ b/packages/admin/docs/10-testing.md
@@ -317,6 +317,8 @@ it('can list posts', function () {
 
 ## Page actions
 
+### Calling actions
+
 You can call a [page action](pages/actions) by passing its name or class to `callPageAction()`:
 
 ```php
@@ -357,6 +359,8 @@ it('can send invoices', function () {
 });
 ```
 
+### Errors
+
 `assertHasNoPageActionErrors()` is used to assert that no validation errors occurred when submitting the action form.
 
 To check if a validation error has occurred with the data, use `assertHasPageActionErrors()`, similar to `assertHasErrors()` in Livewire:
@@ -377,6 +381,8 @@ it('can validate invoice recipient email', function () {
 });
 ```
 
+### Pre-filled Data
+
 To check if a page action is pre-filled with data, you can use the `assertPageActionDataSet()` method:
 
 ```php
@@ -395,12 +401,14 @@ it('can send invoices to the primary contact by default', function () {
         ])
         ->callMountedPageAction()
         ->assertHasNoPageActionErrors();
-        
+
     expect($invoice->refresh())
         ->isSent()->toBeTrue()
         ->recipient_email->toBe($recipientEmail);
 });
 ```
+
+### Action State
 
 To check if a page action is hidden to a user, you can use the `assertPageActionHidden()` method:
 
@@ -414,5 +422,36 @@ it('can not send invoices', function () {
         'invoice' => $invoice,
     ])
         ->assertPageActionHidden('send');
+});
+```
+
+To ensure that an action exists or doesn't in a table, you can use the `assertPageActionExists()` or  `assertPageActionDoesNotExist()` method:
+
+```php
+use function Pest\Livewire\livewire;
+
+it('can send but not unsend invoices', function () {
+    $invoice = Invoice::factory()->create();
+
+    livewire(EditInvoice::class, [
+        'invoice' => $invoice,
+    ])
+        ->assertPageActionExists('send')
+        ->assertPageActionDoesNotExist('unsend');
+});
+```
+
+To ensure sets of actions exist in the correct order, you can use `assertPageActionsExistInOrder`:
+
+```php
+use function Pest\Livewire\livewire;
+
+it('can not send invoices', function () {
+    $invoice = Invoice::factory()->create();
+
+    livewire(EditInvoice::class, [
+        'invoice' => $invoice,
+    ])
+        ->assertPageActionsExistInOrder(['send', 'export']);
 });
 ```

--- a/packages/admin/src/Pages/Concerns/HasActions.php
+++ b/packages/admin/src/Pages/Concerns/HasActions.php
@@ -129,7 +129,7 @@ trait HasActions
         ]);
     }
 
-    protected function getCachedActions(): array
+    public function getCachedActions(): array
     {
         if ($this->cachedActions === null) {
             $this->cacheActions();

--- a/packages/admin/src/Testing/TestsPageActions.php
+++ b/packages/admin/src/Testing/TestsPageActions.php
@@ -155,6 +155,21 @@ class TestsPageActions
         };
     }
 
+    public function assertPageActionsExistInOrder(): Closure
+    {
+        return function (array $names): static {
+            $livewire = $this->instance();
+            $this->assertActionListInOrder(
+                $names,
+                $livewire->getCachedActions(),
+                'page',
+                Action::class,
+            );
+
+            return $this;
+        };
+    }
+
     public function assertPageActionVisible(): Closure
     {
         return function (string $name): static {

--- a/packages/support/src/Testing/TestsActions.php
+++ b/packages/support/src/Testing/TestsActions.php
@@ -43,6 +43,7 @@ class TestsActions
                 if ($namesIndex === count($names)) {
                     break;
                 }
+
                 if ($names[$namesIndex] !== $actionName) {
                     continue;
                 }

--- a/packages/support/src/Testing/TestsActions.php
+++ b/packages/support/src/Testing/TestsActions.php
@@ -39,7 +39,7 @@ class TestsActions
             $names = array_map(fn ($name) => $this->parseActionName($name), $names); //@phpstan-ignore-line
             $namesIndex = 0;
 
-            foreach($actions as $actionName => $action) {
+            foreach ($actions as $actionName => $action) {
                 if ($namesIndex === count($names)) {
                     break;
                 }

--- a/packages/support/src/Testing/TestsActions.php
+++ b/packages/support/src/Testing/TestsActions.php
@@ -4,6 +4,7 @@ namespace Filament\Support\Testing;
 
 use Closure;
 use Filament\Support\Actions\Action as BaseAction;
+use Illuminate\Testing\Assert;
 use Livewire\Component;
 use Livewire\Testing\TestableLivewire;
 
@@ -26,6 +27,41 @@ class TestsActions
             }
 
             return $name::getDefaultName();
+        };
+    }
+
+    public function assertActionListInOrder(): Closure
+    {
+        return function (array $names, array $actions, string $actionType, string $actionClass): self {
+            $livewireClass = $this->instance()::class;
+
+            $names = array_map(fn ($name) => $this->parseActionName($name), $names);
+            $namesIndex = 0;
+
+            foreach($actions as $actionName => $action) {
+                if ($namesIndex === count($names)) {
+                    break;
+                }
+                if ($names[$namesIndex] !== $actionName) {
+                    continue;
+                }
+
+                Assert::assertInstanceOf(
+                    $actionClass,
+                    $action,
+                    message: "Failed asserting that a $actionType action with name [{$actionName}] exists on the [{$livewireClass}] component.",
+                );
+
+                $namesIndex++;
+            }
+
+            Assert::assertEquals(
+                count($names),
+                $namesIndex,
+                message: "Failed asserting that a $actionType actions with names [".implode(', ', $names)."] exist in order on the [{$livewireClass}] component.",
+            );
+
+            return $this;
         };
     }
 }

--- a/packages/support/src/Testing/TestsActions.php
+++ b/packages/support/src/Testing/TestsActions.php
@@ -35,7 +35,8 @@ class TestsActions
         return function (array $names, array $actions, string $actionType, string $actionClass): self {
             $livewireClass = $this->instance()::class;
 
-            $names = array_map(fn ($name) => $this->parseActionName($name), $names);
+            /** @var array<string> $names */
+            $names = array_map(fn ($name) => $this->parseActionName($name), $names); //@phpstan-ignore-line
             $namesIndex = 0;
 
             foreach($actions as $actionName => $action) {

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -53,6 +53,8 @@ namespace Livewire\Testing {
 
         public function assertTableBulkActionDoesNotExist(string $name): static {}
 
+        public function assertTableBulkActionsExistInOrder(array $names): static {}
+
         public function assertTableBulkActionVisible(string $name): static {}
 
         public function assertTableBulkActionHidden(string $name): static {}

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -21,6 +21,10 @@ namespace Livewire\Testing {
 
         public function assertTableActionDoesNotExist(string $name): static {}
 
+        public function assertTableActionsExistInOrder(array $names): static {}
+
+        public function assertTableHeaderActionsExistInOrder(array $names): static {}
+
         public function assertTableActionVisible(string $name, $record = null): static {}
 
         public function assertTableActionHidden(string $name, $record = null): static {}

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -25,6 +25,8 @@ namespace Livewire\Testing {
 
         public function assertTableHeaderActionsExistInOrder(array $names): static {}
 
+        public function assertTableEmptyStateActionsExistInOrder(array $names): static {}
+
         public function assertTableActionVisible(string $name, $record = null): static {}
 
         public function assertTableActionHidden(string $name, $record = null): static {}

--- a/packages/tables/docs/07-testing.md
+++ b/packages/tables/docs/07-testing.md
@@ -191,7 +191,7 @@ it('can reset table filters`', function () {
 });
 ```
 
-## Table Actions
+## Actions
 
 ### Calling actions
 

--- a/packages/tables/docs/07-testing.md
+++ b/packages/tables/docs/07-testing.md
@@ -191,7 +191,9 @@ it('can reset table filters`', function () {
 });
 ```
 
-## Actions
+## Table Actions
+
+### Calling actions
 
 You can call an action by passing its name or class to `callTableAction()`:
 
@@ -246,6 +248,8 @@ it('can edit posts', function () {
 });
 ```
 
+### Errors
+
 `assertHasNoTableActionErrors()` is used to assert that no validation errors occurred when submitting the action form.
 
 To check if a validation error has occurred with the data, use `assertHasTableActionErrors()`, similar to `assertHasErrors()` in Livewire:
@@ -265,6 +269,8 @@ it('can validate edited post data', function () {
 ```
 
 For bulk actions, this method is called `assertHasTableBulkActionErrors()`.
+
+### Pre-filled Data
 
 To check if an action or bulk action is pre-filled with data, you can use the `assertTableActionDataSet()` or `assertTableBulkActionDataSet()` method:
 
@@ -287,6 +293,35 @@ it('can load existing post data for editing', function () {
 
     expect($post->refresh())
         ->title->toBe($title);
+});
+```
+
+### Action State
+
+To ensure that an action or bulk action exists or doesn't in a table, you can use the `assertTableActionExists()`/`assertTableActionDoesNotExist()` or  `assertTableBulkActionExists()`/`assertTableBulkActionDoesNotExist()` method:
+
+```php
+use function Pest\Livewire\livewire;
+
+it('can publish but not unpublish posts', function () {
+    livewire(PostResource\Pages\ListPosts::class)
+        ->assertTableActionExists('publish')
+        ->assertTableActionDoesNotExist('unpublish')
+        ->assertTableBulkActionExists('publish')
+        ->assertTableBulkActionDoesNotExist('unpublish');
+});
+```
+
+To ensure different sets of actions exist in the correct order, you can use the various "InOrder" assertions
+
+```php
+use function Pest\Livewire\livewire;
+
+it('has all actions in expected order', function () {
+    livewire(PostResource\Pages\ListPosts::class)
+        ->assertTableActionsExistInOrder(['edit', 'delete'])
+        ->assertTableHeaderActionsExistInOrder(['create', 'attach'])
+        ->assertTableEmptyStateActionsExistInOrder(['create', 'toggle-trashed-filter'])
 });
 ```
 

--- a/packages/tables/docs/07-testing.md
+++ b/packages/tables/docs/07-testing.md
@@ -270,7 +270,7 @@ it('can validate edited post data', function () {
 
 For bulk actions, this method is called `assertHasTableBulkActionErrors()`.
 
-### Pre-filled Data
+### Pre-filled data
 
 To check if an action or bulk action is pre-filled with data, you can use the `assertTableActionDataSet()` or `assertTableBulkActionDataSet()` method:
 
@@ -296,7 +296,7 @@ it('can load existing post data for editing', function () {
 });
 ```
 
-### Action State
+### Action state
 
 To ensure that an action or bulk action exists or doesn't in a table, you can use the `assertTableActionExists()`/`assertTableActionDoesNotExist()` or  `assertTableBulkActionExists()`/`assertTableBulkActionDoesNotExist()` method:
 

--- a/packages/tables/src/Testing/TestsActions.php
+++ b/packages/tables/src/Testing/TestsActions.php
@@ -175,6 +175,9 @@ class TestsActions
             $namesIndex = 0;
 
             foreach($livewire->getCachedTableActions() as $actionName => $action) {
+                if ($namesIndex === count($names)) {
+                    break;
+                }
                 if ($names[$namesIndex] !== $actionName) {
                     continue;
                 }
@@ -192,6 +195,42 @@ class TestsActions
                 count($names),
                 $namesIndex,
                 message: "Failed asserting that a table actions with names [".implode(', ', $names)."] exist in order on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertTableHeaderActionsExistInOrder(): Closure
+    {
+        return function (array $names): static {
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $names = array_map(fn ($name) => $this->parseActionName($name), $names);
+            $namesIndex = 0;
+
+            foreach($livewire->getCachedTableHeaderActions() as $actionName => $action) {
+                if ($namesIndex === count($names)) {
+                    break;
+                }
+                if ($names[$namesIndex] !== $actionName) {
+                    continue;
+                }
+
+                Assert::assertInstanceOf(
+                    Action::class,
+                    $action,
+                    message: "Failed asserting that a table action with name [{$actionName}] exists on the [{$livewireClass}] component.",
+                );
+
+                $namesIndex++;
+            }
+
+            Assert::assertEquals(
+                count($names),
+                $namesIndex,
+                message: "Failed asserting that a table header actions with names [".implode(', ', $names)."] exist in order on the [{$livewireClass}] component.",
             );
 
             return $this;

--- a/packages/tables/src/Testing/TestsActions.php
+++ b/packages/tables/src/Testing/TestsActions.php
@@ -186,7 +186,7 @@ class TestsActions
             $this->assertActionListInOrder(
                 $names,
                 $livewire->getCachedTableHeaderActions(),
-                'table',
+                'table header',
                 Action::class,
             );
 

--- a/packages/tables/src/Testing/TestsActions.php
+++ b/packages/tables/src/Testing/TestsActions.php
@@ -194,6 +194,21 @@ class TestsActions
         };
     }
 
+    public function assertTableEmptyStateActionsExistInOrder(): Closure
+    {
+        return function (array $names): static {
+            $livewire = $this->instance();
+            $this->assertActionListInOrder(
+                $names,
+                $livewire->getCachedTableEmptyStateActions(),
+                'table empty state',
+                Action::class,
+            );
+
+            return $this;
+        };
+    }
+
     public function assertTableActionVisible(): Closure
     {
         return function (string $name, $record = null): static {

--- a/packages/tables/src/Testing/TestsActions.php
+++ b/packages/tables/src/Testing/TestsActions.php
@@ -7,7 +7,6 @@ use Filament\Support\Testing\TestsActions as BaseTestsActions;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Contracts\HasTable;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Arr;
 use Illuminate\Testing\Assert;
 use Livewire\Testing\TestableLivewire;
 
@@ -169,32 +168,11 @@ class TestsActions
     {
         return function (array $names): static {
             $livewire = $this->instance();
-            $livewireClass = $livewire::class;
-
-            $names = array_map(fn ($name) => $this->parseActionName($name), $names);
-            $namesIndex = 0;
-
-            foreach($livewire->getCachedTableActions() as $actionName => $action) {
-                if ($namesIndex === count($names)) {
-                    break;
-                }
-                if ($names[$namesIndex] !== $actionName) {
-                    continue;
-                }
-
-                Assert::assertInstanceOf(
-                    Action::class,
-                    $action,
-                    message: "Failed asserting that a table action with name [{$actionName}] exists on the [{$livewireClass}] component.",
-                );
-
-                $namesIndex++;
-            }
-
-            Assert::assertEquals(
-                count($names),
-                $namesIndex,
-                message: "Failed asserting that a table actions with names [".implode(', ', $names)."] exist in order on the [{$livewireClass}] component.",
+            $this->assertActionListInOrder(
+                $names,
+                $livewire->getCachedTableActions(),
+                'table',
+                Action::class,
             );
 
             return $this;
@@ -205,32 +183,11 @@ class TestsActions
     {
         return function (array $names): static {
             $livewire = $this->instance();
-            $livewireClass = $livewire::class;
-
-            $names = array_map(fn ($name) => $this->parseActionName($name), $names);
-            $namesIndex = 0;
-
-            foreach($livewire->getCachedTableHeaderActions() as $actionName => $action) {
-                if ($namesIndex === count($names)) {
-                    break;
-                }
-                if ($names[$namesIndex] !== $actionName) {
-                    continue;
-                }
-
-                Assert::assertInstanceOf(
-                    Action::class,
-                    $action,
-                    message: "Failed asserting that a table action with name [{$actionName}] exists on the [{$livewireClass}] component.",
-                );
-
-                $namesIndex++;
-            }
-
-            Assert::assertEquals(
-                count($names),
-                $namesIndex,
-                message: "Failed asserting that a table header actions with names [".implode(', ', $names)."] exist in order on the [{$livewireClass}] component.",
+            $this->assertActionListInOrder(
+                $names,
+                $livewire->getCachedTableHeaderActions(),
+                'table',
+                Action::class,
             );
 
             return $this;

--- a/packages/tables/src/Testing/TestsActions.php
+++ b/packages/tables/src/Testing/TestsActions.php
@@ -7,6 +7,7 @@ use Filament\Support\Testing\TestsActions as BaseTestsActions;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Contracts\HasTable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Illuminate\Testing\Assert;
 use Livewire\Testing\TestableLivewire;
 
@@ -158,6 +159,39 @@ class TestsActions
             Assert::assertNull(
                 $action,
                 message: "Failed asserting that a table action with name [{$name}] does not exist on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertTableActionsExistInOrder(): Closure
+    {
+        return function (array $names): static {
+            $livewire = $this->instance();
+            $livewireClass = $livewire::class;
+
+            $names = array_map(fn ($name) => $this->parseActionName($name), $names);
+            $namesIndex = 0;
+
+            foreach($livewire->getCachedTableActions() as $actionName => $action) {
+                if ($names[$namesIndex] !== $actionName) {
+                    continue;
+                }
+
+                Assert::assertInstanceOf(
+                    Action::class,
+                    $action,
+                    message: "Failed asserting that a table action with name [{$actionName}] exists on the [{$livewireClass}] component.",
+                );
+
+                $namesIndex++;
+            }
+
+            Assert::assertEquals(
+                count($names),
+                $namesIndex,
+                message: "Failed asserting that a table actions with names [".implode(', ', $names)."] exist in order on the [{$livewireClass}] component.",
             );
 
             return $this;

--- a/packages/tables/src/Testing/TestsBulkActions.php
+++ b/packages/tables/src/Testing/TestsBulkActions.php
@@ -172,6 +172,21 @@ class TestsBulkActions
         };
     }
 
+    public function assertTableBulkActionsExistInOrder(): Closure
+    {
+        return function (array $names): static {
+            $livewire = $this->instance();
+            $this->assertActionListInOrder(
+                $names,
+                $livewire->getCachedTableBulkActions(),
+                'table bulk',
+                BulkAction::class,
+            );
+
+            return $this;
+        };
+    }
+
     public function assertTableBulkActionVisible(): Closure
     {
         return function (string $name): static {

--- a/tests/src/Admin/Fixtures/Pages/PageActions.php
+++ b/tests/src/Admin/Fixtures/Pages/PageActions.php
@@ -52,6 +52,7 @@ class PageActions extends Page
             Action::make('has-color')
                 ->color('primary'),
             Action::make('exists'),
+            Action::make('exists_in_order'),
             Action::make('url')
                 ->url('https://filamentphp.com'),
             Action::make('url_in_new_tab')

--- a/tests/src/Admin/Pages/ActionTest.php
+++ b/tests/src/Admin/Pages/ActionTest.php
@@ -107,6 +107,11 @@ it('can state whether a page action exists', function () {
         ->assertPageActionDoesNotExist('does_not_exist');
 });
 
+it('can state whether several page actions exist in order', function () {
+    livewire(PageActions::class)
+        ->assertPageActionsExistInOrder(['exists', 'exists_in_order']);
+});
+
 it('can show a notification', function () {
     livewire(PageActions::class)
         ->callPageAction('shows_notification')

--- a/tests/src/Tables/ActionTest.php
+++ b/tests/src/Tables/ActionTest.php
@@ -113,5 +113,6 @@ it('can state whether a table action exists', function () {
 
 it('can state whether several table actions exist in order', function () {
     livewire(PostsTable::class)
-        ->assertTableActionsExistInOrder(['edit', 'delete']);
+        ->assertTableActionsExistInOrder(['edit', 'delete'])
+        ->assertTableHeaderActionsExistInOrder(['exists', 'exists-in-order']);
 });

--- a/tests/src/Tables/ActionTest.php
+++ b/tests/src/Tables/ActionTest.php
@@ -114,5 +114,6 @@ it('can state whether a table action exists', function () {
 it('can state whether several table actions exist in order', function () {
     livewire(PostsTable::class)
         ->assertTableActionsExistInOrder(['edit', 'delete'])
-        ->assertTableHeaderActionsExistInOrder(['exists', 'exists-in-order']);
+        ->assertTableHeaderActionsExistInOrder(['exists', 'exists-in-order'])
+        ->assertTableEmptyStateActionsExistInOrder(['empty-exists', 'empty-exists-in-order']);
 });

--- a/tests/src/Tables/ActionTest.php
+++ b/tests/src/Tables/ActionTest.php
@@ -110,3 +110,8 @@ it('can state whether a table action exists', function () {
         ->assertTableActionExists('exists')
         ->assertTableActionDoesNotExist('does_not_exist');
 });
+
+it('can state whether several table actions exist in order', function () {
+    livewire(PostsTable::class)
+        ->assertTableActionsExistInOrder(['edit', 'delete']);
+});

--- a/tests/src/Tables/BulkActionTest.php
+++ b/tests/src/Tables/BulkActionTest.php
@@ -110,3 +110,8 @@ it('can state whether a bulk action exists', function () {
         ->assertTableBulkActionExists('exists')
         ->assertTableBulkActionDoesNotExist('does_not_exist');
 });
+
+it('can state whether several bulk actions exist in order', function () {
+    livewire(PostsTable::class)
+        ->assertTableBulkActionsExistInOrder(['exists', 'exists_in_order']);
+});

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -167,6 +167,14 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
         ];
     }
 
+    protected function getTableEmptyStateActions(): array
+    {
+        return [
+            Tables\Actions\Action::make('empty-exists'),
+            Tables\Actions\Action::make('empty-exists-in-order'),
+        ];
+    }
+
     protected function getTableQuery(): Builder
     {
         return Post::query();

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -108,6 +108,7 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
             Tables\Actions\Action::make('has-color')
                 ->color('primary'),
             Tables\Actions\Action::make('exists'),
+            Tables\Actions\Action::make('exists-in-order'),
             Tables\Actions\Action::make('url')
                 ->url('https://filamentphp.com'),
             Tables\Actions\Action::make('url_in_new_tab')

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -163,6 +163,7 @@ class PostsTable extends Component implements Tables\Contracts\HasTable
             Tables\Actions\BulkAction::make('has-color')
                 ->color('primary'),
             Tables\Actions\BulkAction::make('exists'),
+            Tables\Actions\BulkAction::make('exists_in_order'),
         ];
     }
 


### PR DESCRIPTION
This PR adds "In Order" assertions to the TestableLivewire assertions for different actions. Added as well to docs, and did a bit of categorization on the "Actions" sections of Admin & Tables

## This includes
* `assertTableActionsExistInOrder`
* `assertTableHeaderActionsExistInOrder`
* `assertTableEmptyStateActionsExistInOrder`
* `assertTableBulkActionsExistInOrder`
* `assertPageActionsExistInOrder`

## Future 

Right now this does not properly handle action groups, but think that could be a next step. 

If welcome and accepted, I would look at wether there are other opportunities for `InOrder` assertions such as:
* `assertFormFieldsExistInOrder`
* `assertTableColumnsExistInOrder`
* `assertTableFiltersExistInOrder`

Feedback very welcome
