### PR TITLE
Support guest users

### DIFF
--- a/packages/panels/resources/lang/de/layout.php
+++ b/packages/panels/resources/lang/de/layout.php
@@ -6,6 +6,10 @@ return [
 
     'actions' => [
 
+        'login' => [
+            'label' => 'Anmelden',
+        ],
+
         'logout' => [
             'label' => 'Abmelden',
         ],
@@ -14,8 +18,16 @@ return [
             'label' => 'Benachrichtigungen öffnen',
         ],
 
+        'open_guest_menu' => [
+            'label' => 'Gastmenü',
+        ],
+
         'open_user_menu' => [
             'label' => 'Benutzermenü',
+        ],
+
+        'register' => [
+            'label' => 'Registrieren',
         ],
 
         'sidebar' => [

--- a/packages/panels/resources/lang/de/widgets/account-widget.php
+++ b/packages/panels/resources/lang/de/widgets/account-widget.php
@@ -4,8 +4,16 @@ return [
 
     'actions' => [
 
+        'login' => [
+            'label' => 'Anmelden',
+        ],
+
         'logout' => [
             'label' => 'Abmelden',
+        ],
+
+        'register' => [
+            'label' => 'Registrieren',
         ],
 
     ],

--- a/packages/panels/resources/lang/en/layout.php
+++ b/packages/panels/resources/lang/en/layout.php
@@ -22,7 +22,7 @@ return [
             'label' => 'Open notifications',
         ],
 
-        'open_user_menu' => [
+        'open_guest_menu' => [
             'label' => 'Guest menu',
         ],
 

--- a/packages/panels/resources/lang/en/layout.php
+++ b/packages/panels/resources/lang/en/layout.php
@@ -10,6 +10,10 @@ return [
             'label' => 'Manage subscription',
         ],
 
+        'login' => [
+            'label' => 'Sign in',
+        ],
+
         'logout' => [
             'label' => 'Sign out',
         ],
@@ -19,7 +23,15 @@ return [
         ],
 
         'open_user_menu' => [
+            'label' => 'Guest menu',
+        ],
+
+        'open_user_menu' => [
             'label' => 'User menu',
+        ],
+
+        'register' => [
+            'label' => 'Sign up',
         ],
 
         'sidebar' => [

--- a/packages/panels/resources/lang/en/widgets/account-widget.php
+++ b/packages/panels/resources/lang/en/widgets/account-widget.php
@@ -4,8 +4,16 @@ return [
 
     'actions' => [
 
+        'login' => [
+            'label' => 'Sign in',
+        ],
+
         'logout' => [
             'label' => 'Sign out',
+        ],
+
+        'register' => [
+            'label' => 'Sign up',
         ],
 
     ],

--- a/packages/panels/resources/views/components/avatar/guest.blade.php
+++ b/packages/panels/resources/views/components/avatar/guest.blade.php
@@ -1,0 +1,19 @@
+@props([
+    'size' => 'md',
+])
+
+<div 
+    class="flex items-center justify-center bg-gray-950 rounded-full
+    {{ 
+        match ($size) {
+            'md' => 'h-9 w-9',
+            'lg' => 'h-10 w-10',
+            default => $size,
+        }
+    }}"
+>
+    <x-filament::icon
+        icon="heroicon-o-lock-closed"
+        class="h-6 w-6 m-0 text-white"
+    />
+</div>

--- a/packages/panels/resources/views/components/guest-menu.blade.php
+++ b/packages/panels/resources/views/components/guest-menu.blade.php
@@ -1,0 +1,81 @@
+@php
+    $items = filament()->getGuestMenuItems();
+
+    $hasLogin = filament()->hasLogin();
+    $hasRegistration = filament()->hasRegistration();
+
+    $loginItem = $items['login'] ?? null;
+    $registerItem = $items['register'] ?? null;
+
+    $items = \Illuminate\Support\Arr::except($items, ['login', 'register']);
+@endphp
+
+{{ \Filament\Support\Facades\FilamentView::renderHook('panels::guest-menu.before') }}
+
+<x-filament::dropdown
+    placement="bottom-end"
+    teleport
+    :attributes="
+        \Filament\Support\prepare_inherited_attributes($attributes)
+            ->class(['fi-guest-menu'])
+    "
+>
+    <x-slot name="trigger">
+        <button
+            aria-label="{{ __('filament-panels::layout.actions.open_guest_menu.label') }}"
+            type="button"
+        >
+            <x-filament-panels::avatar.guest />
+        </button>
+    </x-slot>
+
+    @if (filament()->hasDarkMode() && (! filament()->hasDarkModeForced()))
+        <x-filament::dropdown.list>
+            <x-filament-panels::theme-switcher />
+        </x-filament::dropdown.list>
+    @endif
+
+    @if ($hasLogin || $hasRegister || count($items) > 0)
+        <x-filament::dropdown.list>
+            @foreach ($items as $key => $item)
+                <x-filament::dropdown.list.item
+                    :color="$item->getColor()"
+                    :href="$item->getUrl()"
+                    :target="$item->shouldOpenUrlInNewTab() ? '_blank' : null"
+                    :icon="$item->getIcon()"
+                    tag="a"
+                >
+                    {{ $item->getLabel() }}
+                </x-filament::dropdown.list.item>
+            @endforeach
+
+            @if ($hasLogin)
+                <x-filament::dropdown.list.item
+                    :action="$loginItem?->getUrl() ?? filament()->getLoginUrl()"
+                    :color="$loginItem?->getColor()"
+                    :icon="$loginItem?->getIcon() ?? 'heroicon-m-arrow-right-on-rectangle'"
+                    icon-alias="panels::guest-menu.login-button"
+                    method="get"
+                    tag="form"
+                >
+                    {{ $loginItem?->getLabel() ?? __('filament-panels::layout.actions.login.label') }}
+                </x-filament::dropdown.list.item>
+            @endif
+
+            @if ($hasRegistration)
+                <x-filament::dropdown.list.item
+                    :action="$registerItem?->getUrl() ?? filament()->getRegistrationUrl()"
+                    :color="$registerItem?->getColor()"
+                    :icon="$registerItem?->getIcon() ?? 'heroicon-m-user-plus'"
+                    icon-alias="panels::guest-menu.register-button"
+                    method="get"
+                    tag="form"
+                >
+                    {{ $loginItem?->getLabel() ?? __('filament-panels::layout.actions.register.label') }}
+                </x-filament::dropdown.list.item>
+            @endif
+        </x-filament::dropdown.list>
+    @endif
+</x-filament::dropdown>
+
+{{ \Filament\Support\Facades\FilamentView::renderHook('panels::guest-menu.after') }}

--- a/packages/panels/resources/views/components/layout/simple.blade.php
+++ b/packages/panels/resources/views/components/layout/simple.blade.php
@@ -6,15 +6,19 @@
     ])
 
     <div class="fi-simple-layout flex min-h-screen flex-col items-center">
-        @if (filament()->auth()->check())
+        @if (filament()->auth()->check() || filament()->allowsGuests())
             <div
                 class="absolute end-0 top-0 flex h-16 items-center gap-x-4 pe-4 md:pe-6 lg:pe-8"
             >
-                @if (filament()->hasDatabaseNotifications())
-                    @livewire(Filament\Livewire\DatabaseNotifications::class, ['lazy' => true])
-                @endif
+                @if (filament()->auth()->check())
+                    @if (filament()->hasDatabaseNotifications())
+                        @livewire(Filament\Livewire\DatabaseNotifications::class, ['lazy' => true])
+                    @endif
 
-                <x-filament-panels::user-menu />
+                    <x-filament-panels::user-menu />
+                @elseif (filament()->allowsGuests() && filament()->guestMenuOnSimplePages())
+                    <x-filament-panels::guest-menu />
+                @endif
             </div>
         @endif
 

--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -133,6 +133,8 @@
                 @endif
 
                 <x-filament-panels::user-menu />
+            @elseif (filament()->allowsGuests())
+                <x-filament-panels::guest-menu />
             @endif
         </div>
 

--- a/packages/panels/resources/views/widgets/account-widget.blade.php
+++ b/packages/panels/resources/views/widgets/account-widget.blade.php
@@ -1,11 +1,16 @@
 @php
     $user = filament()->auth()->user();
+    $allowsGuests = filament()->allowsGuests();
 @endphp
 
 <x-filament-widgets::widget class="fi-account-widget">
     <x-filament::section>
         <div class="flex items-center gap-x-3">
+            @if ($user)
             <x-filament-panels::avatar.user size="lg" :user="$user" />
+            @elseif ($allowsGuests)
+            <x-filament-panels::avatar.guest size="lg" />
+            @endif
 
             <div class="flex-1">
                 <h2
@@ -15,28 +20,53 @@
                 </h2>
 
                 <p class="text-sm text-gray-500 dark:text-gray-400">
-                    {{ filament()->getUserName($user) }}
+                    @if ($user)
+                        {{ filament()->getUserName($user) }}
+                    @endif
                 </p>
             </div>
 
-            <form
-                action="{{ filament()->getLogoutUrl() }}"
-                method="post"
-                class="my-auto -me-2.5 sm:me-0"
-            >
-                @csrf
+            @if ($user)
+                <form
+                    action="{{ filament()->getLogoutUrl() }}"
+                    method="post"
+                    class="my-auto -me-2.5 sm:me-0"
+                >
+                    @csrf
 
+                    <x-filament::button
+                        color="gray"
+                        icon="heroicon-m-arrow-left-on-rectangle"
+                        icon-alias="panels::widgets.account.logout-button"
+                        labeled-from="sm"
+                        tag="button"
+                        type="submit"
+                    >
+                        {{ __('filament-panels::widgets/account-widget.actions.logout.label') }}
+                    </x-filament::button>
+                </form>
+            @elseif ($allowsGuests)
                 <x-filament::button
                     color="gray"
-                    icon="heroicon-m-arrow-left-on-rectangle"
-                    icon-alias="panels::widgets.account.logout-button"
+                    icon="heroicon-m-arrow-right-on-rectangle"
+                    icon-alias="panels::widgets.account.login-button"
                     labeled-from="sm"
-                    tag="button"
-                    type="submit"
+                    tag="a"
+                    :href="filament()->getLoginUrl()"
                 >
-                    {{ __('filament-panels::widgets/account-widget.actions.logout.label') }}
+                    {{ __('filament-panels::widgets/account-widget.actions.login.label') }}
                 </x-filament::button>
-            </form>
+                <x-filament::button
+                    color="gray"
+                    icon="heroicon-m-user-plus"
+                    icon-alias="panels::widgets.account.register-button"
+                    labeled-from="sm"
+                    tag="a"
+                    :href="filament()->getRegistrationUrl()"
+                >
+                    {{ __('filament-panels::widgets/account-widget.actions.register.label') }}
+                </x-filament::button>
+            @endif
         </div>
     </x-filament::section>
 </x-filament-widgets::widget>

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -50,6 +50,11 @@ class FilamentManager
         return $this->getCurrentPanel()->auth();
     }
 
+    public function allowsGuests(): bool
+    {
+        return $this->getCurrentPanel()->getAllowGuests();
+    }
+
     public function bootCurrentPanel(): void
     {
         if ($this->isCurrentPanelBooted) {
@@ -446,6 +451,14 @@ class FilamentManager
         return $this->getCurrentPanel()->getUserMenuItems();
     }
 
+    /**
+     * @return array<MenuItem>
+     */
+    public function getGuestMenuItems(): array
+    {
+        return $this->getCurrentPanel()->getGuestMenuItems();
+    }
+
     public function getUserName(Model | Authenticatable $user): string
     {
         if ($user instanceof HasName) {
@@ -488,6 +501,11 @@ class FilamentManager
     public function getWidgets(): array
     {
         return $this->getCurrentPanel()->getWidgets();
+    }
+
+    public function guestMenuOnSimplePages(): bool
+    {
+        return $this->getCurrentPanel()->getGuestMenuOnSimplePages();
     }
 
     public function hasBreadcrumbs(): bool

--- a/packages/panels/src/Http/Middleware/Authenticate.php
+++ b/packages/panels/src/Http/Middleware/Authenticate.php
@@ -16,7 +16,7 @@ class Authenticate extends Middleware
     {
         $guard = Filament::auth();
 
-        if (! $guard->check()) {
+        if (! $guard->check() && ! Filament::getCurrentPanel()->getAllowGuests()) {
             $this->unauthenticated($request, $guards);
 
             return;
@@ -24,7 +24,7 @@ class Authenticate extends Middleware
 
         $this->auth->shouldUse(Filament::getAuthGuard());
 
-        /** @var Model $user */
+        /** @var ?Model $user */
         $user = $guard->user();
 
         $panel = Filament::getCurrentPanel();
@@ -32,7 +32,7 @@ class Authenticate extends Middleware
         abort_if(
             $user instanceof FilamentUser ?
                 (! $user->canAccessPanel($panel)) :
-                (config('app.env') !== 'local'),
+                (config('app.env') !== 'local' && ! Filament::getCurrentPanel()->getAllowGuests()),
             403,
         );
     }

--- a/packages/panels/src/Http/Middleware/EnsureGuestOrEmailIsVerified.php
+++ b/packages/panels/src/Http/Middleware/EnsureGuestOrEmailIsVerified.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Filament\Http\Middleware;
+
+use Closure;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\URL;
+
+class EnsureGuestOrEmailIsVerified
+{
+    /**
+     * Specify the redirect route for the middleware.
+     *
+     * @param  string  $route
+     * @return string
+     */
+    public static function redirectTo($route)
+    {
+        return static::class.':'.$route;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string|null  $redirectToRoute
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse|null
+     */
+    public function handle($request, Closure $next, $redirectToRoute = null)
+    {   
+        if (! $request->user() ) {
+            return $next($request);
+        }
+                
+        if (($request->user() instanceof MustVerifyEmail && ! $request->user()->hasVerifiedEmail())) {
+            return $request->expectsJson()
+                    ? abort(403, 'Your email address is not verified.')
+                    : Redirect::guest(URL::route($redirectToRoute ?: 'verification.notice'));
+        }
+
+        return $next($request);
+    }
+}

--- a/packages/panels/src/Panel.php
+++ b/packages/panels/src/Panel.php
@@ -21,6 +21,8 @@ class Panel extends Component
     use Panel\Concerns\HasFavicon;
     use Panel\Concerns\HasFont;
     use Panel\Concerns\HasGlobalSearch;
+    use Panel\Concerns\HasGuestMenu;
+    use Panel\Concerns\HasGuests;
     use Panel\Concerns\HasIcons;
     use Panel\Concerns\HasId;
     use Panel\Concerns\HasMaxContentWidth;

--- a/packages/panels/src/Panel/Concerns/HasAuth.php
+++ b/packages/panels/src/Panel/Concerns/HasAuth.php
@@ -3,6 +3,7 @@
 namespace Filament\Panel\Concerns;
 
 use Closure;
+use Filament\Http\Middleware\EnsureGuestOrEmailIsVerified;
 use Filament\Pages\Auth\EditProfile;
 use Filament\Pages\Auth\EmailVerification\EmailVerificationPrompt;
 use Filament\Pages\Auth\Login;
@@ -161,7 +162,9 @@ trait HasAuth
 
     public function getEmailVerifiedMiddleware(): string
     {
-        return "verified:{$this->getEmailVerificationPromptRouteName()}";
+        $emailVerificationPromptRouteName = $this->getEmailVerificationPromptRouteName();
+
+        return $this->getAllowGuests() ? EnsureGuestOrEmailIsVerified::class . ":{$emailVerificationPromptRouteName}" : "verified:{$emailVerificationPromptRouteName}";
     }
 
     /**

--- a/packages/panels/src/Panel/Concerns/HasGuestMenu.php
+++ b/packages/panels/src/Panel/Concerns/HasGuestMenu.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Filament\Panel\Concerns;
+
+use Filament\Navigation\MenuItem;
+
+trait HasGuestMenu
+{
+    /**
+     * @var array<MenuItem>
+     */
+    protected array $guestMenuItems = [];
+
+    protected bool $guestMenuOnSimplePages = false;
+
+    /**
+     * @param  array<MenuItem>  $items
+     */
+    public function guestMenuItems(array $items): static
+    {
+        $this->guestMenuItems = [
+            ...$this->guestMenuItems,
+            ...$items,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * @return array<MenuItem>
+     */
+    public function getGuestMenuItems(): array
+    {
+        return collect($this->guestMenuItems)
+            ->filter(fn (MenuItem $item): bool => $item->isVisible())
+            ->sort(fn (MenuItem $item): int => $item->getSort())
+            ->all();
+    }
+
+    public function guestMenuOnSimplePages(bool $guestMenuOnSimplePages = true): static
+    {
+        $this->guestMenuOnSimplePages = $guestMenuOnSimplePages;
+
+        return $this;
+    }
+
+    public function getGuestMenuOnSimplePages(): bool
+    {
+        return $this->guestMenuOnSimplePages;
+    }
+}

--- a/packages/panels/src/Panel/Concerns/HasGuests.php
+++ b/packages/panels/src/Panel/Concerns/HasGuests.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Filament\Panel\Concerns;
+
+trait HasGuests
+{
+    protected bool $allowGuests = false;
+
+    public function allowGuests(bool $allowGuests = true): static
+    {
+        $this->allowGuests = $allowGuests;
+
+        return $this;
+    }
+
+    public function getAllowGuests(): bool
+    {
+        return $this->allowGuests;
+    }
+}


### PR DESCRIPTION
This PR introduces the possiblity of guests accessing your panels. Users don't have to be authenticated to visit the panel but authentication is still possible.

If the PR is wanted I will:

- [ ] Add missing translations
- [ ] Add documentation

## Problems

- [x] Email verification
- [ ] Language string duplication
- [ ] Menu looks bad, any alternative design ideas?

### Email verification

~~`emailVerification(isRequired: false)` has to be set because the underlying Middleware `\Illuminate\Auth\Middleware\EnsureEmailIsVerified` is not meant for allowing unauthenticated users.~~

~~The middleware should not be applied when the current user is `null` and the panel allows guests. Any tips on where to implement this?~~

This now applies a seperate middleware incase `allowGuests` is true which lets unauthenticated users through.

### Language string duplication

Language strings are currently being duplicated as the strings for "Sign in" and "Sign up" already exist. Should I use the existing strings from the `Login` / `Register` page or should the strings be duplicated to the other files.

## Screenshots

- widget when unauthenticated & guest menu
![grafik](https://github.com/filamentphp/filament/assets/71718414/2166f7d2-9e4e-46af-b00a-4b90653fca5c)

- guest menu
![grafik](https://github.com/filamentphp/filament/assets/71718414/17087c58-2664-494b-adb1-19a904d32740)

- guest menu on simple pages
![grafik](https://github.com/filamentphp/filament/assets/71718414/e5d30e6f-c002-4ae9-ad1e-f41fc7daefdd)

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
