### PR TITLE
Allow to override predefined routes

### DIFF
--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -23,6 +23,10 @@ Route::name('filament.')
                     ->name("{$panelId}.")
                     ->prefix($panel->getPath())
                     ->group(function () use ($panel, $hasTenancy, $tenantRoutePrefix, $tenantSlugAttribute) {
+                        if ($routes = $panel->getRoutes()) {
+                            $routes($panel);
+                        }
+
                         Route::name('auth.')->group(function () use ($panel) {
                             if ($panel->hasLogin()) {
                                 Route::get('/login', $panel->getLoginRouteAction())->name('login');
@@ -43,13 +47,13 @@ Route::name('filament.')
                                 Route::get('/register', $panel->getRegistrationRouteAction())->name('register');
                             }
                         });
-                        
-                        if ($routes = $panel->getRoutes()) {
-                            $routes($panel);
-                        }
 
                         Route::middleware($panel->getAuthMiddleware())
                             ->group(function () use ($panel, $hasTenancy, $tenantRoutePrefix, $tenantSlugAttribute): void {
+                                if ($routes = $panel->getAuthenticatedRoutes()) {
+                                    $routes($panel);
+                                }
+
                                 if ($hasTenancy) {
                                     Route::get('/', RedirectToTenantController::class)->name('tenant');
                                 }
@@ -113,10 +117,6 @@ Route::name('filament.')
                                             }
                                         });
                                     });
-
-                                if ($routes = $panel->getAuthenticatedRoutes()) {
-                                    $routes($panel);
-                                }
 
                             });
 

--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -29,22 +29,21 @@ Route::name('filament.')
 
                         Route::name('auth.')->group(function () use ($panel) {
                             if ($panel->hasLogin()) {
-                                Route::get('/login', $panel->getLoginRouteAction())->name('login');
+                                $panel->getLoginRouteAction()::routes($panel);
                             }
 
                             if ($panel->hasPasswordReset()) {
                                 Route::name('password-reset.')
                                     ->prefix('/password-reset')
                                     ->group(function () use ($panel) {
-                                        Route::get('/request', $panel->getRequestPasswordResetRouteAction())->name('request');
-                                        Route::get('/reset', $panel->getResetPasswordRouteAction())
-                                            ->middleware(['signed'])
-                                            ->name('reset');
+                                        $panel->getRequestPasswordResetRouteAction()::routes($panel);
+
+                                        $panel->getResetPasswordRouteAction()::routes($panel);
                                     });
                             }
 
                             if ($panel->hasRegistration()) {
-                                Route::get('/register', $panel->getRegistrationRouteAction())->name('register');
+                                $panel->getRegistrationRouteAction()::routes($panel);
                             }
                         });
 
@@ -71,7 +70,8 @@ Route::name('filament.')
                                     Route::name('auth.email-verification.')
                                         ->prefix('/email-verification')
                                         ->group(function () use ($panel) {
-                                            Route::get('/prompt', $panel->getEmailVerificationPromptRouteAction())->name('prompt');
+                                            $panel->getEmailVerificationPromptRouteAction()::routes($panel);
+
                                             Route::get('/verify', EmailVerificationController::class)
                                                 ->middleware(['signed'])
                                                 ->name('verify');

--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -23,10 +23,6 @@ Route::name('filament.')
                     ->name("{$panelId}.")
                     ->prefix($panel->getPath())
                     ->group(function () use ($panel, $hasTenancy, $tenantRoutePrefix, $tenantSlugAttribute) {
-                        if ($routes = $panel->getRoutes()) {
-                            $routes($panel);
-                        }
-
                         Route::name('auth.')->group(function () use ($panel) {
                             if ($panel->hasLogin()) {
                                 Route::get('/login', $panel->getLoginRouteAction())->name('login');
@@ -47,13 +43,13 @@ Route::name('filament.')
                                 Route::get('/register', $panel->getRegistrationRouteAction())->name('register');
                             }
                         });
+                        
+                        if ($routes = $panel->getRoutes()) {
+                            $routes($panel);
+                        }
 
                         Route::middleware($panel->getAuthMiddleware())
                             ->group(function () use ($panel, $hasTenancy, $tenantRoutePrefix, $tenantSlugAttribute): void {
-                                if ($routes = $panel->getAuthenticatedRoutes()) {
-                                    $routes($panel);
-                                }
-
                                 if ($hasTenancy) {
                                     Route::get('/', RedirectToTenantController::class)->name('tenant');
                                 }
@@ -117,6 +113,10 @@ Route::name('filament.')
                                             }
                                         });
                                     });
+
+                                if ($routes = $panel->getAuthenticatedRoutes()) {
+                                    $routes($panel);
+                                }
 
                             });
 

--- a/packages/panels/src/Pages/Auth/EmailVerification/EmailVerificationPrompt.php
+++ b/packages/panels/src/Pages/Auth/EmailVerification/EmailVerificationPrompt.php
@@ -10,7 +10,9 @@ use Filament\Facades\Filament;
 use Filament\Forms\Form;
 use Filament\Notifications\Auth\VerifyEmail;
 use Filament\Notifications\Notification;
+use Filament\Pages\Concerns\HasRoutes;
 use Filament\Pages\SimplePage;
+use Filament\Panel;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Contracts\Support\Htmlable;
 
@@ -19,12 +21,23 @@ use Illuminate\Contracts\Support\Htmlable;
  */
 class EmailVerificationPrompt extends SimplePage
 {
+    use HasRoutes;
     use WithRateLimiting;
 
     /**
      * @var view-string
      */
     protected static string $view = 'filament-panels::pages.auth.email-verification.email-verification-prompt';
+
+    public static function getSlug(): string
+    {
+        return 'prompt';
+    }
+
+    public static function getRouteMiddleware(Panel $panel): string|array
+    {
+        return static::$routeMiddleware;
+    }
 
     public function mount(): void
     {

--- a/packages/panels/src/Pages/Auth/Login.php
+++ b/packages/panels/src/Pages/Auth/Login.php
@@ -14,10 +14,13 @@ use Filament\Forms\Form;
 use Filament\Http\Responses\Auth\Contracts\LoginResponse;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Notifications\Notification;
+use Filament\Pages\Concerns\HasRoutes;
 use Filament\Pages\Concerns\InteractsWithFormActions;
 use Filament\Pages\SimplePage;
+use Filament\Panel;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\HtmlString;
 use Illuminate\Validation\ValidationException;
 
@@ -26,6 +29,7 @@ use Illuminate\Validation\ValidationException;
  */
 class Login extends SimplePage
 {
+    use HasRoutes;
     use InteractsWithFormActions;
     use WithRateLimiting;
 
@@ -38,6 +42,11 @@ class Login extends SimplePage
      * @var array<string, mixed> | null
      */
     public ?array $data = [];
+
+    public static function getRouteMiddleware(Panel $panel): string|array
+    {
+        return static::$routeMiddleware;
+    }
 
     public function mount(): void
     {

--- a/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
+++ b/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
@@ -13,8 +13,10 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Notifications\Auth\ResetPassword as ResetPasswordNotification;
 use Filament\Notifications\Notification;
+use Filament\Pages\Concerns\HasRoutes;
 use Filament\Pages\Concerns\InteractsWithFormActions;
 use Filament\Pages\SimplePage;
+use Filament\Panel;
 use Illuminate\Contracts\Auth\CanResetPassword;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Facades\Password;
@@ -24,6 +26,7 @@ use Illuminate\Support\Facades\Password;
  */
 class RequestPasswordReset extends SimplePage
 {
+    use HasRoutes;
     use InteractsWithFormActions;
     use WithRateLimiting;
 
@@ -36,6 +39,16 @@ class RequestPasswordReset extends SimplePage
      * @var array<string, mixed> | null
      */
     public ?array $data = [];
+
+    public static function getSlug(): string
+    {
+        return 'request';
+    }
+
+    public static function getRouteMiddleware(Panel $panel): string|array
+    {
+        return static::$routeMiddleware;
+    }
 
     public function mount(): void
     {

--- a/packages/panels/src/Pages/Auth/PasswordReset/ResetPassword.php
+++ b/packages/panels/src/Pages/Auth/PasswordReset/ResetPassword.php
@@ -12,8 +12,10 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Http\Responses\Auth\Contracts\PasswordResetResponse;
 use Filament\Notifications\Notification;
+use Filament\Pages\Concerns\HasRoutes;
 use Filament\Pages\Concerns\InteractsWithFormActions;
 use Filament\Pages\SimplePage;
+use Filament\Panel;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\CanResetPassword;
@@ -30,6 +32,7 @@ use Livewire\Attributes\Locked;
  */
 class ResetPassword extends SimplePage
 {
+    use HasRoutes;
     use InteractsWithFormActions;
     use WithRateLimiting;
 
@@ -47,6 +50,19 @@ class ResetPassword extends SimplePage
 
     #[Locked]
     public ?string $token = null;
+
+    public static function getSlug(): string
+    {
+        return 'reset';
+    }
+
+    public static function getRouteMiddleware(Panel $panel): string|array
+    {
+        return [
+            'signed',
+            ... static::$routeMiddleware,
+        ];
+    }
 
     public function mount(?string $email = null, ?string $token = null): void
     {

--- a/packages/panels/src/Pages/Auth/Register.php
+++ b/packages/panels/src/Pages/Auth/Register.php
@@ -12,13 +12,16 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Http\Responses\Auth\Contracts\RegistrationResponse;
 use Filament\Notifications\Notification;
+use Filament\Pages\Concerns\HasRoutes;
 use Filament\Pages\Concerns\InteractsWithFormActions;
 use Filament\Pages\SimplePage;
+use Filament\Panel;
 use Illuminate\Auth\EloquentUserProvider;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\SessionGuard;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Validation\Rules\Password;
 
 /**
@@ -26,6 +29,7 @@ use Illuminate\Validation\Rules\Password;
  */
 class Register extends SimplePage
 {
+    use HasRoutes;
     use InteractsWithFormActions;
     use WithRateLimiting;
 
@@ -40,6 +44,11 @@ class Register extends SimplePage
     public ?array $data = [];
 
     protected string $userModel;
+
+    public static function getRouteMiddleware(Panel $panel): string|array
+    {
+        return static::$routeMiddleware;
+    }
 
     public function mount(): void
     {


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This PR allows to override predefined routes like logout, email verification etc.,

It will be useful when developers need to tweak route definitions for predefined routes.

e.g.: When I want to exclude some auth middlewares to the logout route, I can achieve this by overriding the logout route like this
 
```php
$panel->authMiddleware([
                Authenticate::class,
                MustCompleteProfile::class,
            ])
            ->authenticatedRoutes(function (Panel $panel) {
                Route::post('/logout', LogoutController::class)
                            ->name('auth.logout')
                            ->withoutMiddleware(MustCompleteProfile::class);
            })
```