### PR TITLE
Documentation: Filament\Actions\ActionGroup::width does not exist, the correct method is `dropdownWidth`

### DIFF
--- a/packages/actions/docs/05-grouping-actions.md
+++ b/packages/actions/docs/05-grouping-actions.md
@@ -70,7 +70,7 @@ The `dropdown(false)` method puts the actions inside the parent dropdown, instea
 
 ## Setting the width of the dropdown
 
-The dropdown may be set to a width by using the `width()` method. Options correspond to [Tailwind's max-width scale](https://tailwindcss.com/docs/max-width). The options are `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, `6xl` and `7xl`:
+The dropdown may be set to a width by using the `dropdownWidth()` method. Options correspond to [Tailwind's max-width scale](https://tailwindcss.com/docs/max-width). The options are `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, `6xl` and `7xl`:
 
 ```php
 ActionGroup::make([

--- a/packages/actions/docs/05-grouping-actions.md
+++ b/packages/actions/docs/05-grouping-actions.md
@@ -76,7 +76,7 @@ The dropdown may be set to a width by using the `width()` method. Options corres
 ActionGroup::make([
     // Array of actions
 ])
-    ->width('xs')
+    ->dropdownWidth('xs')
 ```
 
 ## Controlling the maximum height of the dropdown


### PR DESCRIPTION
Method Filament\Actions\ActionGroup::width does not exist, the correct method is `dropdownWidth`

Just updating the docs.