### PR TITLE
fix(docs): fixing links in docs

### DIFF
--- a/packages/panels/docs/02-getting-started.md
+++ b/packages/panels/docs/02-getting-started.md
@@ -141,7 +141,7 @@ If you open the `PatientResource.php` file, you can see a `form()` method with a
 
 #### "Name" text input
 
-Filament contains a [large selection of form fields](../forms/fields) built-in. The most simple field to start with is the [text input](../forms/fields/text-input):
+Filament contains a [large selection of form fields](../forms/fields/getting-started) built-in. The most simple field to start with is the [text input](../forms/fields/text-input):
 
 ```php
 use Filament\Forms;
@@ -332,7 +332,7 @@ If you open the `PatientResource.php` file, you can see a `table()` method with 
 
 #### Adding text columns
 
-Filament contains a [selection of table columns](../tables/columns) built-in. The most common column type is the [text column](../tables/columns/text). All of our fields can be added as text columns in our table:
+Filament contains a [selection of table columns](../tables/columns/getting-started) built-in. The most common column type is the [text column](../tables/columns/text). All of our fields can be added as text columns in our table:
 
 ```php
 use Filament\Tables;
@@ -354,7 +354,7 @@ Note that for the owner column, we don't use `owner_id` as the text column name.
 
 ##### Making columns searchable
 
-[Searching](columns/getting-started#searching) through patients in this table would be useful. Patient results should be found by searching for their name, or their owner's name. You can make these columns `searchable()`:
+[Searching](tables/columns/getting-started#searching) through patients in this table would be useful. Patient results should be found by searching for their name, or their owner's name. You can make these columns `searchable()`:
 
 ```php
 use Filament\Tables;
@@ -378,7 +378,7 @@ Now, there will be a search input in the table, and you will be able to filter r
 
 ##### Making the columns sortable
 
-Patients could be [sorted](columns/getting-started#sorting) by their age, by making the `date_of_birth` column `sortable()`:
+Patients could be [sorted](tables/columns/getting-started#sorting) by their age, by making the `date_of_birth` column `sortable()`:
 
 ```php
 use Filament\Tables;
@@ -637,7 +637,7 @@ public function table(Table $table): Table
 
 ## Introducing widgets
 
-Filament has "widgets" - which are components that you can use to display information, especially statistics. Widgets typically get added to the Dashboard of the panel, but you can add them to any page you wish, including resource pages. Filament includes built-in widgets, like the [stats widget](../stats-overview) to render important statistics in a simple card, [chart widget](../widgets/charts) which can render an interactive chart, and [table widget](../panels/dashboard#table-widgets) which allows you to easily embed the table builder.
+Filament has "widgets" - which are components that you can use to display information, especially statistics. Widgets typically get added to the Dashboard of the panel, but you can add them to any page you wish, including resource pages. Filament includes built-in widgets, like the [stats widget](../widgets/stats-overview) to render important statistics in a simple card, [chart widget](../widgets/charts) which can render an interactive chart, and [table widget](../panels/dashboard#table-widgets) which allows you to easily embed the table builder.
 
 In our system, we could add statistics for the type of patient, as well as treatments that are administered over time.
 

--- a/packages/panels/docs/03-resources/07-relation-managers.md
+++ b/packages/panels/docs/03-resources/07-relation-managers.md
@@ -16,7 +16,7 @@ Filament provides many ways to manage relationships in the app. Which feature yo
 
 > These are compatible with `BelongsTo`, `MorphTo` and `BelongsToMany` relationships.
 
-Using a [select](../../forms/fields/select#integrating-with-an-eloquent-relationship), users will be able to choose from a list of existing records. You may also [add a button that allows you to create a new record inside a modal](../../forms/fields/select#creating-new-records), without leaving the page.
+Using a [select](../../forms/fields/select#integrating-with-an-eloquent-relationship), users will be able to choose from a list of existing records. You may also [add a button that allows you to create a new record inside a modal](../../forms/fields/select#creating-a-new-option-in-a-modal), without leaving the page.
 
 When using a `BelongsToMany` relationship with a select, you'll be able to select multiple options, not just one. Records will be automatically added to your pivot table when you submit the form. If you wish, you can swap out the multi-select dropdown with a simple [checkbox list](../../forms/fields/checkbox-list#integrating-with-an-eloquent-relationship). Both components work in the same way.
 
@@ -134,9 +134,9 @@ You can find out more about soft deleting [here](#deleting-records).
 
 ## Listing related records
 
-Related records will be listed in a table. The entire relation manager is based around this table, which contains actions to [create](#creating-records), [edit](#editing-records), [attach / detach](#attaching-and-detaching-records), [associate / dissociate](#associating-and-dissociating-records), and delete records.
+Related records will be listed in a table. The entire relation manager is based around this table, which contains actions to [create](#creating-related-records), [edit](#editing-related-records), [attach / detach](#attaching-and-detaching-records), [associate / dissociate](#associating-and-dissociating-records), and delete records.
 
-You may may use any of the features of the [table builder](../../tables) to customize relation managers.
+You may may use any of the features of the [table builder](../../tables/installation) to customize relation managers.
 
 ### Listing with pivot attributes
 

--- a/packages/panels/docs/03-resources/08-global-search.md
+++ b/packages/panels/docs/03-resources/08-global-search.md
@@ -63,7 +63,7 @@ public static function getGlobalSearchEloquentQuery(): Builder
 
 ## Customizing global search result URLs
 
-Global search results will link to the [Edit page](editing-records) of your resource, or the [View page](viewing-page) if the user does not have [edit permissions](editing-records#authorization). To customize this, you may override the `getGlobalSearchResultUrl()` method and return a route of your choice:
+Global search results will link to the [Edit page](editing-records) of your resource, or the [View page](viewing-records) if the user does not have [edit permissions](editing-records#authorization). To customize this, you may override the `getGlobalSearchResultUrl()` method and return a route of your choice:
 
 ```php
 public static function getGlobalSearchResultUrl(Model $record): string
@@ -124,9 +124,9 @@ protected static int $globalSearchResultsLimit = 20;
 
 ## Disabling global search
 
-As [explained above](#title), global search is automatically enables once you set a title attribute for your resource. Sometimes you may want to specify the title attribute while not enabling global search.
+As [explained above](#setting-global-search-result-titles), global search is automatically enables once you set a title attribute for your resource. Sometimes you may want to specify the title attribute while not enabling global search.
 
-This can be achieved by disabling global search in the [configuration](configuration):
+This can be achieved by disabling global search in the [configuration](../configuration):
 
 ```php
 use Filament\Panel;
@@ -141,7 +141,7 @@ public function panel(Panel $panel): Panel
 
 ## Registering global search keybindings
 
-The global search field can be opened using keyboard shortcuts. To configure these, pass the `globalSearchKeyBindings()` method to the [configuration](configuration):
+The global search field can be opened using keyboard shortcuts. To configure these, pass the `globalSearchKeyBindings()` method to the [configuration](../configuration):
 
 ```php
 use Filament\Panel;

--- a/packages/panels/docs/04-pages.md
+++ b/packages/panels/docs/04-pages.md
@@ -40,9 +40,9 @@ public function mount(): void
 
 ## Adding actions to pages
 
-Actions are buttons that can perform tasks on the page, or visit a URL. You can read more about their capabilities [here](../actions).
+Actions are buttons that can perform tasks on the page, or visit a URL. You can read more about their capabilities [here](../../actions/installation).
 
-Since all pages are Livewire components, you can [add actions](../actions/adding-an-action-to-a-livewire-component#adding-the-action) anywhere. Pages already have the `InteractsWithActions` trait, `HasActions` interface, and `<x-filament-actions::modals />` Blade component all set up for you.
+Since all pages are Livewire components, you can [add actions](../../actions/adding-an-action-to-a-livewire-component#adding-the-action) anywhere. Pages already have the `InteractsWithActions` trait, `HasActions` interface, and `<x-filament-actions::modals />` Blade component all set up for you.
 
 ### Header actions
 
@@ -65,7 +65,7 @@ protected function getHeaderActions(): array
 
 ### Refreshing form data
 
-If you're using actions on an [Edit](resources/editing-records) or [View](resources/viewing-records) resource page, you can refresh data within the main form using the `refreshFormData()` method:
+If you're using actions on an [Edit](../resources/editing-records) or [View](../resources/viewing-records) resource page, you can refresh data within the main form using the `refreshFormData()` method:
 
 ```php
 use Filament\Actions\Action;
@@ -84,7 +84,7 @@ This method accepts an array of model attributes that you wish to refresh in the
 
 ## Adding widgets to pages
 
-Filament allows you to display [widgets](dashboard) inside pages, below the header and above the footer.
+Filament allows you to display [widgets](../resources/dashboard) inside pages, below the header and above the footer.
 
 To add a widget to a page, use the `getHeaderWidgets()` or `getFooterWidgets()` methods:
 
@@ -101,7 +101,7 @@ protected function getHeaderWidgets(): array
 
 `getHeaderWidgets()` returns an array of widgets to display above the page content, whereas `getFooterWidgets()` are displayed below.
 
-If you'd like to learn how to build and customize widgets, check out the [Dashboard](dashboard) documentation section.
+If you'd like to learn how to build and customize widgets, check out the [Dashboard](../dashboard) documentation section.
 
 ### Customizing the widgets grid
 
@@ -130,7 +130,7 @@ protected function getHeaderWidgetsColumns(): int | array
 }
 ```
 
-This pairs well with [responsive widget widths](dashboard#responsive-widget-widths).
+This pairs well with [responsive widget widths](../dashboard#responsive-widget-widths).
 
 #### Passing data to widgets from the page
 
@@ -174,7 +174,7 @@ public function getTitle(): string | Htmlable
 
 ## Customizing the page navigation label
 
-By default, Filament will use the page's [title](#customizing-the-page-title) as its [navigation](navigation) item label. You may override this by defining a `$navigationLabel` property on your page class:
+By default, Filament will use the page's [title](#customizing-the-page-title) as its [navigation](../navigation) item label. You may override this by defining a `$navigationLabel` property on your page class:
 
 ```php
 protected static ?string $navigationLabel = 'Custom Navigation Label';

--- a/packages/panels/docs/05-dashboard.md
+++ b/packages/panels/docs/05-dashboard.md
@@ -12,9 +12,9 @@ The following document will explain how to use these widgets to assemble a dashb
 
 Filament ships with these widgets:
 
-- [Stats overview](../widgets/stats-overview) widgets display any data, often numeric data, within cards in a row.
-- [Chart](../widgets/charts) widgets display numeric data in a visual chart.
-- [Table](#table-widgets) widgets which display a [table](../tables/getting-started) on your dashboard.
+- [Stats overview](../../widgets/stats-overview) widgets display any data, often numeric data, within cards in a row.
+- [Chart](../../widgets/charts) widgets display numeric data in a visual chart.
+- [Table](#table-widgets) widgets which display a [table](../../tables/getting-started) on your dashboard.
 
 You may also [create your own custom widgets](#custom-widgets) which can then have a consistent design with Filament's prebuilt widgets.
 
@@ -97,7 +97,7 @@ You may easily add tables to your dashboard. Start by creating a widget with the
 php artisan make:filament-widget LatestOrders --table
 ```
 
-You may now [customize the table](../tables/getting-started) by editing the widget file.
+You may now [customize the table](../../tables/getting-started) by editing the widget file.
 
 ## Custom widgets
 
@@ -111,7 +111,7 @@ This command will create two files - a widget class in the `/Widgets` directory 
 
 ## Disabling the default widgets
 
-By default, two widgets are displayed on the dashboard. These widgets can be disabled by updating the `widgets()` array of the [configuration](configuration):
+By default, two widgets are displayed on the dashboard. These widgets can be disabled by updating the `widgets()` array of the [configuration](../configuration):
 
 ```php
 use Filament\Panel;
@@ -141,7 +141,7 @@ class Dashboard extends BasePage
 }
 ```
 
-Finally, remove the original `Dashboard` class from [configuration file](configuration):
+Finally, remove the original `Dashboard` class from [configuration file](../configuration):
 
 ```php
 use Filament\Panel;

--- a/packages/panels/docs/06-navigation.md
+++ b/packages/panels/docs/06-navigation.md
@@ -4,7 +4,7 @@ title: Navigation
 
 ## Overview
 
-By default, Filament will register navigation items for each of your [resources](resources) and [custom pages](pages). These classes contain static properties and methods that you can override, to configure that navigation item.
+By default, Filament will register navigation items for each of your [resources](resources/getting-started) and [custom pages](pages). These classes contain static properties and methods that you can override, to configure that navigation item.
 
 ## Customizing a navigation item's label
 
@@ -25,7 +25,7 @@ public static function getNavigationLabel(): ?string
 
 ## Customizing a navigation item's icon
 
-To customize a navigation item's [icon](https://blade-ui-kit.com/blade-icons?set=1#search), you may override the `$navigationIcon` property on the [resource](resources) or [page](pages) class:
+To customize a navigation item's [icon](https://blade-ui-kit.com/blade-icons?set=1#search), you may override the `$navigationIcon` property on the [resource](resources/getting-started) or [page](pages) class:
 
 ```php
 protected static ?string $navigationIcon = 'heroicon-m-document-text';
@@ -71,7 +71,7 @@ public static function getNavigationBadgeColor(): ?string
 
 ## Grouping navigation items
 
-You may group navigation items by specifying a `$navigationGroup` property on a [resource](resources) and [custom page](pages):
+You may group navigation items by specifying a `$navigationGroup` property on a [resource](resources/getting-started) and [custom page](pages):
 
 ```php
 protected static ?string $navigationGroup = 'Settings';

--- a/packages/panels/docs/07-notifications.md
+++ b/packages/panels/docs/07-notifications.md
@@ -4,9 +4,9 @@ title: Notifications
 
 ## Overview
 
-The panel builder uses the [Notifications](../notifications/sending-notifications) package to send messages to users. Please read the [documentation](../notifications/sending-notifications) to discover how to send notifications easily.
+The panel builder uses the [Notifications](../notifications/sending-notifications) package to send messages to users. Please read the [documentation](../../notifications/sending-notifications) to discover how to send notifications easily.
 
-If you'd like to receive [database notifications](../notifications/database-notifications), you can enable them in the [configuration](configuration):
+If you'd like to receive [database notifications](../notifications/database-notifications), you can enable them in the [configuration](../configuration):
 
 ```php
 use Filament\Panel;
@@ -19,7 +19,7 @@ public function panel(Panel $panel): Panel
 }
 ```
 
-You may also control database notification [polling](../notifications/database-notifications#polling-for-new-database-notifications):
+You may also control database notification [polling](../../notifications/database-notifications#polling-for-new-database-notifications):
 
 ```php
 use Filament\Panel;

--- a/packages/panels/docs/08-users.md
+++ b/packages/panels/docs/08-users.md
@@ -88,7 +88,7 @@ class BoringAvatarsProvider implements Contracts\AvatarProvider
 }
 ```
 
-Now, register this new avatar provider in the [configuration](configuration):
+Now, register this new avatar provider in the [configuration](../configuration):
 
 ```php
 use App\Filament\AvatarProviders\BoringAvatarsProvider;

--- a/packages/panels/docs/09-configuration.md
+++ b/packages/panels/docs/09-configuration.md
@@ -8,7 +8,7 @@ By default, the configuration file is located at `app/Providers/Filament/AdminPa
 
 ## Introducing panels
 
-By default, when you install the package, there is one panel that has been set up for you - and it lives on `/admin`. All the [resources](resources), [pages](pages), and [dashboard widgets](dashboard) you create get registered to this panel.
+By default, when you install the package, there is one panel that has been set up for you - and it lives on `/admin`. All the [resources](../resources/getting-started), [pages](../pages), and [dashboard widgets](../dashboard) you create get registered to this panel.
 
 However, you can create as many panels as you want, and each can have its own set of resources, pages and widgets.
 
@@ -101,15 +101,15 @@ The available hooks are as follows:
 - `footer` - footer content (centered)
 - `footer.before` - before footer
 - `footer.after` - after footer
-- `sidebar.start` - before [sidebar](navigation) content
-- `sidebar.end` - after [sidebar](navigation) content
+- `sidebar.start` - before [sidebar](../navigation) content
+- `sidebar.end` - after [sidebar](../navigation) content
 - `sidebar.footer` - pinned to the bottom of the sidebar, below the content
 - `scripts.start` - before scripts are defined
 - `scripts.end` - after scripts are defined
 - `styles.start` - before styles are defined
 - `styles.end` - after styles are defined
-- `global-search.start` - before [global search](resources/global-search) field
-- `global-search.end` - after [global search](resources/global-search) field
+- `global-search.start` - before [global search](../resources/global-search) field
+- `global-search.end` - after [global search](../resources/global-search) field
 - `page.header-widgets.start` - before page header widgets
 - `page.header-widgets.end` - after page header widgets
 - `page.footer-widgets.start` - before page footer widgets
@@ -122,10 +122,10 @@ The available hooks are as follows:
 - `resource.relation-manager.end` - after the relation manager table
 - `tenant-menu.start` - before tenant menu
 - `tenant-menu.end` - after tenant menu
-- `user-menu.start` - before [user menu](navigation#customizing-the-user-menu)
-- `user-menu.end` - after [user menu](navigation#customizing-the-user-menu)
-- `user-menu.profile.before` - before the profile item in the [user menu](navigation#customizing-the-user-menu)
-- `user-menu.profile.after` - after the profile item in the [user menu](navigation#customizing-the-user-menu)
+- `user-menu.start` - before [user menu](../navigation#customizing-the-user-menu)
+- `user-menu.end` - after [user menu](../navigation#customizing-the-user-menu)
+- `user-menu.profile.before` - before the profile item in the [user menu](../navigation#customizing-the-user-menu)
+- `user-menu.profile.after` - after the profile item in the [user menu](../navigation#customizing-the-user-menu)
 
 ## Setting a domain
 

--- a/packages/panels/docs/10-tenancy.md
+++ b/packages/panels/docs/10-tenancy.md
@@ -230,7 +230,7 @@ Now, users will be redirected to the billing page if they don't have an active s
 
 #### Requiring a subscription for specific resources and pages
 
-Sometimes, you may wish to only require a subscription for certain [resources](resources) and [pages](pages) in your app. You can do this by returning `true` from the `isTenantSubscriptionRequired()` method on the resource or page class:
+Sometimes, you may wish to only require a subscription for certain [resources](resources/getting-started) and [pages](pages) in your app. You can do this by returning `true` from the `isTenantSubscriptionRequired()` method on the resource or page class:
 
 ```php
 public static function isTenantSubscriptionRequired(Panel $panel): bool

--- a/packages/panels/docs/12-plugins.md
+++ b/packages/panels/docs/12-plugins.md
@@ -17,7 +17,7 @@ Filament plugins build on top of the concepts of Laravel packages and allow you 
 A plugin class is used to allow your package to interact with a panel [configuration](configuration) file. It's a simple PHP class that implements the `Plugin` interface. 3 methods are required:
 
 - The `getId()` method returns the unique identifier of the plugin amongst other plugins. Please ensure that it is specific enough to not clash with other plugins that might be used in the same project.
-- The `register()` method allows you to use any [configuration](configuration) option that is available to the panel. This includes registering [resources](resources), [pages](pages), [themes](themes), [render hooks](configuration#render-hooks) and more.
+- The `register()` method allows you to use any [configuration](configuration) option that is available to the panel. This includes registering [resources](resources/getting-started), [pages](pages), [themes](themes), [render hooks](configuration#render-hooks) and more.
 - The `boot()` method is run only when the panel that the plugin is being registered to is actually in-use. It is executed by a middleware class.
 
 ```php


### PR DESCRIPTION
I've come across some broken links in the docs and tried to fix them, but don't know if it's caused by the import to the actual docs on beta.filamentphp.com app. Since it seems to need relative paths on e.g. "04-pages.md" but not on "06-navigation.md"

I hope this can at least show as a guide over which links needs some attention, as they either do nothing, or send the user to the https://beta.filamentphp.com/docs/3.x/panels/installation/ page