### PR TITLE
Fix shrinking of icons in infolist text-entry

### DIFF
--- a/packages/infolists/resources/views/components/text-entry.blade.php
+++ b/packages/infolists/resources/views/components/text-entry.blade.php
@@ -79,7 +79,7 @@
                         ]);
 
                         $iconClasses = \Illuminate\Support\Arr::toCssClasses([
-                            'fi-in-text-item-icon h-5 w-5',
+                            'fi-in-text-item-icon h-5 w-5 shrink-0',
                             match ($color) {
                                 'gray', null => 'text-gray-400 dark:text-gray-500',
                                 default => 'text-custom-500',


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Long wrapping text in a Infolist TextEntry forces icons to shrink. Adding the [shrink-0](https://tailwindcss.com/docs/flex-shrink#dont-shrink) class prevents the icons from shrinking below their defined width of `w-5`. Unsure if this happens in other places.

### Before
<img width="379" alt="Bildschirmfoto 2023-08-18 um 13 40 45" src="https://github.com/filamentphp/filament/assets/10193428/4eaf8e49-5cd7-4e54-9d89-054efc1ee714">

### After
<img width="375" alt="Bildschirmfoto 2023-08-18 um 13 41 01" src="https://github.com/filamentphp/filament/assets/10193428/c1bf5991-3718-4f8c-b5b7-185f8acc5cd5">

