### PR TITLE
add translation to breadcrumbs for the plural resource name

### DIFF
--- a/packages/panels/src/Resources/Pages/Page.php
+++ b/packages/panels/src/Resources/Pages/Page.php
@@ -114,7 +114,7 @@ abstract class Page extends BasePage
         $breadcrumb = $this->getBreadcrumb();
 
         return [
-            $resource::getUrl() => $resource::getBreadcrumb(),
+            $resource::getUrl() => __($resource::getBreadcrumb()),
             ...(filled($breadcrumb) ? [$breadcrumb] : []),
         ];
     }


### PR DESCRIPTION
apply translation to the breadcrumbs resource name
