### PR TITLE
Update Status Widget section of Getting Started

### DIFF
--- a/packages/panels/docs/02-getting-started.md
+++ b/packages/panels/docs/02-getting-started.md
@@ -646,7 +646,7 @@ Let's add a stats widget to our default dashboard page that includes a card for 
 
 ### Creating a stats widget
 
-Create a [stats widget](../widgets/stats-overview) to render patient types using the following artisan command (do not specify a Resource and select "admin" for the location when prompted):
+Create a [stats widget](../widgets/stats-overview) to render patient types using the following artisan command (do not specify a resource and select "admin" for the location when prompted):
 
 ```bash
 php artisan make:filament-widget PatientTypeOverview --stats-overview

--- a/packages/panels/docs/02-getting-started.md
+++ b/packages/panels/docs/02-getting-started.md
@@ -646,7 +646,7 @@ Let's add a stats widget to our default dashboard page that includes a card for 
 
 ### Creating a stats widget
 
-Create a [stats widget](../widgets/stats-overview) to render patient types using the following artisan command (select "admin" for the location when prompted):
+Create a [stats widget](../widgets/stats-overview) to render patient types using the following artisan command (do not specify a Resource and select "admin" for the location when prompted):
 
 ```bash
 php artisan make:filament-widget PatientTypeOverview --stats-overview


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.

## Context

I was working through the "Getting Started" tutorial, and in the section on creating a Status Widget, the choice for the widget location ("admin") is documented, but the requirement to not specify a Resource is not. New folks to the Filament world who are going through the tutorial might not realize that specifying a Resource will lead to their widget _not_ appearing on the Dashboard like the instructions say.

There may be a better way to phrase the sentence that I've adjusted, but I'm open to thoughts and pushback on the wording and the idea as a whole.

Let me know what y'all think!