### PR TITLE
Convert closures to arrow functions

### DIFF
--- a/docs-assets/app/app/Providers/RouteServiceProvider.php
+++ b/docs-assets/app/app/Providers/RouteServiceProvider.php
@@ -41,8 +41,6 @@ class RouteServiceProvider extends ServiceProvider
      */
     protected function configureRateLimiting(): void
     {
-        RateLimiter::for('api', function (Request $request) {
-            return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
-        });
+        RateLimiter::for('api', fn (Request $request) => Limit::perMinute(60)->by($request->user()?->id ?: $request->ip()));
     }
 }

--- a/docs-assets/app/routes/api.php
+++ b/docs-assets/app/routes/api.php
@@ -14,6 +14,4 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
-    return $request->user();
-});
+Route::middleware('auth:sanctum')->get('/user', fn (Request $request) => $request->user());

--- a/docs-assets/app/routes/channels.php
+++ b/docs-assets/app/routes/channels.php
@@ -13,6 +13,4 @@ use Illuminate\Support\Facades\Broadcast;
 |
 */
 
-Broadcast::channel('Panel.Models.User.{id}', function ($user, $id) {
-    return (int) $user->id === (int) $id;
-});
+Broadcast::channel('Panel.Models.User.{id}', fn ($user, $id) => (int) $user->id === (int) $id);

--- a/packages/actions/src/CreateAction.php
+++ b/packages/actions/src/CreateAction.php
@@ -33,12 +33,10 @@ class CreateAction extends Action
 
         $this->modalSubmitActionLabel(__('filament-actions::create.single.modal.actions.create.label'));
 
-        $this->extraModalFooterActions(function (): array {
-            return $this->canCreateAnother() ? [
-                $this->makeModalSubmitAction('createAnother', arguments: ['another' => true])
-                    ->label(__('filament-actions::create.single.modal.actions.create_another.label')),
-            ] : [];
-        });
+        $this->extraModalFooterActions(fn (): array => $this->canCreateAnother() ? [
+            $this->makeModalSubmitAction('createAnother', arguments: ['another' => true])
+                ->label(__('filament-actions::create.single.modal.actions.create_another.label')),
+        ] : []);
 
         $this->successNotificationTitle(__('filament-actions::create.single.notifications.created.title'));
 

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -155,9 +155,7 @@ class BaseFileUpload extends Field
             ];
         });
 
-        $this->getUploadedFileNameForStorageUsing(static function (BaseFileUpload $component, TemporaryUploadedFile $file) {
-            return $component->shouldPreserveFilenames() ? $file->getClientOriginalName() : $file->getFilename();
-        });
+        $this->getUploadedFileNameForStorageUsing(static fn (BaseFileUpload $component, TemporaryUploadedFile $file) => $component->shouldPreserveFilenames() ? $file->getClientOriginalName() : $file->getFilename());
 
         $this->saveUploadedFileUsing(static function (BaseFileUpload $component, TemporaryUploadedFile $file): ?string {
             try {

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -93,9 +93,7 @@ class Builder extends Field implements Contracts\CanConcealComponents
             fn (Builder $component): Action => $component->getReorderAction(),
         ]);
 
-        $this->mutateDehydratedStateUsing(static function (?array $state): array {
-            return array_values($state ?? []);
-        });
+        $this->mutateDehydratedStateUsing(static fn (?array $state): array => array_values($state ?? []));
     }
 
     /**

--- a/packages/forms/src/Components/Concerns/CanBeAutocapitalized.php
+++ b/packages/forms/src/Components/Concerns/CanBeAutocapitalized.php
@@ -21,9 +21,7 @@ trait CanBeAutocapitalized
      */
     public function disableAutocapitalize(bool | Closure $condition = true): static
     {
-        $this->autocapitalize(static function (Field $component) use ($condition): ?bool {
-            return $component->evaluate($condition) ? false : null;
-        });
+        $this->autocapitalize(static fn (Field $component): ?bool => $component->evaluate($condition) ? false : null);
 
         return $this;
     }

--- a/packages/forms/src/Components/Concerns/CanBeAutocompleted.php
+++ b/packages/forms/src/Components/Concerns/CanBeAutocompleted.php
@@ -21,9 +21,7 @@ trait CanBeAutocompleted
      */
     public function disableAutocomplete(bool | Closure $condition = true): static
     {
-        $this->autocomplete(static function (Field $component) use ($condition): ?bool {
-            return $component->evaluate($condition) ? false : null;
-        });
+        $this->autocomplete(static fn (Field $component): ?bool => $component->evaluate($condition) ? false : null);
 
         return $this;
     }

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -262,9 +262,7 @@ trait CanBeValidated
 
     public function multipleOf(int | Closure $value): static
     {
-        $this->rule(static function (Field $component) use ($value) {
-            return 'multiple_of:' . $component->evaluate($value);
-        }, static fn (Field $component): bool => filled($component->evaluate($value)));
+        $this->rule(static fn (Field $component) => 'multiple_of:' . $component->evaluate($value), static fn (Field $component): bool => filled($component->evaluate($value)));
 
         return $this;
     }
@@ -301,18 +299,14 @@ trait CanBeValidated
 
     public function notRegex(string | Closure | null $pattern): static
     {
-        $this->rule(static function (Field $component) use ($pattern) {
-            return 'not_regex:' . $component->evaluate($pattern);
-        }, static fn (Field $component): bool => filled($component->evaluate($pattern)));
+        $this->rule(static fn (Field $component) => 'not_regex:' . $component->evaluate($pattern), static fn (Field $component): bool => filled($component->evaluate($pattern)));
 
         return $this;
     }
 
     public function nullable(bool | Closure $condition = true): static
     {
-        $this->required(static function (Field $component) use ($condition): bool {
-            return ! $component->evaluate($condition);
-        });
+        $this->required(static fn (Field $component): bool => ! $component->evaluate($condition));
 
         return $this;
     }

--- a/packages/forms/src/Components/DateTimePicker.php
+++ b/packages/forms/src/Components/DateTimePicker.php
@@ -197,9 +197,7 @@ class DateTimePicker extends Field implements Contracts\HasAffixActions
     {
         $this->maxDate = $date;
 
-        $this->rule(static function (DateTimePicker $component) {
-            return "before_or_equal:{$component->getMaxDate()}";
-        }, static fn (DateTimePicker $component): bool => (bool) $component->getMaxDate());
+        $this->rule(static fn (DateTimePicker $component) => "before_or_equal:{$component->getMaxDate()}", static fn (DateTimePicker $component): bool => (bool) $component->getMaxDate());
 
         return $this;
     }
@@ -208,9 +206,7 @@ class DateTimePicker extends Field implements Contracts\HasAffixActions
     {
         $this->minDate = $date;
 
-        $this->rule(static function (DateTimePicker $component) {
-            return "after_or_equal:{$component->getMinDate()}";
-        }, static fn (DateTimePicker $component): bool => (bool) $component->getMinDate());
+        $this->rule(static fn (DateTimePicker $component) => "after_or_equal:{$component->getMinDate()}", static fn (DateTimePicker $component): bool => (bool) $component->getMinDate());
 
         return $this;
     }

--- a/packages/forms/src/Components/KeyValue.php
+++ b/packages/forms/src/Components/KeyValue.php
@@ -52,12 +52,10 @@ class KeyValue extends Field
 
         $this->default([]);
 
-        $this->dehydrateStateUsing(static function (?array $state) {
-            return collect($state ?? [])
-                ->filter(static fn (?string $value, ?string $key): bool => filled($key))
-                ->map(static fn (?string $value): ?string => filled($value) ? $value : null)
-                ->all();
-        });
+        $this->dehydrateStateUsing(static fn (?array $state) => collect($state ?? [])
+            ->filter(static fn (?string $value, ?string $key): bool => filled($key))
+            ->map(static fn (?string $value): ?string => filled($value) ? $value : null)
+            ->all());
 
         $this->registerActions([
             fn (KeyValue $component): Action => $component->getAddAction(),

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -107,9 +107,7 @@ class Repeater extends Field implements Contracts\CanConcealComponents
             fn (Repeater $component): Action => $component->getReorderAction(),
         ]);
 
-        $this->mutateDehydratedStateUsing(static function (?array $state): array {
-            return array_values($state ?? []);
-        });
+        $this->mutateDehydratedStateUsing(static fn (?array $state): array => array_values($state ?? []));
     }
 
     public function getAddAction(): Action

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -252,11 +252,9 @@ class Select extends Field implements Contracts\HasAffixActions, Contracts\HasNe
         }
 
         $action = Action::make($this->getCreateOptionActionName())
-            ->form(function (Select $component, Form $form): array | Form | null {
-                return $component->getCreateOptionActionForm($form->model(
-                    $component->getRelationship() ? $component->getRelationship()->getModel()::class : null,
-                ));
-            })
+            ->form(fn (Select $component, Form $form): array | Form | null => $component->getCreateOptionActionForm($form->model(
+                $component->getRelationship() ? $component->getRelationship()->getModel()::class : null,
+            )))
             ->action(static function (Action $action, array $arguments, Select $component, array $data, ComponentContainer $form) {
                 if (! $component->getCreateOptionUsing()) {
                     throw new Exception("Select field [{$component->getStatePath()}] must have a [createOptionUsing()] closure set.");
@@ -406,11 +404,9 @@ class Select extends Field implements Contracts\HasAffixActions, Contracts\HasNe
         }
 
         $action = Action::make($this->getEditOptionActionName())
-            ->form(function (Select $component, Form $form): array | Form | null {
-                return $component->getEditOptionActionForm(
-                    $form->model($component->getSelectedRecord()),
-                );
-            })
+            ->form(fn (Select $component, Form $form): array | Form | null => $component->getEditOptionActionForm(
+                $form->model($component->getSelectedRecord()),
+            ))
             ->fillForm($this->getEditOptionActionFormData())
             ->action(static function (Action $action, array $arguments, Select $component, array $data, ComponentContainer $form) {
                 $statePath = $component->getStatePath();
@@ -1004,9 +1000,7 @@ class Select extends Field implements Contracts\HasAffixActions, Contracts\HasNe
             return $record->getKey();
         });
 
-        $this->fillEditOptionActionFormUsing(static function (Select $component): ?array {
-            return $component->getSelectedRecord()?->attributesToArray();
-        });
+        $this->fillEditOptionActionFormUsing(static fn (Select $component): ?array => $component->getSelectedRecord()?->attributesToArray());
 
         $this->updateOptionUsing(static function (array $data, Form $form) {
             $form->getRecord()?->update($data);

--- a/packages/panels/src/FilamentServiceProvider.php
+++ b/packages/panels/src/FilamentServiceProvider.php
@@ -43,9 +43,7 @@ class FilamentServiceProvider extends PackageServiceProvider
 
     public function packageRegistered(): void
     {
-        $this->app->scoped('filament', function (): FilamentManager {
-            return new FilamentManager();
-        });
+        $this->app->scoped('filament', fn (): FilamentManager => new FilamentManager());
 
         $this->app->bind(EmailVerificationResponseContract::class, EmailVerificationResponse::class);
         $this->app->bind(LoginResponseContract::class, LoginResponse::class);

--- a/packages/support/src/Commands/CheckTranslationsCommand.php
+++ b/packages/support/src/Commands/CheckTranslationsCommand.php
@@ -95,9 +95,7 @@ class CheckTranslationsCommand extends Command
                 }
 
                 collect($files)
-                    ->reject(function ($file) use ($localeRootDirectory) {
-                        return ! file_exists(implode(DIRECTORY_SEPARATOR, [$localeRootDirectory, 'en', $file->getRelativePathname()]));
-                    })
+                    ->reject(fn ($file) => ! file_exists(implode(DIRECTORY_SEPARATOR, [$localeRootDirectory, 'en', $file->getRelativePathname()])))
                     ->mapWithKeys(function (SplFileInfo $file) use ($localeDir, $localeRootDirectory) {
                         $expectedKeys = require implode(DIRECTORY_SEPARATOR, [$localeRootDirectory, 'en', $file->getRelativePathname()]);
                         $actualKeys = require $file->getPathname();

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -87,26 +87,17 @@ class SupportServiceProvider extends PackageServiceProvider
             Js::make('support', __DIR__ . '/../dist/index.js'),
         ], 'filament/support');
 
-        Blade::directive('captureSlots', function (string $expression): string {
-            return "<?php \$slotContents = get_defined_vars(); \$slots = collect({$expression})->mapWithKeys(fn (string \$slot): array => [\$slot => \$slotContents[\$slot] ?? null])->all(); unset(\$slotContents) ?>";
-        });
+        Blade::directive('captureSlots', fn (string $expression): string => "<?php \$slotContents = get_defined_vars(); \$slots = collect({$expression})->mapWithKeys(fn (string \$slot): array => [\$slot => \$slotContents[\$slot] ?? null])->all(); unset(\$slotContents) ?>");
 
-        Blade::directive('filamentScripts', function (string $expression): string {
-            return "<?php echo \Filament\Support\Facades\FilamentAsset::renderScripts({$expression}) ?>";
-        });
+        Blade::directive('filamentScripts', fn (string $expression): string => "<?php echo \Filament\Support\Facades\FilamentAsset::renderScripts({$expression}) ?>");
 
-        Blade::directive('filamentStyles', function (string $expression): string {
-            return "<?php echo \Filament\Support\Facades\FilamentAsset::renderStyles({$expression}) ?>";
-        });
+        Blade::directive('filamentStyles', fn (string $expression): string => "<?php echo \Filament\Support\Facades\FilamentAsset::renderStyles({$expression}) ?>");
 
-        Str::macro('sanitizeHtml', function (string $html): string {
-            return app(HtmlSanitizerInterface::class)->sanitize($html);
-        });
+        Str::macro('sanitizeHtml', fn (string $html): string => app(HtmlSanitizerInterface::class)->sanitize($html));
 
-        Stringable::macro('sanitizeHtml', function (): Stringable {
+        Stringable::macro('sanitizeHtml', fn (): Stringable =>
             /** @phpstan-ignore-next-line */
-            return new Stringable(Str::sanitizeHtml($this->value));
-        });
+            new Stringable(Str::sanitizeHtml($this->value)));
 
         if (class_exists(AboutCommand::class) && class_exists(InstalledVersions::class)) {
             $packages = [

--- a/packages/tables/src/Actions/AssociateAction.php
+++ b/packages/tables/src/Actions/AssociateAction.php
@@ -51,12 +51,10 @@ class AssociateAction extends Action
 
         $this->modalWidth('lg');
 
-        $this->extraModalFooterActions(function (): array {
-            return $this->canAssociateAnother ? [
-                $this->makeModalSubmitAction('associateAnother', arguments: ['another' => true])
-                    ->label(__('filament-actions::associate.single.modal.actions.associate_another.label')),
-            ] : [];
-        });
+        $this->extraModalFooterActions(fn (): array => $this->canAssociateAnother ? [
+            $this->makeModalSubmitAction('associateAnother', arguments: ['another' => true])
+                ->label(__('filament-actions::associate.single.modal.actions.associate_another.label')),
+        ] : []);
 
         $this->successNotificationTitle(__('filament-actions::associate.single.notifications.associated.title'));
 

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -51,12 +51,10 @@ class AttachAction extends Action
 
         $this->modalWidth('lg');
 
-        $this->extraModalFooterActions(function (): array {
-            return $this->canAttachAnother() ? [
-                $this->makeModalSubmitAction('attachAnother', ['another' => true])
-                    ->label(__('filament-actions::attach.single.modal.actions.attach_another.label')),
-            ] : [];
-        });
+        $this->extraModalFooterActions(fn (): array => $this->canAttachAnother() ? [
+            $this->makeModalSubmitAction('attachAnother', ['another' => true])
+                ->label(__('filament-actions::attach.single.modal.actions.attach_another.label')),
+        ] : []);
 
         $this->successNotificationTitle(__('filament-actions::attach.single.notifications.attached.title'));
 

--- a/packages/tables/src/Actions/CreateAction.php
+++ b/packages/tables/src/Actions/CreateAction.php
@@ -33,12 +33,10 @@ class CreateAction extends Action
 
         $this->modalSubmitActionLabel(__('filament-actions::create.single.modal.actions.create.label'));
 
-        $this->extraModalFooterActions(function (): array {
-            return $this->canCreateAnother() ? [
-                $this->makeModalSubmitAction('createAnother', ['another' => true])
-                    ->label(__('filament-actions::create.single.modal.actions.create_another.label')),
-            ] : [];
-        });
+        $this->extraModalFooterActions(fn (): array => $this->canCreateAnother() ? [
+            $this->makeModalSubmitAction('createAnother', ['another' => true])
+                ->label(__('filament-actions::create.single.modal.actions.create_another.label')),
+        ] : []);
 
         $this->successNotificationTitle(__('filament-actions::create.single.notifications.created.title'));
 

--- a/packages/tables/src/Columns/Layout/Component.php
+++ b/packages/tables/src/Columns/Layout/Component.php
@@ -109,9 +109,7 @@ class Component extends ViewComponent
      */
     public function getComponents(): array
     {
-        return array_map(function (Component | Column $component): Component | Column {
-            return $component->layout($this);
-        }, $this->evaluate($this->components));
+        return array_map(fn (Component | Column $component): Component | Column => $component->layout($this), $this->evaluate($this->components));
     }
 
     public function isCollapsible(): bool

--- a/packages/tables/src/Concerns/HasRecordAction.php
+++ b/packages/tables/src/Concerns/HasRecordAction.php
@@ -15,9 +15,7 @@ trait HasRecordAction
      */
     protected function getTableRecordActionUsing(): ?Closure
     {
-        return function (Model $record): ?string {
-            return $this->getTableRecordAction();
-        };
+        return fn (Model $record): ?string => $this->getTableRecordAction();
     }
 
     /**

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -25,9 +25,7 @@ class TestsColumns
             $column = $this->instance()->getTable()->getColumn($name);
 
             $html = array_map(
-                function ($record) use ($column) {
-                    return $column->record($record)->toHtml();
-                },
+                fn ($record) => $column->record($record)->toHtml(),
                 $this->instance()->getTableRecords()->all(),
             );
 
@@ -46,9 +44,7 @@ class TestsColumns
             $column = $this->instance()->getTable()->getColumn($name);
 
             $html = array_map(
-                function ($record) use ($column) {
-                    return $column->record($record)->toHtml();
-                },
+                fn ($record) => $column->record($record)->toHtml(),
                 $this->instance()->getTableRecords()->all(),
             );
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,7 +2,5 @@
 
 use Illuminate\Database\Eloquent\Model;
 
-expect()->extend('toBeSameModel', function (Model $model) {
-    return $this
-        ->is($model)->toBeTrue();
-});
+expect()->extend('toBeSameModel', fn (Model $model) => $this
+    ->is($model)->toBeTrue());

--- a/tests/src/Forms/FormsTest.php
+++ b/tests/src/Forms/FormsTest.php
@@ -24,18 +24,14 @@ it('has fields', function () {
     livewire(TestComponentWithForm::class)
         ->assertFormFieldExists('title')
         ->assertFormFieldExists('nested.input')
-        ->assertFormFieldExists('disabled', function (TextInput $field): bool {
-            return $field->isDisabled();
-        });
+        ->assertFormFieldExists('disabled', fn (TextInput $field): bool => $field->isDisabled());
 });
 
 it('has fields on multiple forms', function () {
     livewire(TestComponentWithMultipleForms::class)
         ->assertFormFieldExists('title', 'fooForm')
         ->assertFormFieldExists('title', 'barForm')
-        ->assertFormFieldExists('disabled', 'barForm', function (TextInput $field): bool {
-            return $field->isDisabled();
-        });
+        ->assertFormFieldExists('disabled', 'barForm', fn (TextInput $field): bool => $field->isDisabled());
 });
 
 it('can fill fields on multiple forms', function () {

--- a/tests/src/Notifications/NotificationTest.php
+++ b/tests/src/Notifications/NotificationTest.php
@@ -24,20 +24,16 @@ it('can send notifications', function () {
     $iconSets = app(Factory::class)->all();
     $icons = app(IconsManifest::class)->getManifest($iconSets);
 
-    $getRandomColor = function (): string {
-        return Arr::random([
-            'danger',
-            'gray',
-            'info',
-            'primary',
-            'success',
-            'warning',
-        ]);
-    };
+    $getRandomColor = fn (): string => Arr::random([
+        'danger',
+        'gray',
+        'info',
+        'primary',
+        'success',
+        'warning',
+    ]);
 
-    $getRandomIcon = function () use ($icons): string {
-        return 'heroicon-' . collect($icons)->flatten()->random();
-    };
+    $getRandomIcon = fn (): string => 'heroicon-' . collect($icons)->flatten()->random();
 
     expect(session()->get('filament.notifications'))
         ->toBeEmpty();

--- a/tests/src/Panels/Navigation/NavigationBuilderTest.php
+++ b/tests/src/Panels/Navigation/NavigationBuilderTest.php
@@ -15,25 +15,23 @@ use Filament\Tests\Panels\Navigation\TestCase;
 uses(TestCase::class);
 
 it('can register navigation', function () {
-    Filament::getCurrentPanel()->navigation(function (NavigationBuilder $navigation): NavigationBuilder {
-        return $navigation
-            ->items([
-                ...Dashboard::getNavigationItems(),
-                ...UserResource::getNavigationItems(),
-                ...Settings::getNavigationItems(),
-            ])
-            ->groups([
-                NavigationGroup::make('Blog')
-                    ->items([
-                        ...PostResource::getNavigationItems(),
-                        ...PostCategoryResource::getNavigationItems(),
-                    ]),
-                NavigationGroup::make('Shop')
-                    ->items([
-                        ...ProductResource::getNavigationItems(),
-                    ]),
-            ]);
-    });
+    Filament::getCurrentPanel()->navigation(fn (NavigationBuilder $navigation): NavigationBuilder => $navigation
+        ->items([
+            ...Dashboard::getNavigationItems(),
+            ...UserResource::getNavigationItems(),
+            ...Settings::getNavigationItems(),
+        ])
+        ->groups([
+            NavigationGroup::make('Blog')
+                ->items([
+                    ...PostResource::getNavigationItems(),
+                    ...PostCategoryResource::getNavigationItems(),
+                ]),
+            NavigationGroup::make('Shop')
+                ->items([
+                    ...ProductResource::getNavigationItems(),
+                ]),
+        ]));
 
     expect(Filament::getNavigation())
         ->sequence(
@@ -80,13 +78,11 @@ it('can register navigation', function () {
 });
 
 it('can register navigation groups individually', function () {
-    Filament::getCurrentPanel()->navigation(function (NavigationBuilder $navigation): NavigationBuilder {
-        return $navigation
-            ->group('Blog', [
-                ...PostResource::getNavigationItems(),
-                ...PostCategoryResource::getNavigationItems(),
-            ]);
-    });
+    Filament::getCurrentPanel()->navigation(fn (NavigationBuilder $navigation): NavigationBuilder => $navigation
+        ->group('Blog', [
+            ...PostResource::getNavigationItems(),
+            ...PostCategoryResource::getNavigationItems(),
+        ]));
 
     expect(Filament::getNavigation())
         ->sequence(
@@ -107,20 +103,18 @@ it('can register navigation groups individually', function () {
 });
 
 it('can register navigation groups with hidden items', function () {
-    Filament::getCurrentPanel()->navigation(function (NavigationBuilder $navigation): NavigationBuilder {
-        return $navigation
-            ->items([
-                NavigationItem::make('Products')
-                    ->visible(false)
-                    ->label('Products'),
-                NavigationItem::make('Orders')
-                    ->hidden(fn (): bool => true)
-                    ->label('Orders'),
-                ...Dashboard::getNavigationItems(),
-                ...UserResource::getNavigationItems(),
-                ...Settings::getNavigationItems(),
-            ]);
-    });
+    Filament::getCurrentPanel()->navigation(fn (NavigationBuilder $navigation): NavigationBuilder => $navigation
+        ->items([
+            NavigationItem::make('Products')
+                ->visible(false)
+                ->label('Products'),
+            NavigationItem::make('Orders')
+                ->hidden(fn (): bool => true)
+                ->label('Orders'),
+            ...Dashboard::getNavigationItems(),
+            ...UserResource::getNavigationItems(),
+            ...Settings::getNavigationItems(),
+        ]));
 
     expect(Filament::getNavigation())
         ->sequence(

--- a/tests/src/Support/RenderHooksTest.php
+++ b/tests/src/Support/RenderHooksTest.php
@@ -8,9 +8,7 @@ use Illuminate\Support\HtmlString;
 uses(TestCase::class);
 
 test('render hooks can be registered', function () {
-    FilamentView::registerRenderHook('foo', function (): string {
-        return Blade::render('bar');
-    });
+    FilamentView::registerRenderHook('foo', fn (): string => Blade::render('bar'));
 
     expect(FilamentView::renderHook('foo'))
         ->toBeInstanceOf(HtmlString::class)
@@ -18,9 +16,7 @@ test('render hooks can be registered', function () {
 });
 
 test('render hooks can render view files', function () {
-    FilamentView::registerRenderHook('view-foo', function (): Illuminate\Contracts\View\View {
-        return view('app.fixtures.pages.render-hooks.foo');
-    });
+    FilamentView::registerRenderHook('view-foo', fn (): Illuminate\Contracts\View\View => view('app.fixtures.pages.render-hooks.foo'));
 
     expect(FilamentView::renderHook('view-foo'))
         ->toBeInstanceOf(HtmlString::class)
@@ -28,13 +24,9 @@ test('render hooks can render view files', function () {
 });
 
 test('render hooks can be scopes:d', function () {
-    FilamentView::registerRenderHook('foo', function (): string {
-        return Blade::render('bar');
-    });
+    FilamentView::registerRenderHook('foo', fn (): string => Blade::render('bar'));
 
-    FilamentView::registerRenderHook('foo', function (): string {
-        return Blade::render('bar');
-    }, 'baz');
+    FilamentView::registerRenderHook('foo', fn (): string => Blade::render('bar'), 'baz');
 
     expect(FilamentView::renderHook('foo', scopes: 'baz'))
         ->toBeInstanceOf(HtmlString::class)
@@ -42,13 +34,9 @@ test('render hooks can be scopes:d', function () {
 });
 
 test('render hooks can be scopes:d to multiple scopes:s', function () {
-    FilamentView::registerRenderHook('foo', function (): string {
-        return Blade::render('bar');
-    });
+    FilamentView::registerRenderHook('foo', fn (): string => Blade::render('bar'));
 
-    FilamentView::registerRenderHook('foo', function (): string {
-        return Blade::render('bar');
-    }, ['baz', 'qux']);
+    FilamentView::registerRenderHook('foo', fn (): string => Blade::render('bar'), ['baz', 'qux']);
 
     expect(FilamentView::renderHook('foo', scopes: 'baz'))
         ->toBeInstanceOf(HtmlString::class)
@@ -60,13 +48,9 @@ test('render hooks can be scopes:d to multiple scopes:s', function () {
 });
 
 test('render hooks can be scopes:d to multiple scopes:s but only ever output once', function () {
-    FilamentView::registerRenderHook('foo', function (): string {
-        return Blade::render('bar');
-    });
+    FilamentView::registerRenderHook('foo', fn (): string => Blade::render('bar'));
 
-    FilamentView::registerRenderHook('foo', function (): string {
-        return Blade::render('bar');
-    }, ['baz', 'qux']);
+    FilamentView::registerRenderHook('foo', fn (): string => Blade::render('bar'), ['baz', 'qux']);
 
     expect(FilamentView::renderHook('foo', scopes: ['baz', 'qux']))
         ->toBeInstanceOf(HtmlString::class)


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.

---

This PR converts traditional closures to arrow functions, resulting in cleaner and consistent code style throughout Filament code base.

Used tool: 

- [Rector 0.17.3](https://github.com/rectorphp/rector) (with [`ClosureToArrowFunctionRector`](https://github.com/rectorphp/rector/blob/main/rules/Php74/Rector/Closure/ClosureToArrowFunctionRector.php) rule) for refactoring
- Laravel Pint 1.10.6 for formatting

Each change was verified manually before being applied.