### PR TITLE
Fix all toggle column issues

### DIFF
--- a/packages/tables/resources/views/columns/toggle-column.blade.php
+++ b/packages/tables/resources/views/columns/toggle-column.blade.php
@@ -2,116 +2,116 @@
     $state = $getState();
 @endphp
 
-<div wire:key="{{ 'toggle-column-' . $recordKey . '-' . $getName() . '-' . json_encode($state) }}">
-<div
-    x-data="{
-        error: undefined,
-        state: @js((bool) $state),
-        isLoading: false,
-    }"
-    {{ $attributes->merge($getExtraAttributes())->class([
-        'filament-tables-toggle-column',
-    ]) }}
-    wire:ignore
->
-    <button
-        role="switch"
-        aria-checked="false"
-        x-bind:aria-checked="state.toString()"
-        x-on:click="
-            if (isLoading) return
-
-            isLoading = true
-            response = await $wire.updateTableColumnState(@js($getName()), @js($recordKey), ! state)
-            error = response?.error ?? undefined
-
-            if (error) {
-                return isLoading = false
-            }
-
-            state = ! state
-            isLoading = false
-        "
-        x-tooltip="error"
-        x-bind:class="{
-            'opacity-70 pointer-events-none': isLoading,
-            '{{ match ($getOnColor()) {
-                'danger' => 'bg-danger-500',
-                'secondary' => 'bg-gray-500',
-                'success' => 'bg-success-500',
-                'warning' => 'bg-warning-500',
-                default => 'bg-primary-600',
-            } }}': state,
-            '{{ match ($getOffColor()) {
-                'danger' => 'bg-danger-500',
-                'primary' => 'bg-primary-500',
-                'success' => 'bg-success-500',
-                'warning' => 'bg-warning-500',
-                default => 'bg-gray-200',
-            } }} @if (config('forms.dark_mode')) dark:bg-white/10 @endif': ! state,
+<div wire:key="{{ $this->id }}.table.record.{{ $recordKey }}.column.{{ $getName() }}.toggle-column.{{ json_encode($state) }}">
+    <div
+        x-data="{
+            error: undefined,
+            state: @js((bool) $state),
+            isLoading: false,
         }"
-        {!! $isDisabled() ? 'disabled' : null !!}
-        type="button"
-        class="relative inline-flex shrink-0 ml-4 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 outline-none focus:ring-1 focus:ring-offset-1 focus:ring-primary-500 disabled:opacity-70 disabled:cursor-not-allowed disabled:pointer-events-none"
+        {{ $attributes->merge($getExtraAttributes())->class([
+            'filament-tables-toggle-column',
+        ]) }}
+        wire:ignore
     >
-        <span
-            class="pointer-events-none relative inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 ease-in-out transition duration-200"
+        <button
+            role="switch"
+            aria-checked="false"
+            x-bind:aria-checked="state.toString()"
+            x-on:click="
+                if (isLoading) return
+
+                isLoading = true
+                response = await $wire.updateTableColumnState(@js($getName()), @js($recordKey), ! state)
+                error = response?.error ?? undefined
+
+                if (error) {
+                    return isLoading = false
+                }
+
+                state = ! state
+                isLoading = false
+            "
+            x-tooltip="error"
             x-bind:class="{
-                'translate-x-5 rtl:-translate-x-5': state,
-                'translate-x-0': ! state,
+                'opacity-70 pointer-events-none': isLoading,
+                '{{ match ($getOnColor()) {
+                    'danger' => 'bg-danger-500',
+                    'secondary' => 'bg-gray-500',
+                    'success' => 'bg-success-500',
+                    'warning' => 'bg-warning-500',
+                    default => 'bg-primary-600',
+                } }}': state,
+                '{{ match ($getOffColor()) {
+                    'danger' => 'bg-danger-500',
+                    'primary' => 'bg-primary-500',
+                    'success' => 'bg-success-500',
+                    'warning' => 'bg-warning-500',
+                    default => 'bg-gray-200',
+                } }} @if (config('forms.dark_mode')) dark:bg-white/10 @endif': ! state,
             }"
+            {!! $isDisabled() ? 'disabled' : null !!}
+            type="button"
+            class="relative inline-flex shrink-0 ml-4 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 outline-none focus:ring-1 focus:ring-offset-1 focus:ring-primary-500 disabled:opacity-70 disabled:cursor-not-allowed disabled:pointer-events-none"
         >
             <span
-                class="absolute inset-0 h-full w-full flex items-center justify-center transition-opacity"
-                aria-hidden="true"
+                class="pointer-events-none relative inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 ease-in-out transition duration-200"
                 x-bind:class="{
-                    'opacity-0 ease-out duration-100': state,
-                    'opacity-100 ease-in duration-200': ! state,
+                    'translate-x-5 rtl:-translate-x-5': state,
+                    'translate-x-0': ! state,
                 }"
             >
-                @if ($hasOffIcon())
-                    <x-dynamic-component
-                        :component="$getOffIcon()"
-                        :class="\Illuminate\Support\Arr::toCssClasses([
-                            'h-3 w-3',
-                            match ($getOffColor()) {
-                                'danger' => 'text-danger-500',
-                                'primary' => 'text-primary-500',
-                                'success' => 'text-success-500',
-                                'warning' => 'text-warning-500',
-                                default => 'text-gray-400',
-                            },
-                        ])"
-                    />
-                @endif
-            </span>
+                <span
+                    class="absolute inset-0 h-full w-full flex items-center justify-center transition-opacity"
+                    aria-hidden="true"
+                    x-bind:class="{
+                        'opacity-0 ease-out duration-100': state,
+                        'opacity-100 ease-in duration-200': ! state,
+                    }"
+                >
+                    @if ($hasOffIcon())
+                        <x-dynamic-component
+                            :component="$getOffIcon()"
+                            :class="\Illuminate\Support\Arr::toCssClasses([
+                                'h-3 w-3',
+                                match ($getOffColor()) {
+                                    'danger' => 'text-danger-500',
+                                    'primary' => 'text-primary-500',
+                                    'success' => 'text-success-500',
+                                    'warning' => 'text-warning-500',
+                                    default => 'text-gray-400',
+                                },
+                            ])"
+                        />
+                    @endif
+                </span>
 
-            <span
-                class="absolute inset-0 h-full w-full flex items-center justify-center transition-opacity"
-                aria-hidden="true"
-                x-bind:class="{
-                    'opacity-100 ease-in duration-200': state,
-                    'opacity-0 ease-out duration-100': ! state,
-                }"
-            >
-                @if ($hasOnIcon())
-                    <x-dynamic-component
-                        :component="$getOnIcon()"
-                        x-cloak
-                        :class="\Illuminate\Support\Arr::toCssClasses([
-                            'h-3 w-3',
-                            match ($getOnColor()) {
-                                'danger' => 'text-danger-500',
-                                'secondary' => 'text-gray-400',
-                                'success' => 'text-success-500',
-                                'warning' => 'text-warning-500',
-                                default => 'text-primary-500',
-                            },
-                        ])"
-                    />
-                @endif
+                <span
+                    class="absolute inset-0 h-full w-full flex items-center justify-center transition-opacity"
+                    aria-hidden="true"
+                    x-bind:class="{
+                        'opacity-100 ease-in duration-200': state,
+                        'opacity-0 ease-out duration-100': ! state,
+                    }"
+                >
+                    @if ($hasOnIcon())
+                        <x-dynamic-component
+                            :component="$getOnIcon()"
+                            x-cloak
+                            :class="\Illuminate\Support\Arr::toCssClasses([
+                                'h-3 w-3',
+                                match ($getOnColor()) {
+                                    'danger' => 'text-danger-500',
+                                    'secondary' => 'text-gray-400',
+                                    'success' => 'text-success-500',
+                                    'warning' => 'text-warning-500',
+                                    default => 'text-primary-500',
+                                },
+                            ])"
+                        />
+                    @endif
+                </span>
             </span>
-        </span>
-    </button>
-</div>
+        </button>
+    </div>
 </div>

--- a/packages/tables/resources/views/columns/toggle-column.blade.php
+++ b/packages/tables/resources/views/columns/toggle-column.blade.php
@@ -2,6 +2,7 @@
     $state = $getState();
 @endphp
 
+<div wire:key="{{ 'toggle-column-' . $recordKey . '-' . json_encode($state) }}">
 <div
     x-data="{
         error: undefined,
@@ -31,7 +32,6 @@
             state = ! state
             isLoading = false
         "
-        x-ref="button"
         x-tooltip="error"
         x-bind:class="{
             'opacity-70 pointer-events-none': isLoading,
@@ -113,4 +113,5 @@
             </span>
         </span>
     </button>
+</div>
 </div>

--- a/packages/tables/resources/views/columns/toggle-column.blade.php
+++ b/packages/tables/resources/views/columns/toggle-column.blade.php
@@ -2,7 +2,7 @@
     $state = $getState();
 @endphp
 
-<div wire:key="{{ 'toggle-column-' . $recordKey . '-' . json_encode($state) }}">
+<div wire:key="{{ 'toggle-column-' . $recordKey . '-' . $getName() . '-' . json_encode($state) }}">
 <div
     x-data="{
         error: undefined,

--- a/packages/tables/resources/views/columns/toggle-column.blade.php
+++ b/packages/tables/resources/views/columns/toggle-column.blade.php
@@ -2,7 +2,7 @@
     $state = $getState();
 @endphp
 
-<div wire:key="{{ $this->id }}.table.record.{{ $recordKey }}.column.{{ $getName() }}.toggle-column.{{ json_encode($state) }}">
+<div wire:key="{{ $this->id }}.table.record.{{ $recordKey }}.column.{{ $getName() }}.toggle-column.{{ $state ? 'true' : 'false' }}">
     <div
         x-data="{
             error: undefined,
@@ -19,17 +19,20 @@
             aria-checked="false"
             x-bind:aria-checked="state.toString()"
             x-on:click="
-                if (isLoading) return
-
-                isLoading = true
-                response = await $wire.updateTableColumnState(@js($getName()), @js($recordKey), ! state)
-                error = response?.error ?? undefined
-
-                if (error) {
-                    return isLoading = false
+                if (isLoading) {
+                    return
                 }
 
                 state = ! state
+
+                isLoading = true
+                response = await $wire.updateTableColumnState(@js($getName()), @js($recordKey), state)
+                error = response?.error ?? undefined
+
+                if (error) {
+                    state = ! state
+                }
+
                 isLoading = false
             "
             x-tooltip="error"


### PR DESCRIPTION
I think I got it!

Like I had mentioned previously I think alpine's init watcher was causing the issue so I rewrote the code without using it. This version solves ALL the problems listed in Issue #6215!

1. No more console logs (dont even need the previous bug fix code.
2. Pagination works fine
3. Filtering and then toggling works fine, without multiple duplicate queries
4. No funny loop conditions. (If you toggle them quickly you can see them disable as they await the response). 

This also maintains all the same abilities as the previous toggle (I think):
1. The button will be disabled as the request is processed
5. If there is a validation error the tool tip will display the error and will not change states

However, I am unsure as to why there was a hidden input that was saving the state of the toggle. Was this in response to a different problem you were having with the toggle? If so, please check this code against whatever problem that was.

And let me know what stying changes you have.

Glad to have (hopefully) gotten this fixed!