### PR TITLE
Since the ->disablePlaceHolder() method is deprecated and its suggest…

### DIFF
--- a/packages/forms/docs/03-fields/03-select.md
+++ b/packages/forms/docs/03-fields/03-select.md
@@ -318,7 +318,7 @@ Be aware that you will need to ensure that the HTML is safe to render, otherwise
 
 ## Disable placeholder selection
 
-You can prevent the placeholder (null option) from being selected using the `disablePlaceholderSelection()` method:
+You can prevent the placeholder (null option) from being selected using the `selectablePlaceholder()` method:
 
 ```php
 use Filament\Forms\Components\Select;
@@ -330,7 +330,7 @@ Select::make('status')
         'published' => 'Published',
     ])
     ->default('draft')
-    ->disablePlaceholderSelection()
+    ->selectablePlaceholder(false)
 ```
 
 ## Disabling specific options

--- a/packages/tables/docs/03-columns/06-select.md
+++ b/packages/tables/docs/03-columns/06-select.md
@@ -40,7 +40,7 @@ SelectColumn::make('status')
 
 ## Disabling placeholder selection
 
-You can prevent the placeholder from being selected using the `disablePlaceholderSelection()` method:
+You can prevent the placeholder from being selected using the `selectablePlaceholder()` method:
 
 ```php
 use Filament\Tables\Columns\SelectColumn;
@@ -51,5 +51,5 @@ SelectColumn::make('status')
         'reviewing' => 'Reviewing',
         'published' => 'Published',
     ])
-    ->disablePlaceholderSelection()
+    ->selectablePlaceholder(false)
 ```


### PR DESCRIPTION
Since the ->disablePlaceHolder() method is deprecated and its suggested to use ->selectablePlaceholder(false) the docs should be updated to reflect this.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
