### PR TITLE
Keeping a clean query string for pages with relation manager

### DIFF
--- a/packages/admin/src/Resources/Pages/EditRecord.php
+++ b/packages/admin/src/Resources/Pages/EditRecord.php
@@ -31,7 +31,7 @@ class EditRecord extends Page implements HasFormActions
     public ?string $previousUrl = null;
 
     protected $queryString = [
-        'activeRelationManager',
+        'activeRelationManager' => ['except' => 0],
     ];
 
     public function getBreadcrumb(): string

--- a/packages/admin/src/Resources/Pages/ViewRecord.php
+++ b/packages/admin/src/Resources/Pages/ViewRecord.php
@@ -26,7 +26,7 @@ class ViewRecord extends Page
     public $data;
 
     protected $queryString = [
-        'activeRelationManager',
+        'activeRelationManager' => ['except' => 0],
     ];
 
     public function getBreadcrumb(): string


### PR DESCRIPTION
There is no need for activeRelationManager query string when displaying a single relation or the first one.