### PR TITLE
Fix updating chart

### DIFF
--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -140,7 +140,7 @@
                     chart.update()
                 },
 
-                darkModeToggled: function() {
+                updateChartColors: function() {
                     chart = Chart.getChart(this.$refs.canvas);
                     chart.data.datasets[0].backgroundColor = getComputedStyle($refs.backgroundColorElement).color
                     chart.data.datasets[0].borderColor = getComputedStyle($refs.borderColorElement).color

--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -141,7 +141,6 @@
                 },
 
                 darkModeToggled: function() {
-
                     chart = Chart.getChart(this.$refs.canvas);
                     chart.data.datasets[0].backgroundColor = getComputedStyle($refs.backgroundColorElement).color
                     chart.data.datasets[0].borderColor = getComputedStyle($refs.borderColorElement).color

--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -135,7 +135,6 @@
                 },
 
                 updateChart: function () {
-                    
                     chart.data.labels = this.labels
                     chart.data.datasets[0].data = this.values
                     chart.update()

--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -135,9 +135,9 @@
                 },
 
                 updateChart: function () {
-                    chart.data.labels = this.labels
-                    chart.data.datasets[0].data = this.values
-                    chart.update()
+                    this.chart.data.labels = this.labels
+                    this.chart.data.datasets[0].data = this.values
+                    this.chart.update()
                 },
 
                 updateChartColors: function() {

--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -135,15 +135,21 @@
                 },
 
                 updateChart: function () {
+                    
                     chart.data.labels = this.labels
                     chart.data.datasets[0].data = this.values
                     chart.update()
                 },
+
+                darkModeToggled: function() {
+
+                    chart = Chart.getChart(this.$refs.canvas);
+                    chart.data.datasets[0].backgroundColor = getComputedStyle($refs.backgroundColorElement).color
+                    chart.data.datasets[0].borderColor = getComputedStyle($refs.borderColorElement).color
+                    chart.update('none');
+                }
             }"
-            x-on:dark-mode-toggled.window="
-                chart.destroy()
-                initChart()
-            "
+            x-on:dark-mode-toggled.window="darkModeToggled()"
             class="absolute inset-x-0 bottom-0 overflow-hidden rounded-b-2xl"
         >
             <canvas wire:ignore x-ref="canvas" class="h-6">

--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -147,7 +147,7 @@
                     chart.update('none');
                 }
             }"
-            x-on:dark-mode-toggled.window="darkModeToggled()"
+            x-on:dark-mode-toggled.window="updateChartColors()"
             class="absolute inset-x-0 bottom-0 overflow-hidden rounded-b-2xl"
         >
             <canvas wire:ignore x-ref="canvas" class="h-6">

--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -84,7 +84,8 @@
                 values: {{ json_encode(array_values($chart)) }},
 
                 init: function () {
-                    this.chart ? this.updateChart() : this.initChart()
+                    chart = Chart.getChart(this.$refs.canvas);
+                    chart !== undefined ? this.updateChart() : this.initChart()
                 },
 
                 initChart: function () {
@@ -134,9 +135,9 @@
                 },
 
                 updateChart: function () {
-                    this.chart.data.labels = this.labels
-                    this.chart.data.datasets[0].data = this.values
-                    this.chart.update()
+                    chart.data.labels = this.labels
+                    chart.data.datasets[0].data = this.values
+                    chart.update()
                 },
             }"
             x-on:dark-mode-toggled.window="

--- a/packages/admin/resources/views/components/stats/card.blade.php
+++ b/packages/admin/resources/views/components/stats/card.blade.php
@@ -78,18 +78,16 @@
         <div
             x-title="filament-stats-card-chart"
             x-data="{
-                chart: null,
-
                 labels: {{ json_encode(array_keys($chart)) }},
+
                 values: {{ json_encode(array_values($chart)) }},
 
                 init: function () {
-                    chart = Chart.getChart(this.$refs.canvas);
-                    chart !== undefined ? this.updateChart() : this.initChart()
+                    this.getChart() === undefined ? this.initChart() : this.updateChart()
                 },
 
                 initChart: function () {
-                    return (this.chart = new Chart(this.$refs.canvas, {
+                    return (new Chart(this.$refs.canvas, {
                         type: 'line',
                         data: {
                             labels: this.labels,
@@ -134,17 +132,22 @@
                     }))
                 },
 
+                getChart: function () {
+                    return Chart.getChart(this.$refs.canvas)
+                },
+
                 updateChart: function () {
-                    this.chart.data.labels = this.labels
-                    this.chart.data.datasets[0].data = this.values
-                    this.chart.update()
+                    chart = this.getChart()
+                    chart.data.labels = this.labels
+                    chart.data.datasets[0].data = this.values
+                    chart.update()
                 },
 
                 updateChartColors: function() {
-                    chart = Chart.getChart(this.$refs.canvas);
+                    chart = this.getChart()
                     chart.data.datasets[0].backgroundColor = getComputedStyle($refs.backgroundColorElement).color
                     chart.data.datasets[0].borderColor = getComputedStyle($refs.borderColorElement).color
-                    chart.update('none');
+                    chart.update('none')
                 }
             }"
             x-on:dark-mode-toggled.window="updateChartColors()"


### PR DESCRIPTION
Fixed Error: Canvas is already in use. Chart with ID '0' must be destroyed before the canvas with ID:

![image](https://github.com/filamentphp/filament/assets/3833889/ebd708f3-d578-405d-bf28-ea1a41fa563b)

It is happening when the pollingInterval is enabled.