### PR TITLE
Expand broadcasting config

### DIFF
--- a/packages/support/config/filament.php
+++ b/packages/support/config/filament.php
@@ -17,16 +17,16 @@ return [
     'broadcasting' => [
 
         'echo' => [
-            'broadcaster' => 'pusher',
-            'key' => env('VITE_PUSHER_APP_KEY'),
-            'cluster' => env('VITE_PUSHER_APP_CLUSTER'),
-            'wsHost' => env('VITE_PUSHER_HOST'),
-            'wsPort' => env('VITE_PUSHER_PORT'),
-            'wssPort' => env('VITE_PUSHER_PORT'),
-            // 'authEndpoint' => '/broadcasting/auth',
-            'disableStats' => true,
-            'encrypted' => true,
-        ],
+        //     'broadcaster' => 'pusher',
+        //     'key' => env('VITE_PUSHER_APP_KEY'),
+        //     'cluster' => env('VITE_PUSHER_APP_CLUSTER'),
+        //     'wsHost' => env('VITE_PUSHER_HOST'),
+        //     'wsPort' => env('VITE_PUSHER_PORT'),
+        //     'wssPort' => env('VITE_PUSHER_PORT'),
+        //     'authEndpoint' => '/api/v1/broadcasting/auth',
+        //     'disableStats' => true,
+        //     'encrypted' => true,
+        // ],
 
     ],
 

--- a/packages/support/config/filament.php
+++ b/packages/support/config/filament.php
@@ -16,12 +16,17 @@ return [
 
     'broadcasting' => [
 
-        // 'echo' => [
-        //     'broadcaster' => 'pusher',
-        //     'key' => env('VITE_PUSHER_APP_KEY'),
-        //     'cluster' => env('VITE_PUSHER_APP_CLUSTER'),
-        //     'forceTLS' => true,
-        // ],
+        'echo' => [
+            'broadcaster' => 'pusher',
+            'key' => env('VITE_PUSHER_APP_KEY'),
+            'cluster' => env('VITE_PUSHER_APP_CLUSTER'),
+            'wsHost' => env('VITE_PUSHER_HOST'),
+            'wsPort' => env('VITE_PUSHER_PORT'),
+            'wssPort' => env('VITE_PUSHER_PORT'),
+            // 'authEndpoint' => '/broadcasting/auth',
+            'disableStats' => true,
+            'encrypted' => true,
+        ],
 
     ],
 

--- a/packages/support/config/filament.php
+++ b/packages/support/config/filament.php
@@ -16,7 +16,7 @@ return [
 
     'broadcasting' => [
 
-        'echo' => [
+        // 'echo' => [
         //     'broadcaster' => 'pusher',
         //     'key' => env('VITE_PUSHER_APP_KEY'),
         //     'cluster' => env('VITE_PUSHER_APP_CLUSTER'),


### PR DESCRIPTION
- [X] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

The following section is completely missing in the V3 docs: 
https://filamentphp.com/docs/2.x/admin/notifications#echo

It would be great if you could also add an example of a `.env` file, like this:
```env
PUSHER_HOST=soketi
PUSHER_PORT=6001
PUSHER_SCHEME=http
PUSHER_APP_ID=app-id
PUSHER_APP_KEY=app-key
PUSHER_APP_SECRET=app-secret
PUSHER_APP_CLUSTER=mt1

VITE_APP_NAME="${APP_NAME}"
VITE_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
VITE_PUSHER_HOST="${PUSHER_HOST}"
VITE_PUSHER_PORT="$(PUSHER_PORT)"
VITE_PUSHER_SCHEME="${PUSHER_SCHEME}"
VITE_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
```
The reason being, someone wanting to overrule this. For example, I'm using `ws.example.com` on port 443 with a nginx proxy to the Soketi server.

If you would like me to add this to the docs (including the `ws.example.com` example), please let me know. I didn't know if this was useful or not.