### PR TITLE
Fix wrong operator in docs example

### DIFF
--- a/packages/forms/docs/06-advanced.md
+++ b/packages/forms/docs/06-advanced.md
@@ -151,7 +151,7 @@ TextInput::make('newPassword')
 
 TextInput::make('newPasswordConfirmation')
     ->password()
-    ->hidden(fn (Closure $get) => $get('newPassword') !== null)
+    ->hidden(fn (Closure $get) => $get('newPassword') === null)
 ```
 
 The field/s you're depending on should be `reactive()`, to ensure the Livewire component is reloaded when they are updated.


### PR DESCRIPTION
Fix wrong operator of "dependant fields/components" example. To show confirmation password, the condition should be equals instead of not equals to null.

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
