### PR TITLE
Preserve persisted sort order with defaultSort() set

### DIFF
--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -69,13 +69,14 @@ trait CanSortRecords
             return $query->orderBy($this->getTableReorderColumn());
         }
 
-        $sortColumn = $this->tableSortColumn;
+        $sortColumn = $this->tableSortColumn ?? $this->getDefaultTableSortColumn();
 
         if (! $sortColumn) {
             return $query;
         }
 
-        $sortDirection = $this->tableSortDirection === 'desc' ? 'desc' : 'asc';
+        $sortDirection = $this->tableSortDirection ?? $this->getDefaultTableSortDirection();
+        $sortDirection = $sortDirection === 'desc' ? 'desc' : 'asc';
 
         $column = $this->getCachedTableColumn($sortColumn);
 

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -132,7 +132,9 @@ trait InteractsWithTable
 
             $this->tableSortColumn = $sort['column'] ?? null;
             $this->tableSortDirection = $sort['direction'] ?? null;
-        } elseif ($shouldPersistTableSortInSession) {
+        }
+
+        if ($shouldPersistTableSortInSession) {
             session()->put(
                 $sortSessionKey,
                 [

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -132,9 +132,7 @@ trait InteractsWithTable
 
             $this->tableSortColumn = $sort['column'] ?? null;
             $this->tableSortDirection = $sort['direction'] ?? null;
-        }
-
-        if ($shouldPersistTableSortInSession) {
+        } elseif ($shouldPersistTableSortInSession) {
             session()->put(
                 $sortSessionKey,
                 [
@@ -144,6 +142,9 @@ trait InteractsWithTable
             );
         }
 
+        $this->tableSortColumn ??= $this->getDefaultTableSortColumn();
+        $this->tableSortDirection ??= $this->getDefaultTableSortDirection();
+
         $this->hasMounted = true;
     }
 
@@ -152,9 +153,6 @@ trait InteractsWithTable
         if ($this->isTablePaginationEnabled()) {
             $this->tableRecordsPerPage = $this->getDefaultTableRecordsPerPageSelectOption();
         }
-
-        $this->tableSortColumn ??= $this->getDefaultTableSortColumn();
-        $this->tableSortDirection ??= $this->getDefaultTableSortDirection();
     }
 
     protected function getCachedTable(): Table

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -144,9 +144,6 @@ trait InteractsWithTable
             );
         }
 
-        $this->tableSortColumn ??= $this->getDefaultTableSortColumn();
-        $this->tableSortDirection ??= $this->getDefaultTableSortDirection();
-
         $this->hasMounted = true;
     }
 


### PR DESCRIPTION
### The problem

When using the `->defaultSort()` method on the table builder while using session persisted sort via `shouldPersistTableSortInSession()`, the default sort overrides any persisted sort order on any new render of the table.

### Expected behavior

`defaultSort()` should only be applied if the `$tableSortColumn` is blank AND there is no persisted table sort info in the session.

### Steps to reproduce

Add a `->defaultSort('name')` for any table, and on your ListRecords class, define 
```php
    protected function shouldPersistTableSortInSession(): bool
    {
        return true;
    }
```
The table should now be sorted by `name`. Click on any other column to change the sorting, e.g. to `created_at`. Reload the table from the navigation. The expected result should be a table sorted by `created_at`, but the actual sorting is by `name`.

### Explanation

This behavior has always puzzled me, as it effectively isn't possible to use sort persistence on a table with a default sorting.

The previous code always applied the default sort column and order on component mount, and since persisted sort settings are always applied if no sort column is set, it is never recalled on tables with a default sort order.

This PR suggests a change to mitigate this by setting the default sort column and direction only if the sort column is empty after applying both the user choice and persisted sort settings from the session. 

### Defaulting to default sort order

Because we are now applying the default sort column every time the component is refreshed and the sort column is null, and not only once on mount, the sort behavior changes:

#### Previous behavior

> clicked-column asc
> clicked-column desc
> null null

#### New behavior

> clicked-column asc
> clicked-column desc
> default-column default-sort

I would like to discuss whether it feels more logical to default to no sort at all (table order) if a default order is set for the table. In order to keep this behavior, it would be possible to move the code pulling the persisted sort settings from booted to mounted. 

However, I would personally expect the default sort order to be applied whenever the table would otherwise be unsorted.

What do you think?
