### PR TITLE
Fix attach multiple records in Attach select

### DIFF
--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -68,14 +68,7 @@ class AttachAction extends Action
                 $relationship = $this->getRelationship();
 
                 $record = $relationship->getRelated()->query()
-                    ->when(
-                        is_array($data['recordId']),
-                        fn ($query) => $query->whereIn($relationship->getQualifiedRelatedKeyName(), $data['recordId'])
-                    )
-                    ->when(
-                        ! is_array($data['recordId']),
-                        fn ($query) => $query->where($relationship->getQualifiedRelatedKeyName(), $data['recordId'])
-                    )
+                    ->{is_array($data['recordId']) ? 'whereIn' : 'where'}($relationship->getQualifiedRelatedKeyName(), $data['recordId'])
                     ->get();
 
                 $relationship->attach(

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -67,7 +67,16 @@ class AttachAction extends Action
                 /** @var BelongsToMany $relationship */
                 $relationship = $this->getRelationship();
 
-                $record = $relationship->getRelated()->query()->where($relationship->getQualifiedRelatedKeyName(), $data['recordId'])->first();
+                $record = $relationship->getRelated()->query()
+                ->when(
+                    is_array($data['recordId']),
+                    fn ($query) => $query->whereIn($relationship->getQualifiedRelatedKeyName(), $data['recordId'])
+                )
+                ->when(
+                    ! is_array($data['recordId']),
+                    fn ($query) => $query->where($relationship->getQualifiedRelatedKeyName(), $data['recordId'])
+                )
+                ->get();
 
                 $relationship->attach(
                     $record,

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -68,15 +68,15 @@ class AttachAction extends Action
                 $relationship = $this->getRelationship();
 
                 $record = $relationship->getRelated()->query()
-                ->when(
-                    is_array($data['recordId']),
-                    fn ($query) => $query->whereIn($relationship->getQualifiedRelatedKeyName(), $data['recordId'])
-                )
-                ->when(
-                    ! is_array($data['recordId']),
-                    fn ($query) => $query->where($relationship->getQualifiedRelatedKeyName(), $data['recordId'])
-                )
-                ->get();
+                    ->when(
+                        is_array($data['recordId']),
+                        fn ($query) => $query->whereIn($relationship->getQualifiedRelatedKeyName(), $data['recordId'])
+                    )
+                    ->when(
+                        ! is_array($data['recordId']),
+                        fn ($query) => $query->where($relationship->getQualifiedRelatedKeyName(), $data['recordId'])
+                    )
+                    ->get();
 
                 $relationship->attach(
                     $record,


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

After #5556, only first record saved. This PR fixes the issue.
Allow multiple records in Attach select [https://filamentphp.com/tricks/allow-multiple-records-in-a-attach-select]()
