### PR TITLE
Added instructions for PostgreSQL for searchable()

### DIFF
--- a/packages/tables/docs/03-columns/01-getting-started.md
+++ b/packages/tables/docs/03-columns/01-getting-started.md
@@ -175,6 +175,8 @@ TextColumn::make('full_name')
     })
 ```
 
+If you are using PostgreSQL, check `forceSearchCaseInsensitive()` which is explained in later.
+
 ### Searching individually
 
 You can choose to enable a per-column search input field using the `isIndividual` parameter:
@@ -240,6 +242,7 @@ TextColumn::make('name')
     ->searchable()
     ->forceSearchCaseInsensitive()
 ```
+For PostgreSQL works slighly different that other databases, `forceSearchCaseInsensitive()` is required for search to work properly with PostgreSQL.
 
 ## Column actions and URLs
 


### PR DESCRIPTION
Apparently, the current searchable() implementation does not work with PosgreSQL. Though a better fix might be needed later, this might help with the ones struggling right now.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
