### PR TITLE
[2.x-forms] Fixes CheckboxList's bulkToggleable() method 

### DIFF
--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -33,7 +33,9 @@
             init: function () {
                 this.updateVisibleCheckboxListOptions()
 
-                this.checkIfAllCheckboxesAreChecked()
+                $nextTick(() => {
+                    this.checkIfAllCheckboxesAreChecked()
+                });
 
                 Livewire.hook('message.processed', () => {
                     this.updateVisibleCheckboxListOptions()
@@ -45,10 +47,6 @@
                     this.updateVisibleCheckboxListOptions()
                     this.checkIfAllCheckboxesAreChecked()
                 })
-
-                $nextTick(() => {
-                    this.checkIfAllCheckboxesAreChecked()
-                });
             },
 
             checkIfAllCheckboxesAreChecked: function () {

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -35,7 +35,7 @@
 
                 $nextTick(() => {
                     this.checkIfAllCheckboxesAreChecked()
-                });
+                })
 
                 Livewire.hook('message.processed', () => {
                     this.updateVisibleCheckboxListOptions()

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -48,7 +48,7 @@
 
                 $nextTick(() => {
                     this.checkIfAllCheckboxesAreChecked()
-                });
+                })
             },
 
             checkIfAllCheckboxesAreChecked: function () {

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -45,6 +45,10 @@
                     this.updateVisibleCheckboxListOptions()
                     this.checkIfAllCheckboxesAreChecked()
                 })
+
+                $nextTick(() => {
+                    this.checkIfAllCheckboxesAreChecked()
+                });
             },
 
             checkIfAllCheckboxesAreChecked: function () {


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

**Currently Behaviour:**
when the options are all selected/prefilled before render the `bulkToggleable()` method `Select All` is rendered.

https://github.com/filamentphp/filament/assets/10007504/7130fffe-259e-464b-a773-5d6123449d92

**Expected Behaviour:**
the method should be `Deselect All`

https://github.com/filamentphp/filament/assets/10007504/10a1630f-0525-4d5c-9172-d9e0c83a4d63