### PR TITLE
[Feature] Allow disabling tenant menu

### DIFF
--- a/packages/panels/docs/10-tenancy.md
+++ b/packages/panels/docs/10-tenancy.md
@@ -356,6 +356,21 @@ MenuItem::make()
     ->hidden(fn (): bool => ! auth()->user()->can('manage-team'))
 ```
 
+### Conditionally hiding the entire tenant menu
+
+Finally, you can hide the entire tenant menu all togther by using:
+
+```php
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->hideTenantMenu();
+}
+```
+
 ## Setting up avatars
 
 Out of the box, Filament uses [ui-avatars.com](https://ui-avatars.com) to generate avatars based on a user's name. However, if you user model has an `avatar_url` attribute, that will be used instead. To customize how Filament gets a user's avatar URL, you can implement the `HasAvatar` contract:

--- a/packages/panels/docs/10-tenancy.md
+++ b/packages/panels/docs/10-tenancy.md
@@ -371,6 +371,8 @@ public function panel(Panel $panel): Panel
 }
 ```
 
+This may be desirable in simple multitenant setups where a user can only belong to one tenant and therefore there is no need for a menu to switch tenants.
+
 ## Setting up avatars
 
 Out of the box, Filament uses [ui-avatars.com](https://ui-avatars.com) to generate avatars based on a user's name. However, if you user model has an `avatar_url` attribute, that will be used instead. To customize how Filament gets a user's avatar URL, you can implement the `HasAvatar` contract:

--- a/packages/panels/resources/views/components/sidebar/index.blade.php
+++ b/packages/panels/resources/views/components/sidebar/index.blade.php
@@ -88,7 +88,7 @@
     >
         {{ \Filament\Support\Facades\FilamentView::renderHook('panels::sidebar.nav.start') }}
 
-        @if (filament()->hasTenancy())
+        @if (filament()->hasTenancy() && filament()->getCurrentPanel()->getTenantMenuVisible())
             <div
                 @if (filament()->isSidebarCollapsibleOnDesktop())
                     x-bind:class="$store.sidebar.isOpen ? '-mx-2' : '-mx-4'"

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 trait HasTenancy
 {
+    protected bool $showTenantMenu = true;
+    
     protected ?BillingProvider $tenantBillingProvider = null;
 
     protected ?string $tenantModel = null;
@@ -44,6 +46,13 @@ trait HasTenancy
             ...$this->tenantMenuItems,
             ...$items,
         ];
+
+        return $this;
+    }
+
+    public function hideTenantMenu(): static
+    {
+        $this->showTenantMenu = false;
 
         return $this;
     }
@@ -184,6 +193,11 @@ trait HasTenancy
         return route("filament.{$this->getId()}.tenant.registration", $parameters);
     }
 
+    public function getTenantMenuVisible(): bool
+    {
+        return $this->showTenantMenu;
+    }
+    
     /**
      * @return array<MenuItem>
      */


### PR DESCRIPTION
This PR allows the tenant menu to be entirely hidden for a panel otherwise using multitenancy. I have found this is something I'm wanting to do where I am using tenancy for automatic scoping of resources by setting the User as the tenant. In this case there is no need to have a tenant menu because the setup makes it impossible for a user to belong to multiple tenants. 

Another possible (perhaps more likely) use case would be using multitenancy to share resources between multiple users, but where each user by design will only ever belong to a single tenant.