### PR TITLE
Fixes a sidebar glitch when a section is collapsed

### DIFF
--- a/packages/support/resources/views/components/section/index.blade.php
+++ b/packages/support/resources/views/components/section/index.blade.php
@@ -143,7 +143,7 @@
             @if ($collapsed)
                 x-cloak
             @endif
-            x-bind:class="{ 'invisible h-0 border-none': isCollapsed }"
+            x-bind:class="{ 'hidden h-0 border-none': isCollapsed }"
         @endif
         @class([
             'fi-section-content-ctn',


### PR DESCRIPTION
### Package
filament/support

### Package Version
v3.0.62

### Laravel Version
v10.25.2

### Livewire Version
v3.0.5

### PHP Version
PHP 8.2

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This pull request addresses a bug that occurs when a section is collapsed but continues to occupy space even when it's not visible. The issue relates to the sidebar, and the solution involves changing the `invisible` class with `hidden`.

### Code to reproduce
[https://gist.github.com/therealspoljo/6e219da1c5706d82c4cbce90d690c078#file-apartmentresource-php-L81](https://gist.github.com/therealspoljo/6e219da1c5706d82c4cbce90d690c078#file-apartmentresource-php-L81)

### Screenshot
![image](https://github.com/filamentphp/filament/assets/5055468/aefb3240-7837-49a4-95e1-ecbb2efa2d22)

### Video
https://drive.google.com/file/d/1RgsaxY2GXg4eQC9vDfWtDGt3Wd4lL9A_/view