### PR TITLE
Fix console errors when adding filters to grouped records

### DIFF
--- a/packages/tables/resources/js/components/table.js
+++ b/packages/tables/resources/js/components/table.js
@@ -61,8 +61,12 @@ export default function table() {
             this.isLoading = false
         },
 
-        getRecordsInGroupOnPage: function (group) {
+        getRecordsInGroupOnPage: function (group) {            
             const keys = []
+
+            if (this.$root === undefined) {
+                return keys
+            }
 
             for (let checkbox of this.$root.getElementsByClassName(
                 'fi-ta-record-checkbox',

--- a/packages/tables/resources/js/components/table.js
+++ b/packages/tables/resources/js/components/table.js
@@ -61,7 +61,7 @@ export default function table() {
             this.isLoading = false
         },
 
-        getRecordsInGroupOnPage: function (group) {            
+        getRecordsInGroupOnPage: function (group) {
             const keys = []
 
             if (this.$root === undefined) {


### PR DESCRIPTION
This maybe another LW/$watch issue, but when you are using grouped records and then apply a filter, the console explodes with errors since the original elements are no longer present. You can see the errors in the demo app on the [Order page](https://demo.filamentphp.com/shop/orders?tableGrouping=created_at&tableGroupingDirection=asc) and then clicking on the `Trashed Filter` and selecting `Only deleted records`. 

This PR just returns the empty array when the record is no longer in the dom.

- [X] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
