### PR TITLE
Add non-static `authorizeAccess` to ListRecords

### DIFF
--- a/packages/panels/src/Resources/Pages/ListRecords.php
+++ b/packages/panels/src/Resources/Pages/ListRecords.php
@@ -62,9 +62,14 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
 
     public function mount(): void
     {
-        static::authorizeResourceAccess();
+        $this->authorizeAccess();
 
         $this->loadDefaultActiveTab();
+    }
+
+    protected function authorizeAccess(): void
+    {
+        static::authorizeResourceAccess();
     }
 
     public function getBreadcrumb(): ?string


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

I have a need to check if a user can view any records of a parent record, ViewRecord, CreateRecord, and EditRecord already have a non-static `authorizeAccess` method, so adding it to the ListRecords too allows me to use a trait to manage that behavior instead of overriding the entire `mount` method specifically of the ListRecords page. (Because i need to access `$this` inside `authorizeAccess`)