### PR TITLE
Added animated collapsable sections

### DIFF
--- a/packages/forms/docs/04-layout/06-section.md
+++ b/packages/forms/docs/04-layout/06-section.md
@@ -83,6 +83,24 @@ Section::make('Cart')
 
 Your sections may be `collapsed()` by default:
 
+## Aanimated collapsing sections
+
+Collapsing sections can be animated with this getter:
+
+```php
+use Filament\Forms\Components\Section;
+
+Section::make('Cart')
+    ->description('The items you have selected for purchase')
+    ->schema([
+        // ...
+    ])
+    ->collapsible()
+    ->animated()
+```
+
+Animation lasts for 200ms, and sections are not animated by default.
+
 ```php
 use Filament\Forms\Components\Section;
 

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -13,7 +13,7 @@
     :icon="$getIcon()"
     :icon-color="$getIconColor()"
     :icon-size="$getIconSize()"
-    :animation="$getAnimation()"
+    :animated="$getAnimation()"
     :attributes="
         \Filament\Support\prepare_inherited_attributes($attributes)
             ->merge([

--- a/packages/forms/resources/views/components/section.blade.php
+++ b/packages/forms/resources/views/components/section.blade.php
@@ -13,6 +13,7 @@
     :icon="$getIcon()"
     :icon-color="$getIconColor()"
     :icon-size="$getIconSize()"
+    :animation="$getAnimation()"
     :attributes="
         \Filament\Support\prepare_inherited_attributes($attributes)
             ->merge([

--- a/packages/forms/src/Components/Section.php
+++ b/packages/forms/src/Components/Section.php
@@ -3,6 +3,7 @@
 namespace Filament\Forms\Components;
 
 use Closure;
+use Filament\Support\Concerns\HasAnimation;
 use Filament\Support\Concerns\HasDescription;
 use Filament\Support\Concerns\HasExtraAlpineAttributes;
 use Filament\Support\Concerns\HasHeading;
@@ -17,6 +18,7 @@ class Section extends Component implements Contracts\CanConcealComponents, Contr
     use Concerns\CanBeCompacted;
     use Concerns\EntanglesStateWithSingularRelationship;
     use HasDescription;
+    use HasAnimation;
     use HasExtraAlpineAttributes;
     use HasHeading;
     use HasIcon;

--- a/packages/infolists/resources/views/components/section.blade.php
+++ b/packages/infolists/resources/views/components/section.blade.php
@@ -13,7 +13,7 @@
     :icon="$getIcon()"
     :icon-color="$getIconColor()"
     :icon-size="$getIconSize()"
-    :animation="$getAnimation()"
+    :animated="$getAnimation()"
     :attributes="
         \Filament\Support\prepare_inherited_attributes($attributes)
             ->merge([

--- a/packages/infolists/resources/views/components/section.blade.php
+++ b/packages/infolists/resources/views/components/section.blade.php
@@ -13,6 +13,7 @@
     :icon="$getIcon()"
     :icon-color="$getIconColor()"
     :icon-size="$getIconSize()"
+    :animation="$getAnimation()"
     :attributes="
         \Filament\Support\prepare_inherited_attributes($attributes)
             ->merge([

--- a/packages/infolists/src/Components/Section.php
+++ b/packages/infolists/src/Components/Section.php
@@ -3,6 +3,7 @@
 namespace Filament\Infolists\Components;
 
 use Closure;
+use Filament\Support\Concerns\HasAnimation;
 use Filament\Support\Concerns\HasDescription;
 use Filament\Support\Concerns\HasExtraAlpineAttributes;
 use Filament\Support\Concerns\HasHeading;
@@ -19,6 +20,7 @@ class Section extends Component
     use HasDescription;
     use HasExtraAlpineAttributes;
     use HasHeading;
+    use HasAnimation;   
     use HasIcon;
     use HasIconColor;
 

--- a/packages/support/resources/views/components/section.blade.php
+++ b/packages/support/resources/views/components/section.blade.php
@@ -135,12 +135,6 @@
     @endif
 
     <div
-        @if ($hasAnimation)
-            x-cloak
-            x-show="isCollapsed"
-            x-collapse.duration.200ms
-        @endif
-
         @if ($collapsible)
             x-bind:aria-expanded="(! isCollapsed).toString()"
             @if ($collapsed)
@@ -157,10 +151,15 @@
             'border-t border-gray-200 dark:border-white/10' => $hasHeader && (! $aside),
             'md:order-first' => $contentBefore,
         ])
+        @if ($hasAnimation)
+            x-cloak
+            x-show="!isCollapsed"
+            x-collapse.duration.200ms
+        @endif
     >
         <div
             @class([
-                // 'fi-section-content',
+                'fi-section-content',
                 'rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10' => $aside,
                 match ($compact) {
                     true => 'p-4',

--- a/packages/support/resources/views/components/section.blade.php
+++ b/packages/support/resources/views/components/section.blade.php
@@ -14,12 +14,14 @@
     'icon' => null,
     'iconColor' => 'gray',
     'iconSize' => IconSize::Large,
+    'animation' => null,
 ])
 
 @php
     $hasDescription = filled((string) $description);
     $hasHeading = filled($heading);
     $hasIcon = filled($icon);
+    $hasAniamtion = filled($animation   );
     $hasHeader = $hasIcon || $hasHeading || $hasDescription || $collapsible || filled((string) $headerEnd);
 @endphp
 
@@ -27,6 +29,7 @@
     @if ($collapsible)
         x-data="{
             isCollapsed: @js($collapsed),
+            animation: @js($animation),
         }"
         x-bind:class="isCollapsed && 'fi-collapsed'"
         x-on:collapse-section.window="if ($event.detail.id == $el.id) isCollapsed = true"
@@ -134,12 +137,19 @@
     @endif
 
     <div
+        @if ($hasAnimation)
+            x-cloak
+            x-show="isCollapsed"
+            x-collapse.duration.200ms
+        @endif
         @if ($collapsible)
             x-bind:aria-expanded="(! isCollapsed).toString()"
             @if ($collapsed)
                 x-cloak
             @endif
-            x-bind:class="{ 'invisible h-0 border-none': isCollapsed }"
+            if(!hasAnimation){
+                x-bind:class="{ 'invisible h-0 border-none': isCollapsed }"
+            }
         @endif
         @class([
             'fi-section-content-ctn',

--- a/packages/support/resources/views/components/section.blade.php
+++ b/packages/support/resources/views/components/section.blade.php
@@ -16,7 +16,6 @@
     'iconSize' => IconSize::Large,
     'animation' => null,
 ])
-{{-- test --}}
 @php
     $hasDescription = filled((string) $description);
     $hasHeading = filled($heading);

--- a/packages/support/resources/views/components/section.blade.php
+++ b/packages/support/resources/views/components/section.blade.php
@@ -16,7 +16,7 @@
     'iconSize' => IconSize::Large,
     'animation' => null,
 ])
-
+{{-- test --}}
 @php
     $hasDescription = filled((string) $description);
     $hasHeading = filled($heading);

--- a/packages/support/resources/views/components/section.blade.php
+++ b/packages/support/resources/views/components/section.blade.php
@@ -21,7 +21,7 @@
     $hasDescription = filled((string) $description);
     $hasHeading = filled($heading);
     $hasIcon = filled($icon);
-    $hasAniamtion = filled($animation   );
+    $hasAnimation = filled($animation);
     $hasHeader = $hasIcon || $hasHeading || $hasDescription || $collapsible || filled((string) $headerEnd);
 @endphp
 

--- a/packages/support/resources/views/components/section.blade.php
+++ b/packages/support/resources/views/components/section.blade.php
@@ -14,13 +14,13 @@
     'icon' => null,
     'iconColor' => 'gray',
     'iconSize' => IconSize::Large,
-    'animation' => null,
+    'animated' => null,
 ])
 @php
     $hasDescription = filled((string) $description);
     $hasHeading = filled($heading);
     $hasIcon = filled($icon);
-    $hasAnimation = filled($animation);
+    $hasAnimation = filled($animated);
     $hasHeader = $hasIcon || $hasHeading || $hasDescription || $collapsible || filled((string) $headerEnd);
 @endphp
 

--- a/packages/support/resources/views/components/section.blade.php
+++ b/packages/support/resources/views/components/section.blade.php
@@ -142,14 +142,16 @@
             x-show="isCollapsed"
             x-collapse.duration.200ms
         @endif
+
         @if ($collapsible)
             x-bind:aria-expanded="(! isCollapsed).toString()"
             @if ($collapsed)
                 x-cloak
             @endif
-            if(!hasAnimation){
+            @if (!$hasAnimation){
                 x-bind:class="{ 'invisible h-0 border-none': isCollapsed }"
             }
+            @endif
         @endif
         @class([
             'fi-section-content-ctn',

--- a/packages/support/resources/views/components/section.blade.php
+++ b/packages/support/resources/views/components/section.blade.php
@@ -21,7 +21,6 @@
     $hasHeading = filled($heading);
     $hasIcon = filled($icon);
     $hasAnimation = filled($animation);
-    // dd($animation);
     $hasHeader = $hasIcon || $hasHeading || $hasDescription || $collapsible || filled((string) $headerEnd);
 @endphp
 
@@ -29,9 +28,8 @@
     @if ($collapsible)
         x-data="{
             isCollapsed: @js($collapsed),
-            {{-- animation: @js($animation), --}}
         }"
-        {{-- x-bind:class="isCollapsed && 'fi-collapsed'" --}}
+        x-bind:class="isCollapsed && 'fi-collapsed'"
         x-on:collapse-section.window="if ($event.detail.id == $el.id) isCollapsed = true"
         x-on:expand-concealing-component.window="
             error = $el.querySelector('[data-validation-error]')

--- a/packages/support/resources/views/components/section.blade.php
+++ b/packages/support/resources/views/components/section.blade.php
@@ -21,6 +21,7 @@
     $hasHeading = filled($heading);
     $hasIcon = filled($icon);
     $hasAnimation = filled($animation);
+    // dd($animation);
     $hasHeader = $hasIcon || $hasHeading || $hasDescription || $collapsible || filled((string) $headerEnd);
 @endphp
 
@@ -28,9 +29,9 @@
     @if ($collapsible)
         x-data="{
             isCollapsed: @js($collapsed),
-            animation: @js($animation),
+            {{-- animation: @js($animation), --}}
         }"
-        x-bind:class="isCollapsed && 'fi-collapsed'"
+        {{-- x-bind:class="isCollapsed && 'fi-collapsed'" --}}
         x-on:collapse-section.window="if ($event.detail.id == $el.id) isCollapsed = true"
         x-on:expand-concealing-component.window="
             error = $el.querySelector('[data-validation-error]')
@@ -159,7 +160,7 @@
     >
         <div
             @class([
-                'fi-section-content',
+                // 'fi-section-content',
                 'rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10' => $aside,
                 match ($compact) {
                     true => 'p-4',

--- a/packages/support/src/Concerns/HasAnimation.php
+++ b/packages/support/src/Concerns/HasAnimation.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Filament\Support\Concerns;
+
+use Closure;
+use Illuminate\Contracts\Support\Htmlable;
+
+trait HasAnimation
+{
+    protected string | Htmlable | Closure | null $animation = null;
+
+    public function animation(string | Htmlable | Closure | null $animation = null): static
+    {
+        $this->aniamtion = $animation;
+
+        return $this;
+    }
+
+    public function getAnimation(): string | Htmlable | null
+    {
+        return $this->evaluate($this->description);
+    }
+}

--- a/packages/support/src/Concerns/HasAnimation.php
+++ b/packages/support/src/Concerns/HasAnimation.php
@@ -7,17 +7,17 @@ use Illuminate\Contracts\Support\Htmlable;
 
 trait HasAnimation
 {
-    protected string | Htmlable | Closure | null $animation = null;
+    protected bool | Htmlable | Closure | null $animation = null;
 
-    public function animation(string | Htmlable | Closure | null $animation = null): static
+    public function animation(bool | Closure | null $animation = true): static
     {
-        $this->aniamtion = $animation;
+        $this->animation = $animation;
 
         return $this;
     }
 
-    public function getAnimation(): string | Htmlable | null
+    public function getAnimation(): bool | Htmlable | null
     {
-        return $this->evaluate($this->description);
+        return $this->evaluate($this->animation);
     }
 }

--- a/packages/support/src/Concerns/HasAnimation.php
+++ b/packages/support/src/Concerns/HasAnimation.php
@@ -9,7 +9,7 @@ trait HasAnimation
 {
     protected bool | Htmlable | Closure | null $animation = null;
 
-    public function animation(bool | Closure | null $animation = true): static
+    public function animated(bool | Closure | null $animation = true): static
     {
         $this->animation = $animation;
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

## Description
As the title suggests I added a feature where the user can add a `->animated()` getter and the section would collapse/expand in 200ms time

https://github.com/filamentphp/filament/assets/64212185/d22e23b5-edd0-4cb9-ae65-0b0c0e1cbe85

## How?
This was mainly done by utilizing x-show from alpineJS. I had a look on how the other getters were implemented and I followed the same structure.
