### PR TITLE
Add ability to search values in select fields

### DIFF
--- a/packages/forms/resources/js/components/select.js
+++ b/packages/forms/resources/js/components/select.js
@@ -26,6 +26,7 @@ export default (Alpine) => {
             searchDebounce,
             searchingMessage,
             searchPrompt,
+            searchFields,
             state,
         }) => {
             return {
@@ -56,7 +57,7 @@ export default (Alpine) => {
                         position: position ?? 'auto',
                         removeItemButton: true,
                         renderChoiceLimit: optionsLimit,
-                        searchFields: ['label'],
+                        searchFields: searchFields ?? ['label'],
                         searchPlaceholderValue: searchPrompt,
                         searchResultLimit: optionsLimit,
                         shouldSort: false,

--- a/packages/forms/resources/js/components/select.js
+++ b/packages/forms/resources/js/components/select.js
@@ -26,7 +26,7 @@ export default (Alpine) => {
             searchDebounce,
             searchingMessage,
             searchPrompt,
-            searchFields,
+            searchableOptionFields,
             state,
         }) => {
             return {
@@ -57,7 +57,7 @@ export default (Alpine) => {
                         position: position ?? 'auto',
                         removeItemButton: true,
                         renderChoiceLimit: optionsLimit,
-                        searchFields: searchFields ?? ['label'],
+                        searchFields: searchableOptionFields ?? ['label'],
                         searchPlaceholderValue: searchPrompt,
                         searchResultLimit: optionsLimit,
                         shouldSort: false,

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -99,6 +99,7 @@
                         searchDebounce: @js($getSearchDebounce()),
                         searchingMessage: @js($getSearchingMessage()),
                         searchPrompt: @js($getSearchPrompt()),
+                        searchFields: @js($getSearchFields()),
                         state: $wire.{{ $applyStateBindingModifiers('entangle(\'' . $getStatePath() . '\')') }},
                     })"
                     x-on:keydown.esc="select.dropdown.isActive && $event.stopPropagation()"

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -99,7 +99,7 @@
                         searchDebounce: @js($getSearchDebounce()),
                         searchingMessage: @js($getSearchingMessage()),
                         searchPrompt: @js($getSearchPrompt()),
-                        searchFields: @js($getSearchFields()),
+                        searchableOptionFields: @js($getSearchableOptionFields()),
                         state: $wire.{{ $applyStateBindingModifiers('entangle(\'' . $getStatePath() . '\')') }},
                     })"
                     x-on:keydown.esc="select.dropdown.isActive && $event.stopPropagation()"

--- a/packages/forms/src/Components/Concerns/CanBeSearchable.php
+++ b/packages/forms/src/Components/Concerns/CanBeSearchable.php
@@ -82,12 +82,12 @@ trait CanBeSearchable
 
     public function shouldSearchLabels(): bool
     {
-        return $this->evaluate($this->shouldSearchInLabels);
+        return (bool) $this->evaluate($this->shouldSearchLabels);
     }
 
     public function shouldSearchValues(): bool
     {
-        return $this->evaluate($this->shouldSearchInValues);
+        return (bool) $this->evaluate($this->shouldSearchValues);
     }
 
     public function getSearchFields(): array

--- a/packages/forms/src/Components/Concerns/CanBeSearchable.php
+++ b/packages/forms/src/Components/Concerns/CanBeSearchable.php
@@ -17,9 +17,9 @@ trait CanBeSearchable
 
     protected string | Htmlable | Closure | null $searchPrompt = null;
 
-    protected bool | Closure $shouldSearchInLabels = true;
+    protected bool | Closure $shouldSearchLabels = true;
 
-    protected bool | Closure $shouldSearchInValues = false;
+    protected bool | Closure $shouldSearchValues = false;
 
     public function searchable(bool | Closure $condition = true): static
     {
@@ -56,16 +56,16 @@ trait CanBeSearchable
         return $this;
     }
 
-    public function searchInLabels(bool | null $condition = true): static
+    public function searchLabels(bool | Closure | null $condition = true): static
     {
-        $this->shouldSearchInLabels = $condition;
+        $this->shouldSearchLabels = $condition;
 
         return $this;
     }
 
-    public function searchInValues(bool | null $condition = true): static
+    public function searchValues(bool | Closure | null $condition = true): static
     {
-        $this->shouldSearchInValues = $condition;
+        $this->shouldSearchValues = $condition;
 
         return $this;
     }
@@ -80,21 +80,21 @@ trait CanBeSearchable
         return $this->evaluate($this->searchPrompt) ?? __('forms::components.select.search_prompt');
     }
 
-    public function shouldSearchInLabels(): bool
+    public function shouldSearchLabels(): bool
     {
         return $this->evaluate($this->shouldSearchInLabels);
     }
 
-    public function shouldSearchInValues(): bool
+    public function shouldSearchValues(): bool
     {
         return $this->evaluate($this->shouldSearchInValues);
     }
 
     public function getSearchFields(): array
     {
-        return array_merge([],
-            ($this->shouldSearchInLabels ? ['label'] : []),
-            ($this->shouldSearchInValues ? ['value'] : []),
+        return array_merge(
+            ($this->shouldSearchLabels() ? ['label'] : []),
+            ($this->shouldSearchValues() ? ['value'] : []),
         );
     }
 

--- a/packages/forms/src/Components/Concerns/CanBeSearchable.php
+++ b/packages/forms/src/Components/Concerns/CanBeSearchable.php
@@ -17,6 +17,10 @@ trait CanBeSearchable
 
     protected string | Htmlable | Closure | null $searchPrompt = null;
 
+    protected bool | Closure $shouldSearchInLabels = true;
+
+    protected bool | Closure $shouldSearchInValues = false;
+
     public function searchable(bool | Closure $condition = true): static
     {
         $this->isSearchable = $condition;
@@ -52,6 +56,20 @@ trait CanBeSearchable
         return $this;
     }
 
+    public function searchInLabels(bool | null $condition = true): static
+    {
+        $this->shouldSearchInLabels = $condition;
+
+        return $this;
+    }
+
+    public function searchInValues(bool | null $condition = true): static
+    {
+        $this->shouldSearchInValues = $condition;
+
+        return $this;
+    }
+
     public function getNoSearchResultsMessage(): string | Htmlable
     {
         return $this->evaluate($this->noSearchResultsMessage) ?? __('forms::components.select.no_search_results_message');
@@ -60,6 +78,24 @@ trait CanBeSearchable
     public function getSearchPrompt(): string | Htmlable
     {
         return $this->evaluate($this->searchPrompt) ?? __('forms::components.select.search_prompt');
+    }
+
+    public function shouldSearchInLabels(): bool
+    {
+        return $this->evaluate($this->shouldSearchInLabels);
+    }
+
+    public function shouldSearchInValues(): bool
+    {
+        return $this->evaluate($this->shouldSearchInValues);
+    }
+
+    public function getSearchFields(): array
+    {
+        return array_merge([],
+            ($this->shouldSearchInLabels ? ['label'] : []),
+            ($this->shouldSearchInValues ? ['value'] : []),
+        );
     }
 
     public function getSearchDebounce(): int

--- a/packages/forms/src/Components/Concerns/CanBeSearchable.php
+++ b/packages/forms/src/Components/Concerns/CanBeSearchable.php
@@ -90,7 +90,7 @@ trait CanBeSearchable
         return (bool) $this->evaluate($this->shouldSearchValues);
     }
 
-    public function getSearchFields(): array
+    public function getSearchableOptionFields(): array
     {
         return array_merge(
             ($this->shouldSearchLabels() ? ['label'] : []),


### PR DESCRIPTION
When working on PR #6431 I saw that `select.js` only searches `labels`. However it can sometimes be useful to search the `value` instead/as well, especially when you're trying to avoid `getSearchResultsUsing()`. This PR adds that ability through new `shouldSearchInValues()` and `shouldSearchInLabels()` methods.

Background:
I needed to create my own version of an icon picker where the `value` is the icon name and the `label` is the html that renders the icon. The only way to make this searchable currently is to add `getSearchResultsUsing()` which is slow since it has to load the files again. By NOT using `getSearchResultsUsing()` you can take advantage of `choice.js` searching which is blazing fast. However to do that you need to be able to search the `value`. 

SLOW using `getSearchResultsUsing()`

https://user-images.githubusercontent.com/6097099/236599169-7fa5aa72-ce9e-47cd-9725-84500b2327f5.mov


FAST just using `searchable()`

https://user-images.githubusercontent.com/6097099/236599198-8543fcb0-625c-49a9-bd6f-2ff0828ab2dc.mov


