### PR TITLE
Add ability to use a custom dropdown trigger

### DIFF
--- a/packages/support/resources/views/components/dropdown/index.blade.php
+++ b/packages/support/resources/views/components/dropdown/index.blade.php
@@ -23,12 +23,14 @@
         },
     }"
 >
-    <div
-        x-on:click="toggle"
-        {{ $trigger->attributes->class(['filament-dropdown-trigger cursor-pointer']) }}
-    >
-        {{ $trigger }}
-    </div>
+    @if ($trigger)
+        <div
+            x-on:click="toggle"
+            {{ $trigger->attributes->class(['filament-dropdown-trigger cursor-pointer']) }}
+        >
+            {{ $trigger }}
+        </div>
+    @endif
 
     <div
         x-ref="panel"


### PR DESCRIPTION
Fixes error if you do not define a dropdown trigger. I needed to add `.stop` to prevent a parent event from being called. 
> Attempt to read property "attributes" on null

- [X] Changes have been thoroughly tested to not break existing functionality.
