### PR TITLE
Add custom headers

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/README.md
+++ b/packages/spatie-laravel-media-library-plugin/README.md
@@ -89,7 +89,7 @@ use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 
 SpatieMediaLibraryFileUpload::make('attachments')
     ->multiple()
-    ->customHeaders(['ACL' => 'public-read'])
+    ->customHeaders(['CacheControl' => 'max-age=86400'])
 ```
 
 ### Adding custom properties

--- a/packages/spatie-laravel-media-library-plugin/README.md
+++ b/packages/spatie-laravel-media-library-plugin/README.md
@@ -82,14 +82,14 @@ You may now drag and drop files into order.
 
 ### Adding custom headers
 
-You may pass in custom headers when uploading files using the `addCustomHeaders()` method:
+You may pass in custom headers when uploading files using the `customHeaders()` method:
 
 ```php
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 
 SpatieMediaLibraryFileUpload::make('attachments')
     ->multiple()
-    ->addCustomHeaders(['ACL' => 'public-read'])
+    ->customHeaders(['ACL' => 'public-read'])
 ```
 
 ### Adding custom properties

--- a/packages/spatie-laravel-media-library-plugin/README.md
+++ b/packages/spatie-laravel-media-library-plugin/README.md
@@ -80,6 +80,18 @@ SpatieMediaLibraryFileUpload::make('attachments')
 
 You may now drag and drop files into order.
 
+### Adding custom headers
+
+You may pass in custom headers when uploading files using the `addCustomHeaders()` method:
+
+```php
+use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+
+SpatieMediaLibraryFileUpload::make('attachments')
+    ->multiple()
+    ->addCustomHeaders(['ACL' => 'public-read'])
+```
+
 ### Adding custom properties
 
 You may pass in [custom properties](https://spatie.be/docs/laravel-medialibrary/advanced-usage/using-custom-properties) when uploading files using the `customProperties()` method:

--- a/packages/spatie-laravel-media-library-plugin/README.md
+++ b/packages/spatie-laravel-media-library-plugin/README.md
@@ -80,18 +80,6 @@ SpatieMediaLibraryFileUpload::make('attachments')
 
 You may now drag and drop files into order.
 
-### Adding custom headers
-
-You may pass in custom headers when uploading files using the `customHeaders()` method:
-
-```php
-use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
-
-SpatieMediaLibraryFileUpload::make('attachments')
-    ->multiple()
-    ->customHeaders(['CacheControl' => 'max-age=86400'])
-```
-
 ### Adding custom properties
 
 You may pass in [custom properties](https://spatie.be/docs/laravel-medialibrary/advanced-usage/using-custom-properties) when uploading files using the `customProperties()` method:
@@ -102,6 +90,18 @@ use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 SpatieMediaLibraryFileUpload::make('attachments')
     ->multiple()
     ->customProperties(['zip_filename_prefix' => 'folder/subfolder/'])
+```
+
+### Adding custom headers
+
+You may pass in custom headers when uploading files using the `customHeaders()` method:
+
+```php
+use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+
+SpatieMediaLibraryFileUpload::make('attachments')
+    ->multiple()
+    ->customHeaders(['CacheControl' => 'max-age=86400'])
 ```
 
 ### Generating responsive images

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -28,6 +28,11 @@ class SpatieMediaLibraryFileUpload extends FileUpload
     /**
      * @var array<string, mixed> | Closure | null
      */
+    protected array | Closure | null $customHeaders = null;
+
+    /**
+     * @var array<string, mixed> | Closure | null
+     */
     protected array | Closure | null $customProperties = null;
 
     /**
@@ -134,6 +139,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             $filename = $component->getUploadedFileNameForStorage($file);
 
             $media = $mediaAdder
+                ->addCustomHeaders($component->getCustomHeaders())
                 ->usingFileName($filename)
                 ->usingName($component->getMediaName($file) ?? pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME))
                 ->storingConversionsOnDisk($component->getConversionsDisk() ?? '')
@@ -179,6 +185,16 @@ class SpatieMediaLibraryFileUpload extends FileUpload
     public function conversionsDisk(string | Closure | null $disk): static
     {
         $this->conversionsDisk = $disk;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed> | Closure | null  $headers
+     */
+    public function customHeaders(array | Closure | null $headers): static
+    {
+        $this->customHeaders = $headers;
 
         return $this;
     }
@@ -263,6 +279,14 @@ class SpatieMediaLibraryFileUpload extends FileUpload
     public function getConversionsDisk(): ?string
     {
         return $this->evaluate($this->conversionsDisk);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getCustomHeaders(): array
+    {
+        return $this->evaluate($this->customHeaders) ?? [];
     }
 
     /**


### PR DESCRIPTION
- [ ] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This PR adds the ability to add custom headers for the media library plugin.