### PR TITLE
Fix invalid path when run make widget command options -S or -C

### DIFF
--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -150,7 +150,7 @@ class MakeWidgetCommand extends Command
 
         if (! $this->option('force') && $this->checkForCollision([
             $path,
-            ($this->option('stats-overview') || $this->option('chart')) ?: $viewPath,
+            ...($this->option('stats-overview') || $this->option('chart')) ? [] : [$viewPath],
         ])) {
             return static::INVALID;
         }


### PR DESCRIPTION
Fix issue when run make widget command options -S or -C

- [x] Changes have been thoroughly tested to not break existing functionality.

Example: `php artisan make:filament-widget StatsOverview --stats-overview`

<img width="881" alt="Screenshot 2023-08-23 at 17 11 08" src="https://github.com/filamentphp/filament/assets/20809003/46710a79-d270-428c-bd8d-45ba5ea971bb">
