### PR TITLE
Fix: wrong injection parameter in TextEntry Doc

### DIFF
--- a/packages/infolists/docs/03-entries/02-text.md
+++ b/packages/infolists/docs/03-entries/02-text.md
@@ -100,10 +100,10 @@ use Filament\Infolists\Components\TextEntry;
 
 TextEntry::make('description')
     ->limit(50)
-    ->tooltip(function (TextEntry $entry): ?string {
-        $state = $entry->getState();
+    ->tooltip(function (TextEntry $component): ?string {
+        $state = $component->getState();
 
-        if (strlen($state) <= $entry->getCharacterLimit()) {
+        if (strlen($state) <= $component->getCharacterLimit()) {
             return null;
         }
 


### PR DESCRIPTION
Update `$entry` to `$component` for injection example.
