### PR TITLE
Update 05-viewing-records.md

### DIFF
--- a/packages/panels/docs/03-resources/05-viewing-records.md
+++ b/packages/panels/docs/03-resources/05-viewing-records.md
@@ -18,9 +18,10 @@ By default, the View page will display a disabled form with the record's data. I
 use Filament\Infolists;
 use Filament\Infolists\Infolist;
 
-public static function infolist(Infolist $infolist): Infolist
+public function infolist(Infolist $infolist): Infolist
 {
     return $infolist
+        ->record($this->record)
         ->schema([
             Infolists\Components\TextEntry::make('name'),
             Infolists\Components\TextEntry::make('email'),


### PR DESCRIPTION
If you don't pass `->record($this->record)` you get the following error:

```
Infolist has no [record()] or [state()] set.
```

 given the context of the page (a ViewRecord page), this should be added so people don't run Gto this problem, which is not easy to debug if you are following the "guide" for the first time.

Also in `ViewRecord` pages the `infolist()` should not be static

```
Cannot make non-static method ViewRecord->infolist(infolist: \Filament\Infolists\Infolist) static
```



- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
