### PR TITLE
typo in associating and dissociating records

### DIFF
--- a/packages/admin/docs/02-resources/07-relation-managers.md
+++ b/packages/admin/docs/02-resources/07-relation-managers.md
@@ -495,7 +495,7 @@ protected bool $allowsDuplicates = true;
 
 ## Associating and dissociating records
 
-Filament is able to associate and dissociate records for `HasMany`, `HasManyThrough` and `MorphMany` relationships.
+Filament is able to associate and dissociate records for `HasMany` and `MorphMany` relationships.
 
 When generating your relation manager, you may pass the `--associate` flag to also add `AssociateAction`, `DissociateAction` and `DissociateBulkAction` to the table:
 


### PR DESCRIPTION
Associate, Dissociate actions only support hasMany & morphMany relations

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
