### PR TITLE
Allow action group trigger to be full button

### DIFF
--- a/packages/admin/docs/02-resources/02-listing-records.md
+++ b/packages/admin/docs/02-resources/02-listing-records.md
@@ -134,6 +134,31 @@ public static function table(Table $table): Table
 }
 ```
 
+### Customizing the group trigger
+
+By default, the group trigger is an icon button.
+
+```php
+use Filament\Resources\Table;
+use Filament\Tables;
+
+public static function table(Table $table): Table
+{
+    return $table
+        ->columns([
+            // ...
+        ])
+        ->actions([
+            Tables\Actions\ActionGroup::make([
+                // ...
+            ])
+                ->button() // Use a button instead of an icon button
+                ->icon('heroicon-s-cog')
+                ->label('Settings'),
+        ]);
+}
+```
+
 ## Bulk actions
 
 [Bulk actions](../../tables/actions#bulk-actions) are buttons that are rendered in a dropdown in the header of the table. They appear when you select records using the checkboxes at the start of each table row. They allow the user to perform a task on multiple records at once in the table. To learn how to build bulk actions, see the [full actions documentation](../../tables/actions#bulk-actions).

--- a/packages/admin/docs/02-resources/02-listing-records.md
+++ b/packages/admin/docs/02-resources/02-listing-records.md
@@ -154,6 +154,9 @@ public static function table(Table $table): Table
             ])
                 ->button() // Use a button instead of an icon button
                 ->icon('heroicon-s-cog')
+                ->iconPosition('before')
+                ->outlined()
+                ->color('primary')
                 ->label('Settings'),
         ]);
 }

--- a/packages/admin/docs/03-pages/02-actions.md
+++ b/packages/admin/docs/03-pages/02-actions.md
@@ -245,6 +245,26 @@ protected function getActions(): array
 }
 ```
 
+### Customizing the group trigger
+
+By default, the group trigger is an icon button.
+
+```php
+use Filament\Pages\Actions;
+
+protected function getActions(): array
+{
+    return [
+        Actions\ActionGroup::make([
+            // ...
+        ])
+            ->button() // Use a button instead of an icon button
+            ->icon('heroicon-s-cog')
+            ->label('Settings'),
+    ];
+}
+```
+
 ## Keybindings
 
 You can attach keyboard shortcuts to actions. These use the same key codes as [Mousetrap](https://craig.is/killing/mice):

--- a/packages/admin/docs/03-pages/02-actions.md
+++ b/packages/admin/docs/03-pages/02-actions.md
@@ -260,6 +260,9 @@ protected function getActions(): array
         ])
             ->button() // Use a button instead of an icon button
             ->icon('heroicon-s-cog')
+            ->iconPosition('before')
+            ->outlined()
+            ->color('primary')
             ->label('Settings'),
     ];
 }

--- a/packages/admin/resources/views/pages/actions/group.blade.php
+++ b/packages/admin/resources/views/pages/actions/group.blade.php
@@ -4,6 +4,8 @@
     :dark-mode="config('filament.dark_mode')"
     :color="$getColor()"
     :icon="$getIcon()"
+    :iconPosition="$getIconPosition()"
+    :outlined="$isOutlined()"
     :label="$getLabel()"
     :size="$getSize()"
     :tooltip="$getTooltip()"

--- a/packages/admin/resources/views/pages/actions/group.blade.php
+++ b/packages/admin/resources/views/pages/actions/group.blade.php
@@ -1,5 +1,6 @@
 <x-filament-support::actions.group
     :actions="$getActions()"
+    :button="$isButton()"
     :dark-mode="config('filament.dark_mode')"
     :color="$getColor()"
     :icon="$getIcon()"

--- a/packages/notifications/resources/views/actions/group.blade.php
+++ b/packages/notifications/resources/views/actions/group.blade.php
@@ -4,6 +4,8 @@
     :dark-mode="config('notifications.dark_mode')"
     :color="$getColor()"
     :icon="$getIcon()"
+    :iconPosition="$getIconPosition()"
+    :outlined="$isOutlined()"
     :label="$getLabel()"
     :size="$getSize()"
     :tooltip="$getTooltip()"

--- a/packages/notifications/resources/views/actions/group.blade.php
+++ b/packages/notifications/resources/views/actions/group.blade.php
@@ -1,5 +1,6 @@
 <x-filament-support::actions.group
     :actions="$getActions()"
+    :button="$isButton()"
     :dark-mode="config('notifications.dark_mode')"
     :color="$getColor()"
     :icon="$getIcon()"

--- a/packages/support/resources/views/components/actions/group.blade.php
+++ b/packages/support/resources/views/components/actions/group.blade.php
@@ -4,7 +4,9 @@
     'color' => null,
     'darkMode' => false,
     'icon' => 'heroicon-o-dots-vertical',
+    'iconPosition' => null,
     'label' => __('filament-support::actions/group.trigger.label'),
+    'outlined' => null,
     'size' => null,
     'tooltip' => null,
 ])

--- a/packages/support/resources/views/components/actions/group.blade.php
+++ b/packages/support/resources/views/components/actions/group.blade.php
@@ -1,5 +1,6 @@
 @props([
     'actions',
+    'button' => false,
     'color' => null,
     'darkMode' => false,
     'icon' => 'heroicon-o-dots-vertical',
@@ -15,17 +16,29 @@
     {{ $attributes }}
 >
     <x-slot name="trigger">
-        <x-filament-support::icon-button
-            :color="$color"
-            :dark-mode="$darkMode"
-            :icon="$icon"
-            :size="$size"
-            :tooltip="$tooltip"
-        >
-            <x-slot name="label">
+        @if($button)
+            <x-filament-support::button
+                :color="$color"
+                :dark-mode="$darkMode"
+                :icon="$icon"
+                :size="$size"
+                :tooltip="$tooltip"
+            >
                 {{ $label }}
-            </x-slot>
-        </x-filament-support::icon-button>
+            </x-filament-support::button>
+        @else
+            <x-filament-support::icon-button
+                :color="$color"
+                :dark-mode="$darkMode"
+                :icon="$icon"
+                :size="$size"
+                :tooltip="$tooltip"
+            >
+                <x-slot name="label">
+                    {{ $label }}
+                </x-slot>
+            </x-filament-support::icon-button>
+        @endif
     </x-slot>
 
     <x-filament-support::dropdown.list>

--- a/packages/support/src/Actions/ActionGroup.php
+++ b/packages/support/src/Actions/ActionGroup.php
@@ -25,6 +25,8 @@ class ActionGroup extends ViewComponent
 
     protected string $viewIdentifier = 'group';
 
+    protected bool $isButton = false;
+
     public function __construct(
         protected array $actions,
     ) {
@@ -70,5 +72,17 @@ class ActionGroup extends ViewComponent
         }
 
         return true;
+    }
+
+    public function isButton(): bool
+    {
+        return $this->isButton;
+    }
+
+    public function button(bool $condition = true): static
+    {
+        $this->isButton = $condition;
+
+        return $this;
     }
 }

--- a/packages/support/src/Actions/ActionGroup.php
+++ b/packages/support/src/Actions/ActionGroup.php
@@ -3,6 +3,7 @@
 namespace Filament\Support\Actions;
 
 use Filament\Support\Actions\Concerns\CanBeHidden;
+use Filament\Support\Actions\Concerns\CanBeOutlined;
 use Filament\Support\Actions\Concerns\HasColor;
 use Filament\Support\Actions\Concerns\HasIcon;
 use Filament\Support\Actions\Concerns\HasLabel;
@@ -15,6 +16,7 @@ class ActionGroup extends ViewComponent
     use CanBeHidden {
         isHidden as baseIsHidden;
     }
+    use CanBeOutlined;
     use HasColor;
     use HasIcon;
     use HasLabel;

--- a/packages/tables/docs/05-actions.md
+++ b/packages/tables/docs/05-actions.md
@@ -439,6 +439,9 @@ protected function getTableActions(): array
         ])
             ->button() // Use a button instead of an icon button
             ->icon('heroicon-s-cog')
+            ->iconPosition('before')
+            ->outlined()
+            ->color('primary')
             ->label('Settings'),
     ];
 }

--- a/packages/tables/docs/05-actions.md
+++ b/packages/tables/docs/05-actions.md
@@ -424,6 +424,26 @@ protected function getTableActions(): array
 }
 ```
 
+### Customizing the group trigger
+
+By default, the group trigger is an icon button.
+
+```php
+use Filament\Tables;
+
+protected function getTableActions(): array
+{
+    return [
+        Tables\Actions\ActionGroup::make([
+            // ...
+        ])
+            ->button() // Use a button instead of an icon button
+            ->icon('heroicon-s-cog')
+            ->label('Settings'),
+    ];
+}
+```
+
 ## Position
 
 By default, the row actions in your table are rendered in the final cell. You may change the position by overriding the `getTableActionsPosition()` method:

--- a/packages/tables/resources/views/actions/group.blade.php
+++ b/packages/tables/resources/views/actions/group.blade.php
@@ -1,5 +1,6 @@
 <x-filament-support::actions.group
     :actions="$getActions()"
+    :button="$isButton()"
     :dark-mode="config('tables.dark_mode')"
     :color="$getColor()"
     :icon="$getIcon()"

--- a/packages/tables/resources/views/actions/group.blade.php
+++ b/packages/tables/resources/views/actions/group.blade.php
@@ -4,6 +4,8 @@
     :dark-mode="config('tables.dark_mode')"
     :color="$getColor()"
     :icon="$getIcon()"
+    :iconPosition="$getIconPosition()"
+    :outlined="$isOutlined()"
     :label="$getLabel()"
     :size="$getSize()"
     :tooltip="$getTooltip()"


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
