### PR TITLE
Add ability to discover scoped livewire component

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasComponents.php
+++ b/packages/panels/src/Panel/Concerns/HasComponents.php
@@ -242,6 +242,20 @@ trait HasComponents
         return $this->widgetNamespaces;
     }
 
+    public function discoverLivewireComponents(string $in, string $for): static
+    {
+        $component = [];
+
+        $this->discoverComponents(
+            Component::class,
+            $component,
+            directory: $in,
+            namespace: $for,
+        );
+
+        return $this;
+    }
+
     /**
      * @return array<class-string>
      */
@@ -320,7 +334,7 @@ trait HasComponents
                 continue;
             }
 
-            if (! $class::isDiscovered()) {
+            if (method_exists($class, 'isDiscovered') && !$class::isDiscovered()) {
                 continue;
             }
 

--- a/packages/panels/src/Panel/Concerns/HasComponents.php
+++ b/packages/panels/src/Panel/Concerns/HasComponents.php
@@ -334,7 +334,10 @@ trait HasComponents
                 continue;
             }
 
-            if (method_exists($class, 'isDiscovered') && !$class::isDiscovered()) {
+            if (
+                method_exists($class, 'isDiscovered') &&
+                (! $class::isDiscovered())
+            ) {
                 continue;
             }
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Useful when you want to add scoped livewire component only for the related panel.

Usage:
```php
 $panel->discoverLivewireComponents(in: app_path('Filament/Livewire'), for: 'App\\Filament\\Livewire')
```
