### PR TITLE
[bug] [2.x] fix upload progress indicator

### DIFF
--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -76,7 +76,9 @@
                                 success(fileKey)
                             },
                             error,
-                            progress,
+                            (progressEvent) => {
+                                progress(true, progressEvent.detail.progress, 100);
+                            }
                         )
                     },
                 })"

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -77,8 +77,8 @@
                             },
                             error,
                             (progressEvent) => {
-                                progress(true, progressEvent.detail.progress, 100);
-                            }
+                                progress(true, progressEvent.detail.progress, 100)
+                            },
                         )
                     },
                 })"


### PR DESCRIPTION
This PR fixes the filepond upload progress indicator not working. This is generally not noticable for small files since uploading is very fast but for large files there is no indication of progress.

<img width="74" alt="image" src="https://github.com/filamentphp/filament/assets/84236864/70c9ce55-701e-48bb-8357-fc2ecd78815b">

The livewire `$wire.upload()` progress callback is not directly compatible with the filepond progress callback. This small callback function makes the two compatible