### PR TITLE
Always register the about data

### DIFF
--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -106,34 +106,34 @@ class SupportServiceProvider extends PackageServiceProvider
             return new Stringable(Str::sanitizeHtml($this->value));
         });
 
+        if (class_exists(InstalledVersions::class)) {
+            $packages = [
+                'filament',
+                'forms',
+                'notifications',
+                'support',
+                'tables',
+            ];
+
+            AboutCommand::add('Filament', static fn () => [
+                'Version' => InstalledVersions::getPrettyVersion('filament/support'),
+                'Packages' => collect($packages)
+                    ->filter(fn (string $package): bool => InstalledVersions::isInstalled("filament/{$package}"))
+                    ->join(', '),
+                'Views' => function () use ($packages): string {
+                    $publishedViewPaths = collect($packages)
+                        ->filter(fn (string $package): bool => is_dir(resource_path("views/vendor/{$package}")));
+
+                    if (! $publishedViewPaths->count()) {
+                        return '<fg=green;options=bold>NOT PUBLISHED</>';
+                    }
+
+                    return "<fg=red;options=bold>PUBLISHED:</> {$publishedViewPaths->join(', ')}";
+                },
+            ]);
+        }
+
         if ($this->app->runningInConsole()) {
-            if (class_exists(InstalledVersions::class)) {
-                $packages = [
-                    'filament',
-                    'forms',
-                    'notifications',
-                    'support',
-                    'tables',
-                ];
-
-                AboutCommand::add('Filament', static fn () => [
-                    'Version' => InstalledVersions::getPrettyVersion('filament/support'),
-                    'Packages' => collect($packages)
-                        ->filter(fn (string $package): bool => InstalledVersions::isInstalled("filament/{$package}"))
-                        ->join(', '),
-                    'Views' => function () use ($packages): string {
-                        $publishedViewPaths = collect($packages)
-                            ->filter(fn (string $package): bool => is_dir(resource_path("views/vendor/{$package}")));
-
-                        if (! $publishedViewPaths->count()) {
-                            return '<fg=green;options=bold>NOT PUBLISHED</>';
-                        }
-
-                        return "<fg=red;options=bold>PUBLISHED:</> {$publishedViewPaths->join(', ')}";
-                    },
-                ]);
-            }
-
             $this->publishes([
                 $this->package->basePath('/../config/filament.php') => config_path('filament.php'),
             ], 'filament-config');


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

As mentioned in the docs of Laravel the registration should be without the console check. It prevents usage outside the console.

https://laravel.com/docs/10.x/packages#about-artisan-command
