### PR TITLE
Allow usage of table alias in orderable

### DIFF
--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -242,29 +242,33 @@ export default (Alpine) => {
                         this.insertOpenLink(fileItem)
                     })
 
-                    this.pond.on('processfilestart', async () => {
+                    this.pond.on('addfilestart', async (file) => {
+                        if (file.status !== FilePond.FileStatus.PROCESSING_QUEUED) {
+                            return
+                        }
+
                         this.dispatchFormEvent('file-upload-started')
                     })
 
-                    this.pond.on('processfileprogress', async () => {
-                        this.dispatchFormEvent('file-upload-started')
-                    })
+                    const handleFileProcessing = async () => {
+                        if (
+                            this.pond.getFiles()
+                                .filter(file =>
+                                    file.status === FilePond.FileStatus.PROCESSING ||
+                                    file.status === FilePond.FileStatus.PROCESSING_QUEUED
+                                ).length
+                        ) {
+                            return
+                        }
 
-                    this.pond.on('processfile', async () => {
                         this.dispatchFormEvent('file-upload-finished')
-                    })
+                    }
 
-                    this.pond.on('processfiles', async () => {
-                        this.dispatchFormEvent('file-upload-finished')
-                    })
+                    this.pond.on('processfile', handleFileProcessing)
 
-                    this.pond.on('processfileabort', async () => {
-                        this.dispatchFormEvent('file-upload-finished')
-                    })
+                    this.pond.on('processfileabort', handleFileProcessing)
 
-                    this.pond.on('processfilerevert', async () => {
-                        this.dispatchFormEvent('file-upload-finished')
-                    })
+                    this.pond.on('processfilerevert', handleFileProcessing)
                 },
 
                 dispatchFormEvent: function (name) {

--- a/packages/tables/src/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Concerns/CanReorderRecords.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Concerns;
 
 use Filament\Tables\Contracts\HasRelationshipTable;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Str;
 
 trait CanReorderRecords
 {
@@ -15,7 +16,7 @@ trait CanReorderRecords
             return;
         }
 
-        $orderColumn = $this->getTableReorderColumn();
+        $orderColumn = Str::afterLast($this->getTableReorderColumn(), '.');
 
         if (
             $this instanceof HasRelationshipTable &&


### PR DESCRIPTION
There is sometimes a need to use table alias in ``SELECT`` queries to overcome ambiguous column error when you have a more complex join query in your ``getTableQuery`` and both of the tables got a sort column with the same name. While for ``SELECT`` it perfectly worked before but unfortunately during the update Eloquent did not allow to fill with table alias. So PR takes care of this.

After the change it would be possible to clearly define table for the orderBy column, e.g.
```php
    public static function table(Table $table): Table
    {
           ...
            ->actions([
                Tables\Actions\EditAction::make(),
                Tables\Actions\RestoreAction::make(),
                Tables\Actions\DeleteAction::make(),
            ])
            ->reorderable('products.order_to_display')
            ->defaultSort('products.order_to_display');
    }
```