### PR TITLE
Fix ToggleColumn with icons

### DIFF
--- a/packages/tables/resources/views/columns/toggle-column.blade.php
+++ b/packages/tables/resources/views/columns/toggle-column.blade.php
@@ -102,7 +102,7 @@
                             :icon="$getOffIcon()"
                             @class([
                                 'fi-ta-toggle-off-icon h-3 w-3',
-                                match ($onColor) {
+                                match ($offColor) {
                                     'gray' => 'text-gray-400 dark:text-gray-700',
                                     default => 'text-custom-600',
                                 },

--- a/packages/tables/resources/views/columns/toggle-column.blade.php
+++ b/packages/tables/resources/views/columns/toggle-column.blade.php
@@ -89,41 +89,50 @@
                     'translate-x-0': ! state,
                 }"
             >
-                @if ($hasOffIcon())
-                    <x-filament::icon
-                        :icon="$getOffIcon()"
-                        @class([
-                            'fi-ta-toggle-off-icon h-3 w-3',
-                            match ($onColor) {
-                                'gray' => 'text-gray-400 dark:text-gray-700',
-                                default => 'text-custom-600',
-                            },
-                        ])
-                    />
-                @endif
-            </span>
+                <span
+                    class="absolute inset-0 flex h-full w-full items-center justify-center transition-opacity"
+                    aria-hidden="true"
+                    x-bind:class="{
+                        'opacity-0 ease-out duration-100': state,
+                        'opacity-100 ease-in duration-200': ! state,
+                    }"
+                >
+                    @if ($hasOffIcon())
+                        <x-filament::icon
+                            :icon="$getOffIcon()"
+                            @class([
+                                'fi-ta-toggle-off-icon h-3 w-3',
+                                match ($onColor) {
+                                    'gray' => 'text-gray-400 dark:text-gray-700',
+                                    default => 'text-custom-600',
+                                },
+                            ])
+                        />
+                    @endif
+                </span>
 
-            <span
-                class="absolute inset-0 flex h-full w-full items-center justify-center transition-opacity"
-                aria-hidden="true"
-                x-bind:class="{
-                    'opacity-100 ease-in duration-200': state,
-                    'opacity-0 ease-out duration-100': ! state,
-                }"
-            >
-                @if ($hasOnIcon())
-                    <x-filament::icon
-                        :icon="$getOnIcon()"
-                        x-cloak="x-cloak"
-                        @class([
-                            'fi-ta-toggle-on-icon h-3 w-3',
-                            match ($onColor) {
-                                'gray' => 'text-gray-400 dark:text-gray-700',
-                                default => 'text-custom-600',
-                            },
-                        ])
-                    />
-                @endif
+                <span
+                    class="absolute inset-0 flex h-full w-full items-center justify-center transition-opacity"
+                    aria-hidden="true"
+                    x-bind:class="{
+                        'opacity-100 ease-in duration-200': state,
+                        'opacity-0 ease-out duration-100': ! state,
+                    }"
+                >
+                    @if ($hasOnIcon())
+                        <x-filament::icon
+                            :icon="$getOnIcon()"
+                            x-cloak="x-cloak"
+                            @class([
+                                'fi-ta-toggle-on-icon h-3 w-3',
+                                match ($onColor) {
+                                    'gray' => 'text-gray-400 dark:text-gray-700',
+                                    default => 'text-custom-600',
+                                },
+                            ])
+                        />
+                    @endif
+                </span>
             </span>
         </button>
     </div>


### PR DESCRIPTION
Fix for #8430 
Matched toggle-column.blade.php with toggle.blade.php.
Added missing the missing `span` element that wraps the icons.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Before:
![image](https://github.com/filamentphp/filament/assets/35311720/790e64a1-974f-41db-8ef9-015244d57f1d)

After:
![image](https://github.com/filamentphp/filament/assets/35311720/20970421-d6ca-4703-8bec-1914e45e5efc)
