### PR TITLE
FIX: php > 8.1 str_replace deprecation in HasComponents panels concern

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasComponents.php
+++ b/packages/panels/src/Panel/Concerns/HasComponents.php
@@ -313,7 +313,7 @@ trait HasComponents
                 $variableNamespace = (string) str($variableNamespace)->before('\\');
             }
 
-            if (is_null($variableNamespace)) {
+            if ($variableNamespace === null) {
                 continue;
             }
 

--- a/packages/panels/src/Panel/Concerns/HasComponents.php
+++ b/packages/panels/src/Panel/Concerns/HasComponents.php
@@ -313,7 +313,7 @@ trait HasComponents
                 $variableNamespace = (string) str($variableNamespace)->before('\\');
             }
 
-            if (!$variableNamespace) {
+            if (is_null($variableNamespace)) {
                 continue;
             }
 

--- a/packages/panels/src/Panel/Concerns/HasComponents.php
+++ b/packages/panels/src/Panel/Concerns/HasComponents.php
@@ -313,6 +313,10 @@ trait HasComponents
                 $variableNamespace = (string) str($variableNamespace)->before('\\');
             }
 
+            if (!$variableNamespace) {
+                continue;
+            }
+
             $class = (string) $namespace
                 ->append('\\', $file->getRelativePathname())
                 ->replace('*', $variableNamespace)


### PR DESCRIPTION
This fixes a > PHP 8.1 deprecation where null isn't allowed as 2nd parameter in the replace function.

ErrorException:
```
str_replace(): Passing null to parameter #2 ($replace) of type array|string is deprecated in /var/www/vhost/cms/vendor/laravel/framework/src/Illuminate/Support/Str.php on line 976
```

![xdebug](https://i.imgur.com/LuRP0ic.png)
![stack error](https://i.imgur.com/55IUV9T.png)


- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] ~~New functionality has been documented or existing documentation has been updated to reflect changes.~~  `Not applicable`
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
