### PR TITLE
docs: Fix reference to `recordSelect` method

### DIFF
--- a/packages/panels/docs/03-resources/07-relation-managers.md
+++ b/packages/panels/docs/03-resources/07-relation-managers.md
@@ -305,14 +305,14 @@ AttachAction::make()
 
 ### Customizing the select field in the attach modal
 
-You may customize the select field object that is used during attachment by passing a function to the `modifyRecordSelectUsing()` method:
+You may customize the select field object that is used during attachment by passing a function to the `recordSelect()` method:
 
 ```php
 use Filament\Forms\Components\Select;
 use Filament\Tables\Actions\AttachAction;
 
 AttachAction::make()
-    ->modifyRecordSelectUsing(
+    ->recordSelect(
         fn (Select $select) => $select->placeholder('Select a post'),
     )
 ```
@@ -404,14 +404,14 @@ AssociateAction::make()
 
 ### Customizing the select field in the associate modal
 
-You may customize the select field object that is used during association by passing a function to the `modifyRecordSelectUsing()` method:
+You may customize the select field object that is used during association by passing a function to the `recordSelect()` method:
 
 ```php
 use Filament\Forms\Components\Select;
 use Filament\Tables\Actions\AssociateAction;
 
 AssociateAction::make()
-    ->modifyRecordSelectUsing(
+    ->recordSelect(
         fn (Select $select) => $select->placeholder('Select a post'),
     )
 ```


### PR DESCRIPTION
- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
