### PR TITLE
Ignore UUID `id` fields in form generation

### DIFF
--- a/packages/forms/src/Commands/Concerns/CanGenerateForms.php
+++ b/packages/forms/src/Commands/Concerns/CanGenerateForms.php
@@ -32,8 +32,7 @@ trait CanGenerateForms
             $columnName = $column->getName();
 
             if (str($columnName)->is([
-                'id',
-                'uuid',
+                app($model)->getKeyName(),
                 'created_at',
                 'deleted_at',
                 'updated_at',

--- a/packages/forms/src/Commands/Concerns/CanGenerateForms.php
+++ b/packages/forms/src/Commands/Concerns/CanGenerateForms.php
@@ -29,13 +29,11 @@ trait CanGenerateForms
                 continue;
             }
 
-            if ($column->getName() === 'id' && $column->getLength() === 36) {
-                continue;
-            }
-
             $columnName = $column->getName();
 
             if (str($columnName)->is([
+                'id',
+                'uuid',
                 'created_at',
                 'deleted_at',
                 'updated_at',

--- a/packages/forms/src/Commands/Concerns/CanGenerateForms.php
+++ b/packages/forms/src/Commands/Concerns/CanGenerateForms.php
@@ -29,6 +29,10 @@ trait CanGenerateForms
                 continue;
             }
 
+            if ($column->getName() === 'id' && $column->getLength() === 36) {
+                continue;
+            }
+
             $columnName = $column->getName();
 
             if (str($columnName)->is([


### PR DESCRIPTION
When the table has a UUID `id` primary field, the form is generated with that field as a text input. 

It should be ignored in the same way the auto increments are.

- [X] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
