### PR TITLE
Support state

### DIFF
--- a/packages/infolists/docs/03-entries/01-getting-started.md
+++ b/packages/infolists/docs/03-entries/01-getting-started.md
@@ -111,11 +111,11 @@ TextEntry::make('role')
 
 Sometimes you need to calculate the state of an entry, instead of directly reading it from a database entry.
 
-By passing a callback function to the `getStateUsing()` method, you can customize the returned state for that entry:
+By passing a callback function to the `state()` method, you can customize the returned state for that entry:
 
 ```php
 Infolists\Components\TextEntry::make('amount_including_vat')
-    ->getStateUsing(function (Model $record): float {
+    ->state(function (Model $record): float {
         return $record->amount * (1 + $record->vat_rate);
     })
 ```

--- a/packages/infolists/src/Components/Concerns/HasState.php
+++ b/packages/infolists/src/Components/Concerns/HasState.php
@@ -30,6 +30,13 @@ trait HasState
         return $this;
     }
 
+    public function state(mixed $state): static
+    {
+        $this->getStateUsing(fn (Component $component) => $component->evaluate($state));
+
+        return $this;
+    }
+
     public function default(mixed $state): static
     {
         $this->defaultState = $state;
@@ -52,13 +59,6 @@ trait HasState
     public function getDefaultState(): mixed
     {
         return $this->evaluate($this->defaultState);
-    }
-
-    public function state(mixed $state): static
-    {
-        $this->getStateUsing(fn (Component $component) => $component->evaluate($state));
-
-        return $this;
     }
 
     public function getState(): mixed

--- a/packages/infolists/src/Components/Concerns/HasState.php
+++ b/packages/infolists/src/Components/Concerns/HasState.php
@@ -3,7 +3,6 @@
 namespace Filament\Infolists\Components\Concerns;
 
 use Closure;
-use Filament\Infolists\Components\Component;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 
@@ -13,7 +12,7 @@ trait HasState
 
     protected mixed $defaultState = null;
 
-    protected ?Closure $getStateUsing = null;
+    protected mixed $getStateUsing = null;
 
     protected ?string $statePath = null;
 
@@ -23,7 +22,7 @@ trait HasState
 
     protected string $cachedFullStatePath;
 
-    public function getStateUsing(?Closure $callback): static
+    public function getStateUsing(mixed $callback): static
     {
         $this->getStateUsing = $callback;
 
@@ -32,7 +31,7 @@ trait HasState
 
     public function state(mixed $state): static
     {
-        $this->getStateUsing(fn (Component $component) => $component->evaluate($state));
+        $this->getStateUsing($state);
 
         return $this;
     }

--- a/packages/tables/docs/03-columns/01-getting-started.md
+++ b/packages/tables/docs/03-columns/01-getting-started.md
@@ -354,11 +354,11 @@ public function table(Table $table): Table
 
 Sometimes you need to calculate the state of a column, instead of directly reading it from a database column.
 
-By passing a callback function to the `getStateUsing()` method, you can customize the returned state for that column based on the `$record`:
+By passing a callback function to the `state()` method, you can customize the returned state for that column based on the `$record`:
 
 ```php
 Tables\Columns\TextColumn::make('amount_including_vat')
-    ->getStateUsing(function (Model $record): float {
+    ->state(function (Model $record): float {
         return $record->amount * (1 + $record->vat_rate);
     })
 ```

--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -343,7 +343,7 @@ You may want a column to contain the number of the current row in the table:
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Contracts\HasTable;
 
-TextColumn::make('index')->getStateUsing(
+TextColumn::make('index')->state(
     static function (HasTable $livewire, stdClass $rowLoop): string {
         return (string) (
             $rowLoop->iteration +

--- a/packages/tables/src/Columns/Concerns/HasState.php
+++ b/packages/tables/src/Columns/Concerns/HasState.php
@@ -11,7 +11,7 @@ trait HasState
 {
     protected mixed $defaultState = null;
 
-    protected ?Closure $getStateUsing = null;
+    protected mixed $getStateUsing = null;
 
     protected string | Closure | null $separator = null;
 
@@ -24,7 +24,7 @@ trait HasState
         return $this;
     }
 
-    public function getStateUsing(?Closure $callback): static
+    public function getStateUsing(mixed $callback): static
     {
         $this->getStateUsing = $callback;
 
@@ -33,7 +33,7 @@ trait HasState
 
     public function state(mixed $state): static
     {
-        $this->getStateUsing(fn () => $this->evaluate($state));
+        $this->getStateUsing($state);
 
         return $this;
     }

--- a/packages/tables/src/Columns/Concerns/HasState.php
+++ b/packages/tables/src/Columns/Concerns/HasState.php
@@ -31,6 +31,13 @@ trait HasState
         return $this;
     }
 
+    public function state(mixed $state): static
+    {
+        $this->getStateUsing(fn () => $this->evaluate($state));
+
+        return $this;
+    }
+
     public function default(mixed $state): static
     {
         $this->defaultState = $state;

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -62,7 +62,7 @@ class TextColumn extends Column
 
     public function rowIndex(bool $isFromZero = false): static
     {
-        $this->getStateUsing(static function (HasTable $livewire, stdClass $rowLoop) use ($isFromZero): string {
+        $this->state(static function (HasTable $livewire, stdClass $rowLoop) use ($isFromZero): string {
             $rowIndex = $rowLoop->{$isFromZero ? 'index' : 'iteration'};
 
             return (string) ($rowIndex + ($livewire->getTableRecordsPerPage() * ($livewire->getTablePage() - 1)));

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -68,7 +68,7 @@ class PostsTable extends Component implements HasForms, Tables\Contracts\HasTabl
                 Tables\Columns\TextColumn::make('hidden')
                     ->hidden(),
                 Tables\Columns\TextColumn::make('with_state')
-                    ->state(fn () => 'correct state'),
+                    ->state('correct state'),
                 Tables\Columns\TextColumn::make('formatted_state')
                     ->formatStateUsing(fn () => 'formatted state'),
                 Tables\Columns\TextColumn::make('extra_attributes')

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -68,7 +68,7 @@ class PostsTable extends Component implements HasForms, Tables\Contracts\HasTabl
                 Tables\Columns\TextColumn::make('hidden')
                     ->hidden(),
                 Tables\Columns\TextColumn::make('with_state')
-                    ->getStateUsing(fn () => 'correct state'),
+                    ->state(fn () => 'correct state'),
                 Tables\Columns\TextColumn::make('formatted_state')
                     ->formatStateUsing(fn () => 'formatted state'),
                 Tables\Columns\TextColumn::make('extra_attributes')


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
