### PR TITLE
Support custom columns for form grid

### DIFF
--- a/packages/admin/src/Pages/Dashboard.php
+++ b/packages/admin/src/Pages/Dashboard.php
@@ -31,7 +31,7 @@ class Dashboard extends Page
         return Filament::getWidgets();
     }
 
-    protected function getColumns(): int | array
+    protected function getColumns(): int | string | array
     {
         return 2;
     }

--- a/packages/admin/src/Pages/Page.php
+++ b/packages/admin/src/Pages/Page.php
@@ -188,7 +188,7 @@ class Page extends Component implements Forms\Contracts\HasForms, RendersFormCom
         return $this->filterVisibleWidgets($this->getHeaderWidgets());
     }
 
-    protected function getHeaderWidgetsColumns(): int | array
+    protected function getHeaderWidgetsColumns(): int | string | array
     {
         return 2;
     }
@@ -208,7 +208,7 @@ class Page extends Component implements Forms\Contracts\HasForms, RendersFormCom
         return array_filter($widgets, fn (string $widget): bool => $widget::canView());
     }
 
-    protected function getFooterWidgetsColumns(): int | array
+    protected function getFooterWidgetsColumns(): int | string | array
     {
         return 2;
     }

--- a/packages/admin/src/Resources/Form.php
+++ b/packages/admin/src/Resources/Form.php
@@ -9,7 +9,7 @@ use Filament\Forms\Components\Wizard;
 
 class Form
 {
-    protected array | int | null $columns = null;
+    protected array | int | string | null $columns = null;
 
     protected bool $isDisabled = false;
 
@@ -28,7 +28,7 @@ class Form
         return app(static::class);
     }
 
-    public function columns(array | int | null $columns): static
+    public function columns(array | int | string | null $columns): static
     {
         $this->columns = $columns;
 
@@ -63,7 +63,7 @@ class Form
         return $this;
     }
 
-    public function getColumns(): array | int | null
+    public function getColumns(): array | int | string | null
     {
         return $this->columns;
     }

--- a/packages/forms/src/Components/Concerns/HasContainerGridLayout.php
+++ b/packages/forms/src/Components/Concerns/HasContainerGridLayout.php
@@ -6,7 +6,7 @@ trait HasContainerGridLayout
 {
     protected ?array $gridColumns = null;
 
-    public function grid(array | int | null $columns = 2): static
+    public function grid(array | int | string | null $columns = 2): static
     {
         if (! is_array($columns)) {
             $columns = [
@@ -19,7 +19,7 @@ trait HasContainerGridLayout
         return $this;
     }
 
-    public function getGridColumns($breakpoint = null): array | int | null
+    public function getGridColumns($breakpoint = null): array | int | string | null
     {
         $columns = $this->gridColumns ?? [
             'default' => 1,

--- a/packages/forms/src/Components/Grid.php
+++ b/packages/forms/src/Components/Grid.php
@@ -10,12 +10,12 @@ class Grid extends Component implements CanEntangleWithSingularRelationships
 
     protected string $view = 'forms::components.grid';
 
-    final public function __construct(array | int | null $columns)
+    final public function __construct(array | int | string | null $columns)
     {
         $this->columns($columns);
     }
 
-    public static function make(array | int | null $columns = 2): static
+    public static function make(array | int | string | null $columns = 2): static
     {
         $static = app(static::class, ['columns' => $columns]);
         $static->configure();

--- a/packages/forms/src/Concerns/HasColumns.php
+++ b/packages/forms/src/Concerns/HasColumns.php
@@ -8,7 +8,7 @@ trait HasColumns
 {
     protected ?array $columns = null;
 
-    public function columns(array | int | null $columns = 2): static
+    public function columns(array | int | string | null $columns = 2): static
     {
         if (! is_array($columns)) {
             $columns = [
@@ -21,7 +21,7 @@ trait HasColumns
         return $this;
     }
 
-    public function getColumns($breakpoint = null): array | int | null
+    public function getColumns($breakpoint = null): array | int | string | null
     {
         $columns = $this->getColumnsConfig();
 

--- a/packages/tables/src/Columns/Layout/Grid.php
+++ b/packages/tables/src/Columns/Layout/Grid.php
@@ -8,12 +8,12 @@ class Grid extends Component
 
     protected ?array $columns = null;
 
-    final public function __construct(array | int | null $columns)
+    final public function __construct(array | int | string | null $columns)
     {
         $this->columns($columns);
     }
 
-    public static function make(array | int | null $columns = 2): static
+    public static function make(array | int | string | null $columns = 2): static
     {
         $static = app(static::class, ['columns' => $columns]);
         $static->configure();
@@ -21,7 +21,7 @@ class Grid extends Component
         return $static;
     }
 
-    public function columns(array | int | null $columns = 2): static
+    public function columns(array | int | string | null $columns = 2): static
     {
         if (! is_array($columns)) {
             $columns = [

--- a/packages/tables/src/Filters/Concerns/HasColumns.php
+++ b/packages/tables/src/Filters/Concerns/HasColumns.php
@@ -4,16 +4,16 @@ namespace Filament\Tables\Filters\Concerns;
 
 trait HasColumns
 {
-    protected array | int | null $columns = null;
+    protected array | int | string | null $columns = null;
 
-    public function columns(array | int | null $columns = 2): static
+    public function columns(array | int | string | null $columns = 2): static
     {
         $this->columns = $columns;
 
         return $this;
     }
 
-    public function getColumns(): array | int | null
+    public function getColumns(): array | int | string | null
     {
         return $this->columns;
     }


### PR DESCRIPTION
This PR adds the ability to specify a custom grid template column class.

```php
$component->columns('grid-cols-[auto,1fr]'); 
$component->columns([
    'lg' => 'grid-cols-[auto,1fr]'
]); 
```
