### PR TITLE
Add column labels to table global search field

### DIFF
--- a/packages/tables/docs/03-columns/01-getting-started.md
+++ b/packages/tables/docs/03-columns/01-getting-started.md
@@ -175,7 +175,9 @@ TextColumn::make('full_name')
     })
 ```
 
-You may customize the placeholder in the global searchbox, by either change the `filament-tables::table.fields.search.placeholder` translation (globally) or you can use the table method `searchPlaceholder`:
+#### Customizing the table search field placeholder
+
+You may customize the placeholder in the search field using the `searchPlaceholder()` method on the `$table`:
 
 ```php
 use Filament\Tables\Table;
@@ -186,7 +188,7 @@ public static function table(Table $table): Table
         ->columns([
             // ...
         ])
-        ->searchPlaceholder("Search (ID, Name)");
+        ->searchPlaceholder('Search (ID, Name)');
 }
 ```
 

--- a/packages/tables/docs/03-columns/01-getting-started.md
+++ b/packages/tables/docs/03-columns/01-getting-started.md
@@ -175,6 +175,21 @@ TextColumn::make('full_name')
     })
 ```
 
+You may customize the placeholder in the global searchbox, by either change the `filament-tables::table.fields.search.placeholder` translation (globally) or you can use the table method `searchPlaceholder`:
+
+```php
+use Filament\Tables\Table;
+
+public static function table(Table $table): Table
+{
+    return $table
+        ->columns([
+            // ...
+        ])
+        ->searchPlaceholder("Search (ID, Name)");
+}
+```
+
 ### Searching individually
 
 You can choose to enable a per-column search input field using the `isIndividual` parameter:

--- a/packages/tables/resources/views/components/search-field.blade.php
+++ b/packages/tables/resources/views/components/search-field.blade.php
@@ -1,5 +1,6 @@
 @props([
     'wireModel' => 'tableSearch',
+    'searchPlaceholder' => __('filament-tables::table.fields.search.placeholder')
 ])
 
 <div
@@ -19,7 +20,7 @@
         <x-filament::input
             autocomplete="off"
             inline-prefix
-            :placeholder="__('filament-tables::table.fields.search.placeholder')"
+            :placeholder="$searchPlaceholder"
             type="search"
             :wire:model.live.debounce.500ms="$wireModel"
             x-bind:id="$id('input')"

--- a/packages/tables/resources/views/components/search-field.blade.php
+++ b/packages/tables/resources/views/components/search-field.blade.php
@@ -1,6 +1,6 @@
 @props([
-    'wireModel' => 'tableSearch',
     'placeholder' => __('filament-tables::table.fields.search.placeholder'),
+    'wireModel' => 'tableSearch',
 ])
 
 <div

--- a/packages/tables/resources/views/components/search-field.blade.php
+++ b/packages/tables/resources/views/components/search-field.blade.php
@@ -1,6 +1,6 @@
 @props([
     'wireModel' => 'tableSearch',
-    'searchPlaceholder' => __('filament-tables::table.fields.search.placeholder'),
+    'placeholder' => __('filament-tables::table.fields.search.placeholder'),
 ])
 
 <div
@@ -20,7 +20,7 @@
         <x-filament::input
             autocomplete="off"
             inline-prefix
-            :placeholder="$searchPlaceholder"
+            :placeholder="$placeholder"
             type="search"
             :wire:model.live.debounce.500ms="$wireModel"
             x-bind:id="$id('input')"

--- a/packages/tables/resources/views/components/search-field.blade.php
+++ b/packages/tables/resources/views/components/search-field.blade.php
@@ -1,5 +1,6 @@
 @props([
     'wireModel' => 'tableSearch',
+    'searchableColumnLabels'
 ])
 
 <div
@@ -19,7 +20,7 @@
         <x-filament::input
             autocomplete="off"
             inline-prefix
-            :placeholder="__('filament-tables::table.fields.search.placeholder')"
+            :placeholder="__('filament-tables::table.fields.search.placeholder') . ($searchableColumnLabels ? ' (' . implode(', ', $searchableColumnLabels) .')' : '')"
             type="search"
             :wire:model.live.debounce.500ms="$wireModel"
             x-bind:id="$id('input')"

--- a/packages/tables/resources/views/components/search-field.blade.php
+++ b/packages/tables/resources/views/components/search-field.blade.php
@@ -1,6 +1,5 @@
 @props([
     'wireModel' => 'tableSearch',
-    'searchableColumnLabels'
 ])
 
 <div
@@ -20,7 +19,7 @@
         <x-filament::input
             autocomplete="off"
             inline-prefix
-            :placeholder="__('filament-tables::table.fields.search.placeholder') . ($searchableColumnLabels ? ' (' . implode(', ', $searchableColumnLabels) .')' : '')"
+            :placeholder="__('filament-tables::table.fields.search.placeholder')"
             type="search"
             :wire:model.live.debounce.500ms="$wireModel"
             x-bind:id="$id('input')"

--- a/packages/tables/resources/views/components/search-field.blade.php
+++ b/packages/tables/resources/views/components/search-field.blade.php
@@ -1,6 +1,6 @@
 @props([
     'wireModel' => 'tableSearch',
-    'searchPlaceholder' => __('filament-tables::table.fields.search.placeholder')
+    'searchPlaceholder' => __('filament-tables::table.fields.search.placeholder'),
 ])
 
 <div

--- a/packages/tables/resources/views/components/search-field.blade.php
+++ b/packages/tables/resources/views/components/search-field.blade.php
@@ -1,6 +1,6 @@
 @props([
     'wireModel' => 'tableSearch',
-    'searchableColumnLabels'
+    'searchableColumnLabels',
 ])
 
 <div
@@ -20,7 +20,7 @@
         <x-filament::input
             autocomplete="off"
             inline-prefix
-            :placeholder="__('filament-tables::table.fields.search.placeholder') . ($searchableColumnLabels ? ' (' . implode(', ', $searchableColumnLabels) .')' : '')"
+            :placeholder="__('filament-tables::table.fields.search.placeholder') . ($searchableColumnLabels ? ' (' . implode(', ', $searchableColumnLabels) . ')' : '')"
             type="search"
             :wire:model.live.debounce.500ms="$wireModel"
             x-bind:id="$id('input')"

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -59,7 +59,6 @@
     $isStriped = $isStriped();
     $isLoaded = $isLoaded();
     $hasFilters = $isFilterable();
-    $searchPlaceholder = $getSearchPlaceholder();
     $filtersLayout = $getFiltersLayout();
     $filtersTriggerAction = $getFiltersTriggerAction();
     $hasFiltersDropdown = $hasFilters && ($filtersLayout === FiltersLayout::Dropdown);
@@ -232,9 +231,7 @@
                         {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.before', scopes: static::class) }}
 
                         @if ($isGlobalSearchVisible)
-                            <x-filament-tables::search-field
-                                :search-placeholder="$searchPlaceholder"
-                            />
+                            <x-filament-tables::search-field :placeholder="$getSearchPlaceholder()" />
                         @endif
 
                         {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.after', scopes: static::class) }}

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -231,7 +231,9 @@
                         {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.before', scopes: static::class) }}
 
                         @if ($isGlobalSearchVisible)
-                            <x-filament-tables::search-field :placeholder="$getSearchPlaceholder()" />
+                            <x-filament-tables::search-field
+                                :placeholder="$getSearchPlaceholder()"
+                            />
                         @endif
 
                         {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.after', scopes: static::class) }}

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -59,6 +59,7 @@
     $isStriped = $isStriped();
     $isLoaded = $isLoaded();
     $hasFilters = $isFilterable();
+    $searchPlaceholder = $getSearchPlaceholder();
     $filtersLayout = $getFiltersLayout();
     $filtersTriggerAction = $getFiltersTriggerAction();
     $hasFiltersDropdown = $hasFilters && ($filtersLayout === FiltersLayout::Dropdown);
@@ -231,7 +232,7 @@
                         {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.before', scopes: static::class) }}
 
                         @if ($isGlobalSearchVisible)
-                            <x-filament-tables::search-field />
+                            <x-filament-tables::search-field :search-placeholder="$searchPlaceholder" />
                         @endif
 
                         {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.after', scopes: static::class) }}

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -54,7 +54,6 @@
     $isReordering = $isReordering();
     $isColumnSearchVisible = $isSearchableByColumn();
     $isGlobalSearchVisible = $isSearchable();
-    $searchableColumnLabels = $getGloballySearchableColumnLabels();
     $isSelectionEnabled = $isSelectionEnabled();
     $recordCheckboxPosition = $getRecordCheckboxPosition();
     $isStriped = $isStriped();
@@ -232,7 +231,7 @@
                         {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.before', scopes: static::class) }}
 
                         @if ($isGlobalSearchVisible)
-                            <x-filament-tables::search-field :searchable-column-labels="$searchableColumnLabels" />
+                            <x-filament-tables::search-field />
                         @endif
 
                         {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.after', scopes: static::class) }}

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -232,7 +232,9 @@
                         {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.before', scopes: static::class) }}
 
                         @if ($isGlobalSearchVisible)
-                            <x-filament-tables::search-field :searchable-column-labels="$searchableColumnLabels" />
+                            <x-filament-tables::search-field
+                                :searchable-column-labels="$searchableColumnLabels"
+                            />
                         @endif
 
                         {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.after', scopes: static::class) }}

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -231,9 +231,7 @@
                         {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.before', scopes: static::class) }}
 
                         @if ($isGlobalSearchVisible)
-                            <x-filament-tables::search-field
-                                :placeholder="$getSearchPlaceholder()"
-                            />
+                            <x-filament-tables::search-field :placeholder="$getSearchPlaceholder()" />
                         @endif
 
                         {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.after', scopes: static::class) }}

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -232,7 +232,9 @@
                         {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.before', scopes: static::class) }}
 
                         @if ($isGlobalSearchVisible)
-                            <x-filament-tables::search-field :search-placeholder="$searchPlaceholder" />
+                            <x-filament-tables::search-field
+                                :search-placeholder="$searchPlaceholder"
+                            />
                         @endif
 
                         {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.after', scopes: static::class) }}

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -54,6 +54,7 @@
     $isReordering = $isReordering();
     $isColumnSearchVisible = $isSearchableByColumn();
     $isGlobalSearchVisible = $isSearchable();
+    $searchableColumnLabels = $getGloballySearchableColumnLabels();
     $isSelectionEnabled = $isSelectionEnabled();
     $recordCheckboxPosition = $getRecordCheckboxPosition();
     $isStriped = $isStriped();
@@ -231,7 +232,7 @@
                         {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.before', scopes: static::class) }}
 
                         @if ($isGlobalSearchVisible)
-                            <x-filament-tables::search-field />
+                            <x-filament-tables::search-field :searchable-column-labels="$searchableColumnLabels" />
                         @endif
 
                         {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.search.after', scopes: static::class) }}

--- a/packages/tables/src/Table/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSearchRecords.php
@@ -24,19 +24,6 @@ trait CanSearchRecords
         return $this;
     }
 
-    public function getGloballySearchableColumnLabels(): array
-    {
-        $items = [];
-
-        foreach ($this->getColumns() as $column) {
-            if ($column->isGloballySearchable()) {
-                $items[] = $column->getLabel();
-            }
-        }
-
-        return $items;
-    }
-
     public function isSearchable(): bool
     {
         foreach ($this->getColumns() as $column) {

--- a/packages/tables/src/Table/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSearchRecords.php
@@ -80,7 +80,6 @@ trait CanSearchRecords
         return $this->getLivewire()->getTableColumnSearchIndicators();
     }
 
-
     public function searchPlaceholder(string | Closure $searchPlaceholder): static
     {
         $this->searchPlaceholder = $searchPlaceholder;

--- a/packages/tables/src/Table/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSearchRecords.php
@@ -62,7 +62,7 @@ trait CanSearchRecords
         return (bool) $this->evaluate($this->persistsColumnSearchesInSession);
     }
 
-    public function searchPlaceholder(string | Closure | null $searchPlaceholder = null): static
+    public function searchPlaceholder(string | Closure | null $searchPlaceholder): static
     {
         $this->searchPlaceholder = $searchPlaceholder;
 

--- a/packages/tables/src/Table/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSearchRecords.php
@@ -62,6 +62,18 @@ trait CanSearchRecords
         return (bool) $this->evaluate($this->persistsColumnSearchesInSession);
     }
 
+    public function searchPlaceholder(string | Closure | null $searchPlaceholder = null): static
+    {
+        $this->searchPlaceholder = $searchPlaceholder;
+
+        return $this;
+    }
+
+    public function getSearchPlaceholder(): ?string
+    {
+        return $this->evaluate($this->searchPlaceholder);
+    }
+
     public function hasSearch(): bool
     {
         return $this->getLivewire()->hasTableSearch();
@@ -78,17 +90,5 @@ trait CanSearchRecords
     public function getColumnSearchIndicators(): array
     {
         return $this->getLivewire()->getTableColumnSearchIndicators();
-    }
-
-    public function searchPlaceholder(string | Closure $searchPlaceholder): static
-    {
-        $this->searchPlaceholder = $searchPlaceholder;
-
-        return $this;
-    }
-
-    public function getSearchPlaceholder(): ?string
-    {
-        return $this->evaluate($this->searchPlaceholder);
     }
 }

--- a/packages/tables/src/Table/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSearchRecords.php
@@ -10,6 +10,8 @@ trait CanSearchRecords
 
     protected bool | Closure | null $persistsColumnSearchesInSession = false;
 
+    protected string | Closure | null $searchPlaceholder = null;
+
     public function persistSearchInSession(bool | Closure $condition = true): static
     {
         $this->persistsSearchInSession = $condition;
@@ -76,5 +78,18 @@ trait CanSearchRecords
     public function getColumnSearchIndicators(): array
     {
         return $this->getLivewire()->getTableColumnSearchIndicators();
+    }
+
+
+    public function searchPlaceholder(string | Closure $searchPlaceholder): static
+    {
+        $this->searchPlaceholder = $searchPlaceholder;
+
+        return $this;
+    }
+
+    public function getSearchPlaceholder(): ?string
+    {
+        return $this->evaluate($this->searchPlaceholder);
     }
 }

--- a/packages/tables/src/Table/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSearchRecords.php
@@ -24,6 +24,19 @@ trait CanSearchRecords
         return $this;
     }
 
+    public function getGloballySearchableColumnLabels(): array
+    {
+        $items = [];
+
+        foreach ($this->getColumns() as $column) {
+            if ($column->isGloballySearchable()) {
+                $items[] = $column->getLabel();
+            }
+        }
+
+        return $items;
+    }
+
     public function isSearchable(): bool
     {
         foreach ($this->getColumns() as $column) {


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

# TLDR:
This PR adds the lables of the `searchable` table columns to the search-input box placeholder.

![image](https://github.com/filamentphp/filament/assets/642292/d66fa162-d546-4c8b-b0b6-9965684b0cc7)


# Why this PR?
You can define one or many (globally) searchable columns inside your table beside none searchable columns, just like this:

```php
Tables\Columns\TextColumn::make("id")->searchable(),
Tables\Columns\TextColumn::make("name")->searchable(),
Tables\Columns\TextColumn::make("alt_name")->label("Alt Name"),
```

This will result to this right now:

![image](https://github.com/filamentphp/filament/assets/642292/49c62bae-8dba-4f26-944d-6bd0981de1d1)

How should a user know, which columns are searched? Especially if you have multiple tables, with different searchable columns, nobody would know, what results to expect when entering a search term. This is a usability issue imho. 


