### PR TITLE
Fix bulk actions portuguese translations

### DIFF
--- a/packages/tables/resources/lang/pt_BR/table.php
+++ b/packages/tables/resources/lang/pt_BR/table.php
@@ -85,7 +85,7 @@ return [
         ],
 
         'open_bulk_actions' => [
-            'label' => 'Ações abertas',
+            'label' => 'Abrir ações',
         ],
 
         'toggle_columns' => [

--- a/packages/tables/resources/lang/pt_PT/table.php
+++ b/packages/tables/resources/lang/pt_PT/table.php
@@ -85,7 +85,7 @@ return [
         ],
 
         'open_bulk_actions' => [
-            'label' => 'Ações abertas',
+            'label' => 'Abrir ações',
         ],
 
         'toggle_columns' => [


### PR DESCRIPTION
Just fixing a minor translation error that has been bugging me on my projects 😄 

"Open Actions" was mistranslated with open as an adjective instead of a verb. Think of "The actions that are open" instead of "Open the actions". This PR changes it so it is more in line with similar languages, such as spanish.