### PR TITLE
Fix Action component property

### DIFF
--- a/packages/forms/src/Components/Actions/Action.php
+++ b/packages/forms/src/Components/Actions/Action.php
@@ -40,7 +40,7 @@ class Action extends MountableAction
 
     public function toFormComponent(): ActionContainer
     {
-        return ActionContainer::make($this);
+        return $this->component = ActionContainer::make($this);
     }
 
     /**

--- a/packages/forms/src/Components/Actions/Action.php
+++ b/packages/forms/src/Components/Actions/Action.php
@@ -40,7 +40,11 @@ class Action extends MountableAction
 
     public function toFormComponent(): ActionContainer
     {
-        return $this->component = ActionContainer::make($this);
+        $component = ActionContainer::make($this);
+
+        $this->component($component);
+
+        return $component;
     }
 
     /**


### PR DESCRIPTION
Using `Action`'s `hidden()` function with a `Closure` produces an error about the uninitialized component.

Example code:
```php
use App\Model\FooModel;
use Filament\Forms\Form;
use Filament\Forms\Components\Actions;
use Filament\Forms\Components\Actions\Action;

public static function form(Form $form): Form
{
  return $form
    ->schema([
      Actions::make([
        Action::make('Test action')
          ->hidden(fn (FooModel $model) => true),
      ])
    ]);
}
```

Error stack:
```
Typed property Filament\\Forms\\Components\\Actions\\Action::$component must not be accessed before initialization at /[...]/vendor/filament/forms/src/Components/Actions/Concerns/BelongsToComponent.php:21)
[stacktrace]
#0 /Users/feat/Sites/daken/backend/vendor/filament/forms/src/Components/Actions/Action.php(56): Filament\\Forms\\Components\\Actions\\Action->getComponent()
#1 /Users/feat/Sites/daken/backend/vendor/filament/support/src/Concerns/EvaluatesClosures.php(57): Filament\\Forms\\Components\\Actions\\Action->resolveDefaultClosureDependencyForEvaluationByName('model')
#2 /Users/feat/Sites/daken/backend/vendor/filament/support/src/Concerns/EvaluatesClosures.php(32): Filament\\Support\\Components\\Component->resolveClosureDependencyForEvaluation(Object(ReflectionParameter), Array, Array)
#3 /Users/feat/Sites/daken/backend/vendor/filament/actions/src/Concerns/CanBeHidden.php(97): Filament\\Support\\Components\\Component->evaluate(Object(Closure))
#4 /Users/feat/Sites/daken/backend/vendor/filament/forms/src/Components/Actions/ActionContainer.php(31): Filament\\Actions\\StaticAction->isHidden()
...
```

With this PR the `Actions::make()` (with the `$action->toFormComponent` array mapping) will set the `$this->component` inside `Action` and resolves this issue.