### PR TITLE
Fix input/select/checkbox columns state update

### DIFF
--- a/packages/tables/resources/views/columns/checkbox-column.blade.php
+++ b/packages/tables/resources/views/columns/checkbox-column.blade.php
@@ -18,7 +18,7 @@
     x-init="() => {
         Livewire.hook('commit', ({ component, commit, succeed, fail, respond }) => {
             succeed(({ snapshot, effect }) => {
-                $nextTick(()=>{
+                $nextTick(() => {
                     if (component.id !== @js($this->getId())) {
                         return
                     }

--- a/packages/tables/resources/views/columns/checkbox-column.blade.php
+++ b/packages/tables/resources/views/columns/checkbox-column.blade.php
@@ -15,27 +15,30 @@
 
         state: @js($state),
     }"
-    x-init="
+    x-init="() => {
         Livewire.hook('commit', ({ component, commit, succeed, fail, respond }) => {
             succeed(({ snapshot, effect }) => {
-                if (component.id !== @js($this->getId())) {
-                    return
-                }
+                $nextTick(()=>{
+                    if (component.id !== @js($this->getId())) {
+                        return
+                    }
 
-                if (! $refs.newState) {
-                    return
-                }
+                    if (! $refs.newState) {
+                        return
+                    }
 
-                const newState = $refs.newState.value === '1' ? true : false
+                    const newState = $refs.newState.value === '1' ? true : false
 
-                if (state === newState) {
-                    return
-                }
+                    if (state === newState) {
+                        return
+                    }
 
-                state = newState
+                    state = newState
+                })
             })
         })
-    "
+
+    }"
     {{
         $attributes
             ->merge($getExtraAttributes(), escape: false)

--- a/packages/tables/resources/views/columns/select-column.blade.php
+++ b/packages/tables/resources/views/columns/select-column.blade.php
@@ -24,7 +24,7 @@
     x-init="() => {
         Livewire.hook('commit', ({ component, commit, succeed, fail, respond }) => {
             succeed(({ snapshot, effect }) => {
-                $nextTick(()=>{
+                $nextTick(() => {
                     if (component.id !== @js($this->getId())) {
                         return
                     }

--- a/packages/tables/resources/views/columns/select-column.blade.php
+++ b/packages/tables/resources/views/columns/select-column.blade.php
@@ -21,27 +21,30 @@
 
         state: @js($state),
     }"
-    x-init="
+    x-init="() => {
         Livewire.hook('commit', ({ component, commit, succeed, fail, respond }) => {
             succeed(({ snapshot, effect }) => {
-                if (component.id !== @js($this->getId())) {
-                    return
-                }
+                $nextTick(()=>{
+                    if (component.id !== @js($this->getId())) {
+                        return
+                    }
 
-                if (! $refs.newState) {
-                    return
-                }
+                    if (! $refs.newState) {
+                        return
+                    }
 
-                let newState = $refs.newState.value
+                    let newState = $refs.newState.value
 
-                if (state === newState) {
-                    return
-                }
+                    if (state === newState) {
+                        return
+                    }
 
-                state = newState
+                    state = newState
+                })
+
             })
         })
-    "
+    }"
     {{
         $attributes
             ->merge($getExtraAttributes(), escape: false)

--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -20,31 +20,35 @@
 
         state: @js($state),
     }"
-    x-init="
+    x-init="() => {
         Livewire.hook('commit', ({ component, commit, succeed, fail, respond }) => {
             succeed(({ snapshot, effect }) => {
-                if (component.id !== @js($this->getId())) {
-                    return
-                }
+                $nextTick(()=>{
+                    if (component.id !== @js($this->getId())) {
+                        return
+                    }
 
-                if (isEditing) {
-                    return
-                }
+                    if (isEditing) {
+                        return
+                    }
 
-                if (! $refs.newState) {
-                    return
-                }
+                    if (! $refs.newState) {
+                        return
+                    }
 
-                let newState = $refs.newState.value
+                    let newState = $refs.newState.value
 
-                if (state === newState) {
-                    return
-                }
+                    if (state === newState) {
+                        return
+                    }
 
-                state = newState
+                    state = newState
+                })
+
+
             })
         })
-    "
+    }"
     {{
         $attributes
             ->merge($getExtraAttributes(), escape: false)

--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -23,7 +23,7 @@
     x-init="() => {
         Livewire.hook('commit', ({ component, commit, succeed, fail, respond }) => {
             succeed(({ snapshot, effect }) => {
-                $nextTick(()=>{
+                $nextTick(() => {
                     if (component.id !== @js($this->getId())) {
                         return
                     }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.

This PR fixes the initializiation of the commit hooks defined in the input type table columns.

The main issue here was, that when updating a value in the background, rerendering a table would not update the input/select value or the checkbox state. The simplest example is polling the table and changing the db columns value. 

The return of Livewire.hook() is a destroy or deregister function.
As stated [here](https://github.com/alpinejs/alpine/discussions/3695#discussioncomment-6645021), "the way the [Alpine] expression evaluator works, is that it will keep running any functions returned by the expression until its not a function anymore"

So it immediately destroys the commit hook after defining it in x-init.

Wrapping the init method in an arrow function solves this, and while running the callback via $nextTick the ui should update immediatly (without $nextTick an other commit is neccessery)
