### PR TITLE
Add scrollableContent to modal

### DIFF
--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -13,6 +13,7 @@
     'hrComponent' => 'filament-support::hr',
     'id' => null,
     'openEventName' => 'open-modal',
+    'scrollContent' => false,
     'slideOver' => false,
     'subheading' => null,
     'subheadingComponent' => 'filament-support::modal.subheading',
@@ -90,6 +91,7 @@
                 $attributes->class([
                     'pointer-events-none relative w-full cursor-pointer transition',
                     'my-auto p-4' => ! $slideOver,
+                    'flex shrink max-h-screen ' => $scrollContent,
                 ])
             }}
         >
@@ -167,7 +169,7 @@
 
                 <div
                     @class([
-                        'flex h-full flex-col' => ($width === 'screen') || $slideOver,
+                        'flex h-full flex-col' => ($width === 'screen') || $slideOver || $scrollContent,
                     ])
                 >
                     <div class="space-y-2">
@@ -188,7 +190,7 @@
                     <div
                         @class([
                             'filament-modal-content space-y-2 p-2',
-                            'flex-1 overflow-y-auto' => ($width === 'screen') || $slideOver,
+                            'flex-1 overflow-y-auto' => ($width === 'screen') || $slideOver || $scrollContent,
                         ])
                     >
                         @if ($heading || $subheading)

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -91,7 +91,7 @@
                 $attributes->class([
                     'pointer-events-none relative w-full cursor-pointer transition',
                     'my-auto p-4' => ! $slideOver,
-                    'flex shrink max-h-screen ' => $scrollContent,
+                    'flex max-h-screen shrink' => $scrollContent,
                 ])
             }}
         >

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -13,7 +13,7 @@
     'hrComponent' => 'filament-support::hr',
     'id' => null,
     'openEventName' => 'open-modal',
-    'scrollContent' => false,
+    'scrollableContent' => false,
     'slideOver' => false,
     'subheading' => null,
     'subheadingComponent' => 'filament-support::modal.subheading',
@@ -91,7 +91,7 @@
                 $attributes->class([
                     'pointer-events-none relative w-full cursor-pointer transition',
                     'my-auto p-4' => ! $slideOver,
-                    'flex max-h-screen shrink' => $scrollContent,
+                    'flex max-h-screen shrink' => $scrollableContent,
                 ])
             }}
         >
@@ -169,7 +169,7 @@
 
                 <div
                     @class([
-                        'flex h-full flex-col' => ($width === 'screen') || $slideOver || $scrollContent,
+                        'flex h-full flex-col' => ($width === 'screen') || $slideOver || $scrollableContent,
                     ])
                 >
                     <div class="space-y-2">
@@ -190,7 +190,7 @@
                     <div
                         @class([
                             'filament-modal-content space-y-2 p-2',
-                            'flex-1 overflow-y-auto' => ($width === 'screen') || $slideOver || $scrollContent,
+                            'flex-1 overflow-y-auto' => ($width === 'screen') || $slideOver || $scrollableContent,
                         ])
                     >
                         @if ($heading || $subheading)


### PR DESCRIPTION
Added `scrollContent` to allow for the inner modal content to be scrollable so that it works the same as screen/slideOver but uses the variable modal widths.