### PR TITLE
Add prefix and suffix for tag

### DIFF
--- a/packages/forms/docs/03-fields/14-tags-input.md
+++ b/packages/forms/docs/03-fields/14-tags-input.md
@@ -74,15 +74,15 @@ TagsInput::make('tags')
 
 You can [read more about possible options for keys](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key).
 
-## Defining tags prefix and suffix
-You can add prefix and suffix to tags without modifying the real values. This can be useful if you need to show presentational values to users, without having to add those prefixes manually.
+## Adding a prefix and suffix to individual tags
+
+You can add prefix and suffix to tags without modifying the real state of the field. This can be useful if you need to show presentational formatting to users, without saving it:
 
 ```php
 use Filament\Forms\Components\TagsInput;
 
-TagsInput::make('tags')
-    ->tagPrefix('$')
-    ->tagSuffix('USD')
+TagsInput::make('percentages')
+    ->tagSuffix('%')
 ```
 
 ## Tags validation

--- a/packages/forms/docs/03-fields/14-tags-input.md
+++ b/packages/forms/docs/03-fields/14-tags-input.md
@@ -74,6 +74,17 @@ TagsInput::make('tags')
 
 You can [read more about possible options for keys](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key).
 
+## Defining tags prefix and suffix
+You can add prefix and suffix to tags without modifying the real values. This can be useful if you need to show presentational values to users, without having to add those prefixes manually.
+
+```php
+use Filament\Forms\Components\TagsInput;
+
+TagsInput::make('tags')
+    ->tagPrefix('$')
+    ->tagSuffix('USD')
+```
+
 ## Tags validation
 
 You may add validation rules for each tag by passing an array of rules to the `nestedRecursiveRules()` method:

--- a/packages/forms/docs/03-fields/14-tags-input.md
+++ b/packages/forms/docs/03-fields/14-tags-input.md
@@ -76,7 +76,7 @@ You can [read more about possible options for keys](https://developer.mozilla.or
 
 ## Adding a prefix and suffix to individual tags
 
-You can add prefix and suffix to tags without modifying the real state of the field. This can be useful if you need to show presentational formatting to users, without saving it:
+You can add prefix and suffix to tags without modifying the real state of the field. This can be useful if you need to show presentational formatting to users, without saving it. This is done with the `tagPrefix()` or `tagSuffix()` method:
 
 ```php
 use Filament\Forms\Components\TagsInput;

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -70,8 +70,12 @@
                             class="hidden"
                         >
                             <x-filament::badge>
+                                {{ $getPrefixTag() }}
+
                                 <span class="text-start" x-text="tag"></span>
 
+                                {{ $getSuffixTag() }}
+                                
                                 @if (! $isDisabled)
                                     <x-slot
                                         name="deleteButton"

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -70,11 +70,11 @@
                             class="hidden"
                         >
                             <x-filament::badge>
-                                {{ $getPrefixTag() }}
+                                {{ $getTagPrefix() }}
 
                                 <span class="text-start" x-text="tag"></span>
 
-                                {{ $getSuffixTag() }}
+                                {{ $getTagSuffix() }}
                                 
                                 @if (! $isDisabled)
                                     <x-slot

--- a/packages/forms/src/Components/TagsInput.php
+++ b/packages/forms/src/Components/TagsInput.php
@@ -71,14 +71,14 @@ class TagsInput extends Field implements Contracts\HasNestedRecursiveValidationR
         $this->placeholder(__('filament-forms::components.tags_input.placeholder'));
     }
 
-    public function tagPrefix(string | Closure $prefix): static
+    public function tagPrefix(string | Closure | null $prefix): static
     {
         $this->tagPrefix = $prefix;
 
         return $this;
     }
 
-    public function tagSuffix(string | Closure $suffix): static
+    public function tagSuffix(string | Closure | null $suffix): static
     {
         $this->tagSuffix = $suffix;
 

--- a/packages/forms/src/Components/TagsInput.php
+++ b/packages/forms/src/Components/TagsInput.php
@@ -30,6 +30,10 @@ class TagsInput extends Field implements Contracts\HasNestedRecursiveValidationR
      */
     protected array | Arrayable | Closure | null $suggestions = null;
 
+    protected string | Closure | null $prefixTag = null;
+
+    protected string | Closure | null $suffixTag = null;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -67,6 +71,20 @@ class TagsInput extends Field implements Contracts\HasNestedRecursiveValidationR
         $this->placeholder(__('filament-forms::components.tags_input.placeholder'));
     }
 
+    public function prefixTag(string | Closure | null $prefix = ''): static
+    {
+        $this->prefixTag = $prefix;
+
+        return $this;
+    }
+
+    public function suffixTag(string | Closure | null $suffix = ''): static
+    {
+        $this->suffixTag = $suffix;
+
+        return $this;
+    }
+
     public function separator(string | Closure | null $separator = ','): static
     {
         $this->separator = $separator;
@@ -92,6 +110,16 @@ class TagsInput extends Field implements Contracts\HasNestedRecursiveValidationR
         $this->suggestions = $suggestions;
 
         return $this;
+    }
+
+    public function getPrefixTag(): ?string
+    {
+        return $this->evaluate($this->prefixTag);
+    }
+
+    public function getSuffixTag(): ?string
+    {
+        return $this->evaluate($this->suffixTag);
     }
 
     public function getSeparator(): ?string

--- a/packages/forms/src/Components/TagsInput.php
+++ b/packages/forms/src/Components/TagsInput.php
@@ -30,9 +30,9 @@ class TagsInput extends Field implements Contracts\HasNestedRecursiveValidationR
      */
     protected array | Arrayable | Closure | null $suggestions = null;
 
-    protected string | Closure | null $prefixTag = null;
+    protected string | Closure | null $tagPrefix = null;
 
-    protected string | Closure | null $suffixTag = null;
+    protected string | Closure | null $tagSuffix = null;
 
     protected function setUp(): void
     {
@@ -71,16 +71,16 @@ class TagsInput extends Field implements Contracts\HasNestedRecursiveValidationR
         $this->placeholder(__('filament-forms::components.tags_input.placeholder'));
     }
 
-    public function prefixTag(string | Closure $prefix): static
+    public function tagPrefix(string | Closure $prefix): static
     {
-        $this->prefixTag = $prefix;
+        $this->tagPrefix = $prefix;
 
         return $this;
     }
 
-    public function suffixTag(string | Closure $suffix): static
+    public function tagSuffix(string | Closure $suffix): static
     {
-        $this->suffixTag = $suffix;
+        $this->tagSuffix = $suffix;
 
         return $this;
     }
@@ -112,14 +112,14 @@ class TagsInput extends Field implements Contracts\HasNestedRecursiveValidationR
         return $this;
     }
 
-    public function getPrefixTag(): ?string
+    public function getTagPrefix(): ?string
     {
-        return $this->evaluate($this->prefixTag);
+        return $this->evaluate($this->tagPrefix);
     }
 
-    public function getSuffixTag(): ?string
+    public function getTagSuffix(): ?string
     {
-        return $this->evaluate($this->suffixTag);
+        return $this->evaluate($this->tagSuffix);
     }
 
     public function getSeparator(): ?string

--- a/packages/forms/src/Components/TagsInput.php
+++ b/packages/forms/src/Components/TagsInput.php
@@ -71,14 +71,14 @@ class TagsInput extends Field implements Contracts\HasNestedRecursiveValidationR
         $this->placeholder(__('filament-forms::components.tags_input.placeholder'));
     }
 
-    public function prefixTag(string | Closure | null $prefix = ''): static
+    public function prefixTag(string | Closure $prefix): static
     {
         $this->prefixTag = $prefix;
 
         return $this;
     }
 
-    public function suffixTag(string | Closure | null $suffix = ''): static
+    public function suffixTag(string | Closure $suffix): static
     {
         $this->suffixTag = $suffix;
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This will help folks who need to add prefix, but don't want to type it manually.

<img width="545" alt="image" src="https://github.com/filamentphp/filament/assets/37329575/3f5dc2d8-a7d6-4aa8-9fd6-62773effad8b">
