### PR TITLE
Add tooltip to hint icon

### DIFF
--- a/packages/forms/docs/03-fields/01-getting-started.md
+++ b/packages/forms/docs/03-fields/01-getting-started.md
@@ -175,6 +175,17 @@ RichEditor::make('content')
     ->hintIcon('heroicon-m-language')
 ```
 
+### Adding a tooltip to an hint icon
+
+Additionally, you can add a tooltip to display when you hover over the hint icon.
+
+```php
+use Filament\Forms\Components\TextInput;
+
+TextInput::make('name')
+    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Tooltip helper text')
+```
+
 <AutoScreenshot name="forms/fields/hint-icon" alt="Form field with hint icon" version="3.x" />
 
 ## Adding extra HTML attributes

--- a/packages/forms/docs/03-fields/01-getting-started.md
+++ b/packages/forms/docs/03-fields/01-getting-started.md
@@ -175,9 +175,11 @@ RichEditor::make('content')
     ->hintIcon('heroicon-m-language')
 ```
 
-### Adding a tooltip to an hint icon
+<AutoScreenshot name="forms/fields/hint-icon" alt="Form field with hint icon" version="3.x" />
 
-Additionally, you can add a tooltip to display when you hover over the hint icon.
+#### Adding a tooltip to a hint icon
+
+Additionally, you can add a tooltip to display when you hover over the hint icon, using the `tooltip` parameter of `hintIcon()`:
 
 ```php
 use Filament\Forms\Components\TextInput;
@@ -185,8 +187,6 @@ use Filament\Forms\Components\TextInput;
 TextInput::make('name')
     ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Tooltip helper text')
 ```
-
-<AutoScreenshot name="forms/fields/hint-icon" alt="Form field with hint icon" version="3.x" />
 
 ## Adding extra HTML attributes
 

--- a/packages/forms/docs/03-fields/01-getting-started.md
+++ b/packages/forms/docs/03-fields/01-getting-started.md
@@ -185,7 +185,7 @@ Additionally, you can add a tooltip to display when you hover over the hint icon
 use Filament\Forms\Components\TextInput;
 
 TextInput::make('name')
-    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Tooltip helper text')
+    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Need some more information?')
 ```
 
 ## Adding extra HTML attributes

--- a/packages/forms/resources/views/components/field-wrapper/hint.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/hint.blade.php
@@ -26,6 +26,7 @@
 
     @if ($icon)
         <x-filament::icon
+            x-data="{}"
             :icon="$icon"
             :x-tooltip.raw="$tooltip"
             @class([

--- a/packages/forms/resources/views/components/field-wrapper/hint.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/hint.blade.php
@@ -2,6 +2,7 @@
     'actions' => [],
     'color' => 'gray',
     'icon' => null,
+    'tooltip' => null,
 ])
 
 <div
@@ -26,6 +27,7 @@
     @if ($icon)
         <x-filament::icon
             :icon="$icon"
+            :x-tooltip.raw="$tooltip"
             @class([
                 'fi-fo-field-wrp-hint-icon h-5 w-5',
                 match ($color) {

--- a/packages/forms/resources/views/components/field-wrapper/index.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/index.blade.php
@@ -7,6 +7,7 @@
     'hintActions' => null,
     'hintColor' => null,
     'hintIcon' => null,
+    'hintIconTooltip' => null,
     'id' => null,
     'isDisabled' => null,
     'isMarkedAsRequired' => null,

--- a/packages/forms/resources/views/components/field-wrapper/index.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/index.blade.php
@@ -27,6 +27,7 @@
         $hintActions ??= $field->getHintActions();
         $hintColor ??= $field->getHintColor();
         $hintIcon ??= $field->getHintIcon();
+        $hintIconTooltip ??= $field->getHintIconTooltip();
         $id ??= $field->getId();
         $isDisabled ??= $field->isDisabled();
         $isMarkedAsRequired ??= $field->isMarkedAsRequired();
@@ -87,6 +88,7 @@
                         :actions="$hintActions"
                         :color="$hintColor"
                         :icon="$hintIcon"
+                        :tooltip="$hintIconTooltip"
                     >
                         {{ $hint }}
                     </x-filament-forms::field-wrapper.hint>

--- a/packages/forms/src/Components/Concerns/HasHint.php
+++ b/packages/forms/src/Components/Concerns/HasHint.php
@@ -29,6 +29,8 @@ trait HasHint
 
     protected string | Closure | null $hintIcon = null;
 
+    protected string | Closure | null $hintIconTooltip = null;
+
     public function hint(string | Htmlable | Closure | null $hint): static
     {
         $this->hint = $hint;
@@ -46,9 +48,10 @@ trait HasHint
         return $this;
     }
 
-    public function hintIcon(string | Closure | null $hintIcon): static
+    public function hintIcon(string | Closure | null $hintIcon, string | Closure | null $hintIconTooltip = null): static
     {
         $this->hintIcon = $hintIcon;
+        $this->hintIconTooltip = $hintIconTooltip;
 
         return $this;
     }
@@ -89,6 +92,11 @@ trait HasHint
     public function getHintIcon(): ?string
     {
         return $this->evaluate($this->hintIcon);
+    }
+
+    public function getHintIconTooltip(): ?string
+    {
+        return $this->evaluate($this->hintIconTooltip);
     }
 
     /**

--- a/packages/forms/src/Components/Concerns/HasHint.php
+++ b/packages/forms/src/Components/Concerns/HasHint.php
@@ -51,6 +51,13 @@ trait HasHint
     public function hintIcon(string | Closure | null $icon, string | Closure | null $tooltip = null): static
     {
         $this->hintIcon = $icon;
+        $this->hintIconTooltip($tooltip);
+
+        return $this;
+    }
+
+    public function hintIconTooltip(string | Closure | null $tooltip): static
+    {
         $this->hintIconTooltip = $tooltip;
 
         return $this;

--- a/packages/forms/src/Components/Concerns/HasHint.php
+++ b/packages/forms/src/Components/Concerns/HasHint.php
@@ -48,10 +48,10 @@ trait HasHint
         return $this;
     }
 
-    public function hintIcon(string | Closure | null $hintIcon, string | Closure | null $hintIconTooltip = null): static
+    public function hintIcon(string | Closure | null $icon, string | Closure | null $tooltip = null): static
     {
-        $this->hintIcon = $hintIcon;
-        $this->hintIconTooltip = $hintIconTooltip;
+        $this->hintIcon = $icon;
+        $this->hintIconTooltip = $tooltip;
 
         return $this;
     }

--- a/packages/infolists/docs/03-entries/01-getting-started.md
+++ b/packages/infolists/docs/03-entries/01-getting-started.md
@@ -191,6 +191,19 @@ TextEntry::make('apiKey')
 
 <AutoScreenshot name="infolists/entries/hint-icon" alt="Entry with hint icon" version="3.x" />
 
+#### Adding a tooltip to a hint icon
+
+Additionally, you can add a tooltip to display when you hover over the hint icon, using the `tooltip` parameter of `hintIcon()`:
+
+```php
+use Filament\Infolists\Components\TextEntry;
+
+TextEntry::make('apiKey')
+    ->label('API key')
+    ->hint('[Documentation](/documentation)')
+    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Read it!')
+```
+
 ## Hiding entries
 
 To hide an entry conditionally, you may use the `hidden()` and `visible()` methods, whichever you prefer:

--- a/packages/infolists/resources/views/components/entry-wrapper/hint.blade.php
+++ b/packages/infolists/resources/views/components/entry-wrapper/hint.blade.php
@@ -2,6 +2,7 @@
     'actions' => [],
     'color' => 'gray',
     'icon' => null,
+    'tooltip' => null,
 ])
 
 <div
@@ -25,7 +26,9 @@
 
     @if ($icon)
         <x-filament::icon
+            x-data="{}"
             :icon="$icon"
+            :x-tooltip.raw="$tooltip"
             @class([
                 'fi-in-entry-wrp-hint-icon h-5 w-5',
                 match ($color) {

--- a/packages/infolists/resources/views/components/entry-wrapper/index.blade.php
+++ b/packages/infolists/resources/views/components/entry-wrapper/index.blade.php
@@ -8,6 +8,7 @@
     'hintActions' => null,
     'hintColor' => null,
     'hintIcon' => null,
+    'hintIconTooltip' => null,
     'id' => null,
     'label' => null,
     'labelPrefix' => null,
@@ -31,6 +32,7 @@
         $hintActions ??= $entry->getHintActions();
         $hintColor ??= $entry->getHintColor();
         $hintIcon ??= $entry->getHintIcon();
+        $hintIconTooltip ??= $entry->getHintIconTooltip();
         $id ??= $entry->getId();
         $label ??= $entry->getLabel();
         $labelSrOnly ??= $entry->isLabelHidden();
@@ -79,6 +81,7 @@
                         :actions="$hintActions"
                         :color="$hintColor"
                         :icon="$hintIcon"
+                        :tooltip="$hintIconTooltip"
                     >
                         {{ $hint }}
                     </x-filament-infolists::entry-wrapper.hint>

--- a/packages/infolists/src/Components/Concerns/HasHint.php
+++ b/packages/infolists/src/Components/Concerns/HasHint.php
@@ -29,6 +29,8 @@ trait HasHint
 
     protected string | Closure | null $hintIcon = null;
 
+    protected string | Closure | null $hintIconTooltip = null;
+
     public function hint(string | Htmlable | Closure | null $hint): static
     {
         $this->hint = $hint;
@@ -46,9 +48,17 @@ trait HasHint
         return $this;
     }
 
-    public function hintIcon(string | Closure | null $hintIcon): static
+    public function hintIcon(string | Closure | null $icon, string | Closure | null $tooltip = null): static
     {
-        $this->hintIcon = $hintIcon;
+        $this->hintIcon = $icon;
+        $this->hintIconTooltip($tooltip);
+
+        return $this;
+    }
+
+    public function hintIconTooltip(string | Closure | null $tooltip): static
+    {
+        $this->hintIconTooltip = $tooltip;
 
         return $this;
     }
@@ -89,6 +99,11 @@ trait HasHint
     public function getHintIcon(): ?string
     {
         return $this->evaluate($this->hintIcon);
+    }
+
+    public function getHintIconTooltip(): ?string
+    {
+        return $this->evaluate($this->hintIconTooltip);
     }
 
     /**


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Useful when combined with a question mark icon.
<img width="1122" alt="Screenshot 2023-08-09 at 18 19 02" src="https://github.com/filamentphp/filament/assets/533658/c9a113a4-9f5e-494b-a13c-f3d21a7d4449">

```php
->hintIcon('heroicon-o-question-mark-circle', hintIconTooltip: 'Helper text only visible when user requests it'),
```
