### PR TITLE
Fix PostgreSQL data type incompatibility issue in Notification query

### DIFF
--- a/packages/notifications/src/Http/Livewire/Notifications.php
+++ b/packages/notifications/src/Http/Livewire/Notifications.php
@@ -83,9 +83,9 @@ class Notifications extends Component
     public function getDatabaseNotificationsQuery(): Builder | Relation
     {
         return match ($this->getUser()->notifications()->getConnection()->getDriverName()) {
-             /** @phpstan-ignore-next-line */
+            /** @phpstan-ignore-next-line */
             'pgsql' => $this->getUser()->notifications()->where('data', 'like', '%"format":"filament"%'),
-             /** @phpstan-ignore-next-line */
+            /** @phpstan-ignore-next-line */
             default => $this->getUser()->notifications()->where('data->format', 'filament'),
         };
     }

--- a/packages/notifications/src/Http/Livewire/Notifications.php
+++ b/packages/notifications/src/Http/Livewire/Notifications.php
@@ -55,7 +55,7 @@ class Notifications extends Component
             $this->notifications->forget($id);
         }
 
-        if (! $this->hasDatabaseNotifications()) {
+        if (!$this->hasDatabaseNotifications()) {
             return;
         }
 
@@ -83,11 +83,11 @@ class Notifications extends Component
     public function getDatabaseNotificationsQuery(): Builder | Relation
     {
         /** @phpstan-ignore-next-line */
-        return match ($this->getUser()->notifications()->getConnection()->getDriverName()) {
-            /** @phpstan-ignore-next-line */
-            'pgsql' => $this->getUser()->notifications()->where('data', 'like', '%"format":"filament"%'),
-            /** @phpstan-ignore-next-line */
-            default => $this->getUser()->notifications()->where('data->format', 'filament'),
+        $query = $this->getUser()->notifications();
+
+        return match ($query->getConnection()->getDriverName()) {
+            'pgsql' => $query->notifications()->where('data', 'like', '%"format":"filament"%'),
+            default => $query->notifications()->where('data->format', 'filament'),
         };
     }
 
@@ -104,7 +104,7 @@ class Notifications extends Component
 
     public function handleBroadcastNotification($notification): void
     {
-        if (! is_array($notification)) {
+        if (!is_array($notification)) {
             return;
         }
 
@@ -153,7 +153,7 @@ class Notifications extends Component
     {
         $user = $this->getUser();
 
-        if (! $user) {
+        if (!$user) {
             return null;
         }
 

--- a/packages/notifications/src/Http/Livewire/Notifications.php
+++ b/packages/notifications/src/Http/Livewire/Notifications.php
@@ -55,7 +55,7 @@ class Notifications extends Component
             $this->notifications->forget($id);
         }
 
-        if (!$this->hasDatabaseNotifications()) {
+        if (! $this->hasDatabaseNotifications()) {
             return;
         }
 
@@ -104,7 +104,7 @@ class Notifications extends Component
 
     public function handleBroadcastNotification($notification): void
     {
-        if (!is_array($notification)) {
+        if (! is_array($notification)) {
             return;
         }
 
@@ -153,7 +153,7 @@ class Notifications extends Component
     {
         $user = $this->getUser();
 
-        if (!$user) {
+        if (! $user) {
             return null;
         }
 

--- a/packages/notifications/src/Http/Livewire/Notifications.php
+++ b/packages/notifications/src/Http/Livewire/Notifications.php
@@ -82,8 +82,12 @@ class Notifications extends Component
 
     public function getDatabaseNotificationsQuery(): Builder | Relation
     {
-        /** @phpstan-ignore-next-line */
-        return $this->getUser()->notifications()->where('data->format', 'filament');
+        return match ($this->getUser()->notifications()->getConnection()->getDriverName()) {
+             /** @phpstan-ignore-next-line */
+            'pgsql' => $this->getUser()->notifications()->where('data', 'like', '%"format":"filament"%'),
+             /** @phpstan-ignore-next-line */
+            default => $this->getUser()->notifications()->where('data->format', 'filament'),
+        };
     }
 
     public function getUnreadDatabaseNotificationsQuery(): Builder | Relation

--- a/packages/notifications/src/Http/Livewire/Notifications.php
+++ b/packages/notifications/src/Http/Livewire/Notifications.php
@@ -86,8 +86,8 @@ class Notifications extends Component
         $query = $this->getUser()->notifications();
 
         return match ($query->getConnection()->getDriverName()) {
-            'pgsql' => $query->notifications()->where('data', 'like', '%"format":"filament"%'),
-            default => $query->notifications()->where('data->format', 'filament'),
+            'pgsql' => $query->where('data', 'like', '%"format":"filament"%'),
+            default => $query->where('data->format', 'filament'),
         };
     }
 

--- a/packages/notifications/src/Http/Livewire/Notifications.php
+++ b/packages/notifications/src/Http/Livewire/Notifications.php
@@ -82,6 +82,7 @@ class Notifications extends Component
 
     public function getDatabaseNotificationsQuery(): Builder | Relation
     {
+         /** @phpstan-ignore-next-line */
         return match ($this->getUser()->notifications()->getConnection()->getDriverName()) {
             /** @phpstan-ignore-next-line */
             'pgsql' => $this->getUser()->notifications()->where('data', 'like', '%"format":"filament"%'),

--- a/packages/notifications/src/Http/Livewire/Notifications.php
+++ b/packages/notifications/src/Http/Livewire/Notifications.php
@@ -82,7 +82,7 @@ class Notifications extends Component
 
     public function getDatabaseNotificationsQuery(): Builder | Relation
     {
-         /** @phpstan-ignore-next-line */
+        /** @phpstan-ignore-next-line */
         return match ($this->getUser()->notifications()->getConnection()->getDriverName()) {
             /** @phpstan-ignore-next-line */
             'pgsql' => $this->getUser()->notifications()->where('data', 'like', '%"format":"filament"%'),


### PR DESCRIPTION
The issue was caused by a data type incompatibility between postgres and the given query. Laravel defined the 'data' column as 'text' type.  It should be noted that there may be reasons why the 'data' column is defined as 'text' type, but regardless, this problem can be circumvented by using the 'like' operator to search for a specific string within the 'data' column. This allows for the retrieval of records that correspond to the 'format' key with the value 'filament', regardless of the data type defined in the 'data' column."  

To resolve the issue, this PR updates the query to use appropriate syntax for each database driver. For PostgreSQL, the query now uses '%"format":"filament"%' using the 'like' operator. . For all other drivers, the query continues to searches for the key 'format' using the '->' operator

This fix ensures that notifications are queried correctly regardless of the underlying database driver, allowing for consistent behavior across different database setups.