### PR TITLE
Fix issue where a collapsed section content was still filling space

### DIFF
--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -283,14 +283,14 @@ class CreateRecord extends Page
     {
         $resource = static::getResource();
 
-        if ($resource::hasPage('edit') && $resource::canEdit($this->getRecord())) {
-            return $resource::getUrl('edit', ['record' => $this->getRecord(), ...$this->getRedirectUrlParameters()]);
-        }
-
         if ($resource::hasPage('view') && $resource::canView($this->getRecord())) {
             return $resource::getUrl('view', ['record' => $this->getRecord(), ...$this->getRedirectUrlParameters()]);
         }
 
+        if ($resource::hasPage('edit') && $resource::canEdit($this->getRecord())) {
+            return $resource::getUrl('edit', ['record' => $this->getRecord(), ...$this->getRedirectUrlParameters()]);
+        }
+        
         return $resource::getUrl('index');
     }
 

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -290,7 +290,7 @@ class CreateRecord extends Page
         if ($resource::hasPage('edit') && $resource::canEdit($this->getRecord())) {
             return $resource::getUrl('edit', ['record' => $this->getRecord(), ...$this->getRedirectUrlParameters()]);
         }
-        
+
         return $resource::getUrl('index');
     }
 

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -283,12 +283,12 @@ class CreateRecord extends Page
     {
         $resource = static::getResource();
 
-        if ($resource::hasPage('view') && $resource::canView($this->getRecord())) {
-            return $resource::getUrl('view', ['record' => $this->getRecord(), ...$this->getRedirectUrlParameters()]);
-        }
-
         if ($resource::hasPage('edit') && $resource::canEdit($this->getRecord())) {
             return $resource::getUrl('edit', ['record' => $this->getRecord(), ...$this->getRedirectUrlParameters()]);
+        }
+
+        if ($resource::hasPage('view') && $resource::canView($this->getRecord())) {
+            return $resource::getUrl('view', ['record' => $this->getRecord(), ...$this->getRedirectUrlParameters()]);
         }
 
         return $resource::getUrl('index');

--- a/packages/support/resources/views/components/section.blade.php
+++ b/packages/support/resources/views/components/section.blade.php
@@ -139,7 +139,7 @@
             @if ($collapsed)
                 x-cloak
             @endif
-            x-bind:class="{ 'invisible hidden h-0 border-none': isCollapsed }"
+            x-bind:class="{ 'hidden h-0 border-none': isCollapsed }"
         @endif
         @class([
             'fi-section-content-ctn',

--- a/packages/support/resources/views/components/section.blade.php
+++ b/packages/support/resources/views/components/section.blade.php
@@ -139,7 +139,7 @@
             @if ($collapsed)
                 x-cloak
             @endif
-            x-bind:class="{ 'invisible overflow-hidden h-0 border-none': isCollapsed }"
+            x-bind:class="{ 'invisible hidden h-0 border-none': isCollapsed }"
         @endif
         @class([
             'fi-section-content-ctn',

--- a/packages/support/resources/views/components/section.blade.php
+++ b/packages/support/resources/views/components/section.blade.php
@@ -139,7 +139,7 @@
             @if ($collapsed)
                 x-cloak
             @endif
-            x-bind:class="{ 'invisible h-0 border-none': isCollapsed }"
+            x-bind:class="{ 'invisible overflow-hidden h-0 border-none': isCollapsed }"
         @endif
         @class([
             'fi-section-content-ctn',


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

## Before
<img width="1282" alt="CleanShot 2023-08-25 at 21 31 20@2x" src="https://github.com/filamentphp/filament/assets/4272598/3dec9e5c-3c4a-42f8-9646-ca59d653856c">

## After
<img width="1338" alt="CleanShot 2023-08-25 at 21 32 11@2x" src="https://github.com/filamentphp/filament/assets/4272598/f65717cf-81c4-4218-ba83-e75c98d128c4">


