### PR TITLE
[Enhancement] Allow rounded corners for square image in table and infolist

### DIFF
--- a/packages/infolists/docs/03-entries/04-image.md
+++ b/packages/infolists/docs/03-entries/04-image.md
@@ -68,6 +68,16 @@ ImageEntry::make('author.avatar')
     ->square()
 ```
 
+For rounded corners set parameter `rounded` to `true`:
+
+```php
+use Filament\Infolists\Components\ImageEntry;
+
+ImageEntry::make('author.avatar')
+    ->height(40)
+    ->square(rounded: true)
+```
+
 <AutoScreenshot name="infolists/entries/image/square" alt="Square image entry" version="3.x" />
 
 ## Circular image

--- a/packages/infolists/resources/views/components/image-entry.blade.php
+++ b/packages/infolists/resources/views/components/image-entry.blade.php
@@ -69,7 +69,7 @@
                                 ->class([
                                     'max-w-none object-cover object-center',
                                     'rounded-full' => $isCircular,
-                                    'rouneded-xl' => $isSquareRounded,
+                                    'rounded' => $isSquareRounded,
                                     $ringClasses,
                                 ])
                                 ->style([
@@ -89,7 +89,7 @@
                         @class([
                             'flex items-center justify-center bg-gray-100 font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400',
                             'rounded-full' => $isCircular,
-                            'rouneded-xl' => $isSquareRounded,
+                            'rounded' => $isSquareRounded,
                             $limitedRemainingTextSizeClasses,
                             $ringClasses,
                         ])

--- a/packages/infolists/resources/views/components/image-entry.blade.php
+++ b/packages/infolists/resources/views/components/image-entry.blade.php
@@ -5,6 +5,7 @@
         $limitedState = array_slice($state, 0, $limit);
         $isCircular = $isCircular();
         $isSquare = $isSquare();
+        $isSquareRounded = $isSquareRounded();
         $isStacked = $isStacked();
         $overlap = $isStacked ? ($getOverlap() ?? 2) : null;
         $ring = $isStacked ? ($getRing() ?? 2) : null;

--- a/packages/infolists/resources/views/components/image-entry.blade.php
+++ b/packages/infolists/resources/views/components/image-entry.blade.php
@@ -68,6 +68,7 @@
                                 ->class([
                                     'max-w-none object-cover object-center',
                                     'rounded-full' => $isCircular,
+                                    'rouneded-xl' => $isSquareRounded,
                                     $ringClasses,
                                 ])
                                 ->style([
@@ -87,6 +88,7 @@
                         @class([
                             'flex items-center justify-center bg-gray-100 font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400',
                             'rounded-full' => $isCircular,
+                            'rouneded-xl' => $isSquareRounded,
                             $limitedRemainingTextSizeClasses,
                             $ringClasses,
                         ])

--- a/packages/infolists/src/Components/ImageEntry.php
+++ b/packages/infolists/src/Components/ImageEntry.php
@@ -50,6 +50,8 @@ class ImageEntry extends Entry
 
     protected string | Closure | null $limitedRemainingTextSize = null;
 
+    protected bool $isSquareRounded = false;
+
     public function disk(string | Closure | null $disk): static
     {
         $this->disk = $disk;
@@ -71,9 +73,10 @@ class ImageEntry extends Entry
         return $this;
     }
 
-    public function square(bool | Closure $condition = true): static
+    public function square(bool | Closure $condition = true, bool $rounded = false): static
     {
         $this->isSquare = $condition;
+        $this->isSquareRounded = $rounded;
 
         return $this;
     }
@@ -305,5 +308,10 @@ class ImageEntry extends Entry
     public function getLimitedRemainingTextSize(): ?string
     {
         return $this->evaluate($this->limitedRemainingTextSize);
+    }
+
+    public function isSquareRounded(): bool
+    {
+        return $this->isSquareRounded;
     }
 }

--- a/packages/tables/docs/03-columns/04-image.md
+++ b/packages/tables/docs/03-columns/04-image.md
@@ -67,6 +67,15 @@ ImageColumn::make('avatar')
     ->square()
 ```
 
+For rounded corners use the `rounded` parameter:
+
+```php
+use Filament\Tables\Columns\ImageColumn;
+
+ImageColumn::make('avatar')
+    ->square(rounded: true)
+```
+
 <AutoScreenshot name="tables/columns/image/square" alt="Square image column" version="3.x" />
 
 ## Circular image

--- a/packages/tables/resources/views/columns/image-column.blade.php
+++ b/packages/tables/resources/views/columns/image-column.blade.php
@@ -78,7 +78,7 @@
                                 ->class([
                                     'max-w-none object-cover object-center',
                                     'rounded-full' => $isCircular,
-                                    'rounded-xl' => $isSquareRounded,
+                                    'rounded' => $isSquareRounded,
                                     $ringClasses,
                                 ])
                                 ->style([
@@ -98,7 +98,7 @@
                         @class([
                             'flex items-center justify-center bg-gray-100 font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400',
                             'rounded-full' => $isCircular,
-                            'rounded-xl' => $isSquareRounded,
+                            'rounded' => $isSquareRounded,
                             $limitedRemainingTextSizeClasses,
                             $ringClasses,
                         ])

--- a/packages/tables/resources/views/columns/image-column.blade.php
+++ b/packages/tables/resources/views/columns/image-column.blade.php
@@ -4,6 +4,7 @@
     $limitedState = array_slice($state, 0, $limit);
     $isCircular = $isCircular();
     $isSquare = $isSquare();
+    $isSquareRounded = $isSquareRounded();
     $isStacked = $isStacked();
     $overlap = $isStacked ? ($getOverlap() ?? 2) : null;
     $ring = $isStacked ? ($getRing() ?? 2) : null;
@@ -77,6 +78,7 @@
                                 ->class([
                                     'max-w-none object-cover object-center',
                                     'rounded-full' => $isCircular,
+                                    'rounded-xl' => $isSquareRounded,
                                     $ringClasses,
                                 ])
                                 ->style([
@@ -96,6 +98,7 @@
                         @class([
                             'flex items-center justify-center bg-gray-100 font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400',
                             'rounded-full' => $isCircular,
+                            'rounded-xl' => $isSquareRounded,
                             $limitedRemainingTextSizeClasses,
                             $ringClasses,
                         ])

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -50,6 +50,8 @@ class ImageColumn extends Column
 
     protected string | Closure | null $limitedRemainingTextSize = null;
 
+    protected bool $isSquareRounded = false;
+
     public function disk(string | Closure | null $disk): static
     {
         $this->disk = $disk;
@@ -79,9 +81,10 @@ class ImageColumn extends Column
         return $this->circular($condition);
     }
 
-    public function square(bool | Closure $condition = true): static
+    public function square(bool | Closure $condition = true, bool $rounded = false): static
     {
         $this->isSquare = $condition;
+        $this->isSquareRounded = $rounded;
 
         return $this;
     }
@@ -331,5 +334,10 @@ class ImageColumn extends Column
     public function getLimitedRemainingTextSize(): ?string
     {
         return $this->evaluate($this->limitedRemainingTextSize);
+    }
+
+    public function isSquareRounded(): bool
+    {
+        return $this->isSquareRounded;
     }
 }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

before: 
![image](https://github.com/filamentphp/filament/assets/4368880/3b898527-894a-4e76-858f-19a96c577f62)

after:
![image](https://github.com/filamentphp/filament/assets/4368880/88796d5b-4d64-4859-9375-a3bca5605dbe)

I think this looks better and fits with the overall rounded-corner style of Filament. Nothing breaks, completely backwards-compatible, just a small change for better visual styling.