### PR TITLE
[Docs] Added quotes to Alpine `x-data`

### DIFF
--- a/packages/support/docs/09-blade-components/02-tabs.md
+++ b/packages/support/docs/09-blade-components/02-tabs.md
@@ -54,7 +54,7 @@ You can also use the `active` attribute to make a tab appear active conditionall
 Or you can use the `alpine-active` attribute to make a tab appear active conditionally using Alpine.js:
 
 ```blade
-<x-filament::tabs x-data={ activeTab: 'tab1' }>
+<x-filament::tabs x-data="{ activeTab: 'tab1' }">
     <x-filament::tabs.item
         alpine-active="activeTab === 'tab1'"
         x-on:click="alpineActive = 'tab1'"


### PR DESCRIPTION
- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
