### PR TITLE
[3.x-tables] Update 13-upgrade-guide.md : generating JS & CSS missing instruction

### DIFF
--- a/packages/actions/docs/01-installation.md
+++ b/packages/actions/docs/01-installation.md
@@ -158,7 +158,7 @@ php artisan vendor:publish --tag=filament-config
 
 ## Upgrading
 
-Filament automatically upgrades to the latest non-breaking version when you run `composer update`. If you notice that Filament is not upgrading automatically, ensure that the `filament:upgrade` command is present in your `composer.json`:
+Filament automatically upgrades to the latest non-breaking version when you run `composer update`. After any updates, all Laravel caches need to be cleared, and frontend assets need to be republished. You can do this all at once using the `filament:upgrade` command, which should have been added to your `composer.json` file when you ran `filament:install` the first time:
 
 ```json
 "post-autoload-dump": [
@@ -167,7 +167,7 @@ Filament automatically upgrades to the latest non-breaking version when you run 
 ],
 ```
 
-If you prefer not to use automatic upgrades, remove the `filament:upgrade` command from your `composer.json` and run the following commands:
+Please note that `filament:upgrade` does not actually handle the update process, as Composer does that already. If you're upgrading manually without a `post-autoload-dump` hook, you can run the command yourself:
 
 ```bash
 composer update

--- a/packages/actions/docs/10-upgrade-guide.md
+++ b/packages/actions/docs/10-upgrade-guide.md
@@ -2,7 +2,7 @@
 title: Upgrading from v2.x
 ---
 
-> If you see anything missing from this guide, please do not hesitate to [make a pull request](https://github.com/filamentphp/filament/edit/3.x/packages/actions/docs/14-upgrade-guide.md) to our repository! Any help is appreciated!
+> If you see anything missing from this guide, please do not hesitate to [make a pull request](https://github.com/filamentphp/filament/edit/3.x/packages/actions/docs/10-upgrade-guide.md) to our repository! Any help is appreciated!
 
 ## New requirements
 
@@ -33,6 +33,8 @@ You can now `composer remove filament/upgrade` as you don't need it anymore.
 > Some plugins you're using may not be available in v3 just yet. You could temporarily remove them from your `composer.json` file until they've been upgraded, replace them with a similar plugins that are v3-compatible, wait for the plugins to be upgraded before upgrading your app, or even write PRs to help the authors upgrade them.
 
 ## Upgrading manually
+
+After upgrading the dependency via Composer, you should execute `php artisan filament:upgrade` in order to clear any caches and publish the new assets.
 
 ### Low-impact changes
 

--- a/packages/actions/docs/10-upgrade-guide.md
+++ b/packages/actions/docs/10-upgrade-guide.md
@@ -34,7 +34,7 @@ You can now `composer remove filament/upgrade` as you don't need it anymore.
 
 ## Upgrading manually
 
-After upgrading the dependency via Composer, you should execute `php artisan filament:upgrade` in order to clear any caches and publish the new assets.
+After upgrading the dependency via Composer, you should execute `php artisan filament:upgrade` in order to clear any Laravel caches and publish the new frontend assets.
 
 ### Low-impact changes
 

--- a/packages/forms/docs/01-installation.md
+++ b/packages/forms/docs/01-installation.md
@@ -160,7 +160,7 @@ php artisan vendor:publish --tag=filament-config
 
 > Upgrading from Filament v2? Please review the [upgrade guide](upgrade-guide).
 
-Filament automatically upgrades to the latest non-breaking version when you run `composer update`. If you notice that Filament is not upgrading automatically, ensure that the `filament:upgrade` command is present in your `composer.json`:
+Filament automatically upgrades to the latest non-breaking version when you run `composer update`. After any updates, all Laravel caches need to be cleared, and frontend assets need to be republished. You can do this all at once using the `filament:upgrade` command, which should have been added to your `composer.json` file when you ran `filament:install` the first time:
 
 ```json
 "post-autoload-dump": [
@@ -169,7 +169,7 @@ Filament automatically upgrades to the latest non-breaking version when you run 
 ],
 ```
 
-If you prefer not to use automatic upgrades, remove the `filament:upgrade` command from your `composer.json`, and run the following commands:
+Please note that `filament:upgrade` does not actually handle the update process, as Composer does that already. If you're upgrading manually without a `post-autoload-dump` hook, you can run the command yourself:
 
 ```bash
 composer update

--- a/packages/forms/docs/10-upgrade-guide.md
+++ b/packages/forms/docs/10-upgrade-guide.md
@@ -33,6 +33,8 @@ You can now `composer remove filament/upgrade` as you don't need it anymore.
 
 ## Upgrading manually
 
+After upgrading the dependency via Composer, you should execute `php artisan filament:upgrade` in order to clear any caches and publish the new assets.
+
 ### High-impact changes
 
 #### Config file renamed and combined with other Filament packages

--- a/packages/forms/docs/10-upgrade-guide.md
+++ b/packages/forms/docs/10-upgrade-guide.md
@@ -33,7 +33,7 @@ You can now `composer remove filament/upgrade` as you don't need it anymore.
 
 ## Upgrading manually
 
-After upgrading the dependency via Composer, you should execute `php artisan filament:upgrade` in order to clear any caches and publish the new assets.
+After upgrading the dependency via Composer, you should execute `php artisan filament:upgrade` in order to clear any Laravel caches and publish the new frontend assets.
 
 ### High-impact changes
 

--- a/packages/infolists/docs/01-installation.md
+++ b/packages/infolists/docs/01-installation.md
@@ -158,7 +158,7 @@ php artisan vendor:publish --tag=filament-config
 
 ## Upgrading
 
-Filament automatically upgrades to the latest non-breaking version when you run `composer update`. If you notice that Filament is not upgrading automatically, ensure that the `filament:upgrade` command is present in your `composer.json`:
+Filament automatically upgrades to the latest non-breaking version when you run `composer update`. After any updates, all Laravel caches need to be cleared, and frontend assets need to be republished. You can do this all at once using the `filament:upgrade` command, which should have been added to your `composer.json` file when you ran `filament:install` the first time:
 
 ```json
 "post-autoload-dump": [
@@ -167,7 +167,7 @@ Filament automatically upgrades to the latest non-breaking version when you run 
 ],
 ```
 
-If you prefer not to use automatic upgrades, remove the `filament:upgrade` command from your `composer.json` and run the following commands:
+Please note that `filament:upgrade` does not actually handle the update process, as Composer does that already. If you're upgrading manually without a `post-autoload-dump` hook, you can run the command yourself:
 
 ```bash
 composer update

--- a/packages/notifications/docs/01-installation.md
+++ b/packages/notifications/docs/01-installation.md
@@ -158,7 +158,7 @@ php artisan vendor:publish --tag=filament-config
 
 > Upgrading from Filament v2? Please review the [upgrade guide](upgrade-guide).
 
-Filament automatically upgrades to the latest non-breaking version when you run `composer update`. If you notice that Filament is not upgrading automatically, ensure that the `filament:upgrade` command is present in your `composer.json`:
+Filament automatically upgrades to the latest non-breaking version when you run `composer update`. After any updates, all Laravel caches need to be cleared, and frontend assets need to be republished. You can do this all at once using the `filament:upgrade` command, which should have been added to your `composer.json` file when you ran `filament:install` the first time:
 
 ```json
 "post-autoload-dump": [
@@ -167,7 +167,7 @@ Filament automatically upgrades to the latest non-breaking version when you run 
 ],
 ```
 
-If you prefer not to use automatic upgrades, remove the `filament:upgrade` command from your `composer.json` and run the following commands:
+Please note that `filament:upgrade` does not actually handle the update process, as Composer does that already. If you're upgrading manually without a `post-autoload-dump` hook, you can run the command yourself:
 
 ```bash
 composer update

--- a/packages/notifications/docs/07-upgrade-guide.md
+++ b/packages/notifications/docs/07-upgrade-guide.md
@@ -33,6 +33,8 @@ You can now `composer remove filament/upgrade` as you don't need it anymore.
 
 ## Upgrading manually
 
+After upgrading the dependency via Composer, you should execute `php artisan filament:upgrade` in order to clear any caches and publish the new assets.
+
 ### High-impact changes
 
 #### Config file renamed and combined with other Filament packages

--- a/packages/notifications/docs/07-upgrade-guide.md
+++ b/packages/notifications/docs/07-upgrade-guide.md
@@ -33,7 +33,7 @@ You can now `composer remove filament/upgrade` as you don't need it anymore.
 
 ## Upgrading manually
 
-After upgrading the dependency via Composer, you should execute `php artisan filament:upgrade` in order to clear any caches and publish the new assets.
+After upgrading the dependency via Composer, you should execute `php artisan filament:upgrade` in order to clear any Laravel caches and publish the new frontend assets.
 
 ### High-impact changes
 

--- a/packages/panels/docs/01-installation.md
+++ b/packages/panels/docs/01-installation.md
@@ -105,7 +105,7 @@ php artisan vendor:publish --tag=filament-translations
 
 > Upgrading from Filament v2? Please review the [upgrade guide](upgrade-guide).
 
-Filament automatically upgrades to the latest non-breaking version when you run `composer update`. If you notice that Filament is not upgrading automatically, ensure that the `filament:upgrade` command is present in your `composer.json`:
+Filament automatically upgrades to the latest non-breaking version when you run `composer update`. After any updates, all Laravel caches need to be cleared, and frontend assets need to be republished. You can do this all at once using the `filament:upgrade` command, which should have been added to your `composer.json` file when you ran `filament:install` the first time:
 
 ```json
 "post-autoload-dump": [
@@ -114,7 +114,7 @@ Filament automatically upgrades to the latest non-breaking version when you run 
 ],
 ```
 
-If you prefer not to use automatic upgrades, remove the `filament:upgrade` command from your `composer.json` and run the following commands:
+Please note that `filament:upgrade` does not actually handle the update process, as Composer does that already. If you're upgrading manually without a `post-autoload-dump` hook, you can run the command yourself:
 
 ```bash
 composer update

--- a/packages/panels/docs/14-upgrade-guide.md
+++ b/packages/panels/docs/14-upgrade-guide.md
@@ -36,7 +36,7 @@ You can now `composer remove filament/upgrade` as you don't need it anymore.
 
 ## Upgrading manually
 
-After upgrading the dependency via Composer, you should execute `php artisan filament:upgrade` in order to clear any caches and publish the new assets.
+After upgrading the dependency via Composer, you should execute `php artisan filament:upgrade` in order to clear any Laravel caches and publish the new frontend assets.
 
 ### High-impact changes
 

--- a/packages/panels/docs/14-upgrade-guide.md
+++ b/packages/panels/docs/14-upgrade-guide.md
@@ -36,6 +36,8 @@ You can now `composer remove filament/upgrade` as you don't need it anymore.
 
 ## Upgrading manually
 
+After upgrading the dependency via Composer, you should execute `php artisan filament:upgrade` in order to clear any caches and publish the new assets.
+
 ### High-impact changes
 
 #### Panel provider instead of the config file

--- a/packages/tables/docs/01-installation.md
+++ b/packages/tables/docs/01-installation.md
@@ -160,7 +160,7 @@ php artisan vendor:publish --tag=filament-config
 
 > Upgrading from Filament v2? Please review the [upgrade guide](upgrade-guide).
 
-Filament automatically upgrades to the latest non-breaking version when you run `composer update`. If you notice that Filament is not upgrading automatically, ensure that the `filament:upgrade` command is present in your `composer.json`:
+Filament automatically upgrades to the latest non-breaking version when you run `composer update`. After any updates, all Laravel caches need to be cleared, and frontend assets need to be republished. You can do this all at once using the `filament:upgrade` command, which should have been added to your `composer.json` file when you ran `filament:install` the first time:
 
 ```json
 "post-autoload-dump": [
@@ -169,7 +169,7 @@ Filament automatically upgrades to the latest non-breaking version when you run 
 ],
 ```
 
-If you prefer not to use automatic upgrades, remove the `filament:upgrade` command from your `composer.json` and run the following commands:
+Please note that `filament:upgrade` does not actually handle the update process, as Composer does that already. If you're upgrading manually without a `post-autoload-dump` hook, you can run the command yourself:
 
 ```bash
 composer update

--- a/packages/tables/docs/13-upgrade-guide.md
+++ b/packages/tables/docs/13-upgrade-guide.md
@@ -33,7 +33,7 @@ You can now `composer remove filament/upgrade` as you don't need it anymore.
 
 ## Upgrading manually
 
-After upgrading to v3, you need to execute `php artisan filament:install --tables` in order to generate JavaScript and CSS files.
+After upgrading the dependency via Composer, you should execute `php artisan filament:upgrade` in order to clear any caches and publish the new assets.
 
 ### High-impact changes
 

--- a/packages/tables/docs/13-upgrade-guide.md
+++ b/packages/tables/docs/13-upgrade-guide.md
@@ -33,7 +33,7 @@ You can now `composer remove filament/upgrade` as you don't need it anymore.
 
 ## Upgrading manually
 
-After upgrading to v3, you need to execute `php artisan install --tables` in order to generate JavaScript and CSS files.
+After upgrading to v3, you need to execute `php artisan filament:install --tables` in order to generate JavaScript and CSS files.
 
 ### High-impact changes
 

--- a/packages/tables/docs/13-upgrade-guide.md
+++ b/packages/tables/docs/13-upgrade-guide.md
@@ -33,7 +33,7 @@ You can now `composer remove filament/upgrade` as you don't need it anymore.
 
 ## Upgrading manually
 
-After upgrading the dependency via Composer, you should execute `php artisan filament:upgrade` in order to clear any caches and publish the new assets.
+After upgrading the dependency via Composer, you should execute `php artisan filament:upgrade` in order to clear any Laravel caches and publish the new frontend assets.
 
 ### High-impact changes
 

--- a/packages/tables/docs/13-upgrade-guide.md
+++ b/packages/tables/docs/13-upgrade-guide.md
@@ -2,7 +2,7 @@
 title: Upgrading from v2.x
 ---
 
-> If you see anything missing from this guide, please do not hesitate to [make a pull request](https://github.com/filamentphp/filament/edit/3.x/packages/tables/docs/11-upgrade-guide.md) to our repository! Any help is appreciated!
+> If you see anything missing from this guide, please do not hesitate to [make a pull request](https://github.com/filamentphp/filament/edit/3.x/packages/tables/docs/13-upgrade-guide.md) to our repository! Any help is appreciated!
 
 ## New requirements
 
@@ -32,6 +32,8 @@ You can now `composer remove filament/upgrade` as you don't need it anymore.
 > Some plugins you're using may not be available in v3 just yet. You could temporarily remove them from your `composer.json` file until they've been upgraded, replace them with a similar plugins that are v3-compatible, wait for the plugins to be upgraded before upgrading your app, or even write PRs to help the authors upgrade them.
 
 ## Upgrading manually
+
+After upgrading to v3, you need to execute `php artisan install --tables` in order to generate JavaScript and CSS files.
 
 ### High-impact changes
 

--- a/packages/widgets/docs/01-installation.md
+++ b/packages/widgets/docs/01-installation.md
@@ -158,7 +158,7 @@ php artisan vendor:publish --tag=filament-config
 
 ## Upgrading
 
-Filament automatically upgrades to the latest non-breaking version when you run `composer update`. If you notice that Filament is not upgrading automatically, ensure that the `filament:upgrade` command is present in your `composer.json`:
+Filament automatically upgrades to the latest non-breaking version when you run `composer update`. After any updates, all Laravel caches need to be cleared, and frontend assets need to be republished. You can do this all at once using the `filament:upgrade` command, which should have been added to your `composer.json` file when you ran `filament:install` the first time:
 
 ```json
 "post-autoload-dump": [
@@ -167,7 +167,7 @@ Filament automatically upgrades to the latest non-breaking version when you run 
 ],
 ```
 
-If you prefer not to use automatic upgrades, remove the `filament:upgrade` command from your `composer.json` and run the following commands:
+Please note that `filament:upgrade` does not actually handle the update process, as Composer does that already. If you're upgrading manually without a `post-autoload-dump` hook, you can run the command yourself:
 
 ```bash
 composer update


### PR DESCRIPTION
Hello,

It was impossible for me to use the automatic update.

After making the changes described in the migration guide, I encounterd issues because the JS & CSS files was not published in the public folder.

Executing `filament:install --tables` solved it.


