### PR TITLE
Tables: BulkActions - Fix getSelectedTableRecords query to include filters.

### DIFF
--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -312,6 +312,8 @@ trait HasBulkActions
                 $column->applyRelationshipAggregates($query);
             }
 
+            $this->filterTableQuery($query);
+
             return $this->cachedSelectedTableRecords = $query->get();
         }
 

--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -312,7 +312,9 @@ trait HasBulkActions
                 $column->applyRelationshipAggregates($query);
             }
 
-            $this->filterTableQuery($query);
+            if ($table->shouldDeselectAllRecordsWhenFiltered()) {
+                $this->filterTableQuery($query);
+            }
 
             return $this->cachedSelectedTableRecords = $query->get();
         }


### PR DESCRIPTION
This way the thrashed records will be included in bulk actions if the TrashedFilter is applied.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
