### PR TITLE
[v2.x-forms] Fixes `CheckboxList`'s `->afterStateUpdated()` lifecycle hook

### DIFF
--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -155,7 +155,7 @@
                     wire:key="{{ $this->id }}.{{ $getStatePath() }}.{{ $field::class }}.options.{{ $optionValue }}"
                 >
                     <label
-                        class="flex items-center space-x-3 filament-forms-checkbox-list-component-option-label rtl:space-x-reverse"
+                        class="filament-forms-checkbox-list-component-option-label flex items-center space-x-3 rtl:space-x-reverse"
                         @if ($isSearchable())
                             x-show="
                                 $el.querySelector('.filament-forms-checkbox-list-component-option-label-text')

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -58,14 +58,22 @@
             },
 
             toggleAllCheckboxes: function () {
+                updatedStates = []
                 state = ! this.areAllCheckboxesChecked
 
                 this.visibleCheckboxListOptions.forEach((checkboxLabel) => {
                     checkbox = checkboxLabel.querySelector('input[type=checkbox]')
 
                     checkbox.checked = state
-                    checkbox.dispatchEvent(new Event('change'))
+
+                    if (state) {
+                        updatedStates.push(checkbox.value);
+                    }
+
+                    this.checkIfAllCheckboxesAreChecked()
                 })
+
+                @this.set(@js($getStatePath()), updatedStates);
 
                 this.areAllCheckboxesChecked = state
             },
@@ -147,7 +155,7 @@
                     wire:key="{{ $this->id }}.{{ $getStatePath() }}.{{ $field::class }}.options.{{ $optionValue }}"
                 >
                     <label
-                        class="filament-forms-checkbox-list-component-option-label flex items-center space-x-3 rtl:space-x-reverse"
+                        class="flex items-center space-x-3 filament-forms-checkbox-list-component-option-label rtl:space-x-reverse"
                         @if ($isSearchable())
                             x-show="
                                 $el.querySelector('.filament-forms-checkbox-list-component-option-label-text')
@@ -157,9 +165,6 @@
                         @endif
                     >
                         <input
-                            @if ($isBulkToggleable())
-                                x-on:change="checkIfAllCheckboxesAreChecked()"
-                            @endif
                             wire:loading.attr="disabled"
                             type="checkbox"
                             value="{{ $optionValue }}"

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -63,19 +63,18 @@
                 state = ! this.areAllCheckboxesChecked
 
                 this.visibleCheckboxListOptions.forEach((checkboxLabel) => {
-
                     checkbox = checkboxLabel.querySelector('input[type=checkbox]')
 
                     checkbox.checked = state
 
                     if (state) {
-                        updatedState.push(checkbox.value);
+                        updatedState.push(checkbox.value)
                     }
                 })
 
                 this.checkIfAllCheckboxesAreChecked()
 
-                $wire.set(@js($getStatePath()), updatedStates);
+                $wire.set(@js($getStatePath()), updatedStates)
 
                 this.areAllCheckboxesChecked = state
             },
@@ -157,7 +156,7 @@
                     wire:key="{{ $this->id }}.{{ $getStatePath() }}.{{ $field::class }}.options.{{ $optionValue }}"
                 >
                     <label
-                        class="flex items-center space-x-3 filament-forms-checkbox-list-component-option-label rtl:space-x-reverse"
+                        class="filament-forms-checkbox-list-component-option-label flex items-center space-x-3 rtl:space-x-reverse"
                         @if ($isSearchable())
                             x-show="
                                 $el.querySelector('.filament-forms-checkbox-list-component-option-label-text')

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -69,7 +69,7 @@
                     checkbox.checked = state
 
                     if (state) {
-                        updatedState.push(checkbox.value);
+                        updatedState.push(checkbox.value)
                     }
                 })
 

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -58,22 +58,24 @@
             },
 
             toggleAllCheckboxes: function () {
-                updatedStates = []
+                updatedState = []
+
                 state = ! this.areAllCheckboxesChecked
 
                 this.visibleCheckboxListOptions.forEach((checkboxLabel) => {
+
                     checkbox = checkboxLabel.querySelector('input[type=checkbox]')
 
                     checkbox.checked = state
 
                     if (state) {
-                        updatedStates.push(checkbox.value);
+                        updatedState.push(checkbox.value);
                     }
-
-                    this.checkIfAllCheckboxesAreChecked()
                 })
 
-                @this.set(@js($getStatePath()), updatedStates);
+                this.checkIfAllCheckboxesAreChecked()
+
+                $wire.set(@js($getStatePath()), updatedStates);
 
                 this.areAllCheckboxesChecked = state
             },
@@ -155,7 +157,7 @@
                     wire:key="{{ $this->id }}.{{ $getStatePath() }}.{{ $field::class }}.options.{{ $optionValue }}"
                 >
                     <label
-                        class="filament-forms-checkbox-list-component-option-label flex items-center space-x-3 rtl:space-x-reverse"
+                        class="flex items-center space-x-3 filament-forms-checkbox-list-component-option-label rtl:space-x-reverse"
                         @if ($isSearchable())
                             x-show="
                                 $el.querySelector('.filament-forms-checkbox-list-component-option-label-text')


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Dispatching change event inside the loop creates race conditions and fires the event as many times as the number of options available which makes the `state` inside the `->afterStateUpdated()` lifecycle hook inconsistent.

This PR fixes the state inconsistency without firing events by setting the state directly in one go.

Current Behavior:
![before](https://github.com/filamentphp/filament/assets/10007504/8ad21751-58da-4dbd-bb45-d32a68f06060)

Expected Behavior:
![after](https://github.com/filamentphp/filament/assets/10007504/07159c33-0a2e-4156-a7d0-d7f27c42afaa)

