### PR TITLE
Lighten secondary icon-button for dark mode

### DIFF
--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -19,6 +19,7 @@
         'text-primary-500 focus:bg-primary-500/10' => $color === 'primary',
         'text-danger-500 focus:bg-danger-500/10' => $color === 'danger',
         'text-gray-500 focus:bg-gray-500/10' => $color === 'secondary',
+        'dark:text-gray-400' => $color === 'secondary' && $darkMode,
         'text-success-500 focus:bg-success-500/10' => $color === 'success',
         'text-warning-500 focus:bg-warning-500/10' => $color === 'warning',
         'dark:hover:bg-gray-300/5' => $darkMode,


### PR DESCRIPTION
Small change to icon-button with secondary color. 

Before: 
<img width="563" alt="Screenshot 2023-05-04 at 18 09 02" src="https://user-images.githubusercontent.com/533658/236276714-171c269b-5158-45ec-bff3-32693b5b81af.png">

After
<img width="555" alt="Screenshot 2023-05-04 at 18 08 34" src="https://user-images.githubusercontent.com/533658/236276721-16638f49-9ca6-4d60-9de1-94357429961b.png">
