### PR TITLE
Allow panel routes at root

### DIFF
--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -23,10 +23,6 @@ Route::name('filament.')
                     ->name("{$panelId}.")
                     ->prefix($panel->getPath())
                     ->group(function () use ($panel, $hasTenancy, $tenantRoutePrefix, $tenantSlugAttribute) {
-                        if ($routes = $panel->getRoutes()) {
-                            $routes($panel);
-                        }
-
                         Route::name('auth.')->group(function () use ($panel) {
                             if ($panel->hasLogin()) {
                                 Route::get('/login', $panel->getLoginRouteAction())->name('login');
@@ -128,6 +124,10 @@ Route::name('filament.')
                                         $routes($panel);
                                     }
                                 });
+                        }
+
+                        if ($routes = $panel->getRoutes()) {
+                            $routes($panel);
                         }
                     });
             }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Currently, Filaments `home` route at `/` overrides any panel routes you register at `/`, since it's registered in the routes file after the routes you've configured in the panel provider.