### PR TITLE
Add `requiredIf()` and `requiredUnless()` validation methods

### DIFF
--- a/packages/forms/docs/05-validation.md
+++ b/packages/forms/docs/05-validation.md
@@ -315,6 +315,22 @@ The field value must not be empty. [See the Laravel documentation.](https://lara
 Field::make('name')->required()
 ```
 
+### Required If
+
+The field value must not be empty _only if_ the other specified field has any of the given values. [See the Laravel documentation.](https://laravel.com/docs/validation#rule-required-if)
+
+```php
+Field::make('name')->requiredIf('field', 'value')
+```
+
+### Required Unless
+
+The field value must not be empty _unless_ the other specified field has any of the given values. [See the Laravel documentation.](https://laravel.com/docs/validation#rule-required-unless)
+
+```php
+Field::make('name')->requiredUnless('field', 'value')
+```
+
 ### Required With
 
 The field value must not be empty _only if_ any of the other specified fields are not empty. [See the Laravel documentation.](https://laravel.com/docs/validation#rule-required-with)

--- a/tests/src/Forms/ValidationTest.php
+++ b/tests/src/Forms/ValidationTest.php
@@ -72,3 +72,57 @@ test('fields can be conditionally validated', function () {
             ->not->toContain('Required');
     }
 });
+
+test('fields can be required if', function () {
+    $rules = [];
+    $errors = [];
+
+    try {
+        ComponentContainer::make(Livewire::make())
+            ->statePath('data')
+            ->components([
+                $field1 = (new Field('one'))
+                    ->default('foo'),
+                $field2 = (new Field('two'))
+                    ->requiredIf('one', 'foo'),
+            ])
+            ->fill()
+            ->validate();
+    } catch (ValidationException $exception) {
+        $rules = array_keys($exception->validator->failed()[$field2->getStatePath()]);
+        $errors = $exception->validator->errors()->get($field2->getStatePath());
+    }
+
+    expect($rules)
+        ->toContain('RequiredIf');
+
+    expect($errors)
+        ->toContain('The two field is required when one is foo.');
+});
+
+test('fields can be required unless', function () {
+    $rules = [];
+    $errors = [];
+
+    try {
+        ComponentContainer::make(Livewire::make())
+            ->statePath('data')
+            ->components([
+                $field1 = (new Field('one'))
+                    ->default('bar'),
+                $field2 = (new Field('two'))
+                    ->requiredUnless('one', 'foo'),
+            ])
+            ->fill()
+            ->validate();
+    } catch (ValidationException $exception) {
+        $rules = array_keys($exception->validator->failed()[$field2->getStatePath()]);
+        $errors = $exception->validator->errors()->get($field2->getStatePath());
+    }
+
+    expect($rules)
+        ->toContain('RequiredUnless');
+
+    expect($errors)
+        ->toContain('The two field is required unless one is in foo.');
+});


### PR DESCRIPTION
This PR adds `requiredIf()` and `requiredUnless()` validation methods. I know that performing just the actual underlying validation here is technically already possible using `$get()`, but **that approach results in incorrect error messages**.

I've seen in other issues/PRs and in Discord that the suggested way to accomplish this is manually with `->required()` and a `Closure` and `$get()`, but the error messages produced that way don't accurately describe the actual validation rules. It may be possible to manually override the messages, but that's still extra work and code that this PR makes unnecessary.

**Before**

```php
TextInput::make('status')
    ->in(['pending', 'completed', 'other'])

TextInput::make('status_detail')
    ->required(fn (Closure $get) => $get('status') === 'other')
```

This validates correctly (validation fails if `status` is set to `other` and `status_detail` is left empty), but the error message for the `status_detail` field is just "The status detail is required." That may or may not be true depending on the other input in the form, and it could be misleading because it implies that the field is always required, which it isn't.

It's possible to get a better error message by specifying the rule manually with a string, but that's kind of annoying because you have to prefix it with `data.` (and I saw this discouraged in Discord because it requires knowledge of Filament's internals and could be confusing):

```php
TextInput::make('status_detail')
    ->rule('required_if:data.status,other')
```

Finally, if you want the required state of the field to react to other fields _and_ you want an accurate error message, you have to define your rules twice:

```php
TextInput::make('status')
    ->in(['pending', 'completed', 'other'])
    ->reactive()

TextInput::make('status_detail')
    ->required(fn (Closure $get) => $get('status') === 'other')
    ->rule('required_if:data.status,other')
```

**After**

Adding dedicated methods for both these rules cleans this up nicely:

```php
TextInput::make('status')
    ->in(['pending', 'completed', 'other']),

TextInput::make('status_detail')
    ->requiredIf('status', 'other');
```

This is a lot easier to read and write (in my opinion), and more importantly it provides a much more accurate and helpful error message out of the box: "The status detail field is required when status is other."

The new `multiFieldValueComparisonRule()` method I added here is based on `multiFieldComparisonRule()` but may be able to be simplified further.

See #3682 and #4373.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.