### PR TITLE
Fixed button opacity when disabled stated changes

### DIFF
--- a/packages/support/resources/views/components/button.blade.php
+++ b/packages/support/resources/views/components/button.blade.php
@@ -86,19 +86,18 @@
             form: null,
             isUploadingFile: false,
         }"
-        @unless ($disabled)
-            x-bind:class="{ 'opacity-70 cursor-wait': isUploadingFile }"
-        @endunless
         x-bind:disabled="isUploadingFile"
         x-init="
             form = $el.closest('form')
 
             form?.addEventListener('file-upload-started', () => {
                 isUploadingFile = true
+                $el.classList.add('opacity-70', 'cursor-wait')
             })
 
             form?.addEventListener('file-upload-finished', () => {
                 isUploadingFile = false
+                $el.classList.remove('opacity-70', 'cursor-wait')
             })
         "
         {{ $attributes->class($buttonClasses) }}


### PR DESCRIPTION
# Description

This pull request resolves an issue where the opacity-70 class was not being applied when the disabled state of a button was changed. With this fix, the opacity is properly removed when the disabled state is changed. This can be observed in the before and after examples provided.

## Changes made
- Removed the ﻿`@unless($disabled)` logic from the button, as it was causing issues.
- Within the event listeners, added statements to apply and remove the `opacity-70 cursor-wait` classes.

## Testing Done
- Tested this pull request by manually toggling the button’s disabled state and verifying that the opacity-70 class was correctly applied and removed.
- Tested that the classes are properly added and removed from the buttons within the form when uploading files

## Before:
https://github.com/filamentphp/filament/assets/8775667/a9ac84d5-1b1f-4ae1-a231-2f599075e506

## After
https://github.com/filamentphp/filament/assets/8775667/1a6173c1-fd16-4f33-b92d-5da3ec6beb18

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
