### PR TITLE
Fix: visible is not being considered for core items on Tenant menu

### DIFF
--- a/packages/panels/resources/views/components/tenant-menu.blade.php
+++ b/packages/panels/resources/views/components/tenant-menu.blade.php
@@ -6,14 +6,17 @@
     $billingItem = $items['billing'] ?? null;
     $billingItemUrl = $billingItem?->getUrl();
     $hasTenantBilling = filament()->hasTenantBilling() || filled($billingItemUrl);
+    $tenantBillingIsVisible = isset($items['billing']) ? $items['billing']->isVisible() : true;
 
     $registrationItem = $items['register'] ?? null;
     $registrationItemUrl = $registrationItem?->getUrl();
     $hasTenantRegistration = (filament()->hasTenantRegistration() && filament()->getTenantRegistrationPage()::canView()) || filled($registrationItemUrl);
+    $tenantRegistrationIsVisible = isset($items['register']) ? $items['register']->isVisible() : true;
 
     $profileItem = $items['profile'] ?? null;
     $profileItemUrl = $profileItem?->getUrl();
     $hasTenantProfile = (filament()->hasTenantProfile() && filament()->getTenantProfilePage()::canView($currentTenant)) || filled($profileItemUrl);
+    $tenantProfileIsVisible = isset($items['profile']) ? $items['profile']->isVisible() : true;
 
     $canSwitchTenants = count($tenants = array_filter(
         filament()->getUserTenants(filament()->auth()->user()),
@@ -81,7 +84,7 @@
 
     @if ($hasTenantProfile || $hasTenantBilling)
         <x-filament::dropdown.list>
-            @if ($hasTenantProfile)
+            @if ($hasTenantProfile && $tenantProfileIsVisible)
                 <x-filament::dropdown.list.item
                     :color="$profileItem?->getColor()"
                     :href="$profileItemUrl ?? filament()->getTenantProfileUrl()"
@@ -92,7 +95,7 @@
                 </x-filament::dropdown.list.item>
             @endif
 
-            @if ($hasTenantBilling)
+            @if ($hasTenantBilling && $tenantBillingIsVisible)
                 <x-filament::dropdown.list.item
                     :color="$billingItem?->getColor() ?? 'gray'"
                     :href="$billingItemUrl ?? filament()->getTenantBillingUrl()"
@@ -134,7 +137,7 @@
         </x-filament::dropdown.list>
     @endif
 
-    @if ($hasTenantRegistration)
+    @if ($hasTenantRegistration && $tenantRegistrationIsVisible)
         <x-filament::dropdown.list>
             <x-filament::dropdown.list.item
                 :color="$registrationItem?->getColor()"

--- a/packages/panels/resources/views/components/tenant-menu.blade.php
+++ b/packages/panels/resources/views/components/tenant-menu.blade.php
@@ -5,18 +5,18 @@
 
     $billingItem = $items['billing'] ?? null;
     $billingItemUrl = $billingItem?->getUrl();
-    $hasTenantBilling = filament()->hasTenantBilling() || filled($billingItemUrl);
-    $tenantBillingIsVisible = isset($items['billing']) ? $items['billing']->isVisible() : true;
+    $isBillingItemVisible = $billingItem?->isVisible() ?? true;
+    $hasBillingItem = (filament()->hasTenantBilling() || filled($billingItemUrl)) && $isBillingItemVisible;
 
     $registrationItem = $items['register'] ?? null;
     $registrationItemUrl = $registrationItem?->getUrl();
-    $hasTenantRegistration = (filament()->hasTenantRegistration() && filament()->getTenantRegistrationPage()::canView()) || filled($registrationItemUrl);
-    $tenantRegistrationIsVisible = isset($items['register']) ? $items['register']->isVisible() : true;
+    $isRegistrationItemVisible = $registrationItem?->isVisible() ?? true;
+    $hasRegistrationItem = ((filament()->hasTenantRegistration() && filament()->getTenantRegistrationPage()::canView()) || filled($registrationItemUrl)) && $isRegistrationItemVisible;
 
     $profileItem = $items['profile'] ?? null;
     $profileItemUrl = $profileItem?->getUrl();
-    $hasTenantProfile = (filament()->hasTenantProfile() && filament()->getTenantProfilePage()::canView($currentTenant)) || filled($profileItemUrl);
-    $tenantProfileIsVisible = isset($items['profile']) ? $items['profile']->isVisible() : true;
+    $isProfileItemVisible = $profileItem?->isVisible() ?? true;
+    $hasProfileItem = ((filament()->hasTenantProfile() && filament()->getTenantProfilePage()::canView($currentTenant)) || filled($profileItemUrl)) && $isProfileItemVisible;
 
     $canSwitchTenants = count($tenants = array_filter(
         filament()->getUserTenants(filament()->auth()->user()),
@@ -82,9 +82,9 @@
         </button>
     </x-slot>
 
-    @if ($hasTenantProfile || $hasTenantBilling)
+    @if ($hasProfileItem || $hasBillingItem)
         <x-filament::dropdown.list>
-            @if ($hasTenantProfile && $tenantProfileIsVisible)
+            @if ($hasProfileItem)
                 <x-filament::dropdown.list.item
                     :color="$profileItem?->getColor()"
                     :href="$profileItemUrl ?? filament()->getTenantProfileUrl()"
@@ -95,7 +95,7 @@
                 </x-filament::dropdown.list.item>
             @endif
 
-            @if ($hasTenantBilling && $tenantBillingIsVisible)
+            @if ($hasBillingItem)
                 <x-filament::dropdown.list.item
                     :color="$billingItem?->getColor() ?? 'gray'"
                     :href="$billingItemUrl ?? filament()->getTenantBillingUrl()"
@@ -137,7 +137,7 @@
         </x-filament::dropdown.list>
     @endif
 
-    @if ($hasTenantRegistration && $tenantRegistrationIsVisible)
+    @if ($hasRegistrationItem)
         <x-filament::dropdown.list>
             <x-filament::dropdown.list.item
                 :color="$registrationItem?->getColor()"

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -195,7 +195,7 @@ trait HasTenancy
                     return true;
                 }
 
-                return $item->isVisible()
+                return $item->isVisible();
             })
             ->sort(fn (MenuItem $item): int => $item->getSort())
             ->all();

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -190,7 +190,13 @@ trait HasTenancy
     public function getTenantMenuItems(): array
     {
         return collect($this->tenantMenuItems)
-            ->filter(fn (MenuItem $item, string|int $key): bool => in_array($key,  ['billing', 'profile', 'register']) || !$item->isHidden())
+            ->filter(function (MenuItem $item, string|int $key): bool {
+                if (in_array($key,  ['billing', 'profile', 'register'])) {
+                    return true;
+                }
+
+                return $item->isVisible()
+            })
             ->sort(fn (MenuItem $item): int => $item->getSort())
             ->all();
     }

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -190,7 +190,7 @@ trait HasTenancy
     public function getTenantMenuItems(): array
     {
         return collect($this->tenantMenuItems)
-            ->reject(fn (MenuItem $item): bool => $item->isHidden())
+            ->filter(fn (MenuItem $item, string|int $key): bool => in_array($key,  ['billing', 'profile', 'register']) || !$item->isHidden())
             ->sort(fn (MenuItem $item): int => $item->getSort())
             ->all();
     }


### PR DESCRIPTION
Hey folks,

I hope you're doing well. I wanted to draw your attention to a subtle issue we've encountered related to custom menu items within the panel for a Tenancy menu. Specifically, when customising core items like `billing`, `register`, or `profile` and using the `visible` method, the visibility rule isn't properly applied due to the way the `getTenantMenuItems` method filters solely by `isVisible()`.

```php
// Currently, the visible method for billing, register or profile menu items is never considered
$panel->tenantMenuItems([
    'billing' => MenuItem::make()
        ->visible(fn (): bool => auth()->user()->can('manage-billing'))
    ])
```

To address this, I've put together a pull request that provides a solution. This PR ensures that the visibility rule is consistently applied to custom menu items for the mentioned core functionalities by changing the way `getTenantMenuItems` applies the filter and making sure the visibility are being considered in the view. 

Thanks!

- [X] Changes have been thoroughly tested to not break existing functionality.
- [X] New functionality has been documented or existing documentation has been updated to reflect changes.
- [X] Visual changes are explained in the PR description using a screenshot/recording of before and after.
