### PR TITLE
[Plugin] MediaLibrary: Honor order_column sort order when media is reorderable

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Infolists/Components/SpatieMediaLibraryImageEntry.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Infolists/Components/SpatieMediaLibraryImageEntry.php
@@ -79,6 +79,7 @@ class SpatieMediaLibraryImageEntry extends ImageEntry
 
         return $this->getRecord()->getRelationValue('media')
             ->filter(fn (Media $media): bool => blank($collection) || ($media->getAttributeValue('collection_name') === $collection))
+            ->sortBy('order_column')
             ->map(fn (Media $media): string => $media->uuid)
             ->all();
     }

--- a/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
@@ -81,6 +81,7 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
 
         return $record->getRelationValue('media')
             ->filter(fn (Media $media): bool => blank($collection) || ($media->getAttributeValue('collection_name') === $collection))
+            ->sortBy('order_column')
             ->map(fn (Media $media): string => $media->uuid)
             ->all();
     }


### PR DESCRIPTION
I've tested this by putting the `sortBy()` both above and below the `filter()` call. I feel like it'll be slightly more performant "after" the filtering.

I explored using methods in the `Spatie\MediaLibrary\MediaCollections\Models\Concerns\IsSorted` trait, but that applies to the model, not the collection, and the Filament plugin code is querying the collection data using its own bespoke relationship query.
So I think this hardcoded approach is best.

I suppose another approach could be to offer another helper method like `ordered()` to `ImageColumn`, but perhaps that's a bigger design decision to explore separately.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [N/A] New functionality has been documented or existing documentation has been updated to reflect changes.
- [N/A] Visual changes are explained in the PR description using a screenshot/recording of before and after.
