### PR TITLE
[3.x-Notifications] Added authGuard variable to use custom auth guard provider

### DIFF
--- a/packages/notifications/src/Livewire/DatabaseNotifications.php
+++ b/packages/notifications/src/Livewire/DatabaseNotifications.php
@@ -158,6 +158,11 @@ class DatabaseNotifications extends Component
         static::$pollingInterval = $interval;
     }
 
+    public static function authGuard(?string $guard): void
+    {
+        static::$authGuard = $guard;
+    }
+
     /**
      * @return array<string>
      */

--- a/packages/notifications/src/Livewire/DatabaseNotifications.php
+++ b/packages/notifications/src/Livewire/DatabaseNotifications.php
@@ -26,6 +26,8 @@ class DatabaseNotifications extends Component
 
     public static ?string $pollingInterval = '30s';
 
+    public static ?string $authGuard = null;
+
     #[On('databaseNotificationsSent')]
     public function refresh(): void
     {
@@ -115,7 +117,7 @@ class DatabaseNotifications extends Component
 
     public function getUser(): Model | Authenticatable | null
     {
-        return auth()->user();
+        return auth(static::$authGuard)->user();
     }
 
     public function getBroadcastChannel(): ?string

--- a/packages/notifications/src/Livewire/Notifications.php
+++ b/packages/notifications/src/Livewire/Notifications.php
@@ -114,6 +114,11 @@ class Notifications extends Component
         static::$verticalAlignment = $alignment;
     }
 
+    public static function authGuard(?string $guard): void
+    {
+        static::$authGuard = $guard;
+    }
+
     public function render(): View
     {
         return view('filament-notifications::notifications');

--- a/packages/notifications/src/Livewire/Notifications.php
+++ b/packages/notifications/src/Livewire/Notifications.php
@@ -23,6 +23,8 @@ class Notifications extends Component
 
     public static VerticalAlignment $verticalAlignment = VerticalAlignment::Start;
 
+    public static ?string $authGuard = null;
+
     public function mount(): void
     {
         $this->notifications = new Collection();
@@ -82,7 +84,7 @@ class Notifications extends Component
 
     public function getUser(): Model | Authenticatable | null
     {
-        return auth()->user();
+        return auth(static::$authGuard)->user();
     }
 
     public function getBroadcastChannel(): ?string


### PR DESCRIPTION
Added a static property $authGuard to the Notifications Livewire Classes. This allows for custom Auth Guards, for example i use the default laravel auth guard for the frontend but a different one for the backend (where i use the notification filament package).

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
