### PR TITLE
fix: Paginated while reordering

### DIFF
--- a/packages/tables/src/Table/Concerns/CanPaginateRecords.php
+++ b/packages/tables/src/Table/Concerns/CanPaginateRecords.php
@@ -11,7 +11,7 @@ trait CanPaginateRecords
 
     protected bool | Closure $isPaginated = true;
 
-    protected bool | Closure $isPaginatedWhileReordering = true;
+    protected bool | Closure $isPaginatedWhileReordering = false;
 
     /**
      * @var array<int | string> | Closure | null


### PR DESCRIPTION
The docs are correct - tables should not be paginated while reordering by default. This PR fixes it.