### PR TITLE
[Feature] Auto hide parent component when children are hidden

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeHidden.php
+++ b/packages/forms/src/Components/Concerns/CanBeHidden.php
@@ -3,6 +3,7 @@
 namespace Filament\Forms\Components\Concerns;
 
 use Closure;
+use Filament\Forms\Components\Component;
 use Filament\Forms\Contracts\HasForms;
 use Illuminate\Support\Arr;
 
@@ -34,17 +35,16 @@ trait CanBeHidden
         return $this;
     }
 
-    public function hideIfChildrenHidden(): static
+    public function hiddenWhenAllChildComponentsHidden(): static
     {
         $this->hidden(static function ($component): bool {
-            $shouldBeHidden = true;
-            foreach ($component->getChildComponents() as $child) {
-                if (!$child->isHidden) {
-                    $shouldBeHidden = false;
+            foreach ($component->getChildComponentContainers() as $childComponentContainer) {
+                foreach ($childComponentContainer->getComponents(withHidden: false) as $childComponent) {
+                    return false;
                 }
             }
 
-            return $shouldBeHidden;
+            return true;
         });
 
         return $this;

--- a/packages/forms/src/Components/Concerns/CanBeHidden.php
+++ b/packages/forms/src/Components/Concerns/CanBeHidden.php
@@ -34,7 +34,7 @@ trait CanBeHidden
         return $this;
     }
 
-    public function hideIfChildrenHidden(bool|Closure $condition = true): static
+    public function hideIfChildrenHidden(): static
     {
         $this->hidden(static function ($component): bool {
             $shouldBeHidden = true;

--- a/packages/forms/src/Components/Concerns/CanBeHidden.php
+++ b/packages/forms/src/Components/Concerns/CanBeHidden.php
@@ -34,7 +34,7 @@ trait CanBeHidden
         return $this;
     }
 
-    public function autoHideIfChildrenHidden(bool|Closure $condition = true): static
+    public function hideIfChildrenHidden(bool|Closure $condition = true): static
     {
         $this->hidden(static function ($component): bool {
             $shouldBeHidden = true;

--- a/packages/forms/src/Components/Concerns/CanBeHidden.php
+++ b/packages/forms/src/Components/Concerns/CanBeHidden.php
@@ -34,6 +34,22 @@ trait CanBeHidden
         return $this;
     }
 
+    public function autoHideIfChildrenHidden(bool|Closure $condition = true): static
+    {
+        $this->hidden(static function ($component): bool {
+            $shouldBeHidden = true;
+            foreach ($component->getChildComponents() as $child) {
+                if (!$child->isHidden) {
+                    $shouldBeHidden = false;
+                }
+            }
+
+            return $shouldBeHidden;
+        });
+
+        return $this;
+    }
+
     public function when(bool | Closure $condition = true): static
     {
         $this->visible($condition);


### PR DESCRIPTION
TLDR: Adds a new feature to the CanBeHiddenConcern which hides the parent component if all child components are hidden

# Description
This feature addresses an issue where an empty example component would be shown when all children of a Section component were hidden. For example when the `autoHideIfChildrenHidden()` function is called, the Section component will automatically check if any of its children are hidden. If all children are hidden, the Section component will be hidden as well. If any children are visible, the Section component will be shown along with its children.

Without autoHideIfChildrenHidden():
<img width="846" alt="Screenshot 2023-06-08 at 16 40 20" src="https://github.com/filamentphp/filament/assets/8775667/d0b08d2c-9fb6-4506-887b-bc0dacd86b45">

### Usage

```php
         Forms\Components\Section::make('Pricing')
                            ->schema([
                                Forms\Components\TextInput::make('price')
                                    ->numeric()
                                    ->hidden(() => // some condition)
                                    ->rules(['regex:/^\d{1,6}(\.\d{0,2})?$/'])
                                    ->required(),

                                Forms\Components\TextInput::make('old_price')
                                    ->label('Compare at price')
                                    ->hidden(() => // a different condition)
                                    ->numeric()
                                    ->rules(['regex:/^\d{1,6}(\.\d{0,2})?$/'])
                                    ->required(),


... a lot more components with conditions



                            ])
                            ->hideIfChildrenHidden()
                            ->columns(2),
```

### Why?
I encountered a problem where my ﻿hidden functions were becoming very large for my ﻿Section components, leading to a lot of duplicate code.
