### PR TITLE
Fix grouping direction being reset when called programatically

### DIFF
--- a/packages/tables/resources/views/components/groups.blade.php
+++ b/packages/tables/resources/views/components/groups.blade.php
@@ -15,6 +15,10 @@
     }"
     x-init="
         $watch('group', function (newGroup, oldGroup) {
+            if (newGroup && direction) {
+                return
+            }
+            
             if (! newGroup) {
                 direction = null
 


### PR DESCRIPTION
When setting tableGrouping and tableGroupingDirection programatically, the current implementation was overriding the direction, resetting it to `asc`. This also meant a separate request was made. This PR adds an early return if the grouping and direction are set.

- [X] Changes have been thoroughly tested to not break existing functionality.

