### PR TITLE
Add method to modify global search query

### DIFF
--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -390,7 +390,7 @@ abstract class Resource
         return static::$globalSearchResultsLimit;
     }
 
-    public static function modifyGlobalSearchQuery(Builder $query, string $search)
+    public static function modifyGlobalSearchQuery(Builder $query, string $search): void
     {
     }
 

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -390,6 +390,10 @@ abstract class Resource
         return static::$globalSearchResultsLimit;
     }
 
+    public static function modifyGlobalSearchQuery(Builder $query, string $search)
+    {
+    }
+
     public static function getGlobalSearchResults(string $search): Collection
     {
         $query = static::getGlobalSearchEloquentQuery();
@@ -412,6 +416,8 @@ abstract class Resource
                 }
             });
         }
+
+        static::modifyGlobalSearchQuery($query, $search);
 
         return $query
             ->limit(static::getGlobalSearchResultsLimit())


### PR DESCRIPTION
Add a method to modify the global search query with access to the search term. Otherwise needed to overwrite the whole `getGlobalSearchResults` method, `getGlobalSearchEloquentQuery` is called too early and doesn't have access to the `$search`. 

An example use case was needing to add a HasMany relation.
```php
public static function modifyGlobalSearchQuery(Builder $query, string $search)
{
      if (! $search) {
          return;
      }
      
      $searchTerm = Str::lower($search);
      
      $query->orWhereHas('categories', fn ($query) => $query->where(
          new Expression('lower(title)'),
          'like',
          "%{$searchTerm}%"));
}
```

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
