### PR TITLE
Fixes Summarize Query Bug on PostgreSQL #9177

### DIFF
--- a/packages/tables/src/Columns/Summarizers/Summarizer.php
+++ b/packages/tables/src/Columns/Summarizers/Summarizer.php
@@ -105,7 +105,7 @@ class Summarizer extends ViewComponent
                 );
         }
 
-        $query = DB::table($query->toBase());
+        $query = DB::table($query->toBase(), $query->getModel()->getTable());
 
         if ($this->hasQueryModification()) {
             $query = $this->evaluate($this->modifyQueryUsing, [


### PR DESCRIPTION
This fixes the bug I documented in #9177 .

## Summary

When using a custom Summarizer on PostgreSQL, I get the following QueryException:

SQLSTATE[42601]: Syntax error: 7 ERROR: zero-length delimited identifier at or near """"

with the following code: 

```php
Tables\Columns\TextColumn::make('price')
	->money()
	->summarize(
		Summarizer::make()
			->label('Total')
			->money()
			->using(fn (\Illuminate\Database\Query\Builder $query) => $query->sum(DB::raw('price * quantity')))
	),
```

Before the fix:

![image](https://github.com/filamentphp/filament/assets/77644584/a2901ba3-82fc-4f5b-a59a-4a8b62144f04)


After the fix:

![image](https://github.com/filamentphp/filament/assets/77644584/faf6a4e6-ba02-4368-9fb8-67989c54bcd0)

Copied existing code from:
https://github.com/filamentphp/filament/blob/62cf9339776b6ba517a510774bfe89feb3bd14fe/packages/tables/src/Concerns/CanSummarizeRecords.php#L70

The second parameter being null on the Summarizer generates the faulty `) AS ""` at the end of the query.
