### PR TITLE
Translatable plugin docs: making a model translatable

### DIFF
--- a/packages/spatie-laravel-translatable-plugin/README.md
+++ b/packages/spatie-laravel-translatable-plugin/README.md
@@ -43,27 +43,11 @@ public function panel(Panel $panel): Panel
 
 ## Make your model translatable
 
-Below steps are required to make your model translatable:
-1. Add `Spatie\Translatable\HasTranslations` trait to your model.
-2. Create public property `$translatable` which is an array containing all names of attributes that you want to be translatable.
-
-```php
-use Illuminate\Database\Eloquent\Model;
-use Spatie\Translatable\HasTranslations;
-
-class BlogPost extends Model
-{
-    use HasTranslations;
-    
-    public $translatable = ['title', 'content', 'slug'];
-    
-    // ...
-}
-```
+First, you need to make your models translatable. Read the official spatie's guide from <a href="https://spatie.be/docs/laravel-translatable/v6/installation-setup#content-making-a-model-translatable" target="_blank">here</a>.
 
 ## Preparing your resource class
 
-First, you must apply the `Filament\Resources\Concerns\Translatable` trait to your resource class:
+Second, you must apply the `Filament\Resources\Concerns\Translatable` trait to your resource class:
 
 ```php
 use Filament\Resources\Concerns\Translatable;

--- a/packages/spatie-laravel-translatable-plugin/README.md
+++ b/packages/spatie-laravel-translatable-plugin/README.md
@@ -41,6 +41,26 @@ public function panel(Panel $panel): Panel
 }
 ```
 
+## Make your translatable
+
+Below steps are required to make your model translatable:
+1. Add `Spatie\Translatable\HasTranslations` trait to your model.
+2. Create public property `$translatable` which is an array containing all names of attributes that you want to be translatable.
+
+```php
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Translatable\HasTranslations;
+
+class BlogPost extends Model
+{
+    use HasTranslations;
+    
+    public $translatable = ['title', 'content', 'slug'];
+    
+    // ...
+}
+```
+
 ## Preparing your resource class
 
 First, you must apply the `Filament\Resources\Concerns\Translatable` trait to your resource class:

--- a/packages/spatie-laravel-translatable-plugin/README.md
+++ b/packages/spatie-laravel-translatable-plugin/README.md
@@ -41,13 +41,13 @@ public function panel(Panel $panel): Panel
 }
 ```
 
-## Make your model translatable
+## Preparing your model class
 
-First, you need to make your models translatable. Read the official spatie's guide from [here](https://spatie.be/docs/laravel-translatable/v6/installation-setup#content-making-a-model-translatable).
+You need to make your model translatable. You can read how to do this in [Spatie's documentation](https://spatie.be/docs/laravel-translatable/installation-setup#content-making-a-model-translatable).
 
 ## Preparing your resource class
 
-Second, you must apply the `Filament\Resources\Concerns\Translatable` trait to your resource class:
+You must apply the `Filament\Resources\Concerns\Translatable` trait to your resource class:
 
 ```php
 use Filament\Resources\Concerns\Translatable;

--- a/packages/spatie-laravel-translatable-plugin/README.md
+++ b/packages/spatie-laravel-translatable-plugin/README.md
@@ -41,7 +41,7 @@ public function panel(Panel $panel): Panel
 }
 ```
 
-## Make your translatable
+## Make your model translatable
 
 Below steps are required to make your model translatable:
 1. Add `Spatie\Translatable\HasTranslations` trait to your model.

--- a/packages/spatie-laravel-translatable-plugin/README.md
+++ b/packages/spatie-laravel-translatable-plugin/README.md
@@ -41,6 +41,26 @@ public function panel(Panel $panel): Panel
 }
 ```
 
+## Make your translatable
+
+Below steps are required to make you model translatable:
+1. Add `Spatie\Translatable\HasTranslations` trait to your model.
+2. Create public property `$translatable` which is an array containing all names of attributes that you want to be translatable.
+
+```php
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Translatable\HasTranslations;
+
+class BlogPost extends Model
+{
+    use HasTranslations;
+    
+    public $translatable = ['title', 'content', 'slug'];
+    
+    // ...
+}
+```
+
 ## Preparing your resource class
 
 First, you must apply the `Filament\Resources\Concerns\Translatable` trait to your resource class:

--- a/packages/spatie-laravel-translatable-plugin/README.md
+++ b/packages/spatie-laravel-translatable-plugin/README.md
@@ -43,7 +43,7 @@ public function panel(Panel $panel): Panel
 
 ## Make your model translatable
 
-First, you need to make your models translatable. Read the official spatie's guide from <a href="https://spatie.be/docs/laravel-translatable/v6/installation-setup#content-making-a-model-translatable" target="_blank">here</a>.
+First, you need to make your models translatable. Read the official spatie's guide from [here](https://spatie.be/docs/laravel-translatable/v6/installation-setup#content-making-a-model-translatable).
 
 ## Preparing your resource class
 


### PR DESCRIPTION
Hi, 

I've added a section on making models translatable for those unfamiliar with `spatie/laravel-translatable`.