### PR TITLE
Add brandLogo API to Upgrade Guide

### DIFF
--- a/packages/panels/docs/14-upgrade-guide.md
+++ b/packages/panels/docs/14-upgrade-guide.md
@@ -178,7 +178,7 @@ A side effect of this change is that all custom icons that you use must now be [
 
 #### Logo customization
 
-In v2, you can customize the logo of the admin panel using a `/resources/views/vendor/filament/components/brand.blade.php` file. In v3, this has been moved to `/resources/views/vendor/filament-panels/components/logo.blade.php`. Additional a `brandLogo` API has been added. You can set the logo by adding `brandLogo()` to your panel configuration.
+In v2, you can customize the logo of the admin panel using a `/resources/views/vendor/filament/components/brand.blade.php` file. In v3, this has been moved to `/resources/views/vendor/filament-panels/components/logo.blade.php`. Additionally a `brandLogo` API has been added. You can set the logo by adding `brandLogo()` to your panel configuration.
 
 ```php
 use Filament\Panel;

--- a/packages/panels/docs/14-upgrade-guide.md
+++ b/packages/panels/docs/14-upgrade-guide.md
@@ -178,7 +178,7 @@ A side effect of this change is that all custom icons that you use must now be [
 
 #### Logo customization
 
-In v2, you can customize the logo of the admin panel using a `/resources/views/vendor/filament/components/brand.blade.php` file. In v3, this has been moved to the Panel Provider. You can set the logo by adding `brandLogo()` to your panel configuration.
+In v2, you can customize the logo of the admin panel using a `/resources/views/vendor/filament/components/brand.blade.php` file. In v3, this has been moved to `/resources/views/vendor/filament-panels/components/logo.blade.php`. Additional a `brandLogo` API has been added. You can set the logo by adding `brandLogo()` to your panel configuration.
 
 ```php
 use Filament\Panel;

--- a/packages/panels/docs/14-upgrade-guide.md
+++ b/packages/panels/docs/14-upgrade-guide.md
@@ -178,7 +178,18 @@ A side effect of this change is that all custom icons that you use must now be [
 
 #### Logo customization
 
-In v2, you can customize the logo of the admin panel using a `/resources/views/vendor/filament/components/brand.blade.php` file. In v3, this has been moved to `/resources/views/vendor/filament-panels/components/logo.blade.php`.
+In v2, you can customize the logo of the admin panel using a `/resources/views/vendor/filament/components/brand.blade.php` file. In v3, this has been moved to the Panel Provider. You can set the logo by adding `brandLogo()` to your panel configuration.
+
+```php
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->brandLogo('/path/to/your/logo.png');
+}
+```
 
 #### Plugins
 

--- a/packages/panels/docs/14-upgrade-guide.md
+++ b/packages/panels/docs/14-upgrade-guide.md
@@ -178,7 +178,7 @@ A side effect of this change is that all custom icons that you use must now be [
 
 #### Logo customization
 
-In v2, you can customize the logo of the admin panel using a `/resources/views/vendor/filament/components/brand.blade.php` file. In v3, this has been moved to the new `brandLogo` API. You can now [set the brand logo](themes#adding-a-logo) by adding it to your panel configuration.
+In v2, you can customize the logo of the admin panel using a `/resources/views/vendor/filament/components/brand.blade.php` file. In v3, this has been moved to the new `brandLogo()` API. You can now [set the brand logo](themes#adding-a-logo) by adding it to your panel configuration.
 
 #### Plugins
 

--- a/packages/panels/docs/14-upgrade-guide.md
+++ b/packages/panels/docs/14-upgrade-guide.md
@@ -178,7 +178,7 @@ A side effect of this change is that all custom icons that you use must now be [
 
 #### Logo customization
 
-In v2, you can customize the logo of the admin panel using a `/resources/views/vendor/filament/components/brand.blade.php` file. In v3, this has been moved to `/resources/views/vendor/filament-panels/components/logo.blade.php`. Additionally a `brandLogo` API has been added. You can now [set the brand logo](themes#adding-a-logo) by adding it to your panel configuration.
+In v2, you can customize the logo of the admin panel using a `/resources/views/vendor/filament/components/brand.blade.php` file. In v3, this has been moved to the new `brandLogo` API. You can now [set the brand logo](themes#adding-a-logo) by adding it to your panel configuration.
 
 #### Plugins
 

--- a/packages/panels/docs/14-upgrade-guide.md
+++ b/packages/panels/docs/14-upgrade-guide.md
@@ -178,18 +178,7 @@ A side effect of this change is that all custom icons that you use must now be [
 
 #### Logo customization
 
-In v2, you can customize the logo of the admin panel using a `/resources/views/vendor/filament/components/brand.blade.php` file. In v3, this has been moved to `/resources/views/vendor/filament-panels/components/logo.blade.php`. Additionally a `brandLogo` API has been added. You can set the logo by adding `brandLogo()` to your panel configuration.
-
-```php
-use Filament\Panel;
-
-public function panel(Panel $panel): Panel
-{
-    return $panel
-        // ...
-        ->brandLogo('/path/to/your/logo.png');
-}
-```
+In v2, you can customize the logo of the admin panel using a `/resources/views/vendor/filament/components/brand.blade.php` file. In v3, this has been moved to `/resources/views/vendor/filament-panels/components/logo.blade.php`. Additionally a `brandLogo` API has been added. You can now [set the brand logo](themes#adding-a-logo) by adding it to your panel configuration.
 
 #### Plugins
 


### PR DESCRIPTION
Add `brandLogo` API to upgrade guide in documentation.

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
