### PR TITLE
Allow `toBroadcast` and `toDatabase` methods to be more easily overridden

### DIFF
--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -179,7 +179,7 @@ class Notification extends ViewComponent implements Arrayable
         return $this;
     }
 
-    public function toBroadcast(): BroadcastNotification
+    public function toBroadcast()
     {
         $data = $this->toArray();
         $data['format'] = 'filament';
@@ -187,7 +187,7 @@ class Notification extends ViewComponent implements Arrayable
         return new BroadcastNotification($data);
     }
 
-    public function toDatabase(): DatabaseNotification
+    public function toDatabase()
     {
         return new DatabaseNotification($this->getDatabaseMessage());
     }


### PR DESCRIPTION
I've got a project that uses schema-based multi-tenancy and a separate notifications table per-tenant. I'm using a custom notification channel which has additional logic to make this work.

It seems the best way to use this with Filament is extending `Filament\Notifications\Notification` and overriding the [toDatabasemethod](https://github.com/filamentphp/filament/blob/8c49d1f398b8c1a1cb2040e173c208e3329ded07/packages/notifications/src/Notification.php#L190) so I can use my own class instead of `Filament\Notifications\DatabaseNotification`. But the method is return typed, which makes it very difficult:

`toDatabase() must be compatible with Filament\Notifications\Notification::toDatabase(): Filament\Notifications\DatabaseNotification
`

Strong typing is great, but in this case it reduces the extensibility of the package. It'd be great if this typing could be removed. We need to be able to use custom classes with these methods in order to use custom channels. Otherwise we're [locked to 'database'](https://github.com/filamentphp/filament/blob/8c49d1f398b8c1a1cb2040e173c208e3329ded07/packages/notifications/src/DatabaseNotification.php#L26C1-L29C6) for DB notifications and [locked to 'broadcast'](https://github.com/filamentphp/filament/blob/8c49d1f398b8c1a1cb2040e173c208e3329ded07/packages/notifications/src/BroadcastNotification.php#L27) for broadcast.