### PR TITLE
Allow \Closure on favicon

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasFavicon.php
+++ b/packages/panels/src/Panel/Concerns/HasFavicon.php
@@ -17,9 +17,8 @@ trait HasFavicon
         return $this;
     }
 
-    public function getFavicon():  string | Htmlable | null
+    public function getFavicon(): string | Htmlable | null
     {
         return $this->evaluate($this->favicon);
     }
 }
-

--- a/packages/panels/src/Panel/Concerns/HasFavicon.php
+++ b/packages/panels/src/Panel/Concerns/HasFavicon.php
@@ -2,19 +2,24 @@
 
 namespace Filament\Panel\Concerns;
 
+use Closure;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\HtmlString;
+
 trait HasFavicon
 {
-    protected ?string $favicon = null;
+    protected string | HtmlString | Closure | null $favicon = null;
 
-    public function favicon(?string $url): static
+    public function favicon(string | Htmlable | Closure | null $url): static
     {
         $this->favicon = $url;
 
         return $this;
     }
 
-    public function getFavicon(): ?string
+    public function getFavicon():  string | Htmlable | null
     {
-        return $this->favicon;
+        return $this->evaluate($this->favicon);
     }
 }
+

--- a/packages/panels/src/Panel/Concerns/HasFavicon.php
+++ b/packages/panels/src/Panel/Concerns/HasFavicon.php
@@ -4,11 +4,10 @@ namespace Filament\Panel\Concerns;
 
 use Closure;
 use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Support\HtmlString;
 
 trait HasFavicon
 {
-    protected string | HtmlString | Closure | null $favicon = null;
+    protected string | Htmlable | Closure | null $favicon = null;
 
     public function favicon(string | Htmlable | Closure | null $url): static
     {

--- a/packages/panels/src/Panel/Concerns/HasFavicon.php
+++ b/packages/panels/src/Panel/Concerns/HasFavicon.php
@@ -3,20 +3,19 @@
 namespace Filament\Panel\Concerns;
 
 use Closure;
-use Illuminate\Contracts\Support\Htmlable;
 
 trait HasFavicon
 {
-    protected string | Htmlable | Closure | null $favicon = null;
+    protected string | Closure | null $favicon = null;
 
-    public function favicon(string | Htmlable | Closure | null $url): static
+    public function favicon(string | Closure | null $url): static
     {
         $this->favicon = $url;
 
         return $this;
     }
 
-    public function getFavicon(): string | Htmlable | null
+    public function getFavicon(): ?string
     {
         return $this->evaluate($this->favicon);
     }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This PR allow us to inject in customizing favicon.