### PR TITLE
Update repeater.blade.php

### DIFF
--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -81,7 +81,7 @@
 
                                 setTimeout(
                                     () =>
-                                        $el.scrollIntoView({
+                                        $root.scrollIntoView({
                                             behavior: 'smooth',
                                             block: 'start',
                                             inline: 'start',


### PR DESCRIPTION
Change `$el` to `$root`.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Considering the following PR: https://github.com/filamentphp/filament/issues/5852 it seems the changes have been overwritten.

The issue is that pressing the "Add" button for the repeater makes you scroll all the way up to the top of the page.

awcodes suggested it could be a browser extension, however I've disabled everything, asked 2 other users and tried other browsers. The behavior stays the same; it keeps scrolling up.

I've tested this, changing `$el` to `$root` solves the automatic scrolling issue for me.