### PR TITLE
Document undocumented admin test helpers

### DIFF
--- a/packages/admin/.stubs.php
+++ b/packages/admin/.stubs.php
@@ -33,6 +33,8 @@ namespace Livewire\Testing {
 
         public function assertPageActionHasLabel(string $name, string $label): static {}
 
+        public function assertPageActionDoesNotHaveLabel(string $name, string $label): static {}
+
         public function assertPageActionHasColor(string $name, string $color): static {}
 
         public function assertPageActionDoesNotHaveColor(string $name, string $color): static {}
@@ -44,8 +46,6 @@ namespace Livewire\Testing {
         public function assertPageActionShouldOpenUrlInNewTab(string $name): static {}
 
         public function assertPageActionShouldNotOpenUrlInNewTab(string $name): static {}
-
-        public function assertPageActionDoesNotHaveLabel(string $name, string $label): static {}
 
         public function assertPageActionHalted(string $name): static {}
 

--- a/packages/admin/docs/10-testing.md
+++ b/packages/admin/docs/10-testing.md
@@ -381,7 +381,6 @@ it('can send invoices', function () {
 To check if an action has been halted, you can use `assertPageActionHalted`:
 
 ```php
-use Filament\Pages\Actions\DeleteAction;
 use function Pest\Livewire\livewire;
 
 it('stops sending if invoice has no email address', function () {

--- a/packages/admin/docs/10-testing.md
+++ b/packages/admin/docs/10-testing.md
@@ -376,6 +376,25 @@ it('can send invoices', function () {
 });
 ```
 
+### Execution
+
+To check if an action has been halted, you can use `assertPageActionHalted`:
+
+```php
+use Filament\Pages\Actions\DeleteAction;
+use function Pest\Livewire\livewire;
+
+it('stops sending if invoice has no email address', function () {
+    $invoice = Invoice::factory(['email' => null])->create();
+
+    livewire(EditInvoice::class, [
+        'invoice' => $invoice,
+    ])
+        ->callPageAction('send')
+        ->assertPageActionHalted('send');
+});
+```
+
 ### Errors
 
 `assertHasNoPageActionErrors()` is used to assert that no validation errors occurred when submitting the action form.
@@ -538,5 +557,25 @@ it('actions display proper colors', function () {
     ])
         ->assertPageActionHasColor('delete', 'danger')
         ->assertPageActionDoesNotHaveColor('print', 'danger');
+});
+```
+
+### URL
+
+To ensure an action has the correct URL traits, you can use `assertPageActionHasUrl`, `assertPageActionDoesNotHaveUrl`, `assertPageActionShouldOpenUrlInNewTab`, and `assertPageActionShouldNotOpenUrlInNewTab`.
+
+```php
+use function Pest\Livewire\livewire;
+
+it('links to the correct filament sites', function () {
+    $invoice = Invoice::factory()->create();
+
+    livewire(EditInvoice::class, [
+        'invoice' => $invoice,
+    ])
+        ->assertPageActionHasUrl('filament', 'https://filamentphp.com/')
+        ->assertPageActionDoesNotHaveUrl('filament', 'https://github.com/filamentphp/filament')
+        ->assertPageActionShouldOpenUrlInNewTab('filament')
+        ->assertPageActionShouldNotOpenUrlInNewTab('github');
 });
 ```

--- a/packages/admin/docs/10-testing.md
+++ b/packages/admin/docs/10-testing.md
@@ -489,3 +489,38 @@ it('can not send invoices', function () {
         ->assertPageActionsExistInOrder(['send', 'export']);
 });
 ```
+
+### Button Style
+
+To ensure an action's button is showing the correct icon, you can use `assertPageActionHasIcon` or `assertPageActionDoesNotHaveIcon`.
+
+```php
+use function Pest\Livewire\livewire;
+
+it('when active send button has correct icon', function () {
+    $invoice = Invoice::factory()->create();
+
+    livewire(EditInvoice::class, [
+        'invoice' => $invoice,
+    ])
+        ->assertPageActionEnabled('send')
+        ->assertPageActionHasIcon('send', 'envelope-open')
+        ->assertPageActionDoesNotHaveIcon('send', 'envelope');
+});
+```
+
+To ensure an action's button is displaying the right color, you can use `assertPageActionHasColor` or `assertPageActionDoesNotHaveColor`.
+
+```php
+use function Pest\Livewire\livewire;
+
+it('actions display proper colors', function () {
+    $invoice = Invoice::factory()->create();
+
+    livewire(EditInvoice::class, [
+        'invoice' => $invoice,
+    ])
+        ->assertPageActionHasColor('delete', 'danger')
+        ->assertPageActionDoesNotHaveColor('print', 'danger');
+});
+```

--- a/packages/admin/docs/10-testing.md
+++ b/packages/admin/docs/10-testing.md
@@ -359,6 +359,23 @@ it('can send invoices', function () {
 });
 ```
 
+If you ever need to only set a page action's data without immediately calling it, you can use `setPageActionData`.
+
+```php
+use function Pest\Livewire\livewire;
+
+it('can send invoices', function () {
+    $invoice = Invoice::factory()->create();
+
+    livewire(EditInvoice::class, [
+        'invoice' => $invoice,
+    ])
+        ->setPageActionData('send', data: [
+            'email' => $email = fake()->email(),
+        ])
+});
+```
+
 ### Errors
 
 `assertHasNoPageActionErrors()` is used to assert that no validation errors occurred when submitting the action form.
@@ -410,21 +427,6 @@ it('can send invoices to the primary contact by default', function () {
 
 ### Action State
 
-To check if a page action is hidden to a user, you can use the `assertPageActionHidden()` method:
-
-```php
-use function Pest\Livewire\livewire;
-
-it('can not send invoices', function () {
-    $invoice = Invoice::factory()->create();
-
-    livewire(EditInvoice::class, [
-        'invoice' => $invoice,
-    ])
-        ->assertPageActionHidden('send');
-});
-```
-
 To ensure that an action exists or doesn't in a table, you can use the `assertPageActionExists()` or  `assertPageActionDoesNotExist()` method:
 
 ```php
@@ -438,6 +440,38 @@ it('can send but not unsend invoices', function () {
     ])
         ->assertPageActionExists('send')
         ->assertPageActionDoesNotExist('unsend');
+});
+```
+
+To ensure a page action is hidden or visible for a user, you can use the `assertPageActionHidden()` or `assertPageActionVisible()` methods:
+
+```php
+use function Pest\Livewire\livewire;
+
+it('can only print invoices', function () {
+    $invoice = Invoice::factory()->create();
+
+    livewire(EditInvoice::class, [
+        'invoice' => $invoice,
+    ])
+        ->assertPageActionHidden('send')
+        ->assertPageActionVisible('print');
+});
+```
+
+To ensure a page action is enabled or disabled for a user, you can use the `assertPageActionEnabled()` or `assertPageActionDisabled()` methods:
+
+```php
+use function Pest\Livewire\livewire;
+
+it('can only print a sent invoice', function () {
+    $invoice = Invoice::factory()->create();
+
+    livewire(EditInvoice::class, [
+        'invoice' => $invoice,
+    ])
+        ->assertPageActionDisabled('send')
+        ->assertPageActionEnabled('print');
 });
 ```
 

--- a/packages/admin/docs/10-testing.md
+++ b/packages/admin/docs/10-testing.md
@@ -378,7 +378,7 @@ it('can send invoices', function () {
 
 ### Execution
 
-To check if an action has been halted, you can use `assertPageActionHalted`:
+To check if an action has been halted, you can use `assertPageActionHalted()`:
 
 ```php
 use function Pest\Livewire\livewire;
@@ -493,7 +493,7 @@ it('can only print a sent invoice', function () {
 });
 ```
 
-To ensure sets of actions exist in the correct order, you can use `assertPageActionsExistInOrder`:
+To ensure sets of actions exist in the correct order, you can use `assertPageActionsExistInOrder()`:
 
 ```php
 use function Pest\Livewire\livewire;
@@ -508,9 +508,9 @@ it('can not send invoices', function () {
 });
 ```
 
-### Button Style
+### Button appearance
 
-To ensure an action has the correct label, you can use `assertPageActionHasLabel` and `assertPageActionDoesNotHaveLabel`:
+To ensure an action has the correct label, you can use `assertPageActionHasLabel()` and `assertPageActionDoesNotHaveLabel()`:
 
 ```php
 use function Pest\Livewire\livewire;
@@ -526,7 +526,7 @@ it('send action has correct label', function () {
 });
 ```
 
-To ensure an action's button is showing the correct icon, you can use `assertPageActionHasIcon` or `assertPageActionDoesNotHaveIcon`:
+To ensure an action's button is showing the correct icon, you can use `assertPageActionHasIcon()` or `assertPageActionDoesNotHaveIcon()`:
 
 ```php
 use function Pest\Livewire\livewire;
@@ -543,7 +543,7 @@ it('when enabled the send button has correct icon', function () {
 });
 ```
 
-To ensure an action's button is displaying the right color, you can use `assertPageActionHasColor` or `assertPageActionDoesNotHaveColor`:
+To ensure an action's button is displaying the right color, you can use `assertPageActionHasColor()` or `assertPageActionDoesNotHaveColor()`:
 
 ```php
 use function Pest\Livewire\livewire;
@@ -561,7 +561,7 @@ it('actions display proper colors', function () {
 
 ### URL
 
-To ensure an action has the correct URL traits, you can use `assertPageActionHasUrl`, `assertPageActionDoesNotHaveUrl`, `assertPageActionShouldOpenUrlInNewTab`, and `assertPageActionShouldNotOpenUrlInNewTab`.
+To ensure an action has the correct URL, you can use `assertPageActionHasUrl()`, `assertPageActionDoesNotHaveUrl()`, `assertPageActionShouldOpenUrlInNewTab()`, and `assertPageActionShouldNotOpenUrlInNewTab()`:
 
 ```php
 use function Pest\Livewire\livewire;

--- a/packages/admin/docs/10-testing.md
+++ b/packages/admin/docs/10-testing.md
@@ -492,12 +492,28 @@ it('can not send invoices', function () {
 
 ### Button Style
 
-To ensure an action's button is showing the correct icon, you can use `assertPageActionHasIcon` or `assertPageActionDoesNotHaveIcon`.
+To ensure an action has the correct label, you can use `assertPageActionHasLabel` and `assertPageActionDoesNotHaveLabel`:
 
 ```php
 use function Pest\Livewire\livewire;
 
-it('when active send button has correct icon', function () {
+it('send action has correct label', function () {
+    $invoice = Invoice::factory()->create();
+
+    livewire(EditInvoice::class, [
+        'invoice' => $invoice,
+    ])
+        ->assertPageActionHasLabel('send', 'Email Invoice')
+        ->assertPageActionDoesNotHaveLabel('send', 'Send');
+});
+```
+
+To ensure an action's button is showing the correct icon, you can use `assertPageActionHasIcon` or `assertPageActionDoesNotHaveIcon`:
+
+```php
+use function Pest\Livewire\livewire;
+
+it('when enabled the send button has correct icon', function () {
     $invoice = Invoice::factory()->create();
 
     livewire(EditInvoice::class, [
@@ -509,7 +525,7 @@ it('when active send button has correct icon', function () {
 });
 ```
 
-To ensure an action's button is displaying the right color, you can use `assertPageActionHasColor` or `assertPageActionDoesNotHaveColor`.
+To ensure an action's button is displaying the right color, you can use `assertPageActionHasColor` or `assertPageActionDoesNotHaveColor`:
 
 ```php
 use function Pest\Livewire\livewire;

--- a/packages/admin/docs/10-testing.md
+++ b/packages/admin/docs/10-testing.md
@@ -359,7 +359,7 @@ it('can send invoices', function () {
 });
 ```
 
-If you ever need to only set a page action's data without immediately calling it, you can use `setPageActionData`.
+If you ever need to only set a page action's data without immediately calling it, you can use `setPageActionData()`:
 
 ```php
 use function Pest\Livewire\livewire;
@@ -370,6 +370,7 @@ it('can send invoices', function () {
     livewire(EditInvoice::class, [
         'invoice' => $invoice,
     ])
+        ->mountPageAction('send')
         ->setPageActionData('send', data: [
             'email' => $email = fake()->email(),
         ])


### PR DESCRIPTION
This PR adds all the remaining test helpers from `packages/admin/.stubs.php` to the documentation.

In the Stub file, I moved the two label assertions next to teach other like all the other paired assertions.

Will PR the other sections separately. 