### PR TITLE
Added paths when succesfully creating components from commands

### DIFF
--- a/packages/forms/src/Commands/MakeFieldCommand.php
+++ b/packages/forms/src/Commands/MakeFieldCommand.php
@@ -67,7 +67,7 @@ class MakeFieldCommand extends Command
             $this->copyStubToApp('FieldView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$field}!");
+        $this->components->info(sprintf('%s [%s] created successfully.', "Form Field", $path));
 
         return static::SUCCESS;
     }

--- a/packages/forms/src/Commands/MakeFieldCommand.php
+++ b/packages/forms/src/Commands/MakeFieldCommand.php
@@ -67,7 +67,7 @@ class MakeFieldCommand extends Command
             $this->copyStubToApp('FieldView', $viewPath);
         }
 
-        $this->components->info("Filament Form Field [$path] created successfully.");
+        $this->components->info("Filament Form Field [{$path}] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/forms/src/Commands/MakeFieldCommand.php
+++ b/packages/forms/src/Commands/MakeFieldCommand.php
@@ -67,7 +67,7 @@ class MakeFieldCommand extends Command
             $this->copyStubToApp('FieldView', $viewPath);
         }
 
-        $this->components->info("Form Field [$path] created successfully.");
+        $this->components->info("Filament Form Field [$path] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/forms/src/Commands/MakeFieldCommand.php
+++ b/packages/forms/src/Commands/MakeFieldCommand.php
@@ -67,7 +67,7 @@ class MakeFieldCommand extends Command
             $this->copyStubToApp('FieldView', $viewPath);
         }
 
-        $this->components->info(sprintf('%s [%s] created successfully.', "Form Field", $path));
+        $this->components->info("Form Field [$path] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/forms/src/Commands/MakeFormCommand.php
+++ b/packages/forms/src/Commands/MakeFormCommand.php
@@ -101,7 +101,7 @@ class MakeFormCommand extends Command
             'submitAction' => filled($model) ? ($isEditForm ? 'save' : 'create') : 'submit',
         ]);
 
-        $this->components->info("Filament Form [$path] created successfully.");
+        $this->components->info("Filament Form [{$path}] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/forms/src/Commands/MakeFormCommand.php
+++ b/packages/forms/src/Commands/MakeFormCommand.php
@@ -101,7 +101,7 @@ class MakeFormCommand extends Command
             'submitAction' => filled($model) ? ($isEditForm ? 'save' : 'create') : 'submit',
         ]);
 
-        $this->components->info(sprintf('%s [%s] created successfully.', "Livewire Form", $path));
+        $this->components->info("Livewire Form [$path] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/forms/src/Commands/MakeFormCommand.php
+++ b/packages/forms/src/Commands/MakeFormCommand.php
@@ -101,7 +101,7 @@ class MakeFormCommand extends Command
             'submitAction' => filled($model) ? ($isEditForm ? 'save' : 'create') : 'submit',
         ]);
 
-        $this->components->info("Livewire Form [$path] created successfully.");
+        $this->components->info("Filament Form [$path] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/forms/src/Commands/MakeFormCommand.php
+++ b/packages/forms/src/Commands/MakeFormCommand.php
@@ -101,7 +101,7 @@ class MakeFormCommand extends Command
             'submitAction' => filled($model) ? ($isEditForm ? 'save' : 'create') : 'submit',
         ]);
 
-        $this->components->info("Successfully created {$component}!");
+        $this->components->info(sprintf('%s [%s] created successfully.', "Livewire Form", $path));
 
         return static::SUCCESS;
     }

--- a/packages/forms/src/Commands/MakeLayoutComponentCommand.php
+++ b/packages/forms/src/Commands/MakeLayoutComponentCommand.php
@@ -67,7 +67,7 @@ class MakeLayoutComponentCommand extends Command
             $this->copyStubToApp('LayoutComponentView', $viewPath);
         }
 
-        $this->components->info(sprintf('%s [%s] created successfully.', "Form Layout Component", $path));
+        $this->components->info("Form Layout Component [$path] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/forms/src/Commands/MakeLayoutComponentCommand.php
+++ b/packages/forms/src/Commands/MakeLayoutComponentCommand.php
@@ -67,7 +67,7 @@ class MakeLayoutComponentCommand extends Command
             $this->copyStubToApp('LayoutComponentView', $viewPath);
         }
 
-        $this->components->info("Form Layout Component [$path] created successfully.");
+        $this->components->info("Filament Form Layout Component [$path] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/forms/src/Commands/MakeLayoutComponentCommand.php
+++ b/packages/forms/src/Commands/MakeLayoutComponentCommand.php
@@ -67,7 +67,7 @@ class MakeLayoutComponentCommand extends Command
             $this->copyStubToApp('LayoutComponentView', $viewPath);
         }
 
-        $this->components->info("Filament Form Layout Component [$path] created successfully.");
+        $this->components->info("Filament Form Layout Component [{$path}] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/forms/src/Commands/MakeLayoutComponentCommand.php
+++ b/packages/forms/src/Commands/MakeLayoutComponentCommand.php
@@ -67,7 +67,7 @@ class MakeLayoutComponentCommand extends Command
             $this->copyStubToApp('LayoutComponentView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$component}!");
+        $this->components->info(sprintf('%s [%s] created successfully.', "Form Layout Component", $path));
 
         return static::SUCCESS;
     }

--- a/packages/infolists/src/Commands/MakeEntryCommand.php
+++ b/packages/infolists/src/Commands/MakeEntryCommand.php
@@ -67,7 +67,7 @@ class MakeEntryCommand extends Command
             $this->copyStubToApp('EntryView', $viewPath);
         }
 
-        $this->components->info(sprintf('%s [%s] created successfully.', "Infolist Entry", $path));
+        $this->components->info("Infolist Entry [$path] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/infolists/src/Commands/MakeEntryCommand.php
+++ b/packages/infolists/src/Commands/MakeEntryCommand.php
@@ -67,7 +67,7 @@ class MakeEntryCommand extends Command
             $this->copyStubToApp('EntryView', $viewPath);
         }
 
-        $this->components->info("Infolist Entry [$path] created successfully.");
+        $this->components->info("Filament Infolist Entry [$path] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/infolists/src/Commands/MakeEntryCommand.php
+++ b/packages/infolists/src/Commands/MakeEntryCommand.php
@@ -67,7 +67,7 @@ class MakeEntryCommand extends Command
             $this->copyStubToApp('EntryView', $viewPath);
         }
 
-        $this->components->info("Filament Infolist Entry [$path] created successfully.");
+        $this->components->info("Filament Infolist Entry [{$path}] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/infolists/src/Commands/MakeEntryCommand.php
+++ b/packages/infolists/src/Commands/MakeEntryCommand.php
@@ -67,7 +67,7 @@ class MakeEntryCommand extends Command
             $this->copyStubToApp('EntryView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$entry}!");
+        $this->components->info(sprintf('%s [%s] created successfully.', "Infolist Entry", $path));
 
         return static::SUCCESS;
     }

--- a/packages/infolists/src/Commands/MakeLayoutComponentCommand.php
+++ b/packages/infolists/src/Commands/MakeLayoutComponentCommand.php
@@ -67,7 +67,7 @@ class MakeLayoutComponentCommand extends Command
             $this->copyStubToApp('LayoutComponentView', $viewPath);
         }
 
-        $this->components->info(sprintf('%s [%s] created successfully.', "Infolist Layout", $path));
+        $this->components->info("Infolist Layout [$path] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/infolists/src/Commands/MakeLayoutComponentCommand.php
+++ b/packages/infolists/src/Commands/MakeLayoutComponentCommand.php
@@ -67,7 +67,7 @@ class MakeLayoutComponentCommand extends Command
             $this->copyStubToApp('LayoutComponentView', $viewPath);
         }
 
-        $this->components->info("Infolist Layout [$path] created successfully.");
+        $this->components->info("Filament Infolist Layout Component [$path] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/infolists/src/Commands/MakeLayoutComponentCommand.php
+++ b/packages/infolists/src/Commands/MakeLayoutComponentCommand.php
@@ -67,7 +67,7 @@ class MakeLayoutComponentCommand extends Command
             $this->copyStubToApp('LayoutComponentView', $viewPath);
         }
 
-        $this->components->info("Filament Infolist Layout Component [$path] created successfully.");
+        $this->components->info("Filament Infolist Layout Component [{$path}] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/infolists/src/Commands/MakeLayoutComponentCommand.php
+++ b/packages/infolists/src/Commands/MakeLayoutComponentCommand.php
@@ -67,7 +67,7 @@ class MakeLayoutComponentCommand extends Command
             $this->copyStubToApp('LayoutComponentView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$component}!");
+        $this->components->info(sprintf('%s [%s] created successfully.', "Infolist Layout", $path));
 
         return static::SUCCESS;
     }

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -181,7 +181,7 @@ class MakePageCommand extends Command
             $this->copyStubToApp('PageView', $viewPath);
         }
 
-        $this->components->info("Filament Page [$path] created successfully.");
+        $this->components->info("Filament Page [{$path}] created successfully.");
 
         if ($resource !== null) {
             $this->components->info("Make sure to register the page in `{$resourceClass}::getPages()`.");

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -181,7 +181,7 @@ class MakePageCommand extends Command
             $this->copyStubToApp('PageView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$page}!");
+        $this->components->info(sprintf('%s [%s] created successfully.', "Filament-Page", $path));
 
         if ($resource !== null) {
             $this->components->info("Make sure to register the page in `{$resourceClass}::getPages()`.");

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -181,7 +181,7 @@ class MakePageCommand extends Command
             $this->copyStubToApp('PageView', $viewPath);
         }
 
-        $this->components->info(sprintf('%s [%s] created successfully.', "Filament-Page", $path));
+        $this->components->info("Filament Page [$path] created successfully.");
 
         if ($resource !== null) {
             $this->components->info("Make sure to register the page in `{$resourceClass}::getPages()`.");

--- a/packages/panels/src/Commands/MakePanelCommand.php
+++ b/packages/panels/src/Commands/MakePanelCommand.php
@@ -55,7 +55,7 @@ class MakePanelCommand extends Command
             ));
         }
 
-        $this->components->info("Filament Panel [$path] created successfully.");
+        $this->components->info("Filament Panel [{$path}] created successfully.");
         $this->components->warn("We've attempted to register the {$class} in your [config/app.php] file as a service provider.  If you get an error while trying to access your panel then this process has probably failed. You can manually register the service provider by adding it to the [providers] array.");
 
         return static::SUCCESS;

--- a/packages/panels/src/Commands/MakePanelCommand.php
+++ b/packages/panels/src/Commands/MakePanelCommand.php
@@ -55,7 +55,7 @@ class MakePanelCommand extends Command
             ));
         }
 
-        $this->components->info(sprintf('%s [%s] created successfully.', "Filament-Panel", $path));
+        $this->components->info("Filament Panel [$path] created successfully.");
         $this->components->warn("We've attempted to register the {$class} in your [config/app.php] file as a service provider.  If you get an error while trying to access your panel then this process has probably failed. You can manually register the service provider by adding it to the [providers] array.");
 
         return static::SUCCESS;

--- a/packages/panels/src/Commands/MakePanelCommand.php
+++ b/packages/panels/src/Commands/MakePanelCommand.php
@@ -55,7 +55,7 @@ class MakePanelCommand extends Command
             ));
         }
 
-        $this->components->info("Successfully created {$class}!");
+        $this->components->info(sprintf('%s [%s] created successfully.', "Filament-Panel", $path));
         $this->components->warn("We've attempted to register the {$class} in your [config/app.php] file as a service provider.  If you get an error while trying to access your panel then this process has probably failed. You can manually register the service provider by adding it to the [providers] array.");
 
         return static::SUCCESS;

--- a/packages/panels/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/panels/src/Commands/MakeRelationManagerCommand.php
@@ -180,7 +180,7 @@ class MakeRelationManagerCommand extends Command
             'tableHeaderActions' => $this->indentString($tableHeaderActions, 4),
         ]);
 
-        $this->components->info("Successfully created {$managerClass}!");
+        $this->components->info(sprintf('%s [%s] created successfully.', "Filament Relation-Manager", $path));
 
         $this->components->info("Make sure to register the relation in `{$resource}::getRelations()`.");
 

--- a/packages/panels/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/panels/src/Commands/MakeRelationManagerCommand.php
@@ -180,7 +180,7 @@ class MakeRelationManagerCommand extends Command
             'tableHeaderActions' => $this->indentString($tableHeaderActions, 4),
         ]);
 
-        $this->components->info("Filament Relation Manager [$path] created successfully.");
+        $this->components->info("Filament Relation Manager [{$path}] created successfully.");
 
         $this->components->info("Make sure to register the relation in `{$resource}::getRelations()`.");
 

--- a/packages/panels/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/panels/src/Commands/MakeRelationManagerCommand.php
@@ -180,7 +180,7 @@ class MakeRelationManagerCommand extends Command
             'tableHeaderActions' => $this->indentString($tableHeaderActions, 4),
         ]);
 
-        $this->components->info("Form Relation-Manager [$path] created successfully.");
+        $this->components->info("Filament Relation Manager [$path] created successfully.");
 
         $this->components->info("Make sure to register the relation in `{$resource}::getRelations()`.");
 

--- a/packages/panels/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/panels/src/Commands/MakeRelationManagerCommand.php
@@ -180,7 +180,7 @@ class MakeRelationManagerCommand extends Command
             'tableHeaderActions' => $this->indentString($tableHeaderActions, 4),
         ]);
 
-        $this->components->info(sprintf('%s [%s] created successfully.', "Filament Relation-Manager", $path));
+        $this->components->info("Form Relation-Manager [$path] created successfully.");
 
         $this->components->info("Make sure to register the relation in `{$resource}::getRelations()`.");
 

--- a/packages/panels/src/Commands/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/MakeResourceCommand.php
@@ -261,7 +261,7 @@ class MakeResourceCommand extends Command
             ]);
         }
 
-        $this->components->info("Successfully created {$resource}!");
+        $this->components->info(sprintf('%s [%s] created successfully.', "Filament-Resource", $path));
 
         return static::SUCCESS;
     }

--- a/packages/panels/src/Commands/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/MakeResourceCommand.php
@@ -261,7 +261,7 @@ class MakeResourceCommand extends Command
             ]);
         }
 
-        $this->components->info(sprintf('%s [%s] created successfully.', "Filament-Resource", $path));
+        $this->components->info("Filament Resource [$resourcePath] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/panels/src/Commands/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/MakeResourceCommand.php
@@ -261,7 +261,7 @@ class MakeResourceCommand extends Command
             ]);
         }
 
-        $this->components->info("Filament Resource [$resourcePath] created successfully.");
+        $this->components->info("Filament Resource [{$resourcePath}] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/panels/src/Commands/MakeThemeCommand.php
+++ b/packages/panels/src/Commands/MakeThemeCommand.php
@@ -82,7 +82,7 @@ class MakeThemeCommand extends Command
             'viewPathPrefix' => $viewPathPrefix,
         ]);
 
-        $this->components->info("Successfully created resources/css/filament/{$panelId}/theme.css and resources/css/filament/{$panelId}/tailwind.config.js!");
+        $this->components->info("Filament theme [resources/css/filament/{$panelId}/theme.css] and [resources/css/filament/{$panelId}/tailwind.config.js] created successfully.");
 
         if (! file_exists(base_path('vite.config.js'))) {
             $this->components->warn('Action is required to complete the theme setup:');
@@ -101,7 +101,7 @@ class MakeThemeCommand extends Command
         if (! file_exists($postcssConfigPath)) {
             $this->copyStubToApp('ThemePostcssConfig', $postcssConfigPath);
 
-            $this->components->info('Successfully created postcss.config.js!');
+            $this->components->info('Filament Theme [postcss.config.js] created successfully.');
         }
 
         $this->components->warn('Action is required to complete the theme setup:');

--- a/packages/spatie-laravel-settings-plugin/src/Commands/MakeSettingsPageCommand.php
+++ b/packages/spatie-laravel-settings-plugin/src/Commands/MakeSettingsPageCommand.php
@@ -57,7 +57,7 @@ class MakeSettingsPageCommand extends Command
             'settingsClass' => $settingsClass,
         ]);
 
-        $this->components->info("Successfully created {$page}!");
+        $this->components->info("Filament Settings Page [{$path}] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/tables/src/Commands/MakeColumnCommand.php
+++ b/packages/tables/src/Commands/MakeColumnCommand.php
@@ -67,7 +67,7 @@ class MakeColumnCommand extends Command
             $this->copyStubToApp('ColumnView', $viewPath);
         }
 
-        $this->components->info(sprintf('%s [%s] created successfully.', "Column", $path));
+        $this->components->info("Table Column [$path] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/tables/src/Commands/MakeColumnCommand.php
+++ b/packages/tables/src/Commands/MakeColumnCommand.php
@@ -67,7 +67,7 @@ class MakeColumnCommand extends Command
             $this->copyStubToApp('ColumnView', $viewPath);
         }
 
-        $this->components->info("Table Column [$path] created successfully.");
+        $this->components->info("Filament Table Column [$path] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/tables/src/Commands/MakeColumnCommand.php
+++ b/packages/tables/src/Commands/MakeColumnCommand.php
@@ -67,7 +67,7 @@ class MakeColumnCommand extends Command
             $this->copyStubToApp('ColumnView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$column}!");
+        $this->components->info(sprintf('%s [%s] created successfully.', "Column", $path));
 
         return static::SUCCESS;
     }

--- a/packages/tables/src/Commands/MakeColumnCommand.php
+++ b/packages/tables/src/Commands/MakeColumnCommand.php
@@ -67,7 +67,7 @@ class MakeColumnCommand extends Command
             $this->copyStubToApp('ColumnView', $viewPath);
         }
 
-        $this->components->info("Filament Table Column [$path] created successfully.");
+        $this->components->info("Filament Table Column [{$path}] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/tables/src/Commands/MakeTableCommand.php
+++ b/packages/tables/src/Commands/MakeTableCommand.php
@@ -84,7 +84,7 @@ class MakeTableCommand extends Command
 
         $this->copyStubToApp('TableView', $viewPath);
 
-        $this->info("Successfully created {$component}!");
+        $this->components->info(sprintf('%s [%s] created successfully.', "Table", $path));
 
         return static::SUCCESS;
     }

--- a/packages/tables/src/Commands/MakeTableCommand.php
+++ b/packages/tables/src/Commands/MakeTableCommand.php
@@ -84,7 +84,7 @@ class MakeTableCommand extends Command
 
         $this->copyStubToApp('TableView', $viewPath);
 
-        $this->components->info("Table [$path] created successfully.");
+        $this->components->info("Filament Table [$path] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/tables/src/Commands/MakeTableCommand.php
+++ b/packages/tables/src/Commands/MakeTableCommand.php
@@ -84,7 +84,7 @@ class MakeTableCommand extends Command
 
         $this->copyStubToApp('TableView', $viewPath);
 
-        $this->components->info(sprintf('%s [%s] created successfully.', "Table", $path));
+        $this->components->info("Table [$path] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/tables/src/Commands/MakeTableCommand.php
+++ b/packages/tables/src/Commands/MakeTableCommand.php
@@ -84,7 +84,7 @@ class MakeTableCommand extends Command
 
         $this->copyStubToApp('TableView', $viewPath);
 
-        $this->components->info("Filament Table [$path] created successfully.");
+        $this->components->info("Filament Table [{$path}] created successfully.");
 
         return static::SUCCESS;
     }

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -204,7 +204,7 @@ class MakeWidgetCommand extends Command
             $this->copyStubToApp('WidgetView', $viewPath);
         }
 
-        $this->components->info("Successfully created {$widget}!");
+        $this->components->info(sprintf('%s [%s] created successfully.', "Filament Widget", $path));
 
         if ($resource !== null) {
             $this->components->info("Make sure to register the widget in `{$resourceClass}::getWidgets()`, and then again in `getHeaderWidgets()` or `getFooterWidgets()` of any `{$resourceClass}` page.");

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -204,7 +204,7 @@ class MakeWidgetCommand extends Command
             $this->copyStubToApp('WidgetView', $viewPath);
         }
 
-        $this->components->info(sprintf('%s [%s] created successfully.', "Filament Widget", $path));
+        $this->components->info("Filament Widget [$path] created successfully.");
 
         if ($resource !== null) {
             $this->components->info("Make sure to register the widget in `{$resourceClass}::getWidgets()`, and then again in `getHeaderWidgets()` or `getFooterWidgets()` of any `{$resourceClass}` page.");

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -204,7 +204,7 @@ class MakeWidgetCommand extends Command
             $this->copyStubToApp('WidgetView', $viewPath);
         }
 
-        $this->components->info("Filament Widget [$path] created successfully.");
+        $this->components->info("Filament Widget [{$path}] created successfully.");
 
         if ($resource !== null) {
             $this->components->info("Make sure to register the widget in `{$resourceClass}::getWidgets()`, and then again in `getHeaderWidgets()` or `getFooterWidgets()` of any `{$resourceClass}` page.");


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Before:
![image](https://github.com/filamentphp/filament/assets/64212185/368738c9-1378-4bab-8618-9de65615a438)

After:
![image](https://github.com/filamentphp/filament/assets/64212185/0a99cd47-968b-4f6c-8dcf-68b5eeb30019)
