### PR TITLE
Add closure to `url()` method in documentation

### DIFF
--- a/packages/panels/docs/06-navigation.md
+++ b/packages/panels/docs/06-navigation.md
@@ -331,7 +331,7 @@ public function panel(Panel $panel): Panel
         ->userMenuItems([
             MenuItem::make()
                 ->label('Settings')
-                ->url(fn () => route('filament.admin.pages.settings'))
+                ->url(fn (): string => route('filament.admin.pages.settings'))
                 ->icon('heroicon-o-cog-6-tooth'),
             // ...
         ]);

--- a/packages/panels/docs/06-navigation.md
+++ b/packages/panels/docs/06-navigation.md
@@ -331,7 +331,7 @@ public function panel(Panel $panel): Panel
         ->userMenuItems([
             MenuItem::make()
                 ->label('Settings')
-                ->url(route('filament.admin.pages.settings'))
+                ->url(fn () => route('filament.admin.pages.settings'))
                 ->icon('heroicon-o-cog-6-tooth'),
             // ...
         ]);

--- a/packages/panels/docs/10-tenancy.md
+++ b/packages/panels/docs/10-tenancy.md
@@ -289,7 +289,7 @@ The tenant-switching menu is featured in the sidebar of the admin layout. It's f
 To register new items to the tenant menu, you can use the [configuration](configuration):
 
 ```php
-use App\Filament\Company\Pages\Settings;
+use App\Filament\Pages\Settings;
 use Filament\Navigation\MenuItem;
 use Filament\Panel;
 
@@ -300,7 +300,7 @@ public function panel(Panel $panel): Panel
         ->tenantMenuItems([
             MenuItem::make()
                 ->label('Settings')
-                ->url(fn () => url(Settings::getUrl())),
+                ->url(fn (): string => Settings::getUrl()),
                 ->icon('heroicon-m-cog-8-tooth'),
             // ...
         ]);

--- a/packages/panels/docs/10-tenancy.md
+++ b/packages/panels/docs/10-tenancy.md
@@ -289,6 +289,7 @@ The tenant-switching menu is featured in the sidebar of the admin layout. It's f
 To register new items to the tenant menu, you can use the [configuration](configuration):
 
 ```php
+use App\Filament\Company\Pages\Settings;
 use Filament\Navigation\MenuItem;
 use Filament\Panel;
 
@@ -299,7 +300,7 @@ public function panel(Panel $panel): Panel
         ->tenantMenuItems([
             MenuItem::make()
                 ->label('Settings')
-                ->url(route('filament.pages.settings'))
+                ->url(fn () => url(Settings::getUrl())),
                 ->icon('heroicon-m-cog-8-tooth'),
             // ...
         ]);
@@ -318,7 +319,7 @@ public function panel(Panel $panel): Panel
 {
     return $panel
         // ...
-        ->userMenuItems([
+        ->tenantMenuItems([
             'register' => MenuItem::make()->label('Register new team'),
             // ...
         ]);
@@ -337,7 +338,7 @@ public function panel(Panel $panel): Panel
 {
     return $panel
         // ...
-        ->userMenuItems([
+        ->tenantMenuItems([
             'billing' => MenuItem::make()->label('Manage subscription'),
             // ...
         ]);


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Added the correct method using a closure in `url()` within the documentation for when users register user and tenant menu items. This change corrects the existing guidance to prevent user errors related to this function. Also corrected some other things as well.

For a page inside a panel that **DOESN'T** have tenancy the user can do one of these:
```php
MenuItem::make()
  ->label('Settings')
  ->url(fn() => url(Settings::getUrl()))
  ->icon('heroicon-m-cog-8-tooth'),
```
```php
MenuItem::make()
  ->label('Settings')
  ->url(fn() => route('filament.app.pages.settings'))
  ->icon('heroicon-m-cog-8-tooth'),
```

For a page inside a panel that **DOES** have tenancy the user must do this:
```php
MenuItem::make()
  ->label('Settings')
  ->url(fn() => url(Settings::getUrl()))
  ->icon('heroicon-m-cog-8-tooth'),
```

Currently, not using a closure like this:
```php
MenuItem::make()
  ->label('Settings')
  ->url(route('filament.app.pages.settings'))
  ->icon('heroicon-m-cog-8-tooth'),
```

Results in this error, which a lot of users are tending to have based on help posts in discord.
![Screenshot 2023-08-14 at 7 04 42 PM](https://github.com/filamentphp/filament/assets/104294090/ec167e8b-8c7f-4d38-9d6c-79bb1998300c)

Currently, in a panel that has tenancy, using this:
```php
MenuItem::make()
  ->label('Settings')
  ->url(fn() => route('filament.app.pages.settings'))
  ->icon('heroicon-m-cog-8-tooth'),
```

Results in this error, which users are having a lot as well:
![Screenshot 2023-08-14 at 7 04 59 PM](https://github.com/filamentphp/filament/assets/104294090/5b65e154-d08b-44c9-ace3-cf80a7a86729)