### PR TITLE
Fix darkmode text color

### DIFF
--- a/packages/support/resources/views/components/fieldset.blade.php
+++ b/packages/support/resources/views/components/fieldset.blade.php
@@ -13,7 +13,7 @@
     @if (filled($label))
         <legend
             @class([
-                '-ms-2 px-2 text-sm font-medium leading-6',
+                '-ms-2 px-2 text-sm font-medium leading-6 text-gray-950 dark:text-white',
                 'sr-only' => $labelHidden,
             ])
         >

--- a/packages/tables/resources/views/components/header.blade.php
+++ b/packages/tables/resources/views/components/header.blade.php
@@ -21,7 +21,7 @@
         <div class="grid gap-y-1">
             @if ($heading)
                 <h3
-                    class="fi-ta-header-heading text-base font-semibold leading-6"
+                    class="fi-ta-header-heading text-base font-semibold leading-6 text-gray-950 dark:text-white"
                 >
                     {{ $heading }}
                 </h3>


### PR DESCRIPTION
The optional table heading did not look right in dark:mode so added tailwind classes to be in line with section heading.

Fieldset label also lacked text color classes, added the same ones there.

- [no] Changes have been thoroughly tested to not break existing functionality.
- [no] New functionality has been documented or existing documentation has been updated to reflect changes.
- [yes] Visual changes are explained in the PR description using a screenshot/recording of before and after.

![table-before](https://github.com/filamentphp/filament/assets/46811890/fa9d755a-5324-46bf-b121-a6155abc5dee)
![table-after](https://github.com/filamentphp/filament/assets/46811890/f134800f-57f1-447b-bbfe-64a88bd1dc5a)
![field-before](https://github.com/filamentphp/filament/assets/46811890/4c4ceaa6-61db-44a8-874a-78b6b8cfb15c)
![field-after](https://github.com/filamentphp/filament/assets/46811890/fa5aa19c-2469-405a-8d8b-bf67e1012a45)

