### PR TITLE
Fix options not resetting after backspacing

### DIFF
--- a/packages/forms/resources/js/components/select.js
+++ b/packages/forms/resources/js/components/select.js
@@ -60,6 +60,7 @@ export default (Alpine) => {
                         searchPlaceholderValue: searchPrompt,
                         searchResultLimit: optionsLimit,
                         shouldSort: false,
+                        searchFloor: 0,
                     })
 
                     await this.refreshChoices({ withInitialOptions: true })
@@ -112,16 +113,16 @@ export default (Alpine) => {
                             async (event) => {
                                 let search = event.detail.value?.trim()
 
-                                if ([null, undefined, ''].includes(search)) {
-                                    return
-                                }
+                                let label = [null, undefined, ''].includes(search)
+                                    ? loadingMessage
+                                    : searchingMessage
 
                                 this.isSearching = true
 
                                 this.select.clearChoices()
                                 await this.select.setChoices([
                                     {
-                                        label: searchingMessage,
+                                        label: label,
                                         value: '',
                                         disabled: true,
                                     },

--- a/packages/forms/resources/js/components/select.js
+++ b/packages/forms/resources/js/components/select.js
@@ -60,7 +60,7 @@ export default (Alpine) => {
                         searchPlaceholderValue: searchPrompt,
                         searchResultLimit: optionsLimit,
                         shouldSort: false,
-                        searchFloor: 0,
+                        searchFloor: hasDynamicSearchResults ? 0 : 1,
                     })
 
                     await this.refreshChoices({ withInitialOptions: true })


### PR DESCRIPTION
This PR _mostly_ fixes resetting the select field options when backspacing. Currently, when you search in a select field and then backspace to clear the search term, it will NOT reset to show all the available options when `preload()` is used. The only way to get the original list of options back is to click outside the select filter to close it (thus removing the options from the dom), and then reclicking the select field to open it again.

DEMO:
https://user-images.githubusercontent.com/6097099/236594843-c6008001-f749-412f-bb4f-d6bf116e04f3.mov

This PR mostly fixes it by setting the `searchFloor` in `choices.js` in `select.js` to 0 which allows a backspace on an empty search box to register as a search. I say _mostly_ because it still does not register the first backspace on an empty search box. It takes 2 backspaces to trigger the options to reset. It's not ideal, BUT I think this is a better UX because I think most people just keep smashing the backspace key until things clear up. This at least allows the list of options to reset with enough backspaces.

AFTER:
https://user-images.githubusercontent.com/6097099/236594975-43d7e245-2e52-42d0-90bc-3a9367e620c7.mov