### PR TITLE
Support showing current wizard step heading instead of all steps

### DIFF
--- a/packages/forms/docs/04-layout/05-wizard.md
+++ b/packages/forms/docs/04-layout/05-wizard.md
@@ -202,3 +202,15 @@ Wizard::make([
         fn (Action $action) => $action->label('Next step'),
     )
 ```
+
+## Hiding the header
+
+The whole header of the wizard can be hidden by using `hiddenHeader()` analog to `hiddenLabel()`
+
+```php
+use Filament\Forms\Components\Wizard;
+
+Wizard::make([
+    // ...
+])->hiddenHeader()
+```

--- a/packages/forms/docs/04-layout/05-wizard.md
+++ b/packages/forms/docs/04-layout/05-wizard.md
@@ -205,12 +205,12 @@ Wizard::make([
 
 ## Hiding the header
 
-The whole header of the wizard can be hidden by using `hiddenHeader()` analog to `hiddenLabel()`
+The whole header of the wizard can be hidden by using `hiddenHeader()` analog to `hiddenLabel()`. If you want to still show the current step's label, you can set the `stepLabelAsHeading` parameter to true.
 
 ```php
 use Filament\Forms\Components\Wizard;
 
 Wizard::make([
     // ...
-])->hiddenHeader()
+])->hiddenHeader(stepLabelAsHeading: true)
 ```

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -231,17 +231,15 @@
     $isHeaderHidden = $isHeaderHidden();
     $isStepLabelAsHeading = $isStepLabelAsHeading();
 
-    $isContained = false;
-
-    $visibleStepLabelClasses = \Illuminate\Support\Arr::toCssClasses([
-        'text-lg border-b block px-6 pt-4 pb-4 text-primary-600 dark:text-primary-500'
-    ]);
-
+    $visibleStepLabelClasses = 'block px-6 pt-4 pb-4';
     $invisibleStepLabelClasses = 'invisible h-0 overflow-y-hidden p-0';
     ?>
     @foreach ($getChildComponentContainer()->getComponents() as $step)
         @if ($isHeaderHidden && $isStepLabelAsHeading)
-            <div x-bind:class="step === @js($step->getId()) ? @js($visibleStepLabelClasses) : @js($invisibleStepLabelClasses)">
+            <div
+                class="text-lg border-b border-gray-950/5 dark:border-white-/10 text-primary-600 dark:text-primary-500"
+                x-bind:class="step === @js($step->getId()) ? @js($visibleStepLabelClasses) : @js($invisibleStepLabelClasses)
+            ">
                 @if (filled($icon = $step->getIcon()))
                     <x-filament::icon
                         :icon="$icon"

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -237,7 +237,7 @@
     @foreach ($getChildComponentContainer()->getComponents() as $step)
         @if ($isHeaderHidden && $isStepLabelAsHeading)
             <div
-                class="text-lg border-b border-gray-950/5 dark:border-white-/10 text-primary-600 dark:text-primary-500"
+                class="text-lg border-b border-b-gray-950/5 dark:border-b-white/10 text-primary-600 dark:text-primary-500"
                 x-bind:class="step === @js($step->getId()) ? @js($visibleStepLabelClasses) : @js($invisibleStepLabelClasses)
             ">
                 @if (filled($icon = $step->getIcon()))

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -109,121 +109,123 @@
         x-ref="stepsData"
     />
 
-    <ol
-        @if (filled($label = $getLabel()))
-            aria-label="{{ $label }}"
-        @endif
-        role="list"
-        @class([
-            'fi-fo-wizard-header grid divide-y divide-gray-200 dark:divide-white/5 md:grid-flow-col md:divide-y-0',
-            'border-b border-gray-200 dark:border-white/10' => $isContained,
-            'rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10' => ! $isContained,
-        ])
-    >
-        @foreach ($getChildComponentContainer()->getComponents() as $step)
-            <li class="fi-fo-wizard-header-step relative flex">
-                <button
-                    type="button"
-                    x-bind:aria-current="getStepIndex(step) === {{ $loop->index }} ? 'step' : null"
-                    x-on:click="step = @js($step->getId())"
-                    x-bind:disabled="! isStepAccessible(step, {{ $loop->index }})"
-                    role="step"
-                    class="flex h-full w-full items-center gap-x-4 px-6 py-4"
-                >
-                    <div
-                        class="fi-fo-wizard-header-step-icon-ctn flex h-10 w-10 shrink-0 items-center justify-center rounded-full"
-                        x-bind:class="{
-                            'bg-primary-600 dark:bg-primary-500':
-                                getStepIndex(step) > {{ $loop->index }},
-                            'border-2': getStepIndex(step) <= {{ $loop->index }},
-                            'border-primary-600 dark:border-primary-500':
-                                getStepIndex(step) === {{ $loop->index }},
-                            'border-gray-300 dark:border-gray-600':
-                                getStepIndex(step) < {{ $loop->index }},
-                        }"
+    @if (! $isHeaderHidden())
+        <ol
+            @if (filled($label = $getLabel()))
+                aria-label="{{ $label }}"
+            @endif
+            role="list"
+            @class([
+                'fi-fo-wizard-header grid divide-y divide-gray-200 dark:divide-white/5 md:grid-flow-col md:divide-y-0',
+                'border-b border-gray-200 dark:border-white/10' => $isContained,
+                'rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10' => ! $isContained,
+            ])
+        >
+            @foreach ($getChildComponentContainer()->getComponents() as $step)
+                <li class="fi-fo-wizard-header-step relative flex">
+                    <button
+                        type="button"
+                        x-bind:aria-current="getStepIndex(step) === {{ $loop->index }} ? 'step' : null"
+                        x-on:click="step = @js($step->getId())"
+                        x-bind:disabled="! isStepAccessible(step, {{ $loop->index }})"
+                        role="step"
+                        class="flex h-full w-full items-center gap-x-4 px-6 py-4"
                     >
-                        <x-filament::icon
-                            alias="forms::components.wizard.completed-step"
-                            icon="heroicon-o-check"
-                            x-cloak="x-cloak"
-                            x-show="getStepIndex(step) > {{ $loop->index }}"
-                            class="fi-fo-wizard-header-step-icon h-6 w-6 text-white"
-                        />
-
-                        @if (filled($icon = $step->getIcon()))
-                            <x-filament::icon
-                                :icon="$icon"
-                                x-cloak="x-cloak"
-                                x-show="getStepIndex(step) <= {{ $loop->index }}"
-                                class="fi-fo-wizard-header-step-icon h-6 w-6"
-                                x-bind:class="{
-                                    'text-gray-500 dark:text-gray-400': getStepIndex(step) !== {{ $loop->index }},
-                                    'text-primary-600 dark:text-primary-500': getStepIndex(step) === {{ $loop->index }},
-                                }"
-                            />
-                        @else
-                            <span
-                                x-show="getStepIndex(step) <= {{ $loop->index }}"
-                                class="text-sm font-medium"
-                                x-bind:class="{
-                                    'text-gray-500 dark:text-gray-400':
-                                        getStepIndex(step) !== {{ $loop->index }},
-                                    'text-primary-600 dark:text-primary-500':
-                                        getStepIndex(step) === {{ $loop->index }},
-                                }"
-                            >
-                                {{ str_pad($loop->index + 1, 2, '0', STR_PAD_LEFT) }}
-                            </span>
-                        @endif
-                    </div>
-
-                    <div class="grid justify-items-start">
-                        <span
-                            class="fi-fo-wizard-header-step-label text-sm font-medium"
+                        <div
+                            class="fi-fo-wizard-header-step-icon-ctn flex h-10 w-10 shrink-0 items-center justify-center rounded-full"
                             x-bind:class="{
-                                'text-gray-500 dark:text-gray-400':
-                                    getStepIndex(step) < {{ $loop->index }},
-                                'text-primary-600 dark:text-primary-400':
+                                'bg-primary-600 dark:bg-primary-500':
+                                    getStepIndex(step) > {{ $loop->index }},
+                                'border-2': getStepIndex(step) <= {{ $loop->index }},
+                                'border-primary-600 dark:border-primary-500':
                                     getStepIndex(step) === {{ $loop->index }},
-                                'text-gray-950 dark:text-white': getStepIndex(step) > {{ $loop->index }},
+                                'border-gray-300 dark:border-gray-600':
+                                    getStepIndex(step) < {{ $loop->index }},
                             }"
                         >
-                            {{ $step->getLabel() }}
-                        </span>
+                            <x-filament::icon
+                                alias="forms::components.wizard.completed-step"
+                                icon="heroicon-o-check"
+                                x-cloak="x-cloak"
+                                x-show="getStepIndex(step) > {{ $loop->index }}"
+                                class="fi-fo-wizard-header-step-icon h-6 w-6 text-white"
+                            />
 
-                        @if (filled($description = $step->getDescription()))
+                            @if (filled($icon = $step->getIcon()))
+                                <x-filament::icon
+                                    :icon="$icon"
+                                    x-cloak="x-cloak"
+                                    x-show="getStepIndex(step) <= {{ $loop->index }}"
+                                    class="fi-fo-wizard-header-step-icon h-6 w-6"
+                                    x-bind:class="{
+                                        'text-gray-500 dark:text-gray-400': getStepIndex(step) !== {{ $loop->index }},
+                                        'text-primary-600 dark:text-primary-500': getStepIndex(step) === {{ $loop->index }},
+                                    }"
+                                />
+                            @else
+                                <span
+                                    x-show="getStepIndex(step) <= {{ $loop->index }}"
+                                    class="text-sm font-medium"
+                                    x-bind:class="{
+                                        'text-gray-500 dark:text-gray-400':
+                                            getStepIndex(step) !== {{ $loop->index }},
+                                        'text-primary-600 dark:text-primary-500':
+                                            getStepIndex(step) === {{ $loop->index }},
+                                    }"
+                                >
+                                    {{ str_pad($loop->index + 1, 2, '0', STR_PAD_LEFT) }}
+                                </span>
+                            @endif
+                        </div>
+
+                        <div class="grid justify-items-start">
                             <span
-                                class="fi-fo-wizard-header-step-description text-sm text-gray-500 dark:text-gray-400"
+                                class="fi-fo-wizard-header-step-label text-sm font-medium"
+                                x-bind:class="{
+                                    'text-gray-500 dark:text-gray-400':
+                                        getStepIndex(step) < {{ $loop->index }},
+                                    'text-primary-600 dark:text-primary-400':
+                                        getStepIndex(step) === {{ $loop->index }},
+                                    'text-gray-950 dark:text-white': getStepIndex(step) > {{ $loop->index }},
+                                }"
                             >
-                                {{ $description }}
+                                {{ $step->getLabel() }}
                             </span>
-                        @endif
-                    </div>
-                </button>
 
-                @if (! $loop->last)
-                    <div
-                        aria-hidden="true"
-                        class="absolute end-0 hidden w-5 md:block"
-                    >
-                        <svg
-                            fill="none"
-                            preserveAspectRatio="none"
-                            viewBox="0 0 22 80"
-                            class="h-full w-full text-gray-200 rtl:rotate-180 dark:text-white/5"
+                            @if (filled($description = $step->getDescription()))
+                                <span
+                                    class="fi-fo-wizard-header-step-description text-sm text-gray-500 dark:text-gray-400"
+                                >
+                                    {{ $description }}
+                                </span>
+                            @endif
+                        </div>
+                    </button>
+
+                    @if (! $loop->last)
+                        <div
+                            aria-hidden="true"
+                            class="absolute end-0 hidden w-5 md:block"
                         >
-                            <path
-                                d="M0 -2L20 40L0 82"
-                                stroke-linejoin="round"
-                                stroke="currentcolor"
-                                vector-effect="non-scaling-stroke"
-                            ></path>
-                        </svg>
-                    </div>
-                @endif
-            </li>
-        @endforeach
-    </ol>
+                            <svg
+                                fill="none"
+                                preserveAspectRatio="none"
+                                viewBox="0 0 22 80"
+                                class="h-full w-full text-gray-200 rtl:rotate-180 dark:text-white/5"
+                            >
+                                <path
+                                    d="M0 -2L20 40L0 82"
+                                    stroke-linejoin="round"
+                                    stroke="currentcolor"
+                                    vector-effect="non-scaling-stroke"
+                                ></path>
+                            </svg>
+                        </div>
+                    @endif
+                </li>
+            @endforeach
+        </ol>
+    @endif
 
     @foreach ($getChildComponentContainer()->getComponents() as $step)
         {{ $step }}

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -227,7 +227,32 @@
         </ol>
     @endif
 
+    <?php
+    $isHeaderHidden = $isHeaderHidden();
+    $isStepLabelAsHeading = $isStepLabelAsHeading();
+
+    $isContained = false;
+
+    $visibleStepLabelClasses = \Illuminate\Support\Arr::toCssClasses([
+        'text-lg border-b block px-6 pt-4 pb-4 text-primary-600 dark:text-primary-500'
+    ]);
+
+    $invisibleStepLabelClasses = 'invisible h-0 overflow-y-hidden p-0';
+    ?>
     @foreach ($getChildComponentContainer()->getComponents() as $step)
+        @if ($isHeaderHidden && $isStepLabelAsHeading)
+            <div x-bind:class="step === @js($step->getId()) ? @js($visibleStepLabelClasses) : @js($invisibleStepLabelClasses)">
+                @if (filled($icon = $step->getIcon()))
+                    <x-filament::icon
+                        :icon="$icon"
+                        x-cloak="x-cloak"
+                        x-show="getStepIndex(step) <= {{ $loop->index }}"
+                        class="h-6 w-6 inline-block pr-4"
+                    />
+                @endif
+                {{ $step->getLabel() }}
+            </div>
+        @endif
         {{ $step }}
     @endforeach
 

--- a/packages/forms/src/Components/Wizard.php
+++ b/packages/forms/src/Components/Wizard.php
@@ -29,7 +29,9 @@ class Wizard extends Component
 
     public int | Closure $startStep = 1;
 
-    public bool | Closure | null $isHeaderHidden = null;
+    protected bool | Closure | null $headerHidden = null;
+
+    protected bool $stepLabelAsHeading = false;
 
     /**
      * @var view-string
@@ -233,15 +235,21 @@ class Wizard extends Component
         return filled($this->getStepQueryStringKey());
     }
 
-    public function hiddenHeader(bool | Closure | null $condition = true): static
+    public function hiddenHeader(bool | Closure | null $condition = true, bool $stepLabelAsHeading = false): static
     {
-        $this->isHeaderHidden = $condition;
+        $this->headerHidden = $condition;
+        $this->stepLabelAsHeading = $stepLabelAsHeading;
 
         return $this;
     }
 
     public function isHeaderHidden(): bool
     {
-        return (bool) $this->evaluate($this->isHeaderHidden);
+        return (bool) $this->evaluate($this->headerHidden);
+    }
+
+    public function isStepLabelAsHeading(): bool
+    {
+        return $this->stepLabelAsHeading;
     }
 }

--- a/packages/forms/src/Components/Wizard.php
+++ b/packages/forms/src/Components/Wizard.php
@@ -29,6 +29,8 @@ class Wizard extends Component
 
     public int | Closure $startStep = 1;
 
+    public bool | Closure | null $isHeaderHidden = null;
+
     /**
      * @var view-string
      */
@@ -229,5 +231,17 @@ class Wizard extends Component
     public function isStepPersistedInQueryString(): bool
     {
         return filled($this->getStepQueryStringKey());
+    }
+
+    public function hiddenHeader(bool | Closure | null $condition = true): static
+    {
+        $this->isHeadderHidden = $condition;
+
+        return $this;
+    }
+
+    public function isHeaderHidden(): bool
+    {
+        return (bool) $this->evaluate($this->isHeadderHidden);
     }
 }

--- a/packages/forms/src/Components/Wizard.php
+++ b/packages/forms/src/Components/Wizard.php
@@ -235,13 +235,13 @@ class Wizard extends Component
 
     public function hiddenHeader(bool | Closure | null $condition = true): static
     {
-        $this->isHeadderHidden = $condition;
+        $this->isHeaderHidden = $condition;
 
         return $this;
     }
 
     public function isHeaderHidden(): bool
     {
-        return (bool) $this->evaluate($this->isHeadderHidden);
+        return (bool) $this->evaluate($this->isHeaderHidden);
     }
 }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

before:
![image](https://github.com/filamentphp/filament/assets/4368880/88fc1952-9d33-4076-b5fc-e998d8b6de12)

after:
![image](https://github.com/filamentphp/filament/assets/4368880/7553fc6c-57de-4a0c-bea5-2aeedb049fba)
