### PR TITLE
Make the home redirect route optional

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -19,6 +19,7 @@ trait HasRoutes
     protected Closure | Native | null $authenticatedTenantRoutes = null;
 
     protected string | Closure | null $homeUrl = null;
+    protected bool $needsHomeRedirectUrl = true;
 
     /**
      * @var array<string>
@@ -54,6 +55,13 @@ trait HasRoutes
     public function homeUrl(string | Closure | null $url): static
     {
         $this->homeUrl = $url;
+
+        return $this;
+    }
+
+    public function needsHomeRedirectUrl(bool $value): static
+    {
+        $this->needsHomeRedirectUrl = $value;
 
         return $this;
     }
@@ -109,6 +117,11 @@ trait HasRoutes
     public function getHomeUrl(): ?string
     {
         return $this->evaluate($this->homeUrl);
+    }
+
+    public function getNeedsHomeRedirectUrl(): bool
+    {
+        return $this->needsHomeRedirectUrl;
     }
 
     /**


### PR DESCRIPTION
This PR keeps existing functionality, but allows for the ability to skip the creation of redirect routes similar to other routes.

This is primarily helpful on secondary panels that have a dynamic element to them. Since the service provider that establishes the panel routes runs before any existing route files, a dynamic panel path takes precedence and cannot be overridden. 

