### PR TITLE
fix: Scroll to top when reactive fields change state inside wizard

### DIFF
--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -4,6 +4,7 @@
 @endphp
 
 <div
+    wire:ignore.self
     x-cloak
     x-data="{
         step: null,


### PR DESCRIPTION
- [X] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This was added to Filament v2 In #7490. The bug only occurs when the wizard component has reactive fields using `->live()` method.

See also #6692 

**Before:**
https://github.com/filamentphp/filament/assets/20065018/97bc060f-fb9a-4359-8e9f-b3c144500106

After:
https://github.com/filamentphp/filament/assets/20065018/2a0c216d-4866-4e42-aab1-b38a26698f23


