### PR TITLE
Allow html in table empty state description

### DIFF
--- a/packages/tables/resources/views/components/empty-state/index.blade.php
+++ b/packages/tables/resources/views/components/empty-state/index.blade.php
@@ -30,7 +30,7 @@
 
         @if ($description)
             <x-filament-tables::empty-state.description class="mt-1">
-                {{ $description }}
+                {!! $description !!}
             </x-filament-tables::empty-state.description>
         @endif
 


### PR DESCRIPTION
Small change that allows HTML in table empty state descriptions eg:

<img width="310" alt="image" src="https://github.com/filamentphp/filament/assets/5361908/98f94b7f-502a-44f6-894f-da9a0a7cb807">

It's fine to not escape this since it's not derived from user input.