### PR TITLE
Add `items-center` to user menu component

### DIFF
--- a/packages/panels/resources/views/components/user-menu.blade.php
+++ b/packages/panels/resources/views/components/user-menu.blade.php
@@ -15,7 +15,7 @@
 {{ \Filament\Support\Facades\FilamentView::renderHook('user-menu.start') }}
 
 <x-filament::dropdown placement="bottom-end" class="fi-user-menu">
-    <x-slot name="trigger">
+    <x-slot name="trigger" class="flex items-center">
         <button
             aria-label="{{ __('filament::layout.actions.open_user_menu.label') }}"
             type="button"


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Update user-menu trigger button

Before: 
![image](https://github.com/akunbeben/filament/assets/46495960/121d4ae6-f6a8-4338-a213-d0f364fabbdc)
Testing visually using render hook
![image](https://github.com/akunbeben/filament/assets/46495960/9bf1fa45-f254-4dcf-ae4e-cdb1bef8f735)

After: 
![image](https://github.com/akunbeben/filament/assets/46495960/1fd62f56-0d7a-4241-b595-9034d5edc190)
