### PR TITLE
Explicitly name emptyStateActions when creating relation manager

### DIFF
--- a/packages/panels/resources/views/components/sidebar/index.blade.php
+++ b/packages/panels/resources/views/components/sidebar/index.blade.php
@@ -12,12 +12,12 @@
     @if (filament()->isSidebarCollapsibleOnDesktop())
         x-cloak
         {{-- format-ignore-start --}}
-                    x-bind:class="
-                        $store.sidebar.isOpen
-                            ? @js($openSidebarClasses . ' ' . 'lg:sticky')
-                            : '-translate-x-full rtl:translate-x-full lg:sticky lg:translate-x-0 rtl:lg:-translate-x-0'
-                    "
-                    {{-- format-ignore-end --}}
+                        x-bind:class="
+                            $store.sidebar.isOpen
+                                ? @js($openSidebarClasses . ' ' . 'lg:sticky')
+                                : '-translate-x-full rtl:translate-x-full lg:sticky lg:translate-x-0 rtl:lg:-translate-x-0'
+                        "
+                        {{-- format-ignore-end --}}
     @else
         @if (filament()->hasTopNavigation())
             x-cloak
@@ -25,17 +25,17 @@
         @elseif (filament()->isSidebarFullyCollapsibleOnDesktop())
             x-cloak
             {{-- format-ignore-start --}}
-                        x-bind:class="$store.sidebar.isOpen ? @js($openSidebarClasses . ' ' . 'lg:sticky') : '-translate-x-full rtl:translate-x-full'"
-                        {{-- format-ignore-end --}}
+                            x-bind:class="$store.sidebar.isOpen ? @js($openSidebarClasses . ' ' . 'lg:sticky') : '-translate-x-full rtl:translate-x-full'"
+                            {{-- format-ignore-end --}}
         @else
             x-cloak="-lg"
             {{-- format-ignore-start --}}
-                        x-bind:class="
-                            $store.sidebar.isOpen
-                                ? @js($openSidebarClasses . ' ' . 'lg:sticky')
-                                : 'w-[--sidebar-width] -translate-x-full rtl:translate-x-full lg:sticky'
-                        "
-                        {{-- format-ignore-end --}}
+                            x-bind:class="
+                                $store.sidebar.isOpen
+                                    ? @js($openSidebarClasses . ' ' . 'lg:sticky')
+                                    : 'w-[--sidebar-width] -translate-x-full rtl:translate-x-full lg:sticky'
+                            "
+                            {{-- format-ignore-end --}}
         @endif
     @endif
     @class([

--- a/packages/panels/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/panels/src/Commands/MakeRelationManagerCommand.php
@@ -101,19 +101,24 @@ class MakeRelationManagerCommand extends Command
             return static::INVALID;
         }
 
-        $tableHeaderAndEmptyStateActions = [];
+        $tableHeaderActions = [];
+        $tableEmptyStateActions = [];
 
-        $tableHeaderAndEmptyStateActions[] = 'Tables\Actions\CreateAction::make(),';
+        $tableHeaderActions[] = 'Tables\Actions\CreateAction::make(),';
+        $tableEmptyStateActions[] = 'Tables\Actions\CreateAction::make(\'empty-state-create\'),';
 
         if ($this->option('associate')) {
-            $tableHeaderAndEmptyStateActions[] = 'Tables\Actions\AssociateAction::make(),';
+            $tableHeaderActions[] = 'Tables\Actions\AssociateAction::make(),';
+            $tableEmptyStateActions[] = 'Tables\Actions\AssociateAction::make(\'empty-state-associate\'),';
         }
 
         if ($this->option('attach')) {
-            $tableHeaderAndEmptyStateActions[] = 'Tables\Actions\AttachAction::make(),';
+            $tableHeaderActions[] = 'Tables\Actions\AttachAction::make(),';
+            $tableEmptyStateActions[] = 'Tables\Actions\AttachAction::make(\'empty-state-attach\'),';
         }
 
-        $tableHeaderAndEmptyStateActions = implode(PHP_EOL, $tableHeaderAndEmptyStateActions);
+        $tableHeaderActions = implode(PHP_EOL, $tableHeaderActions);
+        $tableEmptyStateActions = implode(PHP_EOL, $tableEmptyStateActions);
 
         $tableActions = [];
 
@@ -173,12 +178,12 @@ class MakeRelationManagerCommand extends Command
             'relationship' => $relationship,
             'tableActions' => $this->indentString($tableActions, 4),
             'tableBulkActions' => $this->indentString($tableBulkActions, 5),
-            'tableEmptyStateActions' => $this->indentString($tableHeaderAndEmptyStateActions, 4),
+            'tableEmptyStateActions' => $this->indentString($tableEmptyStateActions, 4),
             'tableFilters' => $this->indentString(
                 $this->option('soft-deletes') ? 'Tables\Filters\TrashedFilter::make()' : '//',
                 4,
             ),
-            'tableHeaderActions' => $this->indentString($tableHeaderAndEmptyStateActions, 4),
+            'tableHeaderActions' => $this->indentString($tableHeaderActions, 4),
         ]);
 
         $this->components->info("Successfully created {$managerClass}!");


### PR DESCRIPTION
If the emptyStateActions are not named, they collide with the headerActions.  So when the user sets (say) ->after() on the headerActions CreateAction ... it mysteriously doesn't work, because the (unnamed) CreateAction from emptyStateActions overwrites it.
