### PR TITLE
Fix explode deprecation in php 8.1.

### DIFF
--- a/packages/tables/src/Columns/TagsColumn.php
+++ b/packages/tables/src/Columns/TagsColumn.php
@@ -24,7 +24,7 @@ class TagsColumn extends Column
             return [];
         }
 
-        $tags = explode($separator, $tags);
+        $tags = explode($separator, $tags ?? '');
 
         if (count($tags) === 1 && blank($tags[0])) {
             $tags = [];


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Fixes a PHP 8.1 deprecation where null isn't allowed as 2nd parameter in the explode function.

`Log.warning: explode(): Passing null to parameter #2 of type string is deprecated`