### PR TITLE
Follow policy response status for resource authorization

### DIFF
--- a/packages/admin/src/Resources/Pages/CreateRecord.php
+++ b/packages/admin/src/Resources/Pages/CreateRecord.php
@@ -45,7 +45,7 @@ class CreateRecord extends Page implements HasFormActions
     {
         static::authorizeResourceAccess();
 
-        abort_unless(static::getResource()::canCreate(), 403);
+        static::authorizeResourceAccess('create');
     }
 
     protected function fillForm(): void

--- a/packages/admin/src/Resources/Pages/EditRecord.php
+++ b/packages/admin/src/Resources/Pages/EditRecord.php
@@ -60,7 +60,7 @@ class EditRecord extends Page implements HasFormActions
     {
         static::authorizeResourceAccess();
 
-        abort_unless(static::getResource()::canEdit($this->getRecord()), 403);
+        static::authorizeResourceAccess('edit', $this->getRecord());
     }
 
     protected function fillForm(): void

--- a/packages/admin/src/Resources/Pages/Page.php
+++ b/packages/admin/src/Resources/Pages/Page.php
@@ -2,7 +2,10 @@
 
 namespace Filament\Resources\Pages;
 
+use Filament\Facades\Filament;
 use Filament\Pages\Page as BasePage;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Gate;
 
 class Page extends BasePage
 {
@@ -35,9 +38,14 @@ class Page extends BasePage
         );
     }
 
-    public static function authorizeResourceAccess(): void
+    public static function authorizeResourceAccess(string $action = 'viewAny', Model $record = null): void
     {
-        abort_unless(static::getResource()::canViewAny(), 403);
+        $model = static::getResource()::getModel();
+        $policy = Gate::getPolicyFor($model);
+
+        if (static::getResource()::shouldAuthorizeWithGate() || ($policy !== null && method_exists($policy, $action))) {
+            Gate::forUser(Filament::auth()->user())->authorize($action, $record ?? $model);
+        }
     }
 
     public function getModel(): string

--- a/packages/admin/src/Resources/Pages/ViewRecord.php
+++ b/packages/admin/src/Resources/Pages/ViewRecord.php
@@ -45,7 +45,7 @@ class ViewRecord extends Page
 
         $this->record = $this->resolveRecord($record);
 
-        abort_unless(static::getResource()::canView($this->getRecord()), 403);
+        static::authorizeResourceAccess('view', $this->getRecord());
 
         $this->fillForm();
     }

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
@@ -14,7 +14,7 @@ trait Translatable
     {
         static::authorizeResourceAccess();
 
-        abort_unless(static::getResource()::canCreate(), 403);
+        static::authorizeResourceAccess('create');
 
         $this->setActiveFormLocale();
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This PR aims to respect Laravel's `Response::denyAsNotFound()`usage within `Policy` classes.

Before, regardless of how we try to specify the status to 404, it still responds with a 403 as that is hardcoded to abort to.