### PR TITLE
fix: custom navigation does not respect policies

### DIFF
--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -91,6 +91,10 @@ class Resource
 
     public static function getNavigationItems(): array
     {
+        if (! static::canViewAny()) {
+            return [];
+        }
+
         $routeBaseName = static::getRouteBaseName();
 
         return [


### PR DESCRIPTION
Current behavior: When using the custom navigation builder any resource registered will still appear even if the viewAny policy function is returning false 

Changes: Added canViewAny function to the resource's getNavigationItems to fix this issue