### PR TITLE
Fix "voltar" translation case

### DIFF
--- a/packages/panels/resources/lang/pt_BR/pages/auth/edit-profile.php
+++ b/packages/panels/resources/lang/pt_BR/pages/auth/edit-profile.php
@@ -43,7 +43,7 @@ return [
     'actions' => [
 
         'cancel' => [
-            'label' => 'voltar',
+            'label' => 'Voltar',
         ],
 
     ],


### PR DESCRIPTION
Fixes wrong "cancel" label case for pt_BR translations.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Before:
![Screenshot_20230922_112251](https://github.com/filamentphp/filament/assets/45720067/bc92184c-a93d-4efc-87af-19c593808970)

After:
![Screenshot_20230922_112521](https://github.com/filamentphp/filament/assets/45720067/74a33ca8-7bc3-4e4b-87f3-76863e3f890c)

