### PR TITLE
Add new API to force light theme

### DIFF
--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -78,6 +78,15 @@
             </script>
         @endif
 
+        @if (filament()->hasLightModeForced())
+            <script>
+                document.addEventListener('alpine:init', () => {
+                    localStorage.setItem('theme', 'light')
+                    document.documentElement.classList.remove('dark')
+                })
+            </script>
+        @endif
+
         {{ \Filament\Support\Facades\FilamentView::renderHook('head.end') }}
     </head>
 

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -500,6 +500,11 @@ class FilamentManager
         return $this->getCurrentPanel()->hasDarkModeForced();
     }
 
+    public function hasLightModeForced(): bool
+    {
+        return $this->getCurrentPanel()->hasLightModeForced();
+    }
+
     public function hasDatabaseNotifications(): bool
     {
         return $this->getCurrentPanel()->hasDatabaseNotifications();

--- a/packages/panels/src/Panel/Concerns/HasDarkMode.php
+++ b/packages/panels/src/Panel/Concerns/HasDarkMode.php
@@ -8,12 +8,21 @@ trait HasDarkMode
 
     protected bool $hasDarkModeForced = false;
 
+    protected bool $hasLightModeForced = false;
+
     public function darkMode(bool $condition = true, bool $isForced = false): static
     {
         $this->hasDarkMode = $condition;
         $this->hasDarkModeForced = $isForced;
 
         return $this;
+    }
+
+    public function forceLightMode(bool $condition = true): static
+    {
+        $this->hasLightModeForced = $condition;
+
+        return $this->darkMode(false, false);
     }
 
     public function hasDarkMode(): bool
@@ -24,5 +33,10 @@ trait HasDarkMode
     public function hasDarkModeForced(): bool
     {
         return $this->hasDarkModeForced;
+    }
+
+    public function hasLightModeForced(): bool
+    {
+        return $this->hasLightModeForced;
     }
 }


### PR DESCRIPTION
Before, when we disable `->darkMode(false)`, filament will let the system default to be used for theme.

This may be unintentional as some dev are required to still 'force' the users to use `light` theme.

This PR lets the developers to force the users to use `light` theme.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

