### PR TITLE
Fix pagination layout

### DIFF
--- a/packages/support/resources/views/components/pagination/index.blade.php
+++ b/packages/support/resources/views/components/pagination/index.blade.php
@@ -12,7 +12,7 @@
 <nav
     aria-label="{{ __('filament::components/pagination.label') }}"
     role="navigation"
-    {{ $attributes->class(['fi-pagination grid grid-col-3 grid-flow-col items-center gap-3']) }}
+    {{ $attributes->class(['fi-pagination grid grid-cols-3 grid-flow-col items-center gap-3']) }}
 >
     @if (! $paginator->onFirstPage())
         <x-filament::button

--- a/packages/support/resources/views/components/pagination/index.blade.php
+++ b/packages/support/resources/views/components/pagination/index.blade.php
@@ -12,7 +12,7 @@
 <nav
     aria-label="{{ __('filament::components/pagination.label') }}"
     role="navigation"
-    {{ $attributes->class(['fi-pagination grid grid-cols-3 items-center gap-3']) }}
+    {{ $attributes->class(['fi-pagination grid grid-cols-3 items-center']) }}
 >
     @if (! $paginator->onFirstPage())
         <x-filament::button

--- a/packages/support/resources/views/components/pagination/index.blade.php
+++ b/packages/support/resources/views/components/pagination/index.blade.php
@@ -12,7 +12,7 @@
 <nav
     aria-label="{{ __('filament::components/pagination.label') }}"
     role="navigation"
-    {{ $attributes->class(['fi-pagination grid grid-cols-3 grid-flow-col items-center gap-3']) }}
+    {{ $attributes->class(['fi-pagination grid grid-cols-3 items-center gap-3']) }}
 >
     @if (! $paginator->onFirstPage())
         <x-filament::button

--- a/packages/support/resources/views/components/pagination/index.blade.php
+++ b/packages/support/resources/views/components/pagination/index.blade.php
@@ -12,12 +12,7 @@
 <nav
     aria-label="{{ __('filament::components/pagination.label') }}"
     role="navigation"
-    {{
-        $attributes->class([
-            'fi-pagination grid grid-flow-col items-center gap-3',
-            'grid-cols-3' => (! $isSimple) && (! ($paginator->hasMorePages() || $paginator->hasPages())),
-        ])
-    }}
+    {{ $attributes->class(['fi-pagination grid grid-col-3 grid-flow-col items-center gap-3']) }}
 >
     @if (! $paginator->onFirstPage())
         <x-filament::button


### PR DESCRIPTION
With the latest release, pagination is misaligned in a multiple scenarios such as using simple pagination when there are no records.

This PR updates #8499 by simply always using `grid-cols-3` since it's the cleanest way to handle all the possible combinations and ensures the paginator doesn't jump around. This was test against the following scenarios. If there's one I missed let me know so I can test against it.

  | Simple | Simple mobile | Normal | Normal mobile
-- | -- | -- | -- | --
No results | ✅ | ✅ | Doesn’t display | Doesn’t display
1 page results | ✅ | ✅ | ✅ | ✅
First page | ✅ | ✅ | ✅ | ✅
Middle pages | ✅ | ✅ | ✅ | ✅
Last page | ✅ | ✅ | ✅ | ✅

Before issues:

![Screenshot 2023-09-19 at 9 27 11 PM](https://github.com/filamentphp/filament/assets/6097099/bd308753-2eeb-40e7-8ff1-9f597830ed3e)
![Screenshot 2023-09-19 at 9 27 01 PM](https://github.com/filamentphp/filament/assets/6097099/c87b87e5-d2ab-4f9f-94a9-24995e3d04e3)
![Screenshot 2023-09-19 at 9 26 31 PM](https://github.com/filamentphp/filament/assets/6097099/f8b362c8-5a2e-4416-a62a-6b8c105058b0)

After:

![Screenshot 2023-09-19 at 9 33 52 PM](https://github.com/filamentphp/filament/assets/6097099/8a23ec11-c99a-4d4e-a35f-b63750e5ca45)
![Screenshot 2023-09-19 at 9 32 37 PM](https://github.com/filamentphp/filament/assets/6097099/82c1342b-d1c4-4f42-afad-90301fcde625)
![Screenshot 2023-09-19 at 9 32 31 PM](https://github.com/filamentphp/filament/assets/6097099/3ace22a2-8806-414c-ab63-6a3094238563)


- [X] Changes have been thoroughly tested to not break existing functionality.
- [X] New functionality has been documented or existing documentation has been updated to reflect changes.
- [X] Visual changes are explained in the PR description using a screenshot/recording of before and after.
