### PR TITLE
Add solid background color to icon button

### DIFF
--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -52,9 +52,11 @@
         'w-6 h-6' => $size === 'lg',
     ]);
 
-    $indicatorClasses = \Illuminate\Support\Arr::toCssClasses(array_merge([
-        'filament-icon-button-indicator absolute rounded-full text-xs inline-block w-4 h-4 -top-0.5 -right-0.5'
-        ], $solid ? [
+    $indicatorClasses = \Illuminate\Support\Arr::toCssClasses(array_merge(
+        [
+            'filament-icon-button-indicator absolute rounded-full text-xs inline-block w-4 h-4 -top-0.5 -right-0.5',
+        ],
+        $solid ? [
             'text-white',
             'bg-danger-600' => $color === 'danger',
             'bg-gray-500' => $color === 'secondary',
@@ -68,7 +70,7 @@
             'bg-gray-600/10' => $color === 'gray',
             'bg-primary-500/10' => $color === 'primary',
             'bg-success-500/10' => $color === 'success',
-            'bg-warning-500/10' => $color === 'warning'
+            'bg-warning-500/10' => $color === 'warning',
         ]
     ));
 

--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -4,17 +4,18 @@
     'disabled' => false,
     'form' => null,
     'icon' => null,
-    'keyBindings' => null,
     'indicator' => null,
+    'keyBindings' => null,
     'label' => null,
     'size' => 'md',
+    'solid' => false,
     'tag' => 'button',
     'tooltip' => null,
     'type' => 'button',
 ])
 
 @php
-    $buttonClasses = [
+    $buttonClasses = array_merge([
         'filament-icon-button relative flex items-center justify-center rounded-full outline-none hover:bg-gray-500/5 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70',
         'text-primary-500 focus:bg-primary-500/10' => $color === 'primary',
         'text-danger-500 focus:bg-danger-500/10' => $color === 'danger',
@@ -27,7 +28,21 @@
         'h-8 w-8' => $size === 'sm',
         'h-8 w-8 md:h-10 md:w-10' => $size === 'sm md:md',
         'h-12 w-12' => $size === 'lg',
-    ];
+    ], $solid ? [
+        'text-white',
+        'bg-danger-600 hover:bg-danger-600/20 hover:text-danger-500 focus:bg-danger-700/20 focus:text-danger-500 focus:ring-offset-danger-700' => $color === 'danger',
+        'bg-gray-300 hover:bg-gray-50 hover:text-gray-500 focus:bg-primary-50 focus:text-primary-600 focus:ring-primary-600' => $color === 'secondary',
+        'bg-gray-600 hover:bg-gray-600/20 hover:text-gray-500 focus:bg-gray-700/20 focus:text-gray-500 focus:ring-offset-gray-700' => $color === 'gray',
+        'bg-primary-600 hover:bg-primary-600/20 hover:text-primary-500 focus:bg-primary-700/20 focus:text-primary-500 focus:ring-offset-primary-700' => $color === 'primary',
+        'bg-success-600 hover:bg-success-600/20 hover:text-success-500 focus:bg-success-700/20 focus:text-success-500 focus:ring-offset-success-700' => $color === 'success',
+        'bg-warning-600 hover:bg-warning-600/20 hover:text-warning-500 focus:bg-warning-700/20 focus:text-danger-500 focus:ring-offset-warning-700' => $color === 'warning',
+        'dark:bg-danger-500 dark:hover:bg-danger-500/20 dark:focus:bg-danger-600/20 dark:focus:ring-offset-danger-600' => $color === 'danger' && $darkMode,
+        'dark:bg-gray-400 dark:hover:bg-gray-400/20 dark:focus:bg-gray-600/20 dark:focus:ring-offset-gray-600' => $color === 'gray' && $darkMode,
+        'dark:bg-gray-600 dark:hover:bg-gray-500/20 dark:text-gray-200 dark:focus:bg-gray-800/20' => $color === 'secondary' && $darkMode,
+        'dark:bg-primary-500 dark:hover:bg-primary-500/20 dark:focus:bg-primary-600/20 dark:focus:ring-offset-primary-600' => $color === 'primary' && $darkMode,
+        'dark:bg-success-500 dark:hover:bg-success-500/20 dark:focus:bg-success-600/20 dark:focus:ring-offset-success-600' => $color === 'success' && $darkMode,
+        'dark:bg-warning-500 dark:hover:bg-warning-500/20 dark:focus:bg-warning-600/20 dark:focus:ring-offset-warning-600' => $color === 'warning' && $darkMode,
+    ] : []);
 
     $iconClasses = \Illuminate\Support\Arr::toCssClasses([
         'filament-icon-button-icon',
@@ -37,14 +52,25 @@
         'w-6 h-6' => $size === 'lg',
     ]);
 
-    $indicatorClasses = \Illuminate\Support\Arr::toCssClasses([
-        'filament-icon-button-indicator absolute rounded-full text-xs inline-block w-4 h-4 -top-0.5 -right-0.5',
-        'bg-primary-500/10' => $color === 'primary',
-        'bg-danger-500/10' => $color === 'danger',
-        'bg-gray-500/10' => $color === 'secondary',
-        'bg-success-500/10' => $color === 'success',
-        'bg-warning-500/10' => $color === 'warning',
-    ]);
+    $indicatorClasses = \Illuminate\Support\Arr::toCssClasses(array_merge([
+        'filament-icon-button-indicator absolute rounded-full text-xs inline-block w-4 h-4 -top-0.5 -right-0.5'
+        ], $solid ? [
+            'text-white',
+            'bg-danger-600' => $color === 'danger',
+            'bg-gray-500' => $color === 'secondary',
+            'bg-gray-600' => $color === 'gray',
+            'bg-primary-600' => $color === 'primary',
+            'bg-success-600' => $color === 'success',
+            'bg-warning-600' => $color === 'warning',
+        ] : [
+            'bg-danger-500/10' => $color === 'danger',
+            'bg-gray-500/10' => $color === 'secondary',
+            'bg-gray-600/10' => $color === 'gray',
+            'bg-primary-500/10' => $color === 'primary',
+            'bg-success-500/10' => $color === 'success',
+            'bg-warning-500/10' => $color === 'warning'
+        ]
+    ));
 
     $wireTarget = $attributes->whereStartsWith(['wire:target', 'wire:click'])->first();
 

--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -16,7 +16,7 @@
 
 @php
     $buttonClasses = array_merge([
-        'filament-icon-button relative flex items-center justify-center rounded-full outline-none hover:bg-gray-500/5 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70',
+        "filament-icon-button filament-icon-button-size-{$size} relative flex items-center justify-center rounded-full outline-none hover:bg-gray-500/5 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-70",
         'text-primary-500 focus:bg-primary-500/10' => $color === 'primary',
         'text-danger-500 focus:bg-danger-500/10' => $color === 'danger',
         'text-gray-500 focus:bg-gray-500/10' => $color === 'secondary',


### PR DESCRIPTION
Add `solid` option to control the background color of icon button.

<img width="401" alt="Screenshot 2023-06-10 at 08 31 12" src="https://github.com/filamentphp/filament/assets/533658/89c9f9c2-af61-4db9-8409-e557be669ec6">

<img width="392" alt="Screenshot 2023-06-10 at 08 31 00" src="https://github.com/filamentphp/filament/assets/533658/9855512a-d896-4d91-b0cb-cd7234c76804">

```html
<x-filament::icon-button size="sm" color="primary" icon="heroicon-s-fire" solid>
<x-filament::icon-button size="sm" color="secondary" icon="heroicon-s-bell" solid>
<x-filament::icon-button size="sm" color="gray" icon="heroicon-s-bell" solid>
<x-filament::icon-button size="sm" color="success" icon="heroicon-s-check" solid>
<x-filament::icon-button size="sm" color="warning" icon="heroicon-s-bell" solid>
<x-filament::icon-button size="sm" color="danger" icon="heroicon-s-ban" solid>
<x-filament::icon-button size="sm" color="primary" icon="heroicon-s-fire">
<x-filament::icon-button size="sm" color="danger" icon="heroicon-s-trash">
```