### PR TITLE
Add note to documentation regarding route order of pages

### DIFF
--- a/packages/admin/docs/02-resources/10-custom-pages.md
+++ b/packages/admin/docs/02-resources/10-custom-pages.md
@@ -21,7 +21,8 @@ public static function getPages(): array
     ];
 }
 ```
-Note: Ensure that the new route you define in `getPages()` is defined before any routes with wildcards that will match your new url.
+
+Please note that the order of pages registered in this method matters - any wildcard route segments that are defined before hard-coded ones will be matched by Laravel's router first.
 
 Any [parameters](https://laravel.com/docs/routing#route-parameters) defined in the route's path will be available to the page class, in an identical way to [Livewire](https://laravel-livewire.com/docs/rendering-components#route-params).
 

--- a/packages/admin/docs/02-resources/10-custom-pages.md
+++ b/packages/admin/docs/02-resources/10-custom-pages.md
@@ -21,6 +21,7 @@ public static function getPages(): array
     ];
 }
 ```
+Note: Ensure that the new route you define in `getPages()` is defined before any routes with wildcards that will match your new url.
 
 Any [parameters](https://laravel.com/docs/routing#route-parameters) defined in the route's path will be available to the page class, in an identical way to [Livewire](https://laravel-livewire.com/docs/rendering-components#route-params).
 


### PR DESCRIPTION
If the custom page route is added at the bottom of `getPages()` then it is likely that the standard `view` route will match but give a 404 message

- [Y] Changes have been thoroughly tested to not break existing functionality.
- [Y] New functionality has been documented or existing documentation has been updated to reflect changes.
- [Y] Visual changes are explained in the PR description using a screenshot/recording of before and after.
