### PR TITLE
[Docs] Fix object reference in Infolists Actions

### DIFF
--- a/packages/infolists/docs/05-actions.md
+++ b/packages/infolists/docs/05-actions.md
@@ -135,7 +135,7 @@ ViewEntry::make('status')
             ])
             ->icon('heroicon-m-plus')
             ->action(function (array $data, Post $record) {
-                $post->status()->create($data);
+                $record->status()->create($data);
             }),
     ])
 ```


### PR DESCRIPTION
The change I made in the code is a correction of an object reference error. The original snippet was using $post as the object to call the status() method, whereas the correct approach is to use $record, which is the Post object passed as a parameter to the function.