### PR TITLE
Directory separator fix for Windows

### DIFF
--- a/packages/upgrade/bin/filament-v3
+++ b/packages/upgrade/bin/filament-v3
@@ -328,7 +328,9 @@ render(<<<HTML
     </p>
 HTML);
 
-exec("vendor/bin/rector process {$appDirectory} --config vendor/filament/upgrade/src/rector.php --clear-cache");
+$rectorBin = implode(DIRECTORY_SEPARATOR, ['vendor', 'bin', 'rector']);
+
+exec("{$rectorBin} process {$appDirectory} --config vendor/filament/upgrade/src/rector.php --clear-cache");
 
 render(<<<HTML
     <p class="pt-2">

--- a/packages/upgrade/bin/filament-v3
+++ b/packages/upgrade/bin/filament-v3
@@ -89,7 +89,7 @@ if (file_exists('config/notifications.php')) {
 
     render(<<<HTML
         <p>
-            Removed <stong>config/notifications.php</stong>. All config files have been merged into <strong>config/filament.php</strong>.
+            Removed <strong>config/notifications.php</strong>. All config files have been merged into <strong>config/filament.php</strong>.
         </p>
     HTML);
 }

--- a/packages/upgrade/bin/filament-v3
+++ b/packages/upgrade/bin/filament-v3
@@ -328,9 +328,9 @@ render(<<<HTML
     </p>
 HTML);
 
-$rectorBin = implode(DIRECTORY_SEPARATOR, ['vendor', 'bin', 'rector']);
+$rectorScriptPath = implode(DIRECTORY_SEPARATOR, ['vendor', 'bin', 'rector']);
 
-exec("{$rectorBin} process {$appDirectory} --config vendor/filament/upgrade/src/rector.php --clear-cache");
+exec("{$rectorScriptPath} process {$appDirectory} --config vendor/filament/upgrade/src/rector.php --clear-cache");
 
 render(<<<HTML
     <p class="pt-2">


### PR DESCRIPTION
- [X] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

On Windows, `vendor/bin/filament-v3` outputs the following

`'vendor' is not recognized as an internal or external command, operable program or batch file.`

With `DIRECTORY_SEPARATOR`, rector processes the app directory properly.