### PR TITLE
Add actions to relation managers

### DIFF
--- a/packages/panels/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManager.php
@@ -22,7 +22,7 @@ use Livewire\Component;
 
 use function Filament\authorize;
 
-class RelationManager extends Component implements Actions\Contracts\HasActions, Forms\Contracts\HasForms, Tables\Contracts\HasTable,  Tables\Contracts\RendersActionModal
+class RelationManager extends Component implements Actions\Contracts\HasActions, Forms\Contracts\HasForms, Tables\Contracts\HasTable
 {
     use Actions\Concerns\InteractsWithActions;
     use Forms\Concerns\InteractsWithForms;

--- a/packages/panels/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManager.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Resources\RelationManagers;
 
+use Filament\Actions;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Infolists\Infolist;
@@ -21,8 +22,9 @@ use Livewire\Component;
 
 use function Filament\authorize;
 
-class RelationManager extends Component implements Forms\Contracts\HasForms, Tables\Contracts\HasTable
+class RelationManager extends Component implements Actions\Contracts\HasActions, Forms\Contracts\HasForms, Tables\Contracts\HasTable,  Tables\Contracts\RendersActionModal
 {
+    use Actions\Concerns\InteractsWithActions;
     use Forms\Concerns\InteractsWithForms;
     use Tables\Concerns\InteractsWithTable {
         makeTable as makeBaseTable;


### PR DESCRIPTION
There might be a good reason for this, but currently Relation Managers don't support Actions\Actions as it doesn't use `InteractsWithActions` like `BasePage` does. This is specifically an issue when using renderhooks to render additional actions above the Relation Manager (as my plugin does). 

Test suite is passing, and adding actions normally using `getHeaderActions()` to the edit/view page as well as to Relation Manager `->actions()` and `->headerActions()` on `table()` all work as expected. Maybe I'm missing something??

- [X] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
