### PR TITLE
Fixed HasExtraHeaderAttributes phpdoc

### DIFF
--- a/packages/tables/src/Columns/Concerns/HasExtraHeaderAttributes.php
+++ b/packages/tables/src/Columns/Concerns/HasExtraHeaderAttributes.php
@@ -8,12 +8,12 @@ use Illuminate\View\ComponentAttributeBag;
 trait HasExtraHeaderAttributes
 {
     /**
-     * @var array<mixed>
+     * @var array<array<mixed> | Closure>
      */
     protected array $extraHeaderAttributes = [];
 
     /**
-     * @param  array<array<mixed> | Closure>  $attributes
+     * @param  array<mixed> | Closure  $attributes
      */
     public function extraHeaderAttributes(array | Closure $attributes, bool $merge = false): static
     {


### PR DESCRIPTION
- [X] Changes have been thoroughly tested to not break existing functionality.
- [X] New functionality has been documented or existing documentation has been updated to reflect changes.
- [X] Visual changes are explained in the PR description using a screenshot/recording of before and after.

----

`extraHeaderAttributes()` doc block is wrong. Phpstan is complaining about that.

Just using the same as `HasExtraCellAttributes` which looks correct.