### PR TITLE
only discover valid classes for discoverResources/Pages/Widgets

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasComponents.php
+++ b/packages/panels/src/Panel/Concerns/HasComponents.php
@@ -304,6 +304,10 @@ trait HasComponents
                 ->replace('*', $variableNamespace)
                 ->replace(['/', '.php'], ['\\', '']);
 
+            if (! class_exists($class)) {
+                continue;
+            }
+
             if ((new ReflectionClass($class))->isAbstract()) {
                 continue;
             }


### PR DESCRIPTION
Alternative solution for 
https://github.com/filamentphp/filament/pull/7770

Ignore discovered files that are not a valid class. Similar to how v2 filtered files, see:
https://github.com/filamentphp/filament/blob/9177b9c3fda17409d1c8ea9169805171756c1e9c/packages/admin/src/FilamentServiceProvider.php#L156-L164

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
