### PR TITLE
Extend register-tenant from page.simple instead of layout.simple

### DIFF
--- a/packages/panels/resources/views/pages/tenancy/register-tenant.blade.php
+++ b/packages/panels/resources/views/pages/tenancy/register-tenant.blade.php
@@ -1,4 +1,4 @@
-<x-filament::layout.simple>
+<x-filament::page.simple>
     <x-filament::form wire:submit="register">
         {{ $this->form }}
 
@@ -33,4 +33,4 @@
             @endforeach
         </ul>
     @endif
-</x-filament::layout.simple>
+</x-filament::page.simple>


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

I noticed that having a RegisterTenant page returned an error:
https://flareapp.io/share/v5pBZ6lP

After some debugging, I noticed that other "simple pages" were wrapped in an `<x-filament::page.simple>` instead of `<x-filament::layout.simple>` component. Changing this solved the error.

Before:
<img width="839" alt="image" src="https://github.com/filamentphp/filament/assets/1550749/0ad67b0d-fac3-459e-8bbc-2178d0096e1d">

After:
<img width="829" alt="image" src="https://github.com/filamentphp/filament/assets/1550749/3469f69c-d8bc-4c83-bb23-dbfcc4765ac5">

