### PR TITLE
Add stacking to images

### DIFF
--- a/packages/tables/docs/03-columns/04-image.md
+++ b/packages/tables/docs/03-columns/04-image.md
@@ -77,23 +77,36 @@ ImageColumn::make('logo')
     ->extraImgAttributes(['title' => 'Company logo']),
 ```
 
-## Stacking images
+## Multiple images
 
-You may show a relationship of images as a stack using `stacked()`.  The name of the relationship comes first, followed by a period, followed by the name of the column to display:
+You may display multiple images from an array:
 
 ```php
-ImageColumn::make('users.avatar')
+ImageColumn::make('images')
     ->circular()
-    ->stacked()
 ```
 
-### Using a separator
-
-Instead of using a relationship, you may use a separated string by passing the separator into `separator()`:
+Be sure to add an `array` [cast](https://laravel.com/docs/eloquent-mutators#array-and-json-casting) to the model property:
 
 ```php
-ImageColumn::make('product_images')
-    ->separator(',')
+use Illuminate\Database\Eloquent\Model;
+
+class Product extends Model
+{
+    protected $casts = [
+        'images' => 'array',
+    ];
+
+    // ...
+}
+```
+
+## Stacking images
+
+You may display multiple images as a stack of overlapping images by using `stacked()`:
+
+```php
+ImageColumn::make('images')
     ->circular()
     ->stacked()
 ```
@@ -103,7 +116,7 @@ ImageColumn::make('product_images')
 You may set a limit to the number of images you want to display by passing `limit()`:
 
 ```php
-ImageColumn::make('orderItems.image')
+ImageColumn::make('images')
     ->circular()
     ->stacked()
     ->limit(3)
@@ -114,7 +127,7 @@ ImageColumn::make('orderItems.image')
 When you set a limit you may also display the count of remaining images by passing `showRemaining()`. 
 
 ```php
-ImageColumn::make('orderItems.image')
+ImageColumn::make('images')
     ->circular()
     ->stacked()
     ->limit(3)

--- a/packages/tables/docs/03-columns/04-image.md
+++ b/packages/tables/docs/03-columns/04-image.md
@@ -76,3 +76,71 @@ use Filament\Tables\Columns\ImageColumn;
 ImageColumn::make('logo')
     ->extraImgAttributes(['title' => 'Company logo']),
 ```
+
+## Stacking images
+
+You may show a relationship of images as a stack using `stacked()`.  The name of the relationship comes first, followed by a period, followed by the name of the column to display:
+
+```php
+ImageColumn::make('users.avatar')
+    ->circular()
+    ->stacked()
+```
+
+### Using a separator
+
+Instead of using a relationship, you may use a separated string by passing the separator into `separator()`:
+
+```php
+ImageColumn::make('product_images')
+    ->separator(',')
+    ->circular()
+    ->stacked()
+```
+
+### Setting a limit
+
+You may set a limit to the number of images you want to display by passing `limit()`:
+
+```php
+ImageColumn::make('orderItems.image')
+    ->circular()
+    ->stacked()
+    ->limit(3)
+```
+
+### Showing the remaining images count
+
+When you set a limit you may also display the count of remaining images by passing `showRemaining()`. 
+
+```php
+ImageColumn::make('orderItems.image')
+    ->circular()
+    ->stacked()
+    ->limit(3)
+    ->showRemaining()
+```
+
+By default, `showRemaining()` will display the count of remaining images as a number stacked on the other images. If you prefer to show the count as a number after the images you may use `showRemainingAfterStack()`. You may also set the text size by using `remainingTextSize('xs')`;
+
+### Customizing the ring width
+
+The default ring width is `ring-3` but you may customize the ring width to be either `0`, `1`, `2`, or `4` which correspond to tailwinds `ring-widths`: `ring-0`, `ring-1`, `ring-2`, and `ring-4` respectively.
+
+```php
+ImageColumn::make('users.avatar')
+    ->circular()
+    ->stacked()
+    ->ring(3)
+```
+
+### Customizing the overlap
+
+The default overlap is `-space-x-1` but you may customize the overlap to be either `0`, `1`, `2`, `3`, or `4` which correspond to tailwinds `space-x` options: `space-x-0`, `-space-x-1`, `-space-x-2`, `-space-x-3`, and `-space-x-4` respectively.
+
+```php
+ImageColumn::make('users.avatar')
+    ->circular()
+    ->stacked()
+    ->overlap(3)
+```

--- a/packages/tables/resources/views/columns/image-column.blade.php
+++ b/packages/tables/resources/views/columns/image-column.blade.php
@@ -40,25 +40,23 @@
                     },
                 ])
             >
-                @foreach (array_slice($getImages(), 0, $getLimit()) as $image)
-                    @if ($path = $getStackedImagePath($image))
-                        @php
-                            $imageCount ++;
-                        @endphp
-                        <img
-                            src="{{ $path }}"
-                            style="
-                                {!! $height !== null ? "height: {$height};" : null !!}
-                                {!! $width !== null ? "width: {$width};" : null !!}
-                            "
-                            {{ $getExtraImgAttributeBag()->class([
-                                'max-w-none ring-white',
-                                'dark:ring-gray-800' => config('tables.dark_mode'),
-                                'rounded-full' => $isCircular(),
-                                $ring,
-                            ]) }}
-                        >
-                    @endif
+                @foreach ($getImagesWithPath() as $path)
+                    @php
+                        $imageCount ++;
+                    @endphp
+                    <img
+                        src="{{ $path }}"
+                        style="
+                            {!! $height !== null ? "height: {$height};" : null !!}
+                            {!! $width !== null ? "width: {$width};" : null !!}
+                        "
+                        {{ $getExtraImgAttributeBag()->class([
+                            'max-w-none ring-white',
+                            'dark:ring-gray-800' => config('tables.dark_mode'),
+                            'rounded-full' => $isCircular(),
+                            $ring,
+                        ]) }}
+                    >
                 @endforeach
 
                 @if ($shouldShowRemaining() && (! $shouldShowRemainingAfterStack()) && ($imageCount < count($getImages())))

--- a/packages/tables/resources/views/columns/image-column.blade.php
+++ b/packages/tables/resources/views/columns/image-column.blade.php
@@ -44,6 +44,7 @@
                     @php
                         $imageCount ++;
                     @endphp
+                    
                     <img
                         src="{{ $path }}"
                         style="

--- a/packages/tables/resources/views/columns/image-column.blade.php
+++ b/packages/tables/resources/views/columns/image-column.blade.php
@@ -41,7 +41,7 @@
                 ])
             >
                 @foreach (array_slice($getImages(), 0, $getLimit()) as $image)
-                    @if ($path = $getImagePath($image))
+                    @if ($path = $getStackedImagePath($image))
                         @php
                             $imageCount ++;
                         @endphp

--- a/packages/tables/resources/views/columns/image-column.blade.php
+++ b/packages/tables/resources/views/columns/image-column.blade.php
@@ -5,29 +5,120 @@
     @php
         $height = $getHeight();
         $width = $getWidth() ?? ($isCircular() || $isSquare() ? $height : null);
+        $overlap = $getOverlap() ?? 'sm';
+        $imageCount = 0;
+
+        $ring = match ($getRing()) {
+            0 => 'ring-0',
+            1 => 'ring-1',
+            2 => 'ring-2',
+            4 => 'ring-4',
+            default => 'ring',
+        };
+
+        $remainingTextSize = match ($getRemainingTextSize()) {
+            'xs' => 'text-xs',
+            'sm' => 'text-sm',
+            'md' => 'text-md',
+            'lg' => 'text-lg',
+            default => 'text-sm',
+        };
     @endphp
 
-    <div
-        style="
-            {!! $height !== null ? "height: {$height};" : null !!}
-            {!! $width !== null ? "width: {$width};" : null !!}
-        "
-        @class([
-            'overflow-hidden' => $isCircular() || $isSquare(),
-            'rounded-full' => $isCircular(),
-        ])
-    >
-        @if ($path = $getImagePath())
-            <img
-                src="{{ $path }}"
-                style="
-                    {!! $height !== null ? "height: {$height};" : null !!}
-                    {!! $width !== null ? "width: {$width};" : null !!}
-                "
-                {{ $getExtraImgAttributeBag()->class([
-                    'object-cover object-center' => $isCircular() || $isSquare(),
-                ]) }}
+    @if ($isStacked())
+        <div class="flex items-center space-x-2">
+            <div 
+                @class([
+                    'flex',
+                    match ($overlap) {
+                        0 => 'space-x-0',
+                        1 => '-space-x-1',
+                        2 => '-space-x-2',
+                        3 => '-space-x-3',
+                        4 => '-space-x-4',
+                        default => '-space-x-1',
+                    },
+                ])
             >
-       @endif
-    </div>
+                @foreach (array_slice($getImages(), 0, $getLimit()) as $image)
+                    @if ($path = $getImagePath($image))
+                        @php
+                            $imageCount ++;
+                        @endphp
+                        <img
+                            src="{{ $path }}"
+                            style="
+                                {!! $height !== null ? "height: {$height};" : null !!}
+                                {!! $width !== null ? "width: {$width};" : null !!}
+                            "
+                            {{ $getExtraImgAttributeBag()->class([
+                                'max-w-none ring-white',
+                                'dark:ring-gray-800' => config('tables.dark_mode'),
+                                'rounded-full' => $isCircular(),
+                                $ring,
+                            ]) }}
+                        >
+                    @endif
+                @endforeach
+
+                @if ($shouldShowRemaining() && (! $shouldShowRemainingAfterStack()) && ($imageCount < count($getImages())))
+                    <div 
+                        style="
+                            {!! $height !== null ? "height: {$height};" : null !!}
+                            {!! $width !== null ? "width: {$width};" : null !!}
+                        "
+                        @class([
+                            'flex items-center justify-center bg-gray-100 text-gray-500 ring-white',
+                            'dark:bg-gray-600 dark:text-gray-300 dark:ring-gray-800' => config('tables.dark_mode'),
+                            'rounded-full' => $isCircular(),
+                            $remainingTextSize,
+                            $ring,
+                        ])
+                    >
+                        <span class="-ml-1">
+                            +{{ count($getImages()) - $imageCount }}
+                        </span>
+                    </div>
+                @endif
+
+            </div>
+            
+            @if ($shouldShowRemaining() && $shouldShowRemainingAfterStack() && ($imageCount < count($getImages())))
+                <div 
+                    @class([
+                        'text-gray-500',
+                        'dark:text-gray-300' => config('tables.dark_mode'),
+                        $remainingTextSize,
+                    ])
+                >
+                    +{{ count($getImages()) - $imageCount }}
+                </div>
+            @endif
+
+        </div>
+    @else
+        <div
+            style="
+                {!! $height !== null ? "height: {$height};" : null !!}
+                {!! $width !== null ? "width: {$width};" : null !!}
+            "
+            @class([
+                'overflow-hidden' => $isCircular() || $isSquare(),
+                'rounded-full' => $isCircular(),
+            ])
+        >
+            @if ($path = $getImagePath())
+                <img
+                    src="{{ $path }}"
+                    style="
+                        {!! $height !== null ? "height: {$height};" : null !!}
+                        {!! $width !== null ? "width: {$width};" : null !!}
+                    "
+                    {{ $getExtraImgAttributeBag()->class([
+                        'object-cover object-center' => $isCircular() || $isSquare(),
+                    ]) }}
+                >
+            @endif
+        </div>
+    @endif
 </div>

--- a/packages/tables/resources/views/columns/image-column.blade.php
+++ b/packages/tables/resources/views/columns/image-column.blade.php
@@ -1,11 +1,14 @@
-<div {{ $attributes->merge($getExtraAttributes())->class([
+<div {{ $attributes->merge($getExtraAttributes(), escape: false)->class([
     'filament-tables-image-column',
     'px-4 py-3' => ! $isInline(),
 ]) }}>
     @php
+        $images = $getImages();
+        $isCircular = $isCircular();
+        $isSquare = $isSquare();
         $height = $getHeight();
-        $width = $getWidth() ?? ($isCircular() || $isSquare() ? $height : null);
-        $overlap = $getOverlap() ?? 'sm';
+        $width = $getWidth() ?? ($isCircular || $isSquare ? $height : null);
+        $overlap = $isStacked() ? ($getOverlap() ?? 1) : null;
         $imageCount = 0;
 
         $ring = match ($getRing()) {
@@ -25,7 +28,7 @@
         };
     @endphp
 
-    @if ($isStacked())
+    @if ($images)
         <div class="flex items-center space-x-2">
             <div 
                 @class([
@@ -36,11 +39,11 @@
                         2 => '-space-x-2',
                         3 => '-space-x-3',
                         4 => '-space-x-4',
-                        default => '-space-x-1',
+                        default => 'space-x-1',
                     },
                 ])
             >
-                @foreach ($getImagesWithPath() as $path)
+                @foreach ($images as $path)
                     @php
                         $imageCount ++;
                     @endphp
@@ -48,24 +51,23 @@
                     <img
                         src="{{ $path }}"
                         style="
-                            {!! $height !== null ? "height: {$height};" : null !!}
-                            {!! $width !== null ? "width: {$width};" : null !!}
+                            @if ($height) height: {{ $height }}; @endif
+                            @if ($width) width: {{ $width }}; @endif
                         "
-
                         {{ $getExtraImgAttributeBag()->class([
                             'max-w-none ring-white object-cover object-center',
                             'dark:ring-gray-800' => config('tables.dark_mode'),
-                            'rounded-full' => $isCircular(),
+                            'rounded-full' => $isCircular,
                             $ring,
                         ]) }}
                     >
                 @endforeach
 
-                @if ($shouldShowRemaining() && (! $shouldShowRemainingAfterStack()) && ($imageCount < count($getImages())))
+                @if ($shouldShowRemaining() && (! $shouldShowRemainingAfterStack()) && ($imageCount < count($images)))
                     <div 
                         style="
-                            {!! $height !== null ? "height: {$height};" : null !!}
-                            {!! $width !== null ? "width: {$width};" : null !!}
+                            @if ($height) height: {{ $height }}; @endif
+                            @if ($width) width: {{ $width }}; @endif
                         "
                         @class([
                             'flex items-center justify-center bg-gray-100 text-gray-500 ring-white',
@@ -76,14 +78,14 @@
                         ])
                     >
                         <span class="-ml-1">
-                            +{{ count($getImages()) - $imageCount }}
+                            +{{ count($images) - $imageCount }}
                         </span>
                     </div>
                 @endif
 
             </div>
             
-            @if ($shouldShowRemaining() && $shouldShowRemainingAfterStack() && ($imageCount < count($getImages())))
+            @if ($shouldShowRemaining() && $shouldShowRemainingAfterStack() && ($imageCount < count($images)))
                 <div 
                     @class([
                         'text-gray-500',
@@ -91,7 +93,7 @@
                         $remainingTextSize,
                     ])
                 >
-                    +{{ count($getImages()) - $imageCount }}
+                    +{{ count($images) - $imageCount }}
                 </div>
             @endif
 
@@ -99,26 +101,26 @@
     @else
         <div
             style="
-                {!! $height !== null ? "height: {$height};" : null !!}
-                {!! $width !== null ? "width: {$width};" : null !!}
+                @if ($height) height: {{ $height }}; @endif
+                @if ($width) width: {{ $width }}; @endif
             "
             @class([
-                'overflow-hidden' => $isCircular() || $isSquare(),
-                'rounded-full' => $isCircular(),
+                'overflow-hidden' => $isCircular || $isSquare,
+                'rounded-full' => $isCircular,
             ])
         >
             @if ($path = $getImagePath())
                 <img
                     src="{{ $path }}"
                     style="
-                        {!! $height !== null ? "height: {$height};" : null !!}
-                        {!! $width !== null ? "width: {$width};" : null !!}
+                        @if ($height) height: {{ $height }}; @endif
+                        @if ($width) width: {{ $width }}; @endif
                     "
                     {{ $getExtraImgAttributeBag()->class([
-                        'object-cover object-center' => $isCircular() || $isSquare(),
+                        'object-cover object-center' => $isCircular || $isSquare,
                     ]) }}
                 >
-            @endif
+        @endif
         </div>
     @endif
 </div>

--- a/packages/tables/resources/views/columns/image-column.blade.php
+++ b/packages/tables/resources/views/columns/image-column.blade.php
@@ -50,8 +50,9 @@
                             {!! $height !== null ? "height: {$height};" : null !!}
                             {!! $width !== null ? "width: {$width};" : null !!}
                         "
+
                         {{ $getExtraImgAttributeBag()->class([
-                            'max-w-none ring-white',
+                            'max-w-none ring-white object-cover object-center',
                             'dark:ring-gray-800' => config('tables.dark_mode'),
                             'rounded-full' => $isCircular(),
                             $ring,

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -216,9 +216,12 @@ class ImageColumn extends Column
         return $this->evaluate($this->isStacked);
     }
 
-    public function getStackedImagePath(string | null $image = null): ?string
+    public function getImagesWithPath(): array
     {
-        return $this->getPath($image);
+        return collect($this->getImages())
+            ->filter(fn ($image) => $this->getPath($image))
+            ->take($this->getLimit())
+            ->toArray();
     }
 
     public function getImages(): array
@@ -330,7 +333,7 @@ class ImageColumn extends Column
 
     protected function getPath(string | null $image = null): ?string
     {
-        $state = $image ?: $this->getState();
+        $state = $image ?? $this->getState();
         
         if (! $state) {
             return null;

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -28,6 +28,22 @@ class ImageColumn extends Column
 
     protected array $extraImgAttributes = [];
 
+    protected bool | Closure $isStacked = false;
+
+    protected string | Closure | null $separator = null;
+
+    protected int | Closure | null $overlap = null;
+
+    protected int | Closure | null $ring = null;
+    
+    protected int | Closure | null $limit = null;
+
+    protected bool | Closure $shouldShowRemaining = false;
+
+    protected bool | Closure $shouldShowRemainingAfterStack = false;
+
+    protected string | Closure | null $remainingTextSize = null;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -118,10 +134,10 @@ class ImageColumn extends Column
         return $height;
     }
 
-    public function getImagePath(): ?string
+    public function getImagePath(string | null $image = null): ?string
     {
-        $state = $this->getState();
-
+        $state = $image ?: $this->getState();
+        
         if (! $state) {
             return null;
         }
@@ -218,5 +234,124 @@ class ImageColumn extends Column
     public function getExtraImgAttributeBag(): ComponentAttributeBag
     {
         return new ComponentAttributeBag($this->getExtraImgAttributes());
+    }
+
+    public function stacked(bool | Closure $condition = true): static
+    {
+        $this->isStacked = $condition;
+
+        return $this;
+    }
+
+    public function isStacked(): bool
+    {
+        return $this->evaluate($this->isStacked);
+    }
+
+    public function getImages(): array
+    {        
+        $images = $this->getState();
+
+        if (is_array($images)) {
+            return $images;
+        }
+
+        if (! ($separator = $this->getSeparator())) {
+            return [];
+        }
+
+        $images = explode($separator, $images);
+
+        if (count($images) === 1 && blank($images[0])) {
+            $images = [];
+        }
+
+        return $images;
+    }
+
+    public function separator(string | Closure | null $separator = ','): static
+    {
+        $this->separator = $separator;
+
+        return $this;
+    }
+
+    public function getSeparator(): ?string
+    {
+        return $this->evaluate($this->separator);
+    }
+
+    public function overlap(int | Closure | null $overlap): static
+    {
+        $this->overlap = $overlap;
+
+        return $this;
+    }
+
+    public function getOverlap(): ?int
+    {
+        return $this->evaluate($this->overlap);
+    }
+
+    public function ring(string | Closure | null $ring): static
+    {
+        $this->ring = $ring;
+
+        return $this;
+    }
+
+    public function getRing(): ?int
+    {
+        return $this->evaluate($this->ring);
+    }
+
+    public function limit(int | Closure | null $limit = 3): static
+    {
+        $this->limit = $limit;
+
+        return $this;
+    }
+
+    public function getLimit(): ?int
+    {
+        return $this->evaluate($this->limit);
+    }
+
+    public function showRemaining(bool | Closure $condition = true, bool | Closure $showRemainingAfterStack = false, string | Closure | null $remainingTextSize = null): static
+    {
+        $this->shouldShowRemaining = $condition;
+        $this->showRemainingAfterStack($showRemainingAfterStack);
+        $this->remainingTextSize($remainingTextSize);
+
+        return $this;
+    }
+
+    public function showRemainingAfterStack(bool | Closure $condition = true): static
+    {
+        $this->shouldShowRemainingAfterStack = $condition;
+
+        return $this;
+    }
+
+    public function shouldShowRemaining(): bool
+    {
+        return $this->evaluate($this->shouldShowRemaining);
+    }
+
+    public function shouldShowRemainingAfterStack(): bool
+    {
+        return $this->evaluate($this->shouldShowRemainingAfterStack);
+    }
+
+    public function remainingTextSize(string | Closure | null $remainingTextSize): static
+    {
+        $this->remainingTextSize = $remainingTextSize;
+
+        return $this;
+    }
+
+    public function getRemainingTextSize(): ?string
+    {
+        return $this->evaluate($this->remainingTextSize);
     }
 }

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -213,7 +213,7 @@ class ImageColumn extends Column
 
     public function isStacked(): bool
     {
-        return $this->evaluate($this->isStacked);
+        return (bool) $this->evaluate($this->isStacked);
     }
 
     public function getImagesWithPath(): array
@@ -311,12 +311,12 @@ class ImageColumn extends Column
 
     public function shouldShowRemaining(): bool
     {
-        return $this->evaluate($this->shouldShowRemaining);
+        return (bool) $this->evaluate($this->shouldShowRemaining);
     }
 
     public function shouldShowRemainingAfterStack(): bool
     {
-        return $this->evaluate($this->shouldShowRemainingAfterStack);
+        return (bool) $this->evaluate($this->shouldShowRemainingAfterStack);
     }
 
     public function remainingTextSize(string | Closure | null $remainingTextSize): static

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -219,7 +219,7 @@ class ImageColumn extends Column
     public function getImagesWithPath(): array
     {
         return collect($this->getImages())
-            ->filter(fn ($image) => $this->getPath($image))
+            ->filter(fn ($image) => $this->getPath($image) !== null)
             ->take($this->getLimit())
             ->toArray();
     }

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -134,41 +134,9 @@ class ImageColumn extends Column
         return $height;
     }
 
-    public function getImagePath(string | null $image = null): ?string
+    public function getImagePath(): ?string
     {
-        $state = $image ?: $this->getState();
-        
-        if (! $state) {
-            return null;
-        }
-
-        if (filter_var($state, FILTER_VALIDATE_URL) !== false) {
-            return $state;
-        }
-
-        /** @var FilesystemAdapter $storage */
-        $storage = $this->getDisk();
-
-        try {
-            if (! $storage->exists($state)) {
-                return null;
-            }
-        } catch (UnableToCheckFileExistence $exception) {
-            return null;
-        }
-
-        if ($this->getVisibility() === 'private') {
-            try {
-                return $storage->temporaryUrl(
-                    $state,
-                    now()->addMinutes(5),
-                );
-            } catch (Throwable $exception) {
-                // This driver does not support creating temporary URLs.
-            }
-        }
-
-        return $storage->url($state);
+        return $this->getPath();
     }
 
     public function getVisibility(): string
@@ -246,6 +214,11 @@ class ImageColumn extends Column
     public function isStacked(): bool
     {
         return $this->evaluate($this->isStacked);
+    }
+
+    public function getStackedImagePath(string | null $image = null): ?string
+    {
+        return $this->getPath($image);
     }
 
     public function getImages(): array
@@ -353,5 +326,42 @@ class ImageColumn extends Column
     public function getRemainingTextSize(): ?string
     {
         return $this->evaluate($this->remainingTextSize);
+    }
+
+    protected function getPath(string | null $image = null): ?string
+    {
+        $state = $image ?: $this->getState();
+        
+        if (! $state) {
+            return null;
+        }
+
+        if (filter_var($state, FILTER_VALIDATE_URL) !== false) {
+            return $state;
+        }
+
+        /** @var FilesystemAdapter $storage */
+        $storage = $this->getDisk();
+
+        try {
+            if (! $storage->exists($state)) {
+                return null;
+            }
+        } catch (UnableToCheckFileExistence $exception) {
+            return null;
+        }
+
+        if ($this->getVisibility() === 'private') {
+            try {
+                return $storage->temporaryUrl(
+                    $state,
+                    now()->addMinutes(5),
+                );
+            } catch (Throwable $exception) {
+                // This driver does not support creating temporary URLs.
+            }
+        }
+
+        return $storage->url($state);
     }
 }


### PR DESCRIPTION
Per our discussion on Discord, this PR allows images to be stacked by extending the ImageColumn. 

I added all the additional methods at the end of `ImageColumn` to make it easier to review, but if you prefer to change the order let me know.

As for areas for improvement and future ideas:

1. **IMPLEMENTED:** _You will also see that I'm using the existing logic to only display images that return a path and then I add that to the $imageCount which I then use to calculate the remaining images. This works, however, if one or more images within the set `limit()` don't have an image, then the column could potentially not "fill up" the column with other available images._ 

_In other words, if the limit is set to 4, and say there are 8 potential `users.avatar`, if the users 3 & 4 dont have avatars, then the stack will only show 2 images and then it will say `+6` as the remaining. This is correct so it's not a bug, BUT ideally, we would continue to look through the remaining 4 images to see if there were 2 additional images so that we can show 4 images in the column._ 

_Not sure how big of a deal this is, but I didn't want to hold back on this initial PR to figure it out._

2. It might be nice to be able to add a z-index to the images on hover so they come to the front. 
3. It might also be neat to be able hover over the remaining count to show a window of the remaining images plus a field like name 
4. Right now when you hover over the row the row has it hover state color. The ring-color doesn't update to match this unfortunately. We'd have to add tailwind's `group` to the row class to enable this, but not sure if you want to do that or not.

Alright, let me know what changes need to be made!