### PR TITLE
Docs - remove the Post model

### DIFF
--- a/packages/tables/docs/11-adding-a-table-to-a-livewire-component.md
+++ b/packages/tables/docs/11-adding-a-table-to-a-livewire-component.md
@@ -38,7 +38,6 @@ There are 3 tasks when adding a table to a Livewire component class:
 
 namespace App\Livewire;
 
-use App\Models\Post;
 use App\Models\Shop\Product;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
