### PR TITLE
Set table on empty state actions

### DIFF
--- a/packages/tables/src/Table/Concerns/HasEmptyState.php
+++ b/packages/tables/src/Table/Concerns/HasEmptyState.php
@@ -45,6 +45,8 @@ trait HasEmptyState
     public function emptyStateActions(array | ActionGroup $actions): static
     {
         foreach (Arr::wrap($actions) as $action) {
+            $action->table($this);
+
             if ($action instanceof ActionGroup) {
                 /** @var array<string, Action> $flatActions */
                 $flatActions = $action->getFlatActions();


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
