### PR TITLE
Update textarea component for window events

### DIFF
--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -13,6 +13,8 @@
             ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('textarea', 'filament/forms') }}"
             x-data="textareaFormComponent({ initialHeight: @js($initialHeight) })"
             x-ignore
+            x-on:load.window="render()"
+            x-on:resize.window="render()"
             x-on:input="render()"
             style="height: {{ $initialHeight }}rem"
             {{ $getExtraAlpineAttributeBag() }}


### PR DESCRIPTION
Fix for issue #7620.
Added 'load' and 'resize' window event listeners to the textarea component. These changes are to ensure that, when using autosize, the textarea height is correct when the window is loaded or resized. This improves the responsiveness of the textarea component in different window sizes.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This is are the examples of how the textarea appears before the fix:
1. when typing and firing the 'input' event that calls the render() function that correctly updates the height 
![image](https://github.com/filamentphp/filament/assets/35311720/9d92c6bf-0516-4d8b-b1a6-37f846d77a47)
2. when the page is reloaded the textarea goes back to the default height
![image](https://github.com/filamentphp/filament/assets/35311720/a4e758aa-25b3-429e-86ef-fae99341575f)
3. when changing windows width the textarea does not update
![image](https://github.com/filamentphp/filament/assets/35311720/d2b3d46f-1656-4e58-ab7d-a1035a9cbcca)
![image](https://github.com/filamentphp/filament/assets/35311720/80f20677-942c-4b63-8990-645a820bb1db)
After the fix the height is always correct in both cases.
