### PR TITLE
fix: Tenant profile auth policy method

### DIFF
--- a/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
+++ b/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
@@ -212,7 +212,7 @@ abstract class EditTenantProfile extends Page
     public static function canView(Model $tenant): bool
     {
         try {
-            return authorize('edit', $tenant)->allowed();
+            return authorize('update', $tenant)->allowed();
         } catch (AuthorizationException $exception) {
             return $exception->toResponse()->allowed();
         }

--- a/tests/database/factories/TeamFactory.php
+++ b/tests/database/factories/TeamFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Filament\Tests\Database\Factories;
+
+use Filament\Tests\Models\Team;
+use Filament\Tests\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class TeamFactory extends Factory
+{
+    protected $model = Team::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->company(),
+        ];
+    }
+}

--- a/tests/database/migrations/create_teams_table.php
+++ b/tests/database/migrations/create_teams_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('teams', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('teams');
+    }
+};

--- a/tests/src/Models/Team.php
+++ b/tests/src/Models/Team.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Filament\Tests\Models;
+
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Panel;
+use Filament\Tests\Database\Factories\TeamFactory;
+use Filament\Tests\Database\Factories\UserFactory;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+
+class Team extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected static function newFactory()
+    {
+        return TeamFactory::new();
+    }
+}

--- a/tests/src/Models/User.php
+++ b/tests/src/Models/User.php
@@ -3,15 +3,18 @@
 namespace Filament\Tests\Models;
 
 use Filament\Models\Contracts\FilamentUser;
+use Filament\Models\Contracts\HasTenants;
 use Filament\Panel;
 use Filament\Tests\Database\Factories\UserFactory;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Collection;
 
-class User extends Authenticatable implements FilamentUser, MustVerifyEmail
+class User extends Authenticatable implements FilamentUser, HasTenants, MustVerifyEmail
 {
     use HasFactory;
     use Notifiable;
@@ -36,5 +39,15 @@ class User extends Authenticatable implements FilamentUser, MustVerifyEmail
     protected static function newFactory()
     {
         return UserFactory::new();
+    }
+
+    public function canAccessTenant(Model $tenant): bool
+    {
+        return true;
+    }
+
+    public function getTenants(Panel $panel): array | Collection
+    {
+        return Team::all();
     }
 }

--- a/tests/src/Panels/Pages/Tenancy/EditTenantProfileTest.php
+++ b/tests/src/Panels/Pages/Tenancy/EditTenantProfileTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use Filament\Facades\Filament;
+use Filament\Pages\Tenancy\EditTenantProfile;
+use Filament\Tests\Models\Team;
+use Filament\Tests\Models\User;
+use Filament\Tests\Panels\Pages\TestCase;
+use Illuminate\Support\Facades\Gate;
+use function Filament\Tests\livewire;
+
+uses(TestCase::class);
+
+it('allows the user access to the tenant profile page if the user is authorized', function () {
+    Filament::setTenant(Team::factory()->create());
+
+    Gate::policy(Team::class, TeamPolicyWithAccess::class);
+
+    livewire(EditTeamProfile::class)
+        ->assertSuccessful();
+});
+
+it('denies the user access to the tenant profile page if the user is unauthorized', function () {
+    Filament::setTenant(Team::factory()->create());
+
+    Gate::policy(Team::class, TeamPolicyWithoutAccess::class);
+
+    livewire(EditTeamProfile::class)
+        ->assertNotFound();
+});
+
+class EditTeamProfile extends EditTenantProfile
+{
+    public static function getLabel(): string
+    {
+        return 'Edit team';
+    }
+}
+
+class TeamPolicyWithAccess
+{
+    public function update(User $user, Team $team): bool
+    {
+        return true;
+    }
+}
+
+class TeamPolicyWithoutAccess
+{
+    public function update(User $user, Team $team): bool
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
As the documentation states, the `update` method on the tenant policy should be used to authorise access to the tenant profile page, but it was set to `edit` in the default profile page class.

Fortunately, this isn't an issue where users could access each others tenants, as the `canAccessTenant()` method is used within middleware to verify that, before this check even happens.

I've improved the test coverage around this feature as a result.