### PR TITLE
Improve composer.json snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ If you want to contribute to Filament packages, you may want to test it in a rea
 
 Install the packages in your app's `composer.json`:
 
-```json
+```jsonc
 {
-    ...
+    // ...
     "require": {
         "filament/filament": "*",
     },
@@ -84,7 +84,7 @@ Install the packages in your app's `composer.json`:
             "url": "filament/packages/*"
         }
     ],
-    ...
+    // ...
 }
 ```
 


### PR DESCRIPTION
Right now the `composer.json` example on the README has two ellipses indicating that this is just an example. 

The ellipses are not legal JSON characters so they appear as a red error in the README. 

by swapping to `jsonc` and adding `//` these now appear with "comment" syntax highlighting and do not distract. 

<img width="441" alt="image" src="https://user-images.githubusercontent.com/4480375/230161566-61ebafde-e070-42c4-a696-ab848f2900e1.png">
updated to
<img width="470" alt="CleanShot 2023-04-05 at 12 49 21@2x" src="https://user-images.githubusercontent.com/4480375/230162453-662c03ab-88ff-4d5c-8e3d-dd2e9bef4f4b.png">

