### PR TITLE
Provide a configuration property to determine if remove uploaded file button is shown 

### DIFF
--- a/packages/forms/docs/03-fields/09-file-upload.md
+++ b/packages/forms/docs/03-fields/09-file-upload.md
@@ -224,13 +224,13 @@ FileUpload::make('attachment')
     ->uploadProgressIndicatorPosition('left')
 ```
 
-It is also possible to hide the remove uploaded file button by using the `removable()` method:
+It is also possible to hide the remove uploaded file button by using the `deletable()` method:
 
 ```php
 use Filament\Forms\Components\FileUpload;
 
 FileUpload::make('attachment')
-    ->removable(false)
+    ->deletable(false)
 ```
 
 ## Reordering files

--- a/packages/forms/docs/03-fields/09-file-upload.md
+++ b/packages/forms/docs/03-fields/09-file-upload.md
@@ -224,15 +224,6 @@ FileUpload::make('attachment')
     ->uploadProgressIndicatorPosition('left')
 ```
 
-It is also possible to hide the remove uploaded file button by using the `deletable()` method:
-
-```php
-use Filament\Forms\Components\FileUpload;
-
-FileUpload::make('attachment')
-    ->deletable(false)
-```
-
 ## Reordering files
 
 You can also allow users to re-order uploaded files using the `reorderable()` method:
@@ -325,6 +316,17 @@ use Filament\Forms\Components\FileUpload;
 
 FileUpload::make('attachment')
     ->orientImagesFromExif(false)
+```
+
+## Hiding the remove file button
+
+It is also possible to hide the remove uploaded file button by using `deletable(false)`:
+
+```php
+use Filament\Forms\Components\FileUpload;
+
+FileUpload::make('attachment')
+    ->deletable(false)
 ```
 
 ## File upload validation

--- a/packages/forms/docs/03-fields/09-file-upload.md
+++ b/packages/forms/docs/03-fields/09-file-upload.md
@@ -224,6 +224,15 @@ FileUpload::make('attachment')
     ->uploadProgressIndicatorPosition('left')
 ```
 
+It is also possible to hide the remove uploaded file button by using the `removable()` method:
+
+```php
+use Filament\Forms\Components\FileUpload;
+
+FileUpload::make('attachment')
+    ->removable(false)
+```
+
 ## Reordering files
 
 You can also allow users to re-order uploaded files using the `reorderable()` method:

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -24,6 +24,7 @@ window.FilePond = FilePond
 
 export default function fileUploadFormComponent({
     acceptedFileTypes,
+    allowRemove,
     imageEditorEmptyFillColor,
     imageEditorMode,
     imageEditorViewportHeight,
@@ -89,6 +90,7 @@ export default function fileUploadFormComponent({
                 acceptedFileTypes,
                 allowImageExifOrientation: shouldOrientImageFromExif,
                 allowPaste: false,
+                allowRemove,
                 allowReorder: isReorderable,
                 allowImagePreview: isPreviewable,
                 allowVideoPreview: isPreviewable,

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -24,12 +24,12 @@ window.FilePond = FilePond
 
 export default function fileUploadFormComponent({
     acceptedFileTypes,
-    allowRemove,
     imageEditorEmptyFillColor,
     imageEditorMode,
     imageEditorViewportHeight,
     imageEditorViewportWidth,
     deleteUploadedFileUsing,
+    isDeletable,
     isDisabled,
     getUploadedFilesUsing,
     imageCropAspectRatio,
@@ -90,7 +90,7 @@ export default function fileUploadFormComponent({
                 acceptedFileTypes,
                 allowImageExifOrientation: shouldOrientImageFromExif,
                 allowPaste: false,
-                allowRemove,
+                allowRemove: isDeletable,
                 allowReorder: isReorderable,
                 allowImagePreview: isPreviewable,
                 allowVideoPreview: isPreviewable,

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -22,7 +22,6 @@
         ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('file-upload', 'filament/forms') }}"
         x-data="fileUploadFormComponent({
                     acceptedFileTypes: @js($getAcceptedFileTypes()),
-                    allowRemove: @js($isRemovable()),
                     imageEditorEmptyFillColor: @js($getImageEditorEmptyFillColor()),
                     imageEditorMode: @js($getImageEditorMode()),
                     imageEditorViewportHeight: @js($getImageEditorViewportHeight()),
@@ -41,6 +40,7 @@
                     imageResizeTargetWidth: @js($imageResizeTargetWidth),
                     imageResizeUpscale: @js($getImageResizeUpscale()),
                     isAvatar: @js($isAvatar),
+                    isDeletable: @js($isDeletable()),
                     isDisabled: @js($isDisabled),
                     isDownloadable: @js($isDownloadable()),
                     isOpenable: @js($isOpenable()),

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -22,6 +22,7 @@
         ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('file-upload', 'filament/forms') }}"
         x-data="fileUploadFormComponent({
                     acceptedFileTypes: @js($getAcceptedFileTypes()),
+                    allowRemove: @js($isRemovable()),
                     imageEditorEmptyFillColor: @js($getImageEditorEmptyFillColor()),
                     imageEditorMode: @js($getImageEditorMode()),
                     imageEditorViewportHeight: @js($getImageEditorViewportHeight()),

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -31,6 +31,8 @@ class BaseFileUpload extends Field
 
     protected bool | Closure $isReorderable = false;
 
+    protected bool | Closure $isRemovable = true;
+
     protected string | Closure | null $directory = null;
 
     protected string | Closure | null $diskName = null;
@@ -251,6 +253,13 @@ class BaseFileUpload extends Field
         return $this;
     }
 
+    public function removable(bool | Closure $condition = true): static
+    {
+        $this->isRemovable = $condition;
+
+        return $this;
+    }
+
     public function previewable(bool | Closure $condition = true): static
     {
         $this->isPreviewable = $condition;
@@ -446,6 +455,11 @@ class BaseFileUpload extends Field
     public function isReorderable(): bool
     {
         return (bool) $this->evaluate($this->isReorderable);
+    }
+
+    public function isRemovable(): bool
+    {
+        return (bool) $this->evaluate($this->isRemovable);
     }
 
     /**

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -23,6 +23,8 @@ class BaseFileUpload extends Field
      */
     protected array | Arrayable | Closure | null $acceptedFileTypes = null;
 
+    protected bool | Closure $isDeletable = true;
+
     protected bool | Closure $isDownloadable = false;
 
     protected bool | Closure $isOpenable = false;
@@ -30,8 +32,6 @@ class BaseFileUpload extends Field
     protected bool | Closure $isPreviewable = true;
 
     protected bool | Closure $isReorderable = false;
-
-    protected bool | Closure $isRemovable = true;
 
     protected string | Closure | null $directory = null;
 
@@ -218,6 +218,13 @@ class BaseFileUpload extends Field
         return $this;
     }
 
+    public function deletable(bool | Closure $condition = true): static
+    {
+        $this->isDeletable = $condition;
+
+        return $this;
+    }
+
     public function directory(string | Closure | null $directory): static
     {
         $this->directory = $directory;
@@ -249,13 +256,6 @@ class BaseFileUpload extends Field
     public function reorderable(bool | Closure $condition = true): static
     {
         $this->isReorderable = $condition;
-
-        return $this;
-    }
-
-    public function removable(bool | Closure $condition = true): static
-    {
-        $this->isRemovable = $condition;
 
         return $this;
     }
@@ -437,6 +437,11 @@ class BaseFileUpload extends Field
         return $this;
     }
 
+    public function isDeletable(): bool
+    {
+        return (bool) $this->evaluate($this->isDeletable);
+    }
+
     public function isDownloadable(): bool
     {
         return (bool) $this->evaluate($this->isDownloadable);
@@ -455,11 +460,6 @@ class BaseFileUpload extends Field
     public function isReorderable(): bool
     {
         return (bool) $this->evaluate($this->isReorderable);
-    }
-
-    public function isRemovable(): bool
-    {
-        return (bool) $this->evaluate($this->isRemovable);
     }
 
     /**


### PR DESCRIPTION
The idea here is simply to provide a way to hide the uploaded file button in Filepond through their constructor option `allowRemove`.

Developers that wish their file component does not show a remove button (in cases where it is not allowed to change the file, for instance) can call `removable(false)` to do so.

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
