### PR TITLE
Multi-auth notifications

### DIFF
--- a/packages/notifications/src/Livewire/DatabaseNotifications.php
+++ b/packages/notifications/src/Livewire/DatabaseNotifications.php
@@ -3,6 +3,7 @@
 namespace Filament\Notifications\Livewire;
 
 use Carbon\CarbonInterface;
+use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Pagination\Paginator;
@@ -115,7 +116,7 @@ class DatabaseNotifications extends Component
 
     public function getUser(): Model | Authenticatable | null
     {
-        return auth()->user();
+        return Filament::auth()->user();
     }
 
     public function getBroadcastChannel(): ?string

--- a/packages/notifications/src/Livewire/Notifications.php
+++ b/packages/notifications/src/Livewire/Notifications.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Notifications\Livewire;
 
+use Filament\Facades\Filament;
 use Filament\Notifications\Collection;
 use Filament\Notifications\Notification;
 use Filament\Support\Enums\Alignment;
@@ -82,7 +83,7 @@ class Notifications extends Component
 
     public function getUser(): Model | Authenticatable | null
     {
-        return auth()->user();
+        return Filament::auth()->user();
     }
 
     public function getBroadcastChannel(): ?string


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.