### PR TITLE
Check for index page existence before generating breadcrumb

### DIFF
--- a/packages/panels/src/Resources/Pages/Concerns/InteractsWithRecord.php
+++ b/packages/panels/src/Resources/Pages/Concerns/InteractsWithRecord.php
@@ -47,9 +47,11 @@ trait InteractsWithRecord
     {
         $resource = static::getResource();
 
-        $breadcrumbs = [
-            $resource::getUrl() => $resource::getBreadcrumb(),
-        ];
+        $breadcrumbs = [];
+
+        if ($resource::hasPage('index')) {
+            $breadcrumbs[$resource::getUrl()] = $resource::getBreadcrumb();
+        }
 
         $record = $this->getRecord();
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Currently the `getBreadcrumbs` assumes that every resource has an index page. I'm currently creating an app where this is not the case. This PR adds a check to see if the 'index' page actually exists before adding the breadcrumb, in line with the other breadcrumbs.

I think there is no need to change the documentation or update a screenshot since nothing changes for existing apps. Currently an exception occurs when calling the `$resource::getUrl()` method.