### PR TITLE
only discover PHP files for discoverResources/Pages/Widgets

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasComponents.php
+++ b/packages/panels/src/Panel/Concerns/HasComponents.php
@@ -149,7 +149,7 @@ trait HasComponents
         return $widget;
     }
 
-    public function discoverPages(string $in, string $for): static
+    public function discoverPages(string $in, string $for, bool $all=false): static
     {
         $this->pageDirectories[] = $in;
         $this->pageNamespaces[] = $for;
@@ -159,6 +159,7 @@ trait HasComponents
             $this->pages,
             directory: $in,
             namespace: $for,
+            all: $all,
         );
 
         return $this;
@@ -180,7 +181,7 @@ trait HasComponents
         return $this->pageNamespaces;
     }
 
-    public function discoverResources(string $in, string $for): static
+    public function discoverResources(string $in, string $for, bool $all=false): static
     {
         $this->resourceDirectories[] = $in;
         $this->resourceNamespaces[] = $for;
@@ -190,6 +191,7 @@ trait HasComponents
             $this->resources,
             directory: $in,
             namespace: $for,
+            all: $all,
         );
 
         return $this;
@@ -211,7 +213,7 @@ trait HasComponents
         return $this->resourceNamespaces;
     }
 
-    public function discoverWidgets(string $in, string $for): static
+    public function discoverWidgets(string $in, string $for, bool $all=false): static
     {
         $this->widgetDirectories[] = $in;
         $this->widgetNamespaces[] = $for;
@@ -221,6 +223,7 @@ trait HasComponents
             $this->widgets,
             directory: $in,
             namespace: $for,
+            all: $all,
         );
 
         return $this;
@@ -272,7 +275,7 @@ trait HasComponents
     /**
      * @param  array<string, class-string<Component>>  $register
      */
-    protected function discoverComponents(string $baseClass, array &$register, ?string $directory, ?string $namespace): void
+    protected function discoverComponents(string $baseClass, array &$register, ?string $directory, ?string $namespace, bool $all=false): void
     {
         if (blank($directory) || blank($namespace)) {
             return;
@@ -287,6 +290,10 @@ trait HasComponents
         $namespace = str($namespace);
 
         foreach ($filesystem->allFiles($directory) as $file) {
+            if (!$all && $file->getExtension() !== 'php') {
+                continue;
+            }
+            
             $variableNamespace = $namespace->contains('*') ? str_ireplace(
                 ['\\' . $namespace->before('*'), $namespace->after('*')],
                 ['', ''],


### PR DESCRIPTION
When discovering Resources/Pages/Widgets: only look for files with php extension (which was the case in v2).  
Added optional parameter to continue to use to original v3 behaviour: discover all files.

Use case: easily exclude files by renaming them (to e.g. MyResource.php.bak). Normally discoverResources etc would include those files which would fail composer autoload.

Current PR is set to exclude non-PHP files by default ($all=false), which mimics the v2 behaviour.  
Feel free to inverse that default ($all=true), which makes the PR backwards compatible with original v3.

https://github.com/filamentphp/filament/discussions/7340

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
