### PR TITLE
Support overriding table filters

### DIFF
--- a/packages/tables/src/Table/Concerns/HasActions.php
+++ b/packages/tables/src/Table/Concerns/HasActions.php
@@ -34,6 +34,21 @@ trait HasActions
      */
     public function actions(array | ActionGroup $actions, ActionsPosition | string | Closure | null $position = null): static
     {
+        $this->actions = [];
+        $this->pushActions($actions);
+
+        if ($position) {
+            $this->actionsPosition($position);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param  array<Action | ActionGroup> | ActionGroup  $actions
+     */
+    public function pushActions(array | ActionGroup $actions): static
+    {
         foreach (Arr::wrap($actions) as $action) {
             $action->table($this);
 
@@ -57,8 +72,6 @@ trait HasActions
 
             $this->actions[] = $action;
         }
-
-        $position && $this->actionsPosition($position);
 
         return $this;
     }

--- a/packages/tables/src/Table/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Table/Concerns/HasBulkActions.php
@@ -34,6 +34,17 @@ trait HasBulkActions
      */
     public function bulkActions(array | ActionGroup $actions): static
     {
+        $this->bulkActions = [];
+        $this->pushBulkActions($actions);
+
+        return $this;
+    }
+
+    /**
+     * @param  array<BulkAction | ActionGroup> | ActionGroup  $actions
+     */
+    public function pushBulkActions(array | ActionGroup $actions): static
+    {
         foreach (Arr::wrap($actions) as $action) {
             $action->table($this);
 

--- a/packages/tables/src/Table/Concerns/HasColumns.php
+++ b/packages/tables/src/Table/Concerns/HasColumns.php
@@ -10,8 +10,6 @@ use InvalidArgumentException;
 
 trait HasColumns
 {
-    protected ?ColumnLayoutComponent $collapsibleColumnsLayout = null;
-
     /**
      * @var array<string, Column>
      */
@@ -22,12 +20,28 @@ trait HasColumns
      */
     protected array $columnsLayout = [];
 
+    protected ?ColumnLayoutComponent $collapsibleColumnsLayout = null;
+
     protected bool $hasColumnsLayout = false;
 
     /**
      * @param  array<Column | ColumnLayoutComponent>  $components
      */
     public function columns(array $components): static
+    {
+        $this->columns = [];
+        $this->columnsLayout = [];
+        $this->collapsibleColumnsLayout = null;
+        $this->hasColumnsLayout = false;
+        $this->pushColumns($components);
+
+        return $this;
+    }
+
+    /**
+     * @param  array<Column | ColumnLayoutComponent>  $components
+     */
+    public function pushColumns(array $components): static
     {
         foreach ($components as $component) {
             $component->table($this);

--- a/packages/tables/src/Table/Concerns/HasEmptyState.php
+++ b/packages/tables/src/Table/Concerns/HasEmptyState.php
@@ -44,6 +44,17 @@ trait HasEmptyState
      */
     public function emptyStateActions(array | ActionGroup $actions): static
     {
+        $this->emptyStateActions = [];
+        $this->pushEmptyStateActions($actions);
+
+        return $this;
+    }
+
+    /**
+     * @param  array<Action | ActionGroup> | ActionGroup  $actions
+     */
+    public function pushEmptyStateActions(array | ActionGroup $actions): static
+    {
         foreach (Arr::wrap($actions) as $action) {
             $action->table($this);
 

--- a/packages/tables/src/Table/Concerns/HasFilters.php
+++ b/packages/tables/src/Table/Concerns/HasFilters.php
@@ -43,8 +43,13 @@ trait HasFilters
     /**
      * @param  array<BaseFilter>  $filters
      */
-    public function filters(array $filters, FiltersLayout | string | Closure | null $layout = null): static
+    public function filters(array | null $filters = null, FiltersLayout | string | Closure | null $layout = null): static
     {
+        if (empty($filters)) {
+            $this->filters = [];
+            return $this;
+        }
+
         foreach ($filters as $filter) {
             $filter->table($this);
 

--- a/packages/tables/src/Table/Concerns/HasFilters.php
+++ b/packages/tables/src/Table/Concerns/HasFilters.php
@@ -43,21 +43,27 @@ trait HasFilters
     /**
      * @param  array<BaseFilter>  $filters
      */
-    public function filters(array | null $filters = null, FiltersLayout | string | Closure | null $layout = null): static
+    public function filters(array $filters, FiltersLayout | string | Closure | null $layout = null): static
     {
-        if (empty($filters)) {
-            $this->filters = [];
-            return $this;
+        $this->filters = [];
+        $this->pushFilters($filters);
+
+        if ($layout) {
+            $this->filtersLayout($layout);
         }
 
+        return $this;
+    }
+
+    /**
+     * @param  array<BaseFilter>  $filters
+     */
+    public function pushFilters(array $filters): static
+    {
         foreach ($filters as $filter) {
             $filter->table($this);
 
             $this->filters[$filter->getName()] = $filter;
-        }
-
-        if ($layout) {
-            $this->filtersLayout($layout);
         }
 
         return $this;

--- a/packages/tables/src/Table/Concerns/HasHeaderActions.php
+++ b/packages/tables/src/Table/Concerns/HasHeaderActions.php
@@ -31,6 +31,21 @@ trait HasHeaderActions
      */
     public function headerActions(array | ActionGroup $actions, string | Closure | null $position = null): static
     {
+        $this->headerActions = [];
+        $this->pushHeaderActions($actions);
+
+        if ($position) {
+            $this->headerActionsPosition($position);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param  array<Action | BulkAction | ActionGroup> | ActionGroup  $actions
+     */
+    public function pushHeaderActions(array | ActionGroup $actions): static
+    {
         foreach (Arr::wrap($actions) as $action) {
             $action->table($this);
 
@@ -52,8 +67,6 @@ trait HasHeaderActions
 
             $this->headerActions[] = $action;
         }
-
-        $this->headerActionsPosition($position);
 
         return $this;
     }


### PR DESCRIPTION
Use case: have Resource table with filters, 
and in RelationManager reuse the table, but without / with different filters.

E.g.

```
#UserResource/RelationManagers/PostsRelationManager.php

public function table(Table $table): Table
{
    return PostResource::table($table)->filters(); // reused PostResource table, but without filters.
}
```

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
