### PR TITLE
Fix: overflow in select filter indicator with a large number of options

### DIFF
--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -25,7 +25,7 @@
     {{
         $attributes
             ->class([
-                'fi-badge flex shrink-0 items-center justify-center gap-x-1 whitespace-nowrap rounded-md  text-xs font-medium ring-1 ring-inset',
+                'fi-badge flex items-center justify-center gap-x-1 rounded-md text-xs font-medium ring-1 ring-inset',
                 match ($size) {
                     'xs' => 'px-0.5 min-w-[theme(spacing.4)] tracking-tighter',
                     'sm' => 'px-1.5 min-w-[theme(spacing.5)] py-0.5 tracking-tight',


### PR DESCRIPTION
If there are multiple options selected in a select filter, the filter indicator will overflow as seen here:
![Before](https://github.com/filamentphp/filament/assets/68746821/4477c272-cc02-426b-a889-128388fc13f9)
After removing `shrink-0` and `whitespace-nowrap` from the badge component it will look like this:
![After](https://github.com/filamentphp/filament/assets/68746821/3825b57f-70c1-4fab-b921-eb468cb84420)

I don't know if this will have a large effect on the style where the badge component is used, but the demo app looked fine.
Maybe you guys have a different/better approach to this.