### PR TITLE
fix: Delete media library file for single upload

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -91,8 +91,8 @@ class SpatieMediaLibraryFileUpload extends FileUpload
         });
 
         $this->saveRelationshipsUsing(static function (SpatieMediaLibraryFileUpload $component) {
-            $component->saveUploadedFiles();
             $component->deleteAbandonedFiles();
+            $component->saveUploadedFiles();
         });
 
         $this->saveUploadedFileUsing(static function (SpatieMediaLibraryFileUpload $component, TemporaryUploadedFile $file, ?Model $record): ?string {


### PR DESCRIPTION
When the `multiple()` method is not used with **SpatieMediaLibraryFileUpload**, saving the model would result in the deletion of both old and new files and you have to upload the new one again.

However, by rearranging the order of the `deleteAbandonedFiles()` and `saveUploadedFiles()` methods, it is possible to make it work for both **single** and **multiple** uploads.
