### PR TITLE
Allow us to go a little deeper in relations for Spatie Media Library Table Column

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
@@ -73,7 +73,13 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
     {
         $collection = $this->getCollection();
 
-        return $this->getRecord()->getRelationValue('media')
+        $record = $this->getRecord();
+
+        if ($this->queriesRelationships($record)) {
+            $record = $record->getRelationValue($this->getRelationshipName());
+        }
+
+        return $record->getRelationValue('media')
             ->filter(fn (Media $media): bool => blank($collection) || ($media->getAttributeValue('collection_name') === $collection))
             ->map(fn (Media $media): string => $media->uuid)
             ->all();
@@ -87,9 +93,9 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
 
         if ($this->queriesRelationships($query->getModel())) {
             return $query->with([
-                "{$this->getRelationshipName()}.media" => fn (Builder $query) => $query->when(
+                "{$this->getRelationshipName()}.media" => fn (Builder | Relation $query) => $query->when(
                     $this->getCollection(),
-                    fn (Builder $query, string $collection) => $query->where(
+                    fn (Builder | Relation $query, string $collection) => $query->where(
                         'collection_name',
                         $collection,
                     ),


### PR DESCRIPTION
This is a bug fix for the Spatie Media Library Table Column. Previously there were errors if attempting to use a media collection nested on a relation of the main table record.

There are no documentation or visual changes to add.