### PR TITLE
compact section content

### DIFF
--- a/packages/forms/resources/views/component-container.blade.php
+++ b/packages/forms/resources/views/component-container.blade.php
@@ -2,6 +2,7 @@
     $parent = $container->getParentComponent();
     $isCompact = $parent instanceof \Filament\Forms\Components\Section && $parent->isCompact();
 @endphp
+
 <x-filament::grid
     :default="$getColumns('default')"
     :sm="$getColumns('sm')"
@@ -10,8 +11,8 @@
     :xl="$getColumns('xl')"
     :two-xl="$getColumns('2xl')"
     @class([
-        "fi-fo-component-ctn",
-        "gap-6" => !$isCompact,
+        'fi-fo-component-ctn',
+        'gap-6' => ! $isCompact,
         'gap-2' => $isCompact,
     ])
 >

--- a/packages/forms/resources/views/component-container.blade.php
+++ b/packages/forms/resources/views/component-container.blade.php
@@ -1,3 +1,7 @@
+@php
+    $parent = $container->getParentComponent();
+    $isCompact = $parent instanceof \Filament\Forms\Components\Section && $parent->isCompact();
+@endphp
 <x-filament::grid
     :default="$getColumns('default')"
     :sm="$getColumns('sm')"
@@ -5,7 +9,11 @@
     :lg="$getColumns('lg')"
     :xl="$getColumns('xl')"
     :two-xl="$getColumns('2xl')"
-    class="fi-fo-component-ctn gap-6"
+    @class([
+        "fi-fo-component-ctn",
+        "gap-6" => !$isCompact,
+        'gap-2' => $isCompact,
+    ])
 >
     @foreach ($getComponents(withHidden: true) as $formComponent)
         @php

--- a/packages/infolists/resources/views/component-container.blade.php
+++ b/packages/infolists/resources/views/component-container.blade.php
@@ -2,6 +2,7 @@
     $parent = $container->getParentComponent();
     $isCompact = $parent instanceof \Filament\Infolists\Components\Section && $parent->isCompact();
 @endphp
+
 <dl>
     <x-filament::grid
         :default="$getColumns('default')"
@@ -11,8 +12,8 @@
         :xl="$getColumns('xl')"
         :two-xl="$getColumns('2xl')"
         @class([
-            "fi-in-component-ctn",
-            "gap-6" => !$isCompact,
+            'fi-in-component-ctn',
+            'gap-6' => ! $isCompact,
             'gap-2' => $isCompact,
         ])
     >

--- a/packages/infolists/resources/views/component-container.blade.php
+++ b/packages/infolists/resources/views/component-container.blade.php
@@ -1,3 +1,7 @@
+@php
+    $parent = $container->getParentComponent();
+    $isCompact = $parent instanceof \Filament\Infolists\Components\Section && $parent->isCompact();
+@endphp
 <dl>
     <x-filament::grid
         :default="$getColumns('default')"
@@ -6,7 +10,11 @@
         :lg="$getColumns('lg')"
         :xl="$getColumns('xl')"
         :two-xl="$getColumns('2xl')"
-        class="fi-in-component-ctn gap-6"
+        @class([
+            "fi-in-component-ctn",
+            "gap-6" => !$isCompact,
+            'gap-2' => $isCompact,
+        ])
     >
         @foreach ($getComponents() as $infolistComponent)
             <x-filament::grid.column


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

currently when using Section components in Infolist or Form, its only the section container padding is adjusted
this PR aims to make the content in the Section to be tighter as well

Infolist section with inline label TextEntry
![image](https://github.com/filamentphp/filament/assets/67364036/397b6841-1e8d-4d31-ae14-11f8ed7f1127)

Form with placeholders
![image](https://github.com/filamentphp/filament/assets/67364036/be8af1ba-0e75-46f7-a8d0-68b030045482)
