### PR TITLE
Documentation Admin publishing translations fix

### DIFF
--- a/packages/admin/docs/01-installation.md
+++ b/packages/admin/docs/01-installation.md
@@ -66,8 +66,8 @@ php artisan vendor:publish --tag=filament-translations
 Since this package depends on other Filament packages, you may wish to translate those as well:
 
 ```bash
-php artisan vendor:publish --tag=filament-forms-translations
-php artisan vendor:publish --tag=filament-tables-translations
+php artisan vendor:publish --tag=forms-translations
+php artisan vendor:publish --tag=tables-translations
 php artisan vendor:publish --tag=filament-support-translations
 ```
 


### PR DESCRIPTION
For the admin installation publish translation sections, the commands:
```bash
php artisan vendor:publish --tag=filament-forms-translations
php artisan vendor:publish --tag=filament-tables-translations
```
Do not work, even if you don't have any translation files in your projects.

however, the commands shown in the *tables* and *forms* sections do work:
```bash
php artisan vendor:publish --tag=forms-translations
php artisan vendor:publish --tag=tables-translations
```
I actually reported this issue in the [Discord channel chat](https://discord.com/channels/883083792112300104/883083792653381695/1096482675126190170) for more details.