### PR TITLE
Support removing repeatable entry card

### DIFF
--- a/packages/infolists/docs/03-entries/06-repeatable.md
+++ b/packages/infolists/docs/03-entries/06-repeatable.md
@@ -38,3 +38,17 @@ RepeatableEntry::make('members')
 ```
 
 This method accepts the same options as the `columns()` method of the [grid](../layout/grid). This allows you to responsively customize the number of grid columns at various breakpoints.
+
+## Removing the wrapping card
+
+By default, each item in a repeatable entry gets wrapped in a card. This behavior can be disabled using `wrappedInCard()`:
+
+```php
+use Filament\Infolists\Components\RepeatableEntry;
+
+RepeatableEntry::make('members')
+    ->schema([
+        // ...
+    ])
+    ->wrappedInCard(false)
+```

--- a/packages/infolists/resources/views/components/repeatable-entry.blade.php
+++ b/packages/infolists/resources/views/components/repeatable-entry.blade.php
@@ -19,11 +19,15 @@
             class="gap-6"
         >
             @foreach ($getChildComponentContainers() as $container)
-                <li
-                    class="block rounded-xl bg-white p-6 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-800 dark:ring-white/20"
-                >
+                @if ($isWrappedInCard())
+                    <li
+                        class="block rounded-xl bg-white p-6 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-800 dark:ring-white/20"
+                    >
+                        {{ $container }}
+                    </li>
+                @else
                     {{ $container }}
-                </li>
+                @endif
             @endforeach
         </x-filament::grid>
     </ul>

--- a/packages/infolists/resources/views/components/repeatable-entry.blade.php
+++ b/packages/infolists/resources/views/components/repeatable-entry.blade.php
@@ -1,4 +1,8 @@
 <x-dynamic-component :component="$getEntryWrapperView()" :entry="$entry">
+    @php
+        $isWrappedInCard = $isWrappedInCard();
+    @endphp
+    
     <ul
         {{
             $attributes
@@ -19,15 +23,14 @@
             class="gap-6"
         >
             @foreach ($getChildComponentContainers() as $container)
-                @if ($isWrappedInCard())
-                    <li
-                        class="block rounded-xl bg-white p-6 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-800 dark:ring-white/20"
-                    >
-                        {{ $container }}
-                    </li>
-                @else
+                <li
+                    @class([
+                        'block',
+                        'rounded-xl bg-white p-6 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-800 dark:ring-white/20' => $isWrappedInCard,
+                    ])
+                >
                     {{ $container }}
-                @endif
+                </li>
             @endforeach
         </x-filament::grid>
     </ul>

--- a/packages/infolists/src/Components/RepeatableEntry.php
+++ b/packages/infolists/src/Components/RepeatableEntry.php
@@ -2,12 +2,15 @@
 
 namespace Filament\Infolists\Components;
 
+use Closure;
 use Filament\Infolists\ComponentContainer;
 use Illuminate\Database\Eloquent\Model;
 
 class RepeatableEntry extends Entry
 {
     use Concerns\HasContainerGridLayout;
+
+    protected bool | Closure $isWrappedInCard = true;
 
     /**
      * @var view-string
@@ -36,5 +39,17 @@ class RepeatableEntry extends Entry
         }
 
         return $containers;
+    }
+
+    public function wrappedInCard(bool | Closure $condition = true): static
+    {
+        $this->isWrappedInCard = $condition;
+
+        return $this;
+    }
+
+    public function isWrappedInCard(): bool
+    {
+        return (bool) $this->evaluate($this->isWrappedInCard);
     }
 }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
