### PR TITLE
Fix link Blade component docs

### DIFF
--- a/packages/support/docs/09-blade-components/02-link.md
+++ b/packages/support/docs/09-blade-components/02-link.md
@@ -12,7 +12,7 @@ The link component is used to render a clickable link that can perform an action
 </x-filament::link>
 ```
 
-## Using a link as an anchor link
+## Using a link as a button
 
 By default, a link's underlying HTML tag is `<a>`. You can change it to be a `<button>` tag by using the `tag` attribute:
 


### PR DESCRIPTION
Hey!
Just a quick, small typo to make the docs a bit better. In this case, since we are in the link component page, I think the title should state how to use it as a button instead of as a link, since it's already a link.

Keep up the good work! :-)
