### PR TITLE
Fix: drag animation on mobile

### DIFF
--- a/packages/tables/resources/views/components/reorder/handle.blade.php
+++ b/packages/tables/resources/views/components/reorder/handle.blade.php
@@ -1,4 +1,5 @@
 <x-filament::icon-button
+    class="cursor-move"
     color="gray"
     icon="heroicon-m-bars-2"
     icon-alias="tables::reorder.button"

--- a/packages/tables/resources/views/components/row.blade.php
+++ b/packages/tables/resources/views/components/row.blade.php
@@ -23,7 +23,7 @@
     @endif
     {{
         $attributes->class([
-            'fi-ta-row transition duration-0 md:duration-75',
+            'fi-ta-row transition duration-0 [@media(hover:hover)]:duration-75',
             'hover:bg-gray-50 dark:hover:bg-white/5' => $recordAction || $recordUrl,
             $stripedClasses => $striped,
         ])

--- a/packages/tables/resources/views/components/row.blade.php
+++ b/packages/tables/resources/views/components/row.blade.php
@@ -23,7 +23,7 @@
     @endif
     {{
         $attributes->class([
-            'fi-ta-row duration-0 md:duration-75',
+            'fi-ta-row transition duration-0 md:duration-75',
             'hover:bg-gray-50 dark:hover:bg-white/5' => $recordAction || $recordUrl,
             $stripedClasses => $striped,
         ])

--- a/packages/tables/resources/views/components/row.blade.php
+++ b/packages/tables/resources/views/components/row.blade.php
@@ -23,7 +23,7 @@
     @endif
     {{
         $attributes->class([
-            'fi-ta-row',
+            'fi-ta-row duration-0 md:duration-75',
             'hover:bg-gray-50 dark:hover:bg-white/5' => $recordAction || $recordUrl,
             $stripedClasses => $striped,
         ])

--- a/packages/tables/resources/views/components/row.blade.php
+++ b/packages/tables/resources/views/components/row.blade.php
@@ -23,7 +23,7 @@
     @endif
     {{
         $attributes->class([
-            'fi-ta-row transition duration-75',
+            'fi-ta-row',
             'hover:bg-gray-50 dark:hover:bg-white/5' => $recordAction || $recordUrl,
             $stripedClasses => $striped,
         ])


### PR DESCRIPTION
I have noticed that the row ghost doesn't follow the touch when moving it on mobile:

https://github.com/filamentphp/filament/assets/68746821/587a9c15-43cf-475d-a103-b8948b77882b

After removing `transition duration-75` it works fine: 

https://github.com/filamentphp/filament/assets/68746821/54deda4d-160c-4213-848b-5b9e7f34680e

Obviously `transition` and `duration-75` were there for a reason, but I couldn't see a difference.
I also change the cursor when hovering over the icon-button to `cursor-move` instead of a pointer.

Feel free to fix it the way you think is best!