### PR TITLE
Add dropdown indicator to topbar items

### DIFF
--- a/packages/panels/resources/views/components/topbar/item.blade.php
+++ b/packages/panels/resources/views/components/topbar/item.blade.php
@@ -52,7 +52,7 @@
             </x-filament::badge>
         @endif
 
-        @if(! $url)
+        @if (! $url)
             <x-filament::icon
                 icon="heroicon-m-chevron-down"
                 @class([

--- a/packages/panels/resources/views/components/topbar/item.blade.php
+++ b/packages/panels/resources/views/components/topbar/item.blade.php
@@ -55,8 +55,9 @@
         @if (! $url)
             <x-filament::icon
                 icon="heroicon-m-chevron-down"
+                icon-alias="panels::topbar.item.toggle-button"
                 @class([
-                    'fi-topbar-item-icon h-5 w-5',
+                    'fi-topbar-item-toggle-icon h-5 w-5',
                     'text-gray-400 dark:text-gray-500' => ! $active,
                     'text-primary-500' => $active,
                 ])

--- a/packages/panels/resources/views/components/topbar/item.blade.php
+++ b/packages/panels/resources/views/components/topbar/item.blade.php
@@ -54,9 +54,9 @@
         @if (! $url)
             <x-filament::icon
                 icon="heroicon-m-chevron-down"
-                icon-alias="panels::topbar.group.collapse-button"
+                icon-alias="panels::topbar.group.toggle-button"
                 @class([
-                    'fi-topbar-item-toggle-icon h-5 w-5',
+                    'fi-topbar-group-toggle-icon h-5 w-5',
                     'text-gray-400 dark:text-gray-500' => ! $active,
                     'text-primary-500' => $active,
                 ])

--- a/packages/panels/resources/views/components/topbar/item.blade.php
+++ b/packages/panels/resources/views/components/topbar/item.blade.php
@@ -28,6 +28,7 @@
             'flex items-center justify-center gap-x-2 rounded-lg px-3 py-2 text-sm font-semibold outline-none transition duration-75 hover:bg-gray-50 focus:bg-gray-50 dark:hover:bg-white/5 dark:focus:bg-white/5',
             'text-gray-700 dark:text-gray-200' => ! $active,
             'bg-gray-50 text-primary-600 dark:bg-white/5 dark:text-primary-400' => $active,
+            'flex items-center gap-x-1' => ! $url,
         ])
     >
         @if ($icon || $activeIcon)
@@ -49,6 +50,17 @@
             <x-filament::badge :color="$badgeColor" size="sm">
                 {{ $badge }}
             </x-filament::badge>
+        @endif
+
+        @if(! $url)
+            <x-filament::icon
+                icon="heroicon-m-chevron-down"
+                @class([
+                    'fi-topbar-item-icon h-5 w-5',
+                    'text-gray-400 dark:text-gray-500' => ! $active,
+                    'text-primary-500' => $active,
+                ])
+            />
         @endif
     </{{ $tag }}>
 </li>

--- a/packages/panels/resources/views/components/topbar/item.blade.php
+++ b/packages/panels/resources/views/components/topbar/item.blade.php
@@ -28,7 +28,6 @@
             'flex items-center justify-center gap-x-2 rounded-lg px-3 py-2 text-sm font-semibold outline-none transition duration-75 hover:bg-gray-50 focus:bg-gray-50 dark:hover:bg-white/5 dark:focus:bg-white/5',
             'text-gray-700 dark:text-gray-200' => ! $active,
             'bg-gray-50 text-primary-600 dark:bg-white/5 dark:text-primary-400' => $active,
-            'flex items-center gap-x-1' => ! $url,
         ])
     >
         @if ($icon || $activeIcon)
@@ -55,7 +54,7 @@
         @if (! $url)
             <x-filament::icon
                 icon="heroicon-m-chevron-down"
-                icon-alias="panels::topbar.item.toggle-button"
+                icon-alias="panels::topbar.group.collapse-button"
                 @class([
                     'fi-topbar-item-toggle-icon h-5 w-5',
                     'text-gray-400 dark:text-gray-500' => ! $active,


### PR DESCRIPTION
A dropdown indicator has been added to the topbar items, providing a more intuitive interface for users. This changes the UX to better indicate when a topbar item can be interacted with as a dropdown. A conditional is added to check if the item URL exists, if it doesn't the dropdown indicator is shown.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Before the update:
<img width="282" alt="image" src="https://github.com/filamentphp/filament/assets/35311720/ea2ce75a-1810-485c-bbda-01b4de2a5f52">
<img width="285" alt="image" src="https://github.com/filamentphp/filament/assets/35311720/1b5e85ab-a53c-4a0b-9869-9db08c9490c3">

After the update:
<img width="280" alt="image" src="https://github.com/filamentphp/filament/assets/35311720/a0cc3dd4-db04-4605-b9fd-3c825e10eee9">
<img width="283" alt="image" src="https://github.com/filamentphp/filament/assets/35311720/863a2602-e889-44df-b2c2-3687338665b8">
