### PR TITLE
added applyEagerLoading and applyRelationshipAggregates to get selected table records

### DIFF
--- a/packages/tables/src/Concerns/CanSelectRecords.php
+++ b/packages/tables/src/Concerns/CanSelectRecords.php
@@ -72,6 +72,12 @@ trait CanSelectRecords
 
         if (! ($this instanceof HasRelationshipTable && $this->getRelationship() instanceof BelongsToMany && $this->allowsDuplicates())) {
             $query = $this->getTableQuery()->whereIn(app($this->getTableModel())->getQualifiedKeyName(), $this->selectedTableRecords);
+           
+            foreach ($this->getCachedTableColumns() as $column) {
+                $column->applyEagerLoading($query);
+                $column->applyRelationshipAggregates($query);
+            }
+           
             $this->applySortingToTableQuery($query);
 
             return $this->cachedSelectedTableRecords = $query->get();

--- a/packages/tables/src/Concerns/CanSelectRecords.php
+++ b/packages/tables/src/Concerns/CanSelectRecords.php
@@ -72,12 +72,12 @@ trait CanSelectRecords
 
         if (! ($this instanceof HasRelationshipTable && $this->getRelationship() instanceof BelongsToMany && $this->allowsDuplicates())) {
             $query = $this->getTableQuery()->whereIn(app($this->getTableModel())->getQualifiedKeyName(), $this->selectedTableRecords);
-           
+
             foreach ($this->getCachedTableColumns() as $column) {
                 $column->applyEagerLoading($query);
                 $column->applyRelationshipAggregates($query);
             }
-           
+
             $this->applySortingToTableQuery($query);
 
             return $this->cachedSelectedTableRecords = $query->get();


### PR DESCRIPTION
hey,

when we don't apply relationship aggregates, selected records are being hydrated and passed to actions without aggregates. while adding that, I thought `applyEagerLoading` is also needed here since we have it for the table query.

I think pipeline failure is not related to the changes. So keeping the PR open.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
