### PR TITLE
Allow native DatePicker/DateTimePicker to open onfocus

### DIFF
--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -43,6 +43,7 @@
                             'max' => (! $isConcealed) ? $getMaxDate() : null,
                             'min' => (! $isConcealed) ? $getMinDate() : null,
                             'placeholder' => $getPlaceholder(),
+                            'onfocus' => 'this.showPicker?.()',
                             'readonly' => $isReadOnly(),
                             'required' => $isRequired() && (! $isConcealed),
                             'step' => $getStep(),


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

For consistency between native and non-native, this PR will allow native datetime-local to open onfocus.

Without this PR, this also works:
```php
Forms\Components\DateTimePicker::make('start_date')
    ->extraAlpineAttributes(['onfocus' => 'this.showPicker?.()'])
```

Browser compatibility: https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/showPicker#browser_compatibility

