### PR TITLE
Use Laravel's generated column key name instead of relationship qualified key name 

### DIFF
--- a/packages/tables/src/Actions/AssociateAction.php
+++ b/packages/tables/src/Actions/AssociateAction.php
@@ -213,7 +213,7 @@ class AssociateAction extends Action
                             ->where($relationship->getQualifiedForeignKeyName(), $relationship->getParent()->getKey());
                     }
 
-                    return $query->where($relationship->getParent()->getQualifiedKeyName(), $relationship->getParent()->getKey());
+                    return $query->where($query->qualifyColumn($relationship->getParent()->getKeyName()), $relationship->getParent()->getKey());
                 })
                 ->get()
                 ->mapWithKeys(fn (Model $record): array => [$record->getKey() => $this->getRecordTitle($record)])

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -212,7 +212,7 @@ class AttachAction extends Action
                     fn (Builder $query): Builder => $query->whereDoesntHave(
                         $this->getInverseRelationshipName(),
                         function (Builder $query): Builder {
-                            return $query->where($query->qualifyColumn($query->getRelationship()->getParent()->getKeyName()), $this->getRelationship()->getParent()->getKey());
+                            return $query->where($query->qualifyColumn($this->getRelationship()->getParent()->getKeyName()), $this->getRelationship()->getParent()->getKey());
                         },
                     ),
                 )

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -212,7 +212,7 @@ class AttachAction extends Action
                     fn (Builder $query): Builder => $query->whereDoesntHave(
                         $this->getInverseRelationshipName(),
                         function (Builder $query): Builder {
-                            return $query->where($this->getRelationship()->getParent()->getQualifiedKeyName(), $this->getRelationship()->getParent()->getKey());
+                            return $query->where($query->qualifyColumn($query->getRelationship()->getParent()->getKeyName()), $this->getRelationship()->getParent()->getKey());
                         },
                     ),
                 )


### PR DESCRIPTION
When a model has an relation to itself the query wont build correctly, it now uses the qualifiedKeyName instead of the then generated laravel keyname of the query. 

You can easily reproduce this by creating an model that has an pivot with an relation to itself, then specifing the relationship and the inverse in the model, as in the relationmanager, and when creating the query it will use the keyname of the parent relationship instead of the generated `laravel_reserved_0` one

Becuase of it not using the laravel_reserved_0 column, it will return models that already have an relationship to the model and by that it produces an error when using unique on the pivot