### PR TITLE
Register page form.before and form.after render hooks

### DIFF
--- a/packages/panels/resources/views/pages/auth/register.blade.php
+++ b/packages/panels/resources/views/pages/auth/register.blade.php
@@ -7,6 +7,8 @@
         </x-slot>
     @endif
 
+    {{ \Filament\Support\Facades\FilamentView::renderHook('panels::auth.register.form.before') }}
+
     <x-filament-panels::form wire:submit="register">
         {{ $this->form }}
 
@@ -15,4 +17,6 @@
             :full-width="$this->hasFullWidthFormActions()"
         />
     </x-filament-panels::form>
+
+    {{ \Filament\Support\Facades\FilamentView::renderHook('panels::auth.register.form.after') }}
 </x-filament-panels::page.simple>

--- a/packages/support/docs/06-render-hooks.md
+++ b/packages/support/docs/06-render-hooks.md
@@ -38,6 +38,8 @@ FilamentView::registerRenderHook(
 
 - `panels::auth.login.form.before` - Before login form
 - `panels::auth.login.form.after` - After login form
+- `panels::auth.register.form.before` - Before register form
+- `panels::auth.register.form.after` - After register form
 - `panels::body.start` - After `<body>`
 - `panels::body.end` - Before `</body>`
 - `panels::content.end` - After page content, inside `<main>`


### PR DESCRIPTION
This PR adds to new render hooks. One before the register form and one after, just as already exists for the login form.

I was working on adding [Laravel Socialite](https://laravel.com/docs/10.x/socialite) to a Filament app and while I found I could use a render hook to show the SSO link(s) after the login form I could not find a way to do so in the register form too without replacing the whole view. Obviously render hooks are much more preferable to customizing views.