### PR TITLE
Check if relation is already eagerloaded

### DIFF
--- a/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
@@ -40,7 +40,7 @@ trait InteractsWithTableQuery
             return $query;
         }
 
-        if ($this->queriesRelationships($query->getModel())) {
+        if ($this->queriesRelationships($query->getModel()) && !isset($query->getEagerLoads()[$this->getRelationshipName()])) {
             $query->with([$this->getRelationshipName()]);
         }
 

--- a/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
@@ -39,12 +39,18 @@ trait InteractsWithTableQuery
         if ($this->isHidden()) {
             return $query;
         }
+        
+        if (! $this->queriesRelationships($query->getModel())) {
+            return $query;
+        }
+        
+        $relationshipName = $this->getRelationshipName();
 
-        if ($this->queriesRelationships($query->getModel()) && !isset($query->getEagerLoads()[$this->getRelationshipName()])) {
-            $query->with([$this->getRelationshipName()]);
+        if (array_key_exists($relationshipName, $query->getEagerLoads())) {
+            return $query;
         }
 
-        return $query;
+        return $query->with([$this->getRelationshipName()]);
     }
 
     public function applySearchConstraint(Builder $query, string $search, bool &$isFirst, bool $isIndividual = false): Builder


### PR DESCRIPTION
The table query builder in filament is smart enough to detect if a column is interacting with a relation.
In this case, it adds the eager loading automatically to the query.

If the query itself (set via `getTableQuery`) already sets the eager loading with some custom parameters, like a callback (`->with(['relation' => fn($q) => $q->where('foo', 'bar')])`) filament overrides it with its own eager loading.

This PR adds the check that the eager load is present or not before adding the new eager loading setting