### PR TITLE
Fix UI for hidden affixes action

### DIFF
--- a/packages/support/resources/views/components/input/wrapper.blade.php
+++ b/packages/support/resources/views/components/input/wrapper.blade.php
@@ -16,8 +16,8 @@
 ])
 
 @php
-    $hasPrefix = count($prefixActions) || $prefixIcon || filled($prefix);
-    $hasSuffix = count($suffixActions) || $suffixIcon || filled($suffix);
+    $hasPrefix = collect($prefixActions)->reject(fn ($action) => $action->isHidden())->count() || $prefixIcon || filled($prefix);
+    $hasSuffix = collect($suffixActions)->reject(fn ($action) => $action->isHidden())->count() || $suffixIcon || filled($suffix);
 
     $hasAlpineDisabledClasses = filled($alpineDisabled);
     $hasAlpineValidClasses = filled($alpineValid);

--- a/packages/support/resources/views/components/input/wrapper.blade.php
+++ b/packages/support/resources/views/components/input/wrapper.blade.php
@@ -16,8 +16,18 @@
 ])
 
 @php
-    $hasPrefix = collect($prefixActions)->reject(fn ($action) => $action->isHidden())->count() || $prefixIcon || filled($prefix);
-    $hasSuffix = collect($suffixActions)->reject(fn ($action) => $action->isHidden())->count() || $suffixIcon || filled($suffix);
+    $prefixActions = array_filter(
+        $prefixActions,
+        fn (\Filament\Forms\Components\Actions\Action $prefixAction): bool => $prefixAction->isVisible(),
+    );
+
+    $suffixActions = array_filter(
+        $suffixActions,
+        fn (\Filament\Forms\Components\Actions\Action $suffixAction): bool => $suffixAction->isVisible(),
+    );
+
+    $hasPrefix = count($prefixActions) || $prefixIcon || filled($prefix);
+    $hasSuffix = count($suffixActions) || $suffixIcon || filled($suffix);
 
     $hasAlpineDisabledClasses = filled($alpineDisabled);
     $hasAlpineValidClasses = filled($alpineValid);
@@ -34,16 +44,6 @@
     $actionsClasses = '-mx-1.5 flex items-center';
     $iconClasses = 'fi-input-wrp-icon h-5 w-5 text-gray-400 dark:text-gray-500';
     $labelClasses = 'fi-input-wrp-label whitespace-nowrap text-sm text-gray-500 dark:text-gray-400';
-
-    $prefixActions = array_filter(
-        $prefixActions,
-        fn (\Filament\Forms\Components\Actions\Action $prefixAction): bool => $prefixAction->isVisible(),
-    );
-
-    $suffixActions = array_filter(
-        $suffixActions,
-        fn (\Filament\Forms\Components\Actions\Action $suffixAction): bool => $suffixAction->isVisible(),
-    );
 
     $wireTarget = $attributes->whereStartsWith(['wire:target'])->first();
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Small UI fix for hidden suffix/prefix action

```php
...
->suffixActions([
      Action::make('unlinkAccount')
          ->icon('heroicon-m-minus-circle')
          ->color('danger')
          ->tooltip(__('Unlink account'))
          ->visible(fn (): bool => auth()->user()->is_admin)
...
```

Before:
<img width="737" alt="Screenshot 2023-10-14 at 3 50 29 PM" src="https://github.com/filamentphp/filament/assets/315603/00357ec2-e77f-4007-8551-6eda760a1c53">

After:
<img width="729" alt="Screenshot 2023-10-14 at 3 51 21 PM" src="https://github.com/filamentphp/filament/assets/315603/97b462a8-b0eb-40c4-99d3-4f0ee6c0a719">



