### PR TITLE
Add ability to set the default active tab

### DIFF
--- a/packages/panels/docs/03-resources/02-listing-records.md
+++ b/packages/panels/docs/03-resources/02-listing-records.md
@@ -76,6 +76,28 @@ Tab::make()
 
 As in the example above, this could be quite useful for showing the number of records that pass that filter.
 
+### Customizing the default tab
+
+To customize the default tab that is selected when the page is loaded, you can return the array key of the tab from the `getDefaultActiveTab()` method:
+
+```php
+use Filament\Resources\Pages\ListRecords\Tab;
+
+public function getTabs(): array
+{
+    return [
+        'all' => Tab::make(),
+        'active' => Tab::make(),
+        'inactive' => Tab::make(),
+    ];
+}
+
+public function getDefaultActiveTab(): string | int | null
+{
+    return 'active';
+}
+```
+
 ## Authorization
 
 For authorization, Filament will observe any [model policies](https://laravel.com/docs/authorization#creating-policies) that are registered in your app.

--- a/packages/panels/src/Resources/Pages/ListRecords.php
+++ b/packages/panels/src/Resources/Pages/ListRecords.php
@@ -69,7 +69,7 @@ class ListRecords extends Page implements Forms\Contracts\HasForms, Tables\Contr
             blank($this->activeTab) &&
             count($tabs = $this->getTabs())
         ) {
-            $this->activeTab = array_key_first($tabs);
+            $this->activeTab = $this->getDefaultTab($tabs);
         }
     }
 
@@ -341,6 +341,14 @@ class ListRecords extends Page implements Forms\Contracts\HasForms, Tables\Contr
     public function getTabs(): array
     {
         return [];
+    }
+
+    /**
+     * @param array<string | int, Tab> $tabs
+     */
+    public function getDefaultTab(array $tabs): string | int
+    {
+        return array_key_first($tabs);
     }
 
     public function updatedActiveTab(): void

--- a/packages/panels/src/Resources/Pages/ListRecords.php
+++ b/packages/panels/src/Resources/Pages/ListRecords.php
@@ -65,11 +65,8 @@ class ListRecords extends Page implements Forms\Contracts\HasForms, Tables\Contr
     {
         static::authorizeResourceAccess();
 
-        if (
-            blank($this->activeTab) &&
-            count($tabs = $this->getTabs())
-        ) {
-            $this->activeTab = $this->getDefaultTab($tabs);
+        if (blank($this->activeTab)) {
+            $this->activeTab = $this->getDefaultActiveTab();
         }
     }
 
@@ -343,12 +340,9 @@ class ListRecords extends Page implements Forms\Contracts\HasForms, Tables\Contr
         return [];
     }
 
-    /**
-     * @param  array<string | int, Tab>  $tabs
-     */
-    public function getDefaultTab(array $tabs): string | int
+    public function getDefaultActiveTab(): string | int | null
     {
-        return array_key_first($tabs);
+        return array_key_first($this->getTabs());
     }
 
     public function updatedActiveTab(): void

--- a/packages/panels/src/Resources/Pages/ListRecords.php
+++ b/packages/panels/src/Resources/Pages/ListRecords.php
@@ -344,7 +344,7 @@ class ListRecords extends Page implements Forms\Contracts\HasForms, Tables\Contr
     }
 
     /**
-     * @param array<string | int, Tab> $tabs
+     * @param  array<string | int, Tab>  $tabs
      */
     public function getDefaultTab(array $tabs): string | int
     {


### PR DESCRIPTION
Add the ability to overwrite the logic for setting the default active tab. 

E.g the second 'active' tab could be shown by default.  
```php
public function getDefaultTab(array $tabs): string | int
{
   return 'active';
}

public function getTabs(): array
{
    return [
        'all' => Tab::make(),
        'active' => Tab::make()
            ->modifyQueryUsing(fn (Builder $query) => $query->where('active', true)),
        'inactive' => Tab::make()
            ->modifyQueryUsing(fn (Builder $query) => $query->where('active', false)),
    ];
}
```

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
