### PR TITLE
Load 600 font weight

### DIFF
--- a/packages/app/src/FontProviders/BunnyFontProvider.php
+++ b/packages/app/src/FontProviders/BunnyFontProvider.php
@@ -11,7 +11,7 @@ class BunnyFontProvider implements Contracts\FontProvider
     public function getHtml(string $family, ?string $url = null): Htmlable
     {
         $family = Str::kebab($family);
-        $url ??= "https://fonts.bunny.net/css?family={$family}:400,500,700&display=swap";
+        $url ??= "https://fonts.bunny.net/css?family={$family}:400,500;600,700&display=swap";
 
         return new HtmlString("
             <link rel=\"preconnect\" href=\"https://fonts.bunny.net\">

--- a/packages/app/src/FontProviders/GoogleFontProvider.php
+++ b/packages/app/src/FontProviders/GoogleFontProvider.php
@@ -10,7 +10,7 @@ class GoogleFontProvider implements Contracts\FontProvider
     public function getHtml(string $family, ?string $url = null): Htmlable
     {
         $family = urlencode($family);
-        $url ??= "https://fonts.googleapis.com/css2?family={$family}:wght@400;500;700&display=swap";
+        $url ??= "https://fonts.googleapis.com/css2?family={$family}:wght@400;500;600;700&display=swap";
 
         return new HtmlString("
             <link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">


### PR DESCRIPTION
I encounter a lot of cases where the semibold font weight is needed to make the design look good. I know you've initially removed this weight key to reduce the number of fonts to load, @danharrin, but I think we really need this one.

Also, we might make the font weights configurable?