### PR TITLE
Add RTL layout support to sidebar toggle button

### DIFF
--- a/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
+++ b/packages/admin/resources/views/components/layouts/app/sidebar/index.blade.php
@@ -52,7 +52,7 @@
                     x-transition:enter-end="opacity-100"
                 >
                     <svg
-                        class="h-6 w-6"
+                        class="h-6 w-6 rtl:scale-x-[-1]"
                         width="24"
                         height="24"
                         viewBox="0 0 24 24"


### PR DESCRIPTION
I noticed the sidebar toggle button does not support RTL layout:
![image](https://github.com/filamentphp/filament/assets/15275787/ab5bc201-1868-41b8-81ac-2165016fced7)

This PR adds support for that:
![image](https://github.com/filamentphp/filament/assets/15275787/ce5971b0-baaf-406d-9057-a1914d1c416e)
