### PR TITLE
Allow panels to be used for unauthenticated users.

### DIFF
--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -131,7 +131,9 @@
                 @livewire(Filament\Livewire\DatabaseNotifications::class, ['lazy' => true])
             @endif
 
-            <x-filament-panels::user-menu />
+            @if (filament()->auth()->check())
+                <x-filament-panels::user-menu />
+            @endif
         </div>
 
         {{ \Filament\Support\Facades\FilamentView::renderHook('panels::topbar.end') }}

--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -127,11 +127,11 @@
 
             {{ \Filament\Support\Facades\FilamentView::renderHook('panels::global-search.after') }}
 
-            @if (filament()->hasDatabaseNotifications())
-                @livewire(Filament\Livewire\DatabaseNotifications::class, ['lazy' => true])
-            @endif
-
             @if (filament()->auth()->check())
+                @if (filament()->hasDatabaseNotifications())
+                    @livewire(Filament\Livewire\DatabaseNotifications::class, ['lazy' => true])
+                @endif
+
                 <x-filament-panels::user-menu />
             @endif
         </div>


### PR DESCRIPTION
The only thing stopping a Panel from being used as a public Panel without user authentication is the `user-menu` being required in the top bar. This adds an auth check to only render the `user-menu` component when a user is authenticated.

I saw your [comment](https://github.com/filamentphp/filament/discussions/6119#discussioncomment-5528346) that Panels aren't meant to be used for unauthenticated users, however I think this small change as well as the user removing the Authenticate middleware will allow the panel to be used for unauthenticated users. This will make the panels much more flexible and allow them to be used to build application experiences for unauthenticated users. My use case is to build a docs panel to ship as a plugin in a package. 

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
