### PR TITLE
Wrap all expand-concealing-component event code in $nextTick

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -69,27 +69,29 @@
                         x-on:builder-expand.window="$event.detail === '{{ $statePath }}' && (isCollapsed = false)"
                         x-on:builder-collapse.window="$event.detail === '{{ $statePath }}' && (isCollapsed = true)"
                         x-on:expand-concealing-component.window="
-                            error = $el.querySelector('[data-validation-error]')
+                            $nextTick(() => {
+                                error = $el.querySelector('[data-validation-error]')
 
-                            if (! error) {
-                                return
-                            }
+                                if (! error) {
+                                    return
+                                }
 
-                            isCollapsed = false
+                                isCollapsed = false
 
-                            if (document.body.querySelector('[data-validation-error]') !== error) {
-                                return
-                            }
+                                if (document.body.querySelector('[data-validation-error]') !== error) {
+                                    return
+                                }
 
-                            setTimeout(
-                                () =>
-                                    $el.scrollIntoView({
-                                        behavior: 'smooth',
-                                        block: 'start',
-                                        inline: 'start',
-                                    }),
-                                200,
-                            )
+                                setTimeout(
+                                    () =>
+                                        $el.scrollIntoView({
+                                            behavior: 'smooth',
+                                            block: 'start',
+                                            inline: 'start',
+                                        }),
+                                    200,
+                                )
+                            })
                         "
                         x-sortable-item="{{ $uuid }}"
                         x-bind:class="isCollapsed && 'fi-collapsed'"

--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -72,27 +72,29 @@
                                 isCollapsed: @js($isCollapsed($item)),
                             }"
                             x-on:expand-concealing-component.window="
-                                error = $el.querySelector('[data-validation-error]')
+                                $nextTick(() => {
+                                    error = $el.querySelector('[data-validation-error]')
 
-                                if (! error) {
-                                    return
-                                }
+                                    if (! error) {
+                                        return
+                                    }
 
-                                isCollapsed = false
+                                    isCollapsed = false
 
-                                if (document.body.querySelector('[data-validation-error]') !== error) {
-                                    return
-                                }
+                                    if (document.body.querySelector('[data-validation-error]') !== error) {
+                                        return
+                                    }
 
-                                setTimeout(
-                                    () =>
-                                        $el.scrollIntoView({
-                                            behavior: 'smooth',
-                                            block: 'start',
-                                            inline: 'start',
-                                        }),
-                                    200,
-                                )
+                                    setTimeout(
+                                        () =>
+                                            $el.scrollIntoView({
+                                                behavior: 'smooth',
+                                                block: 'start',
+                                                inline: 'start',
+                                            }),
+                                        200,
+                                    )
+                                })
                             "
                             x-on:repeater-expand.window="$event.detail === '{{ $statePath }}' && (isCollapsed = false)"
                             x-on:repeater-collapse.window="$event.detail === '{{ $statePath }}' && (isCollapsed = true)"

--- a/packages/forms/resources/views/components/tabs/tab.blade.php
+++ b/packages/forms/resources/views/components/tabs/tab.blade.php
@@ -13,27 +13,29 @@
 <div
     x-bind:class="tab === @js($id) ? @js($visibleTabClasses) : @js($invisibleTabClasses)"
     x-on:expand-concealing-component.window="
-        error = $el.querySelector('[data-validation-error]')
+        $nextTick(() => {
+            error = $el.querySelector('[data-validation-error]')
 
-        if (! error) {
-            return
-        }
+            if (! error) {
+                return
+            }
 
-        tab = @js($id)
+            tab = @js($id)
 
-        if (document.body.querySelector('[data-validation-error]') !== error) {
-            return
-        }
+            if (document.body.querySelector('[data-validation-error]') !== error) {
+                return
+            }
 
-        setTimeout(
-            () =>
-                $el.scrollIntoView({
-                    behavior: 'smooth',
-                    block: 'start',
-                    inline: 'start',
-                }),
-            200,
-        )
+            setTimeout(
+                () =>
+                    $el.scrollIntoView({
+                        behavior: 'smooth',
+                        block: 'start',
+                        inline: 'start',
+                    }),
+                200,
+            )
+        })
     "
     {{
         $attributes

--- a/packages/forms/resources/views/components/wizard/step.blade.php
+++ b/packages/forms/resources/views/components/wizard/step.blade.php
@@ -13,31 +13,33 @@
 <div
     x-bind:class="step === @js($id) ? @js($visibleStepClasses) : @js($invisibleStepClasses)"
     x-on:expand-concealing-component.window="
-        error = $el.querySelector('[data-validation-error]')
+        $nextTick(() => {
+            error = $el.querySelector('[data-validation-error]')
 
-        if (! error) {
-            return
-        }
+            if (! error) {
+                return
+            }
 
-        if (! isStepAccessible(step, @js($id))) {
-            return
-        }
+            if (! isStepAccessible(step, @js($id))) {
+                return
+            }
 
-        step = @js($id)
+            step = @js($id)
 
-        if (document.body.querySelector('[data-validation-error]') !== error) {
-            return
-        }
+            if (document.body.querySelector('[data-validation-error]') !== error) {
+                return
+            }
 
-        setTimeout(
-            () =>
-                $el.scrollIntoView({
-                    behavior: 'smooth',
-                    block: 'start',
-                    inline: 'start',
-                }),
-            200,
-        )
+            setTimeout(
+                () =>
+                    $el.scrollIntoView({
+                        behavior: 'smooth',
+                        block: 'start',
+                        inline: 'start',
+                    }),
+                200,
+            )
+        })
     "
     x-ref="step-{{ $id }}"
     {{

--- a/packages/support/resources/views/components/section/index.blade.php
+++ b/packages/support/resources/views/components/section/index.blade.php
@@ -31,27 +31,29 @@
     @if ($collapsible)
         x-on:collapse-section.window="if ($event.detail.id == $el.id) isCollapsed = true"
         x-on:expand-concealing-component.window="
-            error = $el.querySelector('[data-validation-error]')
+            $nextTick(() => {
+                error = $el.querySelector('[data-validation-error]')
 
-            if (! error) {
-                return
-            }
+                if (! error) {
+                    return
+                }
 
-            isCollapsed = false
+                isCollapsed = false
 
-            if (document.body.querySelector('[data-validation-error]') !== error) {
-                return
-            }
+                if (document.body.querySelector('[data-validation-error]') !== error) {
+                    return
+                }
 
-            setTimeout(
-                () =>
-                    $el.scrollIntoView({
-                        behavior: 'smooth',
-                        block: 'start',
-                        inline: 'start',
-                    }),
-                200,
-            )
+                setTimeout(
+                    () =>
+                        $el.scrollIntoView({
+                            behavior: 'smooth',
+                            block: 'start',
+                            inline: 'start',
+                        }),
+                    200,
+                )
+            })
         "
         x-on:open-section.window="if ($event.detail.id == $el.id) isCollapsed = false"
         x-on:toggle-section.window="if ($event.detail.id == $el.id) isCollapsed = ! isCollapsed"


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.

It seems that in LW3, the expand-concealing-component runs before the DOM is mutated, so the "scroll to first error" was broken - the querySelectorAll can't find any data-validation-error because they aren't there yet..  Wrapping all the x-on:expand-concealing-component code in $nextTick({...}) fixes this.

NOTE - what this doesn't fix is that if errors are not in a concealable component, no scrolling happens.  But that's another issue, which I'll raise separately.  I think the whole form needs to be wrapped in some scroll-to-first-error event code, regardless of whether it has concealable components or not.
