### PR TITLE
fix: Empty state actions overriding

### DIFF
--- a/packages/panels/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/panels/src/Commands/MakeRelationManagerCommand.php
@@ -101,19 +101,19 @@ class MakeRelationManagerCommand extends Command
             return static::INVALID;
         }
 
-        $tableHeaderAndEmptyStateActions = [];
+        $tableHeaderActions = [];
 
-        $tableHeaderAndEmptyStateActions[] = 'Tables\Actions\CreateAction::make(),';
+        $tableHeaderActions[] = 'Tables\Actions\CreateAction::make(),';
 
         if ($this->option('associate')) {
-            $tableHeaderAndEmptyStateActions[] = 'Tables\Actions\AssociateAction::make(),';
+            $tableHeaderActions[] = 'Tables\Actions\AssociateAction::make(),';
         }
 
         if ($this->option('attach')) {
-            $tableHeaderAndEmptyStateActions[] = 'Tables\Actions\AttachAction::make(),';
+            $tableHeaderActions[] = 'Tables\Actions\AttachAction::make(),';
         }
 
-        $tableHeaderAndEmptyStateActions = implode(PHP_EOL, $tableHeaderAndEmptyStateActions);
+        $tableHeaderActions = implode(PHP_EOL, $tableHeaderActions);
 
         $tableActions = [];
 
@@ -173,12 +173,11 @@ class MakeRelationManagerCommand extends Command
             'relationship' => $relationship,
             'tableActions' => $this->indentString($tableActions, 4),
             'tableBulkActions' => $this->indentString($tableBulkActions, 5),
-            'tableEmptyStateActions' => $this->indentString($tableHeaderAndEmptyStateActions, 4),
             'tableFilters' => $this->indentString(
                 $this->option('soft-deletes') ? 'Tables\Filters\TrashedFilter::make()' : '//',
                 4,
             ),
-            'tableHeaderActions' => $this->indentString($tableHeaderAndEmptyStateActions, 4),
+            'tableHeaderActions' => $this->indentString($tableHeaderActions, 4),
         ]);
 
         $this->components->info("Successfully created {$managerClass}!");

--- a/packages/panels/src/Commands/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/MakeResourceCommand.php
@@ -162,12 +162,6 @@ class MakeResourceCommand extends Command
 
         $tableActions = implode(PHP_EOL, $tableActions);
 
-        $tableEmptyStateActions = [];
-
-        $tableEmptyStateActions[] = 'Tables\Actions\CreateAction::make(),';
-
-        $tableEmptyStateActions = implode(PHP_EOL, $tableEmptyStateActions);
-
         $tableBulkActions = [];
 
         $tableBulkActions[] = 'Tables\Actions\DeleteBulkAction::make(),';
@@ -203,7 +197,6 @@ class MakeResourceCommand extends Command
             'resourceClass' => $resourceClass,
             'tableActions' => $this->indentString($tableActions, 4),
             'tableBulkActions' => $this->indentString($tableBulkActions, 5),
-            'tableEmptyStateActions' => $this->indentString($tableEmptyStateActions, 4),
             'tableColumns' => $this->indentString($this->option('generate') ? $this->getResourceTableColumns(
                 'App\Models' . ($modelNamespace !== '' ? "\\{$modelNamespace}" : '') . '\\' . $modelClass,
             ) : '//', 4),

--- a/packages/panels/stubs/RelationManager.stub
+++ b/packages/panels/stubs/RelationManager.stub
@@ -44,9 +44,6 @@ class {{ managerClass }} extends RelationManager
                 Tables\Actions\BulkActionGroup::make([
 {{ tableBulkActions }}
                 ]),
-            ])
-            ->emptyStateActions([
-{{ tableEmptyStateActions }}
             ]){{ modifyQueryUsing }};
     }
 }

--- a/packages/panels/stubs/Resource.stub
+++ b/packages/panels/stubs/Resource.stub
@@ -43,9 +43,6 @@ class {{ resourceClass }} extends Resource
                 Tables\Actions\BulkActionGroup::make([
 {{ tableBulkActions }}
                 ]),
-            ])
-            ->emptyStateActions([
-{{ tableEmptyStateActions }}
             ]);
     }
 {{ relations }}

--- a/packages/tables/src/Table/Concerns/HasActions.php
+++ b/packages/tables/src/Table/Concerns/HasActions.php
@@ -150,20 +150,31 @@ trait HasActions
         return array_key_exists($name, $this->getFlatActions());
     }
 
-    protected function cacheAction(Action $action): void
+    protected function cacheAction(Action $action, bool $shouldOverwriteExistingAction = true): void
     {
-        $this->flatActions[$action->getName()] = $action;
+        if ($shouldOverwriteExistingAction) {
+            $this->flatActions[$action->getName()] = $action;
+        } else {
+            $this->flatActions[$action->getName()] ??= $action;
+        }
     }
 
     /**
      * @param  array<string, Action>  $actions
      */
-    protected function mergeCachedFlatActions(array $actions): void
+    protected function mergeCachedFlatActions(array $actions, bool $shouldOverwriteExistingActions = true): void
     {
-        $this->flatActions = [
-            ...$this->flatActions,
-            ...$actions,
-        ];
+        if ($shouldOverwriteExistingActions) {
+            $this->flatActions = [
+                ...$this->flatActions,
+                ...$actions,
+            ];
+        } else {
+            $this->flatActions = [
+                ...$actions,
+                ...$this->flatActions,
+            ];
+        }
     }
 
     /**

--- a/packages/tables/src/Table/Concerns/HasEmptyState.php
+++ b/packages/tables/src/Table/Concerns/HasEmptyState.php
@@ -42,10 +42,10 @@ trait HasEmptyState
     /**
      * @param  array<Action | ActionGroup> | ActionGroup  $actions
      */
-    public function emptyStateActions(array | ActionGroup $actions): static
+    public function emptyStateActions(array | ActionGroup $actions, bool $shouldOverwriteExistingActions = false): static
     {
         $this->emptyStateActions = [];
-        $this->pushEmptyStateActions($actions);
+        $this->pushEmptyStateActions($actions, $shouldOverwriteExistingActions);
 
         return $this;
     }
@@ -53,7 +53,7 @@ trait HasEmptyState
     /**
      * @param  array<Action | ActionGroup> | ActionGroup  $actions
      */
-    public function pushEmptyStateActions(array | ActionGroup $actions): static
+    public function pushEmptyStateActions(array | ActionGroup $actions, bool $shouldOverwriteExistingActions = false): static
     {
         foreach (Arr::wrap($actions) as $action) {
             $action->table($this);
@@ -62,9 +62,9 @@ trait HasEmptyState
                 /** @var array<string, Action> $flatActions */
                 $flatActions = $action->getFlatActions();
 
-                $this->mergeCachedFlatActions($flatActions);
+                $this->mergeCachedFlatActions($flatActions, $shouldOverwriteExistingActions);
             } elseif ($action instanceof Action) {
-                $this->cacheAction($action);
+                $this->cacheAction($action, $shouldOverwriteExistingActions);
             } else {
                 throw new InvalidArgumentException('Table empty state actions must be an instance of ' . Action::class . ' or ' . ActionGroup::class . '.');
             }


### PR DESCRIPTION
Fixes #7649.

On top of preventing empty state actions from overriding header actions, this completely removes empty state actions from the stubs of resources and relation managers. This isn't a breaking change, only new resources and relation managers will be affected. The reason why I made this decision, was due to the confusion surrounding *which* `CreateAction`, `AttachAction`, `AssociateAction` to `modify()`, for beginners. There's two occurrences of the "same" action, and they don't understand which one to touch. This should clear that up. Advanced users can just add these to their stubs.