### PR TITLE
[3.x-tables] Counting all rows even with simple paginate

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -70,7 +70,7 @@
     $hasHeaderToolbar = $isReorderable || count($groups) || $isGlobalSearchVisible || $hasFiltersDropdown || $hasColumnToggleDropdown;
     $pluralModelLabel = $getPluralModelLabel();
     $records = $isLoaded ? $getRecords() : null;
-    $allSelectableRecordsCount = $isSelectionEnabled && $isLoaded ? $getAllSelectableRecordsCount() : null;
+    $allSelectableRecordsCount = ($isSelectionEnabled && $isLoaded) ? $getAllSelectableRecordsCount() : null;
     $columnsCount = count($columns);
     $reorderRecordsTriggerAction = $getReorderRecordsTriggerAction($isReordering);
     $toggleColumnsTriggerAction = $getToggleColumnsTriggerAction();

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -70,7 +70,7 @@
     $hasHeaderToolbar = $isReorderable || count($groups) || $isGlobalSearchVisible || $hasFiltersDropdown || $hasColumnToggleDropdown;
     $pluralModelLabel = $getPluralModelLabel();
     $records = $isLoaded ? $getRecords() : null;
-    $allSelectableRecordsCount = $isLoaded ? $getAllSelectableRecordsCount() : null;
+    $allSelectableRecordsCount = $isSelectionEnabled && $isLoaded ? $getAllSelectableRecordsCount() : null;
     $columnsCount = count($columns);
     $reorderRecordsTriggerAction = $getReorderRecordsTriggerAction($isReordering);
     $toggleColumnsTriggerAction = $getToggleColumnsTriggerAction();


### PR DESCRIPTION
This fix the fact that even with simple paginate activated, there was a `count(*)` query that was running.

I simply used the same condition that use the `$allSelectableRecordsCount` variable.

This "bug" exists also in 2.x of the package.
