### PR TITLE
Fix: Disable accepting IconSize as parameter in icon method.

### DIFF
--- a/packages/support/src/Concerns/HasIcon.php
+++ b/packages/support/src/Concerns/HasIcon.php
@@ -14,7 +14,7 @@ trait HasIcon
 
     protected IconSize | string | Closure | null $iconSize = null;
 
-    public function icon(IconSize | string | Closure | null $icon): static
+    public function icon(string | Closure | null $icon): static
     {
         $this->icon = $icon;
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

