### PR TITLE
Fix nested infolist action record injection

### DIFF
--- a/packages/infolists/src/Components/Actions/Action.php
+++ b/packages/infolists/src/Components/Actions/Action.php
@@ -45,8 +45,9 @@ class Action extends MountableAction
     protected function resolveDefaultClosureDependencyForEvaluationByName(string $parameterName): array
     {
         return match ($parameterName) {
-            'record' => [$this->getRecord()],
-            'infolist' => [$this->getInfolist()],
+            'record' => [$this->getInfolistComponent()->getRecord()],
+            'infolist' => [$this->getInfolistComponent()->getInfolist()],
+            'infolistComponent' => [$this->getInfolistComponent()],
             default => parent::resolveDefaultClosureDependencyForEvaluationByName($parameterName),
         };
     }

--- a/packages/infolists/src/Components/Actions/Action.php
+++ b/packages/infolists/src/Components/Actions/Action.php
@@ -46,7 +46,7 @@ class Action extends MountableAction
     {
         return match ($parameterName) {
             'record' => [$this->getInfolistComponent()->getRecord()],
-            'infolist' => [$this->getInfolistComponent()->getInfolist()],
+            'infolist' => [$this->getInfolist()],
             'infolistComponent' => [$this->getInfolistComponent()],
             default => parent::resolveDefaultClosureDependencyForEvaluationByName($parameterName),
         };


### PR DESCRIPTION
I was just trying out repeatable entries with nested action and I couldn't get the correct model in badge action. I was expecting to have `Role` model injected but `User` model is injected instead.

Currently Infolist action is getting record from infolist but changing that to infolistComponent fixed the issue.
 
```php
        return $infolist
            ->record($this->user)
            ->schema([
                RepeatableEntry::make('roles')
                    ->schema([
                        TextEntry::make('name')
                            ->state(fn (Role $record) => $record->type->name) // Injects Role model as expected
                            ->badge()
                            ->hiddenLabel()
                                ->action(
                                    Action::make('remove allergy')
                                        ->requiresConfirmation()
                                        ->action(function ($record) {
                                            // This injects User model instead of Role model
                                            dump($record); // User{}
                                        })
                                )
                    ])
            ]);
```