### PR TITLE
Use Filament\Forms import in SettingsPage.stub

### DIFF
--- a/packages/spatie-laravel-settings-plugin/stubs/SettingsPage.stub
+++ b/packages/spatie-laravel-settings-plugin/stubs/SettingsPage.stub
@@ -3,6 +3,7 @@
 namespace {{ namespace }};
 
 use App\Settings\{{ settingsClass }};
+use Filament\Forms;
 use Filament\Pages\SettingsPage;
 
 class {{ class }} extends SettingsPage


### PR DESCRIPTION
The stub files for [`Resource`s](https://github.com/filamentphp/filament/blob/2.x/packages/admin/stubs/Resource.stub#L8) from the admin panel include `use Filament\Forms;` by default, making it easier to access the form component classes.

This PR adds the same `use` statement to the stub of the `SettingsPage` of the Spatie Settings integration packgage. Since the primary content of their `SettingsPage`s is the form definition, everybody will import the form components anyway, so I think it makes sense to align both stub files in this regard.

