### PR TITLE
Fix to support nested relationship for select field

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -1085,13 +1085,26 @@ class Select extends Field implements Contracts\HasAffixActions, Contracts\HasNe
 
     public function getRelationship(): BelongsTo | BelongsToMany | \Znck\Eloquent\Relations\BelongsToThrough | null
     {
-        $name = $this->getRelationshipName();
-
-        if (blank($name)) {
+        if (blank($this->getRelationshipName())) {
             return null;
         }
 
-        return $this->getModelInstance()->{$name}();
+        $record = $this->getModelInstance();
+
+        $relationship = null;
+
+        foreach (explode('.', $this->getRelationshipName()) as $nestedRelationshipName) {
+            if (! $record->isRelation($nestedRelationshipName)) {
+                $relationship = null;
+
+                break;
+            }
+
+            $relationship = $record->{$nestedRelationshipName}();
+            $record = $relationship->getRelated();
+        }
+
+        return $relationship;
     }
 
     public function getRelationshipName(): ?string


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Previously
```php
Select::make('foo')->relationship('bar.foo')
```
incorrectly called `Model::bar.foo() ...`

Though it almost doesn't make sense to use nested relationship in form, but this is important for filter.