### PR TITLE
Extend InstallCommand to check if PanelProvider exists if necessary

### DIFF
--- a/packages/support/src/Commands/InstallCommand.php
+++ b/packages/support/src/Commands/InstallCommand.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Support\Commands;
 
+use Filament\PanelProvider;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
@@ -61,8 +62,8 @@ class InstallCommand extends Command
             return true;
         }
 
-        if (! class_exists('Filament\PanelProvider')) {
-            $this->components->error('Error installing panels. Did you require "filament/filament"?');
+        if (! class_exists(PanelProvider::class)) {
+            $this->components->error('Please require [filament/filament] before attempting to install the Panel Builder.');
 
             return false;
         }


### PR DESCRIPTION
This extends the InstallCommand to check if the `Filament\PanelProvider` class exists when the command is called with the `--panels` option.

See https://github.com/filamentphp/filament/discussions/7213#discussioncomment-6701746

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
