### PR TITLE
Fixed FileUpload `avatar` resize

### DIFF
--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -78,6 +78,8 @@ class FileUpload extends BaseFileUpload
         $this->isAvatar = true;
 
         $this->image();
+        $this->imageResizeMode('cover');
+        $this->imageResizeUpscale(false);
         $this->imageCropAspectRatio('1:1');
         $this->imageResizeTargetHeight('500');
         $this->imageResizeTargetWidth('500');


### PR DESCRIPTION
- [X] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

The image resize mode is required to use `imageResizeTargetWidth` and `imageResizeTargetHeight`.
In addition, I think it is appropriate to prevent upscale.