### PR TITLE
[Docs] Fix typo in Forms hint() example

### DIFF
--- a/packages/forms/docs/03-fields/01-getting-started.md
+++ b/packages/forms/docs/03-fields/01-getting-started.md
@@ -138,7 +138,7 @@ use Filament\Forms\Components\TextInput;
 use Illuminate\Support\HtmlString;
 
 TextInput::make('password')
-    ->hint(str(new HtmlString('<a href="/forgotten-password">Forgotten your password?</a>'))
+    ->hint(new HtmlString('<a href="/forgotten-password">Forgotten your password?</a>'))
 
 TextInput::make('password')
     ->hint(str('[Forgotten your password?](/forgotten-password)')->inlineMarkdown()->toHtmlString())


### PR DESCRIPTION
Removed stray `str(` from example because parentheses are mismatched, and the HtmlString can't get converted to a sanitized string without losing the value of being treated as HTML in the first place.

TESTING: Yes I have tested that the example was wrong before the changes made, and works as expected after this change.

Before:
<img width="469" alt="Screen Shot 2023-09-19 at 3 12 02 AM" src="https://github.com/filamentphp/filament/assets/404472/64f8f921-b253-442f-8b24-031832bd41d7">

After:
<img width="194" alt="Screen Shot 2023-09-19 at 3 12 19 AM" src="https://github.com/filamentphp/filament/assets/404472/a7cc39b3-2f80-4b7a-9f64-f747682de8e0">
