### PR TITLE
fix: EditProfile - debounce password change update requests 

### DIFF
--- a/packages/panels/src/Pages/Auth/EditProfile.php
+++ b/packages/panels/src/Pages/Auth/EditProfile.php
@@ -220,7 +220,7 @@ class EditProfile extends SimplePage
             ->autocomplete('new-password')
             ->dehydrated(fn ($state): bool => filled($state))
             ->dehydrateStateUsing(fn ($state): string => Hash::make($state))
-            ->live()
+            ->debounce()
             ->same('passwordConfirmation');
     }
 

--- a/packages/panels/src/Pages/Auth/EditProfile.php
+++ b/packages/panels/src/Pages/Auth/EditProfile.php
@@ -220,7 +220,7 @@ class EditProfile extends SimplePage
             ->autocomplete('new-password')
             ->dehydrated(fn ($state): bool => filled($state))
             ->dehydrateStateUsing(fn ($state): string => Hash::make($state))
-            ->debounce()
+            ->live(debounce: 500)
             ->same('passwordConfirmation');
     }
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.

Changed TextInput::make('password')->live() to debounce() for reducing update requests to the server