### PR TITLE
[Docs] Correct example showing the record passed in as param

### DIFF
--- a/packages/actions/docs/04-modals.md
+++ b/packages/actions/docs/04-modals.md
@@ -38,9 +38,9 @@ Action::make('updateAuthor')
             ->options(User::query()->pluck('name', 'id'))
             ->required(),
     ])
-    ->action(function (array $data): void {
-        $this->record->author()->associate($data['authorId']);
-        $this->record->save();
+    ->action(function (array $data, Model $record): void {
+        $record->author()->associate($data['authorId']);
+        $record->save();
     })
 ```
 

--- a/packages/actions/docs/04-modals.md
+++ b/packages/actions/docs/04-modals.md
@@ -12,8 +12,10 @@ Actions may require additional confirmation or input from the user before they r
 You may require confirmation before an action is run using the `requiresConfirmation()` method. This is useful for particularly destructive actions, such as those that delete records.
 
 ```php
+use App\Models\Post;
+
 Action::make('delete')
-    ->action(fn () => $this->record->delete())
+    ->action(fn (Post $record) => $record->delete())
     ->requiresConfirmation()
 ```
 
@@ -28,6 +30,7 @@ You may also render a form in the modal to collect extra information from the us
 You may use components from the [Form Builder](../forms) to create custom action modal forms. The data from the form is available in the `$data` array of the `action()` closure:
 
 ```php
+use App\Models\Post;
 use App\Models\User;
 use Filament\Forms\Components\Select;
 
@@ -38,7 +41,7 @@ Action::make('updateAuthor')
             ->options(User::query()->pluck('name', 'id'))
             ->required(),
     ])
-    ->action(function (array $data, Model $record): void {
+    ->action(function (array $data, Post $record): void {
         $record->author()->associate($data['authorId']);
         $record->save();
     })
@@ -51,13 +54,14 @@ Action::make('updateAuthor')
 You may fill the form with existing data, using the `fillForm()` method:
 
 ```php
+use App\Models\Post;
 use App\Models\User;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Form;
 
 Action::make('updateAuthor')
-    ->fillForm([
-        'authorId' => $this->record->author->id,
+    ->fillForm(fn (Post $record): array => [
+        'authorId' => $record->author->id,
     ])
     ->form([
         Select::make('authorId')
@@ -65,9 +69,9 @@ Action::make('updateAuthor')
             ->options(User::query()->pluck('name', 'id'))
             ->required(),
     ])
-    ->action(function (array $data): void {
-        $this->record->author()->associate($data['authorId']);
-        $this->record->save();
+    ->action(function (array $data, Post $record): void {
+        $record->author()->associate($data['authorId']);
+        $record->save();
     })
 ```
 
@@ -118,6 +122,7 @@ Action::make('create')
 You may wish to disable all form fields in the modal, ensuring the user cannot edit them. You may do so using the `disabledForm()` method:
 
 ```php
+use App\Models\Post;
 use App\Models\User;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
@@ -127,13 +132,13 @@ Action::make('approvePost')
         TextInput::make('title'),
         Textarea::make('content'),
     ])
-    ->fillForm([
-        'title' => $this->record->title,
-        'content' => $this->record->content,
+    ->fillForm(fn (Post $record): array => [
+        'title' => $record->title,
+        'content' => $record->content,
     ])
     ->disabledForm()
-    ->action(function (): void {
-        $this->record->approve();
+    ->action(function (Post $record): void {
+        $record->approve();
     })
 ```
 
@@ -142,8 +147,10 @@ Action::make('approvePost')
 You may customize the heading, description and label of the submit button in the modal:
 
 ```php
+use App\Models\Post;
+
 Action::make('delete')
-    ->action(fn () => $this->record->delete())
+    ->action(fn (Post $record) => $record->delete())
     ->requiresConfirmation()
     ->modalHeading('Delete post')
     ->modalDescription('Are you sure you\'d like to delete this post? This cannot be undone.')
@@ -157,8 +164,10 @@ Action::make('delete')
 You may add an [icon](https://blade-ui-kit.com/blade-icons?set=1#search) inside the modal using the `modalIcon()` method:
 
 ```php
+use App\Models\Post;
+
 Action::make('delete')
-    ->action(fn () => $this->record->delete())
+    ->action(fn (Post $record) => $record->delete())
     ->requiresConfirmation()
     ->modalIcon('heroicon-o-trash')
 ```
@@ -168,8 +177,10 @@ Action::make('delete')
 By default, the icon will inherit the color of the action button. You may customize the color of the icon using the `modalIconColor()` method:
 
 ```php
+use App\Models\Post;
+
 Action::make('delete')
-    ->action(fn () => $this->record->delete())
+    ->action(fn (Post $record) => $record->delete())
     ->requiresConfirmation()
     ->color('danger')
     ->modalIcon('heroicon-o-trash')
@@ -198,8 +209,10 @@ Action::make('updateAuthor')
 You may define custom content to be rendered inside your modal, which you can specify by passing a Blade view into the `modalContent()` method:
 
 ```php
+use App\Models\Post;
+
 Action::make('advance')
-    ->action(fn () => $this->record->advance())
+    ->action(fn (Post $record) => $record->advance())
     ->modalContent(view('filament.pages.actions.advance'))
 ```
 
@@ -223,8 +236,10 @@ Action::make('advance')
 By default, the custom content is displayed above the modal form if there is one, but you can add content below using `modalContentFooter()` if you wish:
 
 ```php
+use App\Models\Post;
+
 Action::make('advance')
-    ->action(fn () => $this->record->advance())
+    ->action(fn (Post $record) => $record->advance())
     ->modalContentFooter(view('filament.pages.actions.advance'))
 ```
 
@@ -233,15 +248,16 @@ Action::make('advance')
 You can add an action button to your custom modal content, which is useful if you want to add a button that performs an action other than the main action. You can do this by registering an action with the `registerModalActions()` method, and then passing it to the view:
 
 ```php
+use App\Models\Post;
 use Illuminate\Contracts\View\View;
 
 Action::make('advance')
     ->registerModalActions([
         Action::make('report')
             ->requiresConfirmation()
-            ->action(fn () => $this->record->report()),
+            ->action(fn (Post $record) => $record->report()),
     ])
-    ->action(fn () => $this->record->advance())
+    ->action(fn (Post $record) => $record->advance())
     ->modalContent(fn (Action $action): View => view(
         'filament.pages.actions.advance',
         ['action' => $action],

--- a/packages/actions/docs/07-prebuilt-actions/01-create.md
+++ b/packages/actions/docs/07-prebuilt-actions/01-create.md
@@ -155,12 +155,13 @@ CreateAction::make()
 At any time, you may call `$action->halt()` from inside a lifecycle hook or mutation method, which will halt the entire creation process:
 
 ```php
+use App\Models\Post;
 use Filament\Notifications\Actions\Action;
 use Filament\Notifications\Notification;
 
 CreateAction::make()
-    ->before(function (CreateAction $action) {
-        if (! $this->record->team->subscribed()) {
+    ->before(function (CreateAction $action, Post $record) {
+        if (! $record->team->subscribed()) {
             Notification::make()
                 ->warning()
                 ->title('You don\'t have an active subscription!')

--- a/packages/actions/docs/07-prebuilt-actions/02-edit.md
+++ b/packages/actions/docs/07-prebuilt-actions/02-edit.md
@@ -168,13 +168,14 @@ EditAction::make()
 At any time, you may call `$action->halt()` from inside a lifecycle hook or mutation method, which will halt the entire saving process:
 
 ```php
+use App\Models\Post;
 use Filament\Notifications\Actions\Action;
 use Filament\Notifications\Notification;
 use Filament\Tables\Actions\EditAction;
 
 EditAction::make()
-    ->before(function (EditAction $action) {
-        if (! $this->record->team->subscribed()) {
+    ->before(function (EditAction $action, Post $record) {
+        if (! $record->team->subscribed()) {
             Notification::make()
                 ->warning()
                 ->title('You don\'t have an active subscription!')

--- a/packages/actions/docs/07-prebuilt-actions/05-replicate.md
+++ b/packages/actions/docs/07-prebuilt-actions/05-replicate.md
@@ -120,12 +120,13 @@ ReplicateAction::make()
 At any time, you may call `$action->halt()` from inside a lifecycle hook, which will halt the entire replication process:
 
 ```php
+use App\Models\Post;
 use Filament\Notifications\Actions\Action;
 use Filament\Notifications\Notification;
 
 ReplicateAction::make()
-    ->before(function (ReplicateAction $action) {
-        if (! $this->record->team->subscribed()) {
+    ->before(function (ReplicateAction $action, Post $record) {
+        if (! $record->team->subscribed()) {
             Notification::make()
                 ->warning()
                 ->title('You don\'t have an active subscription!')

--- a/packages/forms/docs/04-layout/07-placeholder.md
+++ b/packages/forms/docs/04-layout/07-placeholder.md
@@ -8,10 +8,11 @@ import AutoScreenshot from "@components/AutoScreenshot.astro"
 Placeholders can be used to render text-only "fields" within your forms. Each placeholder has `content()`, which cannot be changed by the user.
 
 ```php
+use App\Models\Post;
 use Filament\Forms\Components\Placeholder;
 
 Placeholder::make('created')
-    ->content($this->getRecord()->created_at->toFormattedDateString())
+    ->content(fn (Post $record): string => $record->created_at->toFormattedDateString())
 ```
 
 <AutoScreenshot name="forms/layout/placeholder/simple" alt="Placeholder" version="3.x" />

--- a/packages/panels/docs/04-pages.md
+++ b/packages/panels/docs/04-pages.md
@@ -68,11 +68,12 @@ protected function getHeaderActions(): array
 If you're using actions on an [Edit](resources/editing-records) or [View](resources/viewing-records) resource page, you can refresh data within the main form using the `refreshFormData()` method:
 
 ```php
+use App\Models\Post;
 use Filament\Actions\Action;
 
 Action::make('approve')
-    ->action(function () {
-        $this->getRecord()->approve();
+    ->action(function (Post $record) {
+        $record->approve();
 
         $this->refreshFormData([
             'status',


### PR DESCRIPTION
When following this example I discovered I could not call `$this->record` from that context. After a quick check I discovered the `$record` must be passed in as a parameter into the closure.

**NOTE:** There are other examples on this docs page of `$this->record` that I suspect may also need to be updated but I have not tested that so I am not updating them, unless someone can confirm that is also the case there. I am making this a draft until I can get confirmation on this.