### PR TITLE
Update Docs for conditionally showing a Nav Item

### DIFF
--- a/packages/panels/docs/06-navigation.md
+++ b/packages/panels/docs/06-navigation.md
@@ -206,9 +206,9 @@ You can also conditionally hide a navigation item by using the `visible()` or `h
 use Filament\Navigation\NavigationItem;
 
 NavigationItem::make('Analytics')
-    ->visible(auth()->user()->can('view-analytics'))
+    ->visible(fn() => auth()->user()->can('view-analytics'))
     // or
-    ->hidden(! auth()->user()->can('view-analytics')),
+    ->hidden(fn() => ! auth()->user()->can('view-analytics')),
 ```
 
 ## Disabling resource or page navigation items

--- a/packages/panels/docs/06-navigation.md
+++ b/packages/panels/docs/06-navigation.md
@@ -208,7 +208,7 @@ use Filament\Navigation\NavigationItem;
 NavigationItem::make('Analytics')
     ->visible(fn(): bool => auth()->user()->can('view-analytics'))
     // or
-    ->hidden(fn() => ! auth()->user()->can('view-analytics')),
+    ->hidden(fn(): bool => ! auth()->user()->can('view-analytics')),
 ```
 
 ## Disabling resource or page navigation items

--- a/packages/panels/docs/06-navigation.md
+++ b/packages/panels/docs/06-navigation.md
@@ -206,7 +206,7 @@ You can also conditionally hide a navigation item by using the `visible()` or `h
 use Filament\Navigation\NavigationItem;
 
 NavigationItem::make('Analytics')
-    ->visible(fn() => auth()->user()->can('view-analytics'))
+    ->visible(fn(): bool => auth()->user()->can('view-analytics'))
     // or
     ->hidden(fn() => ! auth()->user()->can('view-analytics')),
 ```


### PR DESCRIPTION
While trying to conditionally show a nav item I would receive an exception that auth()->user() was null despite following the example on the docs. Someone else seemed to have the same issue. After discussing on discord it was discovered that it needed to be a closure not just a pure boolean statement to work properly.

This PR fixes the example in the docs.

See https://discord.com/channels/883083792112300104/1136539308296257547 for more details.
