### PR TITLE
fix #7892 default registry tenant component 

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasComponents.php
+++ b/packages/panels/src/Panel/Concerns/HasComponents.php
@@ -374,6 +374,14 @@ trait HasComponents
             $this->queueLivewireComponentForRegistration($registrationRouteAction);
         }
 
+        if ($this->hasTenantRegistration()  && is_subclass_of($tenantRegistrationRouteAction = $this->getTenantRegistrationPage(), Component::class)) {
+            $this->queueLivewireComponentForRegistration($tenantRegistrationRouteAction);
+        }
+
+        if ($this->hasTenantProfile()  && is_subclass_of($tenantProfileRouteAction = $this->getTenantProfilePage(), Component::class)) {
+            $this->queueLivewireComponentForRegistration($tenantProfileRouteAction);
+        }
+
         foreach ($this->getResources() as $resource) {
             foreach ($resource::getPages() as $pageRegistration) {
                 $this->queueLivewireComponentForRegistration($pageRegistration->getPage());


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

fix #7892

Registering multi-tenant components by default