### PR TITLE
Fix Text Input Error Focus

### DIFF
--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -71,14 +71,14 @@
                 @endif
                 {{ $getExtraAlpineAttributeBag() }}
                 {{ $getExtraInputAttributeBag()->class([
-                    'block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70',
-                    'dark:bg-gray-700 dark:text-white dark:focus:border-primary-500' => config('forms.dark_mode'),
+                    'block w-full transition duration-75 rounded-lg shadow-sm outline-none focus:ring-1 focus:ring-inset disabled:opacity-70',
+                    'dark:bg-gray-700 dark:text-white' => config('forms.dark_mode'),
                 ]) }}
                 x-bind:class="{
-                    'border-gray-300': ! (@js($getStatePath()) in $wire.__instance.serverMemo.errors),
-                    'dark:border-gray-600': ! (@js($getStatePath()) in $wire.__instance.serverMemo.errors) && @js(config('forms.dark_mode')),
-                    'border-danger-600 ring-danger-600': (@js($getStatePath()) in $wire.__instance.serverMemo.errors),
-                    'dark:border-danger-400 dark:ring-danger-400': (@js($getStatePath()) in $wire.__instance.serverMemo.errors) && @js(config('forms.dark_mode')),
+                    'border-gray-300 focus:border-primary-500 focus:ring-primary-500': ! (@js($getStatePath()) in $wire.__instance.serverMemo.errors),
+                    'dark:border-gray-600 dark:focus:border-primary-500': ! (@js($getStatePath()) in $wire.__instance.serverMemo.errors) && @js(config('forms.dark_mode')),
+                    'border-danger-600 ring-danger-600 focus:border-danger-500 focus:ring-danger-500': (@js($getStatePath()) in $wire.__instance.serverMemo.errors),
+                    'dark:border-danger-400 dark:ring-danger-400 dark:focus:border-danger-500 dark:focus:ring-danger-500': (@js($getStatePath()) in $wire.__instance.serverMemo.errors) && @js(config('forms.dark_mode')),
                 }"
             />
         </div>


### PR DESCRIPTION
This pull request is to fix the text input error focus on Light and Dark mode. The color of the focus while in an "error state" was inconsistent on light and dark mode, and, in my opinion, keeping the focus and border color the same (which is red in an error state) seemed to be the most logical solution. 

These are all examples in an error state with focus.

### Light Old Input Error Focus State:
![LightOldInputError](https://user-images.githubusercontent.com/104294090/234871557-c4e5299e-b60d-4b51-b573-8abaa27e48f2.png)

### Dark Old Input Error Focus State:
![DarkOldInputError](https://user-images.githubusercontent.com/104294090/234873217-74d9938b-eb78-4a18-9790-18465edb7e39.png)

### Light New Input Error Focus State:
![LightNewInputError](https://user-images.githubusercontent.com/104294090/234871786-74a75cfc-8a1a-44a6-9b93-04214831445a.png)

### Dark New Input Error Focus State:
![DarkNewInputError](https://user-images.githubusercontent.com/104294090/234873308-326ce331-db25-40b0-b3bd-5b54b29e66b2.png)