### PR TITLE
adjusting route priority fix #7809

### DIFF
--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -44,6 +44,10 @@ Route::name('filament.')
                             }
                         });
 
+                        if ($routes = $panel->getRoutes()) {
+                            $routes($panel);
+                        }
+
                         Route::middleware($panel->getAuthMiddleware())
                             ->group(function () use ($panel, $hasTenancy, $tenantRoutePrefix, $tenantSlugAttribute): void {
                                 if ($hasTenancy) {
@@ -124,10 +128,6 @@ Route::name('filament.')
                                         $routes($panel);
                                     }
                                 });
-                        }
-
-                        if ($routes = $panel->getRoutes()) {
-                            $routes($panel);
                         }
                     });
             }

--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -23,6 +23,10 @@ Route::name('filament.')
                     ->name("{$panelId}.")
                     ->prefix($panel->getPath())
                     ->group(function () use ($panel, $hasTenancy, $tenantRoutePrefix, $tenantSlugAttribute) {
+                        if ($routes = $panel->getRoutes()) {
+                            $routes($panel);
+                        }
+
                         Route::name('auth.')->group(function () use ($panel) {
                             if ($panel->hasLogin()) {
                                 Route::get('/login', $panel->getLoginRouteAction())->name('login');
@@ -44,12 +48,12 @@ Route::name('filament.')
                             }
                         });
 
-                        if ($routes = $panel->getRoutes()) {
-                            $routes($panel);
-                        }
-
                         Route::middleware($panel->getAuthMiddleware())
                             ->group(function () use ($panel, $hasTenancy, $tenantRoutePrefix, $tenantSlugAttribute): void {
+                                if ($routes = $panel->getAuthenticatedRoutes()) {
+                                    $routes($panel);
+                                }
+
                                 if ($hasTenancy) {
                                     Route::get('/', RedirectToTenantController::class)->name('tenant');
                                 }
@@ -81,13 +85,13 @@ Route::name('filament.')
                                         }
                                     });
 
-                                if ($routes = $panel->getAuthenticatedRoutes()) {
-                                    $routes($panel);
-                                }
-
                                 Route::middleware($hasTenancy ? $panel->getTenantMiddleware() : [])
                                     ->prefix($hasTenancy ? (($tenantRoutePrefix) ? "{$tenantRoutePrefix}/" : '') . ('{tenant' . (($tenantSlugAttribute) ? ":{$tenantSlugAttribute}" : '') . '}') : '')
                                     ->group(function () use ($panel): void {
+                                        if ($routes = $panel->getAuthenticatedTenantRoutes()) {
+                                            $routes($panel);
+                                        }
+                                        
                                         Route::get('/', RedirectToHomeController::class)->name('home');
 
                                         Route::name('tenant.')->group(function () use ($panel): void {
@@ -112,10 +116,6 @@ Route::name('filament.')
                                                 $resource::routes($panel);
                                             }
                                         });
-
-                                        if ($routes = $panel->getAuthenticatedTenantRoutes()) {
-                                            $routes($panel);
-                                        }
                                     });
 
                             });


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

fix #7809 

![CleanShot 2023-08-16 at 18 53 54@2x](https://github.com/filamentphp/filament/assets/31089228/65589587-a130-4b6a-8e84-d57fca70b71d)

Adjusted the last route in the image to take precedence over the tenant route, otherwise the custom route would never be accessible.