### PR TITLE
fix: autocomplete/autofill styling

### DIFF
--- a/packages/support/resources/views/components/input/index.blade.php
+++ b/packages/support/resources/views/components/input/index.blade.php
@@ -6,7 +6,7 @@
 <input
     {{
         $attributes->class([
-            'fi-input block w-full border-none bg-transparent py-1.5 text-base text-gray-950 outline-none transition duration-75 placeholder:text-gray-400 focus:ring-0 disabled:text-gray-500 disabled:[-webkit-text-fill-color:theme(colors.gray.500)] disabled:placeholder:[-webkit-text-fill-color:theme(colors.gray.400)] dark:text-white dark:placeholder:text-gray-500 dark:disabled:text-gray-400 dark:disabled:[-webkit-text-fill-color:theme(colors.gray.400)] dark:disabled:placeholder:[-webkit-text-fill-color:theme(colors.gray.500)] sm:text-sm sm:leading-6',
+            'fi-input block w-full rounded-lg border-none bg-transparent py-1.5 text-base text-gray-950 outline-none transition duration-75 placeholder:text-gray-400 focus:ring-0 disabled:text-gray-500 disabled:[-webkit-text-fill-color:theme(colors.gray.500)] disabled:placeholder:[-webkit-text-fill-color:theme(colors.gray.400)] dark:text-white dark:placeholder:text-gray-500 dark:disabled:text-gray-400 dark:disabled:[-webkit-text-fill-color:theme(colors.gray.400)] dark:disabled:placeholder:[-webkit-text-fill-color:theme(colors.gray.500)] sm:text-sm sm:leading-6',
             'ps-0' => $inlinePrefix,
             'ps-3' => ! $inlinePrefix,
             'pe-0' => $inlineSuffix,


### PR DESCRIPTION
This commit adds the `rounded-lg` class to the input field to ensure that autofilled inputs maintain the same border radius
as non-autofilled inputs, improving visual consistency.

**Before (autofill radius overlaps input radius):**
![Screenshot 2023-07-21 at 7 20 31 PM](https://github.com/filamentphp/filament/assets/104294090/85fc3f1e-ad73-43f2-8730-c9aad8aa64b4)

**After:**
![Screenshot 2023-07-21 at 7 26 03 PM](https://github.com/filamentphp/filament/assets/104294090/4ed80627-e326-4bcf-8460-0c14aa5b91e0)


