### PR TITLE
add the ability to exclude items in a repeater before saving

### DIFF
--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -319,7 +319,7 @@ Repeater::make('qualifications')
 
 ### Mutating related item data before creating
 
-You may mutate the data for a new related item before it is created in the database using the `mutateRelationshipDataBeforeCreateUsing()` method. This method accepts a closure that receives the current item's data in a `$data` variable. You can choose to return either the modified array of data or simply `null` to ignore the item.
+You may mutate the data for a new related item before it is created in the database using the `mutateRelationshipDataBeforeCreateUsing()` method. This method accepts a closure that receives the current item's data in a `$data` variable. You can choose to return either the modified array of data, or `null` to prevent the item from being created:
 
 ```php
 use Filament\Forms\Components\Repeater;
@@ -338,7 +338,7 @@ Repeater::make('qualifications')
 
 ### Mutating related item data before saving
 
-You may mutate the data for an existing related item before it is saved in the database using the `mutateRelationshipDataBeforeSaveUsing()` method. This method accepts a closure that receives the current item's data in a `$data` variable. You must return the modified array of data:
+You may mutate the data for an existing related item before it is saved in the database using the `mutateRelationshipDataBeforeSaveUsing()` method. This method accepts a closure that receives the current item's data in a `$data` variable. You can choose to return either the modified array of data, or `null` to prevent the item from being saved:
 
 ```php
 use Filament\Forms\Components\Repeater;

--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -319,7 +319,7 @@ Repeater::make('qualifications')
 
 ### Mutating related item data before creating
 
-You may mutate the data for a new related item before it is created in the database using the `mutateRelationshipDataBeforeCreateUsing()` method. This method accepts a closure that receives the current item's data in a `$data` variable. You must return the modified array of data:
+You may mutate the data for a new related item before it is created in the database using the `mutateRelationshipDataBeforeCreateUsing()` method. This method accepts a closure that receives the current item's data in a `$data` variable. You can choose to return either the modified array of data or simply `null` to ignore the item.
 
 ```php
 use Filament\Forms\Components\Repeater;

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -734,9 +734,8 @@ class Repeater extends Field implements Contracts\CanConcealComponents
 
                 $itemData = $component->mutateRelationshipDataBeforeCreate($itemData);
 
-                // This is helpful in case we want to ignore an item; we can simply return an empty array,
-                // or even better, we can accept a null return to ignore the item.
-                if($itemData === []){
+                // This is helpful in case we want to ignore an item; we can simply return null from mutateRelationshipDataBeforeCreate
+                if($itemData === null){
                     break;
                 }
 
@@ -901,7 +900,7 @@ class Repeater extends Field implements Contracts\CanConcealComponents
      * @param  array<array<string, mixed>>  $data
      * @return array<array<string, mixed>>
      */
-    public function mutateRelationshipDataBeforeCreate(array $data): array
+    public function mutateRelationshipDataBeforeCreate(array $data): array | null
     {
         if ($this->mutateRelationshipDataBeforeCreateUsing instanceof Closure) {
             $data = $this->evaluate($this->mutateRelationshipDataBeforeCreateUsing, [

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -734,6 +734,12 @@ class Repeater extends Field implements Contracts\CanConcealComponents
 
                 $itemData = $component->mutateRelationshipDataBeforeCreate($itemData);
 
+                // This is helpful in case we want to ignore an item; we can simply return an empty array,
+                // or even better, we can accept a null return to ignore the item.
+                if($itemData === []){
+                    break;
+                }
+
                 if ($translatableContentDriver) {
                     $record = $translatableContentDriver->makeRecord($relatedModel, $itemData);
                 } else {

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -723,6 +723,10 @@ class Repeater extends Field implements Contracts\CanConcealComponents
                 if ($record = ($existingRecords[$itemKey] ?? null)) {
                     $itemData = $component->mutateRelationshipDataBeforeSave($itemData, record: $record);
 
+                    if ($itemData === null) {
+                        continue;
+                    }
+    
                     $translatableContentDriver ?
                         $translatableContentDriver->updateRecord($record, $itemData) :
                         $record->fill($itemData)->save();
@@ -734,9 +738,8 @@ class Repeater extends Field implements Contracts\CanConcealComponents
 
                 $itemData = $component->mutateRelationshipDataBeforeCreate($itemData);
 
-                // This is helpful in case we want to ignore an item; we can simply return null from mutateRelationshipDataBeforeCreate
-                if($itemData === null){
-                    break;
+                if ($itemData === null) {
+                    continue;
                 }
 
                 if ($translatableContentDriver) {
@@ -898,9 +901,9 @@ class Repeater extends Field implements Contracts\CanConcealComponents
 
     /**
      * @param  array<array<string, mixed>>  $data
-     * @return array<array<string, mixed>>
+     * @return array<array<string, mixed>> | null
      */
-    public function mutateRelationshipDataBeforeCreate(array $data): array | null
+    public function mutateRelationshipDataBeforeCreate(array $data): ?array
     {
         if ($this->mutateRelationshipDataBeforeCreateUsing instanceof Closure) {
             $data = $this->evaluate($this->mutateRelationshipDataBeforeCreateUsing, [
@@ -942,9 +945,9 @@ class Repeater extends Field implements Contracts\CanConcealComponents
 
     /**
      * @param  array<array<string, mixed>>  $data
-     * @return array<array<string, mixed>>
+     * @return array<array<string, mixed>> | null
      */
-    public function mutateRelationshipDataBeforeSave(array $data, Model $record): array
+    public function mutateRelationshipDataBeforeSave(array $data, Model $record): ?array
     {
         if ($this->mutateRelationshipDataBeforeSaveUsing instanceof Closure) {
             $data = $this->evaluate(


### PR DESCRIPTION
## Description

This pull request introduces new functionality that enhances the repeater component. It adds the capability to exclude specific items by utilizing the `mutateRelationshipDataBeforeCreateUsing` method.






