### PR TITLE
Add missing Theme Switcher Translation for German

### DIFF
--- a/packages/panels/resources/lang/de/layout.php
+++ b/packages/panels/resources/lang/de/layout.php
@@ -40,6 +40,10 @@ return [
                 'label' => 'Light Mode einschalten',
             ],
 
+            'system' => [
+                'label' => 'Systemthema benutzen',
+            ],
+
         ],
 
     ],


### PR DESCRIPTION
This PR adds missing German Translation for Theme Switcher.