### PR TITLE
Removed unused vendor publish for the Translatable plugin's config file

### DIFF
--- a/packages/spatie-laravel-translatable-plugin/src/SpatieLaravelTranslatablePluginServiceProvider.php
+++ b/packages/spatie-laravel-translatable-plugin/src/SpatieLaravelTranslatablePluginServiceProvider.php
@@ -10,10 +10,6 @@ class SpatieLaravelTranslatablePluginServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__ . '/../config/filament-spatie-laravel-translatable-plugin.php' => config_path('filament-spatie-laravel-translatable-plugin.php'),
-            ], 'filament-spatie-laravel-translatable-plugin-config');
-
-            $this->publishes([
                 __DIR__ . '/../resources/lang' => resource_path('lang/vendor/filament-spatie-laravel-translatable-plugin-translations'),
             ], 'filament-spatie-laravel-translatable-plugin-translations');
         }


### PR DESCRIPTION
Hi,
In this PR, I removed the vendor publish for the Translatable plugin's config file, which was removed in version 3.
- [x] Changes have been thoroughly tested to not break existing functionality.