### PR TITLE
feature: Disable read only relation managers for entire panel at once

### DIFF
--- a/packages/panels/docs/03-resources/07-relation-managers.md
+++ b/packages/panels/docs/03-resources/07-relation-managers.md
@@ -103,6 +103,30 @@ public static function getRelations(): array
 
 Once a table and form have been defined for the relation manager, visit the [Edit](editing-records) or [View](viewing-records) page of your resource to see it in action.
 
+### Read-only mode
+
+Relation managers are usually displayed on either the Edit or View page of a resource. On the View page, Filament will automatically hide all actions that modify the relationship, such as create, edit, and delete. We call this "read-only mode", and it is there by default to preserve the read-only behaviour of the View page. However, you can disable this behaviour, by overriding the `isReadOnly()` method on the relation manager class to return `false` all the time:
+
+```php
+public function isReadOnly(): bool
+{
+    return false;
+}
+```
+
+Alternatively, if you hate this functionality, you can disable it for all relation managers at once in the panel [configuration](../configuration):
+
+```php
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->readOnlyRelationManagersOnResourceViewPagesByDefault(false);
+}
+```
+
 ### Unconventional inverse relationship names
 
 For inverse relationships that do not follow Laravel's naming guidelines, you may wish to use the `inverseRelationship()` method on the table:
@@ -718,17 +742,6 @@ AssociateAction::make()
 
 AttachAction::make()
     ->recordSelectSearchColumns(['title', 'id'])
-```
-
-## Read-only mode
-
-Relation managers are usually displayed on either the Edit or View page of a resource. On the View page, Filament will automatically hide all actions that modify the relationship, such as create, edit, and delete. However, you can disable this behaviour, by overriding the `isReadOnly()` method on the relation manager class to return `false` all the time:
-
-```php
-public function isReadOnly(): bool
-{
-    return false;
-}
 ```
 
 ## Passing properties to relation managers

--- a/packages/panels/src/Panel/Concerns/HasComponents.php
+++ b/packages/panels/src/Panel/Concerns/HasComponents.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Panel\Concerns;
 
+use Closure;
 use Filament\Livewire\DatabaseNotifications;
 use Filament\Livewire\GlobalSearch;
 use Filament\Livewire\Notifications;
@@ -71,6 +72,8 @@ trait HasComponents
      * @var array<string>
      */
     protected array $widgetNamespaces = [];
+
+    protected bool | Closure $hasReadOnlyRelationManagersOnResourceViewPagesByDefault = true;
 
     /**
      * @param  array<class-string>  $pages
@@ -433,5 +436,17 @@ trait HasComponents
         $componentName = app(ComponentRegistry::class)->getName($component);
 
         $this->livewireComponents[$componentName] = $component;
+    }
+
+    public function readOnlyRelationManagersOnResourceViewPagesByDefault(bool | Closure $condition = true): static
+    {
+        $this->hasReadOnlyRelationManagersOnResourceViewPagesByDefault = $condition;
+
+        return $this;
+    }
+
+    public function hasReadOnlyRelationManagersOnResourceViewPagesByDefault(): bool
+    {
+        return (bool) $this->evaluate($this->hasReadOnlyRelationManagersOnResourceViewPagesByDefault);
     }
 }

--- a/packages/panels/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManager.php
@@ -3,6 +3,7 @@
 namespace Filament\Resources\RelationManagers;
 
 use Filament\Actions;
+use Filament\Facades\Filament;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Infolists;
@@ -90,6 +91,16 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
     public function isReadOnly(): bool
     {
         if (blank($this->pageClass)) {
+            return false;
+        }
+
+        $panel = Filament::getCurrentPanel();
+
+        if (! $panel) {
+            return false;
+        }
+
+        if (! $panel->hasReadOnlyRelationManagersOnResourceViewPagesByDefault()) {
             return false;
         }
 


### PR DESCRIPTION
Seems like everyone hates that feature (apart from the people who constantly suggested it in v2 😳) sooooooo