### PR TITLE
fix: Postgres search case insensitivity

### DIFF
--- a/packages/forms/docs/03-fields/03-select.md
+++ b/packages/forms/docs/03-fields/03-select.md
@@ -337,19 +337,6 @@ MorphToSelect::make('commentable')
 
 > Many of the same options in the select field are available for `MorphToSelect`, including `searchable()`, `preload()`, `allowHtml()`, and `optionsLimit()`.
 
-### Forcing case-insensitive search
-
-By default, searching will use the sensitivity settings from the database table column. This is to avoid unnecessary performance overhead when searching large datasets that would arise if we were to force insensitivity for all users. However, if your database does not search case-insensitively by default, you can force it to by using the `forceSearchCaseInsensitive()` method:
-
-```php
-use Filament\Forms\Components\Select;
-
-Select::make('author_id')
-    ->relationship(name: 'author', titleAttribute: 'name')
-    ->searchable()
-    ->forceSearchCaseInsensitive()
-```
-
 ## Allowing HTML in the option labels
 
 By default, Filament will escape any HTML in the option labels. If you'd like to allow HTML, you can use the `allowHtml()` method:

--- a/packages/panels/docs/03-resources/08-global-search.md
+++ b/packages/panels/docs/03-resources/08-global-search.md
@@ -153,11 +153,3 @@ public function panel(Panel $panel): Panel
         ->globalSearchKeyBindings(['command+k', 'ctrl+k']);
 }
 ```
-
-## Forcing case-insensitive global search
-
-By default, searching will use the sensitivity settings from the database table column. This is to avoid unnecessary performance overhead when searching large datasets that would arise if we were to force insensitivity for all users. However, if your database does not search case-insensitively by default, you can force it to by using the `$isGlobalSearchForcedCaseInsensitive` property:
-
-```php
-protected static ?bool $isGlobalSearchForcedCaseInsensitive = true;
-```

--- a/packages/panels/docs/03-resources/08-global-search.md
+++ b/packages/panels/docs/03-resources/08-global-search.md
@@ -159,5 +159,5 @@ public function panel(Panel $panel): Panel
 By default, searching will use the sensitivity settings from the database table column. This is to avoid unnecessary performance overhead when searching large datasets that would arise if we were to force insensitivity for all users. However, if your database does not search case-insensitively by default, you can force it to by using the `$isGlobalSearchForcedCaseInsensitive` property:
 
 ```php
-protected static bool $isGlobalSearchForcedCaseInsensitive = true;
+protected static ?bool $isGlobalSearchForcedCaseInsensitive = true;
 ```

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -655,10 +655,7 @@ abstract class Resource
                 fn (Builder $query): Builder => $query->when(
                     str($searchAttribute)->contains('.'),
                     function (Builder $query) use ($databaseConnection, $searchAttribute, $search, $whereClause): Builder {
-                        $searchColumn = match ($databaseConnection->getDriverName()) {
-                            'pgsql' => "{$searchAttribute}::text",
-                            default => $searchAttribute,
-                        };
+                        $searchColumn = (string) str($searchAttribute)->afterLast('.');
 
                         $caseAwareSearchColumn = static::isGlobalSearchForcedCaseInsensitive($query) ?
                             new Expression("lower({$searchColumn})") :

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -656,7 +656,7 @@ abstract class Resource
                 },
                 fn (Builder $query): Builder => $query->when(
                     str($searchAttribute)->contains('.'),
-                    function (Builder $query) use ($databaseConnection, $searchAttribute, $search, $whereClause): Builder {
+                    function (Builder $query) use ($searchAttribute, $search, $whereClause): Builder {
                         $searchColumn = (string) str($searchAttribute)->afterLast('.');
 
                         $caseAwareSearchColumn = static::isGlobalSearchForcedCaseInsensitive($query) ?

--- a/packages/tables/docs/03-columns/01-getting-started.md
+++ b/packages/tables/docs/03-columns/01-getting-started.md
@@ -229,18 +229,6 @@ public function table(Table $table): Table
 }
 ```
 
-### Forcing case-insensitive column search
-
-By default, searching will use the sensitivity settings from the database table column. This is to avoid unnecessary performance overhead when searching large datasets that would arise if we were to force insensitivity for all users. However, if your database does not search case-insensitively by default, you can force it to by using the `forceSearchCaseInsensitive()` method:
-
-```php
-use Filament\Tables\Columns\TextColumn;
-
-TextColumn::make('name')
-    ->searchable()
-    ->forceSearchCaseInsensitive()
-```
-
 ## Column actions and URLs
 
 When a cell is clicked, you may run an "action", or open a URL.

--- a/packages/tables/src/Actions/AssociateAction.php
+++ b/packages/tables/src/Actions/AssociateAction.php
@@ -7,6 +7,7 @@ use Filament\Actions\Concerns\CanCustomizeProcess;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -33,7 +34,7 @@ class AssociateAction extends Action
      */
     protected array | Closure | null $recordSelectSearchColumns = null;
 
-    protected bool | Closure $isSearchForcedCaseInsensitive = false;
+    protected bool | Closure | null $isSearchForcedCaseInsensitive = null;
 
     public static function getDefaultName(): ?string
     {
@@ -193,11 +194,13 @@ class AssociateAction extends Action
             }
 
             if (filled($search) && ($searchColumns || filled($titleAttribute))) {
-                $search = Str::lower($search);
-
                 $searchColumns ??= [$titleAttribute];
                 $isFirst = true;
-                $isForcedCaseInsensitive = $this->isSearchForcedCaseInsensitive();
+                $isForcedCaseInsensitive = $this->isSearchForcedCaseInsensitive($relationshipQuery);
+
+                if ($isForcedCaseInsensitive) {
+                    $search = Str::lower($search);
+                }
 
                 $relationshipQuery->where(function (Builder $query) use ($isFirst, $isForcedCaseInsensitive, $searchColumns, $search): Builder {
                     foreach ($searchColumns as $searchColumn) {
@@ -270,15 +273,21 @@ class AssociateAction extends Action
         return $select;
     }
 
-    public function forceSearchCaseInsensitive(bool | Closure $condition = true): static
+    public function forceSearchCaseInsensitive(bool | Closure | null $condition = true): static
     {
         $this->isSearchForcedCaseInsensitive = $condition;
 
         return $this;
     }
 
-    public function isSearchForcedCaseInsensitive(): bool
+    public function isSearchForcedCaseInsensitive(Builder $query): bool
     {
-        return (bool) $this->evaluate($this->isSearchForcedCaseInsensitive);
+        /** @var Connection $databaseConnection */
+        $databaseConnection = $query->getConnection();
+
+        return $this->evaluate($this->isSearchForcedCaseInsensitive) ?? match ($databaseConnection->getDriverName()) {
+            'pgsql' => true,
+            default => false,
+        };
     }
 }

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -7,6 +7,7 @@ use Filament\Actions\Concerns\CanCustomizeProcess;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -33,7 +34,7 @@ class AttachAction extends Action
      */
     protected array | Closure | null $recordSelectSearchColumns = null;
 
-    protected bool | Closure $isSearchForcedCaseInsensitive = false;
+    protected bool | Closure | null $isSearchForcedCaseInsensitive = null;
 
     public static function getDefaultName(): ?string
     {
@@ -229,11 +230,13 @@ class AttachAction extends Action
             }
 
             if (filled($search) && ($searchColumns || filled($titleAttribute))) {
-                $search = Str::lower($search);
-
                 $searchColumns ??= [$titleAttribute];
                 $isFirst = true;
-                $isForcedCaseInsensitive = $this->isSearchForcedCaseInsensitive();
+                $isForcedCaseInsensitive = $this->isSearchForcedCaseInsensitive($relationshipQuery);
+
+                if ($isForcedCaseInsensitive) {
+                    $search = Str::lower($search);
+                }
 
                 $relationshipQuery->where(function (Builder $query) use ($isFirst, $isForcedCaseInsensitive, $searchColumns, $search): Builder {
                     foreach ($searchColumns as $searchColumn) {
@@ -322,15 +325,21 @@ class AttachAction extends Action
         return $select;
     }
 
-    public function forceSearchCaseInsensitive(bool | Closure $condition = true): static
+    public function forceSearchCaseInsensitive(bool | Closure | null $condition = true): static
     {
         $this->isSearchForcedCaseInsensitive = $condition;
 
         return $this;
     }
 
-    public function isSearchForcedCaseInsensitive(): bool
+    public function isSearchForcedCaseInsensitive(Builder $query): bool
     {
-        return (bool) $this->evaluate($this->isSearchForcedCaseInsensitive);
+        /** @var Connection $databaseConnection */
+        $databaseConnection = $query->getConnection();
+
+        return $this->evaluate($this->isSearchForcedCaseInsensitive) ?? match ($databaseConnection->getDriverName()) {
+            'pgsql' => true,
+            default => false,
+        };
     }
 }

--- a/packages/tables/src/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Concerns/CanSearchRecords.php
@@ -4,7 +4,6 @@ namespace Filament\Tables\Concerns;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
 
@@ -106,7 +105,7 @@ trait CanSearchRecords
 
     protected function applyGlobalSearchToTableQuery(Builder $query): Builder
     {
-        $search = trim(Str::lower($this->getTableSearch()));
+        $search = trim($this->getTableSearch());
 
         if (blank($search)) {
             return $query;
@@ -249,7 +248,7 @@ trait CanSearchRecords
             // Nested array keys are flattened into `dot.syntax`.
             $searches[
                 implode('.', array_slice($path, 0, $iterator->getDepth() + 1))
-            ] = trim(Str::lower($value));
+            ] = trim($value);
         }
 
         return $searches;

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -25,7 +25,7 @@ class SelectFilter extends BaseFilter
 
     protected int | Closure $optionsLimit = 50;
 
-    protected bool | Closure $isSearchForcedCaseInsensitive = false;
+    protected bool | Closure | null $isSearchForcedCaseInsensitive = null;
 
     protected function setUp(): void
     {
@@ -184,16 +184,16 @@ class SelectFilter extends BaseFilter
         return $this->getAttribute();
     }
 
-    public function forceSearchCaseInsensitive(bool | Closure $condition = true): static
+    public function forceSearchCaseInsensitive(bool | Closure | null $condition = true): static
     {
         $this->isSearchForcedCaseInsensitive = $condition;
 
         return $this;
     }
 
-    public function isSearchForcedCaseInsensitive(): bool
+    public function isSearchForcedCaseInsensitive(): ?bool
     {
-        return (bool) $this->evaluate($this->isSearchForcedCaseInsensitive);
+        return $this->evaluate($this->isSearchForcedCaseInsensitive);
     }
 
     public function getFormField(): Select


### PR DESCRIPTION
Fixes #7717. Also addresses comments in #7818.

This enables the "force case insensitivity" setting by default on Postgres. You can disable it by setting it to `false`.

This is potentially a breaking change for some young applications, but I see it as a more consistent behaviour with other database drivers, and also what we had in v2, while also not compromising on the search performance of other drivers.