### PR TITLE
Feature: Register all colors variants by default

### DIFF
--- a/packages/support/src/Colors/Color.php
+++ b/packages/support/src/Colors/Color.php
@@ -375,4 +375,35 @@ class Color
 
         return $colors;
     }
+
+    /**
+     * @return array<string, array{50: string, 100: string, 200: string, 300: string, 400: string, 500: string, 600: string, 700: string, 800: string, 900: string, 950: string}>
+     */
+    public static function getColors(): array
+    {
+        return [
+            'slate' => static::Slate,
+            'gray' => static::Gray,
+            'zinc' => static::Zinc,
+            'neutral' => static::Neutral,
+            'stone' => static::Stone,
+            'red' => static::Red,
+            'orange' => static::Orange,
+            'amber' => static::Amber,
+            'yellow' => static::Yellow,
+            'lime' => static::Lime,
+            'green' => static::Green,
+            'emerald' => static::Emerald,
+            'teal' => static::Teal,
+            'cyan' => static::Cyan,
+            'sky' => static::Sky,
+            'blue' => static::Blue,
+            'indigo' => static::Indigo,
+            'violet' => static::Violet,
+            'purple' => static::Purple,
+            'fuchsia' => static::Fuchsia,
+            'pink' => static::Pink,
+            'rose' => static::Rose,
+        ];
+    }
 }

--- a/packages/support/src/Colors/ColorManager.php
+++ b/packages/support/src/Colors/ColorManager.php
@@ -64,12 +64,15 @@ class ColorManager
     public function getColors(): array
     {
         return [
-            'danger' => Color::Red,
-            'gray' => Color::Zinc,
-            'info' => Color::Blue,
-            'primary' => Color::Amber,
-            'success' => Color::Green,
-            'warning' => Color::Amber,
+            ...[
+                'danger' => Color::Red,
+                'gray' => Color::Zinc,
+                'info' => Color::Blue,
+                'primary' => Color::Amber,
+                'success' => Color::Green,
+                'warning' => Color::Amber,
+            ],
+            ...Color::getColors(),
             ...$this->colors,
         ];
     }


### PR DESCRIPTION
I use a ton of color variants in badges, table columns, etc. So, I thought about registering these by default. Maybe it's useful for others? I completely understand if you guys only want to register the most important ones (like primary, danger, etc.). At the very least, could we have a `getColors()` method in the `Color` class? This way, users can easily register those colors in their applications, like this:

```
FilamentColor::register([
    ...[
        'red' => Color::Red,
        'gray' => Color::Zinc,
        'info' => Color::Sky,
        'primary' => Color::Blue,
        'success' => Color::Green,
        'warning' => Color::Amber,
    ],
    ...Color::getColors(),
]);
```






Regarding the `getColors()` method in the `Color` class, I considered using `Reflection` to retrieve all the class constants. However, I'm wondering if it's worth it. Since these colors are unlikely to change frequently over time, it seems like unnecessary overhead in this specific case. But I'm open to making changes if necessary.

What you guys think?

Ps: This change preserves the user's ability to override colors using `FilamentColor::register([...])`.


