### PR TITLE
Fix `Group::configureUsing()` not working

### DIFF
--- a/packages/forms/src/ComponentContainer.php
+++ b/packages/forms/src/ComponentContainer.php
@@ -40,7 +40,10 @@ class ComponentContainer extends ViewComponent
 
     public static function make(HasForms $livewire): static
     {
-        return app(static::class, ['livewire' => $livewire]);
+        $static = app(static::class, ['livewire' => $livewire]);
+        $static->configure();
+
+        return $static;
     }
 
     /**

--- a/packages/forms/src/Components/Actions.php
+++ b/packages/forms/src/Components/Actions.php
@@ -29,7 +29,10 @@ class Actions extends Component
      */
     public static function make(array $actions): static
     {
-        return app(static::class, ['actions' => $actions]);
+        $static = app(static::class, ['actions' => $actions]);
+        $static->configure();
+
+        return $static;
     }
 
     /**

--- a/packages/forms/src/Components/Actions/ActionContainer.php
+++ b/packages/forms/src/Components/Actions/ActionContainer.php
@@ -18,7 +18,10 @@ class ActionContainer extends Component
 
     public static function make(Action $action): static
     {
-        return app(static::class, ['action' => $action]);
+        $static = app(static::class, ['action' => $action]);
+        $static->configure();
+
+        return $static;
     }
 
     public function getKey(): string

--- a/packages/forms/src/Components/View.php
+++ b/packages/forms/src/Components/View.php
@@ -17,6 +17,9 @@ class View extends Component
      */
     public static function make(string $view): static
     {
-        return app(static::class, ['view' => $view]);
+        $static = app(static::class, ['view' => $view]);
+        $static->configure();
+
+        return $static;
     }
 }

--- a/packages/infolists/src/ComponentContainer.php
+++ b/packages/infolists/src/ComponentContainer.php
@@ -31,7 +31,10 @@ class ComponentContainer extends ViewComponent
 
     public static function make(?Component $livewire = null): static
     {
-        return app(static::class, ['livewire' => $livewire]);
+        $static = app(static::class, ['livewire' => $livewire]);
+        $static->configure();
+
+        return $static;
     }
 
     /**

--- a/packages/infolists/src/Components/Actions.php
+++ b/packages/infolists/src/Components/Actions.php
@@ -29,7 +29,10 @@ class Actions extends Component
      */
     public static function make(array $actions): static
     {
-        return app(static::class, ['actions' => $actions]);
+        $static = app(static::class, ['actions' => $actions]);
+        $static->configure();
+
+        return $static;
     }
 
     /**

--- a/packages/infolists/src/Components/Actions/ActionContainer.php
+++ b/packages/infolists/src/Components/Actions/ActionContainer.php
@@ -15,7 +15,10 @@ class ActionContainer extends Component
 
     public static function make(Action $action): static
     {
-        return app(static::class, ['action' => $action]);
+        $static = app(static::class, ['action' => $action]);
+        $static->configure();
+
+        return $static;
     }
 
     public function getKey(): string

--- a/packages/infolists/src/Components/View.php
+++ b/packages/infolists/src/Components/View.php
@@ -17,6 +17,9 @@ class View extends Component
      */
     public static function make(string $view): static
     {
-        return app(static::class, ['view' => $view]);
+        $static = app(static::class, ['view' => $view]);
+        $static->configure();
+
+        return $static;
     }
 }

--- a/packages/panels/src/Navigation/MenuItem.php
+++ b/packages/panels/src/Navigation/MenuItem.php
@@ -31,7 +31,10 @@ class MenuItem extends Component
 
     public static function make(): static
     {
-        return app(static::class);
+        $static = app(static::class);
+        $static->configure();
+
+        return $static;
     }
 
     /**

--- a/packages/panels/src/Navigation/NavigationGroup.php
+++ b/packages/panels/src/Navigation/NavigationGroup.php
@@ -29,7 +29,10 @@ class NavigationGroup extends Component
 
     public static function make(string | Closure | null $label = null): static
     {
-        return app(static::class, ['label' => $label]);
+        $static = app(static::class, ['label' => $label]);
+        $static->configure();
+
+        return $static;
     }
 
     public function collapsed(bool | Closure $condition = true): static

--- a/packages/panels/src/Navigation/NavigationItem.php
+++ b/packages/panels/src/Navigation/NavigationItem.php
@@ -43,7 +43,10 @@ class NavigationItem extends Component
 
     public static function make(string | Closure | null $label = null): static
     {
-        return app(static::class, ['label' => $label]);
+        $static = app(static::class, ['label' => $label]);
+        $static->configure();
+
+        return $static;
     }
 
     /**

--- a/packages/tables/src/Columns/Layout/View.php
+++ b/packages/tables/src/Columns/Layout/View.php
@@ -17,6 +17,9 @@ class View extends Component
      */
     public static function make(string $view): static
     {
-        return app(static::class, ['view' => $view]);
+        $static = app(static::class, ['view' => $view]);
+        $static->configure();
+
+        return $static;
     }
 }

--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -40,7 +40,10 @@ class Group extends Component
 
     public static function make(?string $id = null): static
     {
-        return app(static::class, ['id' => $id]);
+        $static = app(static::class, ['id' => $id]);
+		$static->configure();
+		
+		return $static;
     }
 
     public function collapsible(bool $condition = true): static

--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -41,9 +41,9 @@ class Group extends Component
     public static function make(?string $id = null): static
     {
         $static = app(static::class, ['id' => $id]);
-		$static->configure();
-		
-		return $static;
+        $static->configure();
+
+        return $static;
     }
 
     public function collapsible(bool $condition = true): static


### PR DESCRIPTION
This PR fixes the `Group::configureUsing()` because the `->configure()` method was not called.