### PR TITLE
[Enhancement] Update Login Tab-key Order.php

### DIFF
--- a/packages/panels/src/Pages/Auth/Login.php
+++ b/packages/panels/src/Pages/Auth/Login.php
@@ -99,7 +99,7 @@ class Login extends SimplePage
             ->required()
             ->autocomplete()
             ->autofocus()
-            ->extraInputAttributes(['tabindex' => '1']);
+            ->extraInputAttributes(['tabindex' => 1]);
     }
 
     protected function getPasswordFormComponent(): Component
@@ -110,7 +110,7 @@ class Login extends SimplePage
             ->password()
             ->autocomplete('current-password')
             ->required()
-            ->extraInputAttributes(['tabindex' => '2']);;
+            ->extraInputAttributes(['tabindex' => 2]);;
     }
 
     protected function getRememberFormComponent(): Component

--- a/packages/panels/src/Pages/Auth/Login.php
+++ b/packages/panels/src/Pages/Auth/Login.php
@@ -98,7 +98,8 @@ class Login extends SimplePage
             ->email()
             ->required()
             ->autocomplete()
-            ->autofocus();
+            ->autofocus()
+            ->extraInputAttributes(['tabindex' => '1']);
     }
 
     protected function getPasswordFormComponent(): Component
@@ -108,7 +109,8 @@ class Login extends SimplePage
             ->hint(filament()->hasPasswordReset() ? new HtmlString(Blade::render('<x-filament::link :href="filament()->getRequestPasswordResetUrl()"> {{ __(\'filament-panels::pages/auth/login.actions.request_password_reset.label\') }}</x-filament::link>')) : null)
             ->password()
             ->autocomplete('current-password')
-            ->required();
+            ->required()
+            ->extraInputAttributes(['tabindex' => '2']);;
     }
 
     protected function getRememberFormComponent(): Component


### PR DESCRIPTION
change tab order from 
 - email -> forgot_pass -> password -> remember_me
to
 - email -> password -> forgot_pass -> remember_me

Better login flow with:
   email -> _tab_ -> password ->_enter_

currently it is 
  email -> _tab_ -> _tab_ -> password ->_enter_

![Bez názvu](https://github.com/filamentphp/filament/assets/28921659/23c39a34-4616-4e8f-800c-1d6550bf6708)

- [x] Changes have been thoroughly tested to not break existing functionality.
- [Nothing for documentation] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
