### PR TITLE
Fix Display required label in Safari

### DIFF
--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -21,10 +21,10 @@
     >
         {{-- Deliberately poor formatting to ensure that the asterisk sticks to the final word in the label. --}}
         {{ $slot }}@if ($required)<sup
-                    @class([
-                        'text-danger-700 font-medium whitespace-nowrap',
-                        'dark:text-danger-400' => config('forms.dark_mode'),
-                    ])>
+                @class([
+                    'text-danger-700 font-medium whitespace-nowrap',
+                    'dark:text-danger-400' => config('forms.dark_mode'),
+                ])>
                 *
             </sup>
         @endif

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -6,7 +6,8 @@
 ])
 
 <label
-    {{ $attributes->class(['filament-forms-field-wrapper-label inline-flex items-center space-x-3 rtl:space-x-reverse']) }}>
+    {{ $attributes->class(['filament-forms-field-wrapper-label inline-flex items-center space-x-3 rtl:space-x-reverse']) }}
+    >
     {{ $prefix }}
 
     <span
@@ -16,7 +17,8 @@
             'dark:text-gray-300' => !$error && config('forms.dark_mode'),
             'text-danger-700' => $error,
             'dark:text-danger-400' => $error && config('forms.dark_mode'),
-        ])>
+        ])
+        >
         {{-- Deliberately poor formatting to ensure that the asterisk sticks to the final word in the label. --}}
         {{ $slot }}@if ($required)<sup
                 @class([

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -7,7 +7,7 @@
 
 <label
     {{ $attributes->class(['filament-forms-field-wrapper-label inline-flex items-center space-x-3 rtl:space-x-reverse']) }}
-    >
+>
     {{ $prefix }}
 
     <span
@@ -18,7 +18,7 @@
             'text-danger-700' => $error,
             'dark:text-danger-400' => $error && config('forms.dark_mode'),
         ])
-        >
+    >
         {{-- Deliberately poor formatting to ensure that the asterisk sticks to the final word in the label. --}}
         {{ $slot }}@if ($required)<sup
                 @class([

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -21,10 +21,10 @@
     >
         {{-- Deliberately poor formatting to ensure that the asterisk sticks to the final word in the label. --}}
         {{ $slot }}@if ($required)<sup
-                @class([
-                    'text-danger-700 font-medium whitespace-nowrap',
-                    'dark:text-danger-400' => config('forms.dark_mode'),
-                ])
+                 @class([
+                     'text-danger-700 font-medium whitespace-nowrap',
+                     'dark:text-danger-400' => config('forms.dark_mode'),
+                 ])
             >
                 *
             </sup>

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -24,7 +24,8 @@
                 @class([
                     'text-danger-700 font-medium whitespace-nowrap',
                     'dark:text-danger-400' => config('forms.dark_mode'),
-                ])>
+                ])
+            >
                 *
             </sup>
         @endif

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -6,19 +6,17 @@
 ])
 
 <label
-    {{ $attributes->class(['filament-forms-field-wrapper-label inline-flex items-center space-x-3 rtl:space-x-reverse']) }}
->
+       {{ $attributes->class(['filament-forms-field-wrapper-label inline-flex items-center space-x-3 rtl:space-x-reverse']) }}>
     {{ $prefix }}
 
     <span
-        @class([
-            'text-sm font-medium leading-4',
-            'text-gray-700' => ! $error,
-            'dark:text-gray-300' => (! $error) && config('forms.dark_mode'),
-            'text-danger-700' => $error,
-            'dark:text-danger-400' => $error && config('forms.dark_mode'),
-        ])
-    >
+          @class([
+              'text-sm font-medium leading-4',
+              'text-gray-700' => !$error,
+              'dark:text-gray-300' => !$error && config('forms.dark_mode'),
+              'text-danger-700' => $error,
+              'dark:text-danger-400' => $error && config('forms.dark_mode'),
+          ])>
         {{-- Deliberately poor formatting to ensure that the asterisk sticks to the final word in the label. --}}
         {{ $slot }}@if ($required)<sup
                 @class([

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -14,7 +14,7 @@
         @class([
             'text-sm font-medium leading-4',
             'text-gray-700' => ! $error,
-            'dark:text-gray-300' => ! $error && config('forms.dark_mode'),
+            'dark:text-gray-300' => (! $error) && config('forms.dark_mode'),
             'text-danger-700' => $error,
             'dark:text-danger-400' => $error && config('forms.dark_mode'),
         ])

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -21,10 +21,10 @@
     >
         {{-- Deliberately poor formatting to ensure that the asterisk sticks to the final word in the label. --}}
         {{ $slot }}@if ($required)<sup
-             @class([
-                 'text-danger-700 font-medium whitespace-nowrap',
-                 'dark:text-danger-400' => config('forms.dark_mode'),
-             ])
+                @class([
+                    'text-danger-700 font-medium whitespace-nowrap',
+                    'dark:text-danger-400' => config('forms.dark_mode'),
+                ])
             >
                 *
             </sup>

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -6,17 +6,17 @@
 ])
 
 <label
-       {{ $attributes->class(['filament-forms-field-wrapper-label inline-flex items-center space-x-3 rtl:space-x-reverse']) }}>
+    {{ $attributes->class(['filament-forms-field-wrapper-label inline-flex items-center space-x-3 rtl:space-x-reverse']) }}>
     {{ $prefix }}
 
     <span
-          @class([
-              'text-sm font-medium leading-4',
-              'text-gray-700' => !$error,
-              'dark:text-gray-300' => !$error && config('forms.dark_mode'),
-              'text-danger-700' => $error,
-              'dark:text-danger-400' => $error && config('forms.dark_mode'),
-          ])>
+        @class([
+            'text-sm font-medium leading-4',
+            'text-gray-700' => !$error,
+            'dark:text-gray-300' => !$error && config('forms.dark_mode'),
+            'text-danger-700' => $error,
+            'dark:text-danger-400' => $error && config('forms.dark_mode'),
+        ])>
         {{-- Deliberately poor formatting to ensure that the asterisk sticks to the final word in the label. --}}
         {{ $slot }}@if ($required)<sup
                 @class([

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -20,7 +20,8 @@
         ])
     >
         {{-- Deliberately poor formatting to ensure that the asterisk sticks to the final word in the label. --}}
-        {{ $slot }}@if ($required)<span class="whitespace-nowrap">
+        {{ $slot }}@if ($required)
+            <span class="whitespace-nowrap">
                 <sup
                     @class([
                         'text-danger-700 font-medium',

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -20,17 +20,13 @@
         ])
     >
         {{-- Deliberately poor formatting to ensure that the asterisk sticks to the final word in the label. --}}
-        {{ $slot }}@if ($required)
-            <span class="whitespace-nowrap">
-                <sup
+        {{ $slot }}@if ($required)<sup
                     @class([
                         'text-danger-700 font-medium',
                         'dark:text-danger-400' => config('forms.dark_mode'),
-                    ])
-                >
-                    *
-                </sup>
-            </span>
+                    ])>
+                *
+            </sup>
         @endif
     </span>
 

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -13,8 +13,8 @@
     <span
         @class([
             'text-sm font-medium leading-4',
-            'text-gray-700' => !$error,
-            'dark:text-gray-300' => !$error && config('forms.dark_mode'),
+            'text-gray-700' => ! $error,
+            'dark:text-gray-300' => ! $error && config('forms.dark_mode'),
             'text-danger-700' => $error,
             'dark:text-danger-400' => $error && config('forms.dark_mode'),
         ])

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -22,7 +22,7 @@
         {{-- Deliberately poor formatting to ensure that the asterisk sticks to the final word in the label. --}}
         {{ $slot }}@if ($required)<sup
                     @class([
-                        'text-danger-700 font-medium',
+                        'text-danger-700 font-medium whitespace-nowrap',
                         'dark:text-danger-400' => config('forms.dark_mode'),
                     ])>
                 *

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -21,10 +21,10 @@
     >
         {{-- Deliberately poor formatting to ensure that the asterisk sticks to the final word in the label. --}}
         {{ $slot }}@if ($required)<sup
-                 @class([
-                     'text-danger-700 font-medium whitespace-nowrap',
-                     'dark:text-danger-400' => config('forms.dark_mode'),
-                 ])
+             @class([
+                 'text-danger-700 font-medium whitespace-nowrap',
+                 'dark:text-danger-400' => config('forms.dark_mode'),
+             ])
             >
                 *
             </sup>


### PR DESCRIPTION
For some weirdly reason, when you have a required field label containing an hyphen character, the label is displayed with a carrier return in Safari:

<img width="414" alt="Screenshot 2023-06-07 at 16 02 54" src="https://github.com/filamentphp/filament/assets/17174973/29df55ce-ae21-4ef2-8a81-4e3f6140f621">

This quick fix will prevent this UI behaviour:

<img width="403" alt="Screenshot 2023-06-07 at 16 03 04" src="https://github.com/filamentphp/filament/assets/17174973/35ec5e56-1fbe-485c-b4b7-303764978475">

