### PR TITLE
Allows single column condition in Searchable

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanBeSearchable.php
+++ b/packages/tables/src/Columns/Concerns/CanBeSearchable.php
@@ -3,6 +3,7 @@
 namespace Filament\Tables\Columns\Concerns;
 
 use Closure;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 trait CanBeSearchable
@@ -18,17 +19,17 @@ trait CanBeSearchable
     protected ?Closure $searchQuery = null;
 
     public function searchable(
-        bool | array $condition = true,
+        bool | array | string $condition = true,
         ?Closure $query = null,
         bool $isIndividual = false,
         bool $isGlobal = true,
     ): static {
-        if (is_array($condition)) {
-            $this->isSearchable = true;
-            $this->searchColumns = $condition;
-        } else {
+        if (is_bool($condition)) {
             $this->isSearchable = $condition;
             $this->searchColumns = null;
+        } else {
+            $this->isSearchable = true;
+            $this->searchColumns = Arr::wrap($condition);
         }
 
         $this->isGloballySearchable = $isGlobal;


### PR DESCRIPTION
This small PR adds support for string condition if you only need to define a single column in searchable.


before PR you could only do this

```php
Tables\Columns\TextColumn::make('title')->searchable(['products.title'])
```

after PR you will be able to do this

```php
Tables\Columns\TextColumn::make('title')->searchable('products.title')
```
