### PR TITLE
Add autocomplete attribute to password field

### DIFF
--- a/packages/panels/src/Pages/Auth/Login.php
+++ b/packages/panels/src/Pages/Auth/Login.php
@@ -107,6 +107,7 @@ class Login extends SimplePage
             ->label(__('filament-panels::pages/auth/login.form.password.label'))
             ->hint(filament()->hasPasswordReset() ? new HtmlString(Blade::render('<x-filament::link :href="filament()->getRequestPasswordResetUrl()"> {{ __(\'filament-panels::pages/auth/login.actions.request_password_reset.label\') }}</x-filament::link>')) : null)
             ->password()
+            ->autocomplete('current-password')
             ->required();
     }
 


### PR DESCRIPTION
This PR adds an autocomplete attribute to the default login form. Previously the form would produce a warning in Chromium browsers due to the lack of an autocomplete attribute.

Warning:
`[DOM] Input elements should have autocomplete attributes (suggested: "current-password"): (More info: https://goo.gl/9p2vKq)`

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
