### PR TITLE
📝 docs(getting-started.md): update description of relation managers in Filament

### DIFF
--- a/packages/admin/docs/02-resources/01-getting-started.md
+++ b/packages/admin/docs/02-resources/01-getting-started.md
@@ -294,7 +294,7 @@ From a UX perspective, this solution is only suitable if your related model only
 
 #### Relation manager
 
-"Relation managers" in Filament allow admins to list, create, associate, edit, dissociate and delete related records without leaving the resource's Edit page.
+"Relation managers" in Filament allow admins to list, create, edit, and delete related records without leaving the resource's Edit page.
 
 The related records are listed in a table, which has buttons to open a modal for each action.
 


### PR DESCRIPTION
The commit updates the description of "Relation managers" in Filament to accurately reflect the functionality provided. The updated description now states that admins can list, create, edit, and delete related records without leaving the resource's Edit page. The previous description was misleading as it suggested that admins could also associate and dissociate related records, which is not currently supported.

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
