### PR TITLE
Add Notifications Livewire Component to Layout in Docs

### DIFF
--- a/packages/notifications/docs/01-installation.md
+++ b/packages/notifications/docs/01-installation.md
@@ -141,6 +141,7 @@ Create a new `resources/views/components/layouts/app.blade.php` layout file for 
         {{ $slot }}
 
         @filamentScripts
+        @livewire('notifications')
         @vite('resources/js/app.js')
     </body>
 </html>

--- a/packages/notifications/docs/01-installation.md
+++ b/packages/notifications/docs/01-installation.md
@@ -140,8 +140,9 @@ Create a new `resources/views/components/layouts/app.blade.php` layout file for 
     <body class="antialiased">
         {{ $slot }}
 
-        @filamentScripts
         @livewire('notifications')
+
+        @filamentScripts
         @vite('resources/js/app.js')
     </body>
 </html>


### PR DESCRIPTION
Looking through the docs I noticed there is no indication to the user they need to add the notifications component. Not sure if this is how you want to do it, but I think this is important to be in the docs.