### PR TITLE
Add counts for certain strings

### DIFF
--- a/packages/tables/resources/views/components/pagination/index.blade.php
+++ b/packages/tables/resources/views/components/pagination/index.blade.php
@@ -124,7 +124,7 @@
                                         <x-tables::pagination.item
                                             :wire:click="'gotoPage(' . $page . ', \'' . $paginator->getPageName() . '\')'"
                                             :label="$page"
-                                            :aria-label="__('tables::table.pagination.buttons.go_to_page.label', ['page' => $page])"
+                                            :aria-label="trans_choice('tables::table.pagination.buttons.go_to_page.label', $page, ['page' => $page])"
                                             :active="$page === $paginator->currentPage()"
                                             :wire:key="$this->id . '.table.pagination.' . $paginator->getPageName() . '.' . $page"
                                         />

--- a/packages/tables/resources/views/components/selection-indicator.blade.php
+++ b/packages/tables/resources/views/components/selection-indicator.blade.php
@@ -18,13 +18,13 @@
 
     <span id="{{ $this->id }}.table.selection.indicator.record-count.{{ $allRecordsCount }}" x-show="{{ $allRecordsCount }} !== selectedRecords.length">
         <button x-on:click="selectAllRecords" class="text-sm font-medium text-primary-600">
-            {{ __('tables::table.selection_indicator.buttons.select_all.label', ['count' => $allRecordsCount]) }}.
+            {{ trans_choice('tables::table.selection_indicator.buttons.select_all.label', $allRecordsCount, ['count' => $allRecordsCount]) }}.
         </button>
     </span>
 
     <span>
         <button x-on:click="deselectAllRecords" class="text-sm font-medium text-primary-600">
-            {{ __('tables::table.selection_indicator.buttons.deselect_all.label') }}.
+            {{ trans_choice('tables::table.selection_indicator.buttons.deselect_all.label', $allRecordsCount, ['count' => $allRecordsCount]) }}.
         </button>
     </span>
 </div>

--- a/packages/tables/resources/views/components/selection-indicator.blade.php
+++ b/packages/tables/resources/views/components/selection-indicator.blade.php
@@ -24,7 +24,7 @@
 
     <span>
         <button x-on:click="deselectAllRecords" class="text-sm font-medium text-primary-600">
-            {{ trans_choice('tables::table.selection_indicator.buttons.deselect_all.label', $allRecordsCount, ['count' => $allRecordsCount]) }}.
+            {{ __('tables::table.selection_indicator.buttons.deselect_all.label') }}.
         </button>
     </span>
 </div>

--- a/packages/tables/resources/views/components/selection-indicator.blade.php
+++ b/packages/tables/resources/views/components/selection-indicator.blade.php
@@ -18,7 +18,7 @@
 
     <span id="{{ $this->id }}.table.selection.indicator.record-count.{{ $allRecordsCount }}" x-show="{{ $allRecordsCount }} !== selectedRecords.length">
         <button x-on:click="selectAllRecords" class="text-sm font-medium text-primary-600">
-            {{ trans_choice('tables::table.selection_indicator.buttons.select_all.label', $allRecordsCount, ['count' => $allRecordsCount]) }}.
+            {{ trans_choice('tables::table.selection_indicator.buttons.select_all.label', $allRecordsCount) }}.
         </button>
     </span>
 


### PR DESCRIPTION
Replaced `__()` with `trans_choice()` for some strings.

In some languages (like Georgian) it's required to use numeric prefix which is different depending on count. Same as in 1**st**, 2**nd**, 3**rd**, but you cannot say "Go to page 2", instead you should say "Go to 2nd page".

This change doesn't break languages that have not specified multiple strings (separated with `|`).