### PR TITLE
Add CSS hook class to user menu

### DIFF
--- a/packages/admin/resources/views/components/layouts/app/topbar/user-menu.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/topbar/user-menu.blade.php
@@ -88,7 +88,7 @@
             },
         }"
     >
-        <div>
+        <div class="filament-theme-toggle">
             @if (config('filament.dark_mode'))
                 <x-filament::dropdown.list.item
                     icon="heroicon-s-moon"


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

In my use case, I want to display `theme-toggle` between search and user-menu, I can add using render hook.. but I want to hide the toggle inside user-menu. or display the toggle if screen = xx,

This PR add one class `filament-theme-toggle` in `div`. it helps when trying to add custom css