### PR TITLE
Add cell attributes to table columns

### DIFF
--- a/packages/admin/resources/views/pages/actions/modal/actions/button-action.blade.php
+++ b/packages/admin/resources/views/pages/actions/modal/actions/button-action.blade.php
@@ -25,7 +25,7 @@
     :icon="$getIcon()"
     :icon-position="$getIconPosition()"
     :size="$getSize()"
-    :attributes="$getExtraAttributeBag()"
+    :attributes="\Filament\Support\prepare_inherited_attributes($getExtraAttributeBag())"
     class="filament-page-modal-button-action"
 >
     {{ $getLabel() }}

--- a/packages/forms/resources/views/components/actions/modal/actions/button-action.blade.php
+++ b/packages/forms/resources/views/components/actions/modal/actions/button-action.blade.php
@@ -25,7 +25,7 @@
     :icon="$getIcon()"
     :icon-position="$getIconPosition()"
     :size="$getSize()"
-    :attributes="$getExtraAttributeBag()"
+    :attributes="\Filament\Support\prepare_inherited_attributes($getExtraAttributeBag())"
     class="filament-forms-modal-button-action"
 >
     {{ $getLabel() }}

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -116,10 +116,10 @@
             :two-xl="$getColumns('2xl')"
             :direction="$gridDirection ?? 'column'"
             :x-show="$isSearchable() ? 'visibleCheckboxListOptions.length' : null"
-            :attributes="$attributes->class([
+            :attributes="\Filament\Support\prepare_inherited_attributes($attributes->class([
                 'filament-forms-checkbox-list-component gap-1',
                 'space-y-2' => $gridDirection !== 'row',
-            ])"
+            ]))"
         >
             @forelse ($getOptions() as $optionValue => $optionLabel)
                 <div wire:key="{{ $this->id }}.{{ $getStatePath() }}.{{ $field::class }}.options.{{ $optionValue }}">

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -23,10 +23,10 @@
                 :two-xl="$getColumns('2xl')"
                 :is-grid="! $isInline()"
                 direction="column"
-                :attributes="$attributes->merge($getExtraAttributes())->class([
+                :attributes="\Filament\Support\prepare_inherited_attributes($attributes->merge($getExtraAttributes())->class([
                     'filament-forms-radio-component flex flex-wrap gap-3',
                     'flex-col' => ! $isInline(),
-                ])"
+                ]))"
             >
                 @php
                     $isDisabled = $isDisabled();
@@ -36,7 +36,7 @@
                     @php
                         $shouldOptionBeDisabled = $isDisabled || $isOptionDisabled($value, $label);
                     @endphp
-                    
+
                     <div @class([
                         'flex items-start',
                         'gap-3' => ! $isInline(),

--- a/packages/tables/resources/views/actions/modal/actions/button-action.blade.php
+++ b/packages/tables/resources/views/actions/modal/actions/button-action.blade.php
@@ -25,7 +25,7 @@
     :icon="$getIcon()"
     :icon-position="$getIconPosition()"
     :size="$getSize()"
-    :attributes="$getExtraAttributeBag()"
+    :attributes="\Filament\Support\prepare_inherited_attributes($getExtraAttributeBag())"
     class="filament-tables-modal-button-action"
 >
     {{ $getLabel() }}

--- a/packages/tables/resources/views/components/cell.blade.php
+++ b/packages/tables/resources/views/components/cell.blade.php
@@ -1,5 +1,9 @@
+@props([
+    'extraAttributes' => [],
+])
+
 <td
-    {{ $attributes->class([
+    {{ $attributes->merge($extraAttributes)->class([
         'filament-tables-cell',
         'dark:text-white' => config('tables.dark_mode'),
     ]) }}

--- a/packages/tables/resources/views/components/cell.blade.php
+++ b/packages/tables/resources/views/components/cell.blade.php
@@ -1,16 +1,6 @@
-@props([
-    'extraAttributes' => [],
-])
-
-<td
-    {{
-        $attributes
-            ->merge($extraAttributes)
-            ->class([
-                'filament-tables-cell',
-                'dark:text-white' => config('tables.dark_mode'),
-            ])
-    }}
->
+<td {{ $attributes->class([
+    'filament-tables-cell',
+    'dark:text-white' => config('tables.dark_mode'),
+]) }}>
     {{ $slot }}
 </td>

--- a/packages/tables/resources/views/components/cell.blade.php
+++ b/packages/tables/resources/views/components/cell.blade.php
@@ -3,10 +3,14 @@
 ])
 
 <td
-    {{ $attributes->merge($extraAttributes)->class([
-        'filament-tables-cell',
-        'dark:text-white' => config('tables.dark_mode'),
-    ]) }}
+    {{
+        $attributes
+            ->merge($extraAttributes)
+            ->class([
+                'filament-tables-cell',
+                'dark:text-white' => config('tables.dark_mode'),
+            ])
+    }}
 >
     {{ $slot }}
 </td>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -827,6 +827,7 @@
                                     @endphp
 
                                     <x-tables::cell
+                                        :extra-attributes="$column->getExtraCellAttributes()"
                                         class="filament-table-cell-{{ \Illuminate\Support\Str::of($column->getName())->camel()->kebab() }} {{ $getHiddenClasses($column) }}"
                                         wire:key="{{ $this->id }}.table.record.{{ $recordKey }}.column.{{ $column->getName() }}"
                                         wire:loading.remove.delay

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -318,7 +318,7 @@
                             fn (\Filament\Tables\Columns\Column $column): bool => $column->isSortable(),
                         );
                     @endphp
-                    
+
                     <div @class([
                         'bg-gray-500/5 flex items-center gap-4 px-4 border-b',
                         'dark:border-gray-700' => config('tables.dark_mode'),
@@ -827,11 +827,11 @@
                                     @endphp
 
                                     <x-tables::cell
-                                        :extra-attributes="$column->getExtraCellAttributes()"
-                                        class="filament-table-cell-{{ \Illuminate\Support\Str::of($column->getName())->camel()->kebab() }} {{ $getHiddenClasses($column) }}"
                                         wire:key="{{ $this->id }}.table.record.{{ $recordKey }}.column.{{ $column->getName() }}"
                                         wire:loading.remove.delay
                                         wire:target="{{ implode(',', \Filament\Tables\Table::LOADING_TARGETS) }}"
+                                        class="filament-table-cell-{{ \Illuminate\Support\Str::of($column->getName())->camel()->kebab() }} {{ $getHiddenClasses($column) }}"
+                                        :attributes="\Filament\Support\prepare_inherited_attributes($column->getExtraCellAttributeBag())"
                                     >
                                         <x-tables::columns.column
                                             :column="$column"

--- a/packages/tables/src/Columns/Column.php
+++ b/packages/tables/src/Columns/Column.php
@@ -23,6 +23,7 @@ class Column extends ViewComponent
     use Concerns\CanOpenUrl;
     use Concerns\CanSpanColumns;
     use Concerns\HasAlignment;
+    use Concerns\HasExtraCellAttributes;
     use Concerns\HasExtraHeaderAttributes;
     use Concerns\HasLabel;
     use Concerns\HasRowLoopObject;

--- a/packages/tables/src/Columns/Concerns/HasExtraCellAttributes.php
+++ b/packages/tables/src/Columns/Concerns/HasExtraCellAttributes.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Filament\Tables\Columns\Concerns;
+
+use Closure;
+use Illuminate\View\ComponentAttributeBag;
+
+trait HasExtraCellAttributes
+{
+    protected array $extraCellAttributes = [];
+
+    public function extraCellAttributes(array | Closure $attributes, bool $merge = false): static
+    {
+        if ($merge) {
+            $this->extraCellAttributes[] = $attributes;
+        } else {
+            $this->extraCellAttributes = [$attributes];
+        }
+
+        return $this;
+    }
+
+    public function getExtraCellAttributes(): array
+    {
+        $temporaryAttributeBag = new ComponentAttributeBag();
+
+        foreach ($this->extraCellAttributes as $extraCellAttributes) {
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraCellAttributes));
+        }
+
+        return $temporaryAttributeBag->getAttributes();
+    }
+
+    public function getExtraCellAttributeBag(): ComponentAttributeBag
+    {
+        return new ComponentAttributeBag($this->getExtraCellAttributes());
+    }
+}


### PR DESCRIPTION
Add attributes directly to the table cell `<td>` - `extraAttributes` is already added to a cell but it's nested 3 levels deep. 

Needed to change vertical alignment of particular column/cell. 