### PR TITLE
Feature/fix docs

### DIFF
--- a/packages/support/docs/09-blade-components/02-tabs.md
+++ b/packages/support/docs/09-blade-components/02-tabs.md
@@ -56,6 +56,48 @@ public string $activeTab;
 </x-filament::tabs>
 ```
 
+The name of the active tab, will be stored in the attribute `$activeTab`. We can make the tabs interactive by passing the attribute to the Livewire Component of the blade file.
+
+```php
+    public function selectTab(?string $tab): ?string{
+        return "You selected tab: ".$tab;
+    }
+```
+
+```blade
+    <x-filament::section>
+
+        <x-filament::tabs>
+            <x-filament::tabs.item
+                :active="$activeTab === 'tab1'"
+                wire:click="$set('activeTab', 'tab1')"
+            >
+                Tab 1
+            </x-filament::tabs.item>
+
+            <x-filament::tabs.item
+                :active="$activeTab === 'tab2'"
+                wire:click="$set('activeTab', 'tab2')"
+            >
+                Tab 2
+            </x-filament::tabs.item>
+
+            <x-filament::tabs.item
+                :active="$activeTab === 'tab3'"
+                wire:click="$set('activeTab', 'tab3')"
+            >
+                Tab 3
+            </x-filament::tabs.item>
+
+        </x-filament::tabs>
+
+        <x-filament::section>
+            {{$this->selectTab($activeTab)}}
+        </x-filament::section>
+
+    </x-filament::section>
+```
+
 Or you can use the `alpine-active` attribute to make a tab appear active conditionally using Alpine.js:
 
 ```blade

--- a/packages/support/docs/09-blade-components/02-tabs.md
+++ b/packages/support/docs/09-blade-components/02-tabs.md
@@ -36,7 +36,12 @@ By default tabs do not appear "active". To make a tab appear active, you can use
 </x-filament::tabs>
 ```
 
-You can also use the `active` attribute to make a tab appear active conditionally:
+You can also use the `active` attribute to make a tab appear active conditionally. You should also add the attribute to the `Page` in the /Pages directory of the Filament directory
+
+```php
+public string $activeTab;
+```
+
 
 ```blade
 <x-filament::tabs>

--- a/packages/support/docs/09-blade-components/02-tabs.md
+++ b/packages/support/docs/09-blade-components/02-tabs.md
@@ -36,7 +36,7 @@ By default tabs do not appear "active". To make a tab appear active, you can use
 </x-filament::tabs>
 ```
 
-You can also use the `active` attribute to make a tab appear active conditionally. You should also add the attribute to the `Page` in the /Pages directory of the Filament directory
+You can also use the `active` attribute to make a tab appear active conditionally. You should also add the attribute to the `Page` in the /Pages directory of the Filament directory:
 
 ```php
 public string $activeTab;


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.

When trying to use the activeTab in the blade file, you will get the following error:
**Undefined variable $activeTab**
![image](https://github.com/filamentphp/filament/assets/64212185/ca78f574-7c8b-4294-8314-c0ad873d69d1)

Adding the attribute in the class of the Page fixes the error.

Also I added some documentation about the tabs being interactive.