### PR TITLE
add scale to bcdiv to fix format_money method to include decimal values when dividing

### DIFF
--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -12,12 +12,12 @@ use Illuminate\View\ComponentAttributeBag;
 use NumberFormatter;
 
 if (! function_exists('Filament\Support\format_money')) {
-    function format_money(float | int $money, string $currency, int $divideBy = 0): string
+    function format_money(float | int $money, string $currency, int $divideBy = 0, int $scale = 2): string
     {
         $formatter = new NumberFormatter(app()->getLocale(), NumberFormatter::CURRENCY);
 
         if ($divideBy) {
-            $money = bcdiv((string) $money, (string) $divideBy);
+            $money = bcdiv((string) $money, (string) $divideBy, $scale);
         }
 
         return $formatter->formatCurrency($money, $currency);

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -12,12 +12,12 @@ use Illuminate\View\ComponentAttributeBag;
 use NumberFormatter;
 
 if (! function_exists('Filament\Support\format_money')) {
-    function format_money(float | int $money, string $currency, int $divideBy = 0, int $scale = 2): string
+    function format_money(float | int $money, string $currency, int $divideBy = 0): string
     {
         $formatter = new NumberFormatter(app()->getLocale(), NumberFormatter::CURRENCY);
 
         if ($divideBy) {
-            $money = bcdiv((string) $money, (string) $divideBy, $scale);
+            $money /= $divideBy;
         }
 
         return $formatter->formatCurrency($money, $currency);


### PR DESCRIPTION
Fixes the `format_money` helper to use 2 decimal points when dividing

with the current implementation

```php
Filament\Support\format_money(490, 'usd',100); 

//returns $4.00 instead of $4.90
```

with this PR

```php
Filament\Support\format_money(490, 'usd',100); 

//returns $4.90
```

additionally a 4th parameter can be passed to the `format_money` function to include additional decimal points based on the currency being set as different currencies use different decimal points, but it defaults to 2