### PR TITLE
Support disabled option in Choices

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -650,7 +650,7 @@ class Select extends Field implements Contracts\HasAffixActions, Contracts\HasNe
         return collect($options)
             ->map(fn ($label, $value): array => is_array($label)
                 ? ['label' => $value, 'choices' => $this->transformOptionsForJs($label)]
-                : ['label' => $label, 'value' => strval($value)])
+                : ['label' => $label, 'value' => strval($value), 'disabled' => $this->isOptionDisabled($value, $label)])
             ->values()
             ->all();
     }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Existing behavior is that the documented disableOptionWhen() method was never being called for Choices selects, only native.  This PR adds calling isOptionDisabled during transformation of options for JS, so Choices now correctly disables options according to disableOptionWhen().

<img width="244" alt="2023-08-16_18-41-14" src="https://github.com/filamentphp/filament/assets/934456/ee331fde-768a-4dd4-a172-b07a05ca423e">
<img width="202" alt="2023-08-16_18-41-43" src="https://github.com/filamentphp/filament/assets/934456/7e31a9f2-45a0-4445-9ab1-d314190fab85">
