### PR TITLE
Fix/issue 7093

### DIFF
--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -181,7 +181,7 @@
                                     ->merge([
                                         'disabled' => $isDisabled,
                                         'value' => $value,
-                                        'wire:loading.attr' => 'readonly',
+                                        'wire:loading.attr' => 'disabled',
                                         $applyStateBindingModifiers('wire:model') => $statePath,
                                         'x-on:change' => $isBulkToggleable ? 'checkIfAllCheckboxesAreChecked()' : null,
                                     ], escape: false)

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -181,7 +181,7 @@
                                     ->merge([
                                         'disabled' => $isDisabled,
                                         'value' => $value,
-                                        'wire:loading.attr' => 'disabled',
+                                        'wire:loading.attr' => 'readonly',
                                         $applyStateBindingModifiers('wire:model') => $statePath,
                                         'x-on:change' => $isBulkToggleable ? 'checkIfAllCheckboxesAreChecked()' : null,
                                     ], escape: false)

--- a/packages/forms/resources/views/components/checkbox.blade.php
+++ b/packages/forms/resources/views/components/checkbox.blade.php
@@ -13,7 +13,7 @@
                         'disabled' => $isDisabled(),
                         'id' => $getId(),
                         'required' => $isRequired() && (! $isConcealed()),
-                        'wire:loading.attr' => 'disabled',
+                        'wire:loading.attr' => 'readonly',
                         $applyStateBindingModifiers('wire:model') => $statePath,
                     ], escape: false)
                     ->merge($getExtraAttributes(), escape: false)

--- a/packages/forms/resources/views/components/checkbox.blade.php
+++ b/packages/forms/resources/views/components/checkbox.blade.php
@@ -13,7 +13,7 @@
                         'disabled' => $isDisabled(),
                         'id' => $getId(),
                         'required' => $isRequired() && (! $isConcealed()),
-                        'wire:loading.attr' => 'readonly',
+                        'wire:loading.attr' => 'disabled',
                         $applyStateBindingModifiers('wire:model') => $statePath,
                     ], escape: false)
                     ->merge($getExtraAttributes(), escape: false)

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -44,7 +44,7 @@
                             name="{{ $id }}"
                             type="radio"
                             value="{{ $value }}"
-                            wire:loading.attr="disabled"
+                            wire:loading.attr="readonly"
                             {{ $applyStateBindingModifiers('wire:model') }}="{{ $statePath }}"
                             {{
                                 $getExtraInputAttributeBag()

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -44,7 +44,7 @@
                             name="{{ $id }}"
                             type="radio"
                             value="{{ $value }}"
-                            wire:loading.attr="readonly"
+                            wire:loading.attr="disabled"
                             {{ $applyStateBindingModifiers('wire:model') }}="{{ $statePath }}"
                             {{
                                 $getExtraInputAttributeBag()

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -41,7 +41,7 @@
                         'id' => $getId(),
                         'role' => 'switch',
                         'type' => 'button',
-                        'wire:loading.attr' => 'disabled',
+                        'wire:loading.attr' => 'readonly',
                     ], escape: false)
                     ->merge($getExtraAttributes(), escape: false)
                     ->merge($getExtraAlpineAttributes(), escape: false)

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -41,7 +41,7 @@
                         'id' => $getId(),
                         'role' => 'switch',
                         'type' => 'button',
-                        'wire:loading.attr' => 'readonly',
+                        'wire:loading.attr' => 'disabled',
                     ], escape: false)
                     ->merge($getExtraAttributes(), escape: false)
                     ->merge($getExtraAlpineAttributes(), escape: false)


### PR DESCRIPTION
This PR includes the fixes for the issue https://github.com/filamentphp/filament/issues/7093, Livewire wire:loading.attr = "disabled" overrides disabled which is used dynamically which results in the toggle components on the view user screen become toggleable.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
