### PR TITLE
Toggle column - Empty tooltip fix and theme tooltip color when theme is changed

### DIFF
--- a/packages/tables/resources/views/columns/toggle-column.blade.php
+++ b/packages/tables/resources/views/columns/toggle-column.blade.php
@@ -38,22 +38,22 @@
 
                 const response = await $wire.updateTableColumnState(@js($getName()), @js($recordKey), state)
 
-                error = response?.error ?? undefined
-
-                if (error) {
+                if (response?.error) {
+                    error = {
+                        content: response.error,
+                        theme: $store.theme
+                    }
                     state = ! state
                 }
 
                 isLoading = false
             "
-            x-tooltip="
-                error === undefined
-                    ? false
-                    : {
-                          content: error,
-                          theme: $store.theme,
-                      }
-            "
+            x-tooltip="error"
+            @theme-changed.window="    
+                if (error) {
+                    error.theme = $event.detail
+                }
+            "            
             x-bind:class="
                 (state
                     ? '{{


### PR DESCRIPTION
Empty tooltip fix and theme tooltip color when theme is changed

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
