### PR TITLE
Sidebar overflow x on Safari

### DIFF
--- a/packages/panels/resources/views/components/sidebar/index.blade.php
+++ b/packages/panels/resources/views/components/sidebar/index.blade.php
@@ -83,7 +83,7 @@
         @endif
     </header>
 
-    <nav class="fi-sidebar-nav flex flex-col gap-y-7 overflow-y-auto px-6 py-8">
+    <nav class="fi-sidebar-nav flex flex-col gap-y-7 overflow-y-auto overflow-x-hidden px-6 py-8">
         {{ \Filament\Support\Facades\FilamentView::renderHook('panels::sidebar.nav.start') }}
 
         @if (filament()->hasTenancy())


### PR DESCRIPTION
added overflow-x-hidden for unwanted scrollbar on sidebar

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Before:
![SCR-20230827-krkv](https://github.com/filamentphp/filament/assets/1291111/b893cd96-54fc-4cb0-8ee0-0c2cd6447951)

After:
![SCR-20230827-krnx](https://github.com/filamentphp/filament/assets/1291111/615ca0ff-2536-4f75-8554-3f845e60ad74)
