### PR TITLE
add configuration support for Page title without Action name as prefix

### DIFF
--- a/packages/panels/docs/09-configuration.md
+++ b/packages/panels/docs/09-configuration.md
@@ -115,7 +115,7 @@ public function panel(Panel $panel): Panel
 
 ## Hiding the action in title for View / Edit pages
 
-By default, Filament will prefix the page title with the action (e.g. "View John Doe"). It is possible to manually [override the title per page](pages#customizing-the-page-title), e.g. to return only the title of the object: `return $this->getRecordTitle();`.
+By default, Filament will prefix the page title with the action (e.g. "View John Doe"). It is possible to manually [override the title per page](pages#customizing-the-page-title), e.g. override `public function getTitle()` to return only the title of the object: `return $this->getRecordTitle();`.
 
 If you don't want to display the action in the title for any of the View/Edit pages (e.g. show only "John Doe"), you can add this to the Panel configuration:
 

--- a/packages/panels/docs/09-configuration.md
+++ b/packages/panels/docs/09-configuration.md
@@ -112,3 +112,20 @@ public function panel(Panel $panel): Panel
         ->maxContentWidth('full');
 }
 ```
+
+## Hiding the action in title for View / Edit pages
+
+By default, Filament will prefix the page title with the action (e.g. "View John Doe"). It is possible to manually [override the title per page](pages#customizing-the-page-title), e.g. to return only the title of the object: `return $this->getRecordTitle();`.
+
+If you don't want to display the action in the title for any of the View/Edit pages (e.g. show only "John Doe"), you can add this to the Panel configuration:
+
+```php
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->titleAction(showAction: false);
+}
+```

--- a/packages/panels/src/Facades/Filament.php
+++ b/packages/panels/src/Facades/Filament.php
@@ -98,6 +98,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static bool hasTenantBilling()
  * @method static bool hasTenantProfile()
  * @method static bool hasTenantRegistration()
+ * @method static bool hasTitleAction()
  * @method static bool hasTopNavigation()
  * @method static bool isServing()
  * @method static bool isSidebarCollapsibleOnDesktop()

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -565,6 +565,11 @@ class FilamentManager
         return $this->getCurrentPanel()->hasTenantRegistration();
     }
 
+    public function hasTitleAction(): bool
+    {
+        return $this->getCurrentPanel()->hasTitleAction();
+    }
+
     public function hasTopNavigation(): bool
     {
         return $this->getCurrentPanel()->hasTopNavigation();

--- a/packages/panels/src/Panel.php
+++ b/packages/panels/src/Panel.php
@@ -31,6 +31,7 @@ class Panel extends Component
     use Panel\Concerns\HasSidebar;
     use Panel\Concerns\HasTenancy;
     use Panel\Concerns\HasTheme;
+    use Panel\Concerns\HasTitleAction;
     use Panel\Concerns\HasTopNavigation;
     use Panel\Concerns\HasUserMenu;
 

--- a/packages/panels/src/Panel/Concerns/HasTitleAction.php
+++ b/packages/panels/src/Panel/Concerns/HasTitleAction.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Filament\Panel\Concerns;
+
+trait HasTitleAction
+{
+    protected bool $hasTitleAction = true;
+
+    public function titleAction(bool $showAction = true): static
+    {
+        $this->hasTitleAction = $showAction;
+
+        return $this;
+    }
+
+    public function hasTitleAction(): bool
+    {
+        return $this->hasTitleAction;
+    }
+}

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -268,6 +268,10 @@ class EditRecord extends Page
             return static::$title;
         }
 
+        if (!filament()->hasTitleAction()) {
+            return $this->getRecordTitle();
+        }
+
         return __('filament-panels::resources/pages/edit-record.title', [
             'label' => $this->getRecordTitle(),
         ]);

--- a/packages/panels/src/Resources/Pages/ViewRecord.php
+++ b/packages/panels/src/Resources/Pages/ViewRecord.php
@@ -178,6 +178,10 @@ class ViewRecord extends Page implements HasInfolists
             return static::$title;
         }
 
+        if (!filament()->hasTitleAction()) {
+            return $this->getRecordTitle();
+        }
+
         return __('filament-panels::resources/pages/view-record.title', [
             'label' => $this->getRecordTitle(),
         ]);


### PR DESCRIPTION
Triggered by https://github.com/filamentphp/filament/discussions/8108.

It is possible to manually override a specific Page title to only show the record title (e.g. "John Doe") instead of getting the Action name prefixed (e.g. "View John Doe").

This PR adds configuration support so that the Action name is not shown in the title of any View / Edit page.
```
    return $panel
        // ...
        ->titleAction(showAction: false);
```

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
