### PR TITLE
Map uuid to id from already loaded relationship in spatie media library

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -129,7 +129,11 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
             $mediaClass = config('media-library.media_model', Media::class);
 
-            $mappedIds = $mediaClass::query()->whereIn('uuid', $uuids)->pluck('id', 'uuid')->toArray();
+            $mappedIds = $component->getRecord()
+                ->getRelation('media')
+                ->whereIn('uuid', $uuids)
+                ->pluck('id', 'uuid')
+                ->toArray();
 
             $mediaClass::setNewOrder(array_merge(array_flip($uuids), $mappedIds));
 

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -130,10 +130,10 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             $mediaClass = config('media-library.media_model', Media::class);
 
             $mappedIds = $component->getRecord()
-                ->getRelation('media')
+                ->getRelationValue('media')
                 ->whereIn('uuid', $uuids)
                 ->pluck('id', 'uuid')
-                ->toArray();
+                ->all();
 
             $mediaClass::setNewOrder(array_merge(array_flip($uuids), $mappedIds));
 


### PR DESCRIPTION
When reorder save action happens there is an unnecessary database call executed to match uuid with id. There is no need to query database again because we already got all the data loaded in memory. Similar approach we did for #6216 