### PR TITLE
Add CSS hook class to table group header

### DIFF
--- a/packages/tables/resources/views/components/group/header.blade.php
+++ b/packages/tables/resources/views/components/group/header.blade.php
@@ -12,7 +12,7 @@
     @endif
     {{
         $attributes->class([
-            'flex w-full items-center gap-x-3 bg-gray-50 px-3 py-2 dark:bg-white/5',
+            'fi-ta-group-header flex w-full items-center gap-x-3 bg-gray-50 px-3 py-2 dark:bg-white/5',
             'cursor-pointer' => $collapsible,
         ])
     }}


### PR DESCRIPTION
A small PR that adds `fi-ta-group-header` hook CSS class to the header of a group of rows in a table. 

I tried to add a name that follows the naming conventions, but let me know if you want it changed to anything else.

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
