### PR TITLE
Increase font size for lg/xl links

### DIFF
--- a/packages/support/docs/09-blade-components/02-link.md
+++ b/packages/support/docs/09-blade-components/02-link.md
@@ -27,9 +27,13 @@ By default, a link's underlying HTML tag is `<a>`. You can change it to be a `<b
 
 ## Setting the size of a link
 
-By default, the size of a link is "medium". You can make it "small", "large", "extra large" or "extra extra large" by using the `size` attribute:
+By default, the size of a link is "medium". You can make it "extra small", "small", "large" or "extra large" by using the `size` attribute:
 
 ```blade
+<x-filament::link size="xs">
+    New user
+</x-filament::link>
+
 <x-filament::link size="sm">
     New user
 </x-filament::link>
@@ -39,10 +43,6 @@ By default, the size of a link is "medium". You can make it "small", "large", "e
 </x-filament::link>
 
 <x-filament::link size="xl">
-    New user
-</x-filament::link>
-
-<x-filament::link size="2xl">
     New user
 </x-filament::link>
 ```

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -45,8 +45,8 @@
                 ActionSize::ExtraSmall, 'xs' => 'gap-1 px-2 py-1.5 text-xs',
                 ActionSize::Small, 'sm' => 'gap-1 px-2.5 py-1.5 text-sm',
                 ActionSize::Medium, 'md' => 'gap-1.5 px-3 py-2 text-sm',
-                ActionSize::Large, 'lg' => 'gap-1.5 px-3.5 py-2.5 text-sm',
-                ActionSize::ExtraLarge, 'xl' => 'gap-1.5 px-4 py-3 text-sm',
+                ActionSize::Large, 'lg' => 'gap-1.5 px-3.5 py-2.5 text-base',
+                ActionSize::ExtraLarge, 'xl' => 'gap-1.5 px-4 py-3 text-lg',
             },
             'hidden' => $labeledFrom,
             match ($labeledFrom) {

--- a/packages/support/resources/views/components/link.blade.php
+++ b/packages/support/resources/views/components/link.blade.php
@@ -45,8 +45,8 @@
             ActionSize::ExtraSmall, 'xs' => 'gap-1 text-xs',
             ActionSize::Small, 'sm' => 'gap-1 text-sm',
             ActionSize::Medium, 'md' => 'gap-1.5 text-sm',
-            ActionSize::Large, 'lg' => 'gap-1.5 text-sm',
-            ActionSize::ExtraLarge, 'xl' => 'gap-1.5 text-sm',
+            ActionSize::Large, 'lg' => 'gap-1.5 text-base',
+            ActionSize::ExtraLarge, 'xl' => 'gap-1.5 text-lg',
         },
         match ($color) {
             'gray' => 'text-gray-700 dark:text-gray-200',


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Increased font size for lg/xl size for buttons and links. 

The reason for the change is that I needed a large link and apart from 'xs' all size options are the same size. 
```blade
<x-filament::link size="lg">
 Large link
</x-filament::link>
``` 

Applied the same change to the buttons for consistency when stacked alongside.

Before
<img width="617" alt="Screenshot 2023-08-19 at 08 57 34" src="https://github.com/filamentphp/filament/assets/533658/ccde6a7e-53db-488d-9104-d7a51e55887d">

After
<img width="609" alt="Screenshot 2023-08-19 at 08 56 01" src="https://github.com/filamentphp/filament/assets/533658/aa222a4f-2e4c-4ccc-ba33-6e01913a781a">
