### PR TITLE
Missing/removed files fix for Windows

### DIFF
--- a/packages/support/src/Commands/CheckTranslationsCommand.php
+++ b/packages/support/src/Commands/CheckTranslationsCommand.php
@@ -62,8 +62,8 @@ class CheckTranslationsCommand extends Command
                 $files = $filesystem->allFiles($localeDir);
                 $baseFiles = $filesystem->allFiles(implode(DIRECTORY_SEPARATOR, [$localeRootDirectory, 'en']));
 
-                $localeFiles = collect($files)->map(fn ($file) => (string) str($file->getPathname())->after("/{$locale}/"));
-                $englishFiles = collect($baseFiles)->map(fn ($file) => (string) str($file->getPathname())->after('/en/'));
+                $localeFiles = collect($files)->map(fn ($file) => (string) str($file->getPathname())->after(DIRECTORY_SEPARATOR.$locale.DIRECTORY_SEPARATOR));
+                $englishFiles = collect($baseFiles)->map(fn ($file) => (string) str($file->getPathname())->after(DIRECTORY_SEPARATOR.'en'.DIRECTORY_SEPARATOR));
                 $missingFiles = $englishFiles->diff($localeFiles);
                 $removedFiles = $localeFiles->diff($englishFiles);
                 $path = implode(DIRECTORY_SEPARATOR, [$localeRootDirectory, $locale]);

--- a/packages/support/src/Commands/CheckTranslationsCommand.php
+++ b/packages/support/src/Commands/CheckTranslationsCommand.php
@@ -62,8 +62,8 @@ class CheckTranslationsCommand extends Command
                 $files = $filesystem->allFiles($localeDir);
                 $baseFiles = $filesystem->allFiles(implode(DIRECTORY_SEPARATOR, [$localeRootDirectory, 'en']));
 
-                $localeFiles = collect($files)->map(fn ($file) => (string) str($file->getPathname())->after(DIRECTORY_SEPARATOR.$locale.DIRECTORY_SEPARATOR));
-                $englishFiles = collect($baseFiles)->map(fn ($file) => (string) str($file->getPathname())->after(DIRECTORY_SEPARATOR.'en'.DIRECTORY_SEPARATOR));
+                $localeFiles = collect($files)->map(fn ($file) => (string) str($file->getPathname())->after(DIRECTORY_SEPARATOR . $locale . DIRECTORY_SEPARATOR));
+                $englishFiles = collect($baseFiles)->map(fn ($file) => (string) str($file->getPathname())->after(DIRECTORY_SEPARATOR . 'en' . DIRECTORY_SEPARATOR));
                 $missingFiles = $englishFiles->diff($localeFiles);
                 $removedFiles = $localeFiles->diff($englishFiles);
                 $path = implode(DIRECTORY_SEPARATOR, [$localeRootDirectory, $locale]);


### PR DESCRIPTION
- [X] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Without `DIRECTORY_SEPARATOR`, the call to `after()` returns the full string on Windows and subsequent `diff()` doesn't work as intended.

With `DIRECTORY_SEPARATOR`, the path is properly returned in `after()`
