### PR TITLE
Added @auth check to navigation

### DIFF
--- a/packages/panels/resources/views/widgets/account-widget.blade.php
+++ b/packages/panels/resources/views/widgets/account-widget.blade.php
@@ -4,6 +4,7 @@
 
 <x-filament-widgets::widget class="fi-account-widget">
     <x-filament::section>
+        @auth
         <div class="flex items-center gap-x-3">
             <x-filament-panels::avatar.user size="lg" :user="$user" />
 
@@ -38,5 +39,6 @@
                 </x-filament::button>
             </form>
         </div>
+        @endauth
     </x-filament::section>
 </x-filament-widgets::widget>


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

I was playing around with panels and found that if you wanted to have an Authentication Less panel, it would not work with the default theme, as it has a dependency on having a user in the `vendor/filament/filament/resources/views/widgets/account-widget.blade.php` 

This causes an exception ( `Filament\FilamentManager::getUserAvatarUrl(): Argument #1 ($user) must be of type Illuminate\Database\Eloquent\Model|Illuminate\Contracts\Auth\Authenticatable, null given` ) and rather than having to deep dive into creating my own theme just to extend this simple widget i figured a PR would be handy for anyone else experiencing the same :) 



Before:
![image](https://github.com/filamentphp/filament/assets/13419123/a8cc0ebc-363a-47d8-a9da-19231a01881f)

After:
![image](https://github.com/filamentphp/filament/assets/13419123/edfddf89-fc6b-4721-abdc-07ae0202a5c3)


Easy to replicate

Simply do a `php artisan make:filament-panel` and remove the AuthMiddleware part of the panel configuration (`app/Providers/Filament/<panel>PanelProvider.php`
```php
            ->authMiddleware([
                Authenticate::class,
            ]);
```

Visit your panel and there you see the exception

With the change from this PR you can now make Front facing panels for Public view if needed