### PR TITLE
Add renderhooks to the table builder toolbar

### DIFF
--- a/packages/support/docs/06-render-hooks.md
+++ b/packages/support/docs/06-render-hooks.md
@@ -77,6 +77,18 @@ FilamentView::registerRenderHook(
 - `panels::user-menu.profile.after` - After the profile item in the [user menu](../panels/navigation#customizing-the-user-menu)
 - `panels::user-menu.profile.before` - Before the profile item in the [user menu](../panels/navigation#customizing-the-user-menu)
 
+### Table Builder render hooks
+
+- `tables::toolbar.reorder.start` - Before the table [reorder](../tables/advanced#reordering-records) container
+- `tables::toolbar.reorder.end` - After the table [reorder](../tables/advanced#reordering-records) container
+- `tables::toolbar.groups.start` - Before the table [group](../tables/grouping) container
+- `tables::toolbar.groups.end` - After the table [group](../tables/grouping) container
+- `tables::toolbar.search.start` - Before the table [search](../tables/getting-started#making-columns-sortable-and-searchable) container
+- `tables::toolbar.search.end` - After the table [search](../tables/getting-started#making-columns-sortable-and-searchable) container
+- `tables::toolbar.columns.start` - Before the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) container
+- `tables::toolbar.columns.end` - After the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) container
+- `tables::toolbar.end` - The end of the table toolbar
+
 ## Scoping render hooks
 
 Some render hooks can be given a "scope", which allows them to only be output on a specific page or Livewire component. For instance, you might want to register a render hook for just 1 page. To do that, you can pass the class of the page or component as the second argument to `registerRenderHook()`:

--- a/packages/support/docs/06-render-hooks.md
+++ b/packages/support/docs/06-render-hooks.md
@@ -79,16 +79,18 @@ FilamentView::registerRenderHook(
 
 ### Table Builder render hooks
 
-- `tables::toolbar.start` - The start of the table toolbar, also [can be scoped](#scoping-render-hooks) to the table class
-- `tables::toolbar.end` - The end of the table toolbar, also [can be scoped](#scoping-render-hooks) to the table class
-- `tables::toolbar.reorder-trigger.before` - Before the table [reorder](../tables/advanced#reordering-records) trigger, also [can be scoped](#scoping-render-hooks) to the table class
-- `tables::toolbar.reorder-trigger.after` - After the table [reorder](../tables/advanced#reordering-records) trigger, also [can be scoped](#scoping-render-hooks) to the table class
-- `tables::toolbar.groups.before` - Before the table [group](../tables/grouping) container, also [can be scoped](#scoping-render-hooks) to the table class
-- `tables::toolbar.groups.after` - After the table [group](../tables/grouping) container, also [can be scoped](#scoping-render-hooks) to the table class
-- `tables::toolbar.search.before` - Before the table [search](../tables/getting-started#making-columns-sortable-and-searchable) container, also [can be scoped](#scoping-render-hooks) to the table class
-- `tables::toolbar.search.after` - After the table [search](../tables/getting-started#making-columns-sortable-and-searchable) container, also [can be scoped](#scoping-render-hooks) to the table class
-- `tables::toolbar.toggle-column-trigger.before` - Before the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) trigger, also [can be scoped](#scoping-render-hooks) to the table class
-- `tables::toolbar.toggle-column-trigger.after` - After the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) trigger, also [can be scoped](#scoping-render-hooks) to the table class
+All these render hooks [can be scoped](#scoping-render-hooks) to any table Livewire component class. When using the Panel Builder, these classes might be the List or Manage page of a resource, or a relation manager. Table widgets are also Livewire component classes.
+
+- `tables::toolbar.start` - The start of the table toolbar
+- `tables::toolbar.end` - The end of the table toolbar
+- `tables::toolbar.reorder-trigger.before` - Before the table [reorder](../tables/advanced#reordering-records) trigger
+- `tables::toolbar.reorder-trigger.after` - After the table [reorder](../tables/advanced#reordering-records) trigger
+- `tables::toolbar.groups.before` - Before the table [group](../tables/grouping) container
+- `tables::toolbar.groups.after` - After the table [group](../tables/grouping) container
+- `tables::toolbar.search.before` - Before the table [search](../tables/getting-started#making-columns-sortable-and-searchable) container
+- `tables::toolbar.search.after` - After the table [search](../tables/getting-started#making-columns-sortable-and-searchable) container
+- `tables::toolbar.toggle-column-trigger.before` - Before the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) trigger
+- `tables::toolbar.toggle-column-trigger.after` - After the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) trigger
 
 ## Scoping render hooks
 

--- a/packages/support/docs/06-render-hooks.md
+++ b/packages/support/docs/06-render-hooks.md
@@ -87,8 +87,8 @@ FilamentView::registerRenderHook(
 - `tables::toolbar.groups.after` - After the table [group](../tables/grouping) container, also [can be scoped](#scoping-render-hooks) to the table class
 - `tables::toolbar.search.before` - Before the table [search](../tables/getting-started#making-columns-sortable-and-searchable) container, also [can be scoped](#scoping-render-hooks) to the table class
 - `tables::toolbar.search.after` - After the table [search](../tables/getting-started#making-columns-sortable-and-searchable) container, also [can be scoped](#scoping-render-hooks) to the table class
-- `tables::toolbar.column-toggle.before` - Before the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) trigger, also [can be scoped](#scoping-render-hooks) to the table class
-- `tables::toolbar.column-toggle.after` - After the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) trigger, also [can be scoped](#scoping-render-hooks) to the table class
+- `tables::toolbar.toggle-column-trigger.before` - Before the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) trigger, also [can be scoped](#scoping-render-hooks) to the table class
+- `tables::toolbar.toggle-column-trigger.after` - After the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) trigger, also [can be scoped](#scoping-render-hooks) to the table class
 
 ## Scoping render hooks
 

--- a/packages/support/docs/06-render-hooks.md
+++ b/packages/support/docs/06-render-hooks.md
@@ -81,16 +81,16 @@ FilamentView::registerRenderHook(
 
 All these render hooks [can be scoped](#scoping-render-hooks) to any table Livewire component class. When using the Panel Builder, these classes might be the List or Manage page of a resource, or a relation manager. Table widgets are also Livewire component classes.
 
-- `tables::toolbar.start` - The start of the table toolbar
-- `tables::toolbar.end` - The end of the table toolbar
-- `tables::toolbar.reorder-trigger.before` - Before the table [reorder](../tables/advanced#reordering-records) trigger
-- `tables::toolbar.reorder-trigger.after` - After the table [reorder](../tables/advanced#reordering-records) trigger
-- `tables::toolbar.groups.before` - Before the table [group](../tables/grouping) container
-- `tables::toolbar.groups.after` - After the table [group](../tables/grouping) container
-- `tables::toolbar.search.before` - Before the table [search](../tables/getting-started#making-columns-sortable-and-searchable) container
-- `tables::toolbar.search.after` - After the table [search](../tables/getting-started#making-columns-sortable-and-searchable) container
-- `tables::toolbar.toggle-column-trigger.before` - Before the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) trigger
-- `tables::toolbar.toggle-column-trigger.after` - After the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) trigger
+- `tables::toolbar.end` - The end of the toolbar
+- `tables::toolbar.grouping-selector.after` - After the [grouping](../tables/grouping) selector
+- `tables::toolbar.grouping-selector.before` - Before the [grouping](../tables/grouping) selector
+- `tables::toolbar.reorder-trigger.after` - After the [reorder](../tables/advanced#reordering-records) trigger
+- `tables::toolbar.reorder-trigger.before` - Before the [reorder](../tables/advanced#reordering-records) trigger
+- `tables::toolbar.search.after` - After the [search](../tables/getting-started#making-columns-sortable-and-searchable) container
+- `tables::toolbar.search.before` - Before the [search](../tables/getting-started#making-columns-sortable-and-searchable) container
+- `tables::toolbar.start` - The start of the toolbar
+- `tables::toolbar.toggle-column-trigger.after` - After the [toggle columns](../tables/columns/getting-started#toggling-column-visibility) trigger
+- `tables::toolbar.toggle-column-trigger.before` - Before the [toggle columns](../tables/columns/getting-started#toggling-column-visibility) trigger
 
 ## Scoping render hooks
 

--- a/packages/support/docs/06-render-hooks.md
+++ b/packages/support/docs/06-render-hooks.md
@@ -79,15 +79,16 @@ FilamentView::registerRenderHook(
 
 ### Table Builder render hooks
 
-- `tables::toolbar.reorder.start` - Before the table [reorder](../tables/advanced#reordering-records) container
-- `tables::toolbar.reorder.end` - After the table [reorder](../tables/advanced#reordering-records) container
-- `tables::toolbar.groups.start` - Before the table [group](../tables/grouping) container
-- `tables::toolbar.groups.end` - After the table [group](../tables/grouping) container
-- `tables::toolbar.search.start` - Before the table [search](../tables/getting-started#making-columns-sortable-and-searchable) container
-- `tables::toolbar.search.end` - After the table [search](../tables/getting-started#making-columns-sortable-and-searchable) container
-- `tables::toolbar.columns.start` - Before the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) container
-- `tables::toolbar.columns.end` - After the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) container
+- `tables::toolbar.start` - The start of the table toolbar
 - `tables::toolbar.end` - The end of the table toolbar
+- `tables::toolbar.reorder-trigger.before` - Before the table [reorder](../tables/advanced#reordering-records) trigger
+- `tables::toolbar.reorder-trigger.after` - After the table [reorder](../tables/advanced#reordering-records) trigger
+- `tables::toolbar.groups.before` - Before the table [group](../tables/grouping) container
+- `tables::toolbar.groups.after` - After the table [group](../tables/grouping) container
+- `tables::toolbar.search.before` - Before the table [search](../tables/getting-started#making-columns-sortable-and-searchable) container
+- `tables::toolbar.search.after` - After the table [search](../tables/getting-started#making-columns-sortable-and-searchable) container
+- `tables::toolbar.column-toggle.before` - Before the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) trigger
+- `tables::toolbar.column-toggle.after` - After the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) trigger
 
 ## Scoping render hooks
 

--- a/packages/support/docs/06-render-hooks.md
+++ b/packages/support/docs/06-render-hooks.md
@@ -79,16 +79,16 @@ FilamentView::registerRenderHook(
 
 ### Table Builder render hooks
 
-- `tables::toolbar.start` - The start of the table toolbar
-- `tables::toolbar.end` - The end of the table toolbar
-- `tables::toolbar.reorder-trigger.before` - Before the table [reorder](../tables/advanced#reordering-records) trigger
-- `tables::toolbar.reorder-trigger.after` - After the table [reorder](../tables/advanced#reordering-records) trigger
-- `tables::toolbar.groups.before` - Before the table [group](../tables/grouping) container
-- `tables::toolbar.groups.after` - After the table [group](../tables/grouping) container
-- `tables::toolbar.search.before` - Before the table [search](../tables/getting-started#making-columns-sortable-and-searchable) container
-- `tables::toolbar.search.after` - After the table [search](../tables/getting-started#making-columns-sortable-and-searchable) container
-- `tables::toolbar.column-toggle.before` - Before the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) trigger
-- `tables::toolbar.column-toggle.after` - After the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) trigger
+- `tables::toolbar.start` - The start of the table toolbar, also [can be scoped](#scoping-render-hooks) to the table class
+- `tables::toolbar.end` - The end of the table toolbar, also [can be scoped](#scoping-render-hooks) to the table class
+- `tables::toolbar.reorder-trigger.before` - Before the table [reorder](../tables/advanced#reordering-records) trigger, also [can be scoped](#scoping-render-hooks) to the table class
+- `tables::toolbar.reorder-trigger.after` - After the table [reorder](../tables/advanced#reordering-records) trigger, also [can be scoped](#scoping-render-hooks) to the table class
+- `tables::toolbar.groups.before` - Before the table [group](../tables/grouping) container, also [can be scoped](#scoping-render-hooks) to the table class
+- `tables::toolbar.groups.after` - After the table [group](../tables/grouping) container, also [can be scoped](#scoping-render-hooks) to the table class
+- `tables::toolbar.search.before` - Before the table [search](../tables/getting-started#making-columns-sortable-and-searchable) container, also [can be scoped](#scoping-render-hooks) to the table class
+- `tables::toolbar.search.after` - After the table [search](../tables/getting-started#making-columns-sortable-and-searchable) container, also [can be scoped](#scoping-render-hooks) to the table class
+- `tables::toolbar.column-toggle.before` - Before the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) trigger, also [can be scoped](#scoping-render-hooks) to the table class
+- `tables::toolbar.column-toggle.after` - After the table [toggled columns](../tables/columns/getting-started#toggling-column-visibility) trigger, also [can be scoped](#scoping-render-hooks) to the table class
 
 ## Scoping render hooks
 

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -179,10 +179,10 @@
                 x-show="@js($hasHeaderToolbar) || (selectedRecords.length && @js(count($bulkActions)))"
                 class="fi-ta-header-toolbar flex items-center justify-between gap-3 px-4 py-3 sm:px-6"
             >
-                {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.start', scopes: [static::class]) }}
+                {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.start', scopes: static::class) }}
 
                 <div class="flex shrink-0 items-center gap-x-3">
-                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.reorder-trigger.before', scopes: [static::class]) }}
+                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.reorder-trigger.before', scopes: static::class) }}
 
                     @if ($isReorderable)
                         <span
@@ -196,7 +196,7 @@
                         </span>
                     @endif
 
-                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.reorder-trigger.after', scopes: [static::class]) }}
+                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.reorder-trigger.after', scopes: static::class) }}
 
                     @if ((! $isReordering) && count($bulkActions))
                         <x-filament-tables::actions
@@ -206,7 +206,7 @@
                         />
                     @endif
 
-                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.groups.before', scopes: [static::class]) }}
+                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.groups.before', scopes: static::class) }}
 
                     @if (count($groups))
                         <x-filament-tables::groups
@@ -216,7 +216,7 @@
                         />
                     @endif
                     
-                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.groups.after', scopes: [static::class]) }}
+                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.groups.after', scopes: static::class) }}
                 </div>
 
                 @if ($isGlobalSearchVisible || $hasFiltersDropdown || $hasColumnToggleDropdown)
@@ -227,13 +227,13 @@
                             'gap-x-4' => $filtersTriggerAction->isIconButton() && $toggleColumnsTriggerAction->isIconButton(),
                         ])
                     >
-                        {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.before', scopes: [static::class]) }}
+                        {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.before', scopes: static::class) }}
 
                         @if ($isGlobalSearchVisible)
                             <x-filament-tables::search-field />
                         @endif
 
-                        {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.after', scopes: [static::class]) }}
+                        {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.after', scopes: static::class) }}
 
                         @if ($hasFiltersDropdown || $hasColumnToggleDropdown)
                             @if ($hasFiltersDropdown)
@@ -246,7 +246,7 @@
                                 />
                             @endif
 
-                            {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.column-toggle.before', scopes: [static::class]) }}
+                            {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.column-toggle.before', scopes: static::class) }}
 
                             @if ($hasColumnToggleDropdown)
                                 <x-filament-tables::column-toggle.dropdown
@@ -257,7 +257,7 @@
                                 />
                             @endif
 
-                            {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.column-toggle.after', scopes: [static::class]) }}
+                            {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.column-toggle.after', scopes: static::class) }}
                         @endif
                     </div>
                 @endif

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -179,8 +179,10 @@
                 x-show="@js($hasHeaderToolbar) || (selectedRecords.length && @js(count($bulkActions)))"
                 class="fi-ta-header-toolbar flex items-center justify-between gap-3 px-4 py-3 sm:px-6"
             >
+                {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.start', scopes: [static::class]) }}
+
                 <div class="flex shrink-0 items-center gap-x-3">
-                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.reorder.start') }}
+                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.reorder-trigger.before', scopes: [static::class]) }}
 
                     @if ($isReorderable)
                         <span
@@ -194,7 +196,7 @@
                         </span>
                     @endif
 
-                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.reorder.end') }}
+                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.reorder-trigger.after', scopes: [static::class]) }}
 
                     @if ((! $isReordering) && count($bulkActions))
                         <x-filament-tables::actions
@@ -204,7 +206,7 @@
                         />
                     @endif
 
-                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.groups.start') }}
+                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.groups.before', scopes: [static::class]) }}
 
                     @if (count($groups))
                         <x-filament-tables::groups
@@ -214,7 +216,7 @@
                         />
                     @endif
                     
-                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.groups.end') }}
+                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.groups.after', scopes: [static::class]) }}
                 </div>
 
                 @if ($isGlobalSearchVisible || $hasFiltersDropdown || $hasColumnToggleDropdown)
@@ -225,13 +227,13 @@
                             'gap-x-4' => $filtersTriggerAction->isIconButton() && $toggleColumnsTriggerAction->isIconButton(),
                         ])
                     >
-                        {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.start') }}
+                        {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.before', scopes: [static::class]) }}
 
                         @if ($isGlobalSearchVisible)
                             <x-filament-tables::search-field />
                         @endif
 
-                        {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.end') }}
+                        {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.after', scopes: [static::class]) }}
 
                         @if ($hasFiltersDropdown || $hasColumnToggleDropdown)
                             @if ($hasFiltersDropdown)
@@ -244,7 +246,7 @@
                                 />
                             @endif
 
-                            {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.columns.start') }}
+                            {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.column-toggle.before', scopes: [static::class]) }}
 
                             @if ($hasColumnToggleDropdown)
                                 <x-filament-tables::column-toggle.dropdown
@@ -255,7 +257,7 @@
                                 />
                             @endif
 
-                            {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.columns.end') }}
+                            {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.column-toggle.after', scopes: [static::class]) }}
                         @endif
                     </div>
                 @endif

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -206,7 +206,7 @@
                         />
                     @endif
 
-                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.groups.before', scopes: static::class) }}
+                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.grouping-selector.before', scopes: static::class) }}
 
                     @if (count($groups))
                         <x-filament-tables::groups
@@ -216,7 +216,7 @@
                         />
                     @endif
                     
-                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.groups.after', scopes: static::class) }}
+                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.grouping-selector.after', scopes: static::class) }}
                 </div>
 
                 @if ($isGlobalSearchVisible || $hasFiltersDropdown || $hasColumnToggleDropdown)

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -246,7 +246,7 @@
                                 />
                             @endif
 
-                            {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.column-toggle.before', scopes: static::class) }}
+                            {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.toggle-column-trigger.before', scopes: static::class) }}
 
                             @if ($hasColumnToggleDropdown)
                                 <x-filament-tables::column-toggle.dropdown
@@ -257,7 +257,7 @@
                                 />
                             @endif
 
-                            {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.column-toggle.after', scopes: static::class) }}
+                            {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.toggle-column-trigger.after', scopes: static::class) }}
                         @endif
                     </div>
                 @endif

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -180,6 +180,8 @@
                 class="fi-ta-header-toolbar flex items-center justify-between gap-3 px-4 py-3 sm:px-6"
             >
                 <div class="flex shrink-0 items-center gap-x-3">
+                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.reorder.start') }}
+
                     @if ($isReorderable)
                         <span
                             x-show="! selectedRecords.length"
@@ -192,6 +194,8 @@
                         </span>
                     @endif
 
+                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.reorder.end') }}
+
                     @if ((! $isReordering) && count($bulkActions))
                         <x-filament-tables::actions
                             :actions="$bulkActions"
@@ -200,6 +204,8 @@
                         />
                     @endif
 
+                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.groups.start') }}
+
                     @if (count($groups))
                         <x-filament-tables::groups
                             :dropdown-on-desktop="$areGroupsInDropdownOnDesktop()"
@@ -207,6 +213,8 @@
                             :trigger-action="$getGroupRecordsTriggerAction()"
                         />
                     @endif
+                    
+                    {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.groups.end') }}
                 </div>
 
                 @if ($isGlobalSearchVisible || $hasFiltersDropdown || $hasColumnToggleDropdown)
@@ -217,9 +225,13 @@
                             'gap-x-4' => $filtersTriggerAction->isIconButton() && $toggleColumnsTriggerAction->isIconButton(),
                         ])
                     >
+                        {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.start') }}
+
                         @if ($isGlobalSearchVisible)
                             <x-filament-tables::search-field />
                         @endif
+
+                        {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.end') }}
 
                         @if ($hasFiltersDropdown || $hasColumnToggleDropdown)
                             @if ($hasFiltersDropdown)
@@ -232,6 +244,8 @@
                                 />
                             @endif
 
+                            {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.columns.start') }}
+
                             @if ($hasColumnToggleDropdown)
                                 <x-filament-tables::column-toggle.dropdown
                                     :form="$getColumnToggleForm()"
@@ -240,9 +254,13 @@
                                     :width="$getColumnToggleFormWidth()"
                                 />
                             @endif
+
+                            {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.columns.end') }}
                         @endif
                     </div>
                 @endif
+
+                {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.end') }}
             </div>
         </div>
 


### PR DESCRIPTION
Adds multiple renderhooks to the table builder toolbar. Here's how it would look:

![Screenshot 2023-09-13 at 8 23 24 PM](https://github.com/filamentphp/filament/assets/6097099/e3761786-7b51-49b6-b751-2c37e2e55598)

An additional renderhook is added at the end of the table in case the search, filters, and column options are turned off. 

![Screenshot 2023-09-13 at 8 23 34 PM](https://github.com/filamentphp/filament/assets/6097099/c3171a2e-acdd-4c74-a4d6-d728552d9f61)

Works as expected in table builder, resource table, relation manager, and table widgets

- [X] Changes have been thoroughly tested to not break existing functionality.
- [X] New functionality has been documented or existing documentation has been updated to reflect changes.
- [X] Visual changes are explained in the PR description using a screenshot/recording of before and after.
