### PR TITLE
Properly fixes decimal issues for money fields

### DIFF
--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -12,12 +12,12 @@ use Illuminate\View\ComponentAttributeBag;
 use NumberFormatter;
 
 if (! function_exists('Filament\Support\format_money')) {
-    function format_money(float | int $money, string $currency, int $divideBy = 0): string
+    function format_money(float | int $money, string $currency, int $divideBy = 0, int $scale = 2): string
     {
         $formatter = new NumberFormatter(app()->getLocale(), NumberFormatter::CURRENCY);
 
         if ($divideBy) {
-            $money /= $divideBy;
+            $money = bcdiv((string) $money, (string) $divideBy, $scale);
         }
 
         return $formatter->formatCurrency($money, $currency);

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -100,7 +100,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function money(string | Closure | null $currency = null, int $divideBy = 0): static
+    public function money(string | Closure | null $currency = null, int $divideBy = 0, int $scale = 2): static
     {
         $this->isMoney = true;
 
@@ -111,7 +111,7 @@ trait CanFormatState
 
             $currency = $column->evaluate($currency) ?? Table::$defaultCurrency;
 
-            return format_money($state, $currency, $divideBy);
+            return format_money($state, $currency, $divideBy, $scale);
         });
 
         return $this;


### PR DESCRIPTION
Instead of simply dividing without bcdiv, this introduces an optional scaling variable that fixes the decimal display for money fields.
It has the added benefits that the scale can be overridden to display whatever scale you want.