### PR TITLE
Truncate long badge label

### DIFF
--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -57,17 +57,9 @@
         <x-filament::icon :icon="$icon" :class="$iconClasses" />
     @endif
 
-    @if ($truncated)
-        <div class="grid">
-            <span class="truncate">
-                {{ $slot }}
-            </span>
-        </div>
-    @else
-        <span>
-            {{ $slot }}
-        </span>
-    @endif
+    <span class="truncate">
+        {{ $slot }}
+    </span>
 
     @if ($isDeletable)
         <button

--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -27,7 +27,6 @@
         $attributes
             ->class([
                 'fi-badge flex items-center justify-center gap-x-1 rounded-md text-xs font-medium ring-1 ring-inset',
-                'shrink-0 whitespace-nowrap' => ! $truncated,
                 match ($size) {
                     'xs' => 'px-0.5 min-w-[theme(spacing.4)] tracking-tighter',
                     'sm' => 'px-1.5 min-w-[theme(spacing.5)] py-0.5 tracking-tight',

--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -5,6 +5,7 @@
     'icon' => null,
     'iconPosition' => 'before',
     'size' => 'md',
+    'truncated' => false,
 ])
 
 @php
@@ -26,6 +27,7 @@
         $attributes
             ->class([
                 'fi-badge flex items-center justify-center gap-x-1 rounded-md text-xs font-medium ring-1 ring-inset',
+                'shrink-0 whitespace-nowrap' => !$truncated,
                 match ($size) {
                     'xs' => 'px-0.5 min-w-[theme(spacing.4)] tracking-tighter',
                     'sm' => 'px-1.5 min-w-[theme(spacing.5)] py-0.5 tracking-tight',
@@ -55,9 +57,17 @@
         <x-filament::icon :icon="$icon" :class="$iconClasses" />
     @endif
 
-    <span>
-        {{ $slot }}
-    </span>
+    @if($truncated)
+        <div class="grid">
+            <span class="truncate">
+                {{ $slot }}
+            </span>
+        </div>
+    @else
+        <span>
+            {{ $slot }}
+        </span>
+    @endif
 
     @if ($isDeletable)
         <button

--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -25,7 +25,7 @@
     {{
         $attributes
             ->class([
-                'fi-badge flex items-center justify-center gap-x-1 rounded-md text-xs font-medium ring-1 ring-inset',
+                'fi-badge inline-grid grid-flow-col items-center justify-center gap-x-1 rounded-md text-xs font-medium ring-1 ring-inset',
                 match ($size) {
                     'xs' => 'px-0.5 min-w-[theme(spacing.4)] tracking-tighter',
                     'sm' => 'px-1.5 min-w-[theme(spacing.5)] py-0.5 tracking-tight',

--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -27,7 +27,7 @@
         $attributes
             ->class([
                 'fi-badge flex items-center justify-center gap-x-1 rounded-md text-xs font-medium ring-1 ring-inset',
-                'shrink-0 whitespace-nowrap' => !$truncated,
+                'shrink-0 whitespace-nowrap' => ! $truncated,
                 match ($size) {
                     'xs' => 'px-0.5 min-w-[theme(spacing.4)] tracking-tighter',
                     'sm' => 'px-1.5 min-w-[theme(spacing.5)] py-0.5 tracking-tight',
@@ -57,7 +57,7 @@
         <x-filament::icon :icon="$icon" :class="$iconClasses" />
     @endif
 
-    @if($truncated)
+    @if ($truncated)
         <div class="grid">
             <span class="truncate">
                 {{ $slot }}

--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -5,7 +5,6 @@
     'icon' => null,
     'iconPosition' => 'before',
     'size' => 'md',
-    'truncated' => false,
 ])
 
 @php

--- a/packages/tables/resources/views/components/filters/indicators.blade.php
+++ b/packages/tables/resources/views/components/filters/indicators.blade.php
@@ -14,7 +14,7 @@
 
         <div class="flex flex-wrap gap-1.5">
             @foreach ($indicators as $wireClickHandler => $label)
-                <x-filament::badge>
+                <x-filament::badge truncated="true">
                     {{ $label }}
 
                     <x-slot

--- a/packages/tables/resources/views/components/filters/indicators.blade.php
+++ b/packages/tables/resources/views/components/filters/indicators.blade.php
@@ -14,7 +14,7 @@
 
         <div class="flex flex-wrap gap-1.5">
             @foreach ($indicators as $wireClickHandler => $label)
-                <x-filament::badge truncated>
+                <x-filament::badge>
                     {{ $label }}
 
                     <x-slot

--- a/packages/tables/resources/views/components/filters/indicators.blade.php
+++ b/packages/tables/resources/views/components/filters/indicators.blade.php
@@ -14,7 +14,7 @@
 
         <div class="flex flex-wrap gap-1.5">
             @foreach ($indicators as $wireClickHandler => $label)
-                <x-filament::badge truncated="true">
+                <x-filament::badge truncated>
                     {{ $label }}
 
                     <x-slot


### PR DESCRIPTION
I wanted to make the indicator truncate instead of wrapping as discussed in the last PR regarding text indicator overflowing when multiple options are selected.

Why did I use the `grid` class instead of the `flex` class or something else? Well, it turns out that if you have more than one `span` parent with the `flex` class, the `truncate` class won't work (text will overflow).

This will work: 
```html
<div class="flex">
   <span class="truncate">
       *long text here*
   </span>
</div>
``` 
This will not work:
```html
<div class="flex">
  <div class="flex">
     <span class="truncate">
         *long text here*
     </span>
  </div>
</div>
``` 
You may obviously have a better solution than this.

Here are the after images:
Computer:
![Screenshot_2023-08-23-09-59-03-534_com android chrome](https://github.com/filamentphp/filament/assets/68746821/2db7f884-6cdd-406b-a876-c6eb45250505)
Mobile:
![Screenshot_2023-08-23-10-00-20-561_com android chrome](https://github.com/filamentphp/filament/assets/68746821/a4a79bf2-2e4e-45ca-b3dc-22c551e17f0d)

