### PR TITLE
Rich editor underline hover title

### DIFF
--- a/packages/forms/docs/03-fields/10-rich-editor.md
+++ b/packages/forms/docs/03-fields/10-rich-editor.md
@@ -37,6 +37,7 @@ RichEditor::make('content')
         'redo',
         'strike',
         'undo',
+        'underline',
     ])
 ```
 

--- a/packages/forms/docs/03-fields/10-rich-editor.md
+++ b/packages/forms/docs/03-fields/10-rich-editor.md
@@ -36,8 +36,8 @@ RichEditor::make('content')
         'orderedList',
         'redo',
         'strike',
-        'undo',
         'underline',
+        'undo',
     ])
 ```
 

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -128,7 +128,7 @@
                                 @if ($hasToolbarButton('underline'))
                                     <x-filament-forms::rich-editor.toolbar.button
                                         data-trix-attribute="underline"
-                                        title="{{ __('forms::components.rich_editor.toolbar_buttons.underline') }}"
+                                        title="{{ __('filament-forms::components.rich_editor.toolbar_buttons.underline') }}"
                                         tabindex="-1"
                                     >
                                         <svg


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Added `underline` to docs for ease of use

Before:
![Screenshot from 2023-09-23 11-46-30](https://github.com/filamentphp/filament/assets/28250303/78e13f43-450d-44c0-b71b-9b3a516fbdfa)

After:
![Screenshot from 2023-09-23 11-46-46](https://github.com/filamentphp/filament/assets/28250303/b6825055-6ddd-4e17-b02b-72b02b54b2ed)

