### PR TITLE
Add enabled options getter

### DIFF
--- a/packages/forms/docs/03-fields/03-select.md
+++ b/packages/forms/docs/03-fields/03-select.md
@@ -341,6 +341,8 @@ Select::make('status')
     ->disableOptionWhen(fn (string $value): bool => $value === 'published')
 ```
 
+If you want to retrieve the options that have not been disabled, e.g. for validation purposes, you can do so using `getEnabledOptions()`.
+
 ## Adding affix text aside the field
 
 You may place text before and after the input using the `prefix()` and `suffix()` methods:

--- a/packages/forms/docs/03-fields/07-radio.md
+++ b/packages/forms/docs/03-fields/07-radio.md
@@ -83,3 +83,5 @@ Radio::make('status')
     ])
     ->disableOptionWhen(fn (string $value): bool => $value === 'published')
 ```
+
+If you want to retrieve the options that have not been disabled, e.g. for validation purposes, you can do so using `getEnabledOptions()`.

--- a/packages/forms/src/Components/Concerns/CanDisableOptions.php
+++ b/packages/forms/src/Components/Concerns/CanDisableOptions.php
@@ -16,6 +16,18 @@ trait CanDisableOptions
     }
 
     /**
+     * @return array<string>
+     */
+    public function getEnabledOptions(): array
+    {
+        return array_filter(
+            $this->getOptions(),
+            fn ($label, $value) => ! $this->isOptionDisabled($value, $label),
+            ARRAY_FILTER_USE_BOTH,
+        );
+    }
+
+    /**
      * @param  array-key  $value
      */
     public function isOptionDisabled($value, string $label): bool


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
