### PR TITLE
Increase maxInputLength again

### DIFF
--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -71,7 +71,7 @@ class SupportServiceProvider extends PackageServiceProvider
                     ->allowRelativeLinks()
                     ->allowAttribute('class', allowedElements: '*')
                     ->allowAttribute('style', allowedElements: '*')
-                    ->withMaxInputLength(200000),
+                    ->withMaxInputLength(500000),
             ),
         );
     }


### PR DESCRIPTION
Turns out 200,000 isn't enough! 300,000 works for my docs, but bumping to 500,000 just to be safe. 

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
