### PR TITLE
Add tenant related exceptions and update middleware

### DIFF
--- a/packages/panels/src/Exceptions/NonTenantModelException.php
+++ b/packages/panels/src/Exceptions/NonTenantModelException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Filament\Exceptions;
+
+use Exception;
+use Throwable;
+
+class NonTenantModelException extends Exception
+{
+    final public function __construct(string $message = '', int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public static function make(): static
+    {
+        return new static('The authenticated panel user is not an instance of HasTenants. Please ensure the model implements the HasTenants contract.');
+    }
+}

--- a/packages/panels/src/Exceptions/TenantAuthorizationException.php
+++ b/packages/panels/src/Exceptions/TenantAuthorizationException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Filament\Exceptions;
+
+use Exception;
+use Throwable;
+
+class TenantAuthorizationException extends Exception
+{
+    final public function __construct(string $message = '', int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public static function make(): static
+    {
+        return new static('User not allowed to access tenant.');
+    }
+}

--- a/packages/panels/src/Http/Middleware/IdentifyTenant.php
+++ b/packages/panels/src/Http/Middleware/IdentifyTenant.php
@@ -3,10 +3,12 @@
 namespace Filament\Http\Middleware;
 
 use Closure;
-use Filament\Facades\Filament;
-use Filament\Models\Contracts\HasTenants;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
+use Filament\Facades\Filament;
+use Illuminate\Database\Eloquent\Model;
+use Filament\Models\Contracts\HasTenants;
+use Filament\Exceptions\NonTenantModelException;
+use Filament\Exceptions\TenantAuthorizationException;
 
 class IdentifyTenant
 {
@@ -26,13 +28,13 @@ class IdentifyTenant
         $user = $panel->auth()->user();
 
         if (! $user instanceof HasTenants) {
-            abort(404);
+            throw new NonTenantModelException();
         }
 
         $tenant = $panel->getTenant($request->route()->parameter('tenant'));
 
         if (! $user->canAccessTenant($tenant)) {
-            abort(404);
+            throw new TenantAuthorizationException();
         }
 
         Filament::setTenant($tenant);


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation [has been updated to reflect changes](https://github.com/filamentphp/filament/pull/7458).
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Currently, an HTTP 404 error is used in place of the implementation errors that these new exceptions seek to address.

NonTenantModelException and TenantAuthorizationException make it easy to debug issues related to why tenancy may not work.

They each provide contextual information about specific tenancy implementation error and provides helpful note on how to fix them.