### PR TITLE
Fix password confirmation translation key

### DIFF
--- a/packages/app/resources/lang/de/pages/auth/password-reset/reset-password.php
+++ b/packages/app/resources/lang/de/pages/auth/password-reset/reset-password.php
@@ -25,7 +25,7 @@ return [
             'validation_attribute' => 'Passwort',
         ],
 
-        'passwordConfirmation' => [
+        'password_confirmation' => [
             'label' => 'Passwort bestätigen',
         ],
 

--- a/packages/app/resources/lang/de/pages/auth/register.php
+++ b/packages/app/resources/lang/de/pages/auth/register.php
@@ -34,7 +34,7 @@ return [
             'validation_attribute' => 'Passwort',
         ],
 
-        'passwordConfirmation' => [
+        'password_confirmation' => [
             'label' => 'Passwort bestätigen',
         ],
 

--- a/packages/app/resources/lang/en/pages/auth/password-reset/reset-password.php
+++ b/packages/app/resources/lang/en/pages/auth/password-reset/reset-password.php
@@ -26,7 +26,7 @@ return [
         ],
 
         'password_confirmation' => [
-            'label' => 'Confirm your password',
+            'label' => 'Confirm password',
         ],
 
     ],

--- a/packages/app/resources/lang/en/pages/auth/password-reset/reset-password.php
+++ b/packages/app/resources/lang/en/pages/auth/password-reset/reset-password.php
@@ -25,7 +25,7 @@ return [
             'validation_attribute' => 'password',
         ],
 
-        'passwordConfirmation' => [
+        'password_confirmation' => [
             'label' => 'Confirm your password',
         ],
 

--- a/packages/app/resources/lang/en/pages/auth/register.php
+++ b/packages/app/resources/lang/en/pages/auth/register.php
@@ -35,7 +35,7 @@ return [
         ],
 
         'password_confirmation' => [
-            'label' => 'Confirm your password',
+            'label' => 'Confirm password',
         ],
 
     ],

--- a/packages/app/resources/lang/en/pages/auth/register.php
+++ b/packages/app/resources/lang/en/pages/auth/register.php
@@ -34,7 +34,7 @@ return [
             'validation_attribute' => 'password',
         ],
 
-        'passwordConfirmation' => [
+        'password_confirmation' => [
             'label' => 'Confirm your password',
         ],
 

--- a/packages/app/resources/lang/nl/pages/auth/register.php
+++ b/packages/app/resources/lang/nl/pages/auth/register.php
@@ -34,7 +34,7 @@ return [
             'validation_attribute' => 'wachtwoord',
         ],
 
-        'passwordConfirmation' => [
+        'password_confirmation' => [
             'label' => 'Wachtwoord bevestigen',
         ],
 

--- a/packages/app/src/Pages/Auth/PasswordReset/ResetPassword.php
+++ b/packages/app/src/Pages/Auth/PasswordReset/ResetPassword.php
@@ -120,7 +120,7 @@ class ResetPassword extends CardPage
                     ->same('passwordConfirmation')
                     ->validationAttribute(__('filament::pages/auth/password-reset/reset-password.fields.password.validation_attribute')),
                 TextInput::make('passwordConfirmation')
-                    ->label(__('filament::pages/auth/password-reset/reset-password.fields.passwordConfirmation.label'))
+                    ->label(__('filament::pages/auth/password-reset/reset-password.fields.password_confirmation.label'))
                     ->password()
                     ->required()
                     ->dehydrated(false),

--- a/packages/app/src/Pages/Auth/Register.php
+++ b/packages/app/src/Pages/Auth/Register.php
@@ -103,7 +103,7 @@ class Register extends CardPage
                     ->same('passwordConfirmation')
                     ->validationAttribute(__('filament::pages/auth/register.fields.password.validation_attribute')),
                 TextInput::make('passwordConfirmation')
-                    ->label(__('filament::pages/auth/register.fields.passwordConfirmation.label'))
+                    ->label(__('filament::pages/auth/register.fields.password_confirmation.label'))
                     ->password()
                     ->required()
                     ->dehydrated(false),


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
