### PR TITLE
Optimisation for reorderTable action

### DIFF
--- a/packages/tables/src/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Concerns/CanReorderRecords.php
@@ -4,7 +4,6 @@ namespace Filament\Tables\Concerns;
 
 use Filament\Tables\Contracts\HasRelationshipTable;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use DB;
 
 trait CanReorderRecords
 {

--- a/packages/tables/src/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Concerns/CanReorderRecords.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Concerns;
 
 use Filament\Tables\Contracts\HasRelationshipTable;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use DB;
 
 trait CanReorderRecords
 {

--- a/packages/tables/src/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Concerns/CanReorderRecords.php
@@ -31,11 +31,16 @@ trait CanReorderRecords
             return;
         }
 
-        foreach ($order as $index => $recordKey) {
-            $this->getTableRecord($recordKey)->update([
-                $orderColumn => $index + 1,
+        $model = new ($this->getTableModel());
+        $model
+            ->newModelQuery()
+            ->whereIn($model->getKeyName(), array_values($order))
+            ->update([
+                $orderColumn => DB::raw('case ' . collect($order)
+                    ->map(fn ($recordKey, int $index): string => 'when ' . $model->getKeyName() . ' = ' . DB::getPdo()->quote($recordKey) . ' then ' . ($index + 1))
+                    ->implode(' ') . ' end'
+                )
             ]);
-        }
     }
 
     public function toggleTableReordering(): void

--- a/packages/tables/src/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Concerns/CanReorderRecords.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Concerns;
 
 use Filament\Tables\Contracts\HasRelationshipTable;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Facades\DB;
 
 trait CanReorderRecords
 {
@@ -31,15 +32,17 @@ trait CanReorderRecords
             return;
         }
 
-        $model = new ($this->getTableModel());
+        $model = app($this->getTableModel());
+        $modelKeyName = $model->getKeyName();
+        
         $model
             ->newModelQuery()
-            ->whereIn($model->getKeyName(), array_values($order))
+            ->whereIn($modelKeyName, array_values($order))
             ->update([
                 $orderColumn => DB::raw('case ' . collect($order)
-                    ->map(fn ($recordKey, int $index): string => 'when ' . $model->getKeyName() . ' = ' . DB::getPdo()->quote($recordKey) . ' then ' . ($index + 1))
+                    ->map(fn ($recordKey, int $recordIndex): string => 'when ' . $modelKeyName . ' = ' . DB::getPdo()->quote($recordIndex) . ' then ' . ($index + 1))
                     ->implode(' ') . ' end'
-                )
+                ),
             ]);
     }
 


### PR DESCRIPTION
Reordering on larger tables are quite slow because we are iterating over each record and updating them individually. My PR solves the performance issues by introducing the CASE statement to update multiple records in a single query.

I see around 6-7x speed improvement for reorderable tables with 30 records, so there should be greater improvements with even larger tables. At the moment filamentphp executes around 60 queries (SELECT, UPDATE) for 30 records, and after the PR it should be reduced to a single query for the update.