### PR TITLE
Docs: Fixed widget example code

### DIFF
--- a/packages/admin/docs/02-resources/09-widgets.md
+++ b/packages/admin/docs/02-resources/09-widgets.md
@@ -24,7 +24,7 @@ You must register the new widget in your resource's `getWidgets()` method:
 public static function getWidgets(): array
 {
     return [
-        Widgets\CustomerOverview::class,
+        CustomerResource\Widgets\CustomerOverview::class,
     ];
 }
 ```


### PR DESCRIPTION
Fixed example code: Error - Class "App\Filament\Resources\Widgets\CustomerOverview" not found 
Path correction needed.

