### PR TITLE
Add missing `uk` translations

### DIFF
--- a/packages/actions/resources/lang/uk/force-delete.php
+++ b/packages/actions/resources/lang/uk/force-delete.php
@@ -1,0 +1,61 @@
+<?php
+
+return [
+
+    'single' => [
+
+        'label' => 'Видалити назавжди',
+
+        'modal' => [
+
+            'heading' => 'Видалити назавжди :label',
+
+            'actions' => [
+
+                'delete' => [
+                    'label' => 'Видалити',
+                ],
+
+            ],
+
+        ],
+
+        'notifications' => [
+
+            'deleted' => [
+                'title' => 'Запис видалено',
+            ],
+
+        ],
+
+    ],
+
+    'multiple' => [
+
+        'label' => 'Видалити назавжди обране',
+
+        'modal' => [
+
+            'heading' => 'Видалити назавжди обране :label',
+
+            'actions' => [
+
+                'delete' => [
+                    'label' => 'Видалити',
+                ],
+
+            ],
+
+        ],
+
+        'notifications' => [
+
+            'deleted' => [
+                'title' => 'Записи видалено',
+            ],
+
+        ],
+
+    ],
+
+];


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
