### PR TITLE
Update command descriptions

### DIFF
--- a/packages/admin/src/Commands/MakePageCommand.php
+++ b/packages/admin/src/Commands/MakePageCommand.php
@@ -12,7 +12,7 @@ class MakePageCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Creates a Filament page class and view.';
+    protected $description = 'Creates a Filament page class and view';
 
     protected $signature = 'make:filament-page {name?} {--R|resource=} {--T|type=} {--F|force}';
 

--- a/packages/admin/src/Commands/MakePageCommand.php
+++ b/packages/admin/src/Commands/MakePageCommand.php
@@ -12,7 +12,7 @@ class MakePageCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Creates a Filament page class and view';
+    protected $description = 'Create a Filament page class and view';
 
     protected $signature = 'make:filament-page {name?} {--R|resource=} {--T|type=} {--F|force}';
 

--- a/packages/admin/src/Commands/MakePageCommand.php
+++ b/packages/admin/src/Commands/MakePageCommand.php
@@ -12,7 +12,7 @@ class MakePageCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Create a Filament page class and view';
+    protected $description = 'Create a new Filament page class and view';
 
     protected $signature = 'make:filament-page {name?} {--R|resource=} {--T|type=} {--F|force}';
 

--- a/packages/admin/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/admin/src/Commands/MakeRelationManagerCommand.php
@@ -14,7 +14,7 @@ class MakeRelationManagerCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Creates a Filament relation manager class for a resource';
+    protected $description = 'Create a Filament relation manager class for a resource';
 
     protected $signature = 'make:filament-relation-manager {resource?} {relationship?} {recordTitleAttribute?} {--attach} {--associate} {--soft-deletes} {--view} {--F|force}';
 

--- a/packages/admin/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/admin/src/Commands/MakeRelationManagerCommand.php
@@ -14,7 +14,7 @@ class MakeRelationManagerCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Create a Filament relation manager class for a resource';
+    protected $description = 'Create a new Filament relation manager class for a resource';
 
     protected $signature = 'make:filament-relation-manager {resource?} {relationship?} {recordTitleAttribute?} {--attach} {--associate} {--soft-deletes} {--view} {--F|force}';
 

--- a/packages/admin/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/admin/src/Commands/MakeRelationManagerCommand.php
@@ -14,7 +14,7 @@ class MakeRelationManagerCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Creates a Filament relation manager class for a resource.';
+    protected $description = 'Creates a Filament relation manager class for a resource';
 
     protected $signature = 'make:filament-relation-manager {resource?} {relationship?} {recordTitleAttribute?} {--attach} {--associate} {--soft-deletes} {--view} {--F|force}';
 

--- a/packages/admin/src/Commands/MakeResourceCommand.php
+++ b/packages/admin/src/Commands/MakeResourceCommand.php
@@ -20,7 +20,7 @@ class MakeResourceCommand extends Command
     use CanReadModelSchemas;
     use CanValidateInput;
 
-    protected $description = 'Creates a Filament resource class and default page classes.';
+    protected $description = 'Creates a Filament resource class and default page classes';
 
     protected $signature = 'make:filament-resource {name?} {--soft-deletes} {--view} {--G|generate} {--S|simple} {--F|force}';
 

--- a/packages/admin/src/Commands/MakeResourceCommand.php
+++ b/packages/admin/src/Commands/MakeResourceCommand.php
@@ -20,7 +20,7 @@ class MakeResourceCommand extends Command
     use CanReadModelSchemas;
     use CanValidateInput;
 
-    protected $description = 'Creates a Filament resource class and default page classes';
+    protected $description = 'Create a Filament resource class and default page classes';
 
     protected $signature = 'make:filament-resource {name?} {--soft-deletes} {--view} {--G|generate} {--S|simple} {--F|force}';
 

--- a/packages/admin/src/Commands/MakeResourceCommand.php
+++ b/packages/admin/src/Commands/MakeResourceCommand.php
@@ -20,7 +20,7 @@ class MakeResourceCommand extends Command
     use CanReadModelSchemas;
     use CanValidateInput;
 
-    protected $description = 'Create a Filament resource class and default page classes';
+    protected $description = 'Create a new Filament resource class and default page classes';
 
     protected $signature = 'make:filament-resource {name?} {--soft-deletes} {--view} {--G|generate} {--S|simple} {--F|force}';
 

--- a/packages/admin/src/Commands/MakeUserCommand.php
+++ b/packages/admin/src/Commands/MakeUserCommand.php
@@ -15,7 +15,7 @@ class MakeUserCommand extends Command
 {
     use CanValidateInput;
 
-    protected $description = 'Create a Filament user';
+    protected $description = 'Create a new Filament user';
 
     protected $signature = 'make:filament-user
                             {--name= : The name of the user}

--- a/packages/admin/src/Commands/MakeUserCommand.php
+++ b/packages/admin/src/Commands/MakeUserCommand.php
@@ -15,7 +15,7 @@ class MakeUserCommand extends Command
 {
     use CanValidateInput;
 
-    protected $description = 'Creates a Filament user.';
+    protected $description = 'Creates a Filament user';
 
     protected $signature = 'make:filament-user
                             {--name= : The name of the user}

--- a/packages/admin/src/Commands/MakeUserCommand.php
+++ b/packages/admin/src/Commands/MakeUserCommand.php
@@ -15,7 +15,7 @@ class MakeUserCommand extends Command
 {
     use CanValidateInput;
 
-    protected $description = 'Creates a Filament user';
+    protected $description = 'Create a Filament user';
 
     protected $signature = 'make:filament-user
                             {--name= : The name of the user}

--- a/packages/admin/src/Commands/MakeWidgetCommand.php
+++ b/packages/admin/src/Commands/MakeWidgetCommand.php
@@ -12,7 +12,7 @@ class MakeWidgetCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Create a Filament widget class';
+    protected $description = 'Create a new Filament widget class';
 
     protected $signature = 'make:filament-widget {name?} {--R|resource=} {--C|chart} {--T|table} {--S|stats-overview} {--F|force}';
 

--- a/packages/admin/src/Commands/MakeWidgetCommand.php
+++ b/packages/admin/src/Commands/MakeWidgetCommand.php
@@ -12,7 +12,7 @@ class MakeWidgetCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Creates a Filament widget class';
+    protected $description = 'Create a Filament widget class';
 
     protected $signature = 'make:filament-widget {name?} {--R|resource=} {--C|chart} {--T|table} {--S|stats-overview} {--F|force}';
 

--- a/packages/admin/src/Commands/MakeWidgetCommand.php
+++ b/packages/admin/src/Commands/MakeWidgetCommand.php
@@ -12,7 +12,7 @@ class MakeWidgetCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Creates a Filament widget class.';
+    protected $description = 'Creates a Filament widget class';
 
     protected $signature = 'make:filament-widget {name?} {--R|resource=} {--C|chart} {--T|table} {--S|stats-overview} {--F|force}';
 

--- a/packages/forms/src/Commands/InstallCommand.php
+++ b/packages/forms/src/Commands/InstallCommand.php
@@ -10,7 +10,7 @@ class InstallCommand extends Command
 {
     protected $signature = 'forms:install';
 
-    protected $description = 'Set up form builder CSS and JS in a fresh Laravel installation.';
+    protected $description = 'Set up form builder CSS and JS in a fresh Laravel installation';
 
     public function __invoke(): int
     {

--- a/packages/forms/src/Commands/MakeFieldCommand.php
+++ b/packages/forms/src/Commands/MakeFieldCommand.php
@@ -12,7 +12,7 @@ class MakeFieldCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Creates a form field class and view';
+    protected $description = 'Create a form field class and view';
 
     protected $signature = 'make:form-field {name?} {--F|force}';
 

--- a/packages/forms/src/Commands/MakeFieldCommand.php
+++ b/packages/forms/src/Commands/MakeFieldCommand.php
@@ -12,7 +12,7 @@ class MakeFieldCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Creates a form field class and view.';
+    protected $description = 'Creates a form field class and view';
 
     protected $signature = 'make:form-field {name?} {--F|force}';
 

--- a/packages/forms/src/Commands/MakeFieldCommand.php
+++ b/packages/forms/src/Commands/MakeFieldCommand.php
@@ -12,7 +12,7 @@ class MakeFieldCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Create a form field class and view';
+    protected $description = 'Create a new form field class and view';
 
     protected $signature = 'make:form-field {name?} {--F|force}';
 

--- a/packages/forms/src/Commands/MakeFormCommand.php
+++ b/packages/forms/src/Commands/MakeFormCommand.php
@@ -18,7 +18,7 @@ class MakeFormCommand extends Command
     use CanReadModelSchemas;
     use CanValidateInput;
 
-    protected $description = 'Create a Livewire component containing a Filament form';
+    protected $description = 'Create a new Livewire component containing a Filament form';
 
     protected $signature = 'make:livewire-form {name?} {model?} {--E|edit} {--G|generate} {--F|force}';
 

--- a/packages/forms/src/Commands/MakeFormCommand.php
+++ b/packages/forms/src/Commands/MakeFormCommand.php
@@ -18,7 +18,7 @@ class MakeFormCommand extends Command
     use CanReadModelSchemas;
     use CanValidateInput;
 
-    protected $description = 'Creates a Livewire component containing a Filament form.';
+    protected $description = 'Creates a Livewire component containing a Filament form';
 
     protected $signature = 'make:livewire-form {name?} {model?} {--E|edit} {--G|generate} {--F|force}';
 

--- a/packages/forms/src/Commands/MakeFormCommand.php
+++ b/packages/forms/src/Commands/MakeFormCommand.php
@@ -18,7 +18,7 @@ class MakeFormCommand extends Command
     use CanReadModelSchemas;
     use CanValidateInput;
 
-    protected $description = 'Creates a Livewire component containing a Filament form';
+    protected $description = 'Create a Livewire component containing a Filament form';
 
     protected $signature = 'make:livewire-form {name?} {model?} {--E|edit} {--G|generate} {--F|force}';
 

--- a/packages/forms/src/Commands/MakeLayoutComponentCommand.php
+++ b/packages/forms/src/Commands/MakeLayoutComponentCommand.php
@@ -12,7 +12,7 @@ class MakeLayoutComponentCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Creates a form layout component class and view.';
+    protected $description = 'Creates a form layout component class and view';
 
     protected $signature = 'make:form-layout {name?} {--F|force}';
 

--- a/packages/forms/src/Commands/MakeLayoutComponentCommand.php
+++ b/packages/forms/src/Commands/MakeLayoutComponentCommand.php
@@ -12,7 +12,7 @@ class MakeLayoutComponentCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Creates a form layout component class and view';
+    protected $description = 'Create a form layout component class and view';
 
     protected $signature = 'make:form-layout {name?} {--F|force}';
 

--- a/packages/forms/src/Commands/MakeLayoutComponentCommand.php
+++ b/packages/forms/src/Commands/MakeLayoutComponentCommand.php
@@ -12,7 +12,7 @@ class MakeLayoutComponentCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Create a form layout component class and view';
+    protected $description = 'Create a new form layout component class and view';
 
     protected $signature = 'make:form-layout {name?} {--F|force}';
 

--- a/packages/notifications/src/Commands/InstallCommand.php
+++ b/packages/notifications/src/Commands/InstallCommand.php
@@ -10,7 +10,7 @@ class InstallCommand extends Command
 {
     protected $signature = 'notifications:install';
 
-    protected $description = 'Set up notifications CSS and JS in a fresh Laravel installation.';
+    protected $description = 'Set up notifications CSS and JS in a fresh Laravel installation';
 
     public function __invoke(): int
     {

--- a/packages/spatie-laravel-settings-plugin/src/Commands/MakeSettingsPageCommand.php
+++ b/packages/spatie-laravel-settings-plugin/src/Commands/MakeSettingsPageCommand.php
@@ -12,7 +12,7 @@ class MakeSettingsPageCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Creates a Filament settings page class';
+    protected $description = 'Create a Filament settings page class';
 
     protected $signature = 'make:filament-settings-page {name?} {settingsClass?}';
 

--- a/packages/spatie-laravel-settings-plugin/src/Commands/MakeSettingsPageCommand.php
+++ b/packages/spatie-laravel-settings-plugin/src/Commands/MakeSettingsPageCommand.php
@@ -12,7 +12,7 @@ class MakeSettingsPageCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Creates a Filament settings page class.';
+    protected $description = 'Creates a Filament settings page class';
 
     protected $signature = 'make:filament-settings-page {name?} {settingsClass?}';
 

--- a/packages/spatie-laravel-settings-plugin/src/Commands/MakeSettingsPageCommand.php
+++ b/packages/spatie-laravel-settings-plugin/src/Commands/MakeSettingsPageCommand.php
@@ -12,7 +12,7 @@ class MakeSettingsPageCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Create a Filament settings page class';
+    protected $description = 'Create a new Filament settings page class';
 
     protected $signature = 'make:filament-settings-page {name?} {settingsClass?}';
 

--- a/packages/support/src/Commands/CheckTranslationsCommand.php
+++ b/packages/support/src/Commands/CheckTranslationsCommand.php
@@ -16,7 +16,7 @@ class CheckTranslationsCommand extends Command
                             {locales* : The locales to check.}
                             {--source=vendor : The directory containing the translations to check - either \'vendor\' or \'app\'.}';
 
-    protected $description = 'Checks for missing and removed translations';
+    protected $description = 'Check for missing and removed translations';
 
     public function handle()
     {

--- a/packages/support/src/Commands/CheckTranslationsCommand.php
+++ b/packages/support/src/Commands/CheckTranslationsCommand.php
@@ -16,7 +16,7 @@ class CheckTranslationsCommand extends Command
                             {locales* : The locales to check.}
                             {--source=vendor : The directory containing the translations to check - either \'vendor\' or \'app\'.}';
 
-    protected $description = 'Checks for missing and removed translations.';
+    protected $description = 'Checks for missing and removed translations';
 
     public function handle()
     {

--- a/packages/support/src/Commands/UpgradeCommand.php
+++ b/packages/support/src/Commands/UpgradeCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Console\Command;
 
 class UpgradeCommand extends Command
 {
-    protected $description = 'Upgrade Filament to the latest version.';
+    protected $description = 'Upgrade Filament to the latest version';
 
     protected $signature = 'filament:upgrade';
 

--- a/packages/tables/src/Commands/InstallCommand.php
+++ b/packages/tables/src/Commands/InstallCommand.php
@@ -10,7 +10,7 @@ class InstallCommand extends Command
 {
     protected $signature = 'tables:install';
 
-    protected $description = 'Set up table builder CSS and JS in a fresh Laravel installation.';
+    protected $description = 'Set up table builder CSS and JS in a fresh Laravel installation';
 
     public function __invoke(): int
     {

--- a/packages/tables/src/Commands/MakeColumnCommand.php
+++ b/packages/tables/src/Commands/MakeColumnCommand.php
@@ -12,7 +12,7 @@ class MakeColumnCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Creates a table column class and cell view';
+    protected $description = 'Create a table column class and cell view';
 
     protected $signature = 'make:table-column {name?} {--F|force}';
 

--- a/packages/tables/src/Commands/MakeColumnCommand.php
+++ b/packages/tables/src/Commands/MakeColumnCommand.php
@@ -12,7 +12,7 @@ class MakeColumnCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Create a table column class and cell view';
+    protected $description = 'Create a new table column class and cell view';
 
     protected $signature = 'make:table-column {name?} {--F|force}';
 

--- a/packages/tables/src/Commands/MakeColumnCommand.php
+++ b/packages/tables/src/Commands/MakeColumnCommand.php
@@ -12,7 +12,7 @@ class MakeColumnCommand extends Command
     use CanManipulateFiles;
     use CanValidateInput;
 
-    protected $description = 'Creates a table column class and cell view.';
+    protected $description = 'Creates a table column class and cell view';
 
     protected $signature = 'make:table-column {name?} {--F|force}';
 

--- a/packages/tables/src/Commands/MakeTableCommand.php
+++ b/packages/tables/src/Commands/MakeTableCommand.php
@@ -18,7 +18,7 @@ class MakeTableCommand extends Command
     use CanReadModelSchemas;
     use CanValidateInput;
 
-    protected $description = 'Creates a Livewire component containing a Filament table.';
+    protected $description = 'Creates a Livewire component containing a Filament table';
 
     protected $signature = 'make:livewire-table {name?} {model?} {--G|generate} {--F|force}';
 

--- a/packages/tables/src/Commands/MakeTableCommand.php
+++ b/packages/tables/src/Commands/MakeTableCommand.php
@@ -18,7 +18,7 @@ class MakeTableCommand extends Command
     use CanReadModelSchemas;
     use CanValidateInput;
 
-    protected $description = 'Creates a Livewire component containing a Filament table';
+    protected $description = 'Create a Livewire component containing a Filament table';
 
     protected $signature = 'make:livewire-table {name?} {model?} {--G|generate} {--F|force}';
 

--- a/packages/tables/src/Commands/MakeTableCommand.php
+++ b/packages/tables/src/Commands/MakeTableCommand.php
@@ -18,7 +18,7 @@ class MakeTableCommand extends Command
     use CanReadModelSchemas;
     use CanValidateInput;
 
-    protected $description = 'Create a Livewire component containing a Filament table';
+    protected $description = 'Create a new Livewire component containing a Filament table';
 
     protected $signature = 'make:livewire-table {name?} {model?} {--G|generate} {--F|force}';
 


### PR DESCRIPTION
- Removes trailing dots
- Changes `Creates` to `Create`
- Adds `new` to line up with other `artisan make:*` commands

Discussed in https://github.com/filamentphp/filament/discussions/6631

## Before

![image](https://github.com/filamentphp/filament/assets/1066486/6abe465b-5f17-426f-98ad-d40a8198eff4)

## After

![image](https://github.com/filamentphp/filament/assets/1066486/d88bec08-650e-4140-b059-928efde6953e)

---

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.