### PR TITLE
fix: translatable column search

### DIFF
--- a/packages/spatie-laravel-translatable-plugin/src/SpatieLaravelTranslatableContentDriver.php
+++ b/packages/spatie-laravel-translatable-plugin/src/SpatieLaravelTranslatableContentDriver.php
@@ -96,9 +96,11 @@ class SpatieLaravelTranslatableContentDriver implements TranslatableContentDrive
             default => "json_extract({$column}, \"$.{$this->activeLocale}\")",
         };
 
-        $caseAwareSearchColumn = $isCaseInsensitivityForced ?
-            new Expression("lower({$column})") :
-            $column;
+        $caseAwareSearchColumn = new Expression(
+            $isCaseInsensitivityForced ?
+                "lower({$column})" :
+                $column
+        );
 
         return $query->{$whereClause}(
             $caseAwareSearchColumn,


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Fixes #7537