### PR TITLE
Fix icon button indicator displayed over action dropdown

### DIFF
--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -55,7 +55,7 @@
         },
     ]);
 
-    $badgeClasses = 'absolute start-full top-0 z-10 -ms-1 -translate-x-1/2 rounded-md bg-white rtl:translate-x-1/2 dark:bg-gray-900';
+    $badgeClasses = 'absolute start-full top-0 z-[1] -ms-1 -translate-x-1/2 rounded-md bg-white rtl:translate-x-1/2 dark:bg-gray-900';
 
     $wireTarget = $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(fn ($value): bool => filled($value))->first();
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Reduce the z-index of the button indicator so it appears behind the group action dropdown.
<img width="406" alt="Screenshot 2023-08-08 at 12 30 13" src="https://github.com/filamentphp/filament/assets/533658/ccc6a230-8bc6-4277-b570-cba3011ef28c">
