### PR TITLE
fix: Reintroduce CanValidateInput

### DIFF
--- a/packages/support/src/Commands/Concerns/CanValidateInput.php
+++ b/packages/support/src/Commands/Concerns/CanValidateInput.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Filament\Support\Commands\Concerns;
+
+use Closure;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * @deprecated Please refactor to use Laravel Prompts.
+ */
+trait CanValidateInput
+{
+    protected function askRequired(string $question, string $field, ?string $default = null): string
+    {
+        return $this->validateInput(fn () => $this->ask($question, $default), $field, ['required']);
+    }
+
+    /**
+     * @param  array<array-key>  $rules
+     */
+    protected function validateInput(Closure $askUsing, string $field, array $rules, ?Closure $onError = null): string
+    {
+        $input = $askUsing();
+
+        $validator = Validator::make(
+            [$field => $input],
+            [$field => $rules],
+        );
+
+        if ($validator->fails()) {
+            $this->components->error($validator->errors()->first());
+
+            if ($onError) {
+                $onError($validator);
+            }
+
+            $input = $this->validateInput($askUsing, $field, $rules);
+        }
+
+        return $input;
+    }
+}


### PR DESCRIPTION
#7476 removed the `CanValidateInput` in favour of using Laravel Prompts. Which I support. Plugin authors were using this internal trait within their plugins. So I have added it back deprecated it instead.