### PR TITLE
Update MakeThemeCommand.php

### DIFF
--- a/packages/panels/src/Commands/MakeThemeCommand.php
+++ b/packages/panels/src/Commands/MakeThemeCommand.php
@@ -28,7 +28,7 @@ class MakeThemeCommand extends Command
             return static::FAILURE;
         }
 
-        $this->info("Using Node.js v{$npmVersion[0]}");
+        $this->info("Using NPM v{$npmVersion[0]}");
 
         exec('npm install tailwindcss @tailwindcss/forms @tailwindcss/typography postcss autoprefixer --save-dev');
 


### PR DESCRIPTION
Fix "Using NPM" instead of "Using Node.js"

This PR is very simple. As image below, the output told me it was using Node v9, instead of NPM V9.

This just changes that output, to "Using NPM v..."

Let me know if allowing usage of `yarn` and `pnpm` is seen with good eyes.
People that do that will know their way, but it's a convenience that's good to have.
It can be autodetected (based on lockfile search), deafulting to NPM.

What do you think? I'll gladly to that PR.

<img width="635" alt="image" src="https://github.com/filamentphp/filament/assets/26031459/fdcccf36-3993-4edb-994c-a0971eaa3b02">

