### PR TITLE
Added support for login conditions

### DIFF
--- a/packages/panels/src/Pages/Auth/Login.php
+++ b/packages/panels/src/Pages/Auth/Login.php
@@ -65,10 +65,7 @@ class Login extends SimplePage
 
         $data = $this->form->getState();
 
-        if (! Filament::auth()->attempt([
-            'email' => $data['email'],
-            'password' => $data['password'],
-        ], $data['remember'])) {
+        if (! Filament::auth()->attempt($this->loginConditions($data), $data['remember'] ?? false)) {
             throw ValidationException::withMessages([
                 'data.email' => __('filament::pages/auth/login.messages.failed'),
             ]);
@@ -153,5 +150,13 @@ class Login extends SimplePage
     protected function hasFullWidthFormActions(): bool
     {
         return true;
+    }
+
+    protected function loginConditions(array $data): array
+    {
+        return [
+            'email' => $data['email'],
+            'password' => $data['password'],
+        ];
     }
 }

--- a/packages/panels/src/Pages/Auth/Login.php
+++ b/packages/panels/src/Pages/Auth/Login.php
@@ -152,7 +152,7 @@ class Login extends SimplePage
         return true;
     }
 
-    protected function loginConditions(array $data): array
+    protected function getCredentialsFromFormData(array $data): array
     {
         return [
             'email' => $data['email'],

--- a/packages/panels/src/Pages/Auth/Login.php
+++ b/packages/panels/src/Pages/Auth/Login.php
@@ -65,7 +65,7 @@ class Login extends SimplePage
 
         $data = $this->form->getState();
 
-        if (! Filament::auth()->attempt($this->loginConditions($data), $data['remember'] ?? false)) {
+        if (! Filament::auth()->attempt($this->getCredentialsFromFormData($data), $data['remember'] ?? false)) {
             throw ValidationException::withMessages([
                 'data.email' => __('filament::pages/auth/login.messages.failed'),
             ]);


### PR DESCRIPTION
This PR allows to customize login conditions (like `status => active`) and prevent an error if `remember` component was removed from `form` array.


- [X] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
