### PR TITLE
Fixed MorphToSelect\Type's titleAttribute

### DIFF
--- a/packages/forms/src/Components/MorphToSelect/Type.php
+++ b/packages/forms/src/Components/MorphToSelect/Type.php
@@ -61,9 +61,7 @@ class Type
                 $query = $component->evaluate($this->modifyOptionsQueryUsing, [
                     'query' => $query,
                 ]) ?? $query;
-            }
-
-            if (empty($query->getQuery()->orders)) {
+            } elseif (! $this->hasOptionLabelFromRecordUsingCallback() && empty($query->getQuery()->orders)) {
                 $query->orderBy($this->getTitleAttribute());
             }
 
@@ -129,9 +127,7 @@ class Type
                 $query = $component->evaluate($this->modifyOptionsQueryUsing, [
                     'query' => $query,
                 ]) ?? $query;
-            }
-
-            if (empty($query->getQuery()->orders)) {
+            } elseif (! $this->hasOptionLabelFromRecordUsingCallback() && empty($query->getQuery()->orders)) {
                 $query->orderBy($this->getTitleAttribute());
             }
 

--- a/packages/forms/src/Components/MorphToSelect/Type.php
+++ b/packages/forms/src/Components/MorphToSelect/Type.php
@@ -131,10 +131,6 @@ class Type
                 ]) ?? $query;
             }
 
-            if (! $this->hasOptionLabelFromRecordUsingCallback() && empty($query->getQuery()->orders)) {
-                $query->orderBy($this->getTitleAttribute());
-            }
-
             $keyName = $query->getModel()->getKeyName();
 
             if ($this->hasOptionLabelFromRecordUsingCallback()) {
@@ -144,6 +140,10 @@ class Type
                         $record->{$keyName} => $this->getOptionLabelFromRecord($record),
                     ])
                     ->toArray();
+            }
+
+            if (empty($query->getQuery()->orders)) {
+                $query->orderBy($this->getTitleAttribute());
             }
 
             return $query

--- a/packages/forms/src/Components/MorphToSelect/Type.php
+++ b/packages/forms/src/Components/MorphToSelect/Type.php
@@ -63,10 +63,6 @@ class Type
                 ]) ?? $query;
             }
 
-            if (! $this->hasOptionLabelFromRecordUsingCallback() && empty($query->getQuery()->orders)) {
-                $query->orderBy($this->getTitleAttribute());
-            }
-
             $isFirst = true;
             $isForcedCaseInsensitive = $this->isSearchForcedCaseInsensitive($query);
 
@@ -113,8 +109,14 @@ class Type
                     ->toArray();
             }
 
+            $titleAttribute = $this->getTitleAttribute();
+
+            if (empty($query->getQuery()->orders)) {
+                $query->orderBy($titleAttribute);
+            }
+
             return $query
-                ->pluck($this->getTitleAttribute(), $keyName)
+                ->pluck($titleAttribute, $keyName)
                 ->toArray();
         });
 
@@ -142,12 +144,14 @@ class Type
                     ->toArray();
             }
 
+            $titleAttribute = $this->getTitleAttribute();
+
             if (empty($query->getQuery()->orders)) {
-                $query->orderBy($this->getTitleAttribute());
+                $query->orderBy($titleAttribute);
             }
 
             return $query
-                ->pluck($this->getTitleAttribute(), $keyName)
+                ->pluck($titleAttribute, $keyName)
                 ->toArray();
         });
 
@@ -172,7 +176,7 @@ class Type
                 return $this->getOptionLabelFromRecord($record);
             }
 
-            return $record->getAttributeValue($this->getTitleAttribute());
+            return $record->getAttributeValue();
         });
     }
 

--- a/packages/forms/src/Components/MorphToSelect/Type.php
+++ b/packages/forms/src/Components/MorphToSelect/Type.php
@@ -176,7 +176,7 @@ class Type
                 return $this->getOptionLabelFromRecord($record);
             }
 
-            return $record->getAttributeValue();
+            return $record->getAttributeValue($this->getTitleAttribute());
         });
     }
 

--- a/packages/forms/src/Components/MorphToSelect/Type.php
+++ b/packages/forms/src/Components/MorphToSelect/Type.php
@@ -61,7 +61,9 @@ class Type
                 $query = $component->evaluate($this->modifyOptionsQueryUsing, [
                     'query' => $query,
                 ]) ?? $query;
-            } elseif (! $this->hasOptionLabelFromRecordUsingCallback() && empty($query->getQuery()->orders)) {
+            }
+
+            if (! $this->hasOptionLabelFromRecordUsingCallback() && empty($query->getQuery()->orders)) {
                 $query->orderBy($this->getTitleAttribute());
             }
 
@@ -127,7 +129,9 @@ class Type
                 $query = $component->evaluate($this->modifyOptionsQueryUsing, [
                     'query' => $query,
                 ]) ?? $query;
-            } elseif (! $this->hasOptionLabelFromRecordUsingCallback() && empty($query->getQuery()->orders)) {
+            }
+
+            if (! $this->hasOptionLabelFromRecordUsingCallback() && empty($query->getQuery()->orders)) {
                 $query->orderBy($this->getTitleAttribute());
             }
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This PR fixes a problem that occurs when using `getOptionLabelFromRecordUsing` instead of `titleAttribute` as documented in [Customizing the option labels for each morphed type](https://filamentphp.com/docs/3.x/forms/fields/select#customizing-the-option-labels-for-each-morphed-type)

Before:

It throws `MorphToSelect type [{$this->getModel()}] must have a [titleAttribute()] set.` even when using `getOptionLabelFromRecordUsing`.

After:

It doesn't throw error if you set `getOptionLabelFromRecordUsing`.