### PR TITLE
[fix] Notifications borders

### DIFF
--- a/packages/notifications/resources/views/components/database/modal/index.blade.php
+++ b/packages/notifications/resources/views/components/database/modal/index.blade.php
@@ -23,7 +23,7 @@
             </div>
         </x-slot>
 
-        <div class="-mx-6 divide-y border-b dark:border-gray-700">
+        <div class="-mx-6 divide-y border-b dark:divide-gray-600 dark:border-gray-600">
             @foreach ($notifications as $notification)
                 <div
                     @class([


### PR DESCRIPTION
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Before:
<img width="447" alt="image" src="https://github.com/filamentphp/filament/assets/2763884/76280bd0-2f7d-454f-aa24-14765e940f69">

After:
<img width="448" alt="image" src="https://github.com/filamentphp/filament/assets/2763884/597a10c1-d412-4f80-bcd9-35e08b409248">

