### PR TITLE
Add x-cloak to collapsible nav groups

### DIFF
--- a/packages/admin/resources/views/components/layouts/app/sidebar/group.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/group.blade.php
@@ -46,8 +46,11 @@
     @endif
 
     <ul
-        x-show="! ($store.sidebar.groupIsCollapsed(label) && {{ config('filament.layout.sidebar.is_collapsible_on_desktop') ? '$store.sidebar.isOpen' : 'true' }})"
-        x-collapse.duration.200ms
+        @if ($collapsible)
+            x-cloak
+            x-show="! ($store.sidebar.groupIsCollapsed(label) && {{ config('filament.layout.sidebar.is_collapsible_on_desktop') ? '$store.sidebar.isOpen' : 'true' }})"
+            x-collapse.duration.200ms
+        @endif
         @class([
             'text-sm space-y-1 -mx-3',
             'mt-2' => $label,


### PR DESCRIPTION
While alpine is loading all nav groups are visible and if this exceeds the window height you get a nasty scrollbar jump.