### PR TITLE
Fix publish assets command line on windows

### DIFF
--- a/packages/support/src/Commands/AssetsCommand.php
+++ b/packages/support/src/Commands/AssetsCommand.php
@@ -16,7 +16,7 @@ class AssetsCommand extends Command
     protected $signature = 'filament:assets';
 
     /** @var array<string> */
-    protected $publishedAssets = [];
+    protected array $publishedAssets = [];
 
     public function handle(): int
     {
@@ -62,6 +62,8 @@ class AssetsCommand extends Command
     protected function copyAsset(string $from, string $to): void
     {
         $filesystem = app(Filesystem::class);
+
+        [$from, $to] = str_replace('/', DIRECTORY_SEPARATOR, [$from, $to]);
 
         $filesystem->ensureDirectoryExists(
             (string) str($to)


### PR DESCRIPTION

<img width="608" alt="image" src="https://github.com/filamentphp/filament/assets/56961917/6528909b-2a3b-496e-a14b-568d18489511">

In this PR, I go to replace all `/` with `DIRECTORY_SAPERATOR` constant to work Windows.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
