### PR TITLE
Fix duplicate renderhooks in relation managers

### DIFF
--- a/packages/panels/resources/views/components/resources/relation-managers.blade.php
+++ b/packages/panels/resources/views/components/resources/relation-managers.blade.php
@@ -70,7 +70,7 @@
             class="flex flex-col gap-y-4"
         >
             @php
-                $managerLivewireProperties = ['lazy' => true, 'ownerRecord' => $ownerRecord, 'pageClass' => $pageClass];
+                $managerLivewireProperties = ['lazy' => false, 'ownerRecord' => $ownerRecord, 'pageClass' => $pageClass];
 
                 if (filled($activeLocale)) {
                     $managerLivewireProperties['activeLocale'] = $activeLocale;


### PR DESCRIPTION
LW has a [bug](https://github.com/livewire/livewire/pull/6327) where nested components that use `lazy` will call the boot method twice. This PR turns off lazy loading until the bug is fix.

Additional info:
[Filter sets](https://filamentphp.com/plugins/kenneth-sese-filter-sets) uses the boot method to render itself in Relation Managers using renderhooks. The LW bug causes the boot method to be called twice meaning the renderhook gets duplicated. 

I acknowledge that this is a selfish PR that the team is welcome to close. While it would be helpful, it probably doesn't affect most people, and lazy loading RM's is probably more helpful. I mostly wanted to reference it here so people were aware. 