### PR TITLE
Wrap Livewire hook code in $nextTick in CheckboxList

### DIFF
--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -227,7 +227,7 @@
         @if ($isSearchable)
             <div
                 x-cloak
-                x-show="search && (! visibleCheckboxListOptions.length)"
+                x-show="search && ! visibleCheckboxListOptions.length"
                 class="fi-fo-checkbox-list-no-search-results-message text-sm text-gray-500 dark:text-gray-400"
             >
                 {{ $getNoSearchResultsMessage() }}

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -30,13 +30,19 @@
                     'commit',
                     ({ component, commit, succeed, fail, respond }) => {
                         succeed(({ snapshot, effect }) => {
-                            if (component.id !== @js($this->getId())) {
-                                return
-                            }
+                            $nextTick(() => {
+                                if (component.id !== @js($this->getId())) {
+                                    return
+                                }
 
-                            this.updateVisibleCheckboxListOptions()
+                                this.checkboxListOptions = Array.from(
+                                    $root.querySelectorAll('.fi-fo-checkbox-list-option-label'),
+                                )
 
-                            this.checkIfAllCheckboxesAreChecked()
+                                this.updateVisibleCheckboxListOptions()
+
+                                this.checkIfAllCheckboxesAreChecked()
+                            })
                         })
                     },
                 )
@@ -84,7 +90,7 @@
                             .querySelector('.fi-fo-checkbox-list-option-description')
                             ?.innerText.toLowerCase()
                             .includes(this.search.toLowerCase())
-                    },
+                    }
                 )
             },
         }"
@@ -162,11 +168,11 @@
                         x-show="
                             $el
                                 .querySelector('.fi-fo-checkbox-list-option-label')
-                                .innerText.toLowerCase()
+                                ?.innerText.toLowerCase()
                                 .includes(search.toLowerCase()) ||
                                 $el
                                     .querySelector('.fi-fo-checkbox-list-option-description')
-                                    .innerText.toLowerCase()
+                                    ?.innerText.toLowerCase()
                                     .includes(search.toLowerCase())
                         "
                     @endif
@@ -219,7 +225,7 @@
         @if ($isSearchable)
             <div
                 x-cloak
-                x-show="! visibleCheckboxListOptions.length"
+                x-show="search && ! visibleCheckboxListOptions.length"
                 class="fi-fo-checkbox-list-no-search-results-message text-sm text-gray-500 dark:text-gray-400"
             >
                 {{ $getNoSearchResultsMessage() }}

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -36,7 +36,9 @@
                                 }
 
                                 this.checkboxListOptions = Array.from(
-                                    $root.querySelectorAll('.fi-fo-checkbox-list-option-label'),
+                                    $root.querySelectorAll(
+                                        '.fi-fo-checkbox-list-option-label',
+                                    ),
                                 )
 
                                 this.updateVisibleCheckboxListOptions()
@@ -90,7 +92,7 @@
                             .querySelector('.fi-fo-checkbox-list-option-description')
                             ?.innerText.toLowerCase()
                             .includes(this.search.toLowerCase())
-                    }
+                    },
                 )
             },
         }"

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -227,7 +227,7 @@
         @if ($isSearchable)
             <div
                 x-cloak
-                x-show="search && ! visibleCheckboxListOptions.length"
+                x-show="search && (! visibleCheckboxListOptions.length)"
                 class="fi-fo-checkbox-list-no-search-results-message text-sm text-gray-500 dark:text-gray-400"
             >
                 {{ $getNoSearchResultsMessage() }}


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.

Fixes #9063 

Need to re-read the checkboxes from the DOM after a Livewire update (they may have have changed), which also means wrapping the Livewire.hook code in a $nextTick(), so that the DOM changes get performed first.

Also a couple of other tweaks, nullsafe the querySelector() result in x-show (blows up if no checkboxes otherwise), and test if there is a search term in x-show on the "no search results" msg to avoid bogus display of msg if no checkboxes.  This is all corner case stuff for no checkboxes when doing a dependent select, as per #9063
