### PR TITLE
Fixed widget infinite loading

### DIFF
--- a/packages/support/resources/views/components/input/wrapper.blade.php
+++ b/packages/support/resources/views/components/input/wrapper.blade.php
@@ -89,7 +89,7 @@
                 wire:key="{{ \Illuminate\Support\Str::random() }}" {{-- Makes sure the loading indicator gets hidden again. --}}
             @endif
             @class([
-                'flex items-center gap-x-3 ps-3',
+                'hidden items-center gap-x-3 ps-3',
                 'pe-1' => $inlinePrefix && filled($prefix),
                 'pe-2' => $inlinePrefix && blank($prefix),
                 'border-e border-gray-200 pe-3 ps-3 dark:border-white/10' => ! $inlinePrefix,


### PR DESCRIPTION
Fixes #8175.

This PR basically changes `flex` to `hidden`.

This issue is related to livewire's styling in [FrontendAssets.php#L88](https://github.com/livewire/livewire/blob/main/src/Mechanisms/FrontendAssets/FrontendAssets.php#L88) which doesn't include `wire:loading.delay.flex` so instead set hidden by yourself.

Q: why didn't you post this issue to livewire
A:
- Basically i think because it's gonna make livewire's styles long since you can't predict the ordering of delay and the modifiers of loading directives as the examples shows on [Livewire docs](https://livewire.laravel.com/docs/loading) it doesn't dictate that you can use delay and display value.
- Search for `.delay.` in all filament files, the only place that defines `delay` and display property is in the committed file.

A better solution is to remove `delay` from `wire:loading.delay.flex` as the livewire docs doesn't dictate that you can do that and you got to remove `delay` from [wrapper.blade.php#L141](https://github.com/sakanjo/filament/blob/c35fb5a6433e47f2f5b90f8834282fc37fe9ad5a/packages/support/resources/views/components/input/wrapper.blade.php#L141) but this is not my choice it's the author's choice and i respect that.