### PR TITLE
Update French translations

### DIFF
--- a/packages/forms/resources/lang/fr/components.php
+++ b/packages/forms/resources/lang/fr/components.php
@@ -202,6 +202,7 @@ return [
             'ordered_list' => 'Nombres',
             'redo' => 'Refaire',
             'strike' => 'Barré',
+            'underline' => 'Souligné',
             'undo' => 'Annuler',
         ],
 


### PR DESCRIPTION
After last update v2.17.43, I update french translations to support new Underline button in RichText field.