### PR TITLE
Remove `function_exists` checks for `enum_exists`

### DIFF
--- a/packages/actions/src/Concerns/HasSelect.php
+++ b/packages/actions/src/Concerns/HasSelect.php
@@ -45,7 +45,6 @@ trait HasSelect
         $enum = $options;
         if (
             is_string($enum) &&
-            function_exists('enum_exists') &&
             enum_exists($enum)
         ) {
             return collect($enum::cases())

--- a/packages/forms/src/Components/Concerns/HasOptions.php
+++ b/packages/forms/src/Components/Concerns/HasOptions.php
@@ -34,7 +34,6 @@ trait HasOptions
         $enum = $options;
         if (
             is_string($enum) &&
-            function_exists('enum_exists') &&
             enum_exists($enum)
         ) {
             return collect($enum::cases())

--- a/packages/tables/src/Filters/Concerns/HasOptions.php
+++ b/packages/tables/src/Filters/Concerns/HasOptions.php
@@ -40,7 +40,6 @@ trait HasOptions
         $enum = $options;
         if (
             is_string($enum) &&
-            function_exists('enum_exists') &&
             enum_exists($enum)
         ) {
             return collect($enum::cases())


### PR DESCRIPTION
Shouldn't be needed because of PHP >= 8.1, right?

---

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
