### PR TITLE
this allows for setting a closure as brandname

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasBrandName.php
+++ b/packages/panels/src/Panel/Concerns/HasBrandName.php
@@ -1,12 +1,13 @@
 <?php
 
 namespace Filament\Panel\Concerns;
+use Closure;
 
 trait HasBrandName
 {
-    protected ?string $brandName = null;
+    protected string|Closure|null $brandName = null;
 
-    public function brandName(?string $name): static
+    public function brandName(string|Closure $name): static
     {
         $this->brandName = $name;
 
@@ -15,6 +16,6 @@ trait HasBrandName
 
     public function getBrandName(): string
     {
-        return $this->brandName ?? config('app.name');
+        return $this->evaluate($this->brandName ?? config('app.name'));
     }
 }

--- a/packages/panels/src/Panel/Concerns/HasBrandName.php
+++ b/packages/panels/src/Panel/Concerns/HasBrandName.php
@@ -1,13 +1,14 @@
 <?php
 
 namespace Filament\Panel\Concerns;
+
 use Closure;
 
 trait HasBrandName
 {
-    protected string|Closure|null $brandName = null;
+    protected string | Closure | null $brandName = null;
 
-    public function brandName(string|Closure $name): static
+    public function brandName(string | Closure | null $name): static
     {
         $this->brandName = $name;
 
@@ -16,6 +17,6 @@ trait HasBrandName
 
     public function getBrandName(): string
     {
-        return $this->evaluate($this->brandName ?? config('app.name'));
+        return $this->evaluate($this->brandName) ?? config('app.name');
     }
 }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
_nothing found in the docs about brandname for a panel._
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
_no visual changes_