### PR TITLE
Increase HtmlSanitizer MaxInputLength

### DIFF
--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -69,7 +69,8 @@ class SupportServiceProvider extends PackageServiceProvider
                 (new HtmlSanitizerConfig())
                     ->allowSafeElements()
                     ->allowAttribute('class', allowedElements: '*')
-                    ->allowAttribute('style', allowedElements: '*'),
+                    ->allowAttribute('style', allowedElements: '*')
+                    ->withMaxInputLength(200000),
             ),
         );
     }


### PR DESCRIPTION
The default for HtmlSanitizer is 20,000 characters. This is causing long docs in the new site to be truncated. This PR increases the character to 200,000

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
