### PR TITLE
Add minimum-stability "dev" to contribute guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Install the packages in your app's `composer.json`:
     "require": {
         "filament/filament": "*",
     },
+    "minimum-stability": "dev",
     "repositories": [
         {
             "type": "path",


### PR DESCRIPTION
Add minimum-stability "dev" to the contribution guide

In the newest Laravel skeleton, minimum-stability is "stable" so it needs to change to "dev" to install filament on locally

