### PR TITLE
FIX: Usage of HTML Titles

### DIFF
--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -23,7 +23,7 @@
         @endif
 
         <title>
-            {{ filled($title = $livewire->getTitle()) ? "{$title} - " : null }}
+            {{ filled($title = strip_tags($livewire->getTitle())) ? "{$title} - " : null }}
             {{ filament()->getBrandName() }}
         </title>
 

--- a/packages/panels/src/Resources/Pages/Concerns/InteractsWithRecord.php
+++ b/packages/panels/src/Resources/Pages/Concerns/InteractsWithRecord.php
@@ -29,7 +29,7 @@ trait InteractsWithRecord
         return $this->record;
     }
 
-    public function getRecordTitle(): Htmlable|string
+    public function getRecordTitle(): Htmlable | string
     {
         $resource = static::getResource();
 

--- a/packages/panels/src/Resources/Pages/Concerns/InteractsWithRecord.php
+++ b/packages/panels/src/Resources/Pages/Concerns/InteractsWithRecord.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Resources\Pages\Concerns;
 
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Str;
@@ -28,7 +29,7 @@ trait InteractsWithRecord
         return $this->record;
     }
 
-    public function getRecordTitle(): string
+    public function getRecordTitle(): Htmlable|string
     {
         $resource = static::getResource();
 

--- a/packages/panels/src/Resources/Pages/Concerns/InteractsWithRecord.php
+++ b/packages/panels/src/Resources/Pages/Concerns/InteractsWithRecord.php
@@ -29,7 +29,7 @@ trait InteractsWithRecord
         return $this->record;
     }
 
-    public function getRecordTitle(): Htmlable | string
+    public function getRecordTitle(): string | Htmlable
     {
         $resource = static::getResource();
 


### PR DESCRIPTION
Allows the usage of HTML tags inside a title and fixes it on

- Breadcrumb
- Metatitle

# New
![image](https://github.com/filamentphp/filament/assets/642292/8c0e52af-7879-4598-928b-261907484acb)


# Old
![image](https://github.com/filamentphp/filament/assets/642292/e28c779e-705f-439f-b553-7771eeae29fa)


# Changes

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

See my old PR #6652 as well...