### PR TITLE
Fix phpdoc for table pagination options

### DIFF
--- a/packages/tables/src/Table/Concerns/CanPaginateRecords.php
+++ b/packages/tables/src/Table/Concerns/CanPaginateRecords.php
@@ -26,7 +26,7 @@ trait CanPaginateRecords
     }
 
     /**
-     * @param  bool | array<int, string> | Closure  $condition
+     * @param  bool | array<int | string> | Closure  $condition
      */
     public function paginated(bool | array | Closure $condition = true): static
     {
@@ -48,7 +48,7 @@ trait CanPaginateRecords
     }
 
     /**
-     * @param  array<int, string> | Closure | null  $options
+     * @param  array<int | string> | Closure | null  $options
      */
     public function paginationPageOptions(array | Closure | null $options): static
     {


### PR DESCRIPTION
PHPStan will complain when using this method according to the docs:

```
Parameter #1 $options of method Filament\Tables\Table::paginationPageOptions() expects array<int, string>|Closure|null, array{25, 'all'} given. 
```

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
