### PR TITLE
Setting time in DateTimePicker init() after defining the watchers

### DIFF
--- a/packages/forms/resources/js/components/date-time-picker.js
+++ b/packages/forms/resources/js/components/date-time-picker.js
@@ -72,10 +72,6 @@ export default (Alpine) => {
                         date = null
                     }
 
-                    this.hour = date?.hour() ?? 0
-                    this.minute = date?.minute() ?? 0
-                    this.second = date?.second() ?? 0
-
                     this.setDisplayText()
                     this.setMonths()
                     this.setDayLabels()
@@ -249,6 +245,10 @@ export default (Alpine) => {
 
                         this.setDisplayText()
                     })
+
+                    this.hour = date?.hour() ?? 0
+                    this.minute = date?.minute() ?? 0
+                    this.second = date?.second() ?? 0
                 },
 
                 clearState: function () {


### PR DESCRIPTION
<!-- For visual changes, please include a screenshot/recording of before and after. -->
<!-- This allows us to review the pull request faster. -->
PR Summary
Solving issue #6463 by defining setting the time after defining the watchers.