### PR TITLE
Fix type of tag isn't handled correctly

### DIFF
--- a/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
+++ b/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
@@ -40,7 +40,7 @@ class SpatieTagsInput extends TagsInput
                 return;
             }
 
-            if ($type = $component->getType() && ! $component->isAnyTagTypeAllowed()) {
+            if (($type = $component->getType()) && ! $component->isAnyTagTypeAllowed()) {
                 $record->syncTagsWithType($state, $type);
 
                 return;

--- a/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
+++ b/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
@@ -40,7 +40,10 @@ class SpatieTagsInput extends TagsInput
                 return;
             }
 
-            if (($type = $component->getType()) && ! $component->isAnyTagTypeAllowed()) {
+            if (
+                ($type = $component->getType()) &&
+                (! $component->isAnyTagTypeAllowed())
+            ) {
                 $record->syncTagsWithType($state, $type);
 
                 return;


### PR DESCRIPTION
Type of tag wasn't handled correctly because of missing assignment grouping in condition. Because of that newly new tags of default type were created instead of using exiting ones.

- [X] Changes have been thoroughly tested to not break existing functionality.
