### PR TITLE
Do not send unnecessary headers when pretending to be a file

### DIFF
--- a/packages/admin/src/Http/Controllers/AssetController.php
+++ b/packages/admin/src/Http/Controllers/AssetController.php
@@ -79,6 +79,6 @@ class AssetController
             'Expires' => $this->getHttpDate($expires),
             'Cache-Control' => $cacheControl,
             'Last-Modified' => $this->getHttpDate($lastModified),
-        ]);
+        ])->send();
     }
 }

--- a/packages/admin/src/Http/Controllers/AssetController.php
+++ b/packages/admin/src/Http/Controllers/AssetController.php
@@ -79,6 +79,7 @@ class AssetController
             'Expires' => $this->getHttpDate($expires),
             'Cache-Control' => $cacheControl,
             'Last-Modified' => $this->getHttpDate($lastModified),
-        ])->send();
+        ])
+        ->send();
     }
 }

--- a/packages/admin/src/Http/Controllers/AssetController.php
+++ b/packages/admin/src/Http/Controllers/AssetController.php
@@ -74,12 +74,13 @@ class AssetController
             ]);
         }
 
-        return response()->file($path, [
-            'Content-Type' => $contentType,
-            'Expires' => $this->getHttpDate($expires),
-            'Cache-Control' => $cacheControl,
-            'Last-Modified' => $this->getHttpDate($lastModified),
-        ])
-        ->send();
+        return response()
+            ->file($path, [
+                'Content-Type' => $contentType,
+                'Expires' => $this->getHttpDate($expires),
+                'Cache-Control' => $cacheControl,
+                'Last-Modified' => $this->getHttpDate($lastModified),
+            ])
+            ->send();
     }
 }


### PR DESCRIPTION
This PR enhances the handling of Set-Cookie headers, which Laravel typically includes in every request. By preventing these headers, files can more effectively simulate being the requested assets. Additionally, this change has a positive impact on CloudFlare caching since CloudFlare bypasses all requests containing Set-Cookie headers, including static assets. This update ensures better caching behavior and improves overall performance.