### PR TITLE
Pass state into repeater conditional methods

### DIFF
--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -111,6 +111,23 @@ Repeater::make('members')
     ->deletable(false)
 ```
 
+### Preventing the user from deleting specific item
+
+You may prevent the user from deleting specific item from the repeater using the `itemDeletable()` method:
+This method accepts a closure that receive the current item's data in a `$state` variable.
+You must return the boolean value to determine that item deletable or not.
+
+```PHP
+use Filament\Forms\Components\Repeater;
+
+Repeater::make('members')
+    ->schema([
+        // ...
+    ])
+    ->itemDeletable(fn ($state): bool => !$state['is_default'])
+```
+Above example means that attribute `is_default` is true will prevent user delete item.
+
 ## Reordering items
 
 A button is displayed on each item to allow the user to drag and drop to reorder it in the list.

--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -59,6 +59,7 @@
                     @foreach ($containers as $uuid => $item)
                         @php
                             $itemLabel = $getItemLabel($uuid);
+                            $itemDeletable = $getItemDeletable($uuid);
                         @endphp
 
                         <li
@@ -94,7 +95,7 @@
                             x-sortable-item="{{ $uuid }}"
                             class="fi-fo-repeater-item rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10"
                         >
-                            @if ($isReorderableWithDragAndDrop || $isReorderableWithButtons || filled($itemLabel) || $isCloneable || $isDeletable || $isCollapsible)
+                            @if ($isReorderableWithDragAndDrop || $isReorderableWithButtons || filled($itemLabel) || $isCloneable || ($isDeletable && $itemDeletable) || $isCollapsible)
                                 <div
                                     class="flex items-center gap-x-3 px-4 py-2"
                                 >
@@ -138,7 +139,7 @@
                                                 </li>
                                             @endif
 
-                                            @if ($isDeletable)
+                                            @if ($isDeletable && $itemDeletable)
                                                 <li>
                                                     {{ $deleteAction(['item' => $uuid]) }}
                                                 </li>

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -49,6 +49,8 @@ class Repeater extends Field implements Contracts\CanConcealComponents
 
     protected string | Closure | null $itemLabel = null;
 
+    protected bool | Closure $itemDeletable = true;
+
     protected ?Closure $modifyRelationshipQueryUsing = null;
 
     protected ?Closure $modifyAddActionUsing = null;
@@ -517,6 +519,13 @@ class Repeater extends Field implements Contracts\CanConcealComponents
         return $this;
     }
 
+    public function itemDeletable(Closure|bool $condition = true): static
+    {
+        $this->itemDeletable = $condition;
+
+        return $this;
+    }
+
     public function reorderable(bool | Closure $condition = true): static
     {
         $this->isReorderable = $condition;
@@ -857,6 +866,14 @@ class Repeater extends Field implements Contracts\CanConcealComponents
     public function getItemLabel(string $uuid): string | Htmlable | null
     {
         return $this->evaluate($this->itemLabel, [
+            'state' => $this->getChildComponentContainer($uuid)->getRawState(),
+            'uuid' => $uuid,
+        ]);
+    }
+
+    public function getItemDeletable(string $uuid): string | Htmlable | null
+    {
+        return $this->evaluate($this->itemDeletable, [
             'state' => $this->getChildComponentContainer($uuid)->getRawState(),
             'uuid' => $uuid,
         ]);


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

### Preventing the user from deleting specific item

You may prevent the user from deleting specific item from the repeater using the `itemDeletable()` method:
This method accepts a closure that receive the current item's data in a `$state` variable.
You must return the boolean value to determine that item deletable or not.

```PHP
use Filament\Forms\Components\Repeater;

Repeater::make('members')
    ->schema([
        // ...
    ])
    ->itemDeletable(fn ($state): bool => !$state['is_default'])
```
Above example means that attribute `is_default` is true will prevent user delete item.

![image](https://github.com/filamentphp/filament/assets/106950633/826194b7-ea41-4482-95c7-dccb50d10eac)

