### PR TITLE
Allow string to be passed to hiddenOn & visibleOn

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanBeHidden.php
+++ b/packages/tables/src/Columns/Concerns/CanBeHidden.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Columns\Concerns;
 
 use Closure;
 use Filament\Tables\Contracts\HasTable;
+use Illuminate\Support\Arr;
 
 trait CanBeHidden
 {
@@ -28,7 +29,7 @@ trait CanBeHidden
     public function hiddenOn(string | array $livewireComponents): static
     {
         $this->hidden(static function (HasTable $livewire) use ($livewireComponents): bool {
-            foreach ($livewireComponents as $livewireComponent) {
+            foreach (Arr::wrap($livewireComponents) as $livewireComponent) {
                 if ($livewire instanceof $livewireComponent) {
                     return true;
                 }
@@ -53,7 +54,7 @@ trait CanBeHidden
     public function visibleOn(string | array $livewireComponents): static
     {
         $this->visible(static function (HasTable $livewire) use ($livewireComponents): bool {
-            foreach ($livewireComponents as $livewireComponent) {
+            foreach (Arr::wrap($livewireComponents) as $livewireComponent) {
                 if ($livewire instanceof $livewireComponent) {
                     return true;
                 }

--- a/packages/tables/src/Filters/Concerns/CanBeHidden.php
+++ b/packages/tables/src/Filters/Concerns/CanBeHidden.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Filters\Concerns;
 
 use Closure;
 use Filament\Tables\Contracts\HasTable;
+use Illuminate\Support\Arr;
 
 trait CanBeHidden
 {
@@ -24,7 +25,7 @@ trait CanBeHidden
     public function hiddenOn(string | array $livewireComponents): static
     {
         $this->hidden(static function (HasTable $livewire) use ($livewireComponents): bool {
-            foreach ($livewireComponents as $livewireComponent) {
+            foreach (Arr::wrap($livewireComponents) as $livewireComponent) {
                 if ($livewire instanceof $livewireComponent) {
                     return true;
                 }
@@ -49,7 +50,7 @@ trait CanBeHidden
     public function visibleOn(string | array $livewireComponents): static
     {
         $this->visible(static function (HasTable $livewire) use ($livewireComponents): bool {
-            foreach ($livewireComponents as $livewireComponent) {
+            foreach (Arr::wrap($livewireComponents) as $livewireComponent) {
                 if ($livewire instanceof $livewireComponent) {
                     return true;
                 }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
