### PR TITLE
Tab icon position and color

### DIFF
--- a/packages/forms/docs/04-layout.md
+++ b/packages/forms/docs/04-layout.md
@@ -319,6 +319,24 @@ Tabs::make('Heading')
     ])
 ```
 
+Icons can be modified using the `iconPosition()` and `iconColor()` methods:
+
+```php
+use Filament\Forms\Components\Tabs;
+
+Tabs::make('Heading')
+    ->tabs([
+        Tabs\Tab::make('Notifications')
+            ->icon('heroicon-o-bell')
+            ->iconPosition('after') // `before` or `after` [tl! focus:end]
+            ->iconColor('success') // `danger`, `primary`, `success`, `warning` or `secondary` [tl! focus:end]
+            ->schema([
+                // ...
+            ]),
+        // ...
+    ])
+```
+
 ## Wizard
 
 Similar to [tabs](#tabs), you may want to use a multistep form wizard to reduce the number of components that are visible at once. These are especially useful if your form has a definite chronological order, in which you want each step to be validated as the user progresses.

--- a/packages/forms/resources/views/components/tabs.blade.php
+++ b/packages/forms/resources/views/components/tabs.blade.php
@@ -60,7 +60,7 @@
                 $iconPosition = $tab->getIconPosition();
                 $iconColor = $tab->getIconColor();
 
-                $iconColorClass = match ($iconColor) {
+                $iconColorClasses = match ($iconColor) {
                     'danger' => \Illuminate\Support\Arr::toCssClasses(['text-danger-700', 'dark:text-danger-500' => config('tables.dark_mode')]),
                     'primary' => \Illuminate\Support\Arr::toCssClasses(['text-primary-700', 'dark:text-primary-500' => config('tables.dark_mode')]),
                     'success' => \Illuminate\Support\Arr::toCssClasses(['text-success-700', 'dark:text-success-500' => config('tables.dark_mode')]),
@@ -69,6 +69,7 @@
                     default => $iconColor,
                 };
             @endphp
+            
             <button
                 type="button"
                 aria-controls="{{ $tab->getId() }}"
@@ -87,7 +88,7 @@
                         :component="$icon"
                         @class([
                             'w-4 h-4',
-                            $iconColorClass
+                            $iconColorClasses,
                         ])
                     />
                 @endif
@@ -99,7 +100,7 @@
                         :component="$icon"
                         @class([
                             'w-4 h-4',
-                            $iconColorClass
+                            $iconColorClasses,
                         ])
                     />
                 @endif

--- a/packages/forms/resources/views/components/tabs.blade.php
+++ b/packages/forms/resources/views/components/tabs.blade.php
@@ -55,6 +55,20 @@
         ])
     >
         @foreach ($getChildComponentContainer()->getComponents() as $tab)
+            @php
+                $icon = $tab->getIcon();
+                $iconPosition = $tab->getIconPosition();
+                $iconColor = $tab->getIconColor();
+
+                $iconColorClass = match ($iconColor) {
+                    'danger' => \Illuminate\Support\Arr::toCssClasses(['text-danger-700', 'dark:text-danger-500' => config('tables.dark_mode')]),
+                    'primary' => \Illuminate\Support\Arr::toCssClasses(['text-primary-700', 'dark:text-primary-500' => config('tables.dark_mode')]),
+                    'success' => \Illuminate\Support\Arr::toCssClasses(['text-success-700', 'dark:text-success-500' => config('tables.dark_mode')]),
+                    'warning' => \Illuminate\Support\Arr::toCssClasses(['text-warning-700', 'dark:text-warning-500' => config('tables.dark_mode')]),
+                    'secondary' => \Illuminate\Support\Arr::toCssClasses(['text-gray-700', 'dark:text-gray-300' => config('tables.dark_mode')]),
+                    default => $iconColor,
+                };
+            @endphp
             <button
                 type="button"
                 aria-controls="{{ $tab->getId() }}"
@@ -68,14 +82,27 @@
                     'filament-forms-tabs-component-button-active bg-white text-primary-600 @if (config('forms.dark_mode')) dark:bg-gray-800 @endif': tab === '{{ $tab->getId() }}',
                 }"
             >
-                @if ($icon = $tab->getIcon())
+                @if ($icon && $iconPosition === 'before')
                     <x-dynamic-component
                         :component="$icon"
-                        class="h-5 w-5"
+                        @class([
+                            'w-4 h-4',
+                            $iconColorClass
+                        ])
                     />
                 @endif
 
                 <span>{{ $tab->getLabel() }}</span>
+
+                @if ($icon && $iconPosition === 'after')
+                    <x-dynamic-component
+                        :component="$icon"
+                        @class([
+                            'w-4 h-4',
+                            $iconColorClass
+                        ])
+                    />
+                @endif
 
                 @if ($badge = $tab->getBadge())
                     <span

--- a/packages/forms/src/Components/Tabs/Tab.php
+++ b/packages/forms/src/Components/Tabs/Tab.php
@@ -15,6 +15,10 @@ class Tab extends Component implements CanConcealComponents
 
     protected string | Closure | null $icon = null;
 
+    protected string | Closure | null $iconPosition = null;
+
+    protected string | Closure | null $iconColor = null;
+
     final public function __construct(string $label)
     {
         $this->label($label);
@@ -32,6 +36,20 @@ class Tab extends Component implements CanConcealComponents
     public function icon(string | Closure | null $icon): static
     {
         $this->icon = $icon;
+
+        return $this;
+    }
+
+    public function iconPosition(string | Closure | null $position): static
+    {
+        $this->iconPosition = $position;
+
+        return $this;
+    }
+
+    public function iconColor(string | Closure | null $color): static
+    {
+        $this->iconColor = $color;
 
         return $this;
     }
@@ -56,6 +74,16 @@ class Tab extends Component implements CanConcealComponents
     public function getIcon(): ?string
     {
         return $this->evaluate($this->icon);
+    }
+
+    public function getIconPosition(): ?string
+    {
+        return $this->evaluate($this->iconPosition);
+    }
+
+    public function geticonColor(): ?string
+    {
+        return $this->evaluate($this->iconColor);
     }
 
     public function getBadge(): ?string

--- a/packages/forms/src/Components/Tabs/Tab.php
+++ b/packages/forms/src/Components/Tabs/Tab.php
@@ -81,7 +81,7 @@ class Tab extends Component implements CanConcealComponents
         return $this->evaluate($this->iconPosition) ?? 'before';
     }
 
-    public function geticonColor(): ?string
+    public function getIconColor(): ?string
     {
         return $this->evaluate($this->iconColor);
     }

--- a/packages/forms/src/Components/Tabs/Tab.php
+++ b/packages/forms/src/Components/Tabs/Tab.php
@@ -78,7 +78,7 @@ class Tab extends Component implements CanConcealComponents
 
     public function getIconPosition(): ?string
     {
-        return $this->evaluate($this->iconPosition);
+        return $this->evaluate($this->iconPosition) ?? 'before';
     }
 
     public function geticonColor(): ?string


### PR DESCRIPTION
This pull requests adds `iconPosition()` and `iconColor()` methods to the Tab form layout. 

E.g.

```php
Tab::make('nl')
    ->icon(fn (Closure $get) => $get('online') ? 'heroicon-o-status-online' : 'heroicon-o-status-offline')
    ->iconColor(fn (Closure $get) => $get('online') ? 'success' : 'danger')
```

Gives this output:

![image](https://github.com/filamentphp/filament/assets/2447042/9af43b48-f75a-4fd6-b715-3506c35f85f1)
