### PR TITLE
Support custom email verification middleware

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasAuth.php
+++ b/packages/panels/src/Panel/Concerns/HasAuth.php
@@ -18,6 +18,8 @@ use Illuminate\Support\Facades\URL;
 
 trait HasAuth
 {
+    protected string | Closure $emailVerificationMiddlewareName = 'verified';
+
     /**
      * @var string | Closure | array<class-string, string> | null
      */
@@ -54,8 +56,9 @@ trait HasAuth
     /**
      * @param  string | Closure | array<class-string, string> | null  $promptAction
      */
-    public function emailVerification(string | Closure | array | null $promptAction = EmailVerificationPrompt::class, bool $isRequired = true): static
+    public function emailVerification(string | Closure | array | null $promptAction = EmailVerificationPrompt::class, bool $isRequired = true, string | Closure $middlewareName = 'verified'): static
     {
+        $this->emailVerificationMiddlewareName = $middlewareName;
         $this->emailVerificationRouteAction = $promptAction;
         $this->requiresEmailVerification($isRequired);
 
@@ -161,7 +164,7 @@ trait HasAuth
 
     public function getEmailVerifiedMiddleware(): string
     {
-        return "verified:{$this->getEmailVerificationPromptRouteName()}";
+        return "{$this->getEmailVerificationMiddlewareName()}:{$this->getEmailVerificationPromptRouteName()}";
     }
 
     /**
@@ -249,6 +252,11 @@ trait HasAuth
     public function getLogoutUrl(array $parameters = []): string
     {
         return route("filament.{$this->getId()}.auth.logout", $parameters);
+    }
+
+    public function getEmailVerificationMiddlewareName(): string | Closure
+    {
+        return $this->emailVerificationMiddlewareName;
     }
 
     /**

--- a/packages/panels/src/Panel/Concerns/HasAuth.php
+++ b/packages/panels/src/Panel/Concerns/HasAuth.php
@@ -18,7 +18,7 @@ use Illuminate\Support\Facades\URL;
 
 trait HasAuth
 {
-    protected string | Closure $emailVerificationMiddlewareName = 'verified';
+    protected string | Closure $emailVerifiedMiddlewareName = 'verified';
 
     /**
      * @var string | Closure | array<class-string, string> | null
@@ -64,9 +64,9 @@ trait HasAuth
         return $this;
     }
 
-    public function emailVerificationMiddlewareName(string | Closure $middlewareName): static
+    public function emailVerifiedMiddlewareName(string | Closure $name): static
     {
-        $this->emailVerificationMiddlewareName = $middlewareName;
+        $this->emailVerifiedMiddlewareName = $name;
 
         return $this;
     }
@@ -170,7 +170,7 @@ trait HasAuth
 
     public function getEmailVerifiedMiddleware(): string
     {
-        return "{$this->getEmailVerificationMiddlewareName()}:{$this->getEmailVerificationPromptRouteName()}";
+        return "{$this->getEmailVerifiedMiddlewareName()}:{$this->getEmailVerificationPromptRouteName()}";
     }
 
     /**
@@ -260,9 +260,9 @@ trait HasAuth
         return route("filament.{$this->getId()}.auth.logout", $parameters);
     }
 
-    public function getEmailVerificationMiddlewareName(): string
+    public function getEmailVerifiedMiddlewareName(): string
     {
-        return $this->evaluate($this->emailVerificationMiddlewareName);
+        return $this->evaluate($this->emailVerifiedMiddlewareName);
     }
 
     /**

--- a/packages/panels/src/Panel/Concerns/HasAuth.php
+++ b/packages/panels/src/Panel/Concerns/HasAuth.php
@@ -254,9 +254,9 @@ trait HasAuth
         return route("filament.{$this->getId()}.auth.logout", $parameters);
     }
 
-    public function getEmailVerificationMiddlewareName(): string | Closure
+    public function getEmailVerificationMiddlewareName(): string
     {
-        return $this->emailVerificationMiddlewareName;
+        return $this->evaluate($this->emailVerificationMiddlewareName);
     }
 
     /**

--- a/packages/panels/src/Panel/Concerns/HasAuth.php
+++ b/packages/panels/src/Panel/Concerns/HasAuth.php
@@ -56,11 +56,17 @@ trait HasAuth
     /**
      * @param  string | Closure | array<class-string, string> | null  $promptAction
      */
-    public function emailVerification(string | Closure | array | null $promptAction = EmailVerificationPrompt::class, bool $isRequired = true, string | Closure $middlewareName = 'verified'): static
+    public function emailVerification(string | Closure | array | null $promptAction = EmailVerificationPrompt::class, bool $isRequired = true): static
     {
-        $this->emailVerificationMiddlewareName = $middlewareName;
         $this->emailVerificationRouteAction = $promptAction;
         $this->requiresEmailVerification($isRequired);
+
+        return $this;
+    }
+
+    public function emailVerificationMiddlewareName(string | Closure $middlewareName): static
+    {
+        $this->emailVerificationMiddlewareName = $middlewareName;
 
         return $this;
     }


### PR DESCRIPTION
In #8607 first steps have been made to allow unauthenticated users access to the panel. However it still wasn't possible to have email verification forced for authenticated users while still allowing unauthenticated users.

This PR provides the possibility to change the email verification middleware with the optional parameter `middlewareName`. One could then implement custom logic for letting unauthenticated users through.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
