### PR TITLE
Bug: Global Search Crash when searching with ID

### DIFF
--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -678,7 +678,12 @@ abstract class Resource
                             "%{$search}%",
                         );
                     },
-                    function ($query) use ($isForcedCaseInsensitive, $whereClause, $searchAttribute, $search) {
+                    function ($query) use ($databaseConnection, $isForcedCaseInsensitive, $whereClause, $searchAttribute, $search) {
+                        $searchAttribute = match ($databaseConnection->getDriverName()) {
+                            'pgsql' => "{$searchAttribute}::text",
+                            default => $searchAttribute,
+                        };
+                        
                         $caseAwareSearchColumn = $isForcedCaseInsensitive ?
                             new Expression("lower({$searchAttribute})") :
                             $searchAttribute;


### PR DESCRIPTION
The previous PR was a mistake.

This resolves the issue of searching in non-string field such as ID according to the way you have suggested.

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
