### PR TITLE
Add data mutate to replicate action

### DIFF
--- a/packages/support/src/Actions/Concerns/CanReplicateRecords.php
+++ b/packages/support/src/Actions/Concerns/CanReplicateRecords.php
@@ -16,6 +16,8 @@ trait CanReplicateRecords
 
     protected array | Closure | null $excludedAttributes = null;
 
+    protected ?Closure $mutateReplicaDataUsing = null;
+
     public static function getDefaultName(): ?string
     {
         return 'replicate';
@@ -42,7 +44,13 @@ trait CanReplicateRecords
                 return;
             }
 
-            $form->fill($record->attributesToArray());
+            $data = $record->attributesToArray();
+
+            if ($this->mutateReplicaDataUsing) {
+                $data = $this->evaluate($this->mutateReplicaDataUsing, ['data' => $data]);
+            }
+
+            $form->fill($data);
         });
 
         $this->action(function () {
@@ -102,5 +110,12 @@ trait CanReplicateRecords
     public function getExcludedAttributes(): ?array
     {
         return $this->evaluate($this->excludedAttributes);
+    }
+
+    public function mutateReplicaDataUsing(?Closure $callback): static
+    {
+        $this->mutateReplicaDataUsing = $callback;
+
+        return $this;
     }
 }


### PR DESCRIPTION
- [y] Changes have been thoroughly tested to not break existing functionality.

Useful for controlling the data before the form is filled. 

E.g if you have a `key` field a unique value.
```php
->mutateRecordDataUsing(function ($data): array {
 unset($data['key');
 return $data;
});
```