### PR TITLE
Change Notification object naming in Swedish

### DIFF
--- a/packages/notifications/resources/lang/sv/database.php
+++ b/packages/notifications/resources/lang/sv/database.php
@@ -4,7 +4,7 @@ return [
 
     'modal' => [
 
-        'heading' => 'Aviseringar',
+        'heading' => 'Notiser',
 
         'actions' => [
 
@@ -19,7 +19,7 @@ return [
         ],
 
         'empty' => [
-            'heading' => 'Inga aviseringar här',
+            'heading' => 'Inga notiser här',
             'description' => 'Kolla igen lite senare',
         ],
 


### PR DESCRIPTION
I don't know if there is an appointed head of Swedish translations. But I would like to propose a change for the naming of "Notifications" in Swedish.

The current "Aviseringar" (in plural form) is a word more often used when issuing formal notifications like sending invoices, or being notified by an authority.

My proposed change "Notiser" (in plural form), is a direct translation of "Notification" commonly used in digital communication and natural language.

