### PR TITLE
Optimisation for file upload form component in spatie media library

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -68,10 +68,8 @@ class SpatieMediaLibraryFileUpload extends FileUpload
                 return null;
             }
 
-            $mediaClass = config('media-library.media_model', Media::class);
-
             /** @var ?Media $media */
-            $media = $mediaClass::findByUuid($file);
+            $media = $component->getRecord()->getRelation('media')?->firstWhere('uuid', $file);
 
             if ($component->getVisibility() === 'private') {
                 try {


### PR DESCRIPTION
Right now when working with multiple files on a form there are excessive ``SELECT`` queries going into the database, e.g. if we have 10 files associated with a record it results into 11 ``SELECT`` queries (1 to load all the media data, and 10 queries for each file individually to fetch the same data), after PR it will load all the media once and fetch the rest needed data from the memory. 

There is no need to individually query database for each file because we already got all the data loaded in memory.