### PR TITLE
Allow customize max top navigation width

### DIFF
--- a/packages/panels/resources/views/components/layouts/app/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/layouts/app/topbar/index.blade.php
@@ -6,9 +6,20 @@
 <header
     {{ $attributes->class(['filament-main-topbar sticky top-0 z-10 bg-white shadow-[0_1px_0_0_theme(colors.gray.950_/_5%)] dark:border-gray-700 dark:bg-gray-800 dark:shadow-[0_1px_0_0_theme(colors.white_/_20%)]']) }}
 >
-    <div
-        class="flex h-16 items-center justify-between px-2 sm:px-4 md:px-6 lg:px-8"
-    >
+    <div @class([
+        'mx-auto flex h-16 items-center justify-between px-2 sm:px-4 md:px-6 lg:px-8',
+        match ($maxTopNavigationWidth = filament()->getMaxTopNavigationWidth() ?? null) {
+            'xl' => 'max-w-xl',
+            '2xl' => 'max-w-2xl',
+            '3xl' => 'max-w-3xl',
+            '4xl' => 'max-w-4xl',
+            '5xl' => 'max-w-5xl',
+            '6xl' => 'max-w-6xl',
+            '7xl' => 'max-w-7xl',
+            'full' => 'max-w-full',
+            default => $maxTopNavigationWidth,
+        },
+    ])>
         <div class="flex flex-1 items-center">
             {{ filament()->renderHook('topbar.start') }}
 

--- a/packages/panels/src/Facades/Filament.php
+++ b/packages/panels/src/Facades/Filament.php
@@ -45,6 +45,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string | null getLoginUrl(array<mixed> $parameters = [])
  * @method static string getLogoutUrl(array<mixed> $parameters = [])
  * @method static string | null getMaxContentWidth()
+ * @method static string | null getMaxTopNavigationWidth()
  * @method static string | null getModelResource(string | Model $model)
  * @method static string getNameForDefaultAvatar(Model | Authenticatable $user)
  * @method static array<NavigationGroup> getNavigation()

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -178,6 +178,11 @@ class FilamentManager
         return $this->getCurrentPanel()->getMaxContentWidth();
     }
 
+    public function getMaxTopNavigationWidth(): ?string
+    {
+        return $this->getCurrentPanel()->getMaxTopNavigationWidth();
+    }
+
     public function getModelResource(string | Model $model): ?string
     {
         return $this->getCurrentPanel()->getModelResource($model);

--- a/packages/panels/src/Panel/Concerns/HasTopNavigation.php
+++ b/packages/panels/src/Panel/Concerns/HasTopNavigation.php
@@ -6,6 +6,8 @@ trait HasTopNavigation
 {
     protected bool $hasTopNavigation = false;
 
+    protected ?string $maxTopNavigationWidth = null;
+
     public function topNavigation(bool $condition = true): static
     {
         $this->hasTopNavigation = $condition;
@@ -16,5 +18,17 @@ trait HasTopNavigation
     public function hasTopNavigation(): bool
     {
         return $this->hasTopNavigation;
+    }
+
+    public function maxTopNavigationWidth(?string $maxTopNavigationWidth): static
+    {
+        $this->maxTopNavigationWidth = $maxTopNavigationWidth;
+
+        return $this;
+    }
+
+    public function getMaxTopNavigationWidth(): ?string
+    {
+        return $this->maxTopNavigationWidth;
     }
 }


### PR DESCRIPTION
There before cannot set a specific width for the top navigation width.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Before:
![image](https://github.com/filamentphp/filament/assets/56961917/d7b019df-161a-4356-b910-2c2a0d59426e)

After implement: `->maxTopNavigationWidth('7xl')`

![image](https://github.com/filamentphp/filament/assets/56961917/6ac970d4-a984-423e-a7ea-e2b7dfcbf982)
