### PR TITLE
Fix/make form action label translatable and add German translation for button and notification

### DIFF
--- a/packages/panels/resources/lang/de/pages/tenancy/edit-tenant-profile.php
+++ b/packages/panels/resources/lang/de/pages/tenancy/edit-tenant-profile.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+
+    'form' => [
+
+        'actions' => [
+
+            'save' => [
+                'label' => 'Speichern',
+            ],
+
+        ],
+
+    ],
+
+    'notifications' => [
+
+        'saved' => [
+            'title' => 'Gespeichert',
+        ],
+
+    ],
+
+];

--- a/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
+++ b/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
@@ -202,14 +202,9 @@ abstract class EditTenantProfile extends Page
     protected function getSaveFormAction(): Action
     {
         return Action::make('save')
-            ->label($this->getSaveFormActionLabel())
+            ->label(__('filament-panels::pages/tenancy/edit-tenant-profile.form.actions.save.label'))
             ->submit('save')
             ->keyBindings(['mod+s']);
-    }
-
-    protected function getSaveFormActionLabel(): string
-    {
-        return __('filament-panels::pages/tenancy/edit-tenant-profile.form.actions.save.label');
     }
 
     public function getTitle(): string | Htmlable

--- a/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
+++ b/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
@@ -202,9 +202,14 @@ abstract class EditTenantProfile extends Page
     protected function getSaveFormAction(): Action
     {
         return Action::make('save')
-            ->label(__('filament-panels::pages/tenancy/edit-tenant-profile.form.actions.save.label'))
+            ->label($this->getSaveFormActionLabel())
             ->submit('save')
             ->keyBindings(['mod+s']);
+    }
+
+    protected function getSaveFormActionLabel(): string
+    {
+        return __('filament-panels::pages/tenancy/edit-tenant-profile.form.actions.save.label');
     }
 
     public function getTitle(): string | Htmlable


### PR DESCRIPTION
- [X] Changes have been thoroughly tested to not break existing functionality.
- ~New functionality has been documented or existing documentation has been updated to reflect changes.~ not necessary
- ~Visual changes are explained in the PR description using a screenshot/recording of before and after.~ not necessary

We added the German translation for the save button and also add a function to make the button configurable similar to `getSavedNotificationTitle` above.