### PR TITLE
Fix getLivewireClickHandler() method not generating the parameters right

### DIFF
--- a/packages/actions/src/StaticAction.php
+++ b/packages/actions/src/StaticAction.php
@@ -122,17 +122,16 @@ class StaticAction extends ViewComponent
         }
 
         if ($event = $this->getEvent()) {
-
             $arguments = '';
 
-            if ($component = $this->getDispatchToComponent() ) {
-                $arguments .= Js::from( $component)->toHtml();
+            if ($component = $this->getDispatchToComponent()) {
+                $arguments .= Js::from($component)->toHtml();
                 $arguments .= ', ';
             }
 
-            $arguments .= Js::from( $event)->toHtml();
+            $arguments .= Js::from($event)->toHtml();
 
-            if ($this->getEventData()){
+            if ($this->getEventData()) {
                 $arguments .= ', ';
                 $arguments .= Js::from($this->getEventData())->toHtml();
             }

--- a/packages/actions/src/StaticAction.php
+++ b/packages/actions/src/StaticAction.php
@@ -122,14 +122,20 @@ class StaticAction extends ViewComponent
         }
 
         if ($event = $this->getEvent()) {
-            $arguments = collect([$event])
-                ->merge($this->getEventData())
-                ->when(
-                    $this->getDispatchToComponent(),
-                    fn (Collection $collection, string $component) => $collection->prepend($component),
-                )
-                ->map(fn (mixed $value): string => Js::from($value)->toHtml())
-                ->implode(', ');
+
+            $arguments = '';
+
+            if ($component = $this->getDispatchToComponent() ) {
+                $arguments .= Js::from( $component)->toHtml();
+                $arguments .= ', ';
+            }
+
+            $arguments .= Js::from( $event)->toHtml();
+
+            if ($this->getEventData()){
+                $arguments .= ', ';
+                $arguments .= Js::from($this->getEventData())->toHtml();
+            }
 
             return match ($this->getDispatchDirection()) {
                 'self' => "\$dispatchSelf($arguments)",


### PR DESCRIPTION
Right now if you want to add an action that dispatches an event with parameters you need to pass a multidimensional array as a second parameter:
<img width="822" alt="image" src="https://github.com/filamentphp/filament/assets/31577031/2ac5deaa-2f21-4214-943c-63b016205df9">

If you don't, and pass an array with parameters to unpack, it will be rendered like this:
<img width="554" alt="image" src="https://github.com/filamentphp/filament/assets/31577031/5ef5cdf1-f85e-43f7-978b-7a82567eaf2f">
*Notice how the named parameter 'id' has disappeared.

This causes an error when Livewire wants to unpack the parameter array and pass it to the handler function.

After my change, it will render like this:
<img width="588" alt="image" src="https://github.com/filamentphp/filament/assets/31577031/d34bc0c1-3619-43ae-bca9-62122eea46ad">

If I need to do something else, like create a repo with an error, or if I forgot something while contributing, I'm happy to add it. Please let me know :) 

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
