### PR TITLE
Remove disableAutocomplete() from the docs

### DIFF
--- a/packages/forms/docs/03-fields/02-text-input.md
+++ b/packages/forms/docs/03-fields/02-text-input.md
@@ -75,14 +75,14 @@ TextInput::make('password')
     ->autocomplete('new-password')
 ```
 
-As a shortcut for `autocomplete="off"`, you may `disableAutocomplete()`:
+As a shortcut for `autocomplete="off"`, you may use `autocomplete(false)`:
 
 ```php
 use Filament\Forms\Components\TextInput;
 
 TextInput::make('password')
     ->password()
-    ->disableAutocomplete()
+    ->autocomplete(false)
 ```
 
 For more complex autocomplete options, text inputs also support [datalists](#autocompleting-text-with-a-datalist).


### PR DESCRIPTION
disableAutocomplete() is deprecated but it's still mentioned in the docs. This PR is to suggest the new solution.