### PR TITLE
Feat: `CanBeCopied` copyText

### DIFF
--- a/packages/tables/resources/views/columns/badge-column.blade.php
+++ b/packages/tables/resources/views/columns/badge-column.blade.php
@@ -52,7 +52,7 @@
             <span
                 @if ($isCopyable)
                     x-on:click="
-                        window.navigator.clipboard.writeText(@js($getState()))
+                        window.navigator.clipboard.writeText(@js($getCopyText() ?? $getState()))
                         $tooltip(@js($getCopyMessage()), { timeout: @js($getCopyMessageDuration()) })
                     "
                 @endif

--- a/packages/tables/resources/views/columns/badge-column.blade.php
+++ b/packages/tables/resources/views/columns/badge-column.blade.php
@@ -52,7 +52,7 @@
             <span
                 @if ($isCopyable)
                     x-on:click="
-                        window.navigator.clipboard.writeText(@js($getCopyText() ?? $getState()))
+                        window.navigator.clipboard.writeText(@js($getCopyableState()))
                         $tooltip(@js($getCopyMessage()), { timeout: @js($getCopyMessageDuration()) })
                     "
                 @endif

--- a/packages/tables/resources/views/columns/color-column.blade.php
+++ b/packages/tables/resources/views/columns/color-column.blade.php
@@ -8,7 +8,7 @@
         style="background-color: {{ $state }}"
         @if ($isCopyable)
             x-on:click="
-                window.navigator.clipboard.writeText(@js($state))
+                window.navigator.clipboard.writeText(@js($getCopyText() ?? $state))
                 $tooltip(@js($getCopyMessage()), { timeout: @js($getCopyMessageDuration()) })
             "
         @endif

--- a/packages/tables/resources/views/columns/color-column.blade.php
+++ b/packages/tables/resources/views/columns/color-column.blade.php
@@ -8,7 +8,7 @@
         style="background-color: {{ $state }}"
         @if ($isCopyable)
             x-on:click="
-                window.navigator.clipboard.writeText(@js($getCopyText() ?? $state))
+                window.navigator.clipboard.writeText(@js($getCopyableState()))
                 $tooltip(@js($getCopyMessage()), { timeout: @js($getCopyMessageDuration()) })
             "
         @endif

--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -76,7 +76,7 @@
         <span
             @if ($isCopyable)
                 x-on:click="
-                    window.navigator.clipboard.writeText(@js($getState()))
+                    window.navigator.clipboard.writeText(@js($getCopyText() ?? $getState()))
                     $tooltip(@js($getCopyMessage()), { timeout: @js($getCopyMessageDuration()) })
                 "
             @endif

--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -76,7 +76,7 @@
         <span
             @if ($isCopyable)
                 x-on:click="
-                    window.navigator.clipboard.writeText(@js($getCopyText() ?? $getState()))
+                    window.navigator.clipboard.writeText(@js($getCopyableState()))
                     $tooltip(@js($getCopyMessage()), { timeout: @js($getCopyMessageDuration()) })
                 "
             @endif

--- a/packages/tables/src/Columns/Concerns/CanBeCopied.php
+++ b/packages/tables/src/Columns/Concerns/CanBeCopied.php
@@ -12,6 +12,8 @@ trait CanBeCopied
 
     protected int | Closure | null $copyMessageDuration = null;
 
+    protected string | Closure | null $copyText = null;
+
     public function copyable(bool | Closure $condition = true): static
     {
         $this->isCopyable = $condition;
@@ -33,6 +35,13 @@ trait CanBeCopied
         return $this;
     }
 
+    public function copyText(string | Closure | null $text): static
+    {
+        $this->copyText = $text;
+
+        return $this;
+    }
+
     public function getCopyMessage(): string
     {
         return $this->evaluate($this->copyMessage) ?? __('tables::table.columns.messages.copied');
@@ -41,6 +50,11 @@ trait CanBeCopied
     public function getCopyMessageDuration(): int
     {
         return $this->evaluate($this->copyMessageDuration) ?? 2000;
+    }
+
+    public function getCopyText(): ?string
+    {
+        return $this->evaluate($this->copyText);
     }
 
     public function isCopyable(): bool

--- a/packages/tables/src/Columns/Concerns/CanBeCopied.php
+++ b/packages/tables/src/Columns/Concerns/CanBeCopied.php
@@ -12,7 +12,7 @@ trait CanBeCopied
 
     protected int | Closure | null $copyMessageDuration = null;
 
-    protected string | Closure | null $copyText = null;
+    protected string | Closure | null $copyableState = null;
 
     public function copyable(bool | Closure $condition = true): static
     {
@@ -35,9 +35,9 @@ trait CanBeCopied
         return $this;
     }
 
-    public function copyText(string | Closure | null $text): static
+    public function copyableState(string | Closure | null $state): static
     {
-        $this->copyText = $text;
+        $this->copyableState = $state;
 
         return $this;
     }
@@ -52,9 +52,9 @@ trait CanBeCopied
         return $this->evaluate($this->copyMessageDuration) ?? 2000;
     }
 
-    public function getCopyText(): ?string
+    public function getCopyableState(): ?string
     {
-        return $this->evaluate($this->copyText);
+        return $this->evaluate($this->copyableState) ?? $this->getState();
     }
 
     public function isCopyable(): bool


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
