### PR TITLE
Prevent hidden navigation items from being rendered

### DIFF
--- a/packages/panels/resources/views/components/sidebar/group.blade.php
+++ b/packages/panels/resources/views/components/sidebar/group.blade.php
@@ -65,22 +65,20 @@
         class="fi-sidebar-group-items flex flex-col gap-y-1"
     >
         @foreach ($items as $item)
-            @if ($item->isVisible())
-                <x-filament-panels::sidebar.item
-                    :active-icon="$item->getActiveIcon()"
-                    :active="$item->isActive()"
-                    :badge-color="$item->getBadgeColor()"
-                    :badge="$item->getBadge()"
-                    :first="$loop->first"
-                    :grouped="filled($label)"
-                    :icon="$item->getIcon()"
-                    :last="$loop->last"
-                    :should-open-url-in-new-tab="$item->shouldOpenUrlInNewTab()"
-                    :url="$item->getUrl()"
-                >
-                    {{ $item->getLabel() }}
-                </x-filament-panels::sidebar.item>
-            @endif
+            <x-filament-panels::sidebar.item
+                :active-icon="$item->getActiveIcon()"
+                :active="$item->isActive()"
+                :badge-color="$item->getBadgeColor()"
+                :badge="$item->getBadge()"
+                :first="$loop->first"
+                :grouped="filled($label)"
+                :icon="$item->getIcon()"
+                :last="$loop->last"
+                :should-open-url-in-new-tab="$item->shouldOpenUrlInNewTab()"
+                :url="$item->getUrl()"
+            >
+                {{ $item->getLabel() }}
+            </x-filament-panels::sidebar.item>
         @endforeach
     </ul>
 </li>

--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -80,22 +80,24 @@
 
                                 <x-filament::dropdown.list>
                                     @foreach ($group->getItems() as $item)
-                                        @php
-                                            $icon = $item->getIcon();
-                                            $shouldOpenUrlInNewTab = $item->shouldOpenUrlInNewTab();
-                                        @endphp
+                                        @if ($item->isVisible())
+                                            @php
+                                                $icon = $item->getIcon();
+                                                $shouldOpenUrlInNewTab = $item->shouldOpenUrlInNewTab();
+                                            @endphp
 
-                                        <x-filament::dropdown.list.item
-                                            :badge="$item->getBadge()"
-                                            :badge-color="$item->getBadgeColor()"
-                                            :href="$item->getUrl()"
-                                            :icon="$item->isActive() ? ($item->getActiveIcon() ?? $icon) : $icon"
-                                            tag="a"
-                                            :target="$shouldOpenUrlInNewTab ? '_blank' : null"
-                                            {{-- :wire:navigate="$shouldOpenUrlInNewTab ? null : true" --}}
-                                        >
-                                            {{ $item->getLabel() }}
-                                        </x-filament::dropdown.list.item>
+                                            <x-filament::dropdown.list.item
+                                                :badge="$item->getBadge()"
+                                                :badge-color="$item->getBadgeColor()"
+                                                :href="$item->getUrl()"
+                                                :icon="$item->isActive() ? ($item->getActiveIcon() ?? $icon) : $icon"
+                                                tag="a"
+                                                :target="$shouldOpenUrlInNewTab ? '_blank' : null"
+                                                {{-- :wire:navigate="$shouldOpenUrlInNewTab ? null : true" --}}
+                                            >
+                                                {{ $item->getLabel() }}
+                                            </x-filament::dropdown.list.item>
+                                        @endif
                                     @endforeach
                                 </x-filament::dropdown.list>
                             </x-filament::dropdown>

--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -80,24 +80,22 @@
 
                                 <x-filament::dropdown.list>
                                     @foreach ($group->getItems() as $item)
-                                        @if ($item->isVisible())
-                                            @php
-                                                $icon = $item->getIcon();
-                                                $shouldOpenUrlInNewTab = $item->shouldOpenUrlInNewTab();
-                                            @endphp
+                                        @php
+                                            $icon = $item->getIcon();
+                                            $shouldOpenUrlInNewTab = $item->shouldOpenUrlInNewTab();
+                                        @endphp
 
-                                            <x-filament::dropdown.list.item
-                                                :badge="$item->getBadge()"
-                                                :badge-color="$item->getBadgeColor()"
-                                                :href="$item->getUrl()"
-                                                :icon="$item->isActive() ? ($item->getActiveIcon() ?? $icon) : $icon"
-                                                tag="a"
-                                                :target="$shouldOpenUrlInNewTab ? '_blank' : null"
-                                                {{-- :wire:navigate="$shouldOpenUrlInNewTab ? null : true" --}}
-                                            >
-                                                {{ $item->getLabel() }}
-                                            </x-filament::dropdown.list.item>
-                                        @endif
+                                        <x-filament::dropdown.list.item
+                                            :badge="$item->getBadge()"
+                                            :badge-color="$item->getBadgeColor()"
+                                            :href="$item->getUrl()"
+                                            :icon="$item->isActive() ? ($item->getActiveIcon() ?? $icon) : $icon"
+                                            tag="a"
+                                            :target="$shouldOpenUrlInNewTab ? '_blank' : null"
+                                            {{-- :wire:navigate="$shouldOpenUrlInNewTab ? null : true" --}}
+                                        >
+                                            {{ $item->getLabel() }}
+                                        </x-filament::dropdown.list.item>
                                     @endforeach
                                 </x-filament::dropdown.list>
                             </x-filament::dropdown>

--- a/packages/panels/src/Panel/Concerns/HasNavigation.php
+++ b/packages/panels/src/Panel/Concerns/HasNavigation.php
@@ -158,6 +158,7 @@ trait HasNavigation
 
                 return $sort;
             })
+            ->filter(fn (NavigationGroup $group): bool => $group->getItems()->some->isVisible())
             ->all();
     }
 

--- a/packages/panels/src/Panel/Concerns/HasNavigation.php
+++ b/packages/panels/src/Panel/Concerns/HasNavigation.php
@@ -158,7 +158,7 @@ trait HasNavigation
 
                 return $sort;
             })
-            ->filter(fn (NavigationGroup $group): bool => $group->getItems()->some->isVisible())
+            ->filter(fn (NavigationGroup $group): bool => collect($group->getItems())->some->isVisible())
             ->all();
     }
 

--- a/packages/panels/src/Panel/Concerns/HasNavigation.php
+++ b/packages/panels/src/Panel/Concerns/HasNavigation.php
@@ -100,6 +100,7 @@ trait HasNavigation
         }
 
         return collect($this->getNavigationItems())
+            ->filter(fn (NavigationItem $item): bool => $item->isVisible())
             ->sortBy(fn (NavigationItem $item): int => $item->getSort())
             ->groupBy(fn (NavigationItem $item): ?string => $item->getGroup())
             ->map(function (Collection $items, ?string $groupIndex): NavigationGroup {
@@ -158,7 +159,6 @@ trait HasNavigation
 
                 return $sort;
             })
-            ->filter(fn (NavigationGroup $group): bool => collect($group->getItems())->some->isVisible())
             ->all();
     }
 


### PR DESCRIPTION
This PR adds `$item->isVisible()` to the top navigation menu items making sure it's visible when it should be.