### PR TITLE
Fix widget make command

### DIFF
--- a/packages/panels/resources/views/components/sidebar/index.blade.php
+++ b/packages/panels/resources/views/components/sidebar/index.blade.php
@@ -12,12 +12,12 @@
     @if (filament()->isSidebarCollapsibleOnDesktop())
         x-cloak
         {{-- format-ignore-start --}}
-                                                        x-bind:class="
-                                                            $store.sidebar.isOpen
-                                                                ? @js($openSidebarClasses . ' ' . 'lg:sticky')
-                                                                : '-translate-x-full rtl:translate-x-full lg:sticky lg:translate-x-0 rtl:lg:-translate-x-0'
-                                                        "
-                                                        {{-- format-ignore-end --}}
+                                                            x-bind:class="
+                                                                $store.sidebar.isOpen
+                                                                    ? @js($openSidebarClasses . ' ' . 'lg:sticky')
+                                                                    : '-translate-x-full rtl:translate-x-full lg:sticky lg:translate-x-0 rtl:lg:-translate-x-0'
+                                                            "
+                                                            {{-- format-ignore-end --}}
     @else
         @if (filament()->hasTopNavigation())
             x-cloak
@@ -25,17 +25,17 @@
         @elseif (filament()->isSidebarFullyCollapsibleOnDesktop())
             x-cloak
             {{-- format-ignore-start --}}
-                                                            x-bind:class="$store.sidebar.isOpen ? @js($openSidebarClasses . ' ' . 'lg:sticky') : '-translate-x-full rtl:translate-x-full'"
-                                                            {{-- format-ignore-end --}}
+                                                                x-bind:class="$store.sidebar.isOpen ? @js($openSidebarClasses . ' ' . 'lg:sticky') : '-translate-x-full rtl:translate-x-full'"
+                                                                {{-- format-ignore-end --}}
         @else
             x-cloak="-lg"
             {{-- format-ignore-start --}}
-                                                            x-bind:class="
-                                                                $store.sidebar.isOpen
-                                                                    ? @js($openSidebarClasses . ' ' . 'lg:sticky')
-                                                                    : 'w-[--sidebar-width] -translate-x-full rtl:translate-x-full lg:sticky'
-                                                            "
-                                                            {{-- format-ignore-end --}}
+                                                                x-bind:class="
+                                                                    $store.sidebar.isOpen
+                                                                        ? @js($openSidebarClasses . ' ' . 'lg:sticky')
+                                                                        : 'w-[--sidebar-width] -translate-x-full rtl:translate-x-full lg:sticky'
+                                                                "
+                                                                {{-- format-ignore-end --}}
         @endif
     @endif
     @class([

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -97,7 +97,7 @@ class MakeWidgetCommand extends Command
 
         if (! $panel) {
             $namespace = config('livewire.class_namespace');
-            $path = app_path(Str::of($namespace)->after('App\\')->replace('\\', '/')->toString());
+            $path = app_path((string) str($namespace)->after('App\\')->replace('\\', '/'));
         } elseif ($resource === null) {
             $widgetDirectories = $panel->getWidgetDirectories();
             $widgetNamespaces = $panel->getWidgetNamespaces();

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -74,6 +74,7 @@ class MakeWidgetCommand extends Command
 
             if (! $panel) {
                 $panels = Filament::getPanels();
+                $namespace = config('livewire.class_namespace');
 
                 /** @var ?Panel $panel */
                 $panel = $panels[select(
@@ -83,8 +84,8 @@ class MakeWidgetCommand extends Command
                             fn (Panel $panel): string => "The [{$panel->getId()}] panel",
                             $panels,
                         ),
-                        '' => '[App\\Livewire] alongside other Livewire components',
-                    ]),
+                        $namespace => "[{$namespace}] alongside other Livewire components",
+                    ])
                 )] ?? null;
             }
         }
@@ -95,8 +96,8 @@ class MakeWidgetCommand extends Command
         $resourceNamespace = null;
 
         if (! $panel) {
-            $path = app_path('Livewire/');
-            $namespace = 'App\\Livewire';
+            $namespace = config('livewire.class_namespace');
+            $path = app_path(Str::of($namespace)->after('App\\')->replace('\\', '/')->toString());
         } elseif ($resource === null) {
             $widgetDirectories = $panel->getWidgetDirectories();
             $widgetNamespaces = $panel->getWidgetNamespaces();


### PR DESCRIPTION
- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

A recent change to select() in Prompts is breaking the usage in make-widget, whereby a select option cannot be empty, and required(false) no longer works for select().  The fix for this is to name the additional option in the make-widget panel selection.

There is also another "bug", whereby the make fails if the user's Livewire namespace is not App/Livewire, for example if they have updated from v2 to v3 and elected not to move from App/Http/Livewire.  The fix for this is to use config('livewire.class_namespace') for deriving the path and namespace.
