### PR TITLE
bugfix: add fillFormWithDataAndCallHooks so it is the same as in Edit…

### DIFF
--- a/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
+++ b/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
@@ -80,6 +80,16 @@ abstract class EditTenantProfile extends Page
     {
         $data = $this->tenant->attributesToArray();
 
+        $this->fillFormWithDataAndCallHooks($data);
+    }
+
+    /**
+     * @internal Never override or call this method. If you completely override `fillForm()`, copy the contents of this method into your override.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    protected function fillFormWithDataAndCallHooks(array $data): void
+    {
         $this->callHook('beforeFill');
 
         $data = $this->mutateFormDataBeforeFill($data);


### PR DESCRIPTION
…Record Page

- [X] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

I am working on the filament translatable plugin, and in order to get the TenantProfilePage translatable, I think this change is needed. 

However I am not sure if this should become a Trait or not... I was a bit afraid by the "never call this method, but copy it" :)