### PR TITLE
Bump Rector in upgrade script to 0.17

### DIFF
--- a/packages/upgrade/composer.json
+++ b/packages/upgrade/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^8.1",
         "nunomaduro/termwind": "^1.0",
-        "rector/rector": "^0.15"
+        "rector/rector": "^0.17"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This pull requests increases Rector version constraint in upgrade script (`packages/upgrade`) from `^0.15` to `^0.17` (latest at the time of this PR).

- [x] Changes have been thoroughly tested to not break existing functionality.

Test in `packages/upgrade/` directory:

```shell
cd filament/packages/upgrade/
./vendor/bin/rector process src --dry-run --config src/rector.php
                                                                                                                        
 [OK] Rector is done!                                                                                                   
                                                                                                                        
```