### PR TITLE
[Feature] Add optional route tenant prefix

### DIFF
--- a/packages/panels/docs/10-tenancy.md
+++ b/packages/panels/docs/10-tenancy.md
@@ -446,25 +446,6 @@ public function panel(Panel $panel): Panel
 }
 ```
 
-## Configuring the tenant route prefix
-
-By default the URL structure will put the tenant ID or slug immediately after the panel path. If you wish to prefix it with another URL segment, use the `tenantRoutePrefix()` method:
-
-```php
-use Filament\Panel;
-
-public function panel(Panel $panel): Panel
-{
-    return $panel
-        // ...
-        ->path('admin'}
-        ->tenant(Team::class)
-        ->tenantRoutePrefix('team');
-}
-```
-
-Before, the URL structure was `/admin/1` for tenant 1. Now, it is `/admin/team/1`.
-
 ## Configuring the name attribute
 
 By default, Filament will use Filament\Resources\Pages\CreateRecord;use the `name` attribute of the tenant to display its name in the app. To change this, you can implement the `HasName` contract:
@@ -579,6 +560,25 @@ public function panel(Panel $panel): Panel
         ], isPersistent: true);
 }
 ```
+
+## Adding a tenant route prefix
+
+By default the URL structure will put the tenant ID or slug immediately after the panel path. If you wish to prefix it with another URL segment, use the `tenantRoutePrefix()` method:
+
+```php
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->path('admin')
+        ->tenant(Team::class)
+        ->tenantRoutePrefix('team');
+}
+```
+
+Before, the URL structure was `/admin/1` for tenant 1. Now, it is `/admin/team/1`.
 
 ## Tenancy security
 

--- a/packages/panels/docs/10-tenancy.md
+++ b/packages/panels/docs/10-tenancy.md
@@ -448,7 +448,7 @@ public function panel(Panel $panel): Panel
 
 ## Configuring the tenant route prefix
 
-By default the URL structure will put the tenant id or slug immediately after the panel path. If you wish to prefix the tenant id or slug with a value to tenant routes you may do so by using the `tenantRoutePrefix()` method.
+By default the URL structure will put the tenant ID or slug immediately after the panel path. If you wish to prefix it with another URL segment, use the `tenantRoutePrefix()` method:
 
 ```php
 use Filament\Panel;

--- a/packages/panels/docs/10-tenancy.md
+++ b/packages/panels/docs/10-tenancy.md
@@ -446,6 +446,25 @@ public function panel(Panel $panel): Panel
 }
 ```
 
+## Configuring the tenant route prefix
+
+By default the URL structure will put the tenant id or slug immediately after the panel path. If you wish to prefix the tenant id or slug with a value to tenant routes you may do so by using the `tenantRoutePrefix()` method.
+
+```php
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->path('admin'}
+        ->tenant(Team::class)
+        ->tenantRoutePrefix('team');
+}
+```
+
+Without this the URL structure will be `https://example.com/admin/1` for tenant id 1, but with the route prefix it will become `https://example.com/admin/team/1`.
+
 ## Configuring the name attribute
 
 By default, Filament will use Filament\Resources\Pages\CreateRecord;use the `name` attribute of the tenant to display its name in the app. To change this, you can implement the `HasName` contract:

--- a/packages/panels/docs/10-tenancy.md
+++ b/packages/panels/docs/10-tenancy.md
@@ -463,7 +463,7 @@ public function panel(Panel $panel): Panel
 }
 ```
 
-Without this the URL structure will be `https://example.com/admin/1` for tenant id 1, but with the route prefix it will become `https://example.com/admin/team/1`.
+Before, the URL structure was `/admin/1` for tenant 1. Now, it is `/admin/team/1`.
 
 ## Configuring the name attribute
 

--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -13,6 +13,7 @@ Route::name('filament.')
             /** @var \Filament\Panel $panel */
             $panelId = $panel->getId();
             $hasTenancy = $panel->hasTenancy();
+            $tenantRoutePrefix = $panel->getTenantRoutePrefix();
             $tenantSlugAttribute = $panel->getTenantSlugAttribute();
             $domains = $panel->getDomains();
 
@@ -21,7 +22,7 @@ Route::name('filament.')
                     ->middleware($panel->getMiddleware())
                     ->name("{$panelId}.")
                     ->prefix($panel->getPath())
-                    ->group(function () use ($panel, $hasTenancy, $tenantSlugAttribute) {
+                    ->group(function () use ($panel, $hasTenancy, $tenantRoutePrefix, $tenantSlugAttribute) {
                         Route::name('auth.')->group(function () use ($panel) {
                             if ($panel->hasLogin()) {
                                 Route::get('/login', $panel->getLoginRouteAction())->name('login');
@@ -44,7 +45,7 @@ Route::name('filament.')
                         });
 
                         Route::middleware($panel->getAuthMiddleware())
-                            ->group(function () use ($panel, $hasTenancy, $tenantSlugAttribute): void {
+                            ->group(function () use ($panel, $hasTenancy, $tenantRoutePrefix, $tenantSlugAttribute): void {
                                 if ($hasTenancy) {
                                     Route::get('/', RedirectToTenantController::class)->name('tenant');
                                 }
@@ -81,7 +82,7 @@ Route::name('filament.')
                                 }
 
                                 Route::middleware($hasTenancy ? $panel->getTenantMiddleware() : [])
-                                    ->prefix($hasTenancy ? ('{tenant' . (($tenantSlugAttribute) ? ":{$tenantSlugAttribute}" : '') . '}') : '')
+                                    ->prefix($hasTenancy ? (($tenantRoutePrefix) ? "{$tenantRoutePrefix}/" : '') . ('{tenant' . (($tenantSlugAttribute) ? ":{$tenantSlugAttribute}" : '') . '}') : '')
                                     ->group(function () use ($panel): void {
                                         Route::get('/', RedirectToHomeController::class)->name('home');
 
@@ -117,7 +118,7 @@ Route::name('filament.')
 
                         if ($hasTenancy) {
                             Route::middleware($panel->getTenantMiddleware())
-                                ->prefix('{tenant' . (($tenantSlugAttribute) ? ":{$tenantSlugAttribute}" : '') . '}')
+                                ->prefix((($tenantRoutePrefix) ? "{$tenantRoutePrefix}/" : '') . '{tenant' . (($tenantSlugAttribute) ? ":{$tenantSlugAttribute}" : '') . '}')
                                 ->group(function () use ($panel): void {
                                     if ($routes = $panel->getTenantRoutes()) {
                                         $routes($panel);

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -11,6 +11,8 @@ trait HasTenancy
 {
     protected ?BillingProvider $tenantBillingProvider = null;
 
+    protected ?string $tenantRoutePrefix = null;
+    
     protected ?string $tenantModel = null;
 
     protected ?string $tenantProfilePage = null;
@@ -57,6 +59,11 @@ trait HasTenancy
         return $this;
     }
 
+    public function tenantRoutePrefix(string $prefix): static
+    {
+        $this->tenantRoutePrefix = $prefix;
+    }
+
     public function tenantBillingProvider(?BillingProvider $provider): static
     {
         $this->tenantBillingProvider = $provider;
@@ -101,6 +108,16 @@ trait HasTenancy
     public function hasTenantRegistration(): bool
     {
         return filled($this->getTenantRegistrationPage());
+    }
+
+    public function hasTenantRoutePrefix(): bool
+    {
+        return filled($this->getTenantRoutePrefix());
+    }
+
+    public function getTenantRoutePrefix(): ?string
+    {
+        return $this->tenantRoutePrefix;
     }
 
     public function getTenantBillingProvider(): ?BillingProvider

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -62,6 +62,8 @@ trait HasTenancy
     public function tenantRoutePrefix(string $prefix): static
     {
         $this->tenantRoutePrefix = $prefix;
+
+        return $this;
     }
 
     public function tenantBillingProvider(?BillingProvider $provider): static

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -59,7 +59,7 @@ trait HasTenancy
         return $this;
     }
 
-    public function tenantRoutePrefix(string $prefix): static
+    public function tenantRoutePrefix(?string $prefix): static
     {
         $this->tenantRoutePrefix = $prefix;
 


### PR DESCRIPTION
Currently a multitenant configuration adds the tenant id or slug directly to the URL after the panel path. While there is nothing wrong with this behavior some, like myself, would prefer to apply a prefix to the tenant id or slug.

Currently a panel with a path of "admin" on the domain "example.com" that has a default multitenant config has a URL structure that looks like this: "https://example.com/admin/{tenant_id}"

This PR adds a new `->tenantRoutePrefix()` method you can chain on in the panel definition that will accept a string of what to prefix the tenant id or slug with. For example if you use `->tenantRoutePrefix('team')` that URL structure now becomes: "https://example.com/admin/team/{tenant_id}".

I had considered adding the prefix such as "team" in this example to the panel path. For example using `->path('admin/team')` instead of `->path('admin')` but I found this to not be desirable because that became part of the path for non-tenant related routes in the panel. For example "https://example.com/admin/login" would become "https://example.com/admin/team/login". Perhaps worse still "https://example.com/admin/profile" would become "https://example.com/admin/team/profile" which was real confusing because the profile was for the user not the tenant so having team on that route made no sense.

This was a fairly minor change, that is completely optional opt-in only feature and does not affect backwards compatibility and is not a breaking change.
