### PR TITLE
Get form state before rate limiter so the form is validated

### DIFF
--- a/packages/app/src/Pages/Auth/EmailVerification/EmailVerificationPrompt.php
+++ b/packages/app/src/Pages/Auth/EmailVerification/EmailVerificationPrompt.php
@@ -43,7 +43,7 @@ class EmailVerificationPrompt extends CardPage
             ->label(__('filament::pages/auth/email-verification/email-verification-prompt.buttons.resend_notification.label') . '.')
             ->action(function (): void {
                 try {
-                    $this->rateLimit(1);
+                    $this->rateLimit(2);
                 } catch (TooManyRequestsException $exception) {
                     Notification::make()
                         ->title(__('filament::pages/auth/email-verification/email-verification-prompt.messages.notification_resend_throttled', [

--- a/packages/app/src/Pages/Auth/Login.php
+++ b/packages/app/src/Pages/Auth/Login.php
@@ -45,6 +45,8 @@ class Login extends CardPage
 
     public function authenticate(): ?LoginResponse
     {
+        $data = $this->form->getState();
+
         try {
             $this->rateLimit(5);
         } catch (TooManyRequestsException $exception) {
@@ -58,8 +60,6 @@ class Login extends CardPage
 
             return null;
         }
-
-        $data = $this->form->getState();
 
         if (! Filament::auth()->attempt([
             'email' => $data['email'],

--- a/packages/app/src/Pages/Auth/Login.php
+++ b/packages/app/src/Pages/Auth/Login.php
@@ -45,8 +45,6 @@ class Login extends CardPage
 
     public function authenticate(): ?LoginResponse
     {
-        $data = $this->form->getState();
-
         try {
             $this->rateLimit(5);
         } catch (TooManyRequestsException $exception) {
@@ -60,6 +58,8 @@ class Login extends CardPage
 
             return null;
         }
+
+        $data = $this->form->getState();
 
         if (! Filament::auth()->attempt([
             'email' => $data['email'],

--- a/packages/app/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
+++ b/packages/app/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
@@ -41,6 +41,8 @@ class RequestPasswordReset extends CardPage
 
     public function request(): void
     {
+        $data = $this->form->getState();
+
         try {
             $this->rateLimit(1);
         } catch (TooManyRequestsException $exception) {
@@ -54,8 +56,6 @@ class RequestPasswordReset extends CardPage
 
             return;
         }
-
-        $data = $this->form->getState();
 
         $status = Password::sendResetLink(
             $data,

--- a/packages/app/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
+++ b/packages/app/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
@@ -41,10 +41,8 @@ class RequestPasswordReset extends CardPage
 
     public function request(): void
     {
-        $data = $this->form->getState();
-
         try {
-            $this->rateLimit(1);
+            $this->rateLimit(2);
         } catch (TooManyRequestsException $exception) {
             Notification::make()
                 ->title(__('filament::pages/auth/password-reset/request-password-reset.messages.throttled', [
@@ -56,6 +54,8 @@ class RequestPasswordReset extends CardPage
 
             return;
         }
+
+        $data = $this->form->getState();
 
         $status = Password::sendResetLink(
             $data,

--- a/packages/app/src/Pages/Auth/PasswordReset/ResetPassword.php
+++ b/packages/app/src/Pages/Auth/PasswordReset/ResetPassword.php
@@ -56,10 +56,8 @@ class ResetPassword extends CardPage
 
     public function resetPassword(): ?PasswordResetResponse
     {
-        $data = $this->form->getState();
-
         try {
-            $this->rateLimit(1);
+            $this->rateLimit(2);
         } catch (TooManyRequestsException $exception) {
             Notification::make()
                 ->title(__('filament::pages/auth/password-reset/reset-password.messages.throttled', [
@@ -71,6 +69,8 @@ class ResetPassword extends CardPage
 
             return null;
         }
+
+        $data = $this->form->getState();
 
         $data['email'] = $this->email;
         $data['token'] = $this->token;

--- a/packages/app/src/Pages/Auth/PasswordReset/ResetPassword.php
+++ b/packages/app/src/Pages/Auth/PasswordReset/ResetPassword.php
@@ -56,6 +56,8 @@ class ResetPassword extends CardPage
 
     public function resetPassword(): ?PasswordResetResponse
     {
+        $data = $this->form->getState();
+
         try {
             $this->rateLimit(1);
         } catch (TooManyRequestsException $exception) {
@@ -69,8 +71,6 @@ class ResetPassword extends CardPage
 
             return null;
         }
-
-        $data = $this->form->getState();
 
         $data['email'] = $this->email;
         $data['token'] = $this->token;

--- a/packages/app/src/Pages/Auth/Register.php
+++ b/packages/app/src/Pages/Auth/Register.php
@@ -48,10 +48,8 @@ class Register extends CardPage
 
     public function register(): ?RegistrationResponse
     {
-        $data = $this->form->getState();
-
         try {
-            $this->rateLimit(1);
+            $this->rateLimit(2);
         } catch (TooManyRequestsException $exception) {
             Notification::make()
                 ->title(__('filament::pages/auth/register.messages.throttled', [
@@ -63,6 +61,8 @@ class Register extends CardPage
 
             return null;
         }
+
+        $data = $this->form->getState();
 
         $user = $this->getUserModel()::create($data);
 

--- a/packages/app/src/Pages/Auth/Register.php
+++ b/packages/app/src/Pages/Auth/Register.php
@@ -48,6 +48,8 @@ class Register extends CardPage
 
     public function register(): ?RegistrationResponse
     {
+        $data = $this->form->getState();
+
         try {
             $this->rateLimit(1);
         } catch (TooManyRequestsException $exception) {
@@ -61,8 +63,6 @@ class Register extends CardPage
 
             return null;
         }
-
-        $data = $this->form->getState();
 
         $user = $this->getUserModel()::create($data);
 


### PR DESCRIPTION
Currently the rate limiter kicks in before the form is validated so you have to wait a whole minute if some input is invalid. In case of password validation this is really frustrating.