### PR TITLE
[Docs fix] Method getNavigationLabel() fix ?string to string

### DIFF
--- a/packages/panels/docs/06-navigation.md
+++ b/packages/panels/docs/06-navigation.md
@@ -17,7 +17,7 @@ protected static ?string $navigationLabel = 'Custom Navigation Label';
 Alternatively, you may override the `getNavigationLabel()` method:
 
 ```php
-public static function getNavigationLabel(): ?string
+public static function getNavigationLabel(): string
 {
     return 'Custom Navigation Label';
 }


### PR DESCRIPTION
I've noticed that the old `?string` type throws an error.

Checked: it is correct in the other parts of the docs with `getNavigationLabel()`.

- Pages: https://filamentphp.com/docs/3.x/panels/pages#customizing-the-page-navigation-label
- Resources: https://filamentphp.com/docs/3.x/panels/resources/getting-started#resource-navigation-items

---

- [ X ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
