### PR TITLE
Allow action groups to specify icon size

### DIFF
--- a/packages/actions/resources/views/components/group.blade.php
+++ b/packages/actions/resources/views/components/group.blade.php
@@ -9,6 +9,7 @@
     'group' => null,
     'icon' => null,
     'iconButton' => false,
+    'iconSize' => null,
     'label' => null,
     'link' => false,
     'size' => null,
@@ -24,6 +25,7 @@
             ->color($color)
             ->dropdownPlacement($dropdownPlacement)
             ->icon($icon)
+            ->iconSize($iconSize)
             ->label($label)
             ->size($size)
             ->tooltip($tooltip)
@@ -93,6 +95,7 @@
                 :color="$group->getColor()"
                 :tooltip="$group->getTooltip()"
                 :icon="$group->getIcon()"
+                :icon-size="$group->getIconSize()"
                 :size="$group->getSize()"
                 :label-sr-only="$group->isLabelHidden()"
                 :attributes="\Filament\Support\prepare_inherited_attributes($attributes)->merge($group->getExtraAttributes(), escape: false)"

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -94,6 +94,7 @@
         \Filament\Support\get_color_css_variables(
             $color,
             shades: [400, 500, 600],
+            alias: 'button',
         ) => $color !== 'gray',
     ]);
 

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -94,7 +94,6 @@
         \Filament\Support\get_color_css_variables(
             $color,
             shades: [400, 500, 600],
-            alias: 'button',
         ) => $color !== 'gray',
     ]);
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
