### PR TITLE
Revert toggle columns

### DIFF
--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -60,18 +60,11 @@ trait InteractsWithTable
             return;
         }
 
-        $toggleColumnsSessionKey = $this->getTableColumnToggleFormStateSessionKey();
-
-        if ((blank($this->toggledTableColumns) || ($this->toggledTableColumns === [])) && session()->has($toggleColumnsSessionKey)) {
+        if (blank($this->toggledTableColumns) || ($this->toggledTableColumns === [])) {
             $this->getTableColumnToggleForm()->fill(session()->get(
-                $toggleColumnsSessionKey,
+                $this->getTableColumnToggleFormStateSessionKey(),
                 $this->getDefaultTableColumnToggleState()
             ));
-        } else {
-            session()->put(
-                $toggleColumnsSessionKey,
-                $this->toggledTableColumns,
-            );
         }
 
         if (! count($this->tableFilters ?? [])) {


### PR DESCRIPTION
PR #6299 changed the logic of toggle columns breaking toggle columns default. With the change, on the first page load it would load all the columns since the session didn't have a `toggleColumnSessionKey`, but it would also set the ToggleColumnSession to be an empty array, so on subsequent page loads it would turn off all the toggleable columns.

This PR reverts that to the previous code which was working. 

I'm not sure what the intent of the change was, but since any change to toggle columns is ALWAYS set in the session (there isn't a persist method), I don't know if there is a need to set it on boot. 