### PR TITLE
Fix placeholder for Infolist TextEntry

### DIFF
--- a/packages/infolists/resources/views/components/text-entry.blade.php
+++ b/packages/infolists/resources/views/components/text-entry.blade.php
@@ -37,7 +37,11 @@
             }
         }
 
-        $arrayState = \Illuminate\Support\Arr::wrap($arrayState);
+        if ($arrayState === null) {
+            $arrayState = [null];
+        } else {
+            $arrayState = \Illuminate\Support\Arr::wrap($arrayState);
+        }
     @endphp
 
     <x-filament-infolists::affixes


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

The `placeholder()` is currently not working for `Infolists/TextEntry`. 

This happens because the `Arr::wrap()` function by Laravel converts `null` to an empty array `[]`, instead of wrapping `null` to `[null]`. With an empty array, there is no element for the foreach and therefore the placeholder is not being used.

This pull request fixes this by adding an if statement handling the null case.