### PR TITLE
Ignore collapsible sidebar CSS when top navigation is enabled.

### DIFF
--- a/packages/panels/resources/views/components/sidebar/index.blade.php
+++ b/packages/panels/resources/views/components/sidebar/index.blade.php
@@ -10,7 +10,7 @@
 {{-- format-ignore-start --}}
 <aside
     x-data="{}"
-    @if (filament()->isSidebarCollapsibleOnDesktop() && ! filament()->hasTopNavigation())
+    @if (filament()->isSidebarCollapsibleOnDesktop() && (! filament()->hasTopNavigation()))
         x-cloak
         x-bind:class="
             $store.sidebar.isOpen

--- a/packages/panels/resources/views/components/sidebar/index.blade.php
+++ b/packages/panels/resources/views/components/sidebar/index.blade.php
@@ -10,13 +10,13 @@
 {{-- format-ignore-start --}}
 <aside
     x-data="{}"
-    @if (filament()->isSidebarCollapsibleOnDesktop())
+    @if (filament()->isSidebarCollapsibleOnDesktop() && ! filament()->hasTopNavigation())
         x-cloak
-    x-bind:class="
-        $store.sidebar.isOpen
-            ? @js($openSidebarClasses . ' ' . 'lg:sticky')
-            : '-translate-x-full rtl:translate-x-full lg:sticky lg:translate-x-0 rtl:lg:-translate-x-0'
-    "
+        x-bind:class="
+            $store.sidebar.isOpen
+                ? @js($openSidebarClasses . ' ' . 'lg:sticky')
+                : '-translate-x-full rtl:translate-x-full lg:sticky lg:translate-x-0 rtl:lg:-translate-x-0'
+        "
     @else
         @if (filament()->hasTopNavigation())
             x-cloak


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Previous to this PR, the CSS for the collapsible sidebar would still be applied when a User has top navigation enabled. This resulted in the following.

**Before:**
![Screenshot 2023-09-20 at 8 53 02 AM](https://github.com/filamentphp/filament/assets/104294090/c0a54a45-e9ca-4056-a5f1-3fa338be7a71)

The CSS applied for a collapsible sidebar should be ignored when a User has enabled top navigation. Beforehand, using `->sidebarFullyCollapsibleOnDesktop()` would not result in any issues, but using `->sidebarCollapsibleOnDesktop()` would result in issues. This PR improves this. 

**After:**
![Screenshot 2023-09-20 at 8 53 25 AM](https://github.com/filamentphp/filament/assets/104294090/5c1e1e65-d34c-4ace-b664-1023dbf338a7)


