### PR TITLE
Fixed docs

### DIFF
--- a/packages/panels/docs/04-pages.md
+++ b/packages/panels/docs/04-pages.md
@@ -111,7 +111,7 @@ You may change how many grid columns are used to display widgets.
 You may override the `getHeaderWidgetsColumns()` or `getFooterWidgetsColumns()` methods to return a number of grid columns to use:
 
 ```php
-protected function getHeaderWidgetsColumns(): int | array
+public function getHeaderWidgetsColumns(): int | array
 {
     return 3;
 }
@@ -122,7 +122,7 @@ protected function getHeaderWidgetsColumns(): int | array
 You may wish to change the number of widget grid columns based on the responsive [breakpoint](https://tailwindcss.com/docs/responsive-design#overview) of the browser. You can do this using an array that contains the number of columns that should be used at each breakpoint:
 
 ```php
-protected function getHeaderWidgetsColumns(): int | array
+public function getHeaderWidgetsColumns(): int | array
 {
     return [
         'md' => 4,

--- a/packages/panels/src/Pages/Page.php
+++ b/packages/panels/src/Pages/Page.php
@@ -159,7 +159,7 @@ abstract class Page extends BasePage
     /**
      * @return int | string | array<string, int | string | null>
      */
-    protected function getHeaderWidgetsColumns(): int | string | array
+    public function getHeaderWidgetsColumns(): int | string | array
     {
         return 2;
     }

--- a/packages/panels/src/Pages/Page.php
+++ b/packages/panels/src/Pages/Page.php
@@ -159,7 +159,7 @@ abstract class Page extends BasePage
     /**
      * @return int | string | array<string, int | string | null>
      */
-    public function getHeaderWidgetsColumns(): int | string | array
+    protected function getHeaderWidgetsColumns(): int | string | array
     {
         return 2;
     }


### PR DESCRIPTION
- [ ] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Currently by using this function in my custom Page:
```php
protected function getHeaderWidgetsColumns(): int | array
{
    return // ...;
}
```
as stated by the docs:
![image](https://github.com/filamentphp/filament/assets/64212185/bdbef605-73f0-422a-a593-733e8319de03)

Will give the following error:
![image](https://github.com/filamentphp/filament/assets/64212185/688b5132-fda7-4fcc-8cc5-826d3bb1d20d)

This is because `getHeaderWidgetsColumns()` in the Page is public and not protected. Therefore, should both functions be protected or both public?
