### PR TITLE
Update MakeWidgetCommand to work with latest versions of `laravel/prompt`

### DIFF
--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -83,7 +83,7 @@ class MakeWidgetCommand extends Command
                             fn (Panel $panel): string => "The [{$panel->getId()}] panel",
                             $panels,
                         ),
-                        '' => '[App\\Livewire] alongside other Livewire components',
+                        'App\Livewire' => '[App\\Livewire] alongside other Livewire components',
                     ]),
                 )] ?? null;
             }


### PR DESCRIPTION
I'm not sure if this is the correct/preferred solution for this issue, but it seems to work without any side effects. The problem is that an empty value is considered invalid and thus `laravel/prompts` returns a validation error.

By changing the key to a _truthy_, we pass the validation. However, I'm not sure if `App\Livewire` could be a potential panel name (I'm not familiar enough). Maybe a different key (that is guaranteed to never be a panel) could be better?

Fixes #8835 

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
