### PR TITLE
Add `wire:key` in forms select component

### DIFF
--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -61,6 +61,7 @@
                                 <option
                                     @disabled($isOptionDisabled($groupedValue, $groupedLabel))
                                     value="{{ $groupedValue }}"
+                                    wire:key="{{ $groupedValue }}"
                                 >
                                     @if ($isHtmlAllowed)
                                         {!! $groupedLabel !!}
@@ -74,6 +75,7 @@
                         <option
                             @disabled($isOptionDisabled($value, $label))
                             value="{{ $value }}"
+                            wire:key="{{ $value }}"
                         >
                             @if ($isHtmlAllowed)
                                 {!! $label !!}


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

It would seem that the default behaviour with dependent selects has changed from Livewire v2 to v3. It may have been possible to get away without `wire:key` on `select` `option`s previously (perhaps handled by JS) however, now without them, existing functionality of Filament v2 projects breaks.

https://github.com/livewire/livewire/discussions/6882

Have added `wire:key` to `option` elements in the select component in the Forms namespace.
