### PR TITLE
fix global search focus

### DIFF
--- a/packages/panels/resources/views/components/global-search/field.blade.php
+++ b/packages/panels/resources/views/components/global-search/field.blade.php
@@ -28,7 +28,7 @@
             :attributes="
                 \Filament\Support\prepare_inherited_attributes(
                     new \Illuminate\View\ComponentAttributeBag([
-                        'x-mousetrap.global.' . collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') => $keyBindings ? 'document.getElementById($id(&quot;input&quot;)).focus()' : null,
+                        'x-mousetrap.global.' . collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') => $keyBindings ? 'document.getElementById($id(\'input\')).focus()' : null,
                     ])
                 )
             "

--- a/packages/panels/resources/views/components/global-search/field.blade.php
+++ b/packages/panels/resources/views/components/global-search/field.blade.php
@@ -28,7 +28,7 @@
             :attributes="
                 \Filament\Support\prepare_inherited_attributes(
                     new \Illuminate\View\ComponentAttributeBag([
-                        'x-mousetrap.global.' . collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') => $keyBindings ? '$el.focus()' : null,
+                        'x-mousetrap.global.' . collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') => $keyBindings ? 'document.getElementById($id(&quot;input&quot;)).focus()' : null,
                     ])
                 )
             "


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.


Fix: After the global search is used, the focus shortcut does not work.