### PR TITLE
Added the prose class default on markdown option on a text entry

### DIFF
--- a/packages/infolists/resources/views/components/text-entry.blade.php
+++ b/packages/infolists/resources/views/components/text-entry.blade.php
@@ -11,6 +11,7 @@
         $iconPosition = $getIconPosition();
         $isListWithLineBreaks = $isListWithLineBreaks();
         $isProse = $isProse();
+        $isMarkdown = $isMarkdown();
         $url = $getUrl();
 
         $arrayState = $getState();
@@ -158,7 +159,7 @@
 
                                 <div
                                     @class([
-                                        $proseClasses => $isProse,
+                                        $proseClasses => $isProse || $isMarkdown,
                                     ])
                                 >
                                     {{ $formattedState }}

--- a/packages/infolists/src/Components/TextEntry.php
+++ b/packages/infolists/src/Components/TextEntry.php
@@ -28,6 +28,8 @@ class TextEntry extends Entry implements HasAffixActions
 
     protected bool | Closure $isProse = false;
 
+    protected bool | Closure $isMarkdown = false;
+
     protected bool | Closure $isListWithLineBreaks = false;
 
     protected int | Closure | null $listLimit = null;
@@ -96,6 +98,11 @@ class TextEntry extends Entry implements HasAffixActions
     public function isProse(): bool
     {
         return (bool) $this->evaluate($this->isProse);
+    }
+
+    public function isMarkdown(): bool
+    {
+        return (bool) $this->evaluate($this->isMarkdown);
     }
 
     public function isListWithLineBreaks(): bool

--- a/packages/infolists/src/Components/TextEntry.php
+++ b/packages/infolists/src/Components/TextEntry.php
@@ -28,8 +28,6 @@ class TextEntry extends Entry implements HasAffixActions
 
     protected bool | Closure $isProse = false;
 
-    protected bool | Closure $isMarkdown = false;
-
     protected bool | Closure $isListWithLineBreaks = false;
 
     protected int | Closure | null $listLimit = null;
@@ -98,11 +96,6 @@ class TextEntry extends Entry implements HasAffixActions
     public function isProse(): bool
     {
         return (bool) $this->evaluate($this->isProse);
-    }
-
-    public function isMarkdown(): bool
-    {
-        return (bool) $this->evaluate($this->isMarkdown);
     }
 
     public function isListWithLineBreaks(): bool


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

<img width="587" alt="Schermafbeelding 2023-08-22 om 21 10 50" src="https://github.com/filamentphp/filament/assets/102382829/b855b62f-723e-494c-8d4a-0ef679464a14">
<img width="582" alt="Schermafbeelding 2023-08-22 om 21 11 05" src="https://github.com/filamentphp/filament/assets/102382829/d8e539e0-fe80-441b-a25f-9f1b4d2e2fe2">

Before and after images
