### PR TITLE
Global search result scroll bar visibility

### DIFF
--- a/packages/admin/resources/views/components/global-search/results-container.blade.php
+++ b/packages/admin/resources/views/components/global-search/results-container.blade.php
@@ -12,7 +12,7 @@
 >
     <div
         @class([
-            'max-h-96 overflow-x-hidden overflow-y-scroll rounded-xl bg-white shadow',
+            'max-h-96 overflow-x-hidden rounded-xl bg-white shadow',
             'dark:bg-gray-800' => config('filament.dark_mode'),
         ])
     >


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Before: When search anything we can see scroll bar by default (also in empty result)
![before](https://github.com/filamentphp/filament/assets/28250303/0d1ac5c4-4155-459c-9420-35f3d8cdb4b6)

After: Only when search result is scrollable, the scroll bar visible
![after](https://github.com/filamentphp/filament/assets/28250303/83c9222c-659b-4c48-9097-20defa07f98a)

