### PR TITLE
Fix broken cross-links in plugin docs

### DIFF
--- a/packages/support/docs/08-plugins/01-getting-started.md
+++ b/packages/support/docs/08-plugins/01-getting-started.md
@@ -76,6 +76,6 @@ Please read this guide in its entirety before upgrading your plugin. It will hel
 
 1. [Filament Asset Management](/docs/3.x/support/assets)
 2. [Panel Plugin Development](/docs/3.x/panels/plugins)
-3. [Icon Management](docs/3.x/support/icons)
-4. [Colors Management](docs/3.x/support/colors)
-5. [Stying Customization](docs/3.x/support/style-customization)
+3. [Icon Management](/docs/3.x/support/icons)
+4. [Colors Management](/docs/3.x/support/colors)
+5. [Style Customization](/docs/3.x/support/style-customization)

--- a/packages/support/docs/08-plugins/02-build-a-panel-plugin.md
+++ b/packages/support/docs/08-plugins/02-build-a-panel-plugin.md
@@ -134,7 +134,7 @@ class ClockWidget extends Widget
 
 Next, we'll need to create the view for our widget. Create a new file at `resources/views/widget.blade.php` and add the following code. We'll make use of Filament's blade components to save time on writing the html for the widget.
 
-We are using async Alpine to load our Alpine component, so we'll need to add the `x-ignore` attribute to the div that will load our component. We'll also need to add the `ax-load` attribute to the div to tell Alpine to load our component. You can learn more about this in the [Core Concepts](/docs/3.x/support/plugins/core-concepts#alpine-components) section of the docs.
+We are using async Alpine to load our Alpine component, so we'll need to add the `x-ignore` attribute to the div that will load our component. We'll also need to add the `ax-load` attribute to the div to tell Alpine to load our component. You can learn more about this in the [Core Concepts](/docs/3.x/support/assets#asynchronous-alpinejs-components) section of the docs.
 
 ```blade
 <x-filament-widgets::widget>

--- a/packages/support/docs/08-plugins/03-build-a-standalone-plugin.md
+++ b/packages/support/docs/08-plugins/03-build-a-standalone-plugin.md
@@ -195,7 +195,7 @@ class Heading extends Component
 
 Next, we'll need to create the view for our component. Create a new file at `resources/views/heading.blade.php` and add the following code.
 
-We are using x-load to asynchronously load stylesheet, so it's only loaded when necessary. You can learn more about this in the [Core Concepts](docs/3.x/support/assets#lazy-loading-css) section of the docs.
+We are using x-load to asynchronously load stylesheet, so it's only loaded when necessary. You can learn more about this in the [Core Concepts](/docs/3.x/support/assets#lazy-loading-css) section of the docs.
 
 ```blade
 @php


### PR DESCRIPTION
Without the preceding `/` the links were "relative", thus firing some fallback redirects where were unhelpful.