### PR TITLE
2.x minor documentation change: substitute attribute name in custom validation rule message

### DIFF
--- a/packages/forms/docs/05-validation.md
+++ b/packages/forms/docs/05-validation.md
@@ -472,7 +472,7 @@ TextInput::make('slug')->rules([
     function () {
         return function (string $attribute, $value, Closure $fail) {
             if ($value === 'foo') {
-                $fail("The :attribute is invalid.");
+                $fail('The :attribute is invalid.');
             }
         };
     },

--- a/packages/forms/docs/05-validation.md
+++ b/packages/forms/docs/05-validation.md
@@ -472,7 +472,7 @@ TextInput::make('slug')->rules([
     function () {
         return function (string $attribute, $value, Closure $fail) {
             if ($value === 'foo') {
-                $fail("The {$attribute} is invalid.");
+                $fail("The :attribute is invalid.");
             }
         };
     },


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Just a non-functional minor documentation change that may save people a little time and frustration. I can do this for V3 once I've tested it  there. I'm using the documented technique on V2 and it works for me.
