### PR TITLE
Docs - input mask with RawJs

### DIFF
--- a/packages/forms/docs/03-fields/02-text-input.md
+++ b/packages/forms/docs/03-fields/02-text-input.md
@@ -166,7 +166,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Support\RawJs;
 
 TextInput::make('cardNumber')
-    ->mask(RawJs::make(<<<JS
+    ->mask(RawJs::make(<<<'JS'
         $input.startsWith('34') || $input.startsWith('37') ? '9999 999999 99999' : '9999 9999 9999 9999'
     JS))
 ```


### PR DESCRIPTION
single quotes missed

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
