### PR TITLE
Prevent badges from shrinking

### DIFF
--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -25,7 +25,7 @@
     {{
         $attributes
             ->class([
-                'fi-badge flex items-center justify-center gap-x-1 whitespace-nowrap rounded-md  text-xs font-medium ring-1 ring-inset',
+                'fi-badge flex flex-shrink-0 items-center justify-center gap-x-1 whitespace-nowrap rounded-md  text-xs font-medium ring-1 ring-inset',
                 match ($size) {
                     'xs' => 'px-0.5 min-w-[theme(spacing.4)] tracking-tighter',
                     'sm' => 'px-1.5 min-w-[theme(spacing.5)] py-0.5 tracking-tight',


### PR DESCRIPTION
Currently badges will shrink when pushed up against their container. Assuming this isn't desired this PR adds `flex-shrink-0` to the badge.

Before
![Screenshot 2023-08-15 at 9 01 56 PM](https://github.com/filamentphp/filament/assets/6097099/2cda79e7-a9d8-4c7a-9a64-d604d70d05aa)

After
![Screenshot 2023-08-15 at 9 02 34 PM](https://github.com/filamentphp/filament/assets/6097099/3582c829-fc11-4c94-b0d2-c1c6bbef0d9d)
