### PR TITLE
📌 Allow `spatie/laravel-settings:^3.0`

### DIFF
--- a/packages/spatie-laravel-settings-plugin/composer.json
+++ b/packages/spatie-laravel-settings-plugin/composer.json
@@ -13,7 +13,7 @@
         "illuminate/console": "^8.6|^9.0|^10.0",
         "illuminate/filesystem": "^8.6|^9.0|^10.0",
         "illuminate/support": "^8.6|^9.0|^10.0",
-        "spatie/laravel-settings": "^2.2"
+        "spatie/laravel-settings": "^2.2|^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR aims to add support for [`spatie/laravel-settings` v3.x](https://github.com/spatie/laravel-settings/releases/tag/3.0.0).

The major update doesn't have any breaking changes that could break the plugin at its current state so it should be relatively seamless. It should be given that the developer should make sure to read the package's [upgrade guide](https://github.com/spatie/laravel-settings/blob/main/UPGRADING.md).