### PR TITLE
Fix typos and make minor language edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Filament is a collection of full-stack components for accelerated Laravel develo
 
 ### Panel Builder • [Documentation](https://filamentphp.com/docs/panels) • [Demo](https://demo.filamentphp.com)
 
-The panel builder is the foundation of Filament. Combining all the packages together, it allows you to quickly build a Laravel admin panels, customer-facing apps, Software-as-a-Service platforms, and more. Filament makes custom CRUD-driven interfaces feel like a breeze to build and deploy.
+The panel builder is the foundation of Filament. Combining all the packages together, it lets you quickly build Laravel admin panels, customer-facing apps, Software-as-a-Service platforms, and more. Filament makes custom CRUD-driven interfaces feel like a breeze to build and deploy.
 
 ```bash
 composer require filament/filament
@@ -39,7 +39,7 @@ composer require filament/tables
 
 ### Notifications • [Documentation](https://filamentphp.com/docs/notifications)
 
-An important part of any application is the ability to notify your users of important events. Our notifications package allows you to deliver flash notifications to users from any Livewire request, or even from your JavaScript frontend. In addition, it can fetch notifications from the database and render them in a beautiful slide-over modal, or even receive live notifications from a websockets server.
+An important part of any application is the ability to notify your users of important events. Our notifications package lets you deliver flash notifications to users from any Livewire request, or even from your JavaScript frontend. In addition, it can fetch notifications from the database and render them in a beautiful slide-over modal, or even receive live notifications from a websockets server.
 
 ```bash
 composer require filament/notifications
@@ -47,7 +47,7 @@ composer require filament/notifications
 
 ### Actions • [Documentation](https://filamentphp.com/docs/actions)
 
-Actions are buttons that can open modals. They are a very versatile component of many interfaces, avoiding the need for the user to navigate away from the page to complete a task. From confirming a destructive action, to editing an Eloquent record, to importing data from an uploaded CSV file, action modals are a great way to keep the user in the flow of the application. It is built upon our form builder, so it is builds upon the same principles of flexibility and extensibility. Modals can be added to any Livewire component with just a few lines of code, and no HTML or JavaScript.
+Actions are buttons that can open modals. They are a very versatile component of many interfaces, avoiding the need for the user to navigate away from the page to complete a task. From confirming a destructive action, to editing an Eloquent record, to importing data from an uploaded CSV file, action modals are a great way to keep the user in the flow of the application. Modals are built upon our form builder, so they are built upon the same principles of flexibility and extensibility. Modals can be added to any Livewire component with just a few lines of code, and no HTML or JavaScript.
 
 ```bash
 composer require filament/actions
@@ -63,7 +63,7 @@ composer require filament/infolists
 
 ### Widgets • [Documentation](https://filamentphp.com/docs/widgets)
 
-Filament's collection of widgets are built upon Livewire's core principles of real-time reactivity with the server. Combining many widgets allows you to quickly build a dashboard for your application, complete with charts and stats, which are able to update live without refreshing the page. They are also seamlessly integrated with any page in the panel builder.
+Filament's collection of widgets are built upon Livewire's core principles of real-time reactivity with the server. Combining many widgets lets you quickly build a dashboard for your application, complete with charts and stats, which are able to update live without refreshing the page. They are also seamlessly integrated with any page in the panel builder.
 
 ```bash
 composer require filament/widgets
@@ -71,7 +71,7 @@ composer require filament/widgets
 
 ## Contributing
 
-If you want to contribute to Filament packages, you may want to test it in a real Laravel project:
+If you want to contribute to the Filament packages, then you may want to test it in a real Laravel project:
 
 - Fork this repository to your GitHub account.
 - Create a Laravel app locally.


### PR DESCRIPTION
Fix a few typos and make minor language edits for clarity

"allows" is not wrong, but here "lets" is better (less formal) and easier to read.

"it is builds" is grammatically incorrect, so I edited for consistency with other parts of the document

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
