### PR TITLE
Ability to send arguments to specific nested action in tests

### DIFF
--- a/packages/actions/src/Testing/TestsActions.php
+++ b/packages/actions/src/Testing/TestsActions.php
@@ -29,11 +29,13 @@ class TestsActions
             /** @phpstan-ignore-next-line */
             $name = $this->parseNestedActionName($name);
 
-            foreach ($name as $actionNestingIndex => $actionName) {
+            foreach ($name as $actionName) {
                 $this->call(
                     'mountAction',
                     $actionName,
-                    (count($name) === $actionNestingIndex + 1) ? $arguments : [],
+                    count($name) > 1
+                        ? $arguments[$actionName] ?? []
+                        : $arguments,
                 );
             }
 

--- a/packages/actions/src/Testing/TestsActions.php
+++ b/packages/actions/src/Testing/TestsActions.php
@@ -29,13 +29,11 @@ class TestsActions
             /** @phpstan-ignore-next-line */
             $name = $this->parseNestedActionName($name);
 
-            foreach ($name as $actionName) {
+            foreach ($name as $actionNestingIndex => $actionName) {
                 $this->call(
                     'mountAction',
                     $actionName,
-                    count($name) > 1 ?
-                        $arguments[$actionName] ?? $arguments :
-                        $arguments,
+                    $arguments[$actionName] ?? ($actionNestingIndex ? [] : $arguments),
                 );
             }
 

--- a/packages/actions/src/Testing/TestsActions.php
+++ b/packages/actions/src/Testing/TestsActions.php
@@ -33,9 +33,9 @@ class TestsActions
                 $this->call(
                     'mountAction',
                     $actionName,
-                    count($name) > 1
-                        ? $arguments[$actionName] ?? []
-                        : $arguments,
+                    count($name) > 1 ?
+                        $arguments[$actionName] ?? $arguments :
+                        $arguments,
                 );
             }
 

--- a/tests/src/Actions/ActionTest.php
+++ b/tests/src/Actions/ActionTest.php
@@ -54,7 +54,7 @@ it('can mount an action with arguments', function () {
         ]);
 });
 
-it('can mount an nested action with parent arguments', function () {
+it('can mount a nested action with parent arguments', function () {
     livewire(Actions::class)
         ->mountAction('arguments.nested', arguments: [
             'arguments' => ['payload' => Str::random()],
@@ -63,7 +63,7 @@ it('can mount an nested action with parent arguments', function () {
         ->assertDispatched('nested-called', arguments: []);
 });
 
-it('can mount an nested action with nested arguments', function () {
+it('can mount a nested action with nested arguments', function () {
     livewire(Actions::class)
         ->mountAction('arguments.nested', arguments: [
             'nested' => ['payload' => $payload = Str::random()],

--- a/tests/src/Actions/ActionTest.php
+++ b/tests/src/Actions/ActionTest.php
@@ -54,6 +54,26 @@ it('can mount an action with arguments', function () {
         ]);
 });
 
+it('can mount an nested action with parent arguments', function () {
+    livewire(Actions::class)
+        ->mountAction('arguments.nested', arguments: [
+            'arguments' => ['payload' => Str::random()],
+        ])
+        ->callMountedAction()
+        ->assertDispatched('nested-called', arguments: []);
+});
+
+it('can mount an nested action with nested arguments', function () {
+    livewire(Actions::class)
+        ->mountAction('arguments.nested', arguments: [
+            'nested' => ['payload' => $payload = Str::random()],
+        ])
+        ->callMountedAction()
+        ->assertDispatched('nested-called', arguments: [
+            'payload' => $payload,
+        ]);
+});
+
 it('can call an action with arguments', function () {
     livewire(Actions::class)
         ->callAction('arguments', arguments: [

--- a/tests/src/Actions/Fixtures/Pages/Actions.php
+++ b/tests/src/Actions/Fixtures/Pages/Actions.php
@@ -31,7 +31,14 @@ class Actions extends Page
                 ->requiresConfirmation()
                 ->action(function (array $arguments) {
                     $this->dispatch('arguments-called', arguments: $arguments);
-                }),
+                })
+                ->extraModalFooterActions(fn (): array => [
+                    Action::make('nested')
+                        ->requiresConfirmation()
+                        ->action(function (array $arguments) {
+                            $this->dispatch('nested-called', arguments: $arguments);
+                        }),
+                ]),
             Action::make('halt')
                 ->requiresConfirmation()
                 ->action(function (Action $action) {


### PR DESCRIPTION
To use this feature, simply pass the arguments parameter to the mountAction() method when mounting a nested action. The arguments parameter should be a array that key contains the name of the action you want to pass the arguments and value is the array of already mention arguments.

For example, the following action uses nested action in footer.

```PHP
Action::make('edit')
    ->action(function (array $arguments) {
        // $arguments['payload'] contain 'foo'
    })
    ->extraModalFooterActions(fn (): array => [
        Action::make('duplicate')
            ->action(function (array $arguments) {
                // $arguments['payload'] contain 'bar'
            }),
    ]),
```

Mounting this action in a test would look like this:

```PHP
livewire(Actions::class)
    ->mountAction('edit.duplicate', arguments: [
        'edit' => ['payload' => 'foo'],
        'duplicate' => ['payload' => 'bar'],
    ])
```

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
