### PR TITLE
Hint text size

### DIFF
--- a/packages/forms/docs/03-fields/01-getting-started.md
+++ b/packages/forms/docs/03-fields/01-getting-started.md
@@ -161,6 +161,18 @@ RichEditor::make('content')
     ->hintColor('primary')
 ```
 
+### Changing the text size of the hint
+
+You can change the text size of the hint. By default, it's small, but you may use `xs`, `base` and `lg`:
+
+```php
+use Filament\Forms\Components\RichEditor;
+
+RichEditor::make('content')
+    ->hint('Translatable')
+    ->hintSize('xs')
+```
+
 <AutoScreenshot name="forms/fields/hint-color" alt="Form field with hint color" version="3.x" />
 
 ### Adding an icon aside the hint

--- a/packages/forms/resources/views/components/field-wrapper/hint.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/hint.blade.php
@@ -16,7 +16,7 @@
                 },
                 match ($size) {
                     'xs' => 'text-xs',
-                    'md' => 'text-md',
+                    'base' => 'text-base',
                     'lg' => 'text-lg',
                     default => 'text-sm',
                 },

--- a/packages/forms/resources/views/components/field-wrapper/hint.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/hint.blade.php
@@ -1,6 +1,7 @@
 @props([
     'actions' => [],
     'color' => 'gray',
+    'size' => 'sm',
     'icon' => null,
 ])
 
@@ -8,10 +9,16 @@
     {{
         $attributes
             ->class([
-                'fi-fo-field-wrp-hint flex items-center gap-x-3 text-sm',
+                'fi-fo-field-wrp-hint flex items-center gap-x-3',
                 match ($color) {
                     'gray' => 'text-gray-500',
                     default => 'text-custom-600 dark:text-custom-400',
+                },
+                match ($size) {
+                    'xs' => 'text-xs',
+                    'md' => 'text-md',
+                    'lg' => 'text-lg',
+                    default => 'text-sm',
                 },
             ])
             ->style([

--- a/packages/forms/resources/views/components/field-wrapper/index.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/index.blade.php
@@ -6,6 +6,7 @@
     'hint' => null,
     'hintActions' => null,
     'hintColor' => null,
+    'hintSize' => null,
     'hintIcon' => null,
     'id' => null,
     'isDisabled' => null,
@@ -26,6 +27,7 @@
         $hint ??= $field->getHint();
         $hintActions ??= $field->getHintActions();
         $hintColor ??= $field->getHintColor();
+        $hintSize ??= $field->getHintSize();
         $hintIcon ??= $field->getHintIcon();
         $id ??= $field->getId();
         $isDisabled ??= $field->isDisabled();
@@ -86,6 +88,7 @@
                     <x-filament-forms::field-wrapper.hint
                         :actions="$hintActions"
                         :color="$hintColor"
+                        :size="$hintSize"
                         :icon="$hintIcon"
                     >
                         {{ $hint }}

--- a/packages/forms/src/Components/Concerns/HasHint.php
+++ b/packages/forms/src/Components/Concerns/HasHint.php
@@ -26,6 +26,8 @@ trait HasHint
      * @var string | array{50: string, 100: string, 200: string, 300: string, 400: string, 500: string, 600: string, 700: string, 800: string, 900: string, 950: string} | Closure | null
      */
     protected string | array | Closure | null $hintColor = null;
+    
+    protected string | Closure | null $hintSize = null;
 
     protected string | Closure | null $hintIcon = null;
 
@@ -42,6 +44,13 @@ trait HasHint
     public function hintColor(string | array | Closure | null $color): static
     {
         $this->hintColor = $color;
+
+        return $this;
+    }
+
+    public function hintSize(string | Closure | null $size): static
+    {
+        $this->hintSize = $size;
 
         return $this;
     }
@@ -84,6 +93,11 @@ trait HasHint
     public function getHintColor(): string | array | null
     {
         return $this->evaluate($this->hintColor);
+    }
+
+    public function getHintSize(): string | null
+    {
+        return $this->evaluate($this->hintSize);
     }
 
     public function getHintIcon(): ?string

--- a/packages/infolists/docs/03-entries/01-getting-started.md
+++ b/packages/infolists/docs/03-entries/01-getting-started.md
@@ -174,6 +174,19 @@ TextEntry::make('apiKey')
     ->hintColor('primary')
 ```
 
+### Changing the text size of the hint
+
+You can change the text size of the hint. By default, it's small, but you may use `xs`, `base` and `lg`:
+
+```php
+use Filament\Infolists\Components\TextEntry;
+
+TextEntry::make('apiKey')
+    ->label('API key')
+    ->hint('[Documentation](/documentation)')
+    ->hintSize('xs')
+```
+
 <AutoScreenshot name="infolists/entries/hint-color" alt="Entry with hint color" version="3.x" />
 
 ### Adding an icon aside the hint

--- a/packages/infolists/resources/views/components/entry-wrapper/hint.blade.php
+++ b/packages/infolists/resources/views/components/entry-wrapper/hint.blade.php
@@ -16,7 +16,7 @@
                 },
                 match ($size) {
                     'xs' => 'text-xs',
-                    'md' => 'text-md',
+                    'base' => 'text-base',
                     'lg' => 'text-lg',
                     default => 'text-sm',
                 },

--- a/packages/infolists/resources/views/components/entry-wrapper/hint.blade.php
+++ b/packages/infolists/resources/views/components/entry-wrapper/hint.blade.php
@@ -1,6 +1,7 @@
 @props([
     'actions' => [],
     'color' => 'gray',
+    'size' => 'sm',
     'icon' => null,
 ])
 
@@ -8,10 +9,16 @@
     {{
         $attributes
             ->class([
-                'fi-in-entry-wrp-hint flex items-center gap-x-3 text-sm',
+                'fi-in-entry-wrp-hint flex items-center gap-x-3',
                 match ($color) {
                     'gray' => 'text-gray-500',
                     default => 'text-custom-600 dark:text-custom-400',
+                },
+                match ($size) {
+                    'xs' => 'text-xs',
+                    'md' => 'text-md',
+                    'lg' => 'text-lg',
+                    default => 'text-sm',
                 },
             ])
             ->style([

--- a/packages/infolists/resources/views/components/entry-wrapper/index.blade.php
+++ b/packages/infolists/resources/views/components/entry-wrapper/index.blade.php
@@ -7,6 +7,7 @@
     'hint' => null,
     'hintActions' => null,
     'hintColor' => null,
+    'hintSize' => null,
     'hintIcon' => null,
     'id' => null,
     'label' => null,
@@ -30,6 +31,7 @@
         $hint ??= $entry->getHint();
         $hintActions ??= $entry->getHintActions();
         $hintColor ??= $entry->getHintColor();
+        $hintSize ??= $entry->getHintSize();
         $hintIcon ??= $entry->getHintIcon();
         $id ??= $entry->getId();
         $label ??= $entry->getLabel();
@@ -78,6 +80,7 @@
                     <x-filament-infolists::entry-wrapper.hint
                         :actions="$hintActions"
                         :color="$hintColor"
+                        :size="$hintSize"
                         :icon="$hintIcon"
                     >
                         {{ $hint }}

--- a/packages/infolists/src/Components/Concerns/HasHint.php
+++ b/packages/infolists/src/Components/Concerns/HasHint.php
@@ -27,6 +27,8 @@ trait HasHint
      */
     protected string | array | Closure | null $hintColor = null;
 
+    protected string | Closure | null $hintSize = null;
+
     protected string | Closure | null $hintIcon = null;
 
     public function hint(string | Htmlable | Closure | null $hint): static
@@ -42,6 +44,13 @@ trait HasHint
     public function hintColor(string | array | Closure | null $color): static
     {
         $this->hintColor = $color;
+
+        return $this;
+    }
+
+    public function hintSize(string | Closure | null $size): static
+    {
+        $this->hintSize = $size;
 
         return $this;
     }
@@ -84,6 +93,11 @@ trait HasHint
     public function getHintColor(): string | array | null
     {
         return $this->evaluate($this->hintColor);
+    }
+
+    public function getHintSize(): string | null
+    {
+        return $this->evaluate($this->hintSize);
     }
 
     public function getHintIcon(): ?string


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

### Description:
This PR introduces hint text sizes for form and infolists. 

### Example:

```php
Forms\Components\TextInput::make('name')
    ->hint('Xs Text Size')
    ->hintColor('info')
    ->hintSize('xs'),
```

### Form Screenshot:
![Screenshot 2023-07-30 at 12 56 29 PM](https://github.com/filamentphp/filament/assets/10107779/2c6eb381-757f-4fbe-b3e1-cd8b793526de)

### Infolist Screenshot
![Screenshot 2023-07-30 at 12 56 37 PM](https://github.com/filamentphp/filament/assets/10107779/90048f9e-39db-45e0-aeff-1e5917287696)

