### PR TITLE
Constraint order values

### DIFF
--- a/packages/tables/src/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Concerns/CanGroupRecords.php
@@ -44,6 +44,8 @@ trait CanGroupRecords
             return $query;
         }
 
-        return $group->orderQuery($query, $this->tableGroupingDirection ?? 'asc');
+        $orderDirection = $this->tableGroupingDirection === 'desc' ? 'desc' : 'asc';
+
+        return $group->orderQuery($query, $orderDirection);
     }
 }

--- a/packages/tables/src/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Concerns/CanGroupRecords.php
@@ -32,6 +32,15 @@ trait CanGroupRecords
         $this->resetPage();
     }
 
+    public function getTableGroupingDirection(): ?string
+    {
+        return match ($this->tableGroupingDirection) {
+            'asc' => 'asc',
+            'desc' => 'desc',
+            default => null,
+        };
+    }
+
     protected function applyGroupingToTableQuery(Builder $query): Builder
     {
         if ($this->isTableReordering()) {
@@ -44,8 +53,6 @@ trait CanGroupRecords
             return $query;
         }
 
-        $orderDirection = $this->tableGroupingDirection === 'desc' ? 'desc' : 'asc';
-
-        return $group->orderQuery($query, $orderDirection);
+        return $group->orderQuery($query, $this->getTableGroupingDirection());
     }
 }


### PR DESCRIPTION
Setting `tableGroupingDirection` to any value will raise an exception, this PR makes sure it doesn't.