### PR TITLE
Bug: Global Search Crash when searched in Id

### DIFF
--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -653,7 +653,7 @@ abstract class Resource
                     };
 
                     $caseAwareSearchColumn = $isForcedCaseInsensitive ?
-                        new Expression("lower({$searchColumn})") :
+                        new Expression(is_int($searchColumn) ? $searchColumn : "lower({$searchColumn})") :
                         $searchColumn;
 
                     return $query->$whereClause(


### PR DESCRIPTION
Global search crashes if 'id' is one of the search criteria. This worked fine in V2, and this bug is introduced as we are comparing lower() for case insensitive search.

Before this fix:
The search crashes with an SQL error:
function lower(bigint) does not exist. This is tested with PostGres.

After this fix:
The search works normally and returns the result normally.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
