### PR TITLE
Allow usage of table alias in reorderable

### DIFF
--- a/packages/tables/src/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Concerns/CanReorderRecords.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Concerns;
 
 use Filament\Tables\Contracts\HasRelationshipTable;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Str;
 
 trait CanReorderRecords
 {
@@ -15,7 +16,7 @@ trait CanReorderRecords
             return;
         }
 
-        $orderColumn = $this->getTableReorderColumn();
+        $orderColumn = Str::afterLast($this->getTableReorderColumn(), '.');
 
         if (
             $this instanceof HasRelationshipTable &&


### PR DESCRIPTION
There is sometimes a need to use table alias in ``SELECT`` queries to overcome ambiguous column error when you have a more complex join query in your ``getTableQuery`` and both of the tables got a sort column with the same name. While for ``SELECT`` it perfectly worked before but unfortunately during the update Eloquent does not allow to fill with table alias. So PR takes care of this.

After the change it would be possible to clearly define table for the orderBy column and perform update on reordering action, e.g.

```php
    public static function table(Table $table): Table
    {
           ...
            ->actions([
                Tables\Actions\EditAction::make(),
                Tables\Actions\RestoreAction::make(),
                Tables\Actions\DeleteAction::make(),
            ])
            ->reorderable('products.order_to_display')
            ->defaultSort('products.order_to_display');
    }
```