### PR TITLE
Added a space before exclamation mark in command outputs

### DIFF
--- a/packages/forms/src/Commands/MakeFieldCommand.php
+++ b/packages/forms/src/Commands/MakeFieldCommand.php
@@ -67,7 +67,7 @@ class MakeFieldCommand extends Command
             $this->copyStubToApp('FieldView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$field}!");
+        $this->components->info("Successfully created {$field} !");
 
         return static::SUCCESS;
     }

--- a/packages/forms/src/Commands/MakeFieldCommand.php
+++ b/packages/forms/src/Commands/MakeFieldCommand.php
@@ -67,7 +67,7 @@ class MakeFieldCommand extends Command
             $this->copyStubToApp('FieldView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$field} !");
+		$this->components->info(sprintf('Field [%s] created successfully.', $viewPath));
 
         return static::SUCCESS;
     }

--- a/packages/forms/src/Commands/MakeFormCommand.php
+++ b/packages/forms/src/Commands/MakeFormCommand.php
@@ -101,7 +101,7 @@ class MakeFormCommand extends Command
             'submitAction' => filled($model) ? ($isEditForm ? 'save' : 'create') : 'submit',
         ]);
 
-        $this->components->info("Successfully created {$component} !");
+		$this->components->info(sprintf('Form [%s] created successfully.', $viewPath));
 
         return static::SUCCESS;
     }

--- a/packages/forms/src/Commands/MakeFormCommand.php
+++ b/packages/forms/src/Commands/MakeFormCommand.php
@@ -101,7 +101,7 @@ class MakeFormCommand extends Command
             'submitAction' => filled($model) ? ($isEditForm ? 'save' : 'create') : 'submit',
         ]);
 
-        $this->components->info("Successfully created {$component}!");
+        $this->components->info("Successfully created {$component} !");
 
         return static::SUCCESS;
     }

--- a/packages/forms/src/Commands/MakeLayoutComponentCommand.php
+++ b/packages/forms/src/Commands/MakeLayoutComponentCommand.php
@@ -67,7 +67,7 @@ class MakeLayoutComponentCommand extends Command
             $this->copyStubToApp('LayoutComponentView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$component}!");
+        $this->components->info("Successfully created {$component} !");
 
         return static::SUCCESS;
     }

--- a/packages/forms/src/Commands/MakeLayoutComponentCommand.php
+++ b/packages/forms/src/Commands/MakeLayoutComponentCommand.php
@@ -67,7 +67,7 @@ class MakeLayoutComponentCommand extends Command
             $this->copyStubToApp('LayoutComponentView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$component} !");
+        $this->components->info(sprintf('Layout [%s] created successfully.', $viewPath));
 
         return static::SUCCESS;
     }

--- a/packages/infolists/src/Commands/MakeEntryCommand.php
+++ b/packages/infolists/src/Commands/MakeEntryCommand.php
@@ -67,7 +67,7 @@ class MakeEntryCommand extends Command
             $this->copyStubToApp('EntryView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$entry} !");
+        $this->components->info(sprintf('Entry [%s] created successfully.', $viewPath));
 
         return static::SUCCESS;
     }

--- a/packages/infolists/src/Commands/MakeEntryCommand.php
+++ b/packages/infolists/src/Commands/MakeEntryCommand.php
@@ -67,7 +67,7 @@ class MakeEntryCommand extends Command
             $this->copyStubToApp('EntryView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$entry}!");
+        $this->components->info("Successfully created {$entry} !");
 
         return static::SUCCESS;
     }

--- a/packages/infolists/src/Commands/MakeLayoutComponentCommand.php
+++ b/packages/infolists/src/Commands/MakeLayoutComponentCommand.php
@@ -67,7 +67,7 @@ class MakeLayoutComponentCommand extends Command
             $this->copyStubToApp('LayoutComponentView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$component}!");
+        $this->components->info(sprintf('Layout [%s] created successfully.', $viewPath));
 
         return static::SUCCESS;
     }

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -181,7 +181,7 @@ class MakePageCommand extends Command
             $this->copyStubToApp('PageView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$page}!");
+        $this->components->info("Successfully created {$page} !");
 
         if ($resource !== null) {
             $this->components->info("Make sure to register the page in `{$resourceClass}::getPages()`.");

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -181,7 +181,7 @@ class MakePageCommand extends Command
             $this->copyStubToApp('PageView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$page} !");
+        $this->components->info(sprintf('Page [%s] created successfully.', $viewPath));
 
         if ($resource !== null) {
             $this->components->info("Make sure to register the page in `{$resourceClass}::getPages()`.");

--- a/packages/panels/src/Commands/MakePanelCommand.php
+++ b/packages/panels/src/Commands/MakePanelCommand.php
@@ -55,7 +55,7 @@ class MakePanelCommand extends Command
             ));
         }
 
-        $this->components->info("Successfully created {$class}!");
+        $this->components->info("Successfully created {$class} !");
         $this->components->warn("We've attempted to register the {$class} in your [config/app.php] file as a service provider.  If you get an error while trying to access your panel then this process has probably failed. You can manually register the service provider by adding it to the [providers] array.");
 
         return static::SUCCESS;

--- a/packages/panels/src/Commands/MakePanelCommand.php
+++ b/packages/panels/src/Commands/MakePanelCommand.php
@@ -55,7 +55,8 @@ class MakePanelCommand extends Command
             ));
         }
 
-        $this->components->info("Successfully created {$class} !");
+        //$this->components->info("Successfully created {$class} !");
+		$this->components->info(sprintf('Panel [%s] created successfully.', $path));
         $this->components->warn("We've attempted to register the {$class} in your [config/app.php] file as a service provider.  If you get an error while trying to access your panel then this process has probably failed. You can manually register the service provider by adding it to the [providers] array.");
 
         return static::SUCCESS;

--- a/packages/panels/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/panels/src/Commands/MakeRelationManagerCommand.php
@@ -181,7 +181,7 @@ class MakeRelationManagerCommand extends Command
             'tableHeaderActions' => $this->indentString($tableHeaderAndEmptyStateActions, 4),
         ]);
 
-        $this->components->info("Successfully created {$managerClass}!");
+        $this->components->info("Successfully created {$managerClass} !");
 
         $this->components->info("Make sure to register the relation in `{$resource}::getRelations()`.");
 

--- a/packages/panels/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/panels/src/Commands/MakeRelationManagerCommand.php
@@ -181,7 +181,7 @@ class MakeRelationManagerCommand extends Command
             'tableHeaderActions' => $this->indentString($tableHeaderAndEmptyStateActions, 4),
         ]);
 
-        $this->components->info("Successfully created {$managerClass} !");
+		$this->components->info(sprintf('Relation Manager [%s] created successfully.', $path));
 
         $this->components->info("Make sure to register the relation in `{$resource}::getRelations()`.");
 

--- a/packages/panels/src/Commands/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/MakeResourceCommand.php
@@ -268,7 +268,7 @@ class MakeResourceCommand extends Command
             ]);
         }
 
-        $this->components->info("Successfully created {$resource}!");
+        $this->components->info("Successfully created {$resource} !");
 
         return static::SUCCESS;
     }

--- a/packages/panels/src/Commands/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/MakeResourceCommand.php
@@ -268,7 +268,7 @@ class MakeResourceCommand extends Command
             ]);
         }
 
-        $this->components->info("Successfully created {$resource} !");
+		$this->components->info(sprintf('Resource [%s] created successfully.', $resourcePath));
 
         return static::SUCCESS;
     }

--- a/packages/panels/src/Commands/MakeThemeCommand.php
+++ b/packages/panels/src/Commands/MakeThemeCommand.php
@@ -82,7 +82,7 @@ class MakeThemeCommand extends Command
             'viewPathPrefix' => $viewPathPrefix,
         ]);
 
-        $this->components->info("Successfully created resources/css/filament/{$panelId}/theme.css and resources/css/filament/{$panelId}/tailwind.config.js!");
+        $this->components->info("Successfully created resources/css/filament/{$panelId}/theme.css and resources/css/filament/{$panelId}/tailwind.config.js !");
 
         if (! file_exists(base_path('vite.config.js'))) {
             $this->components->warn('Action is required to complete the theme setup:');
@@ -101,7 +101,7 @@ class MakeThemeCommand extends Command
         if (! file_exists($postcssConfigPath)) {
             $this->copyStubToApp('ThemePostcssConfig', $postcssConfigPath);
 
-            $this->components->info('Successfully created postcss.config.js!');
+            $this->components->info('Successfully created postcss.config.js !');
         }
 
         $this->components->warn('Action is required to complete the theme setup:');

--- a/packages/panels/src/Commands/MakeThemeCommand.php
+++ b/packages/panels/src/Commands/MakeThemeCommand.php
@@ -82,7 +82,7 @@ class MakeThemeCommand extends Command
             'viewPathPrefix' => $viewPathPrefix,
         ]);
 
-        $this->components->info("Successfully created resources/css/filament/{$panelId}/theme.css and resources/css/filament/{$panelId}/tailwind.config.js !");
+        $this->components->info("Successfully created [resources/css/filament/{$panelId}/theme.css] and [resources/css/filament/{$panelId}/tailwind.config.js] !");
 
         if (! file_exists(base_path('vite.config.js'))) {
             $this->components->warn('Action is required to complete the theme setup:');
@@ -101,7 +101,7 @@ class MakeThemeCommand extends Command
         if (! file_exists($postcssConfigPath)) {
             $this->copyStubToApp('ThemePostcssConfig', $postcssConfigPath);
 
-            $this->components->info('Successfully created postcss.config.js !');
+            $this->components->info(sprintf('Successfully created [%s]', $postcssConfigPath));
         }
 
         $this->components->warn('Action is required to complete the theme setup:');

--- a/packages/spatie-laravel-settings-plugin/src/Commands/MakeSettingsPageCommand.php
+++ b/packages/spatie-laravel-settings-plugin/src/Commands/MakeSettingsPageCommand.php
@@ -57,7 +57,7 @@ class MakeSettingsPageCommand extends Command
             'settingsClass' => $settingsClass,
         ]);
 
-        $this->components->info("Successfully created {$page}!");
+        $this->components->info("Successfully created {$page} !");
 
         return static::SUCCESS;
     }

--- a/packages/spatie-laravel-settings-plugin/src/Commands/MakeSettingsPageCommand.php
+++ b/packages/spatie-laravel-settings-plugin/src/Commands/MakeSettingsPageCommand.php
@@ -57,7 +57,7 @@ class MakeSettingsPageCommand extends Command
             'settingsClass' => $settingsClass,
         ]);
 
-        $this->components->info("Successfully created {$page} !");
+		$this->components->info(sprintf('Settings Page [%s] created successfully.', $path));
 
         return static::SUCCESS;
     }

--- a/packages/support/src/Commands/InstallCommand.php
+++ b/packages/support/src/Commands/InstallCommand.php
@@ -79,7 +79,7 @@ class InstallCommand extends Command
             ));
         }
 
-        $this->components->info('Successfully created AdminPanelProvider.php!');
+        $this->components->info('Successfully created AdminPanelProvider.php !');
         $this->components->warn('We\'ve attempted to register the AdminPanelProvider in your [config/app.php] file as a service provider. If you get an error while trying to access your panel then this process has probably failed. You can manually register the service provider by adding it to the [providers] array.');
 
         return true;

--- a/packages/tables/src/Commands/MakeColumnCommand.php
+++ b/packages/tables/src/Commands/MakeColumnCommand.php
@@ -67,7 +67,7 @@ class MakeColumnCommand extends Command
             $this->copyStubToApp('ColumnView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$column}!");
+        $this->components->info("Successfully created {$column} !");
 
         return static::SUCCESS;
     }

--- a/packages/tables/src/Commands/MakeColumnCommand.php
+++ b/packages/tables/src/Commands/MakeColumnCommand.php
@@ -67,7 +67,7 @@ class MakeColumnCommand extends Command
             $this->copyStubToApp('ColumnView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$column} !");
+		$this->components->info(sprintf('Column [%s] created successfully.', $viewPath));
 
         return static::SUCCESS;
     }

--- a/packages/tables/src/Commands/MakeTableCommand.php
+++ b/packages/tables/src/Commands/MakeTableCommand.php
@@ -84,7 +84,7 @@ class MakeTableCommand extends Command
 
         $this->copyStubToApp('TableView', $viewPath);
 
-        $this->info("Successfully created {$component} !");
+		$this->components->info(sprintf('Table [%s] created successfully.', $viewPath));
 
         return static::SUCCESS;
     }

--- a/packages/tables/src/Commands/MakeTableCommand.php
+++ b/packages/tables/src/Commands/MakeTableCommand.php
@@ -84,7 +84,7 @@ class MakeTableCommand extends Command
 
         $this->copyStubToApp('TableView', $viewPath);
 
-        $this->info("Successfully created {$component}!");
+        $this->info("Successfully created {$component} !");
 
         return static::SUCCESS;
     }

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -204,7 +204,7 @@ class MakeWidgetCommand extends Command
             $this->copyStubToApp('WidgetView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$widget}!");
+        $this->components->info("Successfully created {$widget} !");
 
         if ($resource !== null) {
             $this->components->info("Make sure to register the widget in `{$resourceClass}::getWidgets()`, and then again in `getHeaderWidgets()` or `getFooterWidgets()` of any `{$resourceClass}` page.");

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -204,7 +204,7 @@ class MakeWidgetCommand extends Command
             $this->copyStubToApp('WidgetView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$widget} !");
+		$this->components->info(sprintf('Widget [%s] created successfully.', $viewPath));
 
         if ($resource !== null) {
             $this->components->info("Make sure to register the widget in `{$resourceClass}::getWidgets()`, and then again in `getHeaderWidgets()` or `getFooterWidgets()` of any `{$resourceClass}` page.");


### PR DESCRIPTION
This will make the filename clickable in VScode's terminal window to automatically open the newly created file (or at least open the search window with the filename)

- [ X ] Changes have been thoroughly tested to not break existing functionality.
