### PR TITLE
[Draft]: Add Label as fallback when `navigationSort` is not set

### DIFF
--- a/packages/panels/src/Navigation/NavigationItem.php
+++ b/packages/panels/src/Navigation/NavigationItem.php
@@ -178,9 +178,9 @@ class NavigationItem extends Component
         return $this->evaluate($this->label);
     }
 
-    public function getSort(): int
+    public function getSort(): ?int
     {
-        return $this->evaluate($this->sort) ?? -1;
+        return $this->evaluate($this->sort) ?? null;
     }
 
     public function getUrl(): ?string

--- a/packages/panels/src/Panel/Concerns/HasNavigation.php
+++ b/packages/panels/src/Panel/Concerns/HasNavigation.php
@@ -101,7 +101,7 @@ trait HasNavigation
 
         return collect($this->getNavigationItems())
             ->filter(fn (NavigationItem $item): bool => $item->isVisible())
-            ->sortBy(fn (NavigationItem $item): int => $item->getSort())
+            ->sortBy(fn (NavigationItem $item): string|int => $item->getSort() ?? $item->getLabel())
             ->groupBy(fn (NavigationItem $item): ?string => $item->getGroup())
             ->map(function (Collection $items, ?string $groupIndex): NavigationGroup {
                 if (blank($groupIndex)) {


### PR DESCRIPTION
This PR introduces a fallback for sorting navigation items when `navigationSort` is not set. It'll use `getLabel()` of the navigation item to provide a alphabetical sorting.

<img width="282" alt="Bildschirmfoto 2023-09-11 um 22 14 41" src="https://github.com/filamentphp/filament/assets/12985989/80142162-0575-4320-a2f0-5f872b6e585d">

<img width="282" alt="Bildschirmfoto 2023-09-11 um 22 16 56" src="https://github.com/filamentphp/filament/assets/12985989/0514fdda-21a6-4ae3-b93c-9d8533154be7">

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x]  New functionality has been documented or existing documentation has been updated to reflect changes.
- [x]  Visual changes are explained in the PR description using a screenshot/recording of before and after.