### PR TITLE
Add grid to builder

### DIFF
--- a/packages/forms/docs/03-fields.md
+++ b/packages/forms/docs/03-fields.md
@@ -1854,7 +1854,48 @@ Builder::make('content')
     ])
     ->collapsed()
 ```
+### Add Multiple Column to Block Picker
+The builder block picker may have multiple columns:
 
+```php
+use Filament\Forms\Components\Builder;
+
+Builder::make('content')
+    ->blocks([
+        // ...
+    ])
+    ->gridColumn(3)
+```
+
+![](https://github.com/filamentphp/filament/assets/47450090/9db9c7ad-58c1-480e-b551-2e932d36a190)
+
+You may change the width of this columns:
+
+```php
+use Filament\Forms\Components\Builder;
+
+Builder::make('content')
+    ->blocks([
+        // ...
+    ])
+    ->gridColumn(3)
+    ->widthColumn('3xl')
+```
+You can use any option below:
+```
+'xs' => 'max-w-xs',
+'sm' => 'max-w-sm',
+'md' => 'max-w-md',
+'lg' => 'max-w-lg',
+'xl' => 'max-w-xl',
+'2xl' => 'max-w-2xl',
+'3xl' => 'max-w-3xl',
+'4xl' => 'max-w-4xl',
+'5xl' => 'max-w-5xl',
+'6xl' => 'max-w-6xl',
+'7xl' => 'max-w-7xl',
+default => 'max-w-[14rem]',
+```
 ## Tags input
 
 The tags input component allows you to interact with a list of tags.

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -357,6 +357,8 @@
                 :blocks="$getBlocks()"
                 :state-path="$getStatePath()"
                 class="flex justify-center"
+                :grid_column="$getGridColumn()"
+                :width_column="$getWidthColumn()"
             >
                 <x-slot name="trigger">
                     <x-forms::button size="sm" outlined>

--- a/packages/forms/resources/views/components/builder/block-picker.blade.php
+++ b/packages/forms/resources/views/components/builder/block-picker.blade.php
@@ -3,6 +3,8 @@
     'createAfterItem' => null,
     'statePath',
     'trigger',
+    'grid_column'=> null,
+    'width_column'=> null,
 ])
 
 <x-forms::dropdown {{ $attributes->class(['filament-forms-builder-component-block-picker']) }}>

--- a/packages/forms/resources/views/components/builder/block-picker.blade.php
+++ b/packages/forms/resources/views/components/builder/block-picker.blade.php
@@ -7,12 +7,13 @@
     'width_column'=> null,
 ])
 
-<x-forms::dropdown {{ $attributes->class(['filament-forms-builder-component-block-picker']) }}>
+<x-forms::dropdown {{ $attributes->class(['filament-forms-builder-component-block-picker']) }}
+  :width="$width_column">
     <x-slot name="trigger">
         {{ $trigger }}
     </x-slot>
 
-    <x-forms::dropdown.list>
+    <x-forms::dropdown.list :class="'grid grid-cols-'.$grid_column">
         @foreach ($blocks as $block)
             <x-forms::dropdown.list.item
                 :wire:click="'dispatchFormEvent(\'builder::createItem\', \'' . $statePath . '\', \'' . $block->getName() . '\'' . ($createAfterItem ? ', \'' . $createAfterItem . '\'' : '') . ')'"

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -16,6 +16,7 @@ class Builder extends Field implements Contracts\CanConcealComponents
     use Concerns\CanLimitItemsLength;
     use Concerns\CanBeCloned;
 
+
     protected string $view = 'forms::components.builder';
 
     protected string | Closure | null $createItemBetweenButtonLabel = null;
@@ -35,6 +36,10 @@ class Builder extends Field implements Contracts\CanConcealComponents
     protected bool | Closure $hasBlockNumbers = true;
 
     protected bool | Closure $isInset = false;
+
+    protected ?int $grid_column;
+
+    protected ?string $width_column;
 
     protected function setUp(): void
     {
@@ -352,5 +357,30 @@ class Builder extends Field implements Contracts\CanConcealComponents
     public function canConcealComponents(): bool
     {
         return $this->isCollapsible();
+    }
+
+    public function gridColumn(int $grid_column): static
+    {
+        $this->grid_column = $grid_column;
+        return $this;
+    }
+
+    public function widthColumn(string $width_column): static
+    {
+        $this->width_column = $width_column;
+
+        return $this;
+    }
+
+    public function getGridColumn(): ?int
+    {
+        return $this->grid_column ?? null;
+    }
+
+    public function getWidthColumn(): ?string
+    {
+
+        return $this->width_column ?? null;
+
     }
 }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Code
```
   Builder::make('content')
                    ...
                    ->gridColumn(3)
                    ->widthColumn('3xl')
                     ...
```
Before 
![image](https://github.com/filamentphp/filament/assets/47450090/a99dd642-ac2b-40d9-b18a-9fe7df6efc41)
After
![image](https://github.com/filamentphp/filament/assets/47450090/5b48536c-485f-44b5-a77d-75edddfdd276)

