### PR TITLE
fix: case insensitive global search for related translatable attributes

### DIFF
--- a/packages/admin/src/Resources/Resource.php
+++ b/packages/admin/src/Resources/Resource.php
@@ -484,7 +484,7 @@ class Resource
                     };
 
                     return $query->{"{$whereClause}Raw"}(
-                        "lower({$searchColumn}) {$searchOperator} lower(?)",
+                        "lower({$searchColumn}) {$searchOperator} ?",
                         "%{$searchQuery}%",
                     );
                 },


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This will enhance global search to allow for case insensitive search on related translatable attributes. 
It will use a `whereRaw` query in order to append the database collation and allow searching for non-english languages.

**To demonstrate:**
Let's say we have a resource that we need to search for the name of the product.
```php
    public static function getGloballySearchableAttributes(): array
    {
        return ['id', 'product.name'];
    }
```

Previously, searching for a product without specifing the exact case and accents would not return any results (e.g. `μαλαγουζια` instead of `Μαλαγουζιά`

<img width="657" alt="before" src="https://github.com/filamentphp/filament/assets/6439071/cdb96b1a-ce50-4e0b-a979-6a37a7357ed8">

After applying the fix, I can search without being strict with case or accents.

<img width="610" alt="after" src="https://github.com/filamentphp/filament/assets/6439071/06c99417-58cc-4880-92f4-1bb62ca52e86">

