### PR TITLE
Default AboveContentCollapsible to hidden to avoid flickering

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -167,7 +167,7 @@
                     <x-filament-tables::filters
                         :form="$getFiltersForm()"
                         x-show="areFiltersOpen"
-                        style="display: none;"
+                        x-cloak
                         @class([
                             'py-1 sm:py-3' => $hasFiltersAboveContentCollapsible,
                         ])

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -167,6 +167,7 @@
                     <x-filament-tables::filters
                         :form="$getFiltersForm()"
                         x-show="areFiltersOpen"
+                        style="display: none;"
                         @class([
                             'py-1 sm:py-3' => $hasFiltersAboveContentCollapsible,
                         ])


### PR DESCRIPTION
Hello, there is a short duration flickering when freshly opening or refreshing list page where table uses ``FiltersLayout::AboveContentCollapsible``. My PR will make the initial loaded state of the filter hidden.

```php

use Filament\Resources\Pages\ListRecords as BaseListRecords;
use Filament\Tables\Enums\FiltersLayout;
use Filament\Tables\Table;

class ListRecords extends BaseListRecords
{
    public function table(Table $table): Table
    {
        return parent::table($table)
            ->filtersLayout(FiltersLayout::AboveContentCollapsible);
    }
}

```