### PR TITLE
Add class to identify fields

### DIFF
--- a/packages/forms/resources/views/components/checkbox.blade.php
+++ b/packages/forms/resources/views/components/checkbox.blade.php
@@ -30,7 +30,7 @@
                         ->merge($getExtraAttributes())
                         ->merge($getExtraInputAttributeBag()->getAttributes())
                         ->class([
-                            'filament-forms-checkbox-component text-primary-600 transition duration-75 rounded shadow-sm focus:border-primary-500 focus:ring-2 focus:ring-primary-500 disabled:opacity-70',
+                            'filament-forms-checkbox-component filament-forms-input text-primary-600 transition duration-75 rounded shadow-sm focus:border-primary-500 focus:ring-2 focus:ring-primary-500 disabled:opacity-70',
                             'dark:bg-gray-700 dark:checked:bg-primary-500' => config('forms.dark_mode'),
                             'border-gray-300' => ! $errors->has($getStatePath()),
                             'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -59,6 +59,7 @@
                     {!! $isRequired() ? 'required' : null !!}
                 @endif
                 {{ $getExtraInputAttributeBag()->class([
+                    'filament-forms-color-picker-component filament-forms-input',
                     'text-gray-900 block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
                     'dark:bg-gray-700 dark:text-white dark:focus:border-primary-500' => config('forms.dark_mode'),
                     'border-gray-300' => ! $errors->has($getStatePath()),

--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -59,7 +59,7 @@
                     {!! $isRequired() ? 'required' : null !!}
                 @endif
                 {{ $getExtraInputAttributeBag()->class([
-                    'filament-forms-color-picker-component filament-forms-input text-gray-900 block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
+                    'filament-forms-input text-gray-900 block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
                     'dark:bg-gray-700 dark:text-white dark:focus:border-primary-500' => config('forms.dark_mode'),
                     'border-gray-300' => ! $errors->has($getStatePath()),
                     'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -59,8 +59,7 @@
                     {!! $isRequired() ? 'required' : null !!}
                 @endif
                 {{ $getExtraInputAttributeBag()->class([
-                    'filament-forms-color-picker-component filament-forms-input',
-                    'text-gray-900 block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
+                    'filament-forms-color-picker-component filament-forms-input text-gray-900 block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
                     'dark:bg-gray-700 dark:text-white dark:focus:border-primary-500' => config('forms.dark_mode'),
                     'border-gray-300' => ! $errors->has($getStatePath()),
                     'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -25,7 +25,7 @@
         {{
             $attributes
                 ->merge($getExtraAttributes())
-                ->class(['filament-forms-date-time-picker-component filament-forms-input relative'])
+                ->class(['filament-forms-date-time-picker-component relative'])
         }}
     >
         <input x-ref="maxDate" type="hidden" value="{{ $getMaxDate() }}" />

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -21,8 +21,10 @@
             state: $wire.{{ $applyStateBindingModifiers('entangle(\'' . $getStatePath() . '\')') }},
         })"
         x-on:keydown.esc="isOpen() && $event.stopPropagation()"
-        {{ $attributes->merge($getExtraAttributes())->class(['filament-forms-date-time-picker-component relative']) }}
         {{ $getExtraAlpineAttributeBag() }}
+        {{ $attributes->merge($getExtraAttributes())->class([
+            'filament-forms-date-time-picker-component filament-forms-input relative'
+        ]) }}
     >
         <input x-ref="maxDate" type="hidden" value="{{ $getMaxDate() }}" />
         <input x-ref="minDate" type="hidden" value="{{ $getMinDate() }}" />

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -22,9 +22,11 @@
         })"
         x-on:keydown.esc="isOpen() && $event.stopPropagation()"
         {{ $getExtraAlpineAttributeBag() }}
-        {{ $attributes->merge($getExtraAttributes())->class([
-            'filament-forms-date-time-picker-component filament-forms-input relative'
-        ]) }}
+        {{
+            $attributes
+                ->merge($getExtraAttributes())
+                ->class(['filament-forms-date-time-picker-component filament-forms-input relative'])
+        }}
     >
         <input x-ref="maxDate" type="hidden" value="{{ $getMaxDate() }}" />
         <input x-ref="minDate" type="hidden" value="{{ $getMinDate() }}" />

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -69,7 +69,7 @@
         {!! ($id = $getId()) ? "id=\"{$id}\"" : null !!}
         style="min-height: {{ $isAvatar() ? '8em' : ($getPanelLayout() === 'compact' ? '2.625em' : '4.75em') }}"
         {{ $attributes->merge($getExtraAttributes())->class([
-            'filament-forms-file-upload-component',
+            'filament-forms-file-upload-component filament-forms-input',
             'w-32 mx-auto' => $isAvatar(),
         ]) }}
         {{ $getExtraAlpineAttributeBag() }}

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -69,7 +69,7 @@
         {!! ($id = $getId()) ? "id=\"{$id}\"" : null !!}
         style="min-height: {{ $isAvatar() ? '8em' : ($getPanelLayout() === 'compact' ? '2.625em' : '4.75em') }}"
         {{ $attributes->merge($getExtraAttributes())->class([
-            'filament-forms-file-upload-component filament-forms-input',
+            'filament-forms-file-upload-component',
             'w-32 mx-auto' => $isAvatar(),
         ]) }}
         {{ $getExtraAlpineAttributeBag() }}

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -47,6 +47,7 @@
                         {!! $isRequired() ? 'required' : null !!}
                     @endif
                     {{ $attributes->merge($getExtraInputAttributes())->merge($getExtraAttributes())->class([
+                        'filament-forms-select-component filament-forms-input',
                         'text-gray-900 block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
                         'dark:bg-gray-700 dark:text-white dark:focus:border-primary-500' => config('forms.dark_mode'),
                         'border-gray-300' => ! $errors->has($getStatePath()),

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -106,7 +106,7 @@
                     {{ $attributes
                         ->merge($getExtraAttributes())
                         ->merge($getExtraAlpineAttributes())
-                        ->merge(['class' => 'filament-forms-select-component filament-forms-input'])
+                        ->class(['filament-forms-select-component filament-forms-input'])
                     }}
                     x-bind:class="{
                         'choices--error': (@js($getStatePath()) in $wire.__instance.serverMemo.errors),

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -47,8 +47,7 @@
                         {!! $isRequired() ? 'required' : null !!}
                     @endif
                     {{ $attributes->merge($getExtraInputAttributes())->merge($getExtraAttributes())->class([
-                        'filament-forms-select-component filament-forms-input',
-                        'text-gray-900 block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
+                        'filament-forms-select-component filament-forms-input text-gray-900 block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
                         'dark:bg-gray-700 dark:text-white dark:focus:border-primary-500' => config('forms.dark_mode'),
                         'border-gray-300' => ! $errors->has($getStatePath()),
                         'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -103,10 +103,11 @@
                     })"
                     x-on:keydown.esc="select.dropdown.isActive && $event.stopPropagation()"
                     wire:ignore
-                    {{ $attributes
-                        ->merge($getExtraAttributes())
-                        ->merge($getExtraAlpineAttributes())
-                        ->class(['filament-forms-select-component filament-forms-input'])
+                    {{
+                        $attributes
+                            ->merge($getExtraAttributes())
+                            ->merge($getExtraAlpineAttributes())
+                            ->class(['filament-forms-select-component filament-forms-input'])
                     }}
                     x-bind:class="{
                         'choices--error': (@js($getStatePath()) in $wire.__instance.serverMemo.errors),

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -103,7 +103,11 @@
                     })"
                     x-on:keydown.esc="select.dropdown.isActive && $event.stopPropagation()"
                     wire:ignore
-                    {{ $attributes->merge($getExtraAttributes())->merge($getExtraAlpineAttributes()) }}
+                    {{ $attributes
+                        ->merge($getExtraAttributes())
+                        ->merge($getExtraAlpineAttributes())
+                        ->merge(['class' => 'filament-forms-select-component filament-forms-input'])
+                    }}
                     x-bind:class="{
                         'choices--error': (@js($getStatePath()) in $wire.__instance.serverMemo.errors),
                     }"

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -47,7 +47,7 @@
                         {!! $isRequired() ? 'required' : null !!}
                     @endif
                     {{ $attributes->merge($getExtraInputAttributes())->merge($getExtraAttributes())->class([
-                        'filament-forms-select-component filament-forms-input text-gray-900 block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
+                        'filament-forms-input text-gray-900 block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
                         'dark:bg-gray-700 dark:text-white dark:focus:border-primary-500' => config('forms.dark_mode'),
                         'border-gray-300' => ! $errors->has($getStatePath()),
                         'dark:border-gray-600' => (! $errors->has($getStatePath())) && config('forms.dark_mode'),
@@ -107,7 +107,7 @@
                         $attributes
                             ->merge($getExtraAttributes())
                             ->merge($getExtraAlpineAttributes())
-                            ->class(['filament-forms-select-component filament-forms-input'])
+                            ->class(['filament-forms-input'])
                     }}
                     x-bind:class="{
                         'choices--error': (@js($getStatePath()) in $wire.__instance.serverMemo.errors),

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -71,7 +71,7 @@
                 @endif
                 {{ $getExtraAlpineAttributeBag() }}
                 {{ $getExtraInputAttributeBag()->class([
-                    'filament-forms-text-input-component filament-forms-input block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
+                    'filament-forms-input block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
                     'dark:bg-gray-700 dark:text-white dark:focus:border-primary-500' => config('forms.dark_mode'),
                 ]) }}
                 x-bind:class="{

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -71,6 +71,7 @@
                 @endif
                 {{ $getExtraAlpineAttributeBag() }}
                 {{ $getExtraInputAttributeBag()->class([
+                    'filament-forms-text-input-component filament-forms-input',
                     'block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
                     'dark:bg-gray-700 dark:text-white dark:focus:border-primary-500' => config('forms.dark_mode'),
                 ]) }}

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -71,8 +71,7 @@
                 @endif
                 {{ $getExtraAlpineAttributeBag() }}
                 {{ $getExtraInputAttributeBag()->class([
-                    'filament-forms-text-input-component filament-forms-input',
-                    'block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
+                    'filament-forms-text-input-component filament-forms-input block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
                     'dark:bg-gray-700 dark:text-white dark:focus:border-primary-500' => config('forms.dark_mode'),
                 ]) }}
                 x-bind:class="{

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -32,7 +32,8 @@
                 ->merge($getExtraAttributes())
                 ->merge($getExtraInputAttributeBag()->getAttributes())
                 ->class([
-                    'filament-forms-textarea-component block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
+                    'filament-forms-textarea-component filament-forms-input',
+                    'block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
                     'dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:focus:border-primary-500' => config('forms.dark_mode'),
                     'border-gray-300' => ! $errors->has($getStatePath()),
                     'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -32,8 +32,7 @@
                 ->merge($getExtraAttributes())
                 ->merge($getExtraInputAttributeBag()->getAttributes())
                 ->class([
-                    'filament-forms-textarea-component filament-forms-input',
-                    'block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
+                    'filament-forms-textarea-component filament-forms-input block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
                     'dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:focus:border-primary-500' => config('forms.dark_mode'),
                     'border-gray-300' => ! $errors->has($getStatePath()),
                     'border-danger-600 ring-danger-600' => $errors->has($getStatePath()),


### PR DESCRIPTION
Also added `filament-forms-input` to allow for cleaner css when targeting input/select/etc. 

e.g helpful to customise grid into a input group
<img width="975" alt="Screenshot 2023-04-26 at 14 57 02" src="https://user-images.githubusercontent.com/533658/234599280-655fbe5b-0699-42bc-931c-811a4918fd14.png">

```php
Forms\Components\Grid::make()
    ->columns(3)
    ->extraAttributes(['class' => 'filament-input-group'])
    ->schema([
        Forms\Components\TextInput::make('first'),
        Forms\Components\Select::make('second'),
        ColorPicker::make('third'),
    ]),
```

```css
/* input group */
@screen lg {
    .filament-input-group > .grid {
        gap: 0;
    }

    .filament-input-group > .grid > :first-child .filament-forms-input,
    .filament-input-group > .grid > :first-child .filament-forms-input .choices__inner {
        border-top-right-radius: 0;
        border-bottom-right-radius: 0;
    }

    .filament-input-group > .grid > :not(:first-child):not(:last-child) .filament-forms-input,
    .filament-input-group > .grid > :not(:first-child):not(:last-child) .filament-forms-input .choices__inner {
        border-radius: 0;
        border-left: none;
    }

    .filament-input-group > .grid > :last-child .filament-forms-input,
    .filament-input-group > .grid > :last-child .filament-forms-input .choices__inner {
        border-top-left-radius: 0;
        border-bottom-left-radius: 0;
        border-left: none;
    }
}
```



