### PR TITLE
add getOptionLabelFromRecord to SelectFilter

### DIFF
--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -27,6 +27,8 @@ class SelectFilter extends BaseFilter
 
     protected bool | Closure | null $isSearchForcedCaseInsensitive = null;
 
+    protected ?Closure $getOptionLabelFromRecordUsing = null;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -227,6 +229,10 @@ class SelectFilter extends BaseFilter
             $field->getOptionLabelsUsing($this->getOptionLabelsUsing);
         }
 
+        if ($this->getOptionLabelFromRecordUsing) {
+            $field->getOptionLabelFromRecordUsing($this->getOptionLabelFromRecordUsing);
+        }
+
         if ($this->getSearchResultsUsing) {
             $field->getSearchResultsUsing($this->getSearchResultsUsing);
         }
@@ -270,5 +276,12 @@ class SelectFilter extends BaseFilter
     public function isNative(): bool
     {
         return (bool) $this->evaluate($this->isNative);
+    }
+
+    public function getOptionLabelFromRecordUsing(?Closure $callback): static
+    {
+        $this->getOptionLabelFromRecordUsing = $callback;
+
+        return $this;
     }
 }


### PR DESCRIPTION
SelectFilter was missing the getOptionLabelFromRecord method, that allows customizing the label on relationship selects

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
