### PR TITLE
[3.x] Add new `Markdown` helper class

### DIFF
--- a/packages/support/src/Markdown.php
+++ b/packages/support/src/Markdown.php
@@ -10,7 +10,8 @@ class Markdown implements Htmlable, Stringable
 {
     public function __construct(
         protected string $text,
-    ) {}
+    ) {
+    }
 
     public function toHtml()
     {

--- a/packages/support/src/Markdown.php
+++ b/packages/support/src/Markdown.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Filament\Support;
+
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Str;
+use Stringable;
+
+class Markdown implements Htmlable, Stringable
+{
+    public function __construct(
+        protected string $text,
+    ) {}
+
+    public function toHtml()
+    {
+        return Str::markdown($this->text);
+    }
+
+    public function __toString(): string
+    {
+        return $this->toHtml();
+    }
+}

--- a/packages/support/src/Markdown.php
+++ b/packages/support/src/Markdown.php
@@ -8,7 +8,7 @@ use Stringable;
 
 class Markdown implements Htmlable, Stringable
 {
-    public function __construct(
+    final public function __construct(
         protected string $text,
         protected bool $isInline = false,
     ) {
@@ -24,9 +24,11 @@ class Markdown implements Htmlable, Stringable
         return new static($text);
     }
 
-    public function toHtml()
+    public function toHtml(): string
     {
-        return $this->isInline ? Str::inlineMarkdown($this->text) : Str::markdown($this->text);
+        return $this->isInline ?
+            Str::inlineMarkdown($this->text) :
+            Str::markdown($this->text);
     }
 
     public function __toString(): string

--- a/packages/support/src/Markdown.php
+++ b/packages/support/src/Markdown.php
@@ -10,12 +10,23 @@ class Markdown implements Htmlable, Stringable
 {
     public function __construct(
         protected string $text,
+        protected bool $isInline = false,
     ) {
+    }
+
+    public static function inline(string $text): static
+    {
+        return new static($text, isInline: true);
+    }
+
+    public static function block(string $text): static
+    {
+        return new static($text);
     }
 
     public function toHtml()
     {
-        return Str::markdown($this->text);
+        return $this->isInline ? Str::inlineMarkdown($this->text) : Str::markdown($this->text);
     }
 
     public function __toString(): string

--- a/tests/src/Support/MarkdownTest.php
+++ b/tests/src/Support/MarkdownTest.php
@@ -5,9 +5,16 @@ use Filament\Tests\TestCase;
 
 uses(TestCase::class);
 
-it('can convert markdown to a string of HTML', function () {
+it('can convert a block of markdown to a string of HTML', function () {
     $markdown = new Markdown('This is a **snippet** of _example_ Markdown.');
 
     expect($markdown->toHtml())
         ->toBe("<p>This is a <strong>snippet</strong> of <em>example</em> Markdown.</p>\n");
+});
+
+it('can convert inline markdown to a string of HTML', function () {
+    $markdown = new Markdown('This is a **snippet** of _example_ Markdown.', isInline: true);
+
+    expect($markdown->toHtml())
+        ->toBe("This is a <strong>snippet</strong> of <em>example</em> Markdown.\n");
 });

--- a/tests/src/Support/MarkdownTest.php
+++ b/tests/src/Support/MarkdownTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use Filament\Support\Markdown;
+use Filament\Tests\TestCase;
+
+uses(TestCase::class);
+
+it('can convert markdown to a string of HTML', function () {
+    $markdown = new Markdown('This is a **snippet** of _example_ Markdown.');
+
+    expect($markdown->toHtml())
+        ->toBe("<p>This is a <strong>snippet</strong> of <em>example</em> Markdown.</p>\n");
+});


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This introduces a new `Markdown` helper class in the support package that will let you write Markdown in all of the places where we currently accept `Htmlable`, e.g. `helperText()`, `hint()`, etc.

Right now it uses block-level parsing, so will produce `<p>Markdown goes here</p>` for example, but I do wonder if it makes more sense to use inline-level parsing with the `Str::inlineMarkdown()` method instead.
