### PR TITLE
fix issue #7646

### DIFF
--- a/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
+++ b/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
@@ -20,10 +20,10 @@ trait InteractsWithToolbarButtons
      */
     public function disableToolbarButtons(array $buttonsToDisable = []): static
     {
-        $this->toolbarButtons = array_filter(
+        $this->toolbarButtons = array_values(array_filter(
             $this->getToolbarButtons(),
             static fn ($button) => ! in_array($button, $buttonsToDisable),
-        );
+        ));
 
         return $this;
     }


### PR DESCRIPTION
re-index the toolbar buttons array after removing one or more toolbar buttons

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

<img width="503" alt="Schermata 2023-08-11 alle 12 51 54" src="https://github.com/filamentphp/filament/assets/13046806/863bff64-fec8-4baa-87b0-69b1bba7dfbf">

Example of code for disabling buttons

<img width="1257" alt="Schermata 2023-08-11 alle 12 52 32" src="https://github.com/filamentphp/filament/assets/13046806/fe6bec2b-de49-46d1-a09c-88e0c29ba90f">

Markdown Editor Component before the fix

<img width="1276" alt="Schermata 2023-08-11 alle 12 51 34" src="https://github.com/filamentphp/filament/assets/13046806/9a7e277c-2ed7-4321-97c4-46f0fde60448">

Markdown Editor Component after the fix

