### PR TITLE
Fix infolists active tab

### DIFF
--- a/packages/infolists/resources/views/components/tabs.blade.php
+++ b/packages/infolists/resources/views/components/tabs.blade.php
@@ -7,8 +7,9 @@
 
             this.tab = @js(collect($getChildComponentContainer()->getComponents())
                         ->filter(static fn (\Filament\Infolists\Components\Tabs\Tab $tab): bool => $tab->isVisible())
-                        ->get($getActiveTab() - 1)
-                        ->getId())
+                        ->map(static fn (\Filament\Infolists\Components\Tabs\Tab $tab) => $tab->getId())
+                        ->values()
+                        ->get($getActiveTab() - 1))
         },
 
         updateQueryString: function () {


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

If I'm correct, this now matches the behavior of form tabs.
When you have 2 tabs and tab 1 is hidden, tab 2 will correspond to 1 when setting `activeTab()`.
To me this is desired behavior and one can always get the count of visible tabs to get the id of a tab dynamically.