### PR TITLE
Filter tabs render hooks

### DIFF
--- a/packages/panels/resources/views/resources/pages/list-records.blade.php
+++ b/packages/panels/resources/views/resources/pages/list-records.blade.php
@@ -6,27 +6,37 @@
 >
     <div class="flex flex-col gap-y-4">
         @if (count($tabs = $this->getTabs()))
-            <div
-                class="mx-auto max-w-full rounded-xl bg-white p-2 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10"
-            >
-                <x-filament::tabs class="self-center">
-                    @foreach ($tabs as $tabKey => $tab)
-                        @php
-                            $activeTab = strval($activeTab);
-                            $tabKey = strval($tabKey);
-                        @endphp
+            <div class="flex max-w-full mx-auto">
+                {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.filter-tabs.before', scopes: $this->getRenderHookScopes()) }}
 
-                        <x-filament::tabs.item
-                            :active="$activeTab === $tabKey"
-                            :badge="$tab->getBadge()"
-                            :icon="$tab->getIcon()"
-                            :icon-position="$tab->getIconPosition()"
-                            :wire:click="'$set(\'activeTab\', ' . (filled($tabKey) ? ('\'' . $tabKey . '\'') : 'null') . ')'"
-                        >
-                            {{ $tab->getLabel() ?? $this->generateTabLabel($tabKey) }}
-                        </x-filament::tabs.item>
-                    @endforeach
-                </x-filament::tabs>
+                <div
+                    class="p-2 bg-white shadow-sm  rounded-xl ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+
+                    <x-filament::tabs class="self-center">
+                        {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.filter-tabs.start', scopes: $this->getRenderHookScopes()) }}
+
+                        @foreach ($tabs as $tabKey => $tab)
+                            @php
+                                $activeTab = strval($activeTab);
+                                $tabKey = strval($tabKey);
+                            @endphp
+
+                            <x-filament::tabs.item
+                                :active="$activeTab === $tabKey"
+                                :badge="$tab->getBadge()"
+                                :icon="$tab->getIcon()"
+                                :icon-position="$tab->getIconPosition()"
+                                :wire:click="'$set(\'activeTab\', ' . (filled($tabKey) ? ('\'' . $tabKey . '\'') : 'null') . ')'"
+                            >
+                                {{ $tab->getLabel() ?? $this->generateTabLabel($tabKey) }}
+                            </x-filament::tabs.item>
+                        @endforeach
+
+                        {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.filter-tabs.end', scopes: $this->getRenderHookScopes()) }}
+                    </x-filament::tabs>
+                </div>
+
+                {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.filter-tabs.after', scopes: $this->getRenderHookScopes()) }}
             </div>
         @endif
 

--- a/packages/panels/resources/views/resources/pages/list-records.blade.php
+++ b/packages/panels/resources/views/resources/pages/list-records.blade.php
@@ -7,13 +7,13 @@
     <div class="flex flex-col gap-y-4">
         @if (count($tabs = $this->getTabs()))
             <div class="flex flex-col max-w-full gap-4 mx-auto md:flex-row">
-                {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.filter-tabs.before', scopes: $this->getRenderHookScopes()) }}
+                {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.tabs.before', scopes: $this->getRenderHookScopes()) }}
 
                 <div
                     class="p-2 bg-white shadow-sm rounded-xl ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
 
                     <x-filament::tabs class="self-center">
-                        {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.filter-tabs.start', scopes: $this->getRenderHookScopes()) }}
+                        {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.tabs.start', scopes: $this->getRenderHookScopes()) }}
 
                         @foreach ($tabs as $tabKey => $tab)
                             @php
@@ -32,11 +32,11 @@
                             </x-filament::tabs.item>
                         @endforeach
 
-                        {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.filter-tabs.end', scopes: $this->getRenderHookScopes()) }}
+                        {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.tabs.end', scopes: $this->getRenderHookScopes()) }}
                     </x-filament::tabs>
                 </div>
 
-                {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.filter-tabs.after', scopes: $this->getRenderHookScopes()) }}
+                {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.tabs.after', scopes: $this->getRenderHookScopes()) }}
             </div>
         @endif
 

--- a/packages/panels/resources/views/resources/pages/list-records.blade.php
+++ b/packages/panels/resources/views/resources/pages/list-records.blade.php
@@ -6,11 +6,11 @@
 >
     <div class="flex flex-col gap-y-4">
         @if (count($tabs = $this->getTabs()))
-            <div class="flex max-w-full mx-auto">
+            <div class="flex flex-col max-w-full gap-4 mx-auto md:flex-row">
                 {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.filter-tabs.before', scopes: $this->getRenderHookScopes()) }}
 
                 <div
-                    class="p-2 bg-white shadow-sm  rounded-xl ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+                    class="p-2 bg-white shadow-sm rounded-xl ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
 
                     <x-filament::tabs class="self-center">
                         {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.filter-tabs.start', scopes: $this->getRenderHookScopes()) }}

--- a/packages/support/docs/06-render-hooks.md
+++ b/packages/support/docs/06-render-hooks.md
@@ -51,10 +51,10 @@ FilamentView::registerRenderHook(
 - `panels::page.header-widgets.after` - After the page header widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::page.header-widgets.before` - Before the page header widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::page.start` - Start of the page content container, also [can be scoped](#scoping-render-hooks) to the page or resource class
-- `panels::resource.pages.list-records.filter-tabs.after` - After the resource filter tabs, also [can be scoped](#scoping-render-hooks) to the page or resource class
-- `panels::resource.pages.list-records.filter-tabs.before` - Before the resource filter tabs, also [can be scoped](#scoping-render-hooks) to the page or resource class
-- `panels::resource.pages.list-records.filter-tabs.end` - The end of the filter tabs (after the tab), also [can be scoped](#scoping-render-hooks) to the page or resource class
-- `panels::resource.pages.list-records.filter-tabs.start` - The start of the filter tabs (before the first tab), also [can be scoped](#scoping-render-hooks) to the page or resource class
+- `panels::resource.pages.list-records.tabs.after` - After the resource filter tabs, also [can be scoped](#scoping-render-hooks) to the page or resource class
+- `panels::resource.pages.list-records.tabs.before` - Before the resource filter tabs, also [can be scoped](#scoping-render-hooks) to the page or resource class
+- `panels::resource.pages.list-records.tabs.end` - The end of the filter tabs (after the tab), also [can be scoped](#scoping-render-hooks) to the page or resource class
+- `panels::resource.pages.list-records.tabs.start` - The start of the filter tabs (before the first tab), also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::resource.pages.list-records.table.after` - After the resource table, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::resource.pages.list-records.table.before` - Before the resource table, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::resource.relation-manager.after` - After the relation manager table, also [can be scoped](#scoping-render-hooks) to the page or relation manager class

--- a/packages/support/docs/06-render-hooks.md
+++ b/packages/support/docs/06-render-hooks.md
@@ -53,7 +53,7 @@ FilamentView::registerRenderHook(
 - `panels::page.start` - Start of the page content container, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::resource.pages.list-records.tabs.after` - After the resource filter tabs, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::resource.pages.list-records.tabs.before` - Before the resource filter tabs, also [can be scoped](#scoping-render-hooks) to the page or resource class
-- `panels::resource.pages.list-records.tabs.end` - The end of the filter tabs (after the tab), also [can be scoped](#scoping-render-hooks) to the page or resource class
+- `panels::resource.pages.list-records.tabs.end` - The end of the filter tabs (after the last tab), also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::resource.pages.list-records.tabs.start` - The start of the filter tabs (before the first tab), also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::resource.pages.list-records.table.after` - After the resource table, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::resource.pages.list-records.table.before` - Before the resource table, also [can be scoped](#scoping-render-hooks) to the page or resource class

--- a/packages/support/docs/06-render-hooks.md
+++ b/packages/support/docs/06-render-hooks.md
@@ -51,6 +51,10 @@ FilamentView::registerRenderHook(
 - `panels::page.header-widgets.after` - After the page header widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::page.header-widgets.before` - Before the page header widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::page.start` - Start of the page content container, also [can be scoped](#scoping-render-hooks) to the page or resource class
+- `panels::resource.pages.list-records.filter-tabs.after` - After the resource filter tabs, also [can be scoped](#scoping-render-hooks) to the page or resource class
+- `panels::resource.pages.list-records.filter-tabs.before` - Before the resource filter tabs, also [can be scoped](#scoping-render-hooks) to the page or resource class
+- `panels::resource.pages.list-records.filter-tabs.end` - The end of the filter tabs (after the tab), also [can be scoped](#scoping-render-hooks) to the page or resource class
+- `panels::resource.pages.list-records.filter-tabs.start` - The start of the filter tabs (before the first tab), also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::resource.pages.list-records.table.after` - After the resource table, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::resource.pages.list-records.table.before` - Before the resource table, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::resource.relation-manager.after` - After the relation manager table, also [can be scoped](#scoping-render-hooks) to the page or relation manager class

--- a/packages/support/docs/06-render-hooks.md
+++ b/packages/support/docs/06-render-hooks.md
@@ -51,12 +51,12 @@ FilamentView::registerRenderHook(
 - `panels::page.header-widgets.after` - After the page header widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::page.header-widgets.before` - Before the page header widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::page.start` - Start of the page content container, also [can be scoped](#scoping-render-hooks) to the page or resource class
+- `panels::resource.pages.list-records.table.after` - After the resource table, also [can be scoped](#scoping-render-hooks) to the page or resource class
+- `panels::resource.pages.list-records.table.before` - Before the resource table, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::resource.pages.list-records.tabs.after` - After the resource filter tabs, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::resource.pages.list-records.tabs.before` - Before the resource filter tabs, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::resource.pages.list-records.tabs.end` - The end of the filter tabs (after the last tab), also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::resource.pages.list-records.tabs.start` - The start of the filter tabs (before the first tab), also [can be scoped](#scoping-render-hooks) to the page or resource class
-- `panels::resource.pages.list-records.table.after` - After the resource table, also [can be scoped](#scoping-render-hooks) to the page or resource class
-- `panels::resource.pages.list-records.table.before` - Before the resource table, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `panels::resource.relation-manager.after` - After the relation manager table, also [can be scoped](#scoping-render-hooks) to the page or relation manager class
 - `panels::resource.relation-manager.before` - Before the relation manager table, also [can be scoped](#scoping-render-hooks) to the page or relation manager class
 - `panels::scripts.after` - After scripts are defined


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Add four new render hooks to filter tabs.

`panels::resource.pages.list-records.filter-tabs.before` - Before the tabs
`panels::resource.pages.list-records.filter-tabs.start` - Start of the tabs (before the first tab)
`panels::resource.pages.list-records.filter-tabs.end` - End of the tabs (after the last tab)
`panels::resource.pages.list-records.filter-tabs.after` - After the tabs

![image](https://github.com/filamentphp/filament/assets/14329460/cfb45a2c-81ab-4a15-832e-00a855a9317a)

<img width="501" alt="image" src="https://github.com/filamentphp/filament/assets/14329460/88be535f-433a-4101-aa48-21be5eff502c">


<details>
  <summary>ps: If we define only one render hook before/ after the tabs, the whole group (filter tabs + rendered hook) will be centered on the page, causing a visual misalignment when only looking at the filter tabs. I can't find a good way around this, maybe @zepfietje  can have a look :)</summary>
  
  <img width="1280" alt="image" src="https://github.com/filamentphp/filament/assets/14329460/3ab7947b-fa86-4d78-b045-32dc1af24ec1">
</details>