### PR TITLE
Added missing preload() to SelectFilter form field

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasRenderHooks.php
+++ b/packages/panels/src/Panel/Concerns/HasRenderHooks.php
@@ -13,7 +13,7 @@ trait HasRenderHooks
     protected array $renderHooks = [];
 
     /**
-     * @param  string | array<string> | null  $scopes
+     * @param string | array<string> | null $scopes
      */
     public function renderHook(string $name, Closure $hook, string | array | null $scopes = null): static
     {

--- a/packages/panels/src/Panel/Concerns/HasRenderHooks.php
+++ b/packages/panels/src/Panel/Concerns/HasRenderHooks.php
@@ -13,7 +13,7 @@ trait HasRenderHooks
     protected array $renderHooks = [];
 
     /**
-     * @param string | array<string> | null $scopes
+     * @param  string | array<string> | null  $scopes
      */
     public function renderHook(string $name, Closure $hook, string | array | null $scopes = null): static
     {

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -187,6 +187,7 @@ class SelectFilter extends BaseFilter
             ->multiple($this->isMultiple())
             ->placeholder($this->getPlaceholder())
             ->searchable($this->isSearchable())
+            ->preload($this->isPreloaded())
             ->optionsLimit($this->getOptionsLimit());
 
         if ($this->queriesRelationships()) {


### PR DESCRIPTION
The preload() method for SelectFilter was missing from the getFormField() definition, so preload() wasn't working.