### PR TITLE
Fix issue #7635

### DIFF
--- a/packages/widgets/resources/js/components/stats-overview/stat/chart.js
+++ b/packages/widgets/resources/js/components/stats-overview/stat/chart.js
@@ -1,7 +1,8 @@
 import Chart from 'chart.js/auto'
 
-export default function statsOverviewStatChart({ labels, values }) {
+export default function statsOverviewStatChart({ dataChecksum, labels, values }) {
     return {
+        dataChecksum: dataChecksum,
         init: function () {
             Alpine.effect(() => {
                 Alpine.store('theme')
@@ -57,6 +58,9 @@ export default function statsOverviewStatChart({ labels, values }) {
                     ],
                 },
                 options: {
+                    animation: {
+                        duration: 0,    
+                    },
                     elements: {
                         point: {
                             radius: 0,

--- a/packages/widgets/resources/js/components/stats-overview/stat/chart.js
+++ b/packages/widgets/resources/js/components/stats-overview/stat/chart.js
@@ -6,7 +6,7 @@ export default function statsOverviewStatChart({
     values,
 }) {
     return {
-        dataChecksum: dataChecksum,
+        dataChecksum,
         
         init: function () {
             Alpine.effect(() => {

--- a/packages/widgets/resources/js/components/stats-overview/stat/chart.js
+++ b/packages/widgets/resources/js/components/stats-overview/stat/chart.js
@@ -1,8 +1,13 @@
 import Chart from 'chart.js/auto'
 
-export default function statsOverviewStatChart({ dataChecksum, labels, values }) {
+export default function statsOverviewStatChart({
+    dataChecksum,
+    labels,
+    values,
+}) {
     return {
         dataChecksum: dataChecksum,
+        
         init: function () {
             Alpine.effect(() => {
                 Alpine.store('theme')

--- a/packages/widgets/resources/views/stats-overview-widget/stat.blade.php
+++ b/packages/widgets/resources/views/stats-overview-widget/stat.blade.php
@@ -7,6 +7,7 @@
     $descriptionIconPosition = $getDescriptionIconPosition();
     $url = $getUrl();
     $tag = $url ? 'a' : 'div';
+    $dataChecksum = $generateDataChecksum();
 
     $descriptionIconClasses = \Illuminate\Support\Arr::toCssClasses([
         'fi-wi-stats-overview-stat-description-icon h-5 w-5',
@@ -98,6 +99,7 @@
                 ax-load
                 ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('stats-overview/stat/chart', 'filament/widgets') }}"
                 x-data="statsOverviewStatChart({
+                            dataChecksum: '{{ $dataChecksum }}',
                             labels: @js(array_keys($chart)),
                             values: @js(array_values($chart)),
                         })"

--- a/packages/widgets/resources/views/stats-overview-widget/stat.blade.php
+++ b/packages/widgets/resources/views/stats-overview-widget/stat.blade.php
@@ -99,7 +99,7 @@
                 ax-load
                 ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('stats-overview/stat/chart', 'filament/widgets') }}"
                 x-data="statsOverviewStatChart({
-                            dataChecksum: '{{ $dataChecksum }}',
+                            dataChecksum: @js($dataChecksum),
                             labels: @js(array_keys($chart)),
                             values: @js(array_values($chart)),
                         })"

--- a/packages/widgets/src/StatsOverviewWidget/Stat.php
+++ b/packages/widgets/src/StatsOverviewWidget/Stat.php
@@ -288,4 +288,9 @@ class Stat extends Component implements Htmlable
     {
         return view('filament-widgets::stats-overview-widget.stat', $this->data());
     }
+
+    public function generateDataChecksum(): string
+    {
+        return md5(json_encode($this->getChart()) . now());
+    }
 }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

## Issue
- When the polling interval is enabled, the chart statistics will update solely when the chart data is dynamic. Should the data be static, the chart will render labels and values only during the initial instance.

https://github.com/filamentphp/filament/assets/3833889/34980533-bfa9-40c7-addb-ad687b54aa4d

## Suggestion
- Send a checksum along with labels and values for updating the chart at each interval.
- Deactivate animation.

https://github.com/filamentphp/filament/assets/3833889/c991b998-25cb-49ac-b7e9-5b924ad9e2fe
