### PR TITLE
Fix filter indicator wrapping

### DIFF
--- a/packages/tables/resources/views/components/filters/indicators.blade.php
+++ b/packages/tables/resources/views/components/filters/indicators.blade.php
@@ -5,9 +5,9 @@
 <div
     {{ $attributes->class(['fi-ta-filter-indicators flex items-start justify-between gap-x-3 bg-gray-50 px-3 py-1.5 dark:bg-white/5 sm:px-6']) }}
 >
-    <div class="flex flex-col gap-x-3 gap-y-1 sm:flex-row sm:items-center">
+    <div class="flex flex-col gap-x-3 gap-y-1 sm:flex-row">
         <span
-            class="text-sm font-medium leading-6 text-gray-700 dark:text-gray-200"
+            class="text-sm font-medium leading-6 text-gray-700 whitespace-nowrap dark:text-gray-200"
         >
             {{ __('filament-tables::table.filters.indicator') }}
         </span>

--- a/packages/tables/resources/views/components/filters/indicators.blade.php
+++ b/packages/tables/resources/views/components/filters/indicators.blade.php
@@ -12,7 +12,7 @@
             {{ __('filament-tables::table.filters.indicator') }}
         </span>
 
-        <div class="flex gap-1.5">
+        <div class="flex flex-wrap gap-1.5">
             @foreach ($indicators as $wireClickHandler => $label)
                 <x-filament::badge>
                     {{ $label }}


### PR DESCRIPTION
Currently when there are multiple filters, the indicators expand past the container. The pushes the "X" close button off screen, but also means you can scroll the table into the navigation. This PR adds `flex-wrap` to the indicator `div` to fix this. 

Before
![Screenshot 2023-08-16 at 10 12 51 PM (2)](https://github.com/filamentphp/filament/assets/6097099/2d672c27-9adc-4f38-b4a7-d5a36ca9dc25)

After
![Screenshot 2023-08-16 at 10 13 32 PM (2)](https://github.com/filamentphp/filament/assets/6097099/f2016fc9-dd46-4a80-aa22-0358892e8477)

While this fixes the main problem, visually you'll see that "Active Filters" is now split onto two lines. There are other options we can consider:

1. We could also add `whitespace-nowrap` to "Active filters" so that it remains on one line:
![Screenshot 2023-08-16 at 10 15 02 PM](https://github.com/filamentphp/filament/assets/6097099/1dd01596-0542-436c-8469-8d5898188058)

2. Another option could be to find a way to move the indicators below "Active filters" and the "X" when the width of the indicators is larger than the space available between "Active filters" and the "X". This is actually what happens on mobile. 
![Screenshot 2023-08-16 at 10 28 44 PM](https://github.com/filamentphp/filament/assets/6097099/e0ea87b8-63fe-4d32-9058-0df8d4169865)

If you remove the `sm:flex-row` and `sm:items-center` you can accomplish this effect, BUT it has the downside that now even just one filter forces two rows, no matter the width. This look worse IMO.
![Screenshot 2023-08-16 at 10 37 04 PM](https://github.com/filamentphp/filament/assets/6097099/5035c171-c8cf-4d63-86f7-2df0c8f7f6ab)

I don't think container queries works here since we need to change the parent container depending on the width of the children (indicators).

Another option would be to use JS/Alpine to keep track of the width of the indicators and conditionally apply classes to the parent so that when the indicators are wider it can move down to a new line like mobile. 

Let me know how you'd like to proceed and I'll gladly dig into it.
