### PR TITLE
Implement prependFilters() and appendFilters() to Table

### DIFF
--- a/packages/admin/src/Resources/Table.php
+++ b/packages/admin/src/Resources/Table.php
@@ -131,6 +131,13 @@ class Table
         return $this;
     }
 
+    public function prependFilters(array $filters): static
+    {
+        $this->filters = array_merge($filters, $this->filters);
+
+        return $this;
+    }
+
     public function prependHeaderActions(array $actions): static
     {
         $this->headerActions = array_merge($actions, $this->headerActions);
@@ -148,6 +155,13 @@ class Table
     public function appendBulkActions(array $actions): static
     {
         $this->bulkActions = array_merge($this->bulkActions, $actions);
+
+        return $this;
+    }
+
+    public function appendFilters(array $filters): static
+    {
+        $this->filters = array_merge($this->filters, $filters);
 
         return $this;
     }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Filament Admin Panel `Table` class has methods to append and prepend `actions`, `bulkActions` and `headerActions` but does not have for `filters`. 

This pull request implements the `prependFilters()` and `appendFilters()` methods.

### Use Case

I want to create a base resource class that has defined filters and actions and do the following table construction in the final resource class:

```php
return $table
    ->appendFilters([
        //
    ])
    ->appendActions([
        //
    ])
    ->appendBulkActions([
        //
    ]);
```
However, I can't append filters at the moment so I'm limited only to:

```php
return $table
    ->appendActions([
        //
    ])
    ->appendBulkActions([
        //
    ]);
```