### PR TITLE
Add `filament-panels` directory to content array in tailwind config

### DIFF
--- a/packages/panels/stubs/ThemeTailwindConfig.stub
+++ b/packages/panels/stubs/ThemeTailwindConfig.stub
@@ -5,6 +5,7 @@ export default {
     content: [
         './app/Filament/{{ classPathPrefix }}**/*.php',
         './resources/views/filament/{{ viewPathPrefix }}**/*.blade.php',
+        './resources/views/vendor/filament-panels/**/*.blade.php',
         './vendor/filament/**/*.blade.php',
     ],
 }


### PR DESCRIPTION
- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

I noticed CSS for Tailwind classes applied inside the logo file needed to be generated. So, I added the directory where the [logo file is supposed to be stored](https://filamentphp.com/docs/3.x/panels/themes#changing-the-logo) in the content array for the custom theme stub (since I am using one).

I tested it with the default theme, and the issue still exists. Could you help me add it to the default theme as well?