### PR TITLE
chore: update public asset paths

### DIFF
--- a/packages/support/src/Assets/AlpineComponent.php
+++ b/packages/support/src/Assets/AlpineComponent.php
@@ -11,7 +11,7 @@ class AlpineComponent extends Asset
 
     public function getRelativePublicPath(): string
     {
-        return "js/{$this->getPackage()}/components/{$this->getId()}.js";
+        return "vendor/{$this->getPackage()}/components/js/{$this->getId()}.js";
     }
 
     public function getSrc(): string

--- a/packages/support/src/Assets/Css.php
+++ b/packages/support/src/Assets/Css.php
@@ -45,7 +45,7 @@ class Css extends Asset
 
     public function getRelativePublicPath(): string
     {
-        return "css/{$this->getPackage()}/{$this->getId()}.css";
+        return "/vendor/{$this->getPackage()}/css/{$this->getId()}.css";
     }
 
     public function getPublicPath(): string

--- a/packages/support/src/Assets/Js.php
+++ b/packages/support/src/Assets/Js.php
@@ -108,7 +108,7 @@ class Js extends Asset
 
     public function getRelativePublicPath(): string
     {
-        return "js/{$this->getPackage()}/{$this->getId()}.js";
+        return "vendor/{$this->getPackage()}/js/{$this->getId()}.js";
     }
 
     public function getPublicPath(): string


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

For consistent placement of assets from vendors and have discussed #8415 

before :
<img width="452" alt="Screenshot 2023-09-12 at 12 02 25" src="https://github.com/filamentphp/filament/assets/37969970/1370cb30-d700-47a6-a61c-5daef0fb3bf1">

after :
<img width="459" alt="Screenshot 2023-09-13 at 04 19 48" src="https://github.com/filamentphp/filament/assets/37969970/c3b1494f-a54a-4597-bf5e-15dd27a6f11d">

<img width="427" alt="Screenshot 2023-09-13 at 04 21 11" src="https://github.com/filamentphp/filament/assets/37969970/7a071549-b0e5-45cf-a4b7-8e95f45853a9">


