### PR TITLE
Add $component evaluation parameter to table columns

### DIFF
--- a/packages/tables/src/Columns/Column.php
+++ b/packages/tables/src/Columns/Column.php
@@ -57,6 +57,7 @@ class Column extends ViewComponent
             'livewire' => $this->getLivewire(),
             'record' => $this->getRecord(),
             'rowLoop' => $this->getRowLoop(),
+            'component' => $this,
         ]);
     }
 }

--- a/packages/tables/src/Columns/Layout/Component.php
+++ b/packages/tables/src/Columns/Layout/Component.php
@@ -106,6 +106,7 @@ class Component extends ViewComponent
             'livewire' => $this->getLivewire(),
             'record' => $this->getRecord(),
             'rowLoop' => $this->getRowLoop(),
+            'component' => $this,
         ]);
     }
 }


### PR DESCRIPTION
This PR adds a `$component` evaluation parameter that will return the current column.

I used this to retrieve the current state of a column in the `->tooltip()` method:

```php
Tables\Columns\BadgeColumn::make('warnings')
    ->getStateUsing(function (Something $record) {
        if ($record->status->isAccepted()) {
            return 0;
        }

        return 1;
    })
    ->tooltip(function (Tables\Columns\BadgeColumn $component) {
        return "{$component->getState()} warning(s)";
    })
```

I was tempted to all add a `$state` parameter, but that would require calling `$this->getState()` in the `getDefaultEvaluationParameters()` and that seemed to cause an infinite loop.

In terms of naming, this could also be called `$column` instead of `$component`.