### PR TITLE
Fix docs: Update variable name to match where used

### DIFF
--- a/packages/forms/docs/09-testing.md
+++ b/packages/forms/docs/09-testing.md
@@ -112,7 +112,7 @@ use function Pest\Livewire\livewire;
 
 it('has a title field', function () {
     livewire(CreatePost::class)
-        ->assertFormFieldExists('title', function (TextInput $field): bool {
+        ->assertFormFieldExists('title', function (TextInput $input): bool {
             return $input->isDisabled();
         });
 });

--- a/packages/forms/docs/09-testing.md
+++ b/packages/forms/docs/09-testing.md
@@ -112,8 +112,8 @@ use function Pest\Livewire\livewire;
 
 it('has a title field', function () {
     livewire(CreatePost::class)
-        ->assertFormFieldExists('title', function (TextInput $input): bool {
-            return $input->isDisabled();
+        ->assertFormFieldExists('title', function (TextInput $field): bool {
+            return $field->isDisabled();
         });
 });
 ```


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This is a fix to the documentation. If preferable, the new `$input` variable could stay `$field` and  `$input->isDisabled()` could change to `$field->isDisabled()`.