### PR TITLE
Allow JS asset to register with type=module

### DIFF
--- a/packages/support/src/Assets/Js.php
+++ b/packages/support/src/Assets/Js.php
@@ -13,6 +13,8 @@ class Js extends Asset
 
     protected bool $isCore = false;
 
+    protected bool $isModule = false;
+
     protected string | Htmlable | null $html = null;
 
     public function async(bool $condition = true): static
@@ -32,6 +34,13 @@ class Js extends Asset
     public function core(bool $condition = true): static
     {
         $this->isCore = $condition;
+
+        return $this;
+    }
+
+    public function module(bool $condition = true): static
+    {
+        $this->isModule = $condition;
 
         return $this;
     }
@@ -58,6 +67,11 @@ class Js extends Asset
         return $this->isCore;
     }
 
+    public function isModule(): bool
+    {
+        return $this->isModule;
+    }
+
     public function getHtml(): Htmlable
     {
         $html = $this->html;
@@ -70,12 +84,14 @@ class Js extends Asset
 
         $async = $this->isAsync() ? 'async' : '';
         $defer = $this->isDeferred() ? 'defer' : '';
+        $module = $this->isModule() ? 'type="module"' : '';
 
         return new HtmlString("
             <script
                 src=\"{$html}\"
                 {$async}
                 {$defer}
+                {$module}
                 data-navigate-track
             ></script>
         ");

--- a/tests/src/Support/JsAssetTest.php
+++ b/tests/src/Support/JsAssetTest.php
@@ -8,14 +8,16 @@ uses(TestCase::class);
 
 it('registers script tag with type of module', function () {
     FilamentAsset::register([
-        Js::make('test-js', 'test.js')
+        Js::make('test-js', 'test.js'),
     ]);
 
-    expect(FilamentAsset::renderScripts())->not->toContain('type="module"');
+    expect(FilamentAsset::renderScripts())
+        ->not->toContain('type="module"');
 
     FilamentAsset::register([
-        Js::make('test-js-with-module', 'test.js')->module()
+        Js::make('test-js-with-module', 'test.js')->module(),
     ]);
 
-    expect(FilamentAsset::renderScripts())->toContain('type="module"');
+    expect(FilamentAsset::renderScripts())
+        ->toContain('type="module"');
 });

--- a/tests/src/Support/JsAssetTest.php
+++ b/tests/src/Support/JsAssetTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Filament\Support\Assets\Js;
+use Filament\Support\Facades\FilamentAsset;
+use Filament\Tests\TestCase;
+
+uses(TestCase::class);
+
+it('registers script tag with type of module', function () {
+    FilamentAsset::register([
+        Js::make('test-js', 'test.js')
+    ]);
+
+    expect(FilamentAsset::renderScripts())->not->toContain('type="module"');
+
+    FilamentAsset::register([
+        Js::make('test-js-with-module', 'test.js')->module()
+    ]);
+
+    expect(FilamentAsset::renderScripts())->toContain('type="module"');
+});


### PR DESCRIPTION
This pull request allows to register js asset with type="module" attribute for script tag.