### PR TITLE
Add commas to code block describing sentences

### DIFF
--- a/packages/tables/docs/07-testing.md
+++ b/packages/tables/docs/07-testing.md
@@ -18,7 +18,7 @@ it('can render page', function () {
 });
 ```
 
-To to test which records are shown, you can use `assertCanSeeTableRecords()`, `assertCanNotSeeTableRecords()` and `assertCountTableRecords()`
+To to test which records are shown, you can use `assertCanSeeTableRecords()`, `assertCanNotSeeTableRecords()` and `assertCountTableRecords()`:
 
 ```php
 use function Pest\Livewire\livewire;
@@ -223,7 +223,7 @@ it('displays author in red', function () {
 
 ### Select Columns
 
-If you have a select column, you can ensure it has the correct options with `assertSelectColumnHasOptions()` and `assertSelectColumnDoesNotHaveOptions()`
+If you have a select column, you can ensure it has the correct options with `assertSelectColumnHasOptions()` and `assertSelectColumnDoesNotHaveOptions()`:
 
 ```php
 use function Pest\Livewire\livewire;
@@ -352,7 +352,7 @@ it('can delete posts', function () {
 
 This example assumes that you have a `DeleteAction` on your table. If you have a custom `Action::make('reorder')`, you may use `callTableAction('reorder')`.
 
-For column actions, you may do the same, using `callTableColumnAction()`,
+For column actions, you may do the same, using `callTableColumnAction()`:
 
 ```php
 use function Pest\Livewire\livewire;


### PR DESCRIPTION
This isn't much, but after seeing 2dac6cb46240954aa8d16713269c9747d99fee18 on the PR, decided to see if any other docs were missing the colons. 