### PR TITLE
Add dropdown item alignment

### DIFF
--- a/packages/support/docs/09-blade-components/02-dropdown.md
+++ b/packages/support/docs/09-blade-components/02-dropdown.md
@@ -115,6 +115,18 @@ You can [change the color](badge#changing-the-color-of-the-badge) of the badge u
 </x-filament::dropdown.list.item>
 ```
 
+## Setting the dropdown item alignment
+
+By default, dropdown item will be aligned to the start. If you wish to change the alignment pass it `end` or `center`:
+
+You can also change the icon's position to be last by passing `end`, this will also change the position of the badge to be at the start.
+
+```blade
+<x-filament::dropdown.list.item alignment="end" icon="heroicon-m-pencil" iconPosition="end">
+    Edit
+</x-filament::dropdown>
+```
+
 ## Setting the placement of a dropdown
 
 The dropdown may be positioned relative to the trigger button by using the `placement` attribute:

--- a/packages/support/resources/views/components/dropdown/list/item.blade.php
+++ b/packages/support/resources/views/components/dropdown/list/item.blade.php
@@ -1,14 +1,18 @@
 @php
+    use Filament\Support\Enums\Alignment;
+    use Filament\Support\Enums\IconPosition;
     use Filament\Support\Enums\IconSize;
 @endphp
 
 @props([
+    'alignment' => null,
     'badge' => null,
     'badgeColor' => null,
     'color' => 'gray',
     'disabled' => false,
     'icon' => null,
     'iconAlias' => null,
+    'iconPosition' => IconPosition::Before,
     'iconSize' => IconSize::Medium,
     'image' => null,
     'keyBindings' => null,
@@ -47,10 +51,17 @@
     $imageClasses = 'fi-dropdown-list-item-image h-5 w-5 rounded-full bg-cover bg-center';
 
     $labelClasses = \Illuminate\Support\Arr::toCssClasses([
-        'fi-dropdown-list-item-label flex-1 truncate text-start',
+        'fi-dropdown-list-item-label flex-1 truncate',
+        match ($alignment) {
+            Alignment::Center, 'center' => 'text-center',
+            Alignment::End, 'end' => 'text-end',
+            Alignment::Left, 'left' => 'text-start',
+            Alignment::Right, 'right' => 'text-end',
+            default => 'text-start',
+        },
         match ($color) {
             'gray' => 'text-gray-700 dark:text-gray-200',
-            default => 'text-custom-600 dark:text-custom-400 ',
+            default => 'text-custom-600 dark:text-custom-400',
         },
     ]);
 
@@ -81,7 +92,7 @@
                 ->style([$buttonStyles])
         }}
     >
-        @if ($icon)
+        @if ($icon && in_array($iconPosition, [IconPosition::Before, 'before']))
             <x-filament::icon
                 :alias="$iconAlias"
                 :icon="$icon"
@@ -89,6 +100,12 @@
                 :wire:target="$hasLoadingIndicator ? $loadingIndicatorTarget : null"
                 :class="$iconClasses"
             />
+        @endif
+
+        @if (filled($badge) && in_array($iconPosition, [IconPosition::After, 'after']))
+            <x-filament::badge :color="$badgeColor" size="sm">
+                {{ $badge }}
+            </x-filament::badge>
         @endif
 
         @if ($image)
@@ -110,10 +127,18 @@
             {{ $slot }}
         </span>
 
-        @if (filled($badge))
+        @if (filled($badge) && in_array($iconPosition, [IconPosition::Before, 'before']))
             <x-filament::badge :color="$badgeColor" size="sm">
                 {{ $badge }}
             </x-filament::badge>
+        @endif
+
+        @if ($icon && in_array($iconPosition, [IconPosition::After, 'after']))
+            <x-filament::icon
+                :alias="$iconAlias"
+                :icon="$icon"
+                :class="$iconClasses"
+            />
         @endif
     </button>
 @elseif ($tag === 'a')
@@ -128,12 +153,18 @@
                 ->style([$buttonStyles])
         }}
     >
-        @if ($icon)
+        @if ($icon && in_array($iconPosition, [IconPosition::Before, 'before']))
             <x-filament::icon
                 :alias="$iconAlias"
                 :icon="$icon"
                 :class="$iconClasses"
             />
+        @endif
+
+        @if (filled($badge) && in_array($iconPosition, [IconPosition::After, 'after']))
+            <x-filament::badge :color="$badgeColor" size="sm">
+                {{ $badge }}
+            </x-filament::badge>
         @endif
 
         @if ($image)
@@ -147,10 +178,18 @@
             {{ $slot }}
         </span>
 
-        @if (filled($badge))
+        @if (filled($badge) && in_array($iconPosition, [IconPosition::Before, 'before']))
             <x-filament::badge :color="$badgeColor" size="sm">
                 {{ $badge }}
             </x-filament::badge>
+        @endif
+
+        @if ($icon && in_array($iconPosition, [IconPosition::After, 'after']))
+            <x-filament::icon
+                :alias="$iconAlias"
+                :icon="$icon"
+                :class="$iconClasses"
+            />
         @endif
     </a>
 @elseif ($tag === 'form')
@@ -172,7 +211,7 @@
                     ->style([$buttonStyles])
             }}
         >
-            @if ($icon)
+            @if ($icon && in_array($iconPosition, [IconPosition::Before, 'before']))
                 <x-filament::icon
                     :alias="$iconAlias"
                     :icon="$icon"
@@ -180,14 +219,28 @@
                 />
             @endif
 
+            @if (filled($badge) && in_array($iconPosition, [IconPosition::After, 'after']))
+                <x-filament::badge :color="$badgeColor" size="sm">
+                    {{ $badge }}
+                </x-filament::badge>
+            @endif
+
             <span class="{{ $labelClasses }}">
                 {{ $slot }}
             </span>
 
-            @if (filled($badge))
+            @if (filled($badge) && in_array($iconPosition, [IconPosition::Before, 'before']))
                 <x-filament::badge :color="$badgeColor" size="sm">
                     {{ $badge }}
                 </x-filament::badge>
+            @endif
+
+            @if ($icon && in_array($iconPosition, [IconPosition::After, 'after']))
+                <x-filament::icon
+                    :alias="$iconAlias"
+                    :icon="$icon"
+                    :class="$iconClasses"
+                />
             @endif
         </button>
     </form>


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Allow for text alignment to be changed.
Allow for icon/badge position to be changed.

<img width="236" alt="Screenshot 2023-08-13 at 10 08 04" src="https://github.com/filamentphp/filament/assets/533658/c5720402-1782-4e41-ba6d-1f11bd0b456f">

Useful if you have a dropdown opened with placement at the end of the window.
<img width="283" alt="Screenshot 2023-08-13 at 12 55 12" src="https://github.com/filamentphp/filament/assets/533658/96e42926-3c94-4b09-998b-c50eef81d400"> <img width="281" alt="Screenshot 2023-08-13 at 12 58 50" src="https://github.com/filamentphp/filament/assets/533658/fcf74394-1617-4019-a42c-5ed418793263">

