### PR TITLE
fix missing state in disabled rich editor component

### DIFF
--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -6,6 +6,7 @@
 
     @if ($isDisabled())
         <div
+            x-data="{ state: $wire.{{ $applyStateBindingModifiers("entangle('{$statePath}')") }} }"
             x-html="state"
             class="prose block w-full max-w-none rounded-lg bg-gray-50 px-3 py-3 text-gray-500 shadow-sm ring-1 ring-gray-950/10 dark:prose-invert dark:bg-transparent dark:text-gray-400 dark:ring-white/10 sm:text-sm"
         ></div>


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [not applicable] New functionality has been documented or existing documentation has been updated to reflect changes.
- [not applicable] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Rich Editor component in disabled state showed `undefined` and threw errors on console due to the alpine variable `state` not being set. Added `x-data` attribute to entangle the state. No more errors after that and the value is shown correctly.

![image](https://github.com/filamentphp/filament/assets/4368880/fc245e46-f8ac-4669-9c81-b54e1c64a6a9)
