### PR TITLE
Fix issue to edit record with combined relation manager tabs

### DIFF
--- a/packages/panels/resources/views/components/resources/relation-managers.blade.php
+++ b/packages/panels/resources/views/components/resources/relation-managers.blade.php
@@ -10,7 +10,7 @@
 
 <div class="fi-resource-relation-managers flex flex-col gap-y-4">
     @php
-        $normalizeRelationManagerClass = function (string | Filament\Resources\RelationManagers\RelationManagerConfiguration $manager): string {
+        $normalizeRelationManagerClass = function (null | string | Filament\Resources\RelationManagers\RelationManagerConfiguration $manager): ?string {
             if ($manager instanceof \Filament\Resources\RelationManagers\RelationManagerConfiguration) {
                 return $manager->relationManager;
             }

--- a/packages/panels/resources/views/components/resources/relation-managers.blade.php
+++ b/packages/panels/resources/views/components/resources/relation-managers.blade.php
@@ -10,7 +10,7 @@
 
 <div class="fi-resource-relation-managers flex flex-col gap-y-4">
     @php
-        $normalizeRelationManagerClass = function (null | string | Filament\Resources\RelationManagers\RelationManagerConfiguration $manager): ?string {
+        $normalizeRelationManagerClass = function (string | Filament\Resources\RelationManagers\RelationManagerConfiguration $manager): ?string {
             if ($manager instanceof \Filament\Resources\RelationManagers\RelationManagerConfiguration) {
                 return $manager->relationManager;
             }
@@ -38,7 +38,7 @@
                     if ($isGroup) {
                         $manager->ownerRecord($ownerRecord);
                         $manager->pageClass($pageClass);
-                    } else {
+                    } elseif (filled($tabKey)) {
                         $manager = $normalizeRelationManagerClass($manager);
                     }
                 @endphp

--- a/packages/panels/resources/views/components/resources/relation-managers.blade.php
+++ b/packages/panels/resources/views/components/resources/relation-managers.blade.php
@@ -10,7 +10,7 @@
 
 <div class="fi-resource-relation-managers flex flex-col gap-y-4">
     @php
-        $normalizeRelationManagerClass = function (string | Filament\Resources\RelationManagers\RelationManagerConfiguration $manager): ?string {
+        $normalizeRelationManagerClass = function (string | Filament\Resources\RelationManagers\RelationManagerConfiguration $manager): string {
             if ($manager instanceof \Filament\Resources\RelationManagers\RelationManagerConfiguration) {
                 return $manager->relationManager;
             }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Edit records with `hasCombinedRelationManagerTabsWithContent()` set to `true` throws `Argument #1 ($manager) must be of type Filament\Resources\RelationManagers\RelationManagerConfiguration|string, null given`