### PR TITLE
Update install instructions to use ^3.0 instead of ^3.0-stable

### DIFF
--- a/packages/actions/docs/01-installation.md
+++ b/packages/actions/docs/01-installation.md
@@ -20,7 +20,7 @@ Filament requires the following to run:
 Require the Actions package using Composer:
 
 ```bash
-composer require filament/actions:"^3.0-stable" -W
+composer require filament/actions:"^3.0" -W
 ```
 
 ## New Laravel projects

--- a/packages/actions/docs/10-upgrade-guide.md
+++ b/packages/actions/docs/10-upgrade-guide.md
@@ -19,7 +19,7 @@ Please upgrade Filament before upgrading to Livewire v3. Instructions on how to 
 The easiest way to upgrade your app is to run the automated upgrade script. This script will automatically upgrade your application to the latest version of Filament and make changes to your code, which handles most breaking changes.
 
 ```bash
-composer require filament/upgrade:"^3.0-stable" -W --dev
+composer require filament/upgrade:"^3.0" -W --dev
 
 vendor/bin/filament-v3
 ```

--- a/packages/forms/docs/01-installation.md
+++ b/packages/forms/docs/01-installation.md
@@ -20,7 +20,7 @@ Filament requires the following to run:
 Require the Form Builder package using Composer:
 
 ```bash
-composer require filament/forms:"^3.0-stable" -W
+composer require filament/forms:"^3.0" -W
 ```
 
 ## New Laravel projects

--- a/packages/forms/docs/10-upgrade-guide.md
+++ b/packages/forms/docs/10-upgrade-guide.md
@@ -19,7 +19,7 @@ Please upgrade Filament before upgrading to Livewire v3. Instructions on how to 
 The easiest way to upgrade your app is to run the automated upgrade script. This script will automatically upgrade your application to the latest version of Filament, and make changes to your code which handle most breaking changes.
 
 ```bash
-composer require filament/upgrade:"^3.0-stable" -W --dev
+composer require filament/upgrade:"^3.0" -W --dev
 vendor/bin/filament-v3
 ```
 

--- a/packages/infolists/docs/01-installation.md
+++ b/packages/infolists/docs/01-installation.md
@@ -20,7 +20,7 @@ Filament requires the following to run:
 Require the Infolist Builder package using Composer:
 
 ```bash
-composer require filament/infolists:"^3.0-stable" -W
+composer require filament/infolists:"^3.0" -W
 ```
 
 ## New Laravel projects

--- a/packages/notifications/docs/01-installation.md
+++ b/packages/notifications/docs/01-installation.md
@@ -18,7 +18,7 @@ Filament requires the following to run:
 Require the Notifications package using Composer:
 
 ```bash
-composer require filament/notifications:"^3.0-stable" -W
+composer require filament/notifications:"^3.0" -W
 ```
 
 ## New Laravel projects

--- a/packages/notifications/docs/07-upgrade-guide.md
+++ b/packages/notifications/docs/07-upgrade-guide.md
@@ -19,7 +19,7 @@ Please upgrade Filament before upgrading to Livewire v3. Instructions on how to 
 The easiest way to upgrade your app is to run the automated upgrade script. This script will automatically upgrade your application to the latest version of Filament, and make changes to your code which handle most breaking changes.
 
 ```bash
-composer require filament/upgrade:"^3.0-stable" -W --dev
+composer require filament/upgrade:"^3.0" -W --dev
 vendor/bin/filament-v3
 ```
 

--- a/packages/panels/docs/01-installation.md
+++ b/packages/panels/docs/01-installation.md
@@ -20,7 +20,7 @@ Filament requires the following to run:
 Install the Filament Panel Builder by running the following commands in your Laravel project directory:
 
 ```bash
-composer require filament/filament:"^3.0-stable" -W
+composer require filament/filament:"^3.0" -W
 
 php artisan filament:install --panels
 ```

--- a/packages/panels/docs/14-upgrade-guide.md
+++ b/packages/panels/docs/14-upgrade-guide.md
@@ -19,7 +19,7 @@ Please upgrade Filament before upgrading to Livewire v3. Instructions on how to 
 The easiest way to upgrade your app is to run the automated upgrade script. This script will automatically upgrade your application to the latest version of Filament and make changes to your code, which handles most breaking changes.
 
 ```bash
-composer require filament/upgrade:"^3.0-stable" -W --dev
+composer require filament/upgrade:"^3.0" -W --dev
 
 vendor/bin/filament-v3
 ```

--- a/packages/spatie-laravel-google-fonts-plugin/README.md
+++ b/packages/spatie-laravel-google-fonts-plugin/README.md
@@ -5,7 +5,7 @@
 Install the plugin with Composer:
 
 ```bash
-composer require filament/spatie-laravel-google-fonts-plugin:"^3.0-stable" -W
+composer require filament/spatie-laravel-google-fonts-plugin:"^3.0" -W
 ```
 
 Please [follow Spatie's documentation about how to set up their package](https://github.com/spatie/laravel-google-fonts) first.

--- a/packages/spatie-laravel-media-library-plugin/README.md
+++ b/packages/spatie-laravel-media-library-plugin/README.md
@@ -5,7 +5,7 @@
 Install the plugin with Composer:
 
 ```bash
-composer require filament/spatie-laravel-media-library-plugin:"^3.0-stable" -W
+composer require filament/spatie-laravel-media-library-plugin:"^3.0" -W
 ```
 
 If you haven't already done so, you need to publish the migration to create the media table:

--- a/packages/spatie-laravel-settings-plugin/README.md
+++ b/packages/spatie-laravel-settings-plugin/README.md
@@ -5,7 +5,7 @@
 Install the plugin with Composer:
 
 ```bash
-composer require filament/spatie-laravel-settings-plugin:"^3.0-stable" -W
+composer require filament/spatie-laravel-settings-plugin:"^3.0" -W
 ```
 
 ## Preparing your page class

--- a/packages/spatie-laravel-tags-plugin/README.md
+++ b/packages/spatie-laravel-tags-plugin/README.md
@@ -5,7 +5,7 @@
 Install the plugin with Composer:
 
 ```bash
-composer require filament/spatie-laravel-tags-plugin:"^3.0-stable" -W
+composer require filament/spatie-laravel-tags-plugin:"^3.0" -W
 ```
 
 If you haven't already done so, you need to publish the migration to create the tags table:

--- a/packages/spatie-laravel-translatable-plugin/README.md
+++ b/packages/spatie-laravel-translatable-plugin/README.md
@@ -5,7 +5,7 @@
 Install the plugin with Composer:
 
 ```bash
-composer require filament/spatie-laravel-translatable-plugin:"^3.0-stable" -W
+composer require filament/spatie-laravel-translatable-plugin:"^3.0" -W
 ```
 
 ## Adding the plugin to a panel

--- a/packages/tables/docs/01-installation.md
+++ b/packages/tables/docs/01-installation.md
@@ -20,7 +20,7 @@ Filament requires the following to run:
 Require the Table Builder package using Composer:
 
 ```bash
-composer require filament/tables:"^3.0-stable" -W
+composer require filament/tables:"^3.0" -W
 ```
 
 ## New Laravel projects

--- a/packages/tables/docs/13-upgrade-guide.md
+++ b/packages/tables/docs/13-upgrade-guide.md
@@ -19,7 +19,7 @@ Please upgrade Filament before upgrading to Livewire v3. Instructions on how to 
 The easiest way to upgrade your app is to run the automated upgrade script. This script will automatically upgrade your application to the latest version of Filament, and make changes to your code which handle most breaking changes.
 
 ```bash
-composer require filament/upgrade:"^3.0-stable" -W --dev
+composer require filament/upgrade:"^3.0" -W --dev
 vendor/bin/filament-v3
 ```
 

--- a/packages/upgrade/bin/filament-v3
+++ b/packages/upgrade/bin/filament-v3
@@ -368,7 +368,7 @@ foreach (json_decode(file_get_contents('composer.json'), true)['require'] as $pa
         continue;
     }
 
-    $requireCommands[] = "composer require {$package}:\"^3.0-stable\" -W --no-update";
+    $requireCommands[] = "composer require {$package}:\"^3.0\" -W --no-update";
 }
 
 $requireCommands = implode("</strong><br /><strong>", $requireCommands);

--- a/packages/widgets/docs/01-installation.md
+++ b/packages/widgets/docs/01-installation.md
@@ -20,7 +20,7 @@ Filament requires the following to run:
 Require the Widgets package using Composer:
 
 ```bash
-composer require filament/widgets:"^3.0-stable" -W
+composer require filament/widgets:"^3.0" -W
 ```
 
 ## New Laravel projects


### PR DESCRIPTION
I'm seeing lots of posts on Discord where people are trying to use "latest" features, but they're not available even after running composer update.
It's because they've put `^3.0-stable` in their composer.json instead of just `^3.0`.
