### PR TITLE
[Docs] Removed `->success()` from icon method

### DIFF
--- a/docs-assets/app/app/Livewire/NotificationsDemo.php
+++ b/docs-assets/app/app/Livewire/NotificationsDemo.php
@@ -33,7 +33,6 @@ class NotificationsDemo extends Component
             ->title('Saved successfully')
             ->icon('heroicon-o-document-text')
             ->iconColor('success')
-            ->success()
             ->send();
     }
 


### PR DESCRIPTION
This change should make the correct notification icon for the screenshot script.
