### PR TITLE
Allow modal footerActions to be used as a slot

### DIFF
--- a/packages/support/docs/09-blade-components/02-modal.md
+++ b/packages/support/docs/09-blade-components/02-modal.md
@@ -115,6 +115,18 @@ You can add a footer to a modal by using the `footer` slot:
 </x-filament::modal>
 ```
 
+Alternatively, you can add actions into the footer by using the `footerActions` slot:
+
+```blade
+<x-filament::modal>
+    {{-- Modal content --}}
+    
+    <x-slot name="footerActions">
+        {{-- Modal footer actions --}}
+    </x-slot>
+</x-filament::modal>
+```
+
 ## Changing the modal's alignment
 
 By default, modal content will be aligned to the start, or centered if the modal is `xs` or `sm` in [width](#changing-the-modal-width). If you wish to change the alignment of content in a modal, you can use the `alignment` attribute and pass it `start` or `center`:

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -263,7 +263,7 @@
                     </div>
                 @endif
 
-                @if (count($footerActions) || (! \Filament\Support\is_slot_empty($footer)))
+                @if ($footerActions || (! \Filament\Support\is_slot_empty($footer)))
                     <div
                         @class([
                             'fi-modal-footer w-full',
@@ -278,7 +278,7 @@
                     >
                         @if (! \Filament\Support\is_slot_empty($footer))
                             {{ $footer }}
-                        @elseif (count($footerActions))
+                        @elseif ($footerActions)
                             <div
                                 @class([
                                     'fi-modal-footer-actions gap-3',
@@ -289,9 +289,13 @@
                                     },
                                 ])
                             >
-                                @foreach ($footerActions as $action)
-                                    {{ $action }}
-                                @endforeach
+                                @if (is_array($footerActions))
+                                    @foreach ($footerActions as $action)
+                                        {{ $action }}
+                                    @endforeach
+                                @else
+                                    {{ $footerActions }}
+                                @endif
                             </div>
                         @endif
                     </div>

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -263,7 +263,7 @@
                     </div>
                 @endif
 
-                @if ($footerActions || (! \Filament\Support\is_slot_empty($footer)))
+                @if ((! \Filament\Support\is_slot_empty($footer)) || (is_array($footerActions) && count($footerActions)) || (! is_array($footerActions) && ! \Filament\Support\is_slot_empty($footerActions)))
                     <div
                         @class([
                             'fi-modal-footer w-full',
@@ -278,7 +278,7 @@
                     >
                         @if (! \Filament\Support\is_slot_empty($footer))
                             {{ $footer }}
-                        @elseif ($footerActions)
+                        @else
                             <div
                                 @class([
                                     'fi-modal-footer-actions gap-3',


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Without these changes you get error from count:
> count(): Argument 1 ($value) must be of type Countable|array, Illuminate\View\ComponentSlot given
