### PR TITLE
[3.x] Use qualified name

### DIFF
--- a/packages/tables/src/Actions/AssociateAction.php
+++ b/packages/tables/src/Actions/AssociateAction.php
@@ -200,6 +200,8 @@ class AssociateAction extends Action
 
                 $relationshipQuery->where(function (Builder $query) use ($isFirst, $isForcedCaseInsensitive, $searchColumns, $search): Builder {
                     foreach ($searchColumns as $searchColumn) {
+                        $searchColumn = $query->qualifyColumn($searchColumn);
+
                         $caseAwareSearchColumn = $isForcedCaseInsensitive ?
                             new Expression("lower({$searchColumn})") :
                             $searchColumn;

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -236,6 +236,8 @@ class AttachAction extends Action
 
                 $relationshipQuery->where(function (Builder $query) use ($isFirst, $isForcedCaseInsensitive, $searchColumns, $search): Builder {
                     foreach ($searchColumns as $searchColumn) {
+                        $searchColumn = $query->qualifyColumn($searchColumn);
+
                         $caseAwareSearchColumn = $isForcedCaseInsensitive ?
                             new Expression("lower({$searchColumn})") :
                             $searchColumn;


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

When following the (Docs)[https://filamentphp.com/docs/3.x/panels/resources/relation-managers#searching-the-options-to-attach-across-multiple-columns] on how to use `AttachAction`, an error occurs: `SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous`.

This PR makes sure to always qualify column name for `AttachAction` & `AssociateAction`.