### PR TITLE
Improve display of multi-line brand name

### DIFF
--- a/packages/admin/resources/views/components/brand.blade.php
+++ b/packages/admin/resources/views/components/brand.blade.php
@@ -1,6 +1,6 @@
 @if (filled($brand = config('filament.brand')))
     <div @class([
-        'filament-brand text-xl font-bold tracking-tight',
+        'filament-brand text-xl font-bold leading-none tracking-tight',
         'dark:text-white' => config('filament.dark_mode'),
     ])>
         {{ $brand }}

--- a/packages/admin/resources/views/components/brand.blade.php
+++ b/packages/admin/resources/views/components/brand.blade.php
@@ -1,6 +1,6 @@
 @if (filled($brand = config('filament.brand')))
     <div @class([
-        'filament-brand text-xl font-bold leading-none tracking-tight',
+        'filament-brand text-xl font-bold leading-5 tracking-tight',
         'dark:text-white' => config('filament.dark_mode'),
     ])>
         {{ $brand }}


### PR DESCRIPTION
Before
<img width="877" alt="Screenshot 2023-05-19 at 12 22 31" src="https://github.com/filamentphp/filament/assets/533658/2b618e07-c481-4441-87b1-798dbaf66bd6">

After
<img width="856" alt="Screenshot 2023-05-19 at 12 23 56" src="https://github.com/filamentphp/filament/assets/533658/a52618e5-6dcf-4c26-bef9-7c6f0146bd29">
