### PR TITLE
respect hiddenLabel() on wizard steps

### DIFF
--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -178,18 +178,20 @@
                     </div>
 
                     <div class="grid justify-items-start">
-                        <span
-                            class="fi-fo-wizard-header-step-label text-sm font-medium"
-                            x-bind:class="{
-                                'text-gray-500 dark:text-gray-400':
-                                    getStepIndex(step) < {{ $loop->index }},
-                                'text-primary-600 dark:text-primary-400':
-                                    getStepIndex(step) === {{ $loop->index }},
-                                'text-gray-950 dark:text-white': getStepIndex(step) > {{ $loop->index }},
-                            }"
-                        >
-                            {{ $step->getLabel() }}
-                        </span>
+                        @if (! $step->isLabelHidden())
+                            <span
+                                class="fi-fo-wizard-header-step-label text-sm font-medium"
+                                x-bind:class="{
+                                    'text-gray-500 dark:text-gray-400':
+                                        getStepIndex(step) < {{ $loop->index }},
+                                    'text-primary-600 dark:text-primary-400':
+                                        getStepIndex(step) === {{ $loop->index }},
+                                    'text-gray-950 dark:text-white': getStepIndex(step) > {{ $loop->index }},
+                                }"
+                            >
+                                {{ $step->getLabel() }}
+                            </span>
+                        @endif
 
                         @if (filled($description = $step->getDescription()))
                             <span


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
not necessary imo, as hiddenLabel() is a method available on all fields, does what is expected

- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

before: 
![image](https://github.com/filamentphp/filament/assets/4368880/7a97b76c-d95a-4b5d-8a94-599f86057d23)
after:
![image](https://github.com/filamentphp/filament/assets/4368880/f7239abe-1fdb-4efc-9e33-5cce4afa9c37)

