### PR TITLE
BugFix: Broken Mask Options

### DIFF
--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -28,7 +28,7 @@
                 ax-load
                 ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('text-input', 'filament/forms') }}"
                 x-data="textInputFormComponent({
-                            getMaskOptionsUsing: (IMask) => {{ $getJsonMaskConfiguration() }},
+                            getMaskOptionsUsing: (IMask) => ({{ $getJsonMaskConfiguration() }}),
                             state: $wire.{{ $applyStateBindingModifiers("entangle('{$statePath}')", lazilyEntangledModifiers: ['defer']) }},
                         })"
                 wire:ignore


### PR DESCRIPTION
In commit 5deaa867494df811aa5d8e2c6b82f7f32e396608 when using Prettier to update the `text-input.blade.php`, a bug was introduced.

When using the mask option on a TextInput, the field will fail to apply the mask and will throw this error in the console. Re-introduction of the parens will fix this bug.

Errant Commit:
https://github.com/filamentphp/filament/commit/5deaa867494df811aa5d8e2c6b82f7f32e396608#r120141338

Error in Console:
![image](https://github.com/filamentphp/filament/assets/1517011/df7368b3-b8c7-4cbd-b2c0-345c1e56eaa8)



