### PR TITLE
Add a way to pass parameters to the redirect url on the create record page

### DIFF
--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -275,6 +275,9 @@ class CreateRecord extends Page
         return $resource::getUrl('index');
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     protected function getRedirectUrlParameters(): array
     {
         return [];

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -265,14 +265,19 @@ class CreateRecord extends Page
         $resource = static::getResource();
 
         if ($resource::hasPage('view') && $resource::canView($this->getRecord())) {
-            return $resource::getUrl('view', ['record' => $this->getRecord()]);
+            return $resource::getUrl('view', ['record' => $this->getRecord(), ...$this->getRedirectUrlParameters()]);
         }
 
         if ($resource::hasPage('edit') && $resource::canEdit($this->getRecord())) {
-            return $resource::getUrl('edit', ['record' => $this->getRecord()]);
+            return $resource::getUrl('edit', ['record' => $this->getRecord(),...$this->getRedirectUrlParameters()]);
         }
 
         return $resource::getUrl('index');
+    }
+
+    protected function getRedirectUrlParameters(): array
+    {
+        return [];
     }
 
     protected function getMountedActionFormModel(): string

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -269,7 +269,7 @@ class CreateRecord extends Page
         }
 
         if ($resource::hasPage('edit') && $resource::canEdit($this->getRecord())) {
-            return $resource::getUrl('edit', ['record' => $this->getRecord(),...$this->getRedirectUrlParameters()]);
+            return $resource::getUrl('edit', ['record' => $this->getRecord(), ...$this->getRedirectUrlParameters()]);
         }
 
         return $resource::getUrl('index');


### PR DESCRIPTION
This PR provide a way to pass parameters to the redirect url on the create record page. For now you must completely override the getRedirectUrl method, to pass extra parameters to the redirect url. This PR allows for different use cases, mine was redirecting to a relation manager tab after the creation, but it could be anything.

```php
class CreateOrder extends CreateRecord
{
    protected static string $resource = OrderResource::class;

    protected function getRedirectUrlParameters(): array
    {
        return ['activeRelationManager' => OrderResource::ITEMS_MANAGER];
    }
}
```

The same method could be implemented on the edit record page, but since the getRedirectUrl method returns null, I didn't see the need.
