### PR TITLE
Docs: Render the filters in a collapsible panel

### DIFF
--- a/packages/admin/docs/02-resources/02-listing-records.md
+++ b/packages/admin/docs/02-resources/02-listing-records.md
@@ -84,7 +84,26 @@ public static function table(Table $table): Table
 }
 ```
 
-To render the filters above the table content in a collapsible panel, you may use: `layout: Layout::AboveContentCollapsible`
+To render the filters above the table content in a collapsible panel, you may use:
+
+```php
+use Filament\Tables\Filters\Layout;
+use Filament\Resources\Table;
+
+public static function table(Table $table): Table
+{
+    return $table
+        ->columns([
+            // ...
+        ])
+        ->filters(
+            [
+                // ...
+            ],
+            layout: Layout::AboveContentCollapsible,
+        );
+}
+```
 
 ## Actions
 

--- a/packages/admin/docs/02-resources/02-listing-records.md
+++ b/packages/admin/docs/02-resources/02-listing-records.md
@@ -84,6 +84,8 @@ public static function table(Table $table): Table
 }
 ```
 
+To render the filters above the table content in a collapsible panel, you may use: `layout: Layout::AboveContentCollapsible`
+
 ## Actions
 
 [Actions](../../tables/actions#single-actions) are buttons that are rendered at the end of table rows. They allow the user to perform a task on a record in the table. To learn how to build actions, see the [full actions documentation](../../tables/actions#single-actions).


### PR DESCRIPTION
To render the filters above the table content in a collapsible panel, you may use: `layout: Layout::AboveContentCollapsible`
