### PR TITLE
Add missing `ar` translations

### DIFF
--- a/packages/tables/resources/lang/ar/table.php
+++ b/packages/tables/resources/lang/ar/table.php
@@ -69,36 +69,36 @@ return [
     'actions' => [
 
         'disable_reordering' => [
-            'label' => 'Finish reordering records',
+            'label' => 'إنهاء إعادة ترتيب السجلات',
         ],
 
         'enable_reordering' => [
-            'label' => 'Reorder records',
+            'label' => 'إعادة ترتيب السجلات',
         ],
 
         'filter' => [
-            'label' => 'Filter',
+            'label' => 'تصفية',
         ],
 
         'group' => [
-            'label' => 'Group',
+            'label' => 'مجموعة',
         ],
 
         'open_bulk_actions' => [
-            'label' => 'Bulk actions',
+            'label' => 'فتح الإجراءات',
         ],
 
         'toggle_columns' => [
-            'label' => 'Toggle columns',
+            'label' => 'تبديل الأعمدة',
         ],
 
     ],
 
     'empty' => [
 
-        'heading' => 'No :model',
+        'heading' => 'لا توجد سجلات',
 
-        'description' => 'Create a :model to get started.',
+        'description' => 'قم بإضافة :model للبدء.',
 
     ],
 
@@ -107,41 +107,41 @@ return [
         'actions' => [
 
             'remove' => [
-                'label' => 'Remove filter',
+                'label' => 'إلغاء الفلاتر',
             ],
 
             'remove_all' => [
-                'label' => 'Remove all filters',
-                'tooltip' => 'Remove all filters',
+                'label' => 'إلغاء كافة الفلاتر',
+                'tooltip' => 'إلغاء كافة الفلاتر',
             ],
 
             'reset' => [
-                'label' => 'Reset',
+                'label' => 'إعادة ضبط الفلاتر',
             ],
 
         ],
 
-        'heading' => 'Filters',
+        'heading' => 'الفلاتر',
 
-        'indicator' => 'Active filters',
+        'indicator' => 'الفلاتر النشطة',
 
         'multi_select' => [
-            'placeholder' => 'All',
+            'placeholder' => 'الكل',
         ],
 
         'select' => [
-            'placeholder' => 'All',
+            'placeholder' => 'الكل',
         ],
 
         'trashed' => [
 
-            'label' => 'Deleted records',
+            'label' => 'السجلات المحذوفة',
 
-            'only_trashed' => 'Only deleted records',
+            'only_trashed' => 'السجلات المحذوفة فقط',
 
-            'with_trashed' => 'With deleted records',
+            'with_trashed' => 'مع السجلات المحذوفة',
 
-            'without_trashed' => 'Without deleted records',
+            'without_trashed' => 'بدون السجلات المحذوفة',
 
         ],
 
@@ -152,17 +152,17 @@ return [
         'fields' => [
 
             'group' => [
-                'label' => 'Group by',
-                'placeholder' => 'Group by',
+                'label' => 'تجميع حسب',
+                'placeholder' => 'تجميع حسب',
             ],
 
             'direction' => [
 
-                'label' => 'Group direction',
+                'label' => 'إتجاه التجميع',
 
                 'options' => [
-                    'asc' => 'Ascending',
-                    'desc' => 'Descending',
+                    'asc' => 'تصاعدي',
+                    'desc' => 'تنازلي',
                 ],
 
             ],
@@ -171,20 +171,20 @@ return [
 
     ],
 
-    'reorder_indicator' => 'Drag and drop the records into order.',
+    'reorder_indicator' => 'قم بسحب وإسقاط السجلات بالترتيب.',
 
     'selection_indicator' => [
 
-        'selected_count' => '1 record selected|:count records selected',
+        'selected_count' => '{1} تم تحديد سجل واحد|[3,10] تم تحديد :count سجلات |[2,*] تم تحديد :count سجل',
 
         'actions' => [
 
             'select_all' => [
-                'label' => 'Select all :count',
+                'label' => 'تحديد كل السجلات :count',
             ],
 
             'deselect_all' => [
-                'label' => 'Deselect all',
+                'label' => 'إلغاء تحديد الكل',
             ],
 
         ],
@@ -196,16 +196,16 @@ return [
         'fields' => [
 
             'column' => [
-                'label' => 'Sort by',
+                'label' => 'ترتيب حسب',
             ],
 
             'direction' => [
 
-                'label' => 'Sort direction',
+                'label' => 'اتجاه الترتيب',
 
                 'options' => [
-                    'asc' => 'Ascending',
-                    'desc' => 'Descending',
+                    'asc' => 'تصاعدي',
+                    'desc' => 'تنازلي',
                 ],
 
             ],

--- a/packages/tables/resources/lang/ar/table.php
+++ b/packages/tables/resources/lang/ar/table.php
@@ -23,7 +23,11 @@ return [
         ],
 
         'bulk_select_record' => [
-            'label' => 'تحديد / إلغاء تحديد العنصر :key للإجراءات الجماعية',
+            'label' => 'تحديد / إلغاء تحديد العنصر :key للإجراءات الجماعية.',
+        ],
+
+        'bulk_select_group' => [
+            'label' => 'تحديد / إلغاء تحديد المجموعة :title للإجراءات الجماعية.',
         ],
 
         'search' => [
@@ -65,36 +69,36 @@ return [
     'actions' => [
 
         'disable_reordering' => [
-            'label' => 'إنهاء إعادة ترتيب السجلات',
+            'label' => 'Finish reordering records',
         ],
 
         'enable_reordering' => [
-            'label' => 'إعادة ترتيب السجلات',
+            'label' => 'Reorder records',
         ],
 
         'filter' => [
-            'label' => 'تصفية',
+            'label' => 'Filter',
         ],
 
         'group' => [
-            'label' => 'مجموعة',
+            'label' => 'Group',
         ],
 
         'open_bulk_actions' => [
-            'label' => 'فتح الإجراءات',
+            'label' => 'Bulk actions',
         ],
 
         'toggle_columns' => [
-            'label' => 'تبديل الأعمدة',
+            'label' => 'Toggle columns',
         ],
 
     ],
 
     'empty' => [
 
-        'heading' => 'لا توجد سجلات',
+        'heading' => 'No :model',
 
-        'description' => 'قم بإضافة :model للبدء.',
+        'description' => 'Create a :model to get started.',
 
     ],
 
@@ -103,41 +107,41 @@ return [
         'actions' => [
 
             'remove' => [
-                'label' => 'إلغاء الفلاتر',
+                'label' => 'Remove filter',
             ],
 
             'remove_all' => [
-                'label' => 'إلغاء كافة الفلاتر',
-                'tooltip' => 'إلغاء كافة الفلاتر',
+                'label' => 'Remove all filters',
+                'tooltip' => 'Remove all filters',
             ],
 
             'reset' => [
-                'label' => 'إعادة ضبط الفلاتر',
+                'label' => 'Reset',
             ],
 
         ],
 
-        'heading' => 'الفلاتر',
+        'heading' => 'Filters',
 
-        'indicator' => 'الفلاتر النشطة',
+        'indicator' => 'Active filters',
 
         'multi_select' => [
-            'placeholder' => 'الكل',
+            'placeholder' => 'All',
         ],
 
         'select' => [
-            'placeholder' => 'الكل',
+            'placeholder' => 'All',
         ],
 
         'trashed' => [
 
-            'label' => 'السجلات المحذوفة',
+            'label' => 'Deleted records',
 
-            'only_trashed' => 'السجلات المحذوفة فقط',
+            'only_trashed' => 'Only deleted records',
 
-            'with_trashed' => 'مع السجلات المحذوفة',
+            'with_trashed' => 'With deleted records',
 
-            'without_trashed' => 'بدون السجلات المحذوفة',
+            'without_trashed' => 'Without deleted records',
 
         ],
 
@@ -148,17 +152,17 @@ return [
         'fields' => [
 
             'group' => [
-                'label' => 'تجميع حسب',
-                'placeholder' => 'تجميع حسب',
+                'label' => 'Group by',
+                'placeholder' => 'Group by',
             ],
 
             'direction' => [
 
-                'label' => 'إتجاه التجميع',
+                'label' => 'Group direction',
 
                 'options' => [
-                    'asc' => 'تصاعدي',
-                    'desc' => 'تنازلي',
+                    'asc' => 'Ascending',
+                    'desc' => 'Descending',
                 ],
 
             ],
@@ -167,20 +171,20 @@ return [
 
     ],
 
-    'reorder_indicator' => 'قم بسحب وإسقاط السجلات بالترتيب.',
+    'reorder_indicator' => 'Drag and drop the records into order.',
 
     'selection_indicator' => [
 
-        'selected_count' => '{1} تم تحديد سجل واحد|[3,10] تم تحديد :count سجلات |[2,*] تم تحديد :count سجل',
+        'selected_count' => '1 record selected|:count records selected',
 
         'actions' => [
 
             'select_all' => [
-                'label' => 'تحديد كل السجلات :count',
+                'label' => 'Select all :count',
             ],
 
             'deselect_all' => [
-                'label' => 'إلغاء تحديد الكل',
+                'label' => 'Deselect all',
             ],
 
         ],
@@ -192,16 +196,16 @@ return [
         'fields' => [
 
             'column' => [
-                'label' => 'ترتيب حسب',
+                'label' => 'Sort by',
             ],
 
             'direction' => [
 
-                'label' => 'اتجاه الترتيب',
+                'label' => 'Sort direction',
 
                 'options' => [
-                    'asc' => 'تصاعدي',
-                    'desc' => 'تنازلي',
+                    'asc' => 'Ascending',
+                    'desc' => 'Descending',
                 ],
 
             ],


### PR DESCRIPTION
- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
