### PR TITLE
Remove unwanted spaces in link

### DIFF
--- a/packages/support/resources/views/components/link.blade.php
+++ b/packages/support/resources/views/components/link.blade.php
@@ -144,6 +144,7 @@
             </div>
         @endif
     </a>
+    @trim
 @elseif ($tag === 'button')
     <button
         @if ($keyBindings || $hasTooltip)
@@ -222,4 +223,5 @@
             </div>
         @endif
     </button>
+    @trim
 @endif

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -97,6 +97,10 @@ class SupportServiceProvider extends PackageServiceProvider
             return "<?php echo \Filament\Support\Facades\FilamentAsset::renderStyles({$expression}) ?>";
         });
 
+        Blade::extend(function($view) {
+            return preg_replace('/\s*@trim\s*/m', '', $view);
+        });
+
         Str::macro('sanitizeHtml', function (string $html): string {
             return app(HtmlSanitizerInterface::class)->sanitize($html);
         });


### PR DESCRIPTION
Resolves #8352 in a good way i think
also leaves a good way to resolve other unwanted space in any other view, if found

- extended blade and added the `@trim` directive (remove spaces before and after the directive when finding it)
- remove unwanted spaces in link.blade.php using the new directive

- [x] Changes have been thoroughly tested to not break existing functionality.
