### PR TITLE
Fix bulk action records should be not loaded before actually executed

### DIFF
--- a/packages/tables/src/Table/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Table/Concerns/HasBulkActions.php
@@ -113,7 +113,7 @@ trait HasBulkActions
     public function getBulkAction(string $name): ?BulkAction
     {
         $action = $this->getFlatBulkActions()[$name] ?? null;
-        $action?->records($this->getLivewire()->getSelectedTableRecords());
+        $action?->records(fn() => $this->getLivewire()->getSelectedTableRecords());
 
         return $action;
     }

--- a/packages/tables/src/Table/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Table/Concerns/HasBulkActions.php
@@ -113,7 +113,7 @@ trait HasBulkActions
     public function getBulkAction(string $name): ?BulkAction
     {
         $action = $this->getFlatBulkActions()[$name] ?? null;
-        $action?->records(fn() => $this->getLivewire()->getSelectedTableRecords());
+        $action?->records($this->getLivewire()->getSelectedTableRecords(...));
 
         return $action;
     }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

"This will prevent the database query from being executed to retrieve records for the action if the action doesn't require using the selected records. For instance, when dealing with a selection of thousands of records, we could utilize the `Table $table` injection into the action closure to manage the query. This approach helps in avoiding the loading of thousands of models, which could potentially lead to reaching the memory limit."