### PR TITLE
Support getting manager instance of a specific panel

### DIFF
--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -45,7 +45,7 @@ class FilamentManager
 
     protected ?Model $tenant = null;
 
-    public function panel(Panel $panel)
+    public function panel(Panel $panel): Panel
     {
         return tap(new static)->setCurrentPanel($panel);
     }

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -45,6 +45,11 @@ class FilamentManager
 
     protected ?Model $tenant = null;
 
+    public function panel(Panel $panel)
+    {
+        return tap(new static)->setCurrentPanel($panel);
+    }
+
     public function auth(): Guard
     {
         return $this->getCurrentPanel()->auth();


### PR DESCRIPTION
- [X] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This provides access to FilamentManager methods related to other panels.

For instance:
```php
// Check if specific panel has registration.
Filament::panel(Filament::getPanel('customer'))->hasRegistration();

// Get password reset url of another panel.
// Useful if you create an action to send password reset email to users that can access to another panel.
Filament::panel(Filament::getPanel('customer'))->getResetPasswordUrl();
```