### PR TITLE
Support loading multiple relation counts

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
+++ b/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
@@ -82,7 +82,7 @@ trait CanAggregateRelatedModels
         return $this->evaluate($this->relationshipToAvg);
     }
 
-    public function getRelationshipToCount(): array | string | null
+    public function getRelationshipToCount(): string | array | null
     {
         return $this->evaluate($this->relationshipToCount);
     }

--- a/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
+++ b/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
@@ -12,7 +12,7 @@ trait CanAggregateRelatedModels
 
     protected string | array | Closure | null $relationshipsToCount = null;
 
-    protected string | Closure | null $relationshipsToExistenceCheck = null;
+    protected string | array | Closure | null $relationshipsToExistenceCheck = null;
 
     protected string | Closure | null $columnToMax = null;
 

--- a/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
+++ b/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
@@ -10,7 +10,7 @@ trait CanAggregateRelatedModels
 
     protected string | Closure | null $relationshipToAvg = null;
 
-    protected string | Closure | null | array $relationshipToCount = null;
+    protected string | array | Closure | null $relationshipToCount = null;
 
     protected string | Closure | null $relationshipToExistenceCheck = null;
 

--- a/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
+++ b/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
@@ -82,7 +82,7 @@ trait CanAggregateRelatedModels
         return $this->evaluate($this->relationshipToAvg);
     }
 
-    public function getRelationshipToCount(): array|string|null
+    public function getRelationshipToCount(): array | string | null
     {
         return $this->evaluate($this->relationshipToCount);
     }

--- a/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
+++ b/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
@@ -10,7 +10,7 @@ trait CanAggregateRelatedModels
 
     protected string | Closure | null $relationshipToAvg = null;
 
-    protected string | Closure | null $relationshipToCount = null;
+    protected string | Closure | null | array $relationshipToCount = null;
 
     protected string | Closure | null $relationshipToExistenceCheck = null;
 
@@ -34,7 +34,7 @@ trait CanAggregateRelatedModels
         return $this;
     }
 
-    public function counts(string | Closure | null $relationship): static
+    public function counts(string | Closure | null | array $relationship): static
     {
         $this->relationshipToCount = $relationship;
 
@@ -82,7 +82,7 @@ trait CanAggregateRelatedModels
         return $this->evaluate($this->relationshipToAvg);
     }
 
-    public function getRelationshipToCount(): ?string
+    public function getRelationshipToCount(): array|string|null
     {
         return $this->evaluate($this->relationshipToCount);
     }

--- a/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
+++ b/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
@@ -34,7 +34,7 @@ trait CanAggregateRelatedModels
         return $this;
     }
 
-    public function counts(string | Closure | null | array $relationship): static
+    public function counts(string | array | Closure | null $relationship): static
     {
         $this->relationshipToCount = $relationship;
 

--- a/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
+++ b/packages/tables/src/Columns/Concerns/CanAggregateRelatedModels.php
@@ -10,9 +10,9 @@ trait CanAggregateRelatedModels
 
     protected string | Closure | null $relationshipToAvg = null;
 
-    protected string | array | Closure | null $relationshipToCount = null;
+    protected string | array | Closure | null $relationshipsToCount = null;
 
-    protected string | Closure | null $relationshipToExistenceCheck = null;
+    protected string | Closure | null $relationshipsToExistenceCheck = null;
 
     protected string | Closure | null $columnToMax = null;
 
@@ -34,16 +34,16 @@ trait CanAggregateRelatedModels
         return $this;
     }
 
-    public function counts(string | array | Closure | null $relationship): static
+    public function counts(string | array | Closure | null $relationships): static
     {
-        $this->relationshipToCount = $relationship;
+        $this->relationshipsToCount = $relationships;
 
         return $this;
     }
 
-    public function exists(string | Closure | null $relationship): static
+    public function exists(string | array | Closure | null $relationships): static
     {
-        $this->relationshipToExistenceCheck = $relationship;
+        $this->relationshipsToExistenceCheck = $relationships;
 
         return $this;
     }
@@ -82,14 +82,14 @@ trait CanAggregateRelatedModels
         return $this->evaluate($this->relationshipToAvg);
     }
 
-    public function getRelationshipToCount(): string | array | null
+    public function getRelationshipsToCount(): string | array | null
     {
-        return $this->evaluate($this->relationshipToCount);
+        return $this->evaluate($this->relationshipsToCount);
     }
 
-    public function getRelationshipToExistenceCheck(): ?string
+    public function getRelationshipsToExistenceCheck(): string | array | null
     {
-        return $this->evaluate($this->relationshipToExistenceCheck);
+        return $this->evaluate($this->relationshipsToExistenceCheck);
     }
 
     public function getColumnToMax(): ?string

--- a/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 trait InteractsWithTableQuery
@@ -16,11 +17,11 @@ trait InteractsWithTableQuery
             filled([$this->getRelationshipToAvg(), $this->getColumnToAvg()]),
             fn ($query) => $query->withAvg($this->getRelationshipToAvg(), $this->getColumnToAvg())
         )->when(
-            filled($this->getRelationshipToCount()),
-            fn ($query) => $query->withCount($this->getRelationshipToCount())
+            filled($this->getRelationshipsToCount()),
+            fn ($query) => $query->withCount(Arr::wrap($this->getRelationshipsToCount()))
         )->when(
-            filled($this->getRelationshipToExistenceCheck()),
-            fn ($query) => $query->withExists($this->getRelationshipToExistenceCheck())
+            filled($this->getRelationshipsToExistenceCheck()),
+            fn ($query) => $query->withExists(Arr::wrap($this->getRelationshipsToExistenceCheck()))
         )->when(
             filled([$this->getRelationshipToMax(), $this->getColumnToMax()]),
             fn ($query) => $query->withMax($this->getRelationshipToMax(), $this->getColumnToMax())

--- a/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
@@ -17,7 +17,7 @@ trait InteractsWithTableQuery
             fn ($query) => $query->withAvg($this->getRelationshipToAvg(), $this->getColumnToAvg())
         )->when(
             filled($this->getRelationshipToCount()),
-            fn ($query) => $query->withCount([$this->getRelationshipToCount()])
+            fn ($query) => $query->withCount($this->getRelationshipToCount())
         )->when(
             filled($this->getRelationshipToExistenceCheck()),
             fn ($query) => $query->withExists($this->getRelationshipToExistenceCheck())


### PR DESCRIPTION
<!-- For visual changes, please include a screenshot/recording of before and after. -->
<!-- This allows us to review the pull request faster. -->

this allow to load multiple count relations

Utilis for example when in custom column you would access to multiple relations count

like this
```php
<?php

namespace App\Tables\Columns;

use Filament\Tables\Columns\Column;

class CustomColumn extends Column
{
    protected string $view = 'tables.columns.custom-column';

    public static function make(string $name): static
    {
        $static = app(static::class, ['name' => $name]);
        $static->configure();
        $static->counts(['comments', 'likes']);
        return $static;
    }
}

```