### PR TITLE
Update CanManipulateFiles.php (WINDOWS)

### DIFF
--- a/packages/support/src/Commands/Concerns/CanManipulateFiles.php
+++ b/packages/support/src/Commands/Concerns/CanManipulateFiles.php
@@ -57,8 +57,7 @@ trait CanManipulateFiles
         $filesystem = app(Filesystem::class);
 
         $filesystem->ensureDirectoryExists(
-            (string) str($path)
-                ->beforeLast('/'),
+            pathinfo($path, PATHINFO_DIRNAME),
         );
 
         $filesystem->put($path, $contents);


### PR DESCRIPTION
I was creating a theme in Windows and I got errors when creating the files because of the ensureDirectoryExists function. It was checking the last '/' but in WIndows this was a '\' but not always, otherwise you could have used the DIRECTORY_SEPERATOR constant. This fix is better using the pathinfo PHP function

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
