### PR TITLE
Fix typo in "Debouncing reactive fields" docs

### DIFF
--- a/packages/forms/docs/07-advanced.md
+++ b/packages/forms/docs/07-advanced.md
@@ -39,7 +39,7 @@ TextInput::make('username')
 
 ### Debouncing reactive fields
 
-You may with to find a middle ground between `live()` and `live(onBlur: true)`, using "debouncing". Debouncing will prevent a network request from being sent until a user has finished typing for a certain period of time. You can do this using the `live(debounce: 500)` method:
+You may wish to find a middle ground between `live()` and `live(onBlur: true)`, using "debouncing". Debouncing will prevent a network request from being sent until a user has finished typing for a certain period of time. You can do this using the `live(debounce: 500)` method:
 
 ```php
 use Filament\Forms\Components\TextInput;


### PR DESCRIPTION
- [ ✅] Changes have been thoroughly tested to not break existing functionality.
- [ ✅] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ Not needed] Visual changes are explained in the PR description using a screenshot/recording of before and after.
