### PR TITLE
Change canView to non-static

### DIFF
--- a/packages/widgets/src/Widget.php
+++ b/packages/widgets/src/Widget.php
@@ -28,7 +28,7 @@ abstract class Widget extends Component
      */
     protected int | string | array $columnStart = [];
 
-    public static function canView(): bool
+    public function canView(): bool
     {
         return true;
     }


### PR DESCRIPTION
The canView method is not really useful as a static method because it doesn't have access to any of the information it might need to determine if the widget should be viewable or not.

Updating to non-static will allow you to override this method with some logic based on the properties in the class.
