### PR TITLE
Add compact wizard styling

### DIFF
--- a/packages/forms/docs/04-layout/05-wizard.md
+++ b/packages/forms/docs/04-layout/05-wizard.md
@@ -202,3 +202,15 @@ Wizard::make([
         fn (Action $action) => $action->label('Next step'),
     )
 ```
+
+## Compact header
+
+By default, the header and steps labels are quite big. For a more compact header (e.g. for use in restricted spaces) use `compact()`. But beware that step descriptions might not fit anymore.
+
+```php
+use Filament\Forms\Components\Wizard;
+
+Wizard::make([
+    // ...
+])->compact()
+```

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -226,11 +226,19 @@
                         <svg
                             fill="none"
                             preserveAspectRatio="none"
-                            viewBox="0 0 10 20"
+                            @if ($isCompact)
+                                viewBox="0 0 10 20"
+                            @else
+                                viewBox="0 0 22 80"
+                            @endif
                             class="h-full w-full text-gray-200 rtl:rotate-180 dark:text-white/5"
                         >
                             <path
-                                d="M0 -2L5 10L0 21"
+                                @if ($isCompact)
+                                    d="M0 -2L5 10L0 21"
+                                @else
+                                    d="M0 -2L20 40L0 82"
+                                @endif
                                 stroke-linejoin="round"
                                 stroke="currentcolor"
                                 vector-effect="non-scaling-stroke"

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -1,6 +1,7 @@
 @php
     $isContained = $isContained();
     $statePath = $getStatePath();
+    $isCompact = $isCompact();
 @endphp
 
 <div
@@ -128,10 +129,18 @@
                     x-on:click="step = @js($step->getId())"
                     x-bind:disabled="! isStepAccessible(step, {{ $loop->index }})"
                     role="step"
-                    class="flex h-full w-full items-center gap-x-4 px-6 py-4"
+                    @class([
+                        "flex h-full w-full items-center",
+                        "gap-x-4 px-6 py-4" => ! $isCompact,
+                        "gap-x-2 px-2 py-2" => $isCompact,
+                    ])
                 >
                     <div
-                        class="fi-fo-wizard-header-step-icon-ctn flex h-10 w-10 shrink-0 items-center justify-center rounded-full"
+                        @class([
+                            "fi-fo-wizard-header-step-icon-ctn flex shrink-0 items-center justify-center rounded-full",
+                            "h-10 w-10" => ! $isCompact,
+                            "h-6 w-6" => $isCompact,
+                        ])
                         x-bind:class="{
                             'bg-primary-600 dark:bg-primary-500':
                                 getStepIndex(step) > {{ $loop->index }},
@@ -147,7 +156,11 @@
                             icon="heroicon-o-check"
                             x-cloak="x-cloak"
                             x-show="getStepIndex(step) > {{ $loop->index }}"
-                            class="fi-fo-wizard-header-step-icon h-6 w-6 text-white"
+                            @class([
+                                "fi-fo-wizard-header-step-icon text-white",
+                                "h-6 w-6" => ! $isCompact,
+                                "h-4 w-4" => $isCompact,
+                            ])
                         />
 
                         @if (filled($icon = $step->getIcon()))
@@ -155,7 +168,11 @@
                                 :icon="$icon"
                                 x-cloak="x-cloak"
                                 x-show="getStepIndex(step) <= {{ $loop->index }}"
-                                class="fi-fo-wizard-header-step-icon h-6 w-6"
+                                @class([
+                                    "fi-fo-wizard-header-step-icon",
+                                    "h-6 w-6" => ! $isCompact,
+                                    "h-4 w-4" => $isCompact,
+                                ])
                                 x-bind:class="{
                                     'text-gray-500 dark:text-gray-400': getStepIndex(step) !== {{ $loop->index }},
                                     'text-primary-600 dark:text-primary-500': getStepIndex(step) === {{ $loop->index }},
@@ -164,7 +181,7 @@
                         @else
                             <span
                                 x-show="getStepIndex(step) <= {{ $loop->index }}"
-                                class="text-sm font-medium"
+                                class="text-xs font-medium"
                                 x-bind:class="{
                                     'text-gray-500 dark:text-gray-400':
                                         getStepIndex(step) !== {{ $loop->index }},
@@ -209,11 +226,11 @@
                         <svg
                             fill="none"
                             preserveAspectRatio="none"
-                            viewBox="0 0 22 80"
+                            viewBox="0 0 10 20"
                             class="h-full w-full text-gray-200 rtl:rotate-180 dark:text-white/5"
                         >
                             <path
-                                d="M0 -2L20 40L0 82"
+                                d="M0 -2L5 10L0 21"
                                 stroke-linejoin="round"
                                 stroke="currentcolor"
                                 vector-effect="non-scaling-stroke"

--- a/packages/forms/src/Components/Wizard.php
+++ b/packages/forms/src/Components/Wizard.php
@@ -4,6 +4,7 @@ namespace Filament\Forms\Components;
 
 use Closure;
 use Filament\Forms\Components\Actions\Action;
+use Filament\Forms\Components\Concerns\CanBeCompacted;
 use Filament\Forms\Components\Wizard\Step;
 use Filament\Support\Concerns;
 use Filament\Support\Enums\IconPosition;
@@ -14,6 +15,7 @@ class Wizard extends Component
 {
     use Concerns\CanBeContained;
     use Concerns\HasExtraAlpineAttributes;
+    use CanBeCompacted;
 
     protected string | Htmlable | null $cancelAction = null;
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

before: 
![Screenshot_20230809_030647](https://github.com/filamentphp/filament/assets/4368880/9bd228f8-af0a-471c-8843-0ca806b0a2b2)

after:
![image](https://github.com/filamentphp/filament/assets/4368880/d4ce78ae-e06e-485e-9182-a544645724bc)
