### PR TITLE
Update IconColumn docs

### DIFF
--- a/packages/tables/docs/03-columns/03-icon.md
+++ b/packages/tables/docs/03-columns/03-icon.md
@@ -8,7 +8,7 @@ Icon columns render a Blade icon component representing their contents:
 use Filament\Tables\Columns\IconColumn;
 
 IconColumn::make('is_featured')
-    ->options([
+    ->icons([
         'heroicon-o-x-circle',
         'heroicon-o-pencil' => 'draft',
         'heroicon-o-clock' => 'reviewing',
@@ -16,13 +16,13 @@ IconColumn::make('is_featured')
     ])
 ```
 
-You may also pass a callback to activate an option, accepting the cell's `$state` and `$record`:
+You may also pass a callback to activate an icon, accepting the cell's `$state` and `$record`:
 
 ```php
 use Filament\Tables\Columns\IconColumn;
 
 IconColumn::make('is_featured')
-    ->options([
+    ->icons([
         'heroicon-o-x-circle',
         'heroicon-o-pencil' => fn ($state, $record): bool => $record->status === 2,
         'heroicon-o-clock' => fn ($state): bool => $state === 'reviewing',
@@ -38,7 +38,7 @@ Icon columns may also have a set of icon colors, using the same syntax. They may
 use Filament\Tables\Columns\IconColumn;
 
 IconColumn::make('is_featured')
-    ->options([
+    ->icons([
         'heroicon-o-x-circle',
         'heroicon-o-pencil' => 'draft',
         'heroicon-o-clock' => 'reviewing',
@@ -60,7 +60,7 @@ The default icon size is `lg`, but you may customize the size to be either `xs`,
 use Filament\Tables\Columns\IconColumn;
 
 IconColumn::make('is_featured')
-    ->options([
+    ->icons([
         'heroicon-s-x-circle',
         'heroicon-s-pencil' => 'draft',
         'heroicon-s-clock' => 'reviewing',


### PR DESCRIPTION
`options()` is deprecated, change to `icons()`

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
