### PR TITLE
Alias the imports for the make:filament-resource command

### DIFF
--- a/packages/panels/src/Commands/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/MakeResourceCommand.php
@@ -51,6 +51,7 @@ class MakeResourceCommand extends Command
             (string) str($model)->beforeLast('\\') :
             '';
         $pluralModelClass = (string) str($modelClass)->pluralStudly();
+        $needsAlias = $modelClass === 'Record';
 
         $panel = $this->option('panel');
 
@@ -208,6 +209,8 @@ class MakeResourceCommand extends Command
 
         if ($this->option('simple')) {
             $this->copyStubToApp('ResourceManagePage', $manageResourcePagePath, [
+                'baseResourcePage' => 'Filament\\Resources\\Pages\\ManageRecords' . ($needsAlias ? ' as BaseManageRecords' : ''),
+                'baseResourcePageClass' => $needsAlias ? 'BaseManageRecords' : 'ManageRecords',
                 'namespace' => "{$namespace}\\{$resourceClass}\\Pages",
                 'resource' => "{$namespace}\\{$resourceClass}",
                 'resourceClass' => $resourceClass,
@@ -215,6 +218,8 @@ class MakeResourceCommand extends Command
             ]);
         } else {
             $this->copyStubToApp('ResourceListPage', $listResourcePagePath, [
+                'baseResourcePage' => 'Filament\\Resources\\Pages\\ListRecords' . ($needsAlias ? ' as BaseListRecords' : ''),
+                'baseResourcePageClass' => $needsAlias ? 'BaseListRecords' : 'ListRecords',
                 'namespace' => "{$namespace}\\{$resourceClass}\\Pages",
                 'resource' => "{$namespace}\\{$resourceClass}",
                 'resourceClass' => $resourceClass,
@@ -222,8 +227,8 @@ class MakeResourceCommand extends Command
             ]);
 
             $this->copyStubToApp('ResourcePage', $createResourcePagePath, [
-                'baseResourcePage' => 'Filament\\Resources\\Pages\\CreateRecord',
-                'baseResourcePageClass' => 'CreateRecord',
+                'baseResourcePage' => 'Filament\\Resources\\Pages\\CreateRecord' . ($needsAlias ? ' as BaseCreateRecord' : ''),
+                'baseResourcePageClass' => $needsAlias ? 'BaseCreateRecord' : 'CreateRecord',
                 'namespace' => "{$namespace}\\{$resourceClass}\\Pages",
                 'resource' => "{$namespace}\\{$resourceClass}",
                 'resourceClass' => $resourceClass,
@@ -234,6 +239,8 @@ class MakeResourceCommand extends Command
 
             if ($this->option('view')) {
                 $this->copyStubToApp('ResourceViewPage', $viewResourcePagePath, [
+                    'baseResourcePage' => 'Filament\\Resources\\Pages\\ViewRecord' . ($needsAlias ? ' as BaseViewRecord' : ''),
+                    'baseResourcePageClass' => $needsAlias ? 'BaseViewRecord' : 'ViewRecord',
                     'namespace' => "{$namespace}\\{$resourceClass}\\Pages",
                     'resource' => "{$namespace}\\{$resourceClass}",
                     'resourceClass' => $resourceClass,
@@ -253,6 +260,8 @@ class MakeResourceCommand extends Command
             $editPageActions = implode(PHP_EOL, $editPageActions);
 
             $this->copyStubToApp('ResourceEditPage', $editResourcePagePath, [
+                'baseResourcePage' => 'Filament\\Resources\\Pages\\EditRecord' . ($needsAlias ? ' as BaseEditRecord' : ''),
+                'baseResourcePageClass' => $needsAlias ? 'BaseEditRecord' : 'EditRecord',
                 'actions' => $this->indentString($editPageActions, 3),
                 'namespace' => "{$namespace}\\{$resourceClass}\\Pages",
                 'resource' => "{$namespace}\\{$resourceClass}",

--- a/packages/panels/stubs/ResourceEditPage.stub
+++ b/packages/panels/stubs/ResourceEditPage.stub
@@ -4,9 +4,9 @@ namespace {{ namespace }};
 
 use {{ resource }};
 use Filament\Actions;
-use Filament\Resources\Pages\EditRecord;
+use {{ baseResourcePage }};
 
-class {{ resourcePageClass }} extends EditRecord
+class {{ resourcePageClass }} extends {{ baseResourcePageClass }}
 {
     protected static string $resource = {{ resourceClass }}::class;
 

--- a/packages/panels/stubs/ResourceListPage.stub
+++ b/packages/panels/stubs/ResourceListPage.stub
@@ -4,9 +4,9 @@ namespace {{ namespace }};
 
 use {{ resource }};
 use Filament\Actions;
-use Filament\Resources\Pages\ListRecords;
+use {{ baseResourcePage }};
 
-class {{ resourcePageClass }} extends ListRecords
+class {{ resourcePageClass }} extends {{ baseResourcePageClass }}
 {
     protected static string $resource = {{ resourceClass }}::class;
 

--- a/packages/panels/stubs/ResourceManagePage.stub
+++ b/packages/panels/stubs/ResourceManagePage.stub
@@ -4,9 +4,9 @@ namespace {{ namespace }};
 
 use {{ resource }};
 use Filament\Actions;
-use Filament\Resources\Pages\ManageRecords;
+use {{ baseResourcePage }};
 
-class {{ resourcePageClass }} extends ManageRecords
+class {{ resourcePageClass }} extends {{ baseResourcePageClass }}
 {
     protected static string $resource = {{ resourceClass }}::class;
 

--- a/packages/panels/stubs/ResourceViewPage.stub
+++ b/packages/panels/stubs/ResourceViewPage.stub
@@ -4,9 +4,9 @@ namespace {{ namespace }};
 
 use {{ resource }};
 use Filament\Actions;
-use Filament\Resources\Pages\ViewRecord;
+use {{ baseResourcePage }};
 
-class {{ resourcePageClass }} extends ViewRecord
+class {{ resourcePageClass }} extends {{ baseResourcePageClass }}
 {
     protected static string $resource = {{ resourceClass }}::class;
 


### PR DESCRIPTION
Fixes #9155 

This PR updates the resource stubs to follow the same convention as the `ResourcePage` stub (CreateRecord). These are then used to alias the import and the extended class when using the `make:filament-resource` command for a model called `Record`.

I have updated all stubs and tested with the following commands.
- `php artisan make:filament-resource Record`
- `php artisan make:filament-resource Record --simple`
- `php artisan make:filament-resource Record --view`

I also tested it with another model to ensure existing functionality hasn't changed. In this case, no alias is used and it works exactly like before.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
