### PR TITLE
Ability to omit currency symbol in `format_money()` and `money()` helpers

### DIFF
--- a/packages/infolists/docs/03-entries/02-text.md
+++ b/packages/infolists/docs/03-entries/02-text.md
@@ -82,6 +82,15 @@ TextEntry::make('price')
     ->money('EUR')
 ```
 
+You may wish to display formatted monetary values, but without the currency symbol. You can achieve this by setting the `omitSymbol` parameter in the `money()` method:
+
+```php
+use Filament\Infolists\Components\TextEntry;
+
+TextEntry::make('price')
+    ->money('EUR', omitSymbol: true)
+```
+
 ## Limiting text length
 
 You may `limit()` the length of the entry's value:

--- a/packages/infolists/src/Components/Concerns/CanFormatState.php
+++ b/packages/infolists/src/Components/Concerns/CanFormatState.php
@@ -84,16 +84,16 @@ trait CanFormatState
         return $this;
     }
 
-    public function money(string | Closure | null $currency = null, int $divideBy = 0): static
+    public function money(string | Closure | null $currency = null, int $divideBy = 0, bool $omitSymbol = false): static
     {
-        $this->formatStateUsing(static function (TextEntry $component, $state) use ($currency, $divideBy): ?string {
+        $this->formatStateUsing(static function (TextEntry $component, $state) use ($currency, $divideBy, $omitSymbol): ?string {
             if (blank($state)) {
                 return null;
             }
 
             $currency = $component->evaluate($currency) ?? Infolist::$defaultCurrency;
 
-            return format_money($state, $currency, $divideBy);
+            return format_money($state, $currency, $divideBy, $omitSymbol);
         });
 
         return $this;

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -12,12 +12,21 @@ use Illuminate\View\ComponentAttributeBag;
 use NumberFormatter;
 
 if (! function_exists('Filament\Support\format_money')) {
-    function format_money(float | int $money, string $currency, int $divideBy = 0): string
+    function format_money(float | int $money, string $currency, int $divideBy = 0, bool $omitSymbol = false): string
     {
         $formatter = new NumberFormatter(app()->getLocale(), NumberFormatter::CURRENCY);
 
         if ($divideBy) {
             $money = bcdiv((string) $money, (string) $divideBy);
+        }
+
+        if ($omitSymbol) {
+            $formatter->setSymbol(NumberFormatter::CURRENCY_SYMBOL, '');
+            return preg_replace(
+                '/[[:^ascii:]]/',
+                '',
+                $formatter->format($money)
+            );
         }
 
         return $formatter->formatCurrency($money, $currency);

--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -108,6 +108,15 @@ TextColumn::make('price')
     ->money('EUR')
 ```
 
+You may wish to display formatted monetary values, but without the currency symbol. You can achieve this by setting the `omitSymbol` parameter in the `money()` method:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('price')
+    ->money('EUR', omitSymbol: true)
+```
+
 ## Limiting text length
 
 You may `limit()` the length of the cell's value:

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -84,16 +84,16 @@ trait CanFormatState
         return $this;
     }
 
-    public function money(string | Closure | null $currency = null, int $divideBy = 0): static
+    public function money(string | Closure | null $currency = null, int $divideBy = 0, bool $omitSymbol = false): static
     {
-        $this->formatStateUsing(static function (TextColumn $column, $state) use ($currency, $divideBy): ?string {
+        $this->formatStateUsing(static function (TextColumn $column, $state) use ($currency, $divideBy, $omitSymbol): ?string {
             if (blank($state)) {
                 return null;
             }
 
             $currency = $column->evaluate($currency) ?? Table::$defaultCurrency;
 
-            return format_money($state, $currency, $divideBy);
+            return format_money($state, $currency, $divideBy, $omitSymbol);
         });
 
         return $this;


### PR DESCRIPTION
This PR adds the `omitSymbol` parameter to the core `format_money()` helper as well as the `money()` methods of Table TextColumns and Infolist TextEntries. This adds the flexibility of formatting monetary values without necessarily prepending or appending the currency symbol, which may be preferred by some of the developers.

As an illustration, instead of having a monetary table column displaying values as **KES 98,000.00**, with this addition you can now omit the symbol and have the same column displaying the values as **98,000.00** which is cleaner in some occasions.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
