### PR TITLE
Improve Laravel Scout example

### DIFF
--- a/packages/tables/docs/10-advanced.md
+++ b/packages/tables/docs/10-advanced.md
@@ -196,21 +196,24 @@ trait InteractsWithScout
 {
     protected function applySearchToTableQuery(Builder $query): Builder
     {
-        $search = $this->getTableSearch();
-
         $this->applyColumnSearchesToTableQuery($query);
+
+        $search = $this->getTableSearch();
 
         if (blank($search)) {
             return $query;
-        }        
+        }
 
         $keys = $this->getModel()::search($search)->keys();
 
         return $query
             ->whereIn('id', $keys)
-            ->orderByRaw("FIND_IN_SET (id, ?)", [$keys->implode(',')]);
+            ->when(blank($this->getTableSortColumn()), fn (Builder $query) => $query
+                ->orderByRaw('FIND_IN_SET (id, ?)', [$keys->implode(',')])
+            );
     }
 }
+
 ```
 
 The `applyColumnSearchesToTableQuery()` method ensures that searching individual columns will still work. You can replace that method with your own implementation if you want to use Scout for those search inputs as well.


### PR DESCRIPTION
- [X] Changes have been thoroughly tested to not break existing functionality.
- [X] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This fixes https://github.com/filamentphp/filament/discussions/7697, as the result order was being parsed incorrectly.
It turns out this wasn't a Laravel issue, but I think a change in the MySQL/MariaDB parsing, and one may use `FIND_IN_SET` as a workaround.

The search will now reflect the actual Laravel Scout result order + the user is allowed to overrule the order of columns.

Please let me know if I need to make any adjustments/improvements. :)