### PR TITLE
fix notification classes in docs

### DIFF
--- a/packages/notifications/docs/05-customizing-notifications.md
+++ b/packages/notifications/docs/05-customizing-notifications.md
@@ -10,14 +10,14 @@ Notifications come fully styled out of the box. However, if you want to apply yo
 
 Notifications have dedicated CSS classes you can hook into to apply your own styling:
 
-- `filament-notifications`
-- `filament-notifications-notification`
-- `filament-notifications-icon`
-- `filament-notifications-title`
-- `filament-notifications-close-button`
-- `filament-notifications-date`
-- `filament-notifications-body`
-- `filament-notifications-actions`
+- `fi-no`
+- `fi-no-notification`
+- `fi-no-notification-icon`
+- `fi-no-notification-title`
+- `fi-no-notification-close-btn`
+- `fi-no-notification-date`
+- `fi-no-notification-body`
+- `fi-no-notification-actions`
 
 ## Using a custom notification view
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.

Just noticed while tinkering with notifications that the css classes differ 