### PR TITLE
Fix TagsInput border when disabled

### DIFF
--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -80,7 +80,10 @@
                         x-if="state?.length"
                         x-cloak
                     >
-                        <div class="relative w-full p-2 overflow-hidden flex flex-wrap gap-1 border-t dark:border-gray-600">
+                        <div @class([
+                            'relative w-full p-2 overflow-hidden flex flex-wrap gap-1',
+                            'border-t dark:border-gray-600' => ! $isDisabled,
+                        ])> 
                             <template class="hidden" x-for="tag in state" x-bind:key="tag">
                                 <button
                                     @unless ($isDisabled)


### PR DESCRIPTION
Just realized that the border fix I implemented with #6569 didn't take into account when it is `disabled()`. This PR only shows the border when it's not disabled.