### PR TITLE
Improvement: clear selected records on Tab (filter) change

### DIFF
--- a/packages/panels/resources/views/resources/pages/list-records.blade.php
+++ b/packages/panels/resources/views/resources/pages/list-records.blade.php
@@ -20,7 +20,7 @@
                         :badge="$tab->getBadge()"
                         :icon="$tab->getIcon()"
                         :icon-position="$tab->getIconPosition()"
-                        :wire:click="'$set(\'activeTab\', ' . (filled($tabKey) ? ('\'' . $tabKey . '\'') : 'null') . ')'"
+                        :wire:click="'$set(\'activeTab\', ' . (filled($tabKey) ? ('\'' . $tabKey . '\'') : 'null') . ');$dispatch(\'deselectAllTableRecords\')'"
                     >
                         {{ $tab->getLabel() ?? $this->generateTabLabel($tabKey) }}
                     </x-filament::tabs.item>

--- a/packages/panels/src/Resources/Pages/ListRecords.php
+++ b/packages/panels/src/Resources/Pages/ListRecords.php
@@ -322,7 +322,6 @@ class ListRecords extends Page implements Forms\Contracts\HasForms, Tables\Contr
             array_key_exists($this->activeTab, $tabs)
         ) {
             $tabs[$this->activeTab]->modifyQuery($query);
-            $this->deselectAllTableRecords();
         }
 
         return $query;

--- a/packages/panels/src/Resources/Pages/ListRecords.php
+++ b/packages/panels/src/Resources/Pages/ListRecords.php
@@ -322,6 +322,7 @@ class ListRecords extends Page implements Forms\Contracts\HasForms, Tables\Contr
             array_key_exists($this->activeTab, $tabs)
         ) {
             $tabs[$this->activeTab]->modifyQuery($query);
+            $this->deselectAllTableRecords();
         }
 
         return $query;


### PR DESCRIPTION
- [X] Changes have been thoroughly tested to not break existing functionality.
- [n/a] New functionality has been documented or existing documentation has been updated to reflect changes.
- [n/a] Visual changes are explained in the PR description using a screenshot/recording of before and after.

"Tab" refers to [these tabs](https://filamentphp.com/docs/3.x/panels/resources/listing-records#using-tabs-to-filter-the-records), not the the Form tabs.

Issue: when records are selected and a Tab filter is clicked, the selection is not cleared, leading to inconsistent UI states and/or confusion to which records are selected or not.

This PR deselects all table records when a Tab filter is clicked.
