### PR TITLE
Multiple domains per panel

### DIFF
--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -6,6 +6,7 @@ use Filament\Http\Controllers\Auth\LogoutController;
 use Filament\Http\Controllers\RedirectToHomeController;
 use Filament\Http\Controllers\RedirectToTenantController;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Arr;
 
 Route::name('filament.')
     ->group(function () {
@@ -15,117 +16,119 @@ Route::name('filament.')
             $hasTenancy = $panel->hasTenancy();
             $tenantSlugAttribute = $panel->getTenantSlugAttribute();
 
-            Route::domain($panel->getDomain())
-                ->middleware($panel->getMiddleware())
-                ->name("{$panelId}.")
-                ->prefix($panel->getPath())
-                ->group(function () use ($panel, $hasTenancy, $tenantSlugAttribute) {
-                    Route::name('auth.')->group(function () use ($panel) {
-                        if ($panel->hasLogin()) {
-                            Route::get('/login', $panel->getLoginRouteAction())->name('login');
-                        }
-
-                        if ($panel->hasPasswordReset()) {
-                            Route::name('password-reset.')
-                                ->prefix('/password-reset')
-                                ->group(function () use ($panel) {
-                                    Route::get('/request', $panel->getRequestPasswordResetRouteAction())->name('request');
-                                    Route::get('/reset', $panel->getResetPasswordRouteAction())
-                                        ->middleware(['signed'])
-                                        ->name('reset');
-                                });
-                        }
-
-                        if ($panel->hasRegistration()) {
-                            Route::get('/register', $panel->getRegistrationRouteAction())->name('register');
-                        }
-                    });
-
-                    Route::middleware($panel->getAuthMiddleware())
-                        ->group(function () use ($panel, $hasTenancy, $tenantSlugAttribute): void {
-                            if ($hasTenancy) {
-                                Route::get('/', RedirectToTenantController::class)->name('tenant');
+            foreach (Arr::wrap($panel->getDomain()) as $domain) {
+                Route::domain($domain)
+                    ->middleware($panel->getMiddleware())
+                    ->name("{$panelId}.")
+                    ->prefix($panel->getPath())
+                    ->group(function () use ($panel, $hasTenancy, $tenantSlugAttribute) {
+                        Route::name('auth.')->group(function () use ($panel) {
+                            if ($panel->hasLogin()) {
+                                Route::get('/login', $panel->getLoginRouteAction())->name('login');
                             }
 
-                            Route::name('auth.')
-                                ->group(function () use ($panel): void {
-                                    Route::post('/logout', LogoutController::class)->name('logout');
-
-                                    if ($panel->hasProfile()) {
-                                        $panel->getProfilePage()::routes($panel);
-                                    }
-                                });
-
-                            if ($panel->hasEmailVerification()) {
-                                Route::name('auth.email-verification.')
-                                    ->prefix('/email-verification')
+                            if ($panel->hasPasswordReset()) {
+                                Route::name('password-reset.')
+                                    ->prefix('/password-reset')
                                     ->group(function () use ($panel) {
-                                        Route::get('/prompt', $panel->getEmailVerificationPromptRouteAction())->name('prompt');
-                                        Route::get('/verify', EmailVerificationController::class)
+                                        Route::get('/request', $panel->getRequestPasswordResetRouteAction())->name('request');
+                                        Route::get('/reset', $panel->getResetPasswordRouteAction())
                                             ->middleware(['signed'])
-                                            ->name('verify');
+                                            ->name('reset');
                                     });
                             }
 
-                            Route::name('tenant.')
-                                ->group(function () use ($panel): void {
-                                    if ($panel->hasTenantRegistration()) {
-                                        $panel->getTenantRegistrationPage()::routes($panel);
-                                    }
-                                });
-
-                            if ($routes = $panel->getAuthenticatedRoutes()) {
-                                $routes($panel);
+                            if ($panel->hasRegistration()) {
+                                Route::get('/register', $panel->getRegistrationRouteAction())->name('register');
                             }
+                        });
 
-                            Route::middleware($hasTenancy ? $panel->getTenantMiddleware() : [])
-                                ->prefix($hasTenancy ? ('{tenant' . (($tenantSlugAttribute) ? ":{$tenantSlugAttribute}" : '') . '}') : '')
+                        Route::middleware($panel->getAuthMiddleware())
+                            ->group(function () use ($panel, $hasTenancy, $tenantSlugAttribute): void {
+                                if ($hasTenancy) {
+                                    Route::get('/', RedirectToTenantController::class)->name('tenant');
+                                }
+
+                                Route::name('auth.')
+                                    ->group(function () use ($panel): void {
+                                        Route::post('/logout', LogoutController::class)->name('logout');
+
+                                        if ($panel->hasProfile()) {
+                                            $panel->getProfilePage()::routes($panel);
+                                        }
+                                    });
+
+                                if ($panel->hasEmailVerification()) {
+                                    Route::name('auth.email-verification.')
+                                        ->prefix('/email-verification')
+                                        ->group(function () use ($panel) {
+                                            Route::get('/prompt', $panel->getEmailVerificationPromptRouteAction())->name('prompt');
+                                            Route::get('/verify', EmailVerificationController::class)
+                                                ->middleware(['signed'])
+                                                ->name('verify');
+                                        });
+                                }
+
+                                Route::name('tenant.')
+                                    ->group(function () use ($panel): void {
+                                        if ($panel->hasTenantRegistration()) {
+                                            $panel->getTenantRegistrationPage()::routes($panel);
+                                        }
+                                    });
+
+                                if ($routes = $panel->getAuthenticatedRoutes()) {
+                                    $routes($panel);
+                                }
+
+                                Route::middleware($hasTenancy ? $panel->getTenantMiddleware() : [])
+                                    ->prefix($hasTenancy ? ('{tenant' . (($tenantSlugAttribute) ? ":{$tenantSlugAttribute}" : '') . '}') : '')
+                                    ->group(function () use ($panel): void {
+                                        Route::get('/', RedirectToHomeController::class)->name('home');
+
+                                        Route::name('tenant.')->group(function () use ($panel): void {
+                                            if ($panel->hasTenantBilling()) {
+                                                Route::get('/billing', $panel->getTenantBillingProvider()->getRouteAction())
+                                                    ->name('billing');
+                                            }
+
+                                            if ($panel->hasTenantProfile()) {
+                                                $panel->getTenantProfilePage()::routes($panel);
+                                            }
+                                        });
+
+                                        Route::name('pages.')->group(function () use ($panel): void {
+                                            foreach ($panel->getPages() as $page) {
+                                                $page::routes($panel);
+                                            }
+                                        });
+
+                                        Route::name('resources.')->group(function () use ($panel): void {
+                                            foreach ($panel->getResources() as $resource) {
+                                                $resource::routes($panel);
+                                            }
+                                        });
+
+                                        if ($routes = $panel->getAuthenticatedTenantRoutes()) {
+                                            $routes($panel);
+                                        }
+                                    });
+
+                            });
+
+                        if ($hasTenancy) {
+                            Route::middleware($panel->getTenantMiddleware())
+                                ->prefix('{tenant' . (($tenantSlugAttribute) ? ":{$tenantSlugAttribute}" : '') . '}')
                                 ->group(function () use ($panel): void {
-                                    Route::get('/', RedirectToHomeController::class)->name('home');
-
-                                    Route::name('tenant.')->group(function () use ($panel): void {
-                                        if ($panel->hasTenantBilling()) {
-                                            Route::get('/billing', $panel->getTenantBillingProvider()->getRouteAction())
-                                                ->name('billing');
-                                        }
-
-                                        if ($panel->hasTenantProfile()) {
-                                            $panel->getTenantProfilePage()::routes($panel);
-                                        }
-                                    });
-
-                                    Route::name('pages.')->group(function () use ($panel): void {
-                                        foreach ($panel->getPages() as $page) {
-                                            $page::routes($panel);
-                                        }
-                                    });
-
-                                    Route::name('resources.')->group(function () use ($panel): void {
-                                        foreach ($panel->getResources() as $resource) {
-                                            $resource::routes($panel);
-                                        }
-                                    });
-
-                                    if ($routes = $panel->getAuthenticatedTenantRoutes()) {
+                                    if ($routes = $panel->getTenantRoutes()) {
                                         $routes($panel);
                                     }
                                 });
+                        }
 
-                        });
-
-                    if ($hasTenancy) {
-                        Route::middleware($panel->getTenantMiddleware())
-                            ->prefix('{tenant' . (($tenantSlugAttribute) ? ":{$tenantSlugAttribute}" : '') . '}')
-                            ->group(function () use ($panel): void {
-                                if ($routes = $panel->getTenantRoutes()) {
-                                    $routes($panel);
-                                }
-                            });
-                    }
-
-                    if ($routes = $panel->getRoutes()) {
-                        $routes($panel);
-                    }
-                });
+                        if ($routes = $panel->getRoutes()) {
+                            $routes($panel);
+                        }
+                    });
+            }
         }
     });

--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -5,7 +5,6 @@ use Filament\Http\Controllers\Auth\EmailVerificationController;
 use Filament\Http\Controllers\Auth\LogoutController;
 use Filament\Http\Controllers\RedirectToHomeController;
 use Filament\Http\Controllers\RedirectToTenantController;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Route;
 
 Route::name('filament.')
@@ -16,7 +15,7 @@ Route::name('filament.')
             $hasTenancy = $panel->hasTenancy();
             $tenantSlugAttribute = $panel->getTenantSlugAttribute();
 
-            foreach (Arr::wrap($panel->getDomain()) as $domain) {
+            foreach ($panel->getDomains() as $domain) {
                 Route::domain($domain)
                     ->middleware($panel->getMiddleware())
                     ->name("{$panelId}.")

--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -14,8 +14,9 @@ Route::name('filament.')
             $panelId = $panel->getId();
             $hasTenancy = $panel->hasTenancy();
             $tenantSlugAttribute = $panel->getTenantSlugAttribute();
+            $domains = $panel->getDomains();
 
-            foreach ($panel->getDomains() as $domain) {
+            foreach ((empty($domains) ? [null] : $domains) as $domain) {
                 Route::domain($domain)
                     ->middleware($panel->getMiddleware())
                     ->name("{$panelId}.")

--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -5,8 +5,8 @@ use Filament\Http\Controllers\Auth\EmailVerificationController;
 use Filament\Http\Controllers\Auth\LogoutController;
 use Filament\Http\Controllers\RedirectToHomeController;
 use Filament\Http\Controllers\RedirectToTenantController;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Route;
 
 Route::name('filament.')
     ->group(function () {

--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -21,9 +21,9 @@ trait HasRoutes
     protected string | Closure | null $homeUrl = null;
 
     /**
-     * @var string|array<string>|null
+     * @var array<string>
      */
-    protected string | array | null $domain = null;
+    protected array $domains = [null];
 
     protected string $path = '';
 
@@ -34,17 +34,24 @@ trait HasRoutes
         return $this;
     }
 
-    /**
-     * @param  string|array<string>|null  $domain
-     */
-    public function domain(string | array | null $domain = null): static
+    public function domain(?string $domain): static
     {
-        $this->domain = $domain;
+        $this->domains(filled($domain) ? [$domain] : []);
 
         return $this;
     }
 
-    public function homeUrl(string | Closure | null $url = null): static
+    /**
+     * @param array<string> $domains
+     */
+    public function domains(array $domains): static
+    {
+        $this->domains = $domain;
+
+        return $this;
+    }
+
+    public function homeUrl(string | Closure | null $url): static
     {
         $this->homeUrl = $url;
 
@@ -109,9 +116,7 @@ trait HasRoutes
      */
     public function getDomains(): array
     {
-        return is_null($this->domain)
-            ? [null]
-            : Arr::wrap($this->domain);
+        return Arr::wrap($this->domains);
     }
 
     public function getPath(): string

--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -42,7 +42,7 @@ trait HasRoutes
     }
 
     /**
-     * @param array<string> $domains
+     * @param  array<string>  $domains
      */
     public function domains(array $domains): static
     {

--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -20,6 +20,9 @@ trait HasRoutes
 
     protected string | Closure | null $homeUrl = null;
 
+    /**
+     * @var string|array<string>|null
+     */
     protected string | array | null $domain = null;
 
     protected string $path = '';
@@ -31,6 +34,9 @@ trait HasRoutes
         return $this;
     }
 
+    /**
+     * @param string|array<string>|null $domain
+     */
     public function domain(string | array | null $domain = null): static
     {
         $this->domain = $domain;
@@ -98,6 +104,9 @@ trait HasRoutes
         return $this->evaluate($this->homeUrl);
     }
 
+    /**
+     * @return string|array<string>|null
+     */
     public function getDomain(): string | array | null
     {
         return $this->domain;

--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -35,7 +35,7 @@ trait HasRoutes
     }
 
     /**
-     * @param string|array<string>|null $domain
+     * @param  string|array<string>|null  $domain
      */
     public function domain(string | array | null $domain = null): static
     {

--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -105,11 +105,13 @@ trait HasRoutes
     }
 
     /**
-     * @return string|array<string>|null
+     * @return array<string>
      */
-    public function getDomain(): string | array | null
+    public function getDomains(): array
     {
-        return $this->domain;
+        return is_null($this->domain)
+            ? [null]
+            : Arr::wrap($this->domain);
     }
 
     public function getPath(): string

--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -23,7 +23,7 @@ trait HasRoutes
     /**
      * @var array<string>
      */
-    protected array $domains = [null];
+    protected array $domains = [];
 
     protected string $path = '';
 
@@ -46,7 +46,7 @@ trait HasRoutes
      */
     public function domains(array $domains): static
     {
-        $this->domains = $domain;
+        $this->domains = $domains;
 
         return $this;
     }

--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -20,7 +20,7 @@ trait HasRoutes
 
     protected string | Closure | null $homeUrl = null;
 
-    protected ?string $domain = null;
+    protected string | array | null $domain = null;
 
     protected string $path = '';
 
@@ -31,7 +31,7 @@ trait HasRoutes
         return $this;
     }
 
-    public function domain(?string $domain = null): static
+    public function domain(string | array | null $domain = null): static
     {
         $this->domain = $domain;
 
@@ -98,7 +98,7 @@ trait HasRoutes
         return $this->evaluate($this->homeUrl);
     }
 
-    public function getDomain(): ?string
+    public function getDomain(): string | array | null
     {
         return $this->domain;
     }


### PR DESCRIPTION
Currently `->domain()` supports only a single domain. For stuff like multi-tenancy it's useful to provide an array. E.g. showing a panel to tenants only. 

With this PR `->domain()` will accept an array of domain.

Need feedback for:
- Should we introduce `->domains()` instead of allowing an array here. But that would clutter the class.
- I renamed `getDomain()` to `getDomains()` to reflect the return value. The method is public so this could already be a breaking change, although we only use it for web.php