### PR TITLE
Add host and port to broadcasting

### DIFF
--- a/packages/admin/config/filament.php
+++ b/packages/admin/config/filament.php
@@ -204,6 +204,9 @@ return [
         //     'broadcaster' => 'pusher',
         //     'key' => env('VITE_PUSHER_APP_KEY'),
         //     'cluster' => env('VITE_PUSHER_APP_CLUSTER'),
+        //     'wsHost' => env('VITE_PUSHER_HOST'),
+        //     'wsPort' => env('VITE_PUSHER_PORT'),
+        //     'wssPort' => env('VITE_PUSHER_PORT'),
         //     'forceTLS' => true,
         // ],
 


### PR DESCRIPTION
- [X] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

I don't think documentation has to be changed for this, if so, I'm happy to sync. :)

The reason for adding wsHost + wsPort/wssPort, is when someone uses a Nginx proxy for sockets (like we do).
It could also be someone using the docker container host and listening on a different url.