### PR TITLE
Add prompt to ask for type of widget when no type is passed in command

### DIFF
--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -21,6 +21,8 @@ class MakeWidgetCommand extends Command
 
     protected $signature = 'make:filament-widget {name?} {--R|resource=} {--C|chart} {--T|table} {--S|stats-overview} {--panel=} {--F|force}';
 
+    protected string $chartType = 'Basic';
+
     public function handle(): int
     {
         $widget = (string) str($this->argument('name') ?? text(
@@ -39,6 +41,17 @@ class MakeWidgetCommand extends Command
 
         $resource = null;
         $resourceClass = null;
+
+        if ($this->option('chart') === false  && $this->option('stats-overview') === false) {
+            // if not, prompt for the type of chart
+            $type = select(
+                label: 'What type of chart do you want to create?',
+                options: ['Basic', 'Stats', 'Chart'],
+                default: 'Basic',
+            );
+
+            $this->chartType = $type;
+        }
 
         if (class_exists(Resource::class)) {
             $resourceInput = $this->option('resource') ?? text(
@@ -156,7 +169,7 @@ class MakeWidgetCommand extends Command
             return static::INVALID;
         }
 
-        if ($this->option('chart')) {
+        if ($this->option('chart') || $this->chartType === 'Chart') {
             $chart = select(
                 label: 'Which type of chart would you like to create?',
                 options: [
@@ -190,7 +203,7 @@ class MakeWidgetCommand extends Command
                 'class' => $widgetClass,
                 'namespace' => filled($resource) ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : ''),
             ]);
-        } elseif ($this->option('stats-overview')) {
+        } elseif ($this->option('stats-overview') || $this->chartType === 'Stats') {
             $this->copyStubToApp('StatsOverviewWidget', $path, [
                 'class' => $widgetClass,
                 'namespace' => filled($resource) ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : ''),

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -21,8 +21,6 @@ class MakeWidgetCommand extends Command
 
     protected $signature = 'make:filament-widget {name?} {--R|resource=} {--C|chart} {--T|table} {--S|stats-overview} {--panel=} {--F|force}';
 
-    protected string $chartType = 'Basic';
-
     public function handle(): int
     {
         $widget = (string) str($this->argument('name') ?? text(
@@ -42,16 +40,15 @@ class MakeWidgetCommand extends Command
         $resource = null;
         $resourceClass = null;
 
-        if ($this->option('chart') === false  && $this->option('stats-overview') === false) {
-            // if not, prompt for the type of chart
-            $type = select(
-                label: 'What type of chart do you want to create?',
-                options: ['Basic', 'Stats', 'Chart'],
-                default: 'Basic',
-            );
-
-            $this->chartType = $type;
-        }
+        $type = match (true) {
+            $this->option('chart') => 'Chart',
+            $this->option('stats-overview') => 'Stats overview',
+            $this->option('table') => 'Table',
+            default => select(
+                label: 'What type of widget do you want to create?',
+                options: ['Chart', 'Stats overview', 'Table', 'Custom'],
+            ),
+        };
 
         if (class_exists(Resource::class)) {
             $resourceInput = $this->option('resource') ?? text(
@@ -169,8 +166,8 @@ class MakeWidgetCommand extends Command
             return static::INVALID;
         }
 
-        if ($this->option('chart') || $this->chartType === 'Chart') {
-            $chart = select(
+        if ($type === 'Chart') {
+            $chartType = select(
                 label: 'Which type of chart would you like to create?',
                 options: [
                     'Bar chart',
@@ -187,7 +184,7 @@ class MakeWidgetCommand extends Command
             $this->copyStubToApp('ChartWidget', $path, [
                 'class' => $widgetClass,
                 'namespace' => filled($resource) ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : ''),
-                'type' => match ($chart) {
+                'type' => match ($chartType) {
                     'Bar chart' => 'bar',
                     'Bubble chart' => 'bubble',
                     'Doughnut chart' => 'doughnut',
@@ -198,13 +195,13 @@ class MakeWidgetCommand extends Command
                     default => 'line',
                 },
             ]);
-        } elseif ($this->option('table')) {
-            $this->copyStubToApp('TableWidget', $path, [
+        } elseif ($type === 'Stats overview') {
+            $this->copyStubToApp('StatsOverviewWidget', $path, [
                 'class' => $widgetClass,
                 'namespace' => filled($resource) ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : ''),
             ]);
-        } elseif ($this->option('stats-overview') || $this->chartType === 'Stats') {
-            $this->copyStubToApp('StatsOverviewWidget', $path, [
+        } elseif ($type === 'Table') {
+            $this->copyStubToApp('TableWidget', $path, [
                 'class' => $widgetClass,
                 'namespace' => filled($resource) ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : ''),
             ]);


### PR DESCRIPTION
Opening this to see if you are interested in this type of update to the `make:filament-widget` command. I find myself constantly making widgets and deleting them because I don't pass in `-C` or `-S`. This would resolve that problem.

The implementation may not be great (this is my first time using Prompts) so happy to make changes if needed. I was hoping the prompt could update the `->option('stats-overview')` instead of creating a new `$chartType` variable on the class, but I couldn't figure out how to do that.

Also wondering if this might cause some issues around this code: 

```php
if (! $this->option('force') && $this->checkForCollision([
            $path,
            ...($this->option('stats-overview') || $this->option('chart')) ? [] : [$viewPath],
        ])) {
            return static::INVALID;
        }
```