### PR TITLE
Added support for before policy filter

### DIFF
--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -135,6 +135,10 @@ class Resource
             return true;
         }
 
+        if (method_exists($policy, 'before') && is_bool($condition = $policy->before($user, $action))) {
+            return $condition;
+        }
+
         if (! method_exists($policy, $action)) {
             return true;
         }


### PR DESCRIPTION
This PR checks before policy filter and triggers (if available). See more at: https://laravel.com/docs/10.x/authorization#policy-filters



```php

use App\Models\User;
use Illuminate\Auth\Access\HandlesAuthorization;

class CompanyPolicy
{
    use HandlesAuthorization;

    public function viewAny(): bool
    {
        return false;
    }

    public function before(User $user, $ability): ?bool
    {
        // check for any condition and return bool / or null to pass authorization further the chain

        return null;
    }
}
```