### PR TITLE
Fix global search panel position on mobile

### DIFF
--- a/packages/admin/resources/views/components/global-search/results-container.blade.php
+++ b/packages/admin/resources/views/components/global-search/results-container.blade.php
@@ -8,7 +8,7 @@
     x-on:keydown.escape.window="isOpen = false"
     x-on:click.away="isOpen = false"
     x-on:open-global-search-results.window="isOpen = true"
-    {{ $attributes->class(['filament-global-search-results-container absolute right-0 rtl:right-auto rtl:left-0 top-auto z-10 mt-2 shadow-xl overflow-hidden rounded-xl w-screen max-w-xs sm:max-w-lg']) }}
+    {{ $attributes->class(['filament-global-search-results-container absolute sm:right-0 rtl:right-auto rtl:left-0 top-auto z-10 mt-2 shadow-xl overflow-hidden rounded-xl w-screen max-w-xs sm:max-w-lg']) }}
 >
     <div @class([
         'overflow-y-scroll overflow-x-hidden max-h-96 bg-white shadow rounded-xl',


### PR DESCRIPTION
Adding sm:right-0 for mobile view search container

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
![image](https://github.com/filamentphp/filament/assets/36026333/cf129d17-a2b2-43e1-a6c2-20180a2292ef)
here we can see the search results are hidden on the left side,,, if we do the change it looks like this 
![image](https://github.com/filamentphp/filament/assets/36026333/82e443e4-6d2b-42a4-bf37-ec4b22c7d91b)
