### PR TITLE
Add Welsh cy to date picker component

### DIFF
--- a/packages/forms/resources/js/components/date-time-picker.js
+++ b/packages/forms/resources/js/components/date-time-picker.js
@@ -498,6 +498,7 @@ const locales = {
     bs: require('dayjs/locale/bs'),
     ca: require('dayjs/locale/ca'),
     cs: require('dayjs/locale/cs'),
+    cy: require('dayjs/locale/cy'),
     da: require('dayjs/locale/da'),
     de: require('dayjs/locale/de'),
     en: require('dayjs/locale/en'),


### PR DESCRIPTION
The date picker dayjs does have the Walsh 'cy' locale:

- https://github.com/iamkun/dayjs/tree/dev/src/locale

The require has been added.

![image](https://user-images.githubusercontent.com/71503011/235937607-0b74c4f2-4448-46a8-93b4-507fec3b7e75.png)

Is this the only other additional step?