### PR TITLE
Allow pagination to be used as livewire component

### DIFF
--- a/packages/tables/resources/views/components/pagination/index.blade.php
+++ b/packages/tables/resources/views/components/pagination/index.blade.php
@@ -1,6 +1,6 @@
 @props([
     'paginator',
-    'recordsPerPageSelectOptions',
+    'recordsPerPageSelectOptions' => [],
 ])
 
 @php


### PR DESCRIPTION
Inside a custom livewire component I wanted to reuse the Filament pagination `{{ $example->links('tables::components.pagination.index') }}` 

This change prevented error:
> count(): Argument #1 ($value) must be of type Countable|array null given