### PR TITLE
Add getQuery function

### DIFF
--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -303,7 +303,8 @@ abstract class Resource
         return static::$breadcrumb ?? Str::headline(static::getPluralModelLabel());
     }
 
-    public static function getQuery(): Builder {
+    public static function getQuery(): Builder
+    {
         return static::getModel()::query();
     }
 

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -303,9 +303,13 @@ abstract class Resource
         return static::$breadcrumb ?? Str::headline(static::getPluralModelLabel());
     }
 
+    public static function getQuery(): Builder {
+        return static::getModel()::query();
+    }
+
     public static function getEloquentQuery(): Builder
     {
-        $query = static::getModel()::query();
+        $query = static::getQuery();
 
         if ($tenant = Filament::getTenant()) {
             static::scopeEloquentQueryToTenant($query, $tenant);


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Pros:

1. I'm working on a big project where i've many auth models `user`, `admin`, `patient`, `doctor`, `nurse` and many more, instead of defining the inverse relation for each model this PR makes it seamless to work with relationships.

2. Doesn't override lines `314-316` which will break multi-tenancy.

Cons:

1. On edit page it breaks and need to specify qualified key name `protected static ?string $recordRouteKeyName = 'analyses.id';` and this problem exists even when using with `getEloquentQuery`.

---

For hasMany relations

Before:
```php
// Patient -> hasMany -> Prescription
public static function getEloquentQuery(): Builder
{
    return parent::getEloquentQuery()
      ->whereBelongsTo(auth('patient')->id());
}
```

After
```php
// Cleaner
public static function getQuery(): Builder {
    return auth('patient)->user()
      ->prescriptions()
      ->getQuery();
}
```

---

For hasManyThrough relations

Before:
```php
// Patient -> hasMany -> Analyses -> through -> AnalysisRequest
public static function getEloquentQuery(): Builder
{
    return parent::getEloquentQuery()
      ->whereRelation('analysis_request', 'patient_id', auth('patient')->id());
}
```

After
```php
// Cleaner
public static function getQuery(): Builder {
    return auth('patient')->user()
        ->analyses()
        ->getQuery();
}
```