### PR TITLE
add applyDefaultSortingToTableQuery method to custom default sort behavior 

### DIFF
--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -86,8 +86,15 @@ trait CanSortRecords
             return $query;
         }
 
+        $this->applyDefaultSortingToTableQuery($query, $sortColumn, $sortDirection);
+
+        return $query;
+    }
+
+    protected function applyDefaultSortingToTableQuery(Builder $query, string $sortColumn, string $sortDirection): Builder
+    {
         if ($sortColumn === $this->getDefaultTableSortColumn()) {
-            return $query->orderBy($sortColumn, $sortDirection);
+            $query->orderBy($sortColumn, $sortDirection);
         }
 
         return $query;

--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -93,11 +93,11 @@ trait CanSortRecords
 
     protected function applyDefaultSortingToTableQuery(Builder $query, string $sortColumn, string $sortDirection): Builder
     {
-        if ($sortColumn === $this->getDefaultTableSortColumn()) {
-            $query->orderBy($sortColumn, $sortDirection);
+        if ($sortColumn !== $this->getDefaultTableSortColumn()) {
+            return $query;
         }
-
-        return $query;
+        
+        return $query->orderBy($sortColumn, $sortDirection);
     }
 
     public function getTableSortSessionKey(): string


### PR DESCRIPTION
This feature allows developers to custom "default sort" behavior in Table builder

Usage:
1. When you need a set of columns to be sorted by default
2. When you need a calculated column to be sorted by default
3. When you need a json object attribute to be sorted by default

Since all the logic just moved to a new method; it's not breaking any thing

Tested scenarios:
1. Not given defaultSort, Not overrided applyDefaultSortingToTableQuery: Nothing have broken, no sort applied
2. Given defaultSort,  Not overrided applyDefaultSortingToTableQuery:  sorted by price order by id
```php
        return $table
            ->columns([
                Tables\Columns\TextColumn::make('price'),
                Tables\Columns\TextColumn::make('count'),
                Tables\Columns\TextColumn::make('discount'),
            ])
            ->filters([
                //
            ])
            ->actions([
                Tables\Actions\EditAction::make(),
            ])
            ->bulkActions([
                Tables\Actions\DeleteBulkAction::make(),
            ])->defaultSort('price', 'desc');
```

4. Given defaultSort, Overrided applyDefaultSortingToTableQuery: 
```php
    protected function applyDefaultSortingToTableQuery(Builder $query, string $sortColumn, string $sortDirection): Builder
    {
        return $query->orderByRaw("$sortColumn * ( 100 - discount ) / 100 $sortDirection"); 
    }
```
sorted by the given formula

5. Multiple sort columns
```php
    protected function applyDefaultSortingToTableQuery(Builder $query, string $sortColumn, string $sortDirection): Builder
    {
        return $query->orderByRaw("price desc, discount asc");
    }
```

5. Json sort
```php
         ...
            ])->defaultSort("prices->'$.tax'", 'desc'); // not working when applyDefaultSortingToTableQuery is not overrided
    . . .
    protected function applyDefaultSortingToTableQuery(Builder $query, string $sortColumn, string $sortDirection): Builder
    {
         return $query->orderByRaw("$sortColumn $sortDirection");
    }
```



