### PR TITLE
Fix console error with select.js when closing modals

### DIFF
--- a/packages/forms/resources/js/components/select.js
+++ b/packages/forms/resources/js/components/select.js
@@ -177,6 +177,10 @@ export default function selectFormComponent({
         refreshChoices: async function (config = {}) {
             const choices = await this.getChoices(config)
 
+            if (!this.select) {
+                return
+            }
+
             this.select.clearStore()
 
             this.refreshPlaceholder()


### PR DESCRIPTION
When a searchable select field is used inside a modal, when the modal is closed the following console error is thrown: `TypeError: Cannot read properties of null (reading 'clearStore')`. It seems Alpine/LW's watcher isn't being destroyed causing this issue. This PR adds an early return to prevent this.

- [X] Changes have been thoroughly tested to not break existing functionality.
