### PR TITLE
feature: add script to quickly setup demo/playground

### DIFF
--- a/bin/setup-playground.sh
+++ b/bin/setup-playground.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+if [ -d "./playground" ];
+then
+    echo "Playground already setup."
+    exit
+fi
+
+echo "Cloning repository..."
+
+git clone git@github.com:filamentphp/demo.git -b 3.x playground &> /dev/null
+
+echo "Configuring application..."
+
+cd playground
+
+rm composer.json
+mv composer-local.json composer.json
+composer config repositories.0 path ../packages/*
+composer install
+cp .env.example .env
+php artisan key:generate
+
+touch database/database.sqlite
+php artisan migrate --seed
+
+if [ -x "$(command -v valet)" ];
+then
+    valet link filament
+fi
+
+cd ..


### PR DESCRIPTION
This adds a new `./bin/setup-playground.sh` script that will setup the `filament/demo` repo for you. Handy if you want to refresh your local testing environment or just mess around with contributions.

It will do the following:
* Clone repo
* Point filament/* packages to local copy (`../packages/*`)
* Install dependencies
* Setup database
* Migrate and seed
* Link Valet site if Valet is installed, links to `filament.test`