### PR TITLE
Return suggestions when the $type is not set on SpatieTagsInput

### DIFF
--- a/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
+++ b/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
@@ -66,8 +66,7 @@ class SpatieTagsInput extends TagsInput
         return $tagClass::query()
             ->when(
                 filled($type),
-                fn (Builder $query) => $query->where('type', $type),
-                fn (Builder $query) => $query->where('type', null),
+                fn (Builder $query) => $query->where('type', $type)
             )
             ->pluck('name')
             ->toArray();


### PR DESCRIPTION
If there is no type set on the SpatieTagsInput component and tags records have types, the suggestions do not work. This is because the suggestions query adds a condition that a type should be NULL if it is not set. By removing this condition, the suggestions always return all types if no type is set. I believe this is the correct behaviour.

- [X] Changes have been thoroughly tested to not break existing functionality.
- [X] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
