### PR TITLE
fix: Ensure routeMiddleware property is array before unpacking

### DIFF
--- a/packages/panels/src/Pages/Auth/EditProfile.php
+++ b/packages/panels/src/Pages/Auth/EditProfile.php
@@ -19,6 +19,7 @@ use Filament\Support\Exceptions\Halt;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Validation\Rules\Password;
@@ -63,7 +64,7 @@ class EditProfile extends SimplePage
     {
         return [
             ...(static::isEmailVerificationRequired($panel) ? [static::getEmailVerifiedMiddleware($panel)] : []),
-            ...static::$routeMiddleware,
+            ...Arr::wrap(static::$routeMiddleware),
         ];
     }
 

--- a/packages/panels/src/Pages/Concerns/HasRoutes.php
+++ b/packages/panels/src/Pages/Concerns/HasRoutes.php
@@ -3,6 +3,7 @@
 namespace Filament\Pages\Concerns;
 
 use Filament\Panel;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Route;
 
 trait HasRoutes
@@ -44,7 +45,7 @@ trait HasRoutes
         return [
             ...(static::isEmailVerificationRequired($panel) ? [static::getEmailVerifiedMiddleware($panel)] : []),
             ...(static::isTenantSubscriptionRequired($panel) ? [static::getTenantSubscribedMiddleware($panel)] : []),
-            ...static::$routeMiddleware,
+            ...Arr::wrap(static::$routeMiddleware),
         ];
     }
 

--- a/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
+++ b/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
@@ -14,6 +14,7 @@ use Filament\Support\Exceptions\Halt;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Route;
 use Livewire\Attributes\Locked;
 
@@ -64,7 +65,7 @@ abstract class EditTenantProfile extends Page
     {
         return [
             ...(static::isEmailVerificationRequired($panel) ? [static::getEmailVerifiedMiddleware($panel)] : []),
-            ...static::$routeMiddleware,
+            ...Arr::wrap(static::$routeMiddleware),
         ];
     }
 

--- a/packages/panels/src/Pages/Tenancy/RegisterTenant.php
+++ b/packages/panels/src/Pages/Tenancy/RegisterTenant.php
@@ -14,6 +14,7 @@ use Filament\Support\Exceptions\Halt;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Route;
 
 use function Filament\authorize;
@@ -57,7 +58,7 @@ abstract class RegisterTenant extends SimplePage
     {
         return [
             ...(static::isEmailVerificationRequired($panel) ? [static::getEmailVerifiedMiddleware($panel)] : []),
-            ...static::$routeMiddleware,
+            ...Arr::wrap(static::$routeMiddleware),
         ];
     }
 


### PR DESCRIPTION
This is in response to a support thread on Discord:
https://discord.com/channels/883083792112300104/1151476494145704087

The error was encountered while upgrading from v2 to v3:
https://flareapp.io/share/J7oeDd3m

Because the `$routeMiddleware` can either be a string or an array, this ensures that string values are wrapped in an array before unpacking the value.

---

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
