### PR TITLE
Add togglable collapsed class

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -61,6 +61,7 @@
                         x-data="{
                             isCollapsed: @js($isCollapsed($item)),
                         }"
+                        x-bind:class="isCollapsed && 'fi-collapsed'"
                         x-on:builder-expand.window="$event.detail === '{{ $statePath }}' && (isCollapsed = false)"
                         x-on:builder-collapse.window="$event.detail === '{{ $statePath }}' && (isCollapsed = true)"
                         x-on:expand-concealing-component.window="

--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -66,6 +66,7 @@
                             x-data="{
                                 isCollapsed: @js($isCollapsed($item)),
                             }"
+                            x-bind:class="isCollapsed && 'fi-collapsed'"
                             x-on:expand-concealing-component.window="
                                 error = $el.querySelector('[data-validation-error]')
 

--- a/packages/support/resources/views/components/section.blade.php
+++ b/packages/support/resources/views/components/section.blade.php
@@ -28,6 +28,7 @@
         x-data="{
             isCollapsed: @js($collapsed),
         }"
+        x-bind:class="isCollapsed && 'fi-collapsed'"
         x-on:collapse-section.window="if ($event.detail.id == $el.id) isCollapsed = true"
         x-on:expand-concealing-component.window="
             error = $el.querySelector('[data-validation-error]')

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -559,6 +559,7 @@
                                 @if ($hasCollapsibleColumnsLayout)
                                     x-data="{ isCollapsed: @js($collapsibleColumnsLayout->isCollapsed()) }"
                                     x-init="$dispatch('collapsible-table-row-initialized')"
+                                    x-bind:class="isCollapsed && 'fi-collapsed'"
                                     x-on:collapse-all-table-rows.window="isCollapsed = true"
                                     x-on:expand-all-table-rows.window="isCollapsed = false"
                                 @endif


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Add the `fi-collapsed` class if the element is collapsed. 

After adding a background color to the section header also needed to adjust the rounding when collapsed. 
<img width="883" alt="Screenshot 2023-08-18 at 13 15 14" src="https://github.com/filamentphp/filament/assets/533658/e0df7b64-f157-4755-941a-7265700ec007">

```css
.fi-section > header {
    @apply rounded-t-xl bg-gray-50 dark:bg-gray-700;
}

.fi-section.fi-collapsed > header {
    @apply rounded-b-xl;
}
```


