### PR TITLE
Provide configuration to SpatieTagsInput to allow original behaviour of suggestions for tags with types

### DIFF
--- a/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
+++ b/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
@@ -27,7 +27,7 @@ class SpatieTagsInput extends TagsInput
             $record->load('tags');
 
             if ($component->isAnyTagTypeAllowed()) {
-                $tags = $record->tags;
+                $tags = $record->getRelationValue('tags');
             } else {
                 $tags = $record->tagsWithType($type);
             }

--- a/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
+++ b/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
@@ -6,9 +6,7 @@ use Closure;
 use Filament\SpatieLaravelTagsPlugin\Types\AllTagTypes;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Arr;
 use Spatie\Tags\Tag;
-use Spatie\Tags\HasTags;
 
 class SpatieTagsInput extends TagsInput
 {
@@ -22,8 +20,7 @@ class SpatieTagsInput extends TagsInput
         $this->type(new AllTagTypes());
 
         $this->loadStateFromRelationshipsUsing(static function (SpatieTagsInput $component, ?Model $record): void {
-            /* @var HasTags $record */
-            if (! method_exists($record, 'tagsWithType') && method_exists($record, 'tags')) {
+            if (! method_exists($record, 'tagsWithType') || !method_exists($record, 'tags')) {
                 return;
             }
 
@@ -66,11 +63,11 @@ class SpatieTagsInput extends TagsInput
      */
     private function syncTagsWithAnyType(?Model $record, array $state): void
     {
-        /**
-         * @var HasTags $record
-         */
-        $tagClassName = $record::getTagClassName();
+        if (!$record || ! method_exists($record, 'tags')) {
+            return;
+        }
 
+        $tagClassName = config('tags.tag_model', Tag::class);
         $tags = collect($state)->map(function ($tagName) use ($tagClassName) {
             $locale = $tagClassName::getLocale();
 

--- a/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
+++ b/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
@@ -10,6 +10,7 @@ use Spatie\Tags\Tag;
 class SpatieTagsInput extends TagsInput
 {
     protected string | Closure | null $type = null;
+    protected bool $disableTypeCheckingForSuggestions = false;
 
     protected function setUp(): void
     {
@@ -50,6 +51,13 @@ class SpatieTagsInput extends TagsInput
         return $this;
     }
 
+    public function disableTypeCheckingForSuggestions(): static
+    {
+        $this->disableTypeCheckingForSuggestions = true;
+
+        return $this;
+    }
+
     /**
      * @return array<string>
      */
@@ -66,7 +74,8 @@ class SpatieTagsInput extends TagsInput
         return $tagClass::query()
             ->when(
                 filled($type),
-                fn (Builder $query) => $query->where('type', $type)
+                fn (Builder $query) => $query->where('type', $type),
+                fn (Builder $query) => $this->disableTypeCheckingForSuggestions ? $query : $query->where('type', null),
             )
             ->pluck('name')
             ->toArray();

--- a/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
+++ b/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
@@ -10,7 +10,7 @@ use Spatie\Tags\Tag;
 class SpatieTagsInput extends TagsInput
 {
     protected string | Closure | null $type = null;
-    protected bool $disableTypeCheckingForSuggestions = false;
+    protected bool $typeIsSet = false;
 
     protected function setUp(): void
     {
@@ -51,13 +51,6 @@ class SpatieTagsInput extends TagsInput
         return $this;
     }
 
-    public function disableTypeCheckingForSuggestions(): static
-    {
-        $this->disableTypeCheckingForSuggestions = true;
-
-        return $this;
-    }
-
     /**
      * @return array<string>
      */
@@ -75,7 +68,7 @@ class SpatieTagsInput extends TagsInput
             ->when(
                 filled($type),
                 fn (Builder $query) => $query->where('type', $type),
-                fn (Builder $query) => $this->disableTypeCheckingForSuggestions ? $query : $query->where('type', null),
+                fn (Builder $query) => $this->typeIsSet ? $query->where('type', null) : $query,
             )
             ->pluck('name')
             ->toArray();

--- a/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
+++ b/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
@@ -3,18 +3,22 @@
 namespace Filament\Forms\Components;
 
 use Closure;
+use Filament\SpatieLaravelTagsPlugin\Types\AllTagTypes;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Spatie\Tags\Tag;
 
 class SpatieTagsInput extends TagsInput
 {
-    protected string | Closure | null $type = null;
-    protected bool $typeIsSet = false;
+    protected string | Closure | AllTagTypes | null $type;
 
     protected function setUp(): void
     {
         parent::setUp();
+
+        //all all tag types by default:
+        $this->type(new AllTagTypes());
 
         $this->loadStateFromRelationshipsUsing(static function (SpatieTagsInput $component, ?Model $record): void {
             if (! method_exists($record, 'tagsWithType')) {
@@ -22,7 +26,14 @@ class SpatieTagsInput extends TagsInput
             }
 
             $type = $component->getType();
-            $tags = $record->load('tags')->tagsWithType($type);
+            $record->load('tags');
+
+            if($component->allowsAllTagTypes()) {
+                $tags = $record->tags;
+            }
+            else {
+                $tags = $record->tagsWithType($type);
+            }
 
             $component->state($tags->pluck('name')->toArray());
         });
@@ -32,28 +43,52 @@ class SpatieTagsInput extends TagsInput
                 return;
             }
 
-            if ($type = $component->getType()) {
+            if ($type = $component->getType() && !$component->allowsAllTagTypes()) {
                 $record->syncTagsWithType($state, $type);
 
                 return;
             }
 
-            $record->syncTags($state);
+            $component->syncTagsWithAnyType($record, $state);
         });
 
         $this->dehydrated(false);
     }
 
-    public function type(string | Closure | null $type): static
+    /**
+     * Syncs tags with the record without taking types into account. This avoids recreating existing tags with an empty type.
+     * The Spatie HasTags trait does not have functionality for this behaviour.
+     * @param Model|null $record
+     * @param array $state
+     * @return void
+     */
+    private function syncTagsWithAnyType(?Model $record, array $state){
+        $tagClassName = $record::getTagClassName();
+
+        $tags = collect($state)->map(function ($tagName) use ($tagClassName) {
+            $locale = $locale ?? $tagClassName::getLocale();
+
+            $tag = $tagClassName::findFromStringOfAnyType($tagName, $locale);
+
+            if (! $tag || $tag->isEmpty()) {
+                $tag = $tagClassName::create([
+                    'name' => [$locale => $tagName],
+                ]);
+            }
+
+            return $tag;
+        })->flatten();
+
+        $record->tags()->sync($tags->pluck('id')->toArray());
+    }
+
+    public function type(string | Closure | AllTagTypes | null $type): static
     {
         $this->type = $type;
 
         return $this;
     }
 
-    /**
-     * @return array<string>
-     */
     public function getSuggestions(): array
     {
         if ($this->suggestions !== null) {
@@ -63,19 +98,27 @@ class SpatieTagsInput extends TagsInput
         $model = $this->getModel();
         $tagClass = $model ? $model::getTagClassName() : config('tags.tag_model', Tag::class);
         $type = $this->getType();
+        $query = $tagClass::query();
 
-        return $tagClass::query()
-            ->when(
+        if(!$this->allowsAllTagTypes()){
+            $query->when(
                 filled($type),
                 fn (Builder $query) => $query->where('type', $type),
-                fn (Builder $query) => $this->typeIsSet ? $query->where('type', null) : $query,
-            )
-            ->pluck('name')
+                fn (Builder $query) => $query->where('type', null),
+            );
+        }
+
+        return $query->pluck('name')
             ->toArray();
     }
 
-    public function getType(): ?string
+    public function getType(): string | AllTagTypes | null
     {
         return $this->evaluate($this->type);
+    }
+
+    public function allowsAllTagTypes(): bool
+    {
+        return $this->getType() instanceof AllTagTypes;
     }
 }

--- a/packages/spatie-laravel-tags-plugin/src/Infolists/Components/SpatieTagsEntry.php
+++ b/packages/spatie-laravel-tags-plugin/src/Infolists/Components/SpatieTagsEntry.php
@@ -2,15 +2,20 @@
 
 namespace Filament\Infolists\Components;
 
+use Closure;
+use Filament\SpatieLaravelTagsPlugin\Types\AllTagTypes;
 use Illuminate\Support\Collection;
 
 class SpatieTagsEntry extends TextEntry
 {
-    protected ?string $type = null;
+    protected string | Closure | AllTagTypes | null $type;
 
     protected function setUp(): void
     {
         parent::setUp();
+
+        //all all tag types by default:
+        $this->type(new AllTagTypes());
 
         $this->badge();
     }
@@ -43,20 +48,32 @@ class SpatieTagsEntry extends TextEntry
         }
 
         $type = $this->getType();
-        $tags = $record->tagsWithType($type);
+        $record->load('tags');
+
+        if($this->allowsAllTagTypes()) {
+            $tags = $record->tags;
+        }
+        else {
+            $tags = $record->tagsWithType($type);
+        }
 
         return $tags->pluck('name')->toArray();
     }
 
-    public function type(?string $type): static
+    public function type(string | Closure | AllTagTypes | null $type): static
     {
         $this->type = $type;
 
         return $this;
     }
 
-    public function getType(): ?string
+    public function getType(): string | AllTagTypes | null
     {
-        return $this->type;
+        return $this->evaluate($this->type);
+    }
+
+    public function allowsAllTagTypes(): bool
+    {
+        return $this->getType() instanceof AllTagTypes;
     }
 }

--- a/packages/spatie-laravel-tags-plugin/src/Infolists/Components/SpatieTagsEntry.php
+++ b/packages/spatie-laravel-tags-plugin/src/Infolists/Components/SpatieTagsEntry.php
@@ -14,7 +14,6 @@ class SpatieTagsEntry extends TextEntry
     {
         parent::setUp();
 
-        //all all tag types by default:
         $this->type(new AllTagTypes());
 
         $this->badge();
@@ -43,20 +42,19 @@ class SpatieTagsEntry extends TextEntry
             $record = $record->getRelationValue($relationshipName);
         }
 
-        if (! method_exists($record, 'tagsWithType') || ! method_exists($record, 'tags')) {
+        if (! (method_exists($record, 'tags') && method_exists($record, 'tagsWithType'))) {
             return [];
         }
 
         $type = $this->getType();
 
-        if($this->allowsAllTagTypes()) {
+        if ($this->isAnyTagTypeAllowed()) {
             $tags = $record->tags();
-        }
-        else {
+        } else {
             $tags = $record->tagsWithType($type);
         }
 
-        return $tags->pluck('name')->toArray();
+        return $tags->pluck('name')->all();
     }
 
     public function type(string | Closure | AllTagTypes | null $type): static
@@ -71,7 +69,7 @@ class SpatieTagsEntry extends TextEntry
         return $this->evaluate($this->type);
     }
 
-    public function allowsAllTagTypes(): bool
+    public function isAnyTagTypeAllowed(): bool
     {
         return $this->getType() instanceof AllTagTypes;
     }

--- a/packages/spatie-laravel-tags-plugin/src/Infolists/Components/SpatieTagsEntry.php
+++ b/packages/spatie-laravel-tags-plugin/src/Infolists/Components/SpatieTagsEntry.php
@@ -43,15 +43,14 @@ class SpatieTagsEntry extends TextEntry
             $record = $record->getRelationValue($relationshipName);
         }
 
-        if (! method_exists($record, 'tagsWithType')) {
+        if (! method_exists($record, 'tagsWithType') || ! method_exists($record, 'tags')) {
             return [];
         }
 
         $type = $this->getType();
-        $record->load('tags');
 
         if($this->allowsAllTagTypes()) {
-            $tags = $record->tags;
+            $tags = $record->tags();
         }
         else {
             $tags = $record->tagsWithType($type);

--- a/packages/spatie-laravel-tags-plugin/src/SpatieLaravelTagsPlugin/Types/AllTagTypes.php
+++ b/packages/spatie-laravel-tags-plugin/src/SpatieLaravelTagsPlugin/Types/AllTagTypes.php
@@ -3,12 +3,8 @@
 namespace Filament\SpatieLaravelTagsPlugin\Types;
 
 /**
- * An empty type class to model that all tag types are allowed by SpatieTagsInput and SpatieTagsColumn.
- *
- * @see \Filament\Forms\Components\SpatieTagsInput
- * @see \Filament\Tables\Columns\SpatieTagsColumn
+ * An empty type class to model that all tag types are allowed on a component.
  */
 class AllTagTypes
 {
-
 }

--- a/packages/spatie-laravel-tags-plugin/src/SpatieLaravelTagsPlugin/Types/AllTagTypes.php
+++ b/packages/spatie-laravel-tags-plugin/src/SpatieLaravelTagsPlugin/Types/AllTagTypes.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Filament\SpatieLaravelTagsPlugin\Types;
+
+/**
+ * An empty type class to model that all tag types are allowed by SpatieTagsInput and SpatieTagsColumn.
+ *
+ * @see \Filament\Forms\Components\SpatieTagsInput
+ * @see \Filament\Tables\Columns\SpatieTagsColumn
+ */
+class AllTagTypes
+{
+
+}

--- a/packages/spatie-laravel-tags-plugin/src/Tables/Columns/SpatieTagsColumn.php
+++ b/packages/spatie-laravel-tags-plugin/src/Tables/Columns/SpatieTagsColumn.php
@@ -2,27 +2,27 @@
 
 namespace Filament\Tables\Columns;
 
+use Closure;
+use Filament\SpatieLaravelTagsPlugin\Types\AllTagTypes;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
 
-class SpatieTagsColumn extends TextColumn
+class SpatieTagsColumn extends TagsColumn
 {
-    protected ?string $type = null;
+    protected string | Closure | AllTagTypes | null $type = null;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->badge();
+        //all all tag types by default:
+        $this->type(new AllTagTypes());
     }
 
-    /**
-     * @return array<string>
-     */
-    public function getState(): array
+    public function getTags(): array
     {
-        $state = parent::getState();
+        $state = $this->getState();
 
         if ($state && (! $state instanceof Collection)) {
             return $state;
@@ -34,27 +34,37 @@ class SpatieTagsColumn extends TextColumn
             $record = $record->getRelationValue($this->getRelationshipName());
         }
 
-        $type = $this->getType();
-
-        if (! method_exists($record, $type ? 'tagsWithType' : 'tags')) {
+        if (! method_exists($record, 'tagsWithType')) {
             return [];
         }
 
-        $tags = $type ? $record->tagsWithType($type) : $record->tags();
+        $type = $this->getType();
+
+        if($this->allowsAllTagTypes()) {
+            $tags = $record->tags;
+        }
+        else {
+            $tags = $record->tagsWithType($type);
+        }
 
         return $tags->pluck('name')->toArray();
     }
 
-    public function type(?string $type): static
+    public function type(string | Closure | AllTagTypes | null $type): static
     {
         $this->type = $type;
 
         return $this;
     }
 
-    public function getType(): ?string
+    public function getType(): string | AllTagTypes | null
     {
-        return $this->type;
+        return $this->evaluate($this->type);
+    }
+
+    public function allowsAllTagTypes(): bool
+    {
+        return $this->getType() instanceof AllTagTypes;
     }
 
     public function applyEagerLoading(Builder | Relation $query): Builder | Relation

--- a/packages/spatie-laravel-tags-plugin/src/Tables/Columns/SpatieTagsColumn.php
+++ b/packages/spatie-laravel-tags-plugin/src/Tables/Columns/SpatieTagsColumn.php
@@ -20,6 +20,9 @@ class SpatieTagsColumn extends TagsColumn
         $this->type(new AllTagTypes());
     }
 
+    /**
+     * @return array<string>
+     */
     public function getTags(): array
     {
         $state = $this->getState();
@@ -34,18 +37,13 @@ class SpatieTagsColumn extends TagsColumn
             $record = $record->getRelationValue($this->getRelationshipName());
         }
 
-        if (! method_exists($record, 'tagsWithType')) {
+        if (! method_exists($record, 'tagsWithType') || ! method_exists($record, 'tags')) {
             return [];
         }
 
         $type = $this->getType();
 
-        if($this->allowsAllTagTypes()) {
-            $tags = $record->tags;
-        }
-        else {
-            $tags = $record->tagsWithType($type);
-        }
+        $tags = $this->allowsAllTagTypes() ? $record->tags() : $record->tagsWithType($type);
 
         return $tags->pluck('name')->toArray();
     }


### PR DESCRIPTION
@danharrin as promised in https://github.com/filamentphp/filament/pull/7374 I added an extra configuration flag to the SpatieTagsInput to be able to overwrite the old default behaviour with the new implementation.

Do you think the naming of the config variable `disableTypeCheckingForSuggestions` is clear?

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
