### PR TITLE
Fix Select with ->multiple() not firing afterStateUpdated event

### DIFF
--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -3,6 +3,7 @@
 namespace Filament\Forms\Concerns;
 
 use Filament\Forms\Components\BaseFileUpload;
+use Filament\Forms\Components\Select;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 
@@ -33,6 +34,16 @@ trait HasState
             }
 
             if ($component instanceof BaseFileUpload && str($path)->startsWith("{$component->getStatePath()}.")) {
+                $component->callAfterStateUpdated();
+
+                return true;
+            }
+
+            if (
+                $component instanceof Select &&
+                $component->isMultiple() &&
+                str($path)->startsWith("{$component->getStatePath()}.")
+            ) {
                 $component->callAfterStateUpdated();
 
                 return true;

--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -33,7 +33,10 @@ trait HasState
                 return true;
             }
 
-            if ($component instanceof BaseFileUpload && str($path)->startsWith("{$component->getStatePath()}.")) {
+            if (
+                $component instanceof BaseFileUpload &&
+                str($path)->startsWith("{$component->getStatePath()}.")
+            ) {
                 $component->callAfterStateUpdated();
 
                 return true;


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

I found that `->afterStateUpdated` was not being fired on a `Select` with `->multiple()` enabled. 

I noticed that the `$statePath` was set to `{$name}.0`, `{$name}.1`, etc, depending on which item got removed or added from the multi-select, therefor not firing.

`BaseFileUpload` had the same solution, so I based my solution on that.