### PR TITLE
Execute custom function after the table reorder

### DIFF
--- a/packages/admin/src/Resources/Pages/ListRecords.php
+++ b/packages/admin/src/Resources/Pages/ListRecords.php
@@ -395,6 +395,11 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
         return filled($this->getTableReorderColumn()) && static::getResource()::canReorder();
     }
 
+    protected function getTableReorderFunction(): ?Closure
+    {
+        return $this->getResourceTable()->getReorderFunction();
+    }
+
     protected function getTablePollingInterval(): ?string
     {
         return $this->getResourceTable()->getPollingInterval();

--- a/packages/admin/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/admin/src/Resources/RelationManagers/RelationManager.php
@@ -488,6 +488,11 @@ class RelationManager extends Component implements Tables\Contracts\HasRelations
         return filled($this->getTableReorderColumn()) && $this->canReorder();
     }
 
+    protected function getTableReorderFunction(): ?Closure
+    {
+        return $this->getResourceTable()->getReorderFunction();
+    }
+
     protected function getTablePollingInterval(): ?string
     {
         return $this->getResourceTable()->getPollingInterval();

--- a/packages/admin/src/Resources/Table.php
+++ b/packages/admin/src/Resources/Table.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Resources;
 
+use Closure;
 use Filament\Tables\Actions\ActionGroup;
 use Illuminate\Support\Arr;
 
@@ -34,6 +35,8 @@ class Table
     protected ?bool $isLoadingDeferred = false;
 
     protected ?string $reorderColumn = null;
+
+    protected ?Closure $reorderFunction = null;
 
     final public function __construct()
     {
@@ -203,9 +206,10 @@ class Table
         return $this;
     }
 
-    public function reorderable(?string $column = 'sort'): static
+    public function reorderable(?string $column = 'sort', ?Closure $function = null): static
     {
         $this->reorderColumn = $column;
+        $this->reorderFunction = $function;
 
         return $this;
     }
@@ -268,6 +272,11 @@ class Table
     public function getReorderColumn(): ?string
     {
         return $this->reorderColumn;
+    }
+
+    public function getReorderFunction(): ?Closure
+    {
+        return $this->reorderFunction;
     }
 
     public function getPollingInterval(): ?string

--- a/packages/tables/src/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Concerns/CanReorderRecords.php
@@ -7,6 +7,7 @@ use Filament\Tables\Contracts\HasRelationshipTable;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+
 trait CanReorderRecords
 {
     public bool $isTableReordering = false;

--- a/packages/tables/src/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Concerns/CanReorderRecords.php
@@ -2,11 +2,11 @@
 
 namespace Filament\Tables\Concerns;
 
+use Closure;
 use Filament\Tables\Contracts\HasRelationshipTable;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
-
 trait CanReorderRecords
 {
     public bool $isTableReordering = false;
@@ -46,6 +46,11 @@ trait CanReorderRecords
                         ->implode(' ') . ' end'
                 ),
             ]);
+
+        $afterReorder = $this->getTableReorderFunction();
+        if (is_callable($afterReorder)) {
+            $afterReorder($this);
+        }
     }
 
     public function toggleTableReordering(): void
@@ -69,6 +74,11 @@ trait CanReorderRecords
     }
 
     protected function getTableReorderColumn(): ?string
+    {
+        return null;
+    }
+
+    protected function getTableReorderFunction(): ?Closure
     {
         return null;
     }


### PR DESCRIPTION
Hi, i'm creating this PR for my friend's request described [here](https://github.com/filamentphp/filament/discussions/6619#discussion-5235550).

I simply added a second not required parameter to `reorderable` function.
In the function you can now, in our case for example, execute something that is not executed because events are not fired.

Let me know for any questions and fixes.

PS. i tried to write it also as string parameter but i don't know well how it works... so if needed please fix and add it
```php
public function getReorderFunction(): ?Closure
{
    $function = $this->reorderFunction;

    if (is_string($function)) {
        $function = Closure::fromCallable(class_exists($function) ? $function : [$this, $function]);
    }

    return $function;
}
```