### PR TITLE
fix: forgot password label trans key

### DIFF
--- a/packages/panels/src/Pages/Auth/Login.php
+++ b/packages/panels/src/Pages/Auth/Login.php
@@ -101,7 +101,7 @@ class Login extends SimplePage
     {
         return TextInput::make('password')
             ->label(__('filament-panels::pages/auth/login.form.password.label'))
-            ->hint(filament()->hasPasswordReset() ? new HtmlString(Blade::render('<x-filament::link :href="filament()->getRequestPasswordResetUrl()"> {{ __(\'filament-panels::layouts/auth/login.actions.request_password_reset.label\') }}</x-filament::link>')) : null)
+            ->hint(filament()->hasPasswordReset() ? new HtmlString(Blade::render('<x-filament::link :href="filament()->getRequestPasswordResetUrl()"> {{ __(\'filament-panels::pages/auth/login.actions.request_password_reset.label\') }}</x-filament::link>')) : null)
             ->password()
             ->required();
     }


### PR DESCRIPTION

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

![filament-issue-forgot-password-before](https://github.com/filamentphp/filament/assets/13122679/136e8593-bc04-4f14-a89c-4f981760a1ba)
![filament-issue-forgot-password-after](https://github.com/filamentphp/filament/assets/13122679/371f8a7a-ae01-4ccc-a6e6-74a116cf0394)

