### PR TITLE
adds `gap-4` for to adjust global search's render hooks

### DIFF
--- a/packages/panels/resources/views/components/global-search/index.blade.php
+++ b/packages/panels/resources/views/components/global-search/index.blade.php
@@ -1,4 +1,6 @@
-<div class="fi-global-search flex items-center gap-4">
+{{ \Filament\Support\Facades\FilamentView::renderHook('panels::global-search.before') }}
+
+<div class="fi-global-search flex items-center">
     {{ \Filament\Support\Facades\FilamentView::renderHook('panels::global-search.start') }}
 
     <div class="relative">
@@ -13,3 +15,5 @@
 
     {{ \Filament\Support\Facades\FilamentView::renderHook('panels::global-search.end') }}
 </div>
+
+{{ \Filament\Support\Facades\FilamentView::renderHook('panels::global-search.after') }}

--- a/packages/panels/resources/views/components/global-search/index.blade.php
+++ b/packages/panels/resources/views/components/global-search/index.blade.php
@@ -1,4 +1,4 @@
-<div class="fi-global-search flex items-center">
+<div class="fi-global-search flex items-center gap-4">
     {{ \Filament\Support\Facades\FilamentView::renderHook('panels::global-search.start') }}
 
     <div class="relative">


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

**Current:**
LTR:
<img width="997" alt="Screenshot 2023-07-30 at 9 07 10 PM" src="https://github.com/filamentphp/filament/assets/10007504/3007be9b-9dfe-4e05-8d39-7ce0f3873425">
RTL:
<img width="997" alt="Screenshot 2023-07-30 at 9 14 33 PM" src="https://github.com/filamentphp/filament/assets/10007504/4a78c471-24c9-44cf-bbd0-c27d6fadb3e3">

now if we try to handle it ourselves then depending on whether its start or end
<img width="997" alt="Screenshot 2023-07-30 at 9 12 13 PM" src="https://github.com/filamentphp/filament/assets/10007504/4f772fd3-9652-4a36-94ca-38a62bbd5370">
<img width="997" alt="Screenshot 2023-07-30 at 9 17 00 PM" src="https://github.com/filamentphp/filament/assets/10007504/143b8ba3-4c0e-47ad-a7d8-dab2bce153ad">

but add the `gap-4` like topbar has would fix all of it.
<img width="997" alt="Screenshot 2023-07-30 at 9 18 44 PM" src="https://github.com/filamentphp/filament/assets/10007504/b606cecf-8a42-4702-a866-afec2129ddaf">
<img width="997" alt="Screenshot 2023-07-30 at 9 18 33 PM" src="https://github.com/filamentphp/filament/assets/10007504/b325b67d-78ed-436e-a3b6-1d0ed770c918">
