### PR TITLE
Improve default state handling for boolean values

### DIFF
--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -85,6 +85,10 @@ trait HasState
 
     public function default(mixed $state): static
     {
+        if (is_bool($state)) {
+            $state = $state ? '1' : '0';
+        }
+
         $this->defaultState = $state;
         $this->hasDefaultState = true;
 

--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -85,10 +85,6 @@ trait HasState
 
     public function default(mixed $state): static
     {
-        if (is_bool($state)) {
-            $state = $state ? '1' : '0';
-        }
-
         $this->defaultState = $state;
         $this->hasDefaultState = true;
 

--- a/packages/forms/src/Components/Radio.php
+++ b/packages/forms/src/Components/Radio.php
@@ -113,4 +113,15 @@ class Radio extends Field
             'value' => $value,
         ]);
     }
+
+    public function getDefaultState(): mixed
+    {
+        $state = parent::getDefaultState();
+
+        if (is_bool($state)) {
+            return $state ? 1 : 0;
+        }
+
+        return $state;
+    }
 }

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -1172,4 +1172,15 @@ class Select extends Field implements Contracts\HasAffixActions, Contracts\HasNe
     {
         return (bool) $this->evaluate($this->isSearchForcedCaseInsensitive);
     }
+
+    public function getDefaultState(): mixed
+    {
+        $state = parent::getDefaultState();
+
+        if (is_bool($state)) {
+            return $state ? 1 : 0;
+        }
+
+        return $state;
+    }
 }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This commit modifies the `default()` method to correctly handle boolean values, enhancing usability and user experience. Prior to this change, passing a boolean value as a default state could cause unexpected behavior due to the JavaScript interpretation of booleans. This could lead to confusion for users expecting boolean values to be applied correctly.

Now, boolean values are explicitly converted to string '1' (for true) or '0' (for false), ensuring proper handling. This provides a more intuitive and predictable functionality for components using default boolean states, aligning with user expectations in the UI. The change thus enhances user experience.

Beforehand, applying a boolean value to the default state could cause unexpected issues for some fields - mostly the Select Field and fields with the `options([])` array:

```php
Forms\Components\Select::make('is_active')
          ->boolean('Yes', 'No')
          ->default('1'),
Forms\Components\Select::make('enabled')
          ->options([
                   '1' => 'Yes',
                   '0' => 'No',
           ])
           ->default(1),
Forms\Components\Select::make('is_company')
           ->boolean('Yes', 'No')
           ->default(true),
Forms\Components\Select::make('is_person')
           ->options([
                    true => 'Yes',
                    false => 'No',
           ])
           ->default(true),
Forms\Components\Select::make('entity')
           ->options([
                    'company' => 'Company',
                    'person' => 'Person',
          ])
          ->default('company'),
```

![Screenshot 2023-08-02 at 6 45 47 PM](https://github.com/filamentphp/filament/assets/104294090/8ef77c65-bcf1-434b-9189-1649b569ddf2)


Now a user can use all boolean accepted values instead of just an int or a string passed into the `default()` method:

![Screenshot 2023-08-02 at 6 50 12 PM](https://github.com/filamentphp/filament/assets/104294090/c4860d83-1749-4914-afe6-411b26a1c103)






