### PR TITLE
Allow passing through badge color prop in `tabs.item`

### DIFF
--- a/packages/support/resources/views/components/tabs/item.blade.php
+++ b/packages/support/resources/views/components/tabs/item.blade.php
@@ -6,6 +6,7 @@
     'active' => false,
     'alpineActive' => null,
     'badge' => null,
+    'badgeColor' => null,
     'icon' => null,
     'iconColor' => 'gray',
     'iconPosition' => IconPosition::Before,
@@ -95,7 +96,7 @@
     @endif
 
     @if (filled($badge))
-        <x-filament::badge size="sm">
+        <x-filament::badge size="sm" :color="$badgeColor">
             {{ $badge }}
         </x-filament::badge>
     @endif


### PR DESCRIPTION
This PR adds a prop to pass through the badge color to a badge on a tab item. I've had a client request for whom I've implemented tabs. One of the tabs has "Coming soon" badge and the primary color doesn't work well, so I'd like to pass through a different color.

Thanks!