### PR TITLE
Add table toolbar render hooks

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -290,6 +290,9 @@
                 class="fi-ta-header-toolbar flex items-center justify-between gap-3 px-4 py-3 sm:px-6"
             >
                 <div class="flex shrink-0 items-center gap-x-3">
+
+                    {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.table.toolbar.reorder.start', scopes: $this->getRenderHookScopes()) }}
+
                     @if ($isReorderable)
                         <span
                             x-show="! selectedRecords.length"
@@ -302,6 +305,8 @@
                         </span>
                     @endif
 
+                    {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.table.toolbar.actions.start', scopes: $this->getRenderHookScopes()) }}
+
                     @if ((! $isReordering) && count($bulkActions))
                         <x-filament-tables::actions
                             :actions="$bulkActions"
@@ -310,6 +315,8 @@
                         />
                     @endif
 
+                    {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.table.toolbar.actions.end', scopes: $this->getRenderHookScopes()) }}
+
                     @if (count($groups))
                         <x-filament-tables::groups
                             :dropdown-on-desktop="$areGroupsInDropdownOnDesktop()"
@@ -317,6 +324,9 @@
                             :trigger-action="$getGroupRecordsTriggerAction()"
                         />
                     @endif
+
+                    {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.table.toolbar.groups.end', scopes: $this->getRenderHookScopes()) }}
+
                 </div>
 
                 @if ($isGlobalSearchVisible || $hasFiltersDropdown || $hasColumnToggleDropdown)
@@ -327,30 +337,38 @@
                             'gap-x-4' => $filtersTriggerAction->isIconButton() && $toggleColumnsTriggerAction->isIconButton(),
                         ])
                     >
+
+                        {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.table.toolbar.search.start', scopes: $this->getRenderHookScopes()) }}
+
                         @if ($isGlobalSearchVisible)
                             <x-filament-tables::search-field />
                         @endif
 
-                        @if ($hasFiltersDropdown || $hasColumnToggleDropdown)
-                            @if ($hasFiltersDropdown)
-                                <x-filament-tables::filters.dropdown
-                                    :form="$getFiltersForm()"
-                                    :indicators-count="count(\Illuminate\Support\Arr::flatten($filterIndicators))"
-                                    :max-height="$getFiltersFormMaxHeight()"
-                                    :trigger-action="$filtersTriggerAction"
-                                    :width="$getFiltersFormWidth()"
-                                />
-                            @endif
+                        {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.table.toolbar.search.end', scopes: $this->getRenderHookScopes()) }}
 
-                            @if ($hasColumnToggleDropdown)
-                                <x-filament-tables::column-toggle.dropdown
-                                    :form="$getColumnToggleForm()"
-                                    :max-height="$getColumnToggleFormMaxHeight()"
-                                    :trigger-action="$toggleColumnsTriggerAction"
-                                    :width="$getColumnToggleFormWidth()"
-                                />
-                            @endif
+                        @if ($hasFiltersDropdown)
+                            <x-filament-tables::filters.dropdown
+                                :form="$getFiltersForm()"
+                                :indicators-count="count(\Illuminate\Support\Arr::flatten($filterIndicators))"
+                                :max-height="$getFiltersFormMaxHeight()"
+                                :trigger-action="$filtersTriggerAction"
+                                :width="$getFiltersFormWidth()"
+                            />
                         @endif
+
+                        {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.table.toolbar.column-toggle.start', scopes: $this->getRenderHookScopes()) }}
+
+                        @if ($hasColumnToggleDropdown)
+                            <x-filament-tables::column-toggle.dropdown
+                                :form="$getColumnToggleForm()"
+                                :max-height="$getColumnToggleFormMaxHeight()"
+                                :trigger-action="$toggleColumnsTriggerAction"
+                                :width="$getColumnToggleFormWidth()"
+                            />
+                        @endif
+
+                        {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.table.toolbar.column-toggle.end', scopes: $this->getRenderHookScopes()) }}
+                       
                     </div>
                 @endif
             </div>


### PR DESCRIPTION
- `panels::resource.pages.list-records.table.toolbar.reorder.start` - The start of the reorder action in the table toolbar, also [can be scoped](#scoping-render-hooks) to the page or resource class
- `panels::resource.pages.list-records.table.toolbar.actions.start` - The start of the bulkactions in the table toolbar, also [can be scoped](#scoping-render-hooks) to the page or resource class
- `panels::resource.pages.list-records.table.toolbar.actions.end` - The end of the bulkactions in the table toolbar, also [can be scoped](#scoping-render-hooks) to the page or resource class
- `panels::resource.pages.list-records.table.toolbar.groups.end` - The end of the groups action in the table toolbar, also [can be scoped](#scoping-render-hooks) to the page or resource class
- `panels::resource.pages.list-records.table.toolbar.search.start` - The start of the search in the table toolbar, also [can be scoped](#scoping-render-hooks) to the page or resource class
- `panels::resource.pages.list-records.table.toolbar.search.end` - The end of the search in the table toolbar, also [can be scoped](#scoping-render-hooks) to the page or resource class
- `panels::resource.pages.list-records.table.toolbar.column-toggle.start` - The start of the column toggle in the table toolbar (or the end of the filters action), also [can be scoped](#scoping-render-hooks) to the page or resource class
- `panels::resource.pages.list-records.table.toolbar.column-toggle.end` - The end of the column toggle in the table toolbar, also [can be scoped](#scoping-render-hooks) to the page or resource class