### PR TITLE
Fix DateTimePicker focus outline

### DIFF
--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -67,7 +67,7 @@
                 x-model="displayText"
                 {!! ($id = $getId()) ? "id=\"{$id}\"" : null !!}
                 @class([
-                    'w-full h-full p-0 placeholder-gray-400 bg-transparent border-0 outline-none focus:placeholder-gray-500 focus:ring-0',
+                    'w-full h-full p-0 placeholder-gray-400 bg-transparent border-0 outline-none focus:outline-none focus:placeholder-gray-500 focus:ring-0',
                     'dark:bg-gray-700 dark:placeholder-gray-400' => config('forms.dark_mode'),
                     'cursor-default' => $isDisabled(),
                 ])


### PR DESCRIPTION
Before:
<img width="383" alt="Screenshot 2023-05-06 at 3 18 35 PM" src="https://user-images.githubusercontent.com/315603/236609622-f2af1c2c-3841-4a06-aebe-0474497fa961.png">

After:
<img width="375" alt="Screenshot 2023-05-06 at 3 19 11 PM" src="https://user-images.githubusercontent.com/315603/236609635-ba094b1f-55aa-42bf-946c-a54f47eab637.png">
