### PR TITLE
Improved handling of file-upload-started/finished events for FileUpload

### DIFF
--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -242,29 +242,33 @@ export default (Alpine) => {
                         this.insertOpenLink(fileItem)
                     })
 
-                    this.pond.on('processfilestart', async () => {
+                    this.pond.on('addfilestart', async (file) => {
+                        if (file.status !== FilePond.FileStatus.PROCESSING_QUEUED) {
+                            return
+                        }
+
                         this.dispatchFormEvent('file-upload-started')
                     })
 
-                    this.pond.on('processfileprogress', async () => {
-                        this.dispatchFormEvent('file-upload-started')
-                    })
+                    const handleFileProcessing = async () => {
+                        if (
+                            this.pond.getFiles()
+                                .filter(file =>
+                                    file.status === FilePond.FileStatus.PROCESSING ||
+                                    file.status === FilePond.FileStatus.PROCESSING_QUEUED
+                                ).length
+                        ) {
+                            return
+                        }
 
-                    this.pond.on('processfile', async () => {
                         this.dispatchFormEvent('file-upload-finished')
-                    })
+                    }
 
-                    this.pond.on('processfiles', async () => {
-                        this.dispatchFormEvent('file-upload-finished')
-                    })
+                    this.pond.on('processfile', handleFileProcessing)
 
-                    this.pond.on('processfileabort', async () => {
-                        this.dispatchFormEvent('file-upload-finished')
-                    })
+                    this.pond.on('processfileabort', handleFileProcessing)
 
-                    this.pond.on('processfilerevert', async () => {
-                        this.dispatchFormEvent('file-upload-finished')
-                    })
+                    this.pond.on('processfilerevert', handleFileProcessing)
                 },
 
                 dispatchFormEvent: function (name) {

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -253,10 +253,11 @@ export default (Alpine) => {
                     const handleFileProcessing = async () => {
                         if (
                             this.pond.getFiles()
-                                .filter(file =>
-                                    file.status === FilePond.FileStatus.PROCESSING ||
-                                    file.status === FilePond.FileStatus.PROCESSING_QUEUED
-                                ).length
+                                .filter(file => (
+                                    (file.status === FilePond.FileStatus.PROCESSING) ||
+                                    (file.status === FilePond.FileStatus.PROCESSING_QUEUED)
+                                ))
+                                .length
                         ) {
                             return
                         }


### PR DESCRIPTION
Before the improvement "Save changes" button was disabled too late and often resulted in user performing save action before file completed uploading.