### PR TITLE
Update 01-installation.md

### DIFF
--- a/packages/panels/docs/01-installation.md
+++ b/packages/panels/docs/01-installation.md
@@ -7,7 +7,7 @@ title: Installation
 Filament has a few requirements to run:
 
 - PHP 8.1+
-- Laravel v9.0+
+- Laravel v10.0+
 - Livewire v3.0+
 
 This package is compatible with other Filament v3.x products. The [form builder](/docs/forms), [table builder](/docs/tables) and [notifications](/docs/notifications) come pre-installed with the package, and no other installation steps are required to use them within a panel.


### PR DESCRIPTION
Livewire v3 requires Laravel 10 in their documentation, it seems wise to reflect that in the Filament docs as well.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
