### PR TITLE
Feature/brandname htmlable

### DIFF
--- a/packages/panels/resources/views/components/logo.blade.php
+++ b/packages/panels/resources/views/components/logo.blade.php
@@ -6,6 +6,6 @@
             ])
         }}
     >
-        {{ $brand }}
+        {!! $brand !!}
     </div>
 @endif

--- a/packages/panels/resources/views/components/logo.blade.php
+++ b/packages/panels/resources/views/components/logo.blade.php
@@ -6,6 +6,6 @@
             ])
         }}
     >
-        {!! $brand !!}
+        {{ $brand }}
     </div>
 @endif

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -79,7 +79,7 @@ class FilamentManager
         return $this->getCurrentPanel()->getAuthPasswordBroker();
     }
 
-    public function getBrandName(): string
+    public function getBrandName(): string | Htmlable
     {
         return $this->getCurrentPanel()->getBrandName();
     }

--- a/packages/panels/src/Panel/Concerns/HasBrandName.php
+++ b/packages/panels/src/Panel/Concerns/HasBrandName.php
@@ -3,12 +3,13 @@
 namespace Filament\Panel\Concerns;
 
 use Closure;
+use Illuminate\Contracts\Support\Htmlable;
 
 trait HasBrandName
 {
-    protected string | Closure | null $brandName = null;
+    protected string | Closure | Htmlable | null $brandName = null;
 
-    public function brandName(string | Closure | null $name): static
+    public function brandName(string | Closure | Htmlable | null $name): static
     {
         $this->brandName = $name;
 

--- a/packages/panels/src/Panel/Concerns/HasBrandName.php
+++ b/packages/panels/src/Panel/Concerns/HasBrandName.php
@@ -7,16 +7,16 @@ use Illuminate\Contracts\Support\Htmlable;
 
 trait HasBrandName
 {
-    protected string | Closure | Htmlable | null $brandName = null;
+    protected string | Htmlable | Closure | null $brandName = null;
 
-    public function brandName(string | Closure | Htmlable | null $name): static
+    public function brandName(string | Htmlable | Closure | null $name): static
     {
         $this->brandName = $name;
 
         return $this;
     }
 
-    public function getBrandName(): string
+    public function getBrandName(): string | Htmlable
     {
         return $this->evaluate($this->brandName) ?? config('app.name');
     }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
There is no real documentation for brandname at the moment, if you tell me where you want this, I can add some documentation on how this could be used.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
<img width="348" alt="image" src="https://github.com/filamentphp/filament/assets/390530/120df4f0-732f-4dd1-8eaa-26b4eb1208c3">

This is for me really a nice to have, and not at all mandatory requirement, but I think it is a small change with low impact that might add a lot of branding possibilities.

