### PR TITLE
Hint to run migration - Update 01-installation.md

### DIFF
--- a/packages/panels/docs/01-installation.md
+++ b/packages/panels/docs/01-installation.md
@@ -29,6 +29,8 @@ This will create and register a new [Laravel service provider](https://laravel.c
 
 > If you get an error when accessing your panel, check that the service provider was registered in your `config/app.php`. If not, you should manually add it to the `providers` array.
 
+> Started with a new Laravel installation? Run `php artisan migrate` if not done yet.
+
 ## Create a user
 You can create a new user account with the following command:
 


### PR DESCRIPTION
If a user is trying the installation guide with a new laravel installation, there is a chance that the migration has not been executed yet. But it's necessary for the next step "Create a user".
![image](https://github.com/filamentphp/filament/assets/439612/827994a5-5bc0-491a-8f36-6042d1f6aa9f)

So, giving the user a hint to run migration before trying and failing to create a user.

- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
