### PR TITLE
Introduce a way to customise how the global search attributes columns are search

### DIFF
--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -394,33 +394,11 @@ abstract class Resource
     {
     }
 
-    public static function globallySearchAttributesUsing(Builder $query, string $search): void
-    {
-        foreach (explode(' ', $search) as $searchWord) {
-            $query->where(function (Builder $query) use ($searchWord) {
-                $isFirst = true;
-
-                foreach (static::getGloballySearchableAttributes() as $attributes) {
-                    static::applyGlobalSearchAttributeConstraint(
-                        query: $query,
-                        search: $searchWord,
-                        searchAttributes: Arr::wrap($attributes),
-                        isFirst: $isFirst,
-                    );
-                }
-            });
-        }
-    }
-
     public static function getGlobalSearchResults(string $search): Collection
     {
         $query = static::getGlobalSearchEloquentQuery();
 
-        if (static::isGlobalSearchForcedCaseInsensitive($query)) {
-            $search = Str::lower($search);
-        }
-
-        static::globallySearchAttributesUsing($query, $search);
+        static::applyGlobalSearchAttributeConstraints($query, $search);
 
         static::modifyGlobalSearchQuery($query, $search);
 
@@ -638,6 +616,28 @@ abstract class Resource
             'pgsql' => true,
             default => false,
         };
+    }
+
+    protected static function applyGlobalSearchAttributeConstraints(Builder $query, string $search): void
+    {
+        if (static::isGlobalSearchForcedCaseInsensitive($query)) {
+            $search = Str::lower($search);
+        }
+
+        foreach (explode(' ', $search) as $searchWord) {
+            $query->where(function (Builder $query) use ($searchWord) {
+                $isFirst = true;
+
+                foreach (static::getGloballySearchableAttributes() as $attributes) {
+                    static::applyGlobalSearchAttributeConstraint(
+                        query: $query,
+                        search: $searchWord,
+                        searchAttributes: Arr::wrap($attributes),
+                        isFirst: $isFirst,
+                    );
+                }
+            });
+        }
     }
 
     /**

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -394,14 +394,8 @@ abstract class Resource
     {
     }
 
-    public static function getGlobalSearchResults(string $search): Collection
+    public static function globallySearchAttributesUsing(Builder $query, string $search): void
     {
-        $query = static::getGlobalSearchEloquentQuery();
-
-        if (static::isGlobalSearchForcedCaseInsensitive($query)) {
-            $search = Str::lower($search);
-        }
-
         foreach (explode(' ', $search) as $searchWord) {
             $query->where(function (Builder $query) use ($searchWord) {
                 $isFirst = true;
@@ -416,6 +410,17 @@ abstract class Resource
                 }
             });
         }
+    }
+
+    public static function getGlobalSearchResults(string $search): Collection
+    {
+        $query = static::getGlobalSearchEloquentQuery();
+
+        if (static::isGlobalSearchForcedCaseInsensitive($query)) {
+            $search = Str::lower($search);
+        }
+
+        static::globallySearchAttributesUsing($query, $search);
 
         static::modifyGlobalSearchQuery($query, $search);
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

For now there are no simple way to customise how global search attributes are search. You have to override the all  `getGlobalSearchResults` method which is cumbersome.

With the introduction of the method `globallySearchAttributesUsing`we can extract only the part preparing the search columns query and therefore we only need to override this method to customise how columns are search.

Then in your specific resource you could use a define scope to tweak the search query.

```php
public static function globallySearchAttributesUsing(Builder $query, string $search): void {
        $query->search($search);
}
```

 