### PR TITLE
Tables Text-Column: allow Descriptions to wrap

### DIFF
--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -50,7 +50,11 @@
     }}
 >
     @if (filled($descriptionAbove))
-        <p class="text-sm text-gray-500 dark:text-gray-400">
+        <p
+            @class([
+               'text-sm text-gray-500 dark:text-gray-400',
+               'whitespace-normal' => $canWrap,
+           ])>
             {{ $descriptionAbove }}
         </p>
     @endif
@@ -184,7 +188,11 @@
     </{{ $isListWithLineBreaks ? 'ul' : 'div' }}>
 
     @if (filled($descriptionBelow))
-        <p class="text-sm text-gray-500 dark:text-gray-400">
+        <p
+            @class([
+               'text-sm text-gray-500 dark:text-gray-400',
+               'whitespace-normal' => $canWrap,
+           ])>
             {{ $descriptionBelow }}
         </p>
     @endif


### PR DESCRIPTION
In a Table TextColumn, whether in a `Resource` or in a `RelationManager`, the `wrap()` directive is ineffective if the `->description()` value is the part that actually needs to wrap.

## Example code:

```php
public function table(Table $table): Table
    {
        return $table
            ->columns([
                Tables\Columns\TextColumn::make('name')
                    ->description(fn (Category $record): string => $record->description ?? '')
                    ->wrap(),
            ])
//...
```

## Screenshots: Resource Table
Before - (notice how the dropdown gets squished because of the lack of wrapping classes):
<img width="797" alt="Screen Shot 2023-09-03 at 10 10 50 PM" src="https://github.com/filamentphp/filament/assets/404472/a89fbf21-475d-46d7-92cc-bf85578f52ae">

After:
<img width="781" alt="Screen Shot 2023-09-03 at 10 11 24 PM" src="https://github.com/filamentphp/filament/assets/404472/a178f6d0-4ef1-47ce-8475-047df1d83152">


## Screenshots: RelationManager

In a `RelationManager`, horizontal scrolling is required to see table actions:

<img width="700" alt="Screen Shot 2023-09-03 at 9 57 40 PM" src="https://github.com/filamentphp/filament/assets/404472/4d4bee61-eeca-42ea-84c0-94ac632ff224">

<img width="714" alt="Screen Shot 2023-09-03 at 9 57 50 PM" src="https://github.com/filamentphp/filament/assets/404472/45277da3-7c4e-4cc2-a8d0-0af0cb14e157">

After this change, the wrapping appears as expected:

<img width="720" alt="Screen Shot 2023-09-03 at 10 00 04 PM" src="https://github.com/filamentphp/filament/assets/404472/a2d853b2-9820-488f-9482-03df19c4f49a">


- [x] Changes have been thoroughly tested to not break existing functionality.
    - [x] TO BE CLEAR: I HAVE tested exactly the scenarios above. I've not explored further.
- [n/a] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

