### PR TITLE
Set default pagination page option to null

### DIFF
--- a/packages/tables/src/Table/Concerns/CanPaginateRecords.php
+++ b/packages/tables/src/Table/Concerns/CanPaginateRecords.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Arr;
 
 trait CanPaginateRecords
 {
-    protected int | string | Closure | null $defaultPaginationPageOption = 10;
+    protected int | string | Closure | null $defaultPaginationPageOption = null;
 
     protected bool | Closure $isPaginated = true;
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Set the default `defaultPaginationPageOption` to null otherwise, it was never reaching the last part of this:
```php
public function getDefaultPaginationPageOption(): int | string | null
{
    return $this->evaluate($this->defaultPaginationPageOption) ?? Arr::first($this->getPaginationPageOptions());
}
```

Use case example:
```php
$table->paginated([5, 10, 25, 50, 100]);
```