### PR TITLE
Add render hooks to table header toolbar

### DIFF
--- a/packages/panels/docs/09-configuration.md
+++ b/packages/panels/docs/09-configuration.md
@@ -120,6 +120,11 @@ The available hooks are as follows:
 - `resource.pages.list-records.table.end` - after the resource table
 - `resource.relation-manager.start` - before the relation manager table
 - `resource.relation-manager.end` - after the relation manager table
+- `table.header-toolbar.actions.start` - before a table's header toolbar actions
+- `table.header-toolbar.actions.end` - after a table's header toolbar actions
+- `table.header-toolbar` - between a table's header toolbar actions and filters
+- `table.header-toolbar.filters.start` - before a table's header toolbar filters
+- `table.header-toolbar.filters.end` - after a table's header toolbar filters
 - `tenant-menu.start` - before tenant menu
 - `tenant-menu.end` - after tenant menu
 - `user-menu.start` - before [user menu](navigation#customizing-the-user-menu)

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -57,6 +57,7 @@
     $recordCheckboxPosition = $getRecordCheckboxPosition();
     $isStriped = $isStriped();
     $isLoaded = $isLoaded();
+    $isPanel = function_exists('filament');
     $hasFilters = $isFilterable();
     $filtersLayout = $getFiltersLayout();
     $hasFiltersDropdown = $hasFilters && ($filtersLayout === FiltersLayout::Dropdown);
@@ -293,6 +294,10 @@
                 }"
             >
                 <div class="flex shrink-0 items-center sm:gap-3">
+                    @if ($isPanel)
+                        {{ filament()->renderHook('tables.header-toolbar.actions.start') }}
+                    @endif
+       
                     @if ($isReorderable)
                         {{ $getReorderRecordsTriggerAction($isReordering) }}
                     @endif
@@ -312,12 +317,24 @@
                             x-cloak="x-cloak"
                         />
                     @endif
+
+                    @if ($isPanel)
+                        {{ filament()->renderHook('tables.header-toolbar.actions.end') }}
+                    @endif
                 </div>
+
+                @if ($isPanel)
+                    {{ filament()->renderHook('tables.header-toolbar') }}
+                @endif
 
                 @if ($isGlobalSearchVisible || $hasFiltersDropdown || $isColumnToggleFormVisible)
                     <div
                         class="flex flex-1 items-center justify-end gap-3 md:max-w-md"
                     >
+                        @if ($isPanel)
+                            {{ filament()->renderHook('tables.header-toolbar.filters.start') }}
+                        @endif
+
                         @if ($isGlobalSearchVisible)
                             <div
                                 class="filament-tables-search-container flex flex-1 items-center justify-end"
@@ -349,6 +366,10 @@
                                     />
                                 @endif
                             </div>
+                        @endif
+
+                        @if ($isPanel)
+                            {{ filament()->renderHook('tables.header-toolbar.filters.end') }}
                         @endif
                     </div>
                 @endif


### PR DESCRIPTION
This PR adds several render hooks to the table header toolbar. In short it adds renderhooks:
- before and after the left hand side group of actions (reorder, bulk, group)
- before and after the right hand side group of filters (search, filter, toggle)
- one "in the middle" between those two. This renderhook isn't meant to be in the middle, but when search, filters, and toggle columns are turned off there wouldn't be a way to render a hook there, so adding this renderhook allows someone to take advantage of the `justify-between` on the parent and then render something on the far right.

Since renderhooks are only available in the Panel, i've done a check to ensure it is the panel. There might be a better way to do this, but what occured to me is to see if the `filament` helper function exists.

Of course, another approach would be to actually add the ability to call renderhooks in the tablebuilder, but that would require a much larger discussion.

Finally, I think you could make an argument for at least one additional render hook between the search and the filters/toggle column icons. That way if someone wanted to add an icon before those two they could.

Let me know and I can do that.

Dan please work your naming magic!!! 