### PR TITLE
Fix: Get disk name from registered collection inside Model.

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -9,6 +9,7 @@ use League\Flysystem\UnableToCheckFileExistence;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\MediaCollections\FileAdder;
+use Spatie\MediaLibrary\MediaCollections\MediaCollection;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Throwable;
 
@@ -225,6 +226,20 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             ->getMedia($this->getCollection())
             ->whereNotIn('uuid', array_keys($this->getState() ?? []))
             ->each(fn (Media $media) => $media->delete());
+    }
+
+    public function getDiskName(): string
+    {
+        if ($diskName = $this->evaluate($this->diskName)) {
+            return $diskName;
+        }
+
+        $diskNameFromRegisteredConversions = $this->getModelInstance()
+            ->getRegisteredMediaCollections()
+            ->filter(fn (MediaCollection $collection) => $collection->name === $this->getCollection())
+            ->value('diskName');
+
+        return $diskNameFromRegisteredConversions ?? config('filament.default_filesystem_disk');
     }
 
     public function getCollection(): string

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -234,7 +234,10 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             return $diskName;
         }
 
-        $diskNameFromRegisteredConversions = $this->getModelInstance()
+        /** @var Model&HasMedia $model */
+        $model = $this->getModelInstance();
+        
+        $diskNameFromRegisteredConversions = $model
             ->getRegisteredMediaCollections()
             ->filter(fn (MediaCollection $collection) => $collection->name === $this->getCollection())
             ->value('diskName');

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -237,8 +237,8 @@ class SpatieMediaLibraryFileUpload extends FileUpload
         /** @var Model&HasMedia $model */
         $model = $this->getModelInstance();
 
+        /** @phpstan-ignore-next-line */
         $diskNameFromRegisteredConversions = $model
-            /** @phpstan-ignore-next-line */
             ->getRegisteredMediaCollections()
             ->filter(fn (MediaCollection $collection): bool => $collection->name === $this->getCollection())
             ->first()

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -236,7 +236,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
         /** @var Model&HasMedia $model */
         $model = $this->getModelInstance();
-        
+
         $diskNameFromRegisteredConversions = $model
             ->getRegisteredMediaCollections()
             ->filter(fn (MediaCollection $collection) => $collection->name === $this->getCollection())

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -240,7 +240,8 @@ class SpatieMediaLibraryFileUpload extends FileUpload
         $diskNameFromRegisteredConversions = $model
             ->getRegisteredMediaCollections()
             ->filter(fn (MediaCollection $collection): bool => $collection->name === $this->getCollection())
-            ->value('diskName');
+            ->first()
+            ?->diskName;
 
         return $diskNameFromRegisteredConversions ?? config('filament.default_filesystem_disk');
     }

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -239,7 +239,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
         $diskNameFromRegisteredConversions = $model
             ->getRegisteredMediaCollections()
-            ->filter(fn (MediaCollection $collection) => $collection->name === $this->getCollection())
+            ->filter(fn (MediaCollection $collection): bool => $collection->name === $this->getCollection())
             ->value('diskName');
 
         return $diskNameFromRegisteredConversions ?? config('filament.default_filesystem_disk');

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -238,6 +238,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
         $model = $this->getModelInstance();
 
         $diskNameFromRegisteredConversions = $model
+            /** @phpstan-ignore-next-line */
             ->getRegisteredMediaCollections()
             ->filter(fn (MediaCollection $collection): bool => $collection->name === $this->getCollection())
             ->first()


### PR DESCRIPTION
This PR adds support to optionally get disk name from the collection that is defined inside the model.

## Problem:

`SpatieMediaLibraryFileUpload` field does not pick the disk name from the registered collections inside the model.

```php
// App\Models\Attachment.php
class Attachment extends Model implements HasMedia
{
    use InteractsWithMedia;

    public function registerMediaCollections(): void
    {
        $this->addMediaCollection('file')
            ->useDisk('attachments_disk') // We have disk specified here for this collection.
            ->singleFile();
    }
}
```

**This would not save the file to `attachments_disk` unless we explicity pass the disk name in `disk()` method**
```php
SpatieMediaLibraryFileUpload::make('file')->collection('file'),
```

## Solution

This pull request overrides the `getDiskName` method of `FileUpload` and adds code to optionally load the disk name from the collection defined in model. The first preference is still given to `disk()` so users can specify disk on field itself.

## Checklist

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
