### PR TITLE
[Docs] Update docs on navagation to named routes

### DIFF
--- a/packages/panels/docs/06-navigation.md
+++ b/packages/panels/docs/06-navigation.md
@@ -202,6 +202,8 @@ public function panel(Panel $panel): Panel
 }
 ```
 
+**NOTE:** When using Laravel's `route()` helper to access a named route be sure to include it in a closure to ensure the route will be found. Otherwise you may get a Route Not Defined Exception.
+
 ## Conditionally hiding navigation items
 
 You can also conditionally hide a navigation item by using the `visible()` or `hidden()` methods, passing in a condition to check:

--- a/packages/panels/docs/06-navigation.md
+++ b/packages/panels/docs/06-navigation.md
@@ -262,7 +262,7 @@ public function panel(Panel $panel): Panel
                 NavigationItem::make('Dashboard')
                     ->icon('heroicon-o-home')
                     ->isActiveWhen(fn (): bool => request()->routeIs('filament.admin.pages.dashboard'))
-                    ->url(route('filament.admin.pages.dashboard')),
+                    ->url(fn() => route('filament.admin.pages.dashboard')),
                 ...UserResource::getNavigationItems(),
                 ...Settings::getNavigationItems(),
             ]);
@@ -331,7 +331,7 @@ public function panel(Panel $panel): Panel
         ->userMenuItems([
             MenuItem::make()
                 ->label('Settings')
-                ->url(route('filament.admin.pages.settings'))
+                ->url(fn() => route('filament.admin.pages.settings'))
                 ->icon('heroicon-o-cog-6-tooth'),
             // ...
         ]);


### PR DESCRIPTION
Most of the examples on the docs page for navigation showed using the Laravel `route()` helper directly. However I noticed when doing this I always get a "Route Not Defined" Exception. Calling the route helper in a closure solves this.

This PR updates the examples to ensure they are all shown in closure form. I optionally added a note warning the helper should only be used in a closure, however in case you do not wish to include that it is a separate commit that can be easily removed.