### PR TITLE
Dutch translations panels profile

### DIFF
--- a/packages/panels/resources/lang/nl/pages/auth/edit-profile.php
+++ b/packages/panels/resources/lang/nl/pages/auth/edit-profile.php
@@ -1,0 +1,51 @@
+<?php
+
+return [
+
+    'label' => 'Profiel',
+
+    'form' => [
+
+        'email' => [
+            'label' => 'E-mailadres',
+        ],
+
+        'name' => [
+            'label' => 'Naam',
+        ],
+
+        'password' => [
+            'label' => 'Nieuw wachtwoord',
+        ],
+
+        'password_confirmation' => [
+            'label' => 'Bevestig nieuw wachtwoord',
+        ],
+
+        'actions' => [
+
+            'save' => [
+                'label' => 'Opslaan',
+            ],
+
+        ],
+
+    ],
+
+    'notifications' => [
+
+        'saved' => [
+            'title' => 'Opgeslagen',
+        ],
+
+    ],
+
+    'actions' => [
+
+        'back' => [
+            'label' => 'terug',
+        ],
+
+    ],
+
+];

--- a/packages/panels/resources/lang/nl/pages/auth/login.php
+++ b/packages/panels/resources/lang/nl/pages/auth/login.php
@@ -30,7 +30,7 @@ return [
         ],
 
         'remember' => [
-            'label' => 'Herinner mij',
+            'label' => 'Onthoud mij',
         ],
 
         'actions' => [


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] (n/a) New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] (n/a) Visual changes are explained in the PR description using a screenshot/recording of before and after.
