### PR TITLE
[Fix]  - reactivity of CheckboxList

### DIFF
--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -3,6 +3,7 @@
 namespace Filament\Forms\Concerns;
 
 use Filament\Forms\Components\BaseFileUpload;
+use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\Select;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
@@ -45,6 +46,15 @@ trait HasState
             if (
                 $component instanceof Select &&
                 $component->isMultiple() &&
+                str($path)->startsWith("{$component->getStatePath()}.")
+            ) {
+                $component->callAfterStateUpdated();
+
+                return true;
+            }
+
+            if (
+                $component instanceof CheckboxList &&
                 str($path)->startsWith("{$component->getStatePath()}.")
             ) {
                 $component->callAfterStateUpdated();


### PR DESCRIPTION
There is a problem with the reactivity of the CheckboxList. Does not work. Same issue as with select(multiple). The path of the component is "data.name" but the path of the changed checkbox in the checkbox list is "data.name.0" so I added a condition to figure out the base path in HasState, similar to select(multiple).