### PR TITLE
Fix globally configuring filters layout

### DIFF
--- a/packages/tables/src/Table/Concerns/HasFilters.php
+++ b/packages/tables/src/Table/Concerns/HasFilters.php
@@ -51,8 +51,10 @@ trait HasFilters
             $this->filters[$filter->getName()] = $filter;
         }
 
-        $this->filtersLayout($layout);
-
+        if($layout !== null) {
+            $this->filtersLayout($layout);
+        }
+        
         return $this;
     }
 

--- a/packages/tables/src/Table/Concerns/HasFilters.php
+++ b/packages/tables/src/Table/Concerns/HasFilters.php
@@ -51,7 +51,7 @@ trait HasFilters
             $this->filters[$filter->getName()] = $filter;
         }
 
-        if($layout !== null) {
+        if ($layout) {
             $this->filtersLayout($layout);
         }
         


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.

**Fix: overwriting filters layout when it's not configured in component/resource table builder**

This issue overwrites the filter layout when nothing is configured in the component/resource table builder.

For example: when we try to set a global filter layout in a service provider using Table::configureUsing, it gets overwritten.