### PR TITLE
Prevent GitHub from opening when installing with --no-interaction

### DIFF
--- a/packages/support/src/Commands/InstallCommand.php
+++ b/packages/support/src/Commands/InstallCommand.php
@@ -37,7 +37,7 @@ class InstallCommand extends Command
 
         if (confirm(
             label: 'All done! Would you like to show some love by starring the Filament repo on GitHub?',
-            default: true,
+            default: ! $this->option('no-interaction'),
         )) {
             if (PHP_OS_FAMILY === 'Darwin') {
                 exec('open https://github.com/filamentphp/filament');

--- a/packages/support/src/Commands/InstallCommand.php
+++ b/packages/support/src/Commands/InstallCommand.php
@@ -35,9 +35,20 @@ class InstallCommand extends Command
 
         $this->installUpgradeCommand();
 
+        $this->askToStar();
+
+        return static::SUCCESS;
+    }
+
+    protected function askToStar(): void
+    {
+        if ($this->option('no-interaction')) {
+            return;
+        }
+
         if (confirm(
             label: 'All done! Would you like to show some love by starring the Filament repo on GitHub?',
-            default: ! $this->option('no-interaction'),
+            default: true,
         )) {
             if (PHP_OS_FAMILY === 'Darwin') {
                 exec('open https://github.com/filamentphp/filament');
@@ -51,8 +62,6 @@ class InstallCommand extends Command
 
             $this->components->info('Thank you!');
         }
-
-        return static::SUCCESS;
     }
 
     protected function installAdminPanel(): bool


### PR DESCRIPTION
Fixes #8880 

I know this issue was assigned to the person who raised it, so I hope you don't mind me raising a PR. The simplest solution in my opinion is to set the confirmation default to false when the no-interaction option is passed.

I've tested this for normal installation (without `--no-interaction`) and you are still prompted with the default being 'yes'.
When running with `--no-interaction` or `-n`, the rest of the script runs as before but the browser is no longer opened with the filament GitHub page.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
