### PR TITLE
Fix for PHP 8.2 deprecated warning for ${var} string interpolation

### DIFF
--- a/packages/support/src/Concerns/EvaluatesClosures.php
+++ b/packages/support/src/Concerns/EvaluatesClosures.php
@@ -92,7 +92,7 @@ trait EvaluatesClosures
 
         $staticClass = static::class;
 
-        throw new BindingResolutionException("An attempt was made to evaluate a closure for [{$staticClass}], but [${$parameterName}] was unresolvable.");
+        throw new BindingResolutionException("An attempt was made to evaluate a closure for [{$staticClass}], but [\${$parameterName}] was unresolvable.");
     }
 
     /**


### PR DESCRIPTION
- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
