### PR TITLE
Support extraAlpineAttributes on non-masked text input

### DIFF
--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -52,7 +52,6 @@
                     {!! $isLazy() ? "x-on:blur=\"\$wire.\$refresh\"" : null !!}
                     {!! $isDebounced() ? "x-on:input.debounce.{$getDebounce()}=\"\$wire.\$refresh\"" : null !!}
                 @endunless
-                {{ $getExtraAlpineAttributeBag() }}
                 dusk="filament.forms.{{ $getStatePath() }}"
                 {!! ($autocapitalize = $getAutocapitalize()) ? "autocapitalize=\"{$autocapitalize}\"" : null !!}
                 {!! ($autocomplete = $getAutocomplete()) ? "autocomplete=\"{$autocomplete}\"" : null !!}
@@ -70,6 +69,7 @@
                     {!! filled($value = $getMinValue()) ? "min=\"{$value}\"" : null !!}
                     {!! $isRequired() ? 'required' : null !!}
                 @endif
+                {{ $getExtraAlpineAttributeBag() }}
                 {{ $getExtraInputAttributeBag()->class([
                     'block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
                     'dark:bg-gray-700 dark:text-white dark:focus:border-primary-500' => config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -51,8 +51,8 @@
                     wire:ignore
                     {!! $isLazy() ? "x-on:blur=\"\$wire.\$refresh\"" : null !!}
                     {!! $isDebounced() ? "x-on:input.debounce.{$getDebounce()}=\"\$wire.\$refresh\"" : null !!}
-                    {{ $getExtraAlpineAttributeBag() }}
                 @endunless
+                {{ $getExtraAlpineAttributeBag() }}
                 dusk="filament.forms.{{ $getStatePath() }}"
                 {!! ($autocapitalize = $getAutocapitalize()) ? "autocapitalize=\"{$autocapitalize}\"" : null !!}
                 {!! ($autocomplete = $getAutocomplete()) ? "autocomplete=\"{$autocomplete}\"" : null !!}


### PR DESCRIPTION
Please note that the extraAlpineAttributes option is only available when using the mask option. However, with this feature, the position can be changed, allowing it to be used without a mask as well.