### PR TITLE
Fix widget CSS classes

### DIFF
--- a/packages/panels/resources/views/components/page/index.blade.php
+++ b/packages/panels/resources/views/components/page/index.blade.php
@@ -94,6 +94,7 @@
                         :columns="$this->getHeaderWidgetsColumns()"
                         :data="$widgetData"
                         :widgets="$headerWidgets"
+                        class="fi-page-header-widgets"
                     />
                 @endif
 
@@ -108,6 +109,7 @@
                         :columns="$this->getFooterWidgetsColumns()"
                         :data="$widgetData"
                         :widgets="$footerWidgets"
+                        class="fi-page-footer-widgets"
                     />
                 @endif
 

--- a/packages/widgets/resources/views/chart-widget.blade.php
+++ b/packages/widgets/resources/views/chart-widget.blade.php
@@ -5,12 +5,8 @@
     $filters = $this->getFilters();
 @endphp
 
-<x-filament-widgets::widget>
-    <x-filament::section
-        :description="$description"
-        :heading="$heading"
-        class="fi-wi-chart"
-    >
+<x-filament-widgets::widget class="fi-wi-chart">
+    <x-filament::section :description="$description" :heading="$heading">
         @if ($filters)
             <x-slot name="headerEnd">
                 <x-filament::input.wrapper

--- a/packages/widgets/resources/views/components/widget.blade.php
+++ b/packages/widgets/resources/views/components/widget.blade.php
@@ -29,6 +29,7 @@
     :lgStart="$columnStart['lg'] ?? null"
     :xlStart="$columnStart['xl'] ?? null"
     :twoXlStart="$columnStart['2xl'] ?? null"
+    :attributes="\Filament\Support\prepare_inherited_attributes($attributes)->class('fi-wi-widget')"
 >
     {{ $slot }}
 </x-filament::grid.column>

--- a/packages/widgets/resources/views/components/widgets.blade.php
+++ b/packages/widgets/resources/views/components/widgets.blade.php
@@ -13,7 +13,7 @@
     :lg="$columns['lg'] ?? ($columns ? (is_array($columns) ? null : $columns) : 2)"
     :xl="$columns['xl'] ?? null"
     :two-xl="$columns['2xl'] ?? null"
-    class="fi-wi gap-6"
+    :attributes="\Filament\Support\prepare_inherited_attributes($attributes)->class('fi-wi gap-6')"
 >
     @php
         $normalizeWidgetClass = function (string | Filament\Widgets\WidgetConfiguration $widget): string {

--- a/packages/widgets/resources/views/stats-overview-widget.blade.php
+++ b/packages/widgets/resources/views/stats-overview-widget.blade.php
@@ -2,13 +2,13 @@
     $columns = $this->getColumns();
 @endphp
 
-<x-filament-widgets::widget>
+<x-filament-widgets::widget class="fi-wi-stats-overview">
     <div
         @if ($pollingInterval = $this->getPollingInterval())
             wire:poll.{{ $pollingInterval }}
         @endif
         @class([
-            'fi-wi-stats-overview grid gap-6',
+            'fi-wi-stats-overview-stats-ctn grid gap-6',
             'md:grid-cols-1' => $columns === 1,
             'md:grid-cols-2' => $columns === 2,
             'md:grid-cols-3' => $columns === 3,


### PR DESCRIPTION
- [ ] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

---

`fi-wi-stats-overview` and `fi-wi-chart` were incorrectly placed on a child instead of the root element. This change could be breaking, though it's a bug fix in my opinion. Needed to properly target certain types of widgets.