### PR TITLE
Update notifications docs about Markdown

### DIFF
--- a/packages/notifications/resources/views/notification.blade.php
+++ b/packages/notifications/resources/views/notification.blade.php
@@ -84,7 +84,7 @@
 
             @if (filled($body = $getBody()))
                 <x-filament-notifications::body class="mt-1">
-                    {{ str($body)->sanitizeHtml()->toHtmlString() }}
+                    {{ str($body)->markdown()->sanitizeHtml()->toHtmlString() }}
                 </x-filament-notifications::body>
             @endif
 

--- a/packages/notifications/resources/views/notification.blade.php
+++ b/packages/notifications/resources/views/notification.blade.php
@@ -72,7 +72,7 @@
         <div class="mt-0.5 grid flex-1">
             @if (filled($title = $getTitle()))
                 <x-filament-notifications::title>
-                    {{ str($title)->sanitizeHtml()->toHtmlString() }}
+                    {{ str($title)->markdown()->sanitizeHtml()->toHtmlString() }}
                 </x-filament-notifications::title>
             @endif
 


### PR DESCRIPTION
This PR adds the missing markdown support to filament notifications.

The documentation for filament notifications says the body supports markdown. This is clearly not the case. 
see https://filamentphp.com/docs/3.x/notifications/sending-notifications#setting-body-text

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
