### PR TITLE
Support `Htmlable` record titles

### DIFF
--- a/packages/admin/src/Pages/Page.php
+++ b/packages/admin/src/Pages/Page.php
@@ -13,6 +13,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
+use Illuminate\Support\HtmlString;
 use Illuminate\Validation\ValidationException;
 use Livewire\Component;
 
@@ -223,7 +224,7 @@ class Page extends Component implements Forms\Contracts\HasForms, RendersFormCom
         return $this->subheading;
     }
 
-    protected function getTitle(): string
+    protected function getTitle(): string | HtmlString
     {
         return static::$title ?? (string) Str::of(class_basename(static::class))
             ->kebab()

--- a/packages/admin/src/Pages/Page.php
+++ b/packages/admin/src/Pages/Page.php
@@ -13,7 +13,6 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
-use Illuminate\Support\HtmlString;
 use Illuminate\Validation\ValidationException;
 use Livewire\Component;
 
@@ -224,7 +223,7 @@ class Page extends Component implements Forms\Contracts\HasForms, RendersFormCom
         return $this->subheading;
     }
 
-    protected function getTitle(): string | HtmlString
+    protected function getTitle(): string | Htmlable
     {
         return static::$title ?? (string) Str::of(class_basename(static::class))
             ->kebab()

--- a/packages/admin/src/Pages/Page.php
+++ b/packages/admin/src/Pages/Page.php
@@ -12,8 +12,8 @@ use Filament\Tables\Contracts\RendersFormComponentActionModal;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Str;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Livewire\Component;
 

--- a/packages/admin/src/Resources/Pages/Concerns/InteractsWithRecord.php
+++ b/packages/admin/src/Resources/Pages/Concerns/InteractsWithRecord.php
@@ -5,7 +5,7 @@ namespace Filament\Resources\Pages\Concerns;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Str;
-use Illuminate\Support\HtmlString;
+use Illuminate\Contracts\Support\Htmlable;
 
 trait InteractsWithRecord
 {
@@ -27,7 +27,7 @@ trait InteractsWithRecord
         return $this->record;
     }
 
-    public function getRecordTitle(): string | HtmlString
+    public function getRecordTitle(): string | Htmlable
     {
         $resource = static::getResource();
 

--- a/packages/admin/src/Resources/Pages/Concerns/InteractsWithRecord.php
+++ b/packages/admin/src/Resources/Pages/Concerns/InteractsWithRecord.php
@@ -5,6 +5,7 @@ namespace Filament\Resources\Pages\Concerns;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Str;
+use Illuminate\Support\HtmlString;
 
 trait InteractsWithRecord
 {
@@ -26,7 +27,7 @@ trait InteractsWithRecord
         return $this->record;
     }
 
-    public function getRecordTitle(): string
+    public function getRecordTitle(): string | HtmlString
     {
         $resource = static::getResource();
 

--- a/packages/admin/src/Resources/Pages/Concerns/InteractsWithRecord.php
+++ b/packages/admin/src/Resources/Pages/Concerns/InteractsWithRecord.php
@@ -4,8 +4,8 @@ namespace Filament\Resources\Pages\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Support\Str;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
 
 trait InteractsWithRecord
 {

--- a/packages/admin/src/Resources/Pages/Concerns/InteractsWithRecord.php
+++ b/packages/admin/src/Resources/Pages/Concerns/InteractsWithRecord.php
@@ -2,10 +2,10 @@
 
 namespace Filament\Resources\Pages\Concerns;
 
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Str;
-use Illuminate\Contracts\Support\Htmlable;
 
 trait InteractsWithRecord
 {

--- a/packages/admin/src/Resources/Pages/EditRecord.php
+++ b/packages/admin/src/Resources/Pages/EditRecord.php
@@ -13,7 +13,7 @@ use Filament\Pages\Actions\ViewAction;
 use Filament\Pages\Contracts\HasFormActions;
 use Filament\Support\Exceptions\Halt;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\HtmlString;
+use Illuminate\Contracts\Support\Htmlable;
 
 /**
  * @property ComponentContainer $form
@@ -302,7 +302,7 @@ class EditRecord extends Page implements HasFormActions
             ->action(fn () => $this->delete());
     }
 
-    protected function getTitle(): string | HtmlString
+    protected function getTitle(): string | Htmlable
     {
         if (filled(static::$title)) {
             return static::$title;

--- a/packages/admin/src/Resources/Pages/EditRecord.php
+++ b/packages/admin/src/Resources/Pages/EditRecord.php
@@ -12,8 +12,8 @@ use Filament\Pages\Actions\RestoreAction;
 use Filament\Pages\Actions\ViewAction;
 use Filament\Pages\Contracts\HasFormActions;
 use Filament\Support\Exceptions\Halt;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * @property ComponentContainer $form

--- a/packages/admin/src/Resources/Pages/EditRecord.php
+++ b/packages/admin/src/Resources/Pages/EditRecord.php
@@ -13,6 +13,7 @@ use Filament\Pages\Actions\ViewAction;
 use Filament\Pages\Contracts\HasFormActions;
 use Filament\Support\Exceptions\Halt;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\HtmlString;
 
 /**
  * @property ComponentContainer $form
@@ -301,7 +302,7 @@ class EditRecord extends Page implements HasFormActions
             ->action(fn () => $this->delete());
     }
 
-    protected function getTitle(): string
+    protected function getTitle(): string | HtmlString
     {
         if (filled(static::$title)) {
             return static::$title;

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Traits\Macroable;
 
 class Resource
@@ -367,7 +368,7 @@ class Resource
         return static::$recordTitleAttribute;
     }
 
-    public static function getRecordTitle(?Model $record): ?string
+    public static function getRecordTitle(?Model $record): string | HtmlString | null
     {
         return $record?->getAttribute(static::getRecordTitleAttribute()) ?? static::getModelLabel();
     }

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -15,8 +15,8 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Str;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 
 class Resource

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -8,6 +8,7 @@ use Filament\GlobalSearch\GlobalSearchResult;
 use Filament\Navigation\NavigationItem;
 use function Filament\Support\get_model_label;
 use function Filament\Support\locale_has_pluralization;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -16,7 +17,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
-use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Traits\Macroable;
 
 class Resource

--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
-use Illuminate\Support\HtmlString;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Traits\Macroable;
 
 class Resource
@@ -368,7 +368,7 @@ class Resource
         return static::$recordTitleAttribute;
     }
 
-    public static function getRecordTitle(?Model $record): string | HtmlString | null
+    public static function getRecordTitle(?Model $record): string | Htmlable | null
     {
         return $record?->getAttribute(static::getRecordTitleAttribute()) ?? static::getModelLabel();
     }

--- a/packages/forms/src/Components/Concerns/HasHelperText.php
+++ b/packages/forms/src/Components/Concerns/HasHelperText.php
@@ -3,20 +3,20 @@
 namespace Filament\Forms\Components\Concerns;
 
 use Closure;
-use Illuminate\Support\HtmlString;
+use Illuminate\Contracts\Support\Htmlable;
 
 trait HasHelperText
 {
-    protected string | HtmlString | Closure | null $helperText = null;
+    protected string | Htmlable | Closure | null $helperText = null;
 
-    public function helperText(string | HtmlString | Closure | null $text): static
+    public function helperText(string | Htmlable | Closure | null $text): static
     {
         $this->helperText = $text;
 
         return $this;
     }
 
-    public function getHelperText(): string | HtmlString | null
+    public function getHelperText(): string | Htmlable | null
     {
         return $this->evaluate($this->helperText);
     }

--- a/packages/forms/src/Components/Concerns/HasHint.php
+++ b/packages/forms/src/Components/Concerns/HasHint.php
@@ -4,11 +4,11 @@ namespace Filament\Forms\Components\Concerns;
 
 use Closure;
 use Filament\Forms\Components\Actions\Action;
-use Illuminate\Support\HtmlString;
+use Illuminate\Contracts\Support\Htmlable;
 
 trait HasHint
 {
-    protected string | HtmlString | Closure | null $hint = null;
+    protected string | Htmlable | Closure | null $hint = null;
 
     protected Action | Closure | null $hintAction = null;
 
@@ -16,7 +16,7 @@ trait HasHint
 
     protected string | Closure | null $hintIcon = null;
 
-    public function hint(string | HtmlString | Closure | null $hint): static
+    public function hint(string | Htmlable | Closure | null $hint): static
     {
         $this->hint = $hint;
 
@@ -44,7 +44,7 @@ trait HasHint
         return $this;
     }
 
-    public function getHint(): string | HtmlString | null
+    public function getHint(): string | Htmlable | null
     {
         return $this->evaluate($this->hint);
     }

--- a/packages/tables/src/Columns/Concerns/HasDescription.php
+++ b/packages/tables/src/Columns/Concerns/HasDescription.php
@@ -3,15 +3,15 @@
 namespace Filament\Tables\Columns\Concerns;
 
 use Closure;
-use Illuminate\Support\HtmlString;
+use Illuminate\Contracts\Support\Htmlable;
 
 trait HasDescription
 {
-    protected string | HtmlString | Closure | null $descriptionAbove = null;
+    protected string | Htmlable | Closure | null $descriptionAbove = null;
 
-    protected string | HtmlString | Closure | null $descriptionBelow = null;
+    protected string | Htmlable | Closure | null $descriptionBelow = null;
 
-    public function description(string | HtmlString | Closure | null $description, string | Closure | null $position = 'below'): static
+    public function description(string | Htmlable | Closure | null $description, string | Closure | null $position = 'below'): static
     {
         if ($position == 'above') {
             $this->descriptionAbove = $description;
@@ -35,12 +35,12 @@ trait HasDescription
         return $this;
     }
 
-    public function getDescriptionAbove(): string | HtmlString | null
+    public function getDescriptionAbove(): string | Htmlable | null
     {
         return $this->evaluate($this->descriptionAbove);
     }
 
-    public function getDescriptionBelow(): string | HtmlString | null
+    public function getDescriptionBelow(): string | Htmlable | null
     {
         return $this->evaluate($this->descriptionBelow);
     }


### PR DESCRIPTION
TLDR: This PR only adds `HtmlString` as a return type to the `getTitle` and `getRecordTitle` method.

Reason:

I have a hotels resource, where some of the hotels have HTML inside their name, like `Hotel XY <sup>Superior</sup>` (Hotel XY <sup>Superior</sup>).  On edit pages and inside the breadcrumb, this looks obviously uggly, since its rendered htmlencoded. After PR I can:

```php

  public static function getRecordTitle(?Model $record): string | HtmlString | null
  {
        return new HtmlString($record->name);
  }
```