### PR TITLE
Should display dynamic options for checkbox list

### DIFF
--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -36,6 +36,7 @@
                 this.checkIfAllCheckboxesAreChecked()
 
                 Livewire.hook('message.processed', () => {
+                    this.updateVisibleCheckboxListOptions()
                     this.checkIfAllCheckboxesAreChecked()
                 })
 

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -37,6 +37,7 @@
 
                 Livewire.hook('message.processed', () => {
                     this.updateVisibleCheckboxListOptions()
+
                     this.checkIfAllCheckboxesAreChecked()
                 })
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This PR aims to fix displaying dynamic options for `CheckboxList`.

Given the ff:
```
Forms\Components\CheckboxList::make('states')
    ->options(
        fn (Closure $get) => ($country = $get('country'))
            ? State::whereCountryId($country)->pluck('name', 'id')
            : []
    )
```

Prior to this PR, the options are not displayed but is available in the DOM.

The proposed solution is to call `updateVisibleCheckboxListOptions()` in the `'message.processed'` hook.