### PR TITLE
Truncate parameter for badge in text column

### DIFF
--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -5,6 +5,7 @@
     'icon' => null,
     'iconPosition' => 'before',
     'size' => 'md',
+    'canTruncateBadge' => true,
 ])
 
 @php
@@ -56,7 +57,7 @@
     @endif
 
     <span class="grid">
-        <span class="truncate">
+        <span @class(["truncate" => $canTruncateBadge])>
             {{ $slot }}
         </span>
     </span>

--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -34,6 +34,15 @@ TextColumn::make('status')
 
 <AutoScreenshot name="tables/columns/text/badge" alt="Text column as badge" version="3.x" />
 
+By default, badge content will be truncated to maintain the column width as necessary. You can prevent this behavior by adding `truncate` parameter as false to the method:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('status')
+    ->badge(truncate: false)
+```
+
 You may add other things to the badge, like an [icon](#adding-an-icon).
 
 ## Displaying a description

--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -104,6 +104,7 @@
                             :color="$color"
                             :icon="$icon"
                             :icon-position="$iconPosition"
+                            :can-truncate-badge="$canTruncateBadge()"
                         >
                             {{ $formattedState }}
                         </x-filament::badge>

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -22,6 +22,8 @@ class TextColumn extends Column
      */
     protected string $view = 'filament-tables::columns.text-column';
 
+    protected bool | Closure $canTruncateBadge = true;
+
     protected bool | Closure $canWrap = false;
 
     protected bool | Closure $isBadge = false;
@@ -34,9 +36,11 @@ class TextColumn extends Column
 
     protected TextColumnSize | string | Closure | null $size = null;
 
-    public function badge(bool | Closure $condition = true): static
+    public function badge(bool | Closure $condition = true, bool | Closure $truncate = true): static
     {
         $this->isBadge = $condition;
+
+        $this->canTruncateBadge = $truncate;
 
         return $this;
     }
@@ -97,6 +101,11 @@ class TextColumn extends Column
     public function canWrap(): bool
     {
         return (bool) $this->evaluate($this->canWrap);
+    }
+
+    public function canTruncateBadge(): bool
+    {
+        return (bool) $this->evaluate($this->canTruncateBadge);
     }
 
     public function isBadge(): bool


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

### Add `truncate` parameter to `badge()` method.
I'm not sure why badge should use truncate class as it will be very hard to see the content if it is truncated, and unfortunately there's no tooltip to help. In the other side, I think the reason behind using badge is simply "for a better appearance", then truncated text of badge is really nonsense for that reason. At this point, I really want to make truncate class is not used by default.

However, this change keeps the default badge to use truncate class so it won't change the previous behavior.

Before:
![image](https://github.com/filamentphp/filament/assets/26832856/9682840d-532c-4760-ab28-b400bc726a82)
_Wait, also check the icons become smaller there, we can fix it later._

After (with `truncate: false` parameter):
```php
use Filament\Tables\Columns\TextColumn;

TextColumn::make('status')
    ->badge(truncate: false),
// ...
```
![image](https://github.com/filamentphp/filament/assets/26832856/4a291e29-12b6-4d5f-93c5-98d369af9939)

