### PR TITLE
add new method `hasPlugin`

### DIFF
--- a/packages/panels/src/Facades/Filament.php
+++ b/packages/panels/src/Facades/Filament.php
@@ -54,6 +54,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static Panel getPanel(?string $id = null)
  * @method static array<string, Panel> getPanels()
  * @method static Plugin getPlugin(string $id)
+ * @method static bool hasPlugin(string $id)
  * @method static string | null getProfileUrl(array $parameters = [])
  * @method static string | null getRegistrationUrl(array $parameters = [])
  * @method static string | null getRequestPasswordResetUrl(array $parameters = [])

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -252,6 +252,11 @@ class FilamentManager
         return $this->getCurrentPanel()->getPlugin($id);
     }
 
+    public function hasPlugin(string $id): bool
+    {
+        return $this->getCurrentPanel()->hasPlugin($id);
+    }
+
     /**
      * @param  array<mixed>  $parameters
      */

--- a/packages/panels/src/Panel/Concerns/HasPlugins.php
+++ b/packages/panels/src/Panel/Concerns/HasPlugins.php
@@ -44,4 +44,9 @@ trait HasPlugins
     {
         return $this->getPlugins()[$id] ?? throw new Exception("Plugin [{$id}] is not registered for panel [{$this->getId()}].");
     }
+
+    public function hasPlugin(string $id): bool
+    {
+        return array_key_exists($id, $this->getPlugins());
+    }
 }


### PR DESCRIPTION
Adding `hasPlugin` make it easier to check if a plugin is enabled in the current panel to set routes or other usages from the plugin service provider.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
    _currently no docs for internal methods, so I don't know where to add it to._
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
    _no visual changes._
