### PR TITLE
Support starting on last step of Wizard

### DIFF
--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -12,7 +12,7 @@
         init: function () {
             this.$watch('step', () => this.updateQueryString())
 
-            this.step = this.getSteps()[{{ $getStartStep() }} - 1]
+            this.step = this.getSteps().at({{ $getStartStep() - 1 }})
         },
 
         nextStep: function () {


### PR DESCRIPTION
By using array `.at()`, you can use `startOnStep(0)` to start on the last step of the Wizard. This is useful in Workflow scenario's where the Wizard is growing dynamically at every "step" in the workflow.