### PR TITLE
Update 02-getting-started.md

### DIFF
--- a/packages/forms/docs/02-getting-started.md
+++ b/packages/forms/docs/02-getting-started.md
@@ -196,7 +196,7 @@ use Illuminate\Support\Str;
         ->live()
         ->afterStateUpdated(function (Set $set, $state) {
             $set('slug', Str::slug($state));
-        })
+        }),
     TextInput::make('slug')
         ->required()
         ->maxLength(255),


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
