### PR TITLE
[Docs] Clarify that actions should have the same name as the Livewire method

### DIFF
--- a/packages/actions/docs/06-adding-an-action-to-a-livewire-component.md
+++ b/packages/actions/docs/06-adding-an-action-to-a-livewire-component.md
@@ -65,7 +65,7 @@ class ManagePost extends Component implements HasForms, HasActions
     
     public function deleteAction(): Action
     {
-        return Action::make('delete')
+        return Action::make('deleteAction')
             ->requiresConfirmation()
             ->action(fn () => $this->post->delete());
     }
@@ -73,6 +73,8 @@ class ManagePost extends Component implements HasForms, HasActions
     // ...
 }
 ```
+
+> Note that the function name and the action name need to be the same (`deleteAction`)
 
 Finally, you need to render the action in your view. To do this, you can use `{{ $this->deleteAction }}`, where you replace `deleteAction` with the name of your action method:
 


### PR DESCRIPTION
While trying to add an action to a Livewire component, I noticed that if the function name and the action name didn't match, the action didn't work properly.

Even though the button was rendered, the action 

1. would not show a confirmation message
2. would not actually execute the `action` method/closure

That's why I added the note that the names should match.

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
