### PR TITLE
Fix select placeholder not showing

### DIFF
--- a/packages/forms/resources/js/components/select.js
+++ b/packages/forms/resources/js/components/select.js
@@ -157,6 +157,8 @@ export default (Alpine) => {
 
                         this.select.clearStore()
 
+                        this.refreshPlaceholder()
+
                         this.setChoices(choices)
 
                         if (![null, undefined, ''].includes(this.state)) {


### PR DESCRIPTION
- [X] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This PR should fix issue #6736 

It seems the problem lies in watch method. `this.refreshPlaceholder()` is called at the beginnging of the watch, but then `this.select.clearStore()` is called which removes the placeholder. Adding `this.refreshPlaceholder()` after `this.select.clearStore()` fixes this issue.

You can test this by just removing `clearStore()` and the placeholder will show. I'm sure `clearStore` is needed so the easiest option seems to be to refresh the placholder after calling `clearStore()`.

Potentially we could get rid of the first `refreshPlaceholder`, but with the early return when the state is still being updated, maybe it needs to stay?