### PR TITLE
Fixed Search with PostGres

### DIFF
--- a/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
@@ -96,17 +96,19 @@ trait InteractsWithTableQuery
                         new Expression("lower({$searchColumn})") :
                         $searchColumn;
 
+                    $operator = config('database.default') === 'pgsql' ? 'ilike' : 'like';
+                    
                     return $query->when(
                         $this->queriesRelationships($query->getModel()),
                         fn (EloquentBuilder $query): EloquentBuilder => $query->{"{$whereClause}Relation"}(
                             $this->getRelationshipName(),
                             $caseAwareSearchColumn,
-                            'like',
+                            $operator,
                             "%{$search}%",
                         ),
                         fn (EloquentBuilder $query): EloquentBuilder => $query->{$whereClause}(
                             $caseAwareSearchColumn,
-                            'like',
+                            $operator,
                             "%{$search}%",
                         ),
                     );


### PR DESCRIPTION
'like' is does not perform case-insensitive query in Postgres, so we need to check the SQL Driver and then do 'ilike' if it is PostGres

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
