### PR TITLE
Fix issue with refresh after DatabaseNotificationsSent event

### DIFF
--- a/packages/notifications/resources/views/components/database/echo.blade.php
+++ b/packages/notifications/resources/views/components/database/echo.blade.php
@@ -10,6 +10,10 @@
                 setTimeout(() => $wire.call('$refresh'), 500)
             })
         })
+
+        if (window.Echo) {
+            window.dispatchEvent(new CustomEvent('EchoLoaded'))
+        }
     "
     {{ $attributes }}
 ></div>


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [X] New functionality has been documented or existing documentation has been updated to reflect changes.
- [X] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Resolves #7262

The database notifications component now properly refreshes after the DatabaseNotificationsSent event is dispatched. Broadcasting notifications also still work with this pull request.