### PR TITLE
Use data_get in applyFiltersToTableQuery to support dotted relations

### DIFF
--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -107,7 +107,7 @@ trait HasFilters
         foreach ($this->getTable()->getFilters() as $filter) {
             $filter->applyToBaseQuery(
                 $query,
-                $data[$filter->getName()] ?? [],
+                data_get($data, $filter->getName()) ?? [],
             );
         }
 
@@ -115,7 +115,7 @@ trait HasFilters
             foreach ($this->getTable()->getFilters() as $filter) {
                 $filter->apply(
                     $query,
-                    $data[$filter->getName()] ?? [],
+                    data_get($data, $filter->getName()) ?? [],
                 );
             }
         });


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Using data_get in applyFiltersToTableQuery() allows the use of dotted syntax in things like SelectFilter and TernaryFilter.

Without this PR, related filters have to be done like this:

```php
                SelectFilter::make('agency_id')
                    ->label('Agency')
                    ->relationship('agency', 'name')
                    ->searchable(),
                    
                TernaryFilter::make('all-users')
                    ->relationship('channelType', 'is_all_users')
                    ->label('All Users'),
```

After the PR, they can be done like this:

```php
                SelectFilter::make('agency.name')
                    ->label('Agency')
                    ->searchable(),

                TernaryFilter::make('channelType.is_all_users')
                    ->label('All Users'),
```

Is it strictly necessary?  Probably not.  But as the columns themselves are built using the dotted notation, seems like it makes sense to be able to use the same dotted notation for the filters.  And afaict, it's literally only that data_get() which is needed to allow it.  And there's no bc issues because anything that worked with $data[$filter->getName()] will still work with data_get($data, $filter->getName()).

