### PR TITLE
[Spatie Media Library] fallback to original file when conversion does not exist

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Infolists/Components/SpatieMediaLibraryImageEntry.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Infolists/Components/SpatieMediaLibraryImageEntry.php
@@ -67,7 +67,7 @@ class SpatieMediaLibraryImageEntry extends ImageEntry
             }
         }
 
-        return $media->getUrl($this->getConversion());
+        return $media->getAvailableUrl([$this->getConversion()]);
     }
 
     /**

--- a/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
@@ -63,7 +63,7 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
             }
         }
 
-        return $media->getUrl($this->getConversion());
+        return $media->getAvailableUrl([$this->getConversion()]);
     }
 
     /**


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This PR will fix the broken image when the conversion file is not exist yet. 