### PR TITLE
Allow spatie/invade 2.x

### DIFF
--- a/packages/support/composer.json
+++ b/packages/support/composer.json
@@ -18,7 +18,7 @@
         "livewire/livewire": "^3.0",
         "ryangjchandler/blade-capture-directive": "^0.2|^0.3",
         "spatie/color": "^1.5",
-        "spatie/invade": "^1.0",
+        "spatie/invade": "^1.0|^2.0",
         "spatie/laravel-package-tools": "^1.9",
         "symfony/html-sanitizer": "^6.1"
     },


### PR DESCRIPTION
- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Trying to keep packages up to date.
Based on the `spatie/invade` [v2 change log](https://github.com/spatie/invade/releases/tag/2.0.0) it should be fine.