### PR TITLE
fix new global search render hooks(before,after)

### DIFF
--- a/packages/panels/resources/views/components/global-search/index.blade.php
+++ b/packages/panels/resources/views/components/global-search/index.blade.php
@@ -1,4 +1,3 @@
-
 <div class="fi-global-search flex items-center">
     {{ \Filament\Support\Facades\FilamentView::renderHook('panels::global-search.start') }}
 
@@ -14,4 +13,3 @@
 
     {{ \Filament\Support\Facades\FilamentView::renderHook('panels::global-search.end') }}
 </div>
-

--- a/packages/panels/resources/views/components/global-search/index.blade.php
+++ b/packages/panels/resources/views/components/global-search/index.blade.php
@@ -1,4 +1,3 @@
-{{ \Filament\Support\Facades\FilamentView::renderHook('panels::global-search.before') }}
 
 <div class="fi-global-search flex items-center">
     {{ \Filament\Support\Facades\FilamentView::renderHook('panels::global-search.start') }}
@@ -16,4 +15,3 @@
     {{ \Filament\Support\Facades\FilamentView::renderHook('panels::global-search.end') }}
 </div>
 
-{{ \Filament\Support\Facades\FilamentView::renderHook('panels::global-search.after') }}

--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -119,13 +119,13 @@
             {{-- x-persist="topbar.end" --}}
             class="ms-auto flex items-center gap-x-4"
         >
+            {{ \Filament\Support\Facades\FilamentView::renderHook('panels::global-search.before') }}
+
             @if (filament()->isGlobalSearchEnabled())
-                {{ \Filament\Support\Facades\FilamentView::renderHook('panels::global-search.before') }}
-
                 @livewire(Filament\Livewire\GlobalSearch::class, ['lazy' => true])
-
-                {{ \Filament\Support\Facades\FilamentView::renderHook('panels::global-search.after') }}
             @endif
+
+            {{ \Filament\Support\Facades\FilamentView::renderHook('panels::global-search.after') }}
 
             @if (filament()->hasDatabaseNotifications())
                 @livewire(Filament\Livewire\DatabaseNotifications::class, ['lazy' => true])

--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -120,7 +120,11 @@
             class="ms-auto flex items-center gap-x-4"
         >
             @if (filament()->isGlobalSearchEnabled())
+                {{ \Filament\Support\Facades\FilamentView::renderHook('panels::global-search.before') }}
+
                 @livewire(Filament\Livewire\GlobalSearch::class, ['lazy' => true])
+
+                {{ \Filament\Support\Facades\FilamentView::renderHook('panels::global-search.after') }}
             @endif
 
             @if (filament()->hasDatabaseNotifications())


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

They can be added either inside the `@if (filament()->isGlobalSearchEnabled())` check or outside. 
I prefer them to be outside so even if the global search is not enabled these hooks can be used. Just a thought