### PR TITLE
Proposal: let columns apply table filters

### DIFF
--- a/packages/tables/resources/views/columns/tags-column.blade.php
+++ b/packages/tables/resources/views/columns/tags-column.blade.php
@@ -29,9 +29,9 @@
             @if ($hasFilter)
                 @if (! blank($filterName))
                     wire:click="$set('tableFilters.tags.values', [ '{{ $tag }}' ])"
-            @endif
-            @if (! blank($filterFunctionName))
-                wire:click="{{ $filterFunctionName }}('{{ $state }}')"
+                @endif
+                @if (! blank($filterFunctionName))
+                    wire:click="{{ $filterFunctionName }}('{{ $state }}')"
                 @endif
             @endif
         >

--- a/packages/tables/resources/views/columns/tags-column.blade.php
+++ b/packages/tables/resources/views/columns/tags-column.blade.php
@@ -1,5 +1,9 @@
 @php
     $state = $getTags();
+
+    $hasFilter = $hasFilter();
+    $filterName = $getFilterName();
+    $filterFunctionName = $getFilterFunctionName();
 @endphp
 
 <div {{ $attributes->merge($getExtraAttributes())->class([
@@ -16,10 +20,21 @@
     },
 ]) }}>
     @foreach (array_slice($getTags(), 0, $getLimit()) as $tag)
-        <span @class([
-            'inline-flex items-center justify-center min-h-6 px-2 py-0.5 text-sm font-medium tracking-tight rounded-xl text-primary-700 bg-primary-500/10 whitespace-normal',
-            'dark:text-primary-500' => config('tables.dark_mode'),
-        ])>
+        <span
+            @class([
+                'inline-flex items-center justify-center min-h-6 px-2 py-0.5 text-sm font-medium tracking-tight rounded-xl text-primary-700 bg-primary-500/10 whitespace-normal',
+                'dark:text-primary-500' => config('tables.dark_mode'),
+                'transition hover:text-primary-500 cursor-pointer' => $hasFilter,
+            ])
+            @if ($hasFilter)
+                @if (! blank($filterName))
+                    wire:click="$set('tableFilters.tags.values', [ '{{ $tag }}' ])"
+            @endif
+            @if (! blank($filterFunctionName))
+                wire:click="{{ $filterFunctionName }}('{{ $state }}')"
+                @endif
+            @endif
+        >
             {{ $tag }}
         </span>
     @endforeach

--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -78,10 +78,10 @@
             @if ($hasFilter)
                 @if (! blank($filterName))
                     wire:click="$set('tableFilters.{{ $filterName }}', '{{ $state }}')"
-            @endif
-            @if (! blank($filterFunctionName))
-                wire:click="{{ $filterFunctionName }}('{{ $state }}')"
-               @endif
+                @endif
+                @if (! blank($filterFunctionName))
+                    wire:click="{{ $filterFunctionName }}('{{ $state }}')"
+                @endif
             @endif
             @class([
                 'cursor-pointer' => $isCopyable,

--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -9,6 +9,10 @@
     $iconClasses = 'w-4 h-4';
 
     $isCopyable = $isCopyable();
+
+    $hasFilter = $hasFilter();
+    $filterName = $getFilterName();
+    $filterFunctionName = $getFilterFunctionName();
 @endphp
 
 <div
@@ -71,8 +75,17 @@
                     $tooltip(@js($getCopyMessage()), { timeout: @js($getCopyMessageDuration()) })
                 "
             @endif
+            @if ($hasFilter)
+                @if (! blank($filterName))
+                    wire:click="$set('tableFilters.{{ $filterName }}', '{{ $state }}')"
+            @endif
+            @if (! blank($filterFunctionName))
+                wire:click="{{ $filterFunctionName }}('{{ $state }}')"
+               @endif
+            @endif
             @class([
                 'cursor-pointer' => $isCopyable,
+                'transition hover:text-primary-500 cursor-pointer' => $hasFilter,
             ])
         >
             {{ $state }}

--- a/packages/tables/src/Columns/Concerns/CanFilter.php
+++ b/packages/tables/src/Columns/Concerns/CanFilter.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Filament\Tables\Columns\Concerns;
+
+use Closure;
+
+trait CanFilter
+{
+    protected string | Closure | null $filterName = null;
+
+    protected string | Closure | null $filterFunctionName = null;
+
+    public function filterName(string | Closure $filterName): static
+    {
+        $this->filterName = $filterName;
+
+        return $this;
+    }
+
+    public function getFilterName(): string
+    {
+        return $this->evaluate($this->filterName) ?? '';
+    }
+
+    public function hasFilter(): bool
+    {
+        return filled($this->getFilterName()) || filled($this->getFilterFunctionName());
+    }
+
+    public function filterFunctionName(string | Closure $filterFunctionName): static
+    {
+        $this->filterFunctionName = $filterFunctionName;
+
+        return $this;
+    }
+
+    public function getFilterFunctionName(): string
+    {
+        return $this->evaluate($this->filterFunctionName) ?? '';
+    }
+}

--- a/packages/tables/src/Columns/TagsColumn.php
+++ b/packages/tables/src/Columns/TagsColumn.php
@@ -6,6 +6,8 @@ use Closure;
 
 class TagsColumn extends Column
 {
+    use Concerns\CanFilter;
+
     protected string $view = 'tables::columns.tags-column';
 
     protected string | Closure | null $separator = null;

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -15,6 +15,7 @@ class TextColumn extends Column
     use Concerns\HasIcon;
     use Concerns\HasSize;
     use Concerns\HasWeight;
+    use Concerns\CanFilter;
 
     protected string $view = 'tables::columns.text-column';
 


### PR DESCRIPTION
Since this trick (https://filamentphp.com/tricks/apply-filter-by-clicking-on-value-in-column) doesn't work due to escaping of the `extraAttributes` I wanted to propose another in-built solution, allowing to apply filters by clicking the column values.

I implemented the concern and applied it to the text and tags columns for demonstration.

With `filterName` on such a column the name of the filter that the value should be applied to can be specified (assuming single values for text and multiple for tags by default). If that's not enough, a `filterFunctionName` can be supplied, giving the name of a public component function that will be called on click instead.

Let me know if you think that is something that you'd consider adding the core, and if so, if you'd like me to change anything.