### PR TITLE
Fix error with morphing toggled relation manager tabs

### DIFF
--- a/packages/panels/resources/views/components/resources/relation-managers.blade.php
+++ b/packages/panels/resources/views/components/resources/relation-managers.blade.php
@@ -18,14 +18,6 @@
 
             return $manager;
         };
-
-        //when previously active manager is hidden, reset tabs
-        //but not when hasCombinedRelationManagerTabsWithContent and active tab is the form
-        if ($activeManager !== "" && !isset($managers[$activeManager])){
-            $activeManager = strval(array_key_first($managers));
-            $this->activeRelationManager = strval(array_key_first($managers));
-        }
-
     @endphp
 
     @if ((count($managers) > 1) || $content)
@@ -70,13 +62,14 @@
 
 
     @if (filled($activeManager) && isset($managers[$activeManager]))
-        <div wire:key="{{$this->getId().'.relationManager.panel'}}"
-             @if (count($managers) > 1)
-                 id="relationManager{{ ucfirst($activeManager) }}"
-                 role="tabpanel"
-                 tabindex="0"
-             @endif
-             class="flex flex-col gap-y-4"
+        <div
+            @if (count($managers) > 1)
+                id="relationManager{{ ucfirst($activeManager) }}"
+                role="tabpanel"
+                tabindex="0"
+            @endif
+            wire:key="{{ $this->getId() }}.relation-managers.active"
+            class="flex flex-col gap-y-4"
         >
             @php
                 $managerLivewireProperties = ['lazy' => true, 'ownerRecord' => $ownerRecord, 'pageClass' => $pageClass];

--- a/packages/panels/resources/views/components/resources/relation-managers.blade.php
+++ b/packages/panels/resources/views/components/resources/relation-managers.blade.php
@@ -60,7 +60,6 @@
         </x-filament::tabs>
     @endif
 
-
     @if (filled($activeManager) && isset($managers[$activeManager]))
         <div
             @if (count($managers) > 1)

--- a/packages/panels/resources/views/components/resources/relation-managers.blade.php
+++ b/packages/panels/resources/views/components/resources/relation-managers.blade.php
@@ -18,6 +18,14 @@
 
             return $manager;
         };
+
+        //when previously active manager is hidden, reset tabs
+        //but not when hasCombinedRelationManagerTabsWithContent and active tab is the form
+        if ($activeManager !== "" && !isset($managers[$activeManager])){
+            $activeManager = strval(array_key_first($managers));
+            $this->activeRelationManager = strval(array_key_first($managers));
+        }
+
     @endphp
 
     @if ((count($managers) > 1) || $content)
@@ -60,14 +68,15 @@
         </x-filament::tabs>
     @endif
 
+
     @if (filled($activeManager) && isset($managers[$activeManager]))
-        <div
-            @if (count($managers) > 1)
-                id="relationManager{{ ucfirst($activeManager) }}"
-                role="tabpanel"
-                tabindex="0"
-            @endif
-            class="flex flex-col gap-y-4"
+        <div wire:key="{{$this->getId().'.relationManager.panel'}}"
+             @if (count($managers) > 1)
+                 id="relationManager{{ ucfirst($activeManager) }}"
+                 role="tabpanel"
+                 tabindex="0"
+             @endif
+             class="flex flex-col gap-y-4"
         >
             @php
                 $managerLivewireProperties = ['lazy' => true, 'ownerRecord' => $ownerRecord, 'pageClass' => $pageClass];


### PR DESCRIPTION
This PR fixes the bug described in #8788
Defining a key to the element will help livewire/alpine to morph the dom as expected.

After hiding a currently active manager, the activeRelationManager is set to the first item.


- [x] Changes have been thoroughly tested to not break existing functionality.

Tested with all possible relationmanager configuration what i could think of (with groups,  with hasCombinedRelationManagerTabsWithContent, with associative array keys,with more than 2 relationmanagers .. )

- [x] New functionality has been documented or existing documentation has been updated to reflect changes.

some inline comment describing the activemanager reset case