### PR TITLE
Exclude non-selectable records from select all

### DIFF
--- a/packages/tables/docs/05-actions.md
+++ b/packages/tables/docs/05-actions.md
@@ -146,34 +146,6 @@ public function isTableRecordSelectable(): ?Closure
 }
 ```
 
-Please note that this will only hide the checkbox, and the record will still be selectable by clicking "Select All". This is because checking if each record is selectable is a very expensive operation and is not done by default, since it requires every model to be loaded into memory. If you are aware of the performance implications, you can enable this behaviour by overriding the `getAllSelectableTableRecordKeys()` method:
-
-```php
-use Illuminate\Database\Eloquent\Model;
-
-public function getAllSelectableTableRecordKeys(): array
-{
-    $query = $this->getFilteredTableQuery();
-
-    $records = $this->shouldSelectCurrentPageOnly() ?
-        $this->getTableRecords() :
-        $query->get();
-
-    return $records->reduce(
-        function (array $carry, Model $record): array {
-            if (! $this->isTableRecordSelectable($record)) {
-                return $carry;
-            }
-
-            $carry[] = (string) $record->getKey();
-            
-            return $carry;
-        },
-        initial: [],
-    );
-}
-```
-
 ## Setting a size
 
 The default size for table actions is `sm` but you may also change it to either `md` or `lg`:

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -144,7 +144,7 @@
         selectAllRecords: async function () {
             this.isLoading = true
 
-            this.selectedRecords = await $wire.getAllTableRecordKeys()
+            this.selectedRecords = await $wire.getAllSelectableTableRecordKeys()
 
             this.isLoading = false
         },

--- a/packages/tables/src/Concerns/CanSelectRecords.php
+++ b/packages/tables/src/Concerns/CanSelectRecords.php
@@ -28,7 +28,7 @@ trait CanSelectRecords
         return true;
     }
 
-    public function getAllTableRecordKeys(): array
+    public function getAllSelectableTableRecordKeys(): array
     {
         $query = $this->getFilteredTableQuery();
 

--- a/packages/tables/src/Contracts/HasTable.php
+++ b/packages/tables/src/Contracts/HasTable.php
@@ -21,7 +21,7 @@ interface HasTable extends HasForms
 
     public function getActiveTableLocale(): ?string;
 
-    public function getAllTableRecordKeys(): array;
+    public function getAllSelectableTableRecordKeys(): array;
 
     public function getAllTableRecordsCount(): int;
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
