### PR TITLE
Fix for Repeater custom view

### DIFF
--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1077,6 +1077,10 @@ class Repeater extends Field implements Contracts\CanConcealComponents
 
     public function getView(): string
     {
+        if (isset($this->view)) {
+            return $this->view;
+        }
+
         if ($this->isSimple()) {
             return 'filament-forms::components.simple-repeater';
         }

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1075,12 +1075,11 @@ class Repeater extends Field implements Contracts\CanConcealComponents
         return $this->isCollapsible();
     }
 
-    public function getView(): string
+    /**
+     * @return view-string
+     */
+    public function getDefaultView(): string
     {
-        if (isset($this->view)) {
-            return $this->view;
-        }
-
         if ($this->isSimple()) {
             return 'filament-forms::components.simple-repeater';
         }


### PR DESCRIPTION
Changes made inside this PR https://github.com/filamentphp/filament/pull/7315 to Repeater.php override the ability to set a custom view. This is a potential fix for that issue.

When using the `->view(...)` method on a Repeater we want that custom view to be shown and override any default views. 

```
Repeater::make('...')
    ->schema([])
    ->view('filament.plugins.components.table-repeater-custom')
```

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
