### PR TITLE
Apply column search when overriding applySearchToTableQuery

### DIFF
--- a/packages/tables/docs/10-advanced.md
+++ b/packages/tables/docs/10-advanced.md
@@ -193,6 +193,8 @@ use Illuminate\Database\Eloquent\Builder;
 
 protected function applySearchToTableQuery(Builder $query): Builder
 {
+    $this->applyColumnSearchesToTableQuery($query);
+    
     if (filled($search = $this->getTableSearch())) {
         $query->whereIn('id', Post::search($search)->keys());
     }

--- a/packages/tables/docs/10-advanced.md
+++ b/packages/tables/docs/10-advanced.md
@@ -205,6 +205,8 @@ protected function applySearchToTableQuery(Builder $query): Builder
 
 Scout uses this `whereIn()` method to retrieve results internally, so there is no performance penalty for using it.
 
+The `applyColumnSearchesToTableQuery()` method ensures that searching individual columns will still work. You can replace that method with your own implementation if you want to use Scout for those search inputs as well.
+
 ## Query string
 
 Livewire ships with a feature to store data in the URL's query string, to access across requests.


### PR DESCRIPTION
In the documentation for Laravel Scout one needs to apply individual column searches to the Table query like in the parent version of the method.
