### PR TITLE
non-native date-picker month dropdown dark mode

### DIFF
--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -145,7 +145,7 @@
                             <div class="flex items-center justify-between">
                                 <select
                                     x-model="focusedMonth"
-                                    class="grow cursor-pointer border-none bg-transparent p-0 text-sm font-medium text-gray-950 focus:ring-0 dark:text-white"
+                                    class="grow cursor-pointer border-none bg-transparent p-0 text-sm font-medium text-gray-950 focus:ring-0 dark:bg-gray-900 dark:text-white"
                                 >
                                     <template
                                         x-for="(month, index) in months"


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Before:
![Screenshot from 2023-09-01 12-01-15](https://github.com/filamentphp/filament/assets/28250303/6bc2e38a-af99-4f87-a0b3-dcfc0338840b)

After:
![Screenshot from 2023-09-01 12-01-27](https://github.com/filamentphp/filament/assets/28250303/a4f9fb9f-341a-409f-8374-d5521e114c94)

This fix #8208 