### PR TITLE
Update card.blade.php

### DIFF
--- a/packages/widgets/resources/views/stats-overview-widget/card.blade.php
+++ b/packages/widgets/resources/views/stats-overview-widget/card.blade.php
@@ -99,9 +99,7 @@
                         values: @js(array_values($chart)),
                     })"
             x-ignore
-            @class([
-                'fi-wi-stats-overview-card-chart absolute inset-x-0 bottom-0 overflow-hidden rounded-b-xl',
-            ])
+            class="fi-wi-stats-overview-card-chart absolute inset-x-0 bottom-0 overflow-hidden rounded-b-xl"
             @style([
                 \Filament\Support\get_color_css_variables($chartColor, shades: [50, 400, 500]) => $chartColor !== 'gray',
             ])

--- a/packages/widgets/resources/views/stats-overview-widget/card.blade.php
+++ b/packages/widgets/resources/views/stats-overview-widget/card.blade.php
@@ -100,7 +100,7 @@
                     })"
             x-ignore
             @class([
-                'absolute inset-x-0 bottom-0 overflow-hidden rounded-b-xl',
+                'fi-wi-stats-overview-card-chart absolute inset-x-0 bottom-0 overflow-hidden rounded-b-xl',
             ])
             @style([
                 \Filament\Support\get_color_css_variables($chartColor, shades: [50, 400, 500]) => $chartColor !== 'gray',


### PR DESCRIPTION
Add a class hook to change the classes on the chart inside the stats overview card. My specific use case is, I changed the border radius of the `fi-wi-stats-overview-card`, however when I add the chart to the card the chart does not have a hook for changing the border radius on the chart. This PR adds a new class hook for the chart titled: `fi-wi-stats-overview-card-chart`.

- [x] Changes have been thoroughly tested to not break existing functionality.
--- N/A
- [x] New functionality has been documented or existing documentation has been updated to reflect changes. 
--- Existing class hook guidance applies to this change. 
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
--- N/A
