### PR TITLE
Update 09-configuration.md - Ensure Absence of Conflicting Route in web.php

### DIFF
--- a/packages/panels/docs/09-configuration.md
+++ b/packages/panels/docs/09-configuration.md
@@ -60,6 +60,8 @@ public function panel(Panel $panel): Panel
 }
 ```
 
+Make sure your `web.php` file doesn't already define the `''` or `'/'` route, as it will take presedence. 
+
 ## Render hooks
 
 [Render hooks](../support/render-hooks) allow you to render Blade content at various points in the framework views. You can [register global render hooks](../support/render-hooks#registering-render-hooks) in a service provider or middleware, but it also allows you to register render hooks that are specific to a panel. To do that, you can use the `renderHook()` method on the panel configuration object. Here's an example, integrating [`wire-elements/modal`](https://github.com/wire-elements/modal) with Filament:

--- a/packages/panels/docs/09-configuration.md
+++ b/packages/panels/docs/09-configuration.md
@@ -60,7 +60,7 @@ public function panel(Panel $panel): Panel
 }
 ```
 
-Make sure your `web.php` file doesn't already define the `''` or `'/'` route, as it will take presedence. 
+Make sure your `routes/web.php` file doesn't already define the `''` or `'/'` route, as it will take precedence.
 
 ## Render hooks
 


### PR DESCRIPTION
Add note regarding the web.php file taking precedence in case of clash of path.

- [✓] Changes have been thoroughly tested to not break existing functionality.
- [N/A] New functionality has been documented or existing documentation has been updated to reflect changes.
- [N/A] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Just spent half an hour figuring out why 

```PHP
$panel->path('')
```

wasn't working to realize that it was clashing with the default Laravel web.php file containing
```PHP
Route::get('/', function () {
    return view('welcome');
});
```

Hope this note will save someone else some time.
