### PR TITLE
fix bug unset active filter for relations

### DIFF
--- a/packages/tables/src/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Concerns/CanSearchRecords.php
@@ -40,11 +40,7 @@ trait CanSearchRecords
      */
     public function updatedTableColumnSearches($value = null, ?string $key = null): void
     {
-        if (blank($value) && ! str($key)->contains('.')) {
-            unset($this->tableColumnSearches[$key]);
-        }
-
-        if (blank($value) && str($key)->contains('.')) {
+        if (blank($value) && filled($key)) {
             Arr::forget($this->tableColumnSearches, $key);
         }
 

--- a/packages/tables/src/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Concerns/CanSearchRecords.php
@@ -44,6 +44,10 @@ trait CanSearchRecords
             unset($this->tableColumnSearches[$key]);
         }
 
+        if (blank($value) && str($key)->contains('.')) {
+            Arr::forget($this->tableColumnSearches, $key);
+        }
+
         if ($this->getTable()->persistsColumnSearchesInSession()) {
             session()->put(
                 $this->getTableColumnSearchesSessionKey(),


### PR DESCRIPTION
Fixes bug where you are unable to remove active filter for a column search on a relation.

(Image: clicking on "x" does nothing...)

<img width="531" alt="image" src="https://github.com/filamentphp/filament/assets/21239634/d2c6130d-8884-49a5-89e8-9cd9bf98d7e8">

