### PR TITLE
reset all (from x button) fixed

### DIFF
--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -164,7 +164,7 @@ trait HasFilters
         return $name::getDefaultName();
     }
 
-    protected function getTableFiltersFormColumns(): int|array
+    protected function getTableFiltersFormColumns(): int | array
     {
         return match ($this->getTableFiltersLayout()) {
             Layout::AboveContent, Layout::BelowContent => [

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -105,11 +105,12 @@ trait HasFilters
             $field->state(match (true) {
                 is_array($state) => [],
                 $state === true => false,
+                $state === false => false,
                 default => null,
             });
         }
 
-        $this->resetTableFiltersForm();
+        $this->updatedTableFilters();
     }
 
     public function resetTableFiltersForm(): void
@@ -163,7 +164,7 @@ trait HasFilters
         return $name::getDefaultName();
     }
 
-    protected function getTableFiltersFormColumns(): int | array
+    protected function getTableFiltersFormColumns(): int|array
     {
         return match ($this->getTableFiltersLayout()) {
             Layout::AboveContent, Layout::BelowContent => [

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -109,7 +109,7 @@ trait HasFilters
             });
         }
 
-        $this->updatedTableFilters();
+        $this->resetTableFiltersForm();
     }
 
     public function resetTableFiltersForm(): void


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
No new function
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Before:
When clicking reset all (X) button, then it remove all filter and only show toggle filter (but not visible what it filter)
[Screencast from 06-09-2023 09:21:54 AM.webm](https://github.com/filamentphp/filament/assets/28250303/4f40105c-fc82-44cc-ae96-f6f68fb30544)


After:
[Screencast from 06-09-2023 09:22:18 AM.webm](https://github.com/filamentphp/filament/assets/28250303/6b5f79f5-37da-413e-bed9-84747c49dbe0)

This fixed #6722 
