### PR TITLE
Fix Octane tenant navigation

### DIFF
--- a/packages/panels/src/Panel.php
+++ b/packages/panels/src/Panel.php
@@ -7,6 +7,7 @@ use Filament\Support\Components\Component;
 use Filament\Support\Facades\FilamentColor;
 use Filament\Support\Facades\FilamentIcon;
 use Filament\Support\Facades\FilamentView;
+use Illuminate\Support\Facades\Event;
 
 class Panel extends Component
 {
@@ -70,6 +71,14 @@ class Panel extends Component
 
         foreach ($this->plugins as $plugin) {
             $plugin->boot($this);
+        }
+
+        if (class_exists(\Laravel\Octane\Events\RequestTerminated::class)) {
+            Event::listen(\Laravel\Octane\Events\RequestTerminated::class, function () {
+                $this->isNavigationMounted = false;
+                $this->navigationGroups = [];
+                $this->navigationItems = [];
+            });
         }
 
         if ($callback = $this->bootUsing) {

--- a/packages/panels/src/Panel.php
+++ b/packages/panels/src/Panel.php
@@ -73,16 +73,16 @@ class Panel extends Component
             $plugin->boot($this);
         }
 
+        if ($callback = $this->bootUsing) {
+            $callback($this);
+        }
+
         if (class_exists(\Laravel\Octane\Events\RequestTerminated::class)) {
             Event::listen(\Laravel\Octane\Events\RequestTerminated::class, function () {
                 $this->isNavigationMounted = false;
                 $this->navigationGroups = [];
                 $this->navigationItems = [];
             });
-        }
-
-        if ($callback = $this->bootUsing) {
-            $callback($this);
         }
     }
 


### PR DESCRIPTION
This fixes the issues described in https://github.com/filamentphp/filament/issues/7969

It's a bit hacky. We're resetting state for [`$isNavigationMounted`](https://github.com/filamentphp/filament/blob/95ad3aa5e777381d447b3604a01bb64346e226b8/packages/panels/src/Panel/Concerns/HasNavigation.php#L13), [`$navigationGroups`](https://github.com/filamentphp/filament/blob/95ad3aa5e777381d447b3604a01bb64346e226b8/packages/panels/src/Panel/Concerns/HasNavigation.php#L18) and [`$navigationItems`](https://github.com/filamentphp/filament/blob/95ad3aa5e777381d447b3604a01bb64346e226b8/packages/panels/src/Panel/Concerns/HasNavigation.php#L23) for Octane users at the end of the request. It'd be better to refactor so they're not used statically, but it gets things working for now.