### PR TITLE
Fix entangle state path in markdown-editor

### DIFF
--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -14,7 +14,7 @@
             ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('markdown-editor', 'filament/forms') }}"
             x-data="markdownEditorFormComponent({
                 placeholder: @js($getPlaceholder()),
-                state: $wire.{{ $applyStateBindingModifiers("entangle({$statePath})") }},
+                state: $wire.{{ $applyStateBindingModifiers("entangle('{$statePath}')") }},
                 toolbarButtons: @js($getToolbarButtons()),
                 translations: @js(__('filament-forms::components.markdown_editor')),
                 uploadFileAttachmentUsing: async (file, onSuccess, onError) => {


### PR DESCRIPTION
fix missing `''` in markdown-editor state path.

Else error:
Alpine Expression Error: data is not defined

