### PR TITLE
Update Resource.php

### DIFF
--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -451,6 +451,8 @@ class Resource
     {
         /** @var Connection $databaseConnection */
         $databaseConnection = $query->getConnection();
+        
+        $databaseCollation = $databaseConnection->getConfig('collation');
 
         $searchOperator = match ($databaseConnection->getDriverName()) {
             'pgsql' => 'ilike',
@@ -471,7 +473,7 @@ class Resource
                     };
 
                     return $query->{"{$whereClause}Raw"}(
-                        "lower({$searchColumn}) {$searchOperator} ?",
+                        "lower({$searchColumn}) COLLATE {$databaseCollation} {$searchOperator} ?",
                         "%{$searchQuery}%",
                     );
                 },


### PR DESCRIPTION
global search not works properly when the searchable field is a json, and also it does not respect the database collation.
I mean when you have a spatie-translatable field (so it works as a json field) it ignores the database.php collation config.
(my desire case is to search words ignoring accents)

todo : how to apply this at the individual search query of each resource?

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

 Current result:
![image](https://github.com/filamentphp/filament/assets/93589477/05da73bb-fc42-4f1b-9897-50bab0326043)
Expecting result:
![image](https://github.com/filamentphp/filament/assets/93589477/8364c646-8ca0-4fd7-8021-95cb58316fcb)
