### PR TITLE
Updating docs to fix reference to the max content width settings

### DIFF
--- a/packages/panels/docs/04-pages.md
+++ b/packages/panels/docs/04-pages.md
@@ -292,14 +292,3 @@ public function getFooter(): ?View
 ```
 
 This example assumes you have a Blade view at `resources/views/filament/settings/custom-footer.blade.php`.
-
-## Customizing the maximum content width
-
-By default, Filament will restrict the width of the content on the page so it doesn't become too wide on large screens. To change this, you may override the `getMaxContentWidth()` method. Options correspond to [Tailwind's max-width scale](https://tailwindcss.com/docs/max-width). The options are `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, `6xl`, `7xl`, and `full`. The default is `7xl`:
-
-```php
-public function getMaxContentWidth(): ?string
-{
-    return 'full';
-}
-```

--- a/packages/panels/docs/04-pages.md
+++ b/packages/panels/docs/04-pages.md
@@ -292,3 +292,14 @@ public function getFooter(): ?View
 ```
 
 This example assumes you have a Blade view at `resources/views/filament/settings/custom-footer.blade.php`.
+
+## Customizing the maximum content width
+
+By default, Filament will restrict the width of the content on the page so it doesn't become too wide on large screens. To change this, you may override the `getMaxContentWidth()` method. Options correspond to [Tailwind's max-width scale](https://tailwindcss.com/docs/max-width). The options are `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, `6xl`, `7xl`, and `full`. The default is `7xl`:
+
+```php
+public function getMaxContentWidth(): ?string
+{
+    return 'full';
+}
+```

--- a/packages/panels/docs/09-configuration.md
+++ b/packages/panels/docs/09-configuration.md
@@ -100,7 +100,7 @@ public function panel(Panel $panel): Panel
 
 ## Customizing the maximum content width
 
-By default, Filament will restrict the width of the content on a page so it doesn't become too wide on large screens. To change this, you may override the `getMaxContentWidth()` method. Options correspond to [Tailwind's max-width scale](https://tailwindcss.com/docs/max-width). The options are `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, `6xl`, `7xl`, and `full`. The default is `7xl`:
+By default, Filament will restrict the width of the content on a page so it doesn't become too wide on large screens. To change this, you may use the `maxContentWidth()` method. Options correspond to [Tailwind's max-width scale](https://tailwindcss.com/docs/max-width). The options are `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, `6xl`, `7xl`, and `full`. The default is `7xl`:
 
 ```php
 use Filament\Panel;

--- a/packages/panels/docs/09-configuration.md
+++ b/packages/panels/docs/09-configuration.md
@@ -97,18 +97,3 @@ public function panel(Panel $panel): Panel
         ->domain('admin.example.com');
 }
 ```
-
-## Customizing the maximum content width
-
-By default, Filament will restrict the width of the content on a page so it doesn't become too wide on large screens. To change this, you may override the `getMaxContentWidth()` method. Options correspond to [Tailwind's max-width scale](https://tailwindcss.com/docs/max-width). The options are `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, `6xl`, `7xl`, and `full`. The default is `7xl`:
-
-```php
-use Filament\Panel;
-
-public function panel(Panel $panel): Panel
-{
-    return $panel
-        // ...
-        ->maxContentWidth('full');
-}
-```

--- a/packages/panels/docs/09-configuration.md
+++ b/packages/panels/docs/09-configuration.md
@@ -97,3 +97,18 @@ public function panel(Panel $panel): Panel
         ->domain('admin.example.com');
 }
 ```
+
+## Customizing the maximum content width
+
+By default, Filament will restrict the width of the content on a page so it doesn't become too wide on large screens. To change this, you may override the `getMaxContentWidth()` method. Options correspond to [Tailwind's max-width scale](https://tailwindcss.com/docs/max-width). The options are `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, `6xl`, `7xl`, and `full`. The default is `7xl`:
+
+```php
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->maxContentWidth('full');
+}
+```


### PR DESCRIPTION
This update looks to fix the outdated documentation for `maxContentWidth()`.

Filament v2 had this available on the Page, but in v3 it is moved to the Panel settings.
