### PR TITLE
fix: convert column to string

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanBeSearchable.php
+++ b/packages/tables/src/Columns/Concerns/CanBeSearchable.php
@@ -94,6 +94,6 @@ trait CanBeSearchable
      */
     public function getDefaultSearchColumns(): array
     {
-        return [str($this->getName())->afterLast('.')];
+        return [(string) str($this->getName())->afterLast('.')];
     }
 }


### PR DESCRIPTION
Used to return stringable. Causes issues when using MongoDB. Should return string.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
