### PR TITLE
Fix an SQL error for Postgres on JSON field.

### DIFF
--- a/packages/notifications/src/Livewire/DatabaseNotifications.php
+++ b/packages/notifications/src/Livewire/DatabaseNotifications.php
@@ -85,7 +85,7 @@ class DatabaseNotifications extends Component
     public function getNotificationsQuery(): Builder | Relation
     {
         /** @phpstan-ignore-next-line */
-        return $this->getUser()->notifications()->where('data->format', 'filament');
+        return $this->getUser()->notifications()->whereJsonContains('data', ['format' => 'filament']);
     }
 
     public function getUnreadNotificationsQuery(): Builder | Relation


### PR DESCRIPTION
We are using Postgres database with the Filamentphp. However, after I login into the admin area I'm receiving an error caused by Json field (see screenshot).
![image](https://github.com/filamentphp/filament/assets/3956177/d1c20f40-7a64-4119-9910-233077572f3c)


After a change query should be formatted in the correct way and error isn't thrown anymore:
![image](https://github.com/filamentphp/filament/assets/3956177/7f7a26d7-bb34-4481-97af-d2b42eb9645f)

EDIT: I have accidentally taken screenshots of "different" queries, but codebase is still the same. One is the count of the same query results, another fetches results instead. However the difference I guess is pretty clear here.
