### PR TITLE
Fix empty element in table header toolbar

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -291,27 +291,29 @@
                             </div>
                         @endif
 
-                        <div class="flex items-center">
-                            @if ($hasFiltersDropdown)
-                                <x-filament-tables::filters.dropdown
-                                    :form="$getFiltersForm()"
-                                    :indicators-count="count(\Illuminate\Support\Arr::flatten($filterIndicators))"
-                                    :max-height="$getFiltersFormMaxHeight()"
-                                    :trigger-action="$getFiltersTriggerAction()"
-                                    :width="$getFiltersFormWidth()"
-                                    class="shrink-0"
-                                />
-                            @endif
+                        @if ($hasFiltersDropdown || $isColumnToggleFormVisible)
+                            <div class="flex items-center">
+                                @if ($hasFiltersDropdown)
+                                    <x-filament-tables::filters.dropdown
+                                        :form="$getFiltersForm()"
+                                        :indicators-count="count(\Illuminate\Support\Arr::flatten($filterIndicators))"
+                                        :max-height="$getFiltersFormMaxHeight()"
+                                        :trigger-action="$getFiltersTriggerAction()"
+                                        :width="$getFiltersFormWidth()"
+                                        class="shrink-0"
+                                    />
+                                @endif
 
-                            @if ($isColumnToggleFormVisible)
-                                <x-filament-tables::toggleable
-                                    :form="$getColumnToggleForm()"
-                                    :max-height="$getColumnToggleFormMaxHeight()"
-                                    :width="$getColumnToggleFormWidth()"
-                                    class="shrink-0"
-                                />
-                            @endif
-                        </div>
+                                @if ($isColumnToggleFormVisible)
+                                    <x-filament-tables::toggleable
+                                        :form="$getColumnToggleForm()"
+                                        :max-height="$getColumnToggleFormMaxHeight()"
+                                        :width="$getColumnToggleFormWidth()"
+                                        class="shrink-0"
+                                    />
+                                @endif
+                            </div>
+                        @endif
                     </div>
                 @endif
             </div>


### PR DESCRIPTION
The tables header toolbar uses a `gap-3` class for spacing, but in the situations where you have searchable columns, but no filters or toggleable columns, there's an empty `div` that creates unnecessary spacing. This PR wraps that `div` in a conditional to address that.

<img width="1267" alt="Screenshot 2023-05-10 at 9 52 24 AM" src="https://github.com/filamentphp/filament/assets/38760117/5386d967-0f44-4e69-b4e4-5a5b790ae68d">
<img width="803" alt="Screenshot 2023-05-10 at 9 56 50 AM" src="https://github.com/filamentphp/filament/assets/38760117/80a0faa7-1834-438e-9f6f-55602a614f96">
