### PR TITLE
fix: Translatable edit

### DIFF
--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
@@ -62,8 +62,6 @@ trait Translatable
                 try {
                     $this->setActiveLocale($locale);
 
-                    $this->callHook('beforeValidate');
-
                     $this->data[$locale] = array_merge(
                         $this->data[$locale] ?? [],
                         Arr::except(
@@ -71,6 +69,8 @@ trait Translatable
                             $translatableAttributes,
                         ),
                     );
+
+                    $this->callHook('beforeValidate');
 
                     $data[$locale] = $this->form->getState();
 

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
@@ -33,6 +33,11 @@ trait Translatable
             foreach ($this->getTranslatableLocales() as $locale) {
                 $this->setActiveLocale($locale);
 
+                $this->data[$locale] = array_merge(
+                    $this->data[$locale] ?? [],
+                    Arr::except($this->data[$originalActiveLocale], app(static::getModel())->getTranslatableAttributes()),
+                );
+                
                 /** @internal Read the DocBlock above the following method. */
                 $this->validateFormAndUpdateRecordAndCallHooks();
             }

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
@@ -81,5 +81,24 @@ trait Translatable
         }
 
         $this->setActiveLocale($newActiveLocale);
+
+        if (blank($this->oldActiveLocale)) {
+            return;
+        }
+
+        $translatableAttributes = app(static::getModel())->getTranslatableAttributes();
+
+        $this->data[$newActiveLocale] = array_merge(
+            $this->data[$newActiveLocale] ?? [],
+            Arr::except(
+                $this->data[$this->oldActiveLocale] ?? [],
+                $translatableAttributes,
+            ),
+        );
+
+        $this->data[$this->oldActiveLocale] = Arr::only(
+            $this->data[$this->oldActiveLocale] ?? [],
+            $translatableAttributes,
+        );
     }
 }

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
@@ -29,15 +29,17 @@ trait Translatable
 
         $originalActiveLocale = $this->activeLocale;
 
+        $translatableAttributes = $this->getRecord()->getTranslatableAttributes();
+
         try {
             foreach ($this->getTranslatableLocales() as $locale) {
                 $this->setActiveLocale($locale);
 
                 $this->data[$locale] = array_merge(
                     $this->data[$locale] ?? [],
-                    Arr::except($this->data[$originalActiveLocale], app(static::getModel())->getTranslatableAttributes()),
+                    Arr::except($this->data[$originalActiveLocale], $translatableAttributes),
                 );
-                
+
                 /** @internal Read the DocBlock above the following method. */
                 $this->validateFormAndUpdateRecordAndCallHooks();
             }


### PR DESCRIPTION
- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
