### PR TITLE
Adds the possibility of having '0' as a prefix or postfix for different form inputs

### DIFF
--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -102,7 +102,7 @@
             </div>
         </div>
 
-        @if ($label = $getSuffixLabel())
+        @if (filled($label = $getSuffixLabel()) && ($getSuffixLabel() !== false))
             <span @class($affixLabelClasses)>
                 {{ $label }}
             </span>

--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -29,7 +29,7 @@
             <x-dynamic-component :component="$icon" class="w-5 h-5" />
         @endif
 
-        @if (filled($label = $getPrefixLabel()) && ($getPrefixLabel() !== false))
+        @if (filled($label = $getPrefixLabel()))
             <span @class($affixLabelClasses)>
                 {{ $label }}
             </span>
@@ -102,7 +102,7 @@
             </div>
         </div>
 
-        @if (filled($label = $getSuffixLabel()) && ($getSuffixLabel() !== false))
+        @if (filled($label = $getSuffixLabel()))
             <span @class($affixLabelClasses)>
                 {{ $label }}
             </span>

--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -29,7 +29,7 @@
             <x-dynamic-component :component="$icon" class="w-5 h-5" />
         @endif
 
-        @if ($label = $getPrefixLabel())
+        @if (filled($label = $getPrefixLabel()) && ($getPrefixLabel() !== false))
             <span @class($affixLabelClasses)>
                 {{ $label }}
             </span>

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -29,7 +29,7 @@
             <x-dynamic-component :component="$icon" class="w-5 h-5" />
         @endif
 
-        @if (filled($label = $getPrefixLabel()) && ($getPrefixLabel() !== false))
+        @if (filled($label = $getPrefixLabel()))
             <span @class($affixLabelClasses)>
                 {{ $label }}
             </span>
@@ -126,7 +126,7 @@
             @endif
         </div>
 
-        @if (filled($label = $getSuffixLabel()) && ($getSuffixLabel() !== false))
+        @if (filled($label = $getSuffixLabel()))
             <span @class($affixLabelClasses)>
                 {{ $label }}
             </span>

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -126,7 +126,7 @@
             @endif
         </div>
 
-        @if ($label = $getSuffixLabel())
+        @if (filled($label = $getSuffixLabel()) && ($getSuffixLabel() !== false))
             <span @class($affixLabelClasses)>
                 {{ $label }}
             </span>

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -29,7 +29,7 @@
             <x-dynamic-component :component="$icon" class="w-5 h-5" />
         @endif
 
-        @if ($label = $getPrefixLabel())
+        @if (filled($label = $getPrefixLabel()) && ($getPrefixLabel() !== false))
             <span @class($affixLabelClasses)>
                 {{ $label }}
             </span>

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -83,7 +83,7 @@
             />
         </div>
 
-        @if ($label = $getSuffixLabel())
+        @if (filled($label = $getSuffixLabel()) && ($getSuffixLabel() !== false)))
             <span @class($affixLabelClasses)>
                 {{ $label }}
             </span>

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -30,7 +30,7 @@
             <x-dynamic-component :component="$icon" class="w-5 h-5" />
         @endif
 
-        @if (filled($label = $getPrefixLabel()) && ($getPrefixLabel() !== false))
+        @if (filled($label = $getPrefixLabel()))
             <span @class($affixLabelClasses)>
                 {{ $label }}
             </span>
@@ -83,7 +83,7 @@
             />
         </div>
 
-        @if (filled($label = $getSuffixLabel()) && ($getSuffixLabel() !== false)))
+        @if (filled($label = $getSuffixLabel()))
             <span @class($affixLabelClasses)>
                 {{ $label }}
             </span>

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -30,7 +30,7 @@
             <x-dynamic-component :component="$icon" class="w-5 h-5" />
         @endif
 
-        @if ($label = $getPrefixLabel())
+        @if (filled($label = $getPrefixLabel()) && ($getPrefixLabel() !== false))
             <span @class($affixLabelClasses)>
                 {{ $label }}
             </span>


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This PR adds the possibility of having `'0'` as a prefix or postfix for three form inputs:
- text input
- select input
- color-picker input

I tried to add `0` as a prefix to the phone number input with `->prefix('0')` and I noticed it is not being rendered, since it is being evaluated as a falsy parameter for the blade's `@if ($label = $getPrefixLabel())` directive.

before prefix fixation:
![before](https://github.com/filamentphp/filament/assets/4992968/635dea89-8786-4a71-81f6-a2164ff87895)
after prefix fixation:
![after](https://github.com/filamentphp/filament/assets/4992968/5c759d4a-fb52-4884-ac82-a65f26e79e16)

I don't know if this is the most elegant way to do so or if it is really needed to support both prefixes and postfixes of all three inputs.
I just did every six of them to make it consistent.

Feel free to cherry-pick, make changes in any shape or form, or even close the PR. I just need `'0'` as a prefix to the text input and I did open the PR to document the desired result, instead of opening an issue.
