### PR TITLE
Evaluate the conditions in the alignment shorthand methods

### DIFF
--- a/packages/support/src/Concerns/HasAlignment.php
+++ b/packages/support/src/Concerns/HasAlignment.php
@@ -18,32 +18,32 @@ trait HasAlignment
 
     public function alignStart(bool | Closure $condition = true): static
     {
-        return $this->alignment(static fn (): ?Alignment => $condition ? Alignment::Start : null);
+        return $this->alignment(static fn (): ?Alignment => value($condition) ? Alignment::Start : null);
     }
 
     public function alignCenter(bool | Closure $condition = true): static
     {
-        return $this->alignment(static fn (): ?Alignment => $condition ? Alignment::Center : null);
+        return $this->alignment(static fn (): ?Alignment => value($condition) ? Alignment::Center : null);
     }
 
     public function alignEnd(bool | Closure $condition = true): static
     {
-        return $this->alignment(static fn (): ?Alignment => $condition ? Alignment::End : null);
+        return $this->alignment(static fn (): ?Alignment => value($condition) ? Alignment::End : null);
     }
 
     public function alignJustify(bool | Closure $condition = true): static
     {
-        return $this->alignment(static fn (): ?Alignment => $condition ? Alignment::Justify : null);
+        return $this->alignment(static fn (): ?Alignment => value($condition) ? Alignment::Justify : null);
     }
 
     public function alignLeft(bool | Closure $condition = true): static
     {
-        return $this->alignment(static fn (): ?Alignment => $condition ? Alignment::Left : null);
+        return $this->alignment(static fn (): ?Alignment => value($condition) ? Alignment::Left : null);
     }
 
     public function alignRight(bool | Closure $condition = true): static
     {
-        return $this->alignment(static fn (): ?Alignment => $condition ? Alignment::Right : null);
+        return $this->alignment(static fn (): ?Alignment => value($condition) ? Alignment::Right : null);
     }
 
     public function getAlignment(): Alignment | string | null

--- a/packages/support/src/Concerns/HasAlignment.php
+++ b/packages/support/src/Concerns/HasAlignment.php
@@ -18,32 +18,32 @@ trait HasAlignment
 
     public function alignStart(bool | Closure $condition = true): static
     {
-        return $this->alignment(static fn (): ?Alignment => value($condition) ? Alignment::Start : null);
+        return $this->alignment(fn (): ?Alignment => $this->evaluate($condition) ? Alignment::Start : null);
     }
 
     public function alignCenter(bool | Closure $condition = true): static
     {
-        return $this->alignment(static fn (): ?Alignment => value($condition) ? Alignment::Center : null);
+        return $this->alignment(fn (): ?Alignment => $this->evaluate($condition) ? Alignment::Center : null);
     }
 
     public function alignEnd(bool | Closure $condition = true): static
     {
-        return $this->alignment(static fn (): ?Alignment => value($condition) ? Alignment::End : null);
+        return $this->alignment(fn (): ?Alignment => $this->evaluate($condition) ? Alignment::End : null);
     }
 
     public function alignJustify(bool | Closure $condition = true): static
     {
-        return $this->alignment(static fn (): ?Alignment => value($condition) ? Alignment::Justify : null);
+        return $this->alignment(fn (): ?Alignment => $this->evaluate($condition) ? Alignment::Justify : null);
     }
 
     public function alignLeft(bool | Closure $condition = true): static
     {
-        return $this->alignment(static fn (): ?Alignment => value($condition) ? Alignment::Left : null);
+        return $this->alignment(fn (): ?Alignment => $this->evaluate($condition) ? Alignment::Left : null);
     }
 
     public function alignRight(bool | Closure $condition = true): static
     {
-        return $this->alignment(static fn (): ?Alignment => value($condition) ? Alignment::Right : null);
+        return $this->alignment(fn (): ?Alignment => $this->evaluate($condition) ? Alignment::Right : null);
     }
 
     public function getAlignment(): Alignment | string | null


### PR DESCRIPTION
Fixes #9152 

Currently if you pass a closure it isn't evaluated. Because the closure itself is always truthy, this leads to it always setting the alignment. This PR evaluates the conditions using the Laravel `value` helper. I checked and saw this used in other places throughout the codebase so assume it is okay to use here too.

I noticed there is an `evaluate` method used in `getAlignment` but it seems overkill for this.

Here is an output of the same code block shown in the issue.

<img width="539" alt="image" src="https://github.com/filamentphp/filament/assets/26444425/19331f59-c2af-43e8-9f65-f9b297ec53d5">

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
