### PR TITLE
Accept closure for builder blocks

### DIFF
--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -3,12 +3,12 @@
 namespace Filament\Forms\Components;
 
 use Closure;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use Filament\Forms\ComponentContainer;
-use Filament\Forms\Components\Builder\Block;
 use function Filament\Forms\array_move_after;
 use function Filament\Forms\array_move_before;
+use Filament\Forms\ComponentContainer;
+use Filament\Forms\Components\Builder\Block;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 class Builder extends Field implements Contracts\CanConcealComponents
 {
@@ -316,7 +316,7 @@ class Builder extends Field implements Contracts\CanConcealComponents
 
     public function isReorderableWithButtons(): bool
     {
-        return $this->evaluate($this->isReorderableWithButtons) && (!$this->isItemMovementDisabled());
+        return $this->evaluate($this->isReorderableWithButtons) && (! $this->isItemMovementDisabled());
     }
 
     public function isItemMovementDisabled(): bool

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -3,12 +3,12 @@
 namespace Filament\Forms\Components;
 
 use Closure;
-use function Filament\Forms\array_move_after;
-use function Filament\Forms\array_move_before;
-use Filament\Forms\ComponentContainer;
-use Filament\Forms\Components\Builder\Block;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Filament\Forms\ComponentContainer;
+use Filament\Forms\Components\Builder\Block;
+use function Filament\Forms\array_move_after;
+use function Filament\Forms\array_move_before;
 
 class Builder extends Field implements Contracts\CanConcealComponents
 {
@@ -191,7 +191,7 @@ class Builder extends Field implements Contracts\CanConcealComponents
         });
     }
 
-    public function blocks(array $blocks): static
+    public function blocks(array | Closure $blocks): static
     {
         $this->childComponents($blocks);
 
@@ -316,7 +316,7 @@ class Builder extends Field implements Contracts\CanConcealComponents
 
     public function isReorderableWithButtons(): bool
     {
-        return $this->evaluate($this->isReorderableWithButtons) && (! $this->isItemMovementDisabled());
+        return $this->evaluate($this->isReorderableWithButtons) && (!$this->isItemMovementDisabled());
     }
 
     public function isItemMovementDisabled(): bool


### PR DESCRIPTION
When creating blocks for the Builder component, the `blocks()` method redirects calls to the `childComponents()` method, since the `childComponents()` method accept array and closure, we should be able to pass the closure also to the `blocks()` method on the Builder component 