### PR TITLE
Fixed wrong comma in the docs

### DIFF
--- a/packages/forms/docs/03-fields/13-builder.md
+++ b/packages/forms/docs/03-fields/13-builder.md
@@ -100,7 +100,7 @@ Builder\Block::make('heading')
             ->live(onBlur: true)
             ->required(),
         // ...
-    ]),
+    ])
     ->label(function (?array $state): string {
         if ($state === null) {
             return 'Heading';


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
