### PR TITLE
Update RelationManager.php

### DIFF
--- a/packages/panels/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManager.php
@@ -248,7 +248,7 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
         $model = $ownerRecord->{static::getRelationshipName()}()->getQuery()->getModel()::class;
 
         try {
-            return authorize('viewAll', $model, static::shouldCheckPolicyExistence())->allowed();
+            return authorize('viewAny', $model, static::shouldCheckPolicyExistence())->allowed();
         } catch (AuthorizationException $exception) {
             return $exception->toResponse()->allowed();
         }


### PR DESCRIPTION
Closes #8089 

Fixes the relation manager's `canVewRecord()` method which was trying to authorize against `viewAll` when it should be `viewAny`. 
