### PR TITLE
Fix issue with null filter values in query string on refresh

### DIFF
--- a/packages/panels/src/Resources/Pages/ListRecords.php
+++ b/packages/panels/src/Resources/Pages/ListRecords.php
@@ -71,6 +71,10 @@ class ListRecords extends Page implements Forms\Contracts\HasForms, Tables\Contr
         ) {
             $this->activeTab = array_key_first($tabs);
         }
+
+        if ($this->tableFilters) {
+            $this->replaceNullValues($this->tableFilters);
+        }
     }
 
     public function getBreadcrumb(): ?string
@@ -348,5 +352,20 @@ class ListRecords extends Page implements Forms\Contracts\HasForms, Tables\Contr
         return (string) str($key)
             ->replace(['_', '-'], ' ')
             ->ucfirst();
+    }
+
+    protected function replaceNullValues(array &$data): void
+    {
+        foreach ($data as &$value) {
+            if (is_array($value)) {
+                $this->replaceNullValues($value);
+            } elseif ($value === 'null') {
+                $value = null;
+            } elseif ($value === 'false') {
+                $value = false;
+            } elseif ($value === 'true') {
+                $value = true;
+            }
+        }
     }
 }

--- a/packages/panels/src/Resources/Pages/ListRecords.php
+++ b/packages/panels/src/Resources/Pages/ListRecords.php
@@ -71,10 +71,6 @@ class ListRecords extends Page implements Forms\Contracts\HasForms, Tables\Contr
         ) {
             $this->activeTab = array_key_first($tabs);
         }
-
-        if ($this->tableFilters) {
-            $this->replaceNullValues($this->tableFilters);
-        }
     }
 
     public function getBreadcrumb(): ?string
@@ -352,20 +348,5 @@ class ListRecords extends Page implements Forms\Contracts\HasForms, Tables\Contr
         return (string) str($key)
             ->replace(['_', '-'], ' ')
             ->ucfirst();
-    }
-
-    protected function replaceNullValues(array &$data): void
-    {
-        foreach ($data as &$value) {
-            if (is_array($value)) {
-                $this->replaceNullValues($value);
-            } elseif ($value === 'null') {
-                $value = null;
-            } elseif ($value === 'false') {
-                $value = false;
-            } elseif ($value === 'true') {
-                $value = true;
-            }
-        }
     }
 }

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -84,6 +84,7 @@ trait InteractsWithTable
             ];
         }
 
+        // https://github.com/livewire/livewire/pull/6188
         if ($this->tableFilters) {
             $this->normalizeTableFilterValuesFromQueryString($this->tableFilters);
         }

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -85,7 +85,7 @@ trait InteractsWithTable
         }
 
         if ($this->tableFilters) {
-            $this->replaceNullValues($this->tableFilters);
+            $this->normalizeBooleanAndNullValues($this->tableFilters);
         }
 
         $this->getTableFiltersForm()->fill($this->tableFilters);
@@ -269,11 +269,11 @@ trait InteractsWithTable
         return null;
     }
 
-    protected function replaceNullValues(array &$data): void
+    protected function normalizeBooleanAndNullValues(array &$data): void
     {
         foreach ($data as &$value) {
             if (is_array($value)) {
-                $this->replaceNullValues($value);
+                $this->normalizeBooleanAndNullValues($value);
             } elseif ($value === 'null') {
                 $value = null;
             } elseif ($value === 'false') {

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -85,7 +85,7 @@ trait InteractsWithTable
         }
 
         if ($this->tableFilters) {
-            $this->normalizeBooleanAndNullValues($this->tableFilters);
+            $this->normalizeTableFilterValuesFromQueryString($this->tableFilters);
         }
 
         $this->getTableFiltersForm()->fill($this->tableFilters);
@@ -269,11 +269,11 @@ trait InteractsWithTable
         return null;
     }
 
-    protected function normalizeBooleanAndNullValues(array &$data): void
+    protected function normalizeTableFilterValuesFromQueryString(array &$data): void
     {
         foreach ($data as &$value) {
             if (is_array($value)) {
-                $this->normalizeBooleanAndNullValues($value);
+                $this->normalizeTableFilterValuesFromQueryString($value);
             } elseif ($value === 'null') {
                 $value = null;
             } elseif ($value === 'false') {

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -84,6 +84,10 @@ trait InteractsWithTable
             ];
         }
 
+        if ($this->tableFilters) {
+            $this->replaceNullValues($this->tableFilters);
+        }
+
         $this->getTableFiltersForm()->fill($this->tableFilters);
 
         if ($shouldPersistFiltersInSession) {
@@ -263,5 +267,20 @@ trait InteractsWithTable
     protected function getTableQuery(): Builder | Relation | null
     {
         return null;
+    }
+
+    protected function replaceNullValues(array &$data): void
+    {
+        foreach ($data as &$value) {
+            if (is_array($value)) {
+                $this->replaceNullValues($value);
+            } elseif ($value === 'null') {
+                $value = null;
+            } elseif ($value === 'false') {
+                $value = false;
+            } elseif ($value === 'true') {
+                $value = true;
+            }
+        }
     }
 }

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -84,7 +84,7 @@ trait InteractsWithTable
             ];
         }
 
-        // https://github.com/livewire/livewire/pull/6188
+        // https://github.com/filamentphp/filament/pull/7999
         if ($this->tableFilters) {
             $this->normalizeTableFilterValuesFromQueryString($this->tableFilters);
         }


### PR DESCRIPTION
- [X] Changes have been thoroughly tested to not break existing functionality.

In light of Caleb's [comment](https://github.com/livewire/livewire/pull/6188#issuecomment-1686492498) that he won't be able to address this in Livewire until later, this PR implements the work done by @KennedyTedesco and @jvitasek into Filament until LW can be fixed. 

Test suite is passing and I have confirmed this fixes the issue with selectFilters, trashedFilter, ternaryFilter, and filters with forms with textFields on refresh. It also works when filters have `->default()` values.

Closes #7129
