### PR TITLE
Add actions modals to simple page

### DIFF
--- a/packages/panels/resources/views/components/page/simple.blade.php
+++ b/packages/panels/resources/views/components/page/simple.blade.php
@@ -13,4 +13,8 @@
 
         {{ $slot }}
     </section>
+
+    @if (! $this instanceof \Filament\Tables\Contracts\HasTable)
+        <x-filament-actions::modals />
+    @endif
 </div>


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This PR aims to allow the use of action modals for the `SimplePage`.

I believe that this is particularly useful. For example, I'm creating a "Password Expired" page where the users can either update their password *or* waive the update for now. And when they choose to waive, I'll show a confirmation modal.