### PR TITLE
Check if editor exists before destroying it in file-upload

### DIFF
--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -288,8 +288,7 @@ export default function fileUploadFormComponent({
         },
 
         destroy: function () {
-            this.editor.destroy()
-            this.editor = null
+            this.destroyEditor()
 
             FilePond.destroy(this.$refs.input)
             this.pond = null
@@ -450,8 +449,7 @@ export default function fileUploadFormComponent({
 
             this.isEditorOpen = false
 
-            this.editor.destroy()
-            this.editor = null
+            this.destroyEditor()
         },
 
         loadEditor: function (file) {
@@ -532,6 +530,13 @@ export default function fileUploadFormComponent({
                             })
                     })
                 }, this.editingFile.type)
+        },
+
+        destroyEditor: function () {
+            if (this.editor && typeof this.editor.destroy === 'function') {
+                this.editor.destroy()
+            }
+            this.editor = null
         },
     }
 }

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -533,9 +533,10 @@ export default function fileUploadFormComponent({
         },
 
         destroyEditor: function () {
-            if (this.editor && typeof this.editor.destroy === 'function') {
+            if (this.editor && (typeof this.editor.destroy === 'function')) {
                 this.editor.destroy()
             }
+            
             this.editor = null
         },
     }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

When the FileUpload field was used in an action modal, we got the error that `this.editor.destroy is not a function`.

I made a `destroyEditor` method, since editor is initialized as an empty object, but will afterwards be set to null.

Can be tested with: 

```php
TextInput::make('cost')
                ->prefix('€')
                ->suffixAction(
                    Action::make('copyCostToPrice')
                        ->form([
                            FileUpload::make('test'),
                        ])
```

Found this while testing Filament v3 and Livewire v3 for the tiptap field: https://github.com/awcodes/filament-tiptap-editor.