### PR TITLE
Fix for toggle-column console error

### DIFF
--- a/packages/tables/resources/views/columns/toggle-column.blade.php
+++ b/packages/tables/resources/views/columns/toggle-column.blade.php
@@ -16,7 +16,7 @@
                 return
             }
 
-            if (!$refs.newState) {
+            if (! $refs.newState) {
                 return
             }
 

--- a/packages/tables/resources/views/columns/toggle-column.blade.php
+++ b/packages/tables/resources/views/columns/toggle-column.blade.php
@@ -16,7 +16,7 @@
                 return
             }
 
-            if (! $refs.newState) {
+            if (!$refs.newState) {
                 return
             }
 

--- a/packages/tables/resources/views/columns/toggle-column.blade.php
+++ b/packages/tables/resources/views/columns/toggle-column.blade.php
@@ -9,10 +9,14 @@
         isLoading: false,
     }"
     x-init="
-        $watch('state', () => $refs.button.dispatchEvent(new Event('change')))
+        $watch('state', () => $refs.button?.dispatchEvent(new Event('change')))
 
         Livewire.hook('message.processed', (component) => {
             if (component.component.id !== @js($this->id)) {
+                return
+            }
+
+            if (! $refs.newState) {
                 return
             }
 


### PR DESCRIPTION
This PR fixes the toggle column so it doesn't throw console errors. You can read the dicussion on [discord](https://discord.com/channels/883083792112300104/1081226427069894656).

**Console Error 1**
The first console error is: `cannot read properties of undefined (reading 'value')`. This can be reproduced in at least 2 ways:
1. Load a table (with toggle columns), navigate to the next page, and then return to the page you were on before. You will see the error
2. Load a table, search for something, then clear the serach, you will see the error.

This is fixed by this part of the commit:

```php
if (! $refs.newState) {
     return
}
```

**Console Error 2**
The other issue is the console error `cannot read properties of undefined (reading 'dispatchEvent')`. This is thrown when you filter by a toggle column and then toggle that toggle column so that it's removed by the filter. Ej. if you have a filter that is set to show only `active` products, then toggle one of those active products so it's inactive, you'll get error above. 

This is fixed by this part of the commit.

```php
$watch('state', () => $refs.button?.dispatchEvent(new Event('change')))
```

The errors appear to occur because livewire has removed the inputs `newState`, in the case of the first error, and `button`, in the case of the second error, from the dom, BUT it appears that something is maintaining the reference in the browser. I'm not sure if it's alpine, or the browser, or what. You can see this by adding `console.log(@js($recordKey))` before you call `let newState = ...` and as you go back and forth between the pages that recordKey is still there, even though Livewire has removed the input. This in turns throws the error above. I have a feeling that alpine's init that adds the reference but doesn't get rid of it, even though livewire has removed it.

So while this PR fixes the console errors, there still seems to be an underlying problem with alpine/the browser/something maintaining these references even though livewire has removed them. This could also be the reason why people are having trouble with toggles since it's easy to get into a situation where there are multiple references to the same object so toggling something cuases the action to happen multiple times. We still need a fix for that. 

