### PR TITLE
[Docs] Clarify using a custom indicator with filter forms

### DIFF
--- a/packages/tables/docs/04-filters.md
+++ b/packages/tables/docs/04-filters.md
@@ -307,6 +307,8 @@ Filter::make('is_admin')
     ->indicator('Administrators')
 ```
 
+If you are using a [custom filter form](#custom-filter-forms), you should use `indicateUsing()` to display an active indicator.
+
 ### Custom active indicators
 
 Not all indicators are simple, so you may need to use `indicateUsing()` to customize which indicators should be shown at any time.

--- a/packages/tables/docs/04-filters.md
+++ b/packages/tables/docs/04-filters.md
@@ -307,7 +307,7 @@ Filter::make('is_admin')
     ->indicator('Administrators')
 ```
 
-If you are using a [custom filter form](#custom-filter-forms), you should use `indicateUsing()` to display an active indicator.
+If you are using a [custom filter form](#custom-filter-forms), you should use [`indicateUsing()`](#custom-active-indicators) to display an active indicator.
 
 ### Custom active indicators
 


### PR DESCRIPTION
Using `indicator()` to define an active indicator doesn't work with custom filter forms. This adds a clarifying sentance so devs know to use `indicateUsing()` to show an active indicator.