### PR TITLE
Fix support for BelongsToThrough relationships in Select/SelectFilter

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -844,6 +844,19 @@ class Select extends Field implements Contracts\HasAffixActions, Contracts\HasNe
                 return;
             }
 
+            if ($relationship instanceof \Znck\Eloquent\Relations\BelongsToThrough) {
+                /** @var \Znck\Eloquent\Relations\BelongsToThrough $relationship */
+                $relatedModel = $relationship->getResults();
+
+                $component->state(
+                    $relatedModel->getAttribute(
+                        $relationship->getRelated()->getKeyName(),
+                    ),
+                );
+
+                return;
+            }
+
             /** @var BelongsTo $relationship */
             $relatedModel = $relationship->getResults();
 
@@ -893,8 +906,16 @@ class Select extends Field implements Contracts\HasAffixActions, Contracts\HasNe
                     ->select($relationshipQuery->getModel()->getTable() . '.*');
             }
 
+            if ($relationship instanceof BelongsToMany) {
+                $relatedKeyName = $relationship->getRelatedKeyName();
+            } elseif ($relationship instanceof \Znck\Eloquent\Relations\BelongsToThrough) {
+                $relatedKeyName = $relationship->getRelated()->getQualifiedKeyName();
+            } else {
+                $relatedKeyName = $relationship->getOwnerKeyName();
+            }
+
             $relationshipQuery->where(
-                $relationship instanceof BelongsToMany ? $relationship->getRelatedKeyName() : $relationship->getOwnerKeyName(),
+                $relatedKeyName,
                 $state,
             );
 
@@ -935,7 +956,7 @@ class Select extends Field implements Contracts\HasAffixActions, Contracts\HasNe
             } else {
                 $relatedKeyName = $relationship->getQualifiedOwnerKeyName();
             }
-            
+
             $relationshipQuery->whereIn($relatedKeyName, $values);
 
             if ($modifyQueryUsing) {

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -845,7 +845,7 @@ class Select extends Field implements Contracts\HasAffixActions, Contracts\HasNe
             }
 
             if ($relationship instanceof \Znck\Eloquent\Relations\BelongsToThrough) {
-                /** @var \Znck\Eloquent\Relations\BelongsToThrough $relationship */
+                /** @var Collection $relatedModels */
                 $relatedModel = $relationship->getResults();
 
                 $component->state(

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -928,8 +928,14 @@ class Select extends Field implements Contracts\HasAffixActions, Contracts\HasNe
                     ->select($relationshipQuery->getModel()->getTable() . '.*');
             }
 
-            $relatedKeyName = $relationship instanceof BelongsToMany ? $relationship->getQualifiedRelatedKeyName() : $relationship->getQualifiedOwnerKeyName();
-
+            if ($relationship instanceof BelongsToMany) {
+                $relatedKeyName = $relationship->getQualifiedRelatedKeyName();
+            } elseif ($relationship instanceof \Znck\Eloquent\Relations\BelongsToThrough) {
+                $relatedKeyName = $relationship->getRelated()->getQualifiedKeyName();
+            } else {
+                $relatedKeyName = $relationship->getQualifiedOwnerKeyName();
+            }
+            
             $relationshipQuery->whereIn($relatedKeyName, $values);
 
             if ($modifyQueryUsing) {

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -914,10 +914,7 @@ class Select extends Field implements Contracts\HasAffixActions, Contracts\HasNe
                 $relatedKeyName = $relationship->getOwnerKeyName();
             }
 
-            $relationshipQuery->where(
-                $relatedKeyName,
-                $state,
-            );
+            $relationshipQuery->where($relatedKeyName, $state);
 
             if ($modifyQueryUsing) {
                 $relationshipQuery = $component->evaluate($modifyQueryUsing, [

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -49,6 +49,7 @@ class SelectFilter extends BaseFilter
                     $relationshipQuery = $filter->getRelationshipQuery();
 
                     $labels = $relationshipQuery
+                        ->distinct()
                         ->whereKey($state['values'])
                         ->pluck($relationshipQuery->qualifyColumn($filter->getRelationshipTitleAttribute()))
                         ->all();

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -49,7 +49,10 @@ class SelectFilter extends BaseFilter
                     $relationshipQuery = $filter->getRelationshipQuery();
 
                     $labels = $relationshipQuery
-                        ->when($filter->getRelationship() instanceof \Znck\Eloquent\Relations\BelongsToThrough, fn ($query) => $query->distinct())
+                        ->when(
+                            $filter->getRelationship() instanceof \Znck\Eloquent\Relations\BelongsToThrough,
+                            fn (Builder $query) => $query->distinct(),
+                        )
                         ->whereKey($state['values'])
                         ->pluck($relationshipQuery->qualifyColumn($filter->getRelationshipTitleAttribute()))
                         ->all();

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -49,7 +49,7 @@ class SelectFilter extends BaseFilter
                     $relationshipQuery = $filter->getRelationshipQuery();
 
                     $labels = $relationshipQuery
-                        ->distinct()
+                        ->when($filter->getRelationship() instanceof \Znck\Eloquent\Relations\BelongsToThrough, fn ($query) => $query->distinct())
                         ->whereKey($state['values'])
                         ->pluck($relationshipQuery->qualifyColumn($filter->getRelationshipTitleAttribute()))
                         ->all();


### PR DESCRIPTION
- [X] Changes have been thoroughly tested to not break existing functionality.
See examples below.
- [X] New functionality has been documented or existing documentation has been updated to reflect changes.
No need for docs changes, works as documented.
- [X] Visual changes are explained in the PR description using a screenshot/recording of before and after.
No visual changes.

This PR fixes support for [staudenmeir/belongs-to-through](https://github.com/staudenmeir/belongs-to-through) relationships which used to be (at least partially) supported in V2.

Changes in `packages/forms/src/Components/Select.php` handle the proper key retrieval for this type of relationship for select population and searching.

A `distinct()` was added to the relationship query in `packages/tables/src/Filters/SelectFilter.php` to de-duplicate values used to build indicator labels.

Before:
<img width="1239" alt="image" src="https://github.com/filamentphp/filament/assets/5067998/7fa6f0d4-2c02-4c23-97c7-6359c30de170">

After:
<img width="1267" alt="image" src="https://github.com/filamentphp/filament/assets/5067998/37a6c097-26d1-47b2-968c-64283c7a4c93">

