### PR TITLE
Add render hooks before and after table

### DIFF
--- a/packages/admin/docs/08-appearance.md
+++ b/packages/admin/docs/08-appearance.md
@@ -320,7 +320,7 @@ The available hooks are as follows:
 - `page.footer-widgets.end` - after page footer widgets
 - `page.actions.start` - before page actions
 - `page.actions.end` - after page actions
-- `resource.table.start` - before the resource table
-- `resource.table.end` - after the resource table
+- `resource.pages.list-records.table.start` - before the resource table
+- `resource.pages.list-records.table.end` - after the resource table
 - `resource.relation-manager.start` - before the relation manager table
 - `resource.relation-manager.end` - after the relation manager table

--- a/packages/admin/docs/08-appearance.md
+++ b/packages/admin/docs/08-appearance.md
@@ -320,5 +320,7 @@ The available hooks are as follows:
 - `page.footer-widgets.end` - after page footer widgets
 - `page.actions.start` - before page actions
 - `page.actions.end` - after page actions
+- `resource.table.start` - before the resource table
+- `resource.table.end` - after the resource table
 - `resource.relation-manager.start` - before the relation manager table
 - `resource.relation-manager.end` - after the relation manager table

--- a/packages/admin/resources/views/resources/pages/list-records.blade.php
+++ b/packages/admin/resources/views/resources/pages/list-records.blade.php
@@ -4,9 +4,9 @@
         'filament-resources-' . str_replace('/', '-', $this->getResource()::getSlug()),
     ])"
 >
-    {{ \Filament\Facades\Filament::renderHook('resource.table.start') }}
+    {{ \Filament\Facades\Filament::renderHook('resource.pages.list-records.table.start') }}
 
     {{ $this->table }}
 
-    {{ \Filament\Facades\Filament::renderHook('resource.table.end') }}
+    {{ \Filament\Facades\Filament::renderHook('resource.pages.list-records.table.end') }}
 </x-filament::page>

--- a/packages/admin/resources/views/resources/pages/list-records.blade.php
+++ b/packages/admin/resources/views/resources/pages/list-records.blade.php
@@ -4,9 +4,9 @@
         'filament-resources-' . str_replace('/', '-', $this->getResource()::getSlug()),
     ])"
 >
-    {{ \Filament\Facades\Filament::renderHook('table.start') }}
+    {{ \Filament\Facades\Filament::renderHook('resource.table.start') }}
 
     {{ $this->table }}
 
-    {{ \Filament\Facades\Filament::renderHook('table.end') }}
+    {{ \Filament\Facades\Filament::renderHook('resource.table.end') }}
 </x-filament::page>

--- a/packages/admin/resources/views/resources/pages/list-records.blade.php
+++ b/packages/admin/resources/views/resources/pages/list-records.blade.php
@@ -4,5 +4,9 @@
         'filament-resources-' . str_replace('/', '-', $this->getResource()::getSlug()),
     ])"
 >
+    {{ \Filament\Facades\Filament::renderHook('table.start') }}
+
     {{ $this->table }}
+
+    {{ \Filament\Facades\Filament::renderHook('table.end') }}
 </x-filament::page>


### PR DESCRIPTION
Similiar to PR #6317 which added render hooks before and after the relation manger table, this PR adds render hooks before and after the `list-records` table. 

This allows devs who are using the hooks on both tables to have a consistent dev experience. Currently you have to use `page.header-widgets.end`, to render before the `list-records` table, but everything rendered there has the parents `space-y-6` applied meaning you have to use 2 separate margins to keep the views the same. 