### PR TITLE
Fix current tenant avatar styling

### DIFF
--- a/packages/panels/resources/views/components/avatar/tenant.blade.php
+++ b/packages/panels/resources/views/components/avatar/tenant.blade.php
@@ -6,6 +6,6 @@
     :src="filament()->getTenantAvatarUrl($tenant)"
     :attributes="
         \Filament\Support\prepare_inherited_attributes($attributes)
-            ->class(['fi-tenant-avatar rounded-md'])
+            ->class(['fi-tenant-avatar rounded-md shrink-0'])
     "
 />

--- a/packages/panels/resources/views/components/tenant-menu.blade.php
+++ b/packages/panels/resources/views/components/tenant-menu.blade.php
@@ -74,7 +74,7 @@
                 icon="heroicon-m-chevron-down"
                 icon-alias="panels::tenant-menu.toggle-button"
                 :x-show="filament()->isSidebarCollapsibleOnDesktop() ? '$store.sidebar.isOpen' : null"
-                class="ms-auto h-5 w-5 text-gray-400 transition duration-75 group-hover:text-gray-500 group-focus:text-gray-500 dark:text-gray-500 dark:group-hover:text-gray-400 dark:group-focus:text-gray-400 shrink-0"
+                class="ms-auto h-5 w-5 shrink-0 text-gray-400 transition duration-75 group-hover:text-gray-500 group-focus:text-gray-500 dark:text-gray-500 dark:group-hover:text-gray-400 dark:group-focus:text-gray-400"
             />
         </button>
     </x-slot>

--- a/packages/panels/resources/views/components/tenant-menu.blade.php
+++ b/packages/panels/resources/views/components/tenant-menu.blade.php
@@ -57,7 +57,7 @@
                 @if (filament()->isSidebarCollapsibleOnDesktop())
                     x-show="$store.sidebar.isOpen"
                 @endif
-                class="grid justify-items-start"
+                class="grid justify-items-start text-start"
             >
                 @if ($currentTenant instanceof \Filament\Models\Contracts\HasCurrentTenantLabel)
                     <span class="text-xs text-gray-500 dark:text-gray-400">
@@ -74,7 +74,7 @@
                 icon="heroicon-m-chevron-down"
                 icon-alias="panels::tenant-menu.toggle-button"
                 :x-show="filament()->isSidebarCollapsibleOnDesktop() ? '$store.sidebar.isOpen' : null"
-                class="ms-auto h-5 w-5 text-gray-400 transition duration-75 group-hover:text-gray-500 group-focus:text-gray-500 dark:text-gray-500 dark:group-hover:text-gray-400 dark:group-focus:text-gray-400"
+                class="ms-auto h-5 w-5 text-gray-400 transition duration-75 group-hover:text-gray-500 group-focus:text-gray-500 dark:text-gray-500 dark:group-hover:text-gray-400 dark:group-focus:text-gray-400 shrink-0"
             />
         </button>
     </x-slot>


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Tenant avatar is not styling correctly when current tenant name/label is long.

Before:
<img width="309" alt="Screenshot 2023-08-02 at 7 43 46 PM" src="https://github.com/filamentphp/filament/assets/315603/95149196-7f69-4f31-9bad-7bb02c53f1ad">

After:
<img width="304" alt="Screenshot 2023-08-02 at 7 44 18 PM" src="https://github.com/filamentphp/filament/assets/315603/c598b1d2-8ec7-4467-be9b-6b2a60a833b7">
