### PR TITLE
Decrease width of open sidebar on mobile

### DIFF
--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -2,7 +2,7 @@
     x-data="{}"
     @if (config('filament.layout.sidebar.is_collapsible_on_desktop'))
         x-cloak
-        x-bind:class="$store.sidebar.isOpen ? 'filament-sidebar-open translate-x-0 max-w-[75%] lg:max-w-[var(--sidebar-width)]' : '-translate-x-full lg:translate-x-0 lg:max-w-[var(--collapsed-sidebar-width)] rtl:lg:-translate-x-0 rtl:translate-x-full'"
+        x-bind:class="$store.sidebar.isOpen ? 'filament-sidebar-open translate-x-0 max-w-[20em] lg:max-w-[var(--sidebar-width)]' : '-translate-x-full lg:translate-x-0 lg:max-w-[var(--collapsed-sidebar-width)] rtl:lg:-translate-x-0 rtl:translate-x-full'"
     @else
         x-cloak="-lg"
         x-bind:class="$store.sidebar.isOpen ? 'filament-sidebar-open translate-x-0' : '-translate-x-full lg:translate-x-0 rtl:lg:-translate-x-0 rtl:translate-x-full'"

--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -44,6 +44,7 @@
             @endif
 
             <div
+                data-turbo="false"
                 @class([
                     'block w-full relative',
                     'lg:ml-3' => config('filament.layout.sidebar.is_collapsible_on_desktop') && (config('filament.layout.sidebar.collapsed_width') !== 0),
@@ -51,7 +52,6 @@
             >
                 <a
                     href="{{ config('filament.home_url') }}"
-                    data-turbo="false"
                     class="inline-block"
                 >
                     <x-filament::brand />

--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -2,7 +2,7 @@
     x-data="{}"
     @if (config('filament.layout.sidebar.is_collapsible_on_desktop'))
         x-cloak
-        x-bind:class="$store.sidebar.isOpen ? 'filament-sidebar-open translate-x-0 max-w-[16rem] lg:max-w-[var(--sidebar-width)]' : '-translate-x-full lg:translate-x-0 lg:max-w-[var(--collapsed-sidebar-width)] rtl:lg:-translate-x-0 rtl:translate-x-full'"
+        x-bind:class="$store.sidebar.isOpen ? 'filament-sidebar-open translate-x-0 max-w-[75%] lg:max-w-[var(--sidebar-width)]' : '-translate-x-full lg:translate-x-0 lg:max-w-[var(--collapsed-sidebar-width)] rtl:lg:-translate-x-0 rtl:translate-x-full'"
     @else
         x-cloak="-lg"
         x-bind:class="$store.sidebar.isOpen ? 'filament-sidebar-open translate-x-0' : '-translate-x-full lg:translate-x-0 rtl:lg:-translate-x-0 rtl:translate-x-full'"

--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -2,7 +2,7 @@
     x-data="{}"
     @if (config('filament.layout.sidebar.is_collapsible_on_desktop'))
         x-cloak
-        x-bind:class="$store.sidebar.isOpen ? 'filament-sidebar-open translate-x-0 max-w-[20em] lg:max-w-[var(--sidebar-width)]' : '-translate-x-full lg:translate-x-0 lg:max-w-[var(--collapsed-sidebar-width)] rtl:lg:-translate-x-0 rtl:translate-x-full'"
+        x-bind:class="$store.sidebar.isOpen ? 'filament-sidebar-open translate-x-0 max-w-[16rem] lg:max-w-[var(--sidebar-width)]' : '-translate-x-full lg:translate-x-0 lg:max-w-[var(--collapsed-sidebar-width)] rtl:lg:-translate-x-0 rtl:translate-x-full'"
     @else
         x-cloak="-lg"
         x-bind:class="$store.sidebar.isOpen ? 'filament-sidebar-open translate-x-0' : '-translate-x-full lg:translate-x-0 rtl:lg:-translate-x-0 rtl:translate-x-full'"
@@ -43,16 +43,20 @@
                 </button>
             @endif
 
-            <a
-                href="{{ config('filament.home_url') }}"
-                data-turbo="false"
+            <div
                 @class([
-                    'block w-full',
+                    'block w-full relative',
                     'lg:ml-3' => config('filament.layout.sidebar.is_collapsible_on_desktop') && (config('filament.layout.sidebar.collapsed_width') !== 0),
                 ])
             >
-                <x-filament::brand />
-            </a>
+                <a
+                    href="{{ config('filament.home_url') }}"
+                    data-turbo="false"
+                    class="inline-block"
+                >
+                    <x-filament::brand />
+                </a>
+            </div>
         </div>
 
         @if (config('filament.layout.sidebar.is_collapsible_on_desktop'))


### PR DESCRIPTION
The mobile width was a little too wide, making it a little difficult to click outside of it with your thumb. Also, the brand in the Sidebar's header had a wide clickable area, which could cause a user to be redirected to the application's `home_url`, so I made the clickable area match the text width of the brand/application name.

### Before: Around 85% of Screen Width
![OldFilamentMobileUncollapsedSidebar](https://user-images.githubusercontent.com/104294090/235292139-8e734f85-0bad-47e1-bf8a-a6bb1299d4cd.png)

### After: 75% of Screen Width
![Screenshot 2023-04-29 080408](https://user-images.githubusercontent.com/104294090/235301575-bca6d7f5-b163-49b9-af1e-4e2ceb36b82c.png)