### PR TITLE
Fix relative links in documentation

### DIFF
--- a/packages/panels/docs/03-resources/08-global-search.md
+++ b/packages/panels/docs/03-resources/08-global-search.md
@@ -126,7 +126,7 @@ protected static int $globalSearchResultsLimit = 20;
 
 As [explained above](#title), global search is automatically enables once you set a title attribute for your resource. Sometimes you may want to specify the title attribute while not enabling global search.
 
-This can be achieved by disabling global search in the [configuration](configuration):
+This can be achieved by disabling global search in the [configuration](../configuration):
 
 ```php
 use Filament\Panel;
@@ -141,7 +141,7 @@ public function panel(Panel $panel): Panel
 
 ## Registering global search keybindings
 
-The global search field can be opened using keyboard shortcuts. To configure these, pass the `globalSearchKeyBindings()` method to the [configuration](configuration):
+The global search field can be opened using keyboard shortcuts. To configure these, pass the `globalSearchKeyBindings()` method to the [configuration](../configuration):
 
 ```php
 use Filament\Panel;

--- a/packages/panels/docs/03-resources/08-global-search.md
+++ b/packages/panels/docs/03-resources/08-global-search.md
@@ -126,7 +126,7 @@ protected static int $globalSearchResultsLimit = 20;
 
 As [explained above](#title), global search is automatically enables once you set a title attribute for your resource. Sometimes you may want to specify the title attribute while not enabling global search.
 
-This can be achieved by disabling global search in the [configuration](../configuration):
+This can be achieved by disabling global search in the [configuration](../../configuration):
 
 ```php
 use Filament\Panel;

--- a/packages/panels/docs/05-dashboard.md
+++ b/packages/panels/docs/05-dashboard.md
@@ -111,7 +111,7 @@ This command will create two files - a widget class in the `/Widgets` directory 
 
 ## Disabling the default widgets
 
-By default, two widgets are displayed on the dashboard. These widgets can be disabled by updating the `widgets()` array of the [configuration](configuration):
+By default, two widgets are displayed on the dashboard. These widgets can be disabled by updating the `widgets()` array of the [configuration](../configuration):
 
 ```php
 use Filament\Panel;
@@ -141,7 +141,7 @@ class Dashboard extends BasePage
 }
 ```
 
-Finally, remove the original `Dashboard` class from [configuration file](configuration):
+Finally, remove the original `Dashboard` class from [configuration file](../configuration):
 
 ```php
 use Filament\Panel;

--- a/packages/panels/docs/06-navigation.md
+++ b/packages/panels/docs/06-navigation.md
@@ -81,7 +81,7 @@ All items in the same navigation group will be displayed together under the same
 
 ### Customizing navigation groups
 
-You may customize navigation groups by calling `navigationGroups()` in the [configuration](configuration), and passing `NavigationGroup` objects in order:
+You may customize navigation groups by calling `navigationGroups()` in the [configuration](../configuration), and passing `NavigationGroup` objects in order:
 
 ```php
 use Filament\Navigation\NavigationGroup;
@@ -134,7 +134,7 @@ NavigationGroup::make()
     ->collapsible(false);
 ```
 
-Or, you can do it globally for all groups in the [configuration](configuration):
+Or, you can do it globally for all groups in the [configuration](../configuration):
 
 ```php
 use Filament\Panel;
@@ -149,7 +149,7 @@ public function panel(Panel $panel): Panel
 
 ## Collapsible sidebar on desktop
 
-To make the sidebar collapsible on desktop as well as mobile, you can use the [configuration](configuration):
+To make the sidebar collapsible on desktop as well as mobile, you can use the [configuration](../configuration):
 
 ```php
 use Filament\Panel;
@@ -177,7 +177,7 @@ public function panel(Panel $panel): Panel
 
 ## Registering custom navigation items
 
-To register new navigation items, you can use the [configuration](configuration):
+To register new navigation items, you can use the [configuration](../configuration):
 
 ```php
 use Filament\Navigation\NavigationItem;
@@ -221,7 +221,7 @@ protected static bool $shouldRegisterNavigation = false;
 
 ## Advanced navigation customization
 
-The `navigation()` method can be called from the [configuration](configuration). It allows you to build a custom navigation that overrides Filament's automatically generated items. This API is designed to give you complete control over the navigation.
+The `navigation()` method can be called from the [configuration](../configuration). It allows you to build a custom navigation that overrides Filament's automatically generated items. This API is designed to give you complete control over the navigation.
 
 ### Registering custom navigation items
 
@@ -299,7 +299,7 @@ public function panel(Panel $panel): Panel
 
 The user menu is featured in the top right corner of the admin layout. It's fully customizable.
 
-To register new items to the user menu, you can use the [configuration](configuration):
+To register new items to the user menu, you can use the [configuration](../configuration):
 
 ```php
 use Filament\Navigation\MenuItem;
@@ -363,7 +363,7 @@ public function panel(Panel $panel): Panel
 
 The default layout will show breadcrumbs to indicate the location of the current page within the hierarchy of the app.
 
-You may disable breadcrumbs in your [configuration](configuration):
+You may disable breadcrumbs in your [configuration](../configuration):
 
 ```php
 use Filament\Panel;

--- a/packages/panels/docs/07-notifications.md
+++ b/packages/panels/docs/07-notifications.md
@@ -6,7 +6,7 @@ title: Notifications
 
 The panel builder uses the [Notifications](../notifications/sending-notifications) package to send messages to users. Please read the [documentation](../notifications/sending-notifications) to discover how to send notifications easily.
 
-If you'd like to receive [database notifications](../notifications/database-notifications), you can enable them in the [configuration](configuration):
+If you'd like to receive [database notifications](../notifications/database-notifications), you can enable them in the [configuration](../configuration):
 
 ```php
 use Filament\Panel;

--- a/packages/panels/docs/08-users.md
+++ b/packages/panels/docs/08-users.md
@@ -88,7 +88,7 @@ class BoringAvatarsProvider implements Contracts\AvatarProvider
 }
 ```
 
-Now, register this new avatar provider in the [configuration](configuration):
+Now, register this new avatar provider in the [configuration](../configuration):
 
 ```php
 use App\Filament\AvatarProviders\BoringAvatarsProvider;

--- a/packages/panels/docs/10-tenancy.md
+++ b/packages/panels/docs/10-tenancy.md
@@ -10,7 +10,7 @@ Multi-tenancy is a very sensitive topic. It's important to understand the securi
 
 ## Setting up tenancy
 
-To set up tenancy, you'll need to specify the "tenant" (like team or organization) model in the [configuration](configuration):
+To set up tenancy, you'll need to specify the "tenant" (like team or organization) model in the [configuration](../configuration):
 
 ```php
 use App\Models\Team;
@@ -103,7 +103,7 @@ class RegisterTeam extends RegisterTenant
 
 You may add any [form components](../forms/getting-started) to the `form()` method, and create the team inside the `handleRegistration()` method.
 
-Now, we need to tell Filament to use this page. We can do this in the [configuration](configuration):
+Now, we need to tell Filament to use this page. We can do this in the [configuration](../configuration):
 
 ```php
 use App\Filament\Pages\Tenancy\RegisterTeam;
@@ -155,7 +155,7 @@ class EditTeamProfile extends EditTenantProfile
 
 You may add any [form components](../forms/getting-started) to the `form()` method. They will get saved directly to the tenant model.
 
-Now, we need to tell Filament to use this page. We can do this in the [configuration](configuration):
+Now, we need to tell Filament to use this page. We can do this in the [configuration](../configuration):
 
 ```php
 use App\Filament\Pages\Tenancy\RegisterTeam;
@@ -195,7 +195,7 @@ Now, you can install the Filament billing provider for Spark using Composer:
 composer require filament/spark-billing-provider
 ```
 
-In the [configuration](configuration), set Spark as the `tenantBillingProvider()`:
+In the [configuration](../configuration), set Spark as the `tenantBillingProvider()`:
 
 ```php
 use Filament\Billing\Providers\SparkBillingProvider;
@@ -276,7 +276,7 @@ class ExampleBillingProvider implements Provider
 
 The tenant-switching menu is featured in the sidebar of the admin layout. It's fully customizable.
 
-To register new items to the tenant menu, you can use the [configuration](configuration):
+To register new items to the tenant menu, you can use the [configuration](../configuration):
 
 ```php
 use Filament\Navigation\MenuItem;
@@ -509,7 +509,7 @@ class User extends Model implements FilamentUser, HasDefaultTenant, HasTenants
 
 ## Applying middleware to tenant-aware routes
 
-You can apply extra middleware to all tenant-aware routes by passing an array of middleware classes to the `tenantMiddleware()` method in the [panel configuration file](configuration):
+You can apply extra middleware to all tenant-aware routes by passing an array of middleware classes to the `tenantMiddleware()` method in the [panel configuration file](../configuration):
 
 ```php
 use Filament\Panel;

--- a/packages/panels/docs/11-themes.md
+++ b/packages/panels/docs/11-themes.md
@@ -4,7 +4,7 @@ title: Themes
 
 ## Changing the colors
 
-In the [configuration](configuration), you can easily change the colors that are used. Filament ships with 7 predefined colors that are used everywhere within the framework. They are customizable as follows:
+In the [configuration](../configuration), you can easily change the colors that are used. Filament ships with 7 predefined colors that are used everywhere within the framework. They are customizable as follows:
 
 ```php
 use Filament\Panel;
@@ -66,7 +66,7 @@ $panel
 
 ## Changing the font
 
-By default, we use the [Be Vietnam Pro](https://fonts.google.com/specimen/Be+Vietnam+Pro) font. You can change this using the `font()` method in the [configuration](configuration) file:
+By default, we use the [Be Vietnam Pro](https://fonts.google.com/specimen/Be+Vietnam+Pro) font. You can change this using the `font()` method in the [configuration](../configuration) file:
 
 ```php
 use Filament\Panel;
@@ -145,7 +145,7 @@ You may create a `resources/views/vendor/filament/components/logo.blade.php` fil
 
 ## Disabling dark mode
 
-To disable dark mode switching, you can use the [configuration](configuration) file:
+To disable dark mode switching, you can use the [configuration](../configuration) file:
 
 ```php
 use Filament\Panel;
@@ -160,7 +160,7 @@ public function panel(Panel $panel): Panel
 
 ## Adding a favicon
 
-To add a favicon, you can use the [configuration](configuration) file, passing the public URL of the favicon:
+To add a favicon, you can use the [configuration](../configuration) file, passing the public URL of the favicon:
 
 ```php
 use Filament\Panel;

--- a/packages/panels/docs/12-plugins.md
+++ b/packages/panels/docs/12-plugins.md
@@ -14,10 +14,10 @@ Filament plugins build on top of the concepts of Laravel packages and allow you 
 
 ## Configuring the panel with a plugin class
 
-A plugin class is used to allow your package to interact with a panel [configuration](configuration) file. It's a simple PHP class that implements the `Plugin` interface. 3 methods are required:
+A plugin class is used to allow your package to interact with a panel [configuration](../configuration) file. It's a simple PHP class that implements the `Plugin` interface. 3 methods are required:
 
 - The `getId()` method returns the unique identifier of the plugin amongst other plugins. Please ensure that it is specific enough to not clash with other plugins that might be used in the same project.
-- The `register()` method allows you to use any [configuration](configuration) option that is available to the panel. This includes registering [resources](resources), [pages](pages), [themes](themes), [render hooks](configuration#render-hooks) and more.
+- The `register()` method allows you to use any [configuration](../configuration) option that is available to the panel. This includes registering [resources](resources), [pages](pages), [themes](themes), [render hooks](configuration#render-hooks) and more.
 - The `boot()` method is run only when the panel that the plugin is being registered to is actually in-use. It is executed by a middleware class.
 
 ```php
@@ -57,7 +57,7 @@ class BlogPlugin implements Plugin
 }
 ```
 
-The users of your plugin can add it to a panel by instantiating the plugin class and passing it to the `plugin()` method of the [configuration](configuration):
+The users of your plugin can add it to a panel by instantiating the plugin class and passing it to the `plugin()` method of the [configuration](../configuration):
 
 ```php
 use DanHarrin\FilamentBlog\BlogPlugin;
@@ -183,7 +183,7 @@ BlogPlugin::get()->hasAuthorResource()
 
 It's very easy to distribute an entire panel in a Laravel package. This way, a user can simply install your plugin and have an entirely new part of their app pre-built.
 
-When [configuring](configuration) a panel, the configuration class extends the `PanelProvider` class, and that is a standard Laravel service provider. You can use it as a service provider in your package:
+When [configuring](../configuration) a panel, the configuration class extends the `PanelProvider` class, and that is a standard Laravel service provider. You can use it as a service provider in your package:
 
 ```php
 <?php

--- a/packages/panels/docs/14-upgrade-guide.md
+++ b/packages/panels/docs/14-upgrade-guide.md
@@ -42,7 +42,7 @@ php artisan filament:install --panels
 
 A new `app/Providers/Filament/AdminPanelProvider.php` file will be created, ready for you to transfer over your old configuration from the `config/filament.php` file.
 
-Most configuration transfer is very self-explanatory, but if you get stuck please refer to the [configuration documentation](configuration).
+Most configuration transfer is very self-explanatory, but if you get stuck please refer to the [configuration documentation](../configuration).
 
 Finally, you can run the following command to replace the old config file with the shiny new one:
 


### PR DESCRIPTION
- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Configuration link in docs doesn't redirect to the actual link.. this PR fix those