### PR TITLE
Introduce a way to set the priority between view and edit for the record url 

### DIFF
--- a/packages/panels/src/Resources/Concerns/InteractsWithRelationshipTable.php
+++ b/packages/panels/src/Resources/Concerns/InteractsWithRelationshipTable.php
@@ -59,7 +59,11 @@ trait InteractsWithRelationshipTable
             ->modifyQueryUsing($this->modifyQueryWithActiveTab(...))
             ->queryStringIdentifier(Str::lcfirst(class_basename(static::class)))
             ->recordAction(function (Model $record, Table $table): ?string {
-                foreach (['view', 'edit'] as $action) {
+                $actions = array_keys(
+                    Arr::only($table->getFlatActions(), ['view', 'edit'])
+                );
+                
+                foreach ($actions as $action) {
                     $action = $table->getAction($action);
 
                     if (! $action) {
@@ -82,7 +86,11 @@ trait InteractsWithRelationshipTable
                 return null;
             })
             ->recordUrl(function (Model $record, Table $table): ?string {
-                foreach (['view', 'edit'] as $action) {
+                $actions = array_keys(
+                    Arr::only($table->getFlatActions(), ['view', 'edit'])
+                );
+                
+                foreach ($actions as $action) {
                     $action = $table->getAction($action);
 
                     if (! $action) {

--- a/packages/panels/src/Resources/Concerns/InteractsWithRelationshipTable.php
+++ b/packages/panels/src/Resources/Concerns/InteractsWithRelationshipTable.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
+use Illuminate\Support\Arr;
 
 trait InteractsWithRelationshipTable
 {

--- a/packages/panels/src/Resources/Pages/ListRecords.php
+++ b/packages/panels/src/Resources/Pages/ListRecords.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
+use Illuminate\Support\Arr;
 use Livewire\Attributes\Url;
 
 class ListRecords extends Page implements Tables\Contracts\HasTable

--- a/packages/panels/src/Resources/Pages/ListRecords.php
+++ b/packages/panels/src/Resources/Pages/ListRecords.php
@@ -241,7 +241,11 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
             ->modelLabel($this->getModelLabel() ?? static::getResource()::getModelLabel())
             ->pluralModelLabel($this->getPluralModelLabel() ?? static::getResource()::getPluralModelLabel())
             ->recordAction(function (Model $record, Table $table): ?string {
-                foreach (['view', 'edit'] as $action) {
+                $actions = array_keys(
+                    Arr::only($table->getFlatActions(), ['view', 'edit'])
+                );
+                
+                foreach ($actions as $action) {
                     $action = $table->getAction($action);
 
                     if (! $action) {
@@ -265,7 +269,11 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
             })
             ->recordTitle(fn (Model $record): string => static::getResource()::getRecordTitle($record))
             ->recordUrl($this->getTableRecordUrlUsing() ?? function (Model $record, Table $table): ?string {
-                foreach (['view', 'edit'] as $action) {
+                $actions = array_keys(
+                    Arr::only($table->getFlatActions(), ['view', 'edit'])
+                );
+                
+                foreach ($actions as $action) {
                     $action = $table->getAction($action);
 
                     if (! $action) {
@@ -289,7 +297,11 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
 
                 $resource = static::getResource();
 
-                foreach (['view', 'edit'] as $action) {
+                $actions = array_keys(
+                    Arr::only($resource::getPages(), ['view', 'edit'])
+                );
+
+                foreach ($actions as $action) {
                     if (! $resource::hasPage($action)) {
                         continue;
                     }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This PR introduce a way to set the priority between the view and edit action for the record url.

There are cases when we don't necessarily want to default to the view page when the user has the view and edit privilege.