### PR TITLE
Update Swedish translations

### DIFF
--- a/packages/actions/resources/lang/sv/associate.php
+++ b/packages/actions/resources/lang/sv/associate.php
@@ -4,16 +4,16 @@ return [
 
     'single' => [
 
-        'label' => 'Associera',
+        'label' => 'Koppla',
 
         'modal' => [
 
-            'heading' => 'Associera :label',
+            'heading' => 'Koppla :label',
 
             'fields' => [
 
                 'record_id' => [
-                    'label' => 'Rad',
+                    'label' => 'Objekt',
                 ],
 
             ],
@@ -21,11 +21,11 @@ return [
             'actions' => [
 
                 'associate' => [
-                    'label' => 'Associera',
+                    'label' => 'Koppla',
                 ],
 
                 'associate_another' => [
-                    'label' => 'Associera & associera en till',
+                    'label' => 'Koppla & koppla en till',
                 ],
 
             ],
@@ -35,7 +35,7 @@ return [
         'notifications' => [
 
             'associated' => [
-                'title' => 'Associerades',
+                'title' => 'Kopplades',
             ],
 
         ],

--- a/packages/actions/resources/lang/sv/associate.php
+++ b/packages/actions/resources/lang/sv/associate.php
@@ -13,7 +13,7 @@ return [
             'fields' => [
 
                 'record_id' => [
-                    'label' => 'Post',
+                    'label' => 'Rad',
                 ],
 
             ],

--- a/packages/actions/resources/lang/sv/associate.php
+++ b/packages/actions/resources/lang/sv/associate.php
@@ -13,7 +13,7 @@ return [
             'fields' => [
 
                 'record_id' => [
-                    'label' => 'Rader',
+                    'label' => 'Post',
                 ],
 
             ],
@@ -35,7 +35,7 @@ return [
         'notifications' => [
 
             'associated' => [
-                'title' => 'Associerad',
+                'title' => 'Associerades',
             ],
 
         ],

--- a/packages/actions/resources/lang/sv/attach.php
+++ b/packages/actions/resources/lang/sv/attach.php
@@ -13,7 +13,7 @@ return [
             'fields' => [
 
                 'record_id' => [
-                    'label' => 'Post',
+                    'label' => 'Rad',
                 ],
 
             ],

--- a/packages/actions/resources/lang/sv/attach.php
+++ b/packages/actions/resources/lang/sv/attach.php
@@ -13,7 +13,7 @@ return [
             'fields' => [
 
                 'record_id' => [
-                    'label' => 'Rader',
+                    'label' => 'Post',
                 ],
 
             ],
@@ -35,7 +35,7 @@ return [
         'notifications' => [
 
             'attached' => [
-                'title' => 'Kopplad',
+                'title' => 'Kopplades',
             ],
 
         ],

--- a/packages/actions/resources/lang/sv/attach.php
+++ b/packages/actions/resources/lang/sv/attach.php
@@ -13,7 +13,7 @@ return [
             'fields' => [
 
                 'record_id' => [
-                    'label' => 'Rad',
+                    'label' => 'Objekt',
                 ],
 
             ],

--- a/packages/actions/resources/lang/sv/create.php
+++ b/packages/actions/resources/lang/sv/create.php
@@ -27,7 +27,7 @@ return [
         'notifications' => [
 
             'created' => [
-                'title' => 'Skapad',
+                'title' => 'Skapades',
             ],
 
         ],

--- a/packages/actions/resources/lang/sv/delete.php
+++ b/packages/actions/resources/lang/sv/delete.php
@@ -51,7 +51,7 @@ return [
         'notifications' => [
 
             'deleted' => [
-                'title' => 'Raderade',
+                'title' => 'Raderades',
             ],
 
         ],

--- a/packages/actions/resources/lang/sv/detach.php
+++ b/packages/actions/resources/lang/sv/detach.php
@@ -4,16 +4,16 @@ return [
 
     'single' => [
 
-        'label' => 'Koppla loss',
+        'label' => 'Frånkoppla',
 
         'modal' => [
 
-            'heading' => 'Koppla loss :label',
+            'heading' => 'Frånkoppla :label',
 
             'actions' => [
 
                 'detach' => [
-                    'label' => 'Koppla loss',
+                    'label' => 'Frånkoppla',
                 ],
 
             ],
@@ -23,7 +23,7 @@ return [
         'notifications' => [
 
             'detached' => [
-                'title' => 'Koppling släppt',
+                'title' => 'Frånkopplades',
             ],
 
         ],
@@ -32,16 +32,16 @@ return [
 
     'multiple' => [
 
-        'label' => 'Koppla loss valda',
+        'label' => 'Frånkoppla valda',
 
         'modal' => [
 
-            'heading' => 'Koppla loss valda :label',
+            'heading' => 'Frånkoppla valda :label',
 
             'actions' => [
 
                 'detach' => [
-                    'label' => 'Koppla loss valda',
+                    'label' => 'Frånkoppla',
                 ],
 
             ],
@@ -51,7 +51,7 @@ return [
         'notifications' => [
 
             'detached' => [
-                'title' => 'Koppling släppt',
+                'title' => 'Frånkopplades',
             ],
 
         ],

--- a/packages/actions/resources/lang/sv/dissociate.php
+++ b/packages/actions/resources/lang/sv/dissociate.php
@@ -23,7 +23,7 @@ return [
         'notifications' => [
 
             'dissociated' => [
-                'title' => 'Dissocierad',
+                'title' => 'Dissocierades',
             ],
 
         ],
@@ -41,7 +41,7 @@ return [
             'actions' => [
 
                 'dissociate' => [
-                    'label' => 'Dissociera valda',
+                    'label' => 'Dissociera',
                 ],
 
             ],
@@ -51,7 +51,7 @@ return [
         'notifications' => [
 
             'dissociated' => [
-                'title' => 'Dissocierade',
+                'title' => 'Dissocierades',
             ],
 
         ],

--- a/packages/actions/resources/lang/sv/dissociate.php
+++ b/packages/actions/resources/lang/sv/dissociate.php
@@ -4,16 +4,16 @@ return [
 
     'single' => [
 
-        'label' => 'Dissociera',
+        'label' => 'Frånkoppla',
 
         'modal' => [
 
-            'heading' => 'Dissociera :label',
+            'heading' => 'Frånkoppla :label',
 
             'actions' => [
 
                 'dissociate' => [
-                    'label' => 'Dissociera',
+                    'label' => 'Frånkoppla',
                 ],
 
             ],
@@ -23,7 +23,7 @@ return [
         'notifications' => [
 
             'dissociated' => [
-                'title' => 'Dissocierades',
+                'title' => 'Frånkopplades',
             ],
 
         ],
@@ -32,16 +32,16 @@ return [
 
     'multiple' => [
 
-        'label' => 'Dissociera valda',
+        'label' => 'Frånkoppla valda',
 
         'modal' => [
 
-            'heading' => 'Dissociera valda :label',
+            'heading' => 'Frånkoppla valda :label',
 
             'actions' => [
 
                 'dissociate' => [
-                    'label' => 'Dissociera',
+                    'label' => 'Frånkoppla',
                 ],
 
             ],
@@ -51,7 +51,7 @@ return [
         'notifications' => [
 
             'dissociated' => [
-                'title' => 'Dissocierades',
+                'title' => 'Frånkopplades',
             ],
 
         ],

--- a/packages/actions/resources/lang/sv/edit.php
+++ b/packages/actions/resources/lang/sv/edit.php
@@ -23,7 +23,7 @@ return [
         'notifications' => [
 
             'saved' => [
-                'title' => 'Sparad',
+                'title' => 'Sparades',
             ],
 
         ],

--- a/packages/actions/resources/lang/sv/force-delete.php
+++ b/packages/actions/resources/lang/sv/force-delete.php
@@ -23,7 +23,7 @@ return [
         'notifications' => [
 
             'deleted' => [
-                'title' => 'Rad raderad',
+                'title' => 'Raderades',
             ],
 
         ],
@@ -51,7 +51,7 @@ return [
         'notifications' => [
 
             'deleted' => [
-                'title' => 'Rader raderade',
+                'title' => 'Raderades',
             ],
 
         ],

--- a/packages/actions/resources/lang/sv/replicate.php
+++ b/packages/actions/resources/lang/sv/replicate.php
@@ -23,7 +23,7 @@ return [
         'notifications' => [
 
             'replicated' => [
-                'title' => 'Rad replikerad',
+                'title' => 'Replikerades',
             ],
 
         ],

--- a/packages/actions/resources/lang/sv/replicate.php
+++ b/packages/actions/resources/lang/sv/replicate.php
@@ -4,16 +4,16 @@ return [
 
     'single' => [
 
-        'label' => 'Replikera',
+        'label' => 'Duplicera',
 
         'modal' => [
 
-            'heading' => 'Replikera :label',
+            'heading' => 'Duplicera :label',
 
             'actions' => [
 
                 'replicate' => [
-                    'label' => 'Replikera',
+                    'label' => 'Duplicera',
                 ],
 
             ],
@@ -23,7 +23,7 @@ return [
         'notifications' => [
 
             'replicated' => [
-                'title' => 'Replikerades',
+                'title' => 'Duplicerades',
             ],
 
         ],

--- a/packages/actions/resources/lang/sv/restore.php
+++ b/packages/actions/resources/lang/sv/restore.php
@@ -23,7 +23,7 @@ return [
         'notifications' => [
 
             'restored' => [
-                'title' => 'Rad återställd',
+                'title' => 'Återställdes',
             ],
 
         ],
@@ -51,7 +51,7 @@ return [
         'notifications' => [
 
             'restored' => [
-                'title' => 'Rader återställda',
+                'title' => 'Återställdes',
             ],
 
         ],

--- a/packages/forms/resources/lang/sv/components.php
+++ b/packages/forms/resources/lang/sv/components.php
@@ -14,8 +14,8 @@ return [
                 'label' => 'Lägg till i :label',
             ],
 
-            'add_item_between' => [
-                'label' => 'Infoga',
+            'add_between' => [
+                'label' => 'Infoga mellan block',
             ],
 
             'delete' => [
@@ -27,7 +27,7 @@ return [
             ],
 
             'move_down' => [
-                'label' => 'Flytta ned',
+                'label' => 'Flytta ner',
             ],
 
             'move_up' => [
@@ -77,7 +77,7 @@ return [
             'actions' => [
 
                 'cancel' => [
-                    'label' => 'Ångra',
+                    'label' => 'Avbryt',
                 ],
 
                 'drag_crop' => [
@@ -113,7 +113,7 @@ return [
                 ],
 
                 'reset' => [
-                    'label' => 'Reset',
+                    'label' => 'Återställ',
                 ],
 
                 'rotate_left' => [
@@ -154,7 +154,7 @@ return [
                 ],
 
                 'rotation' => [
-                    'label' => 'Rotera',
+                    'label' => 'Rotation',
                     'unit' => 'grad',
                 ],
 
@@ -225,15 +225,18 @@ return [
 
         'toolbar_buttons' => [
             'attach_files' => 'Lägg till filer',
+            'blockquote' => 'Citat',
             'bold' => 'Fet',
             'bullet_list' => 'Punktlista',
             'code_block' => 'Kod',
-            'edit' => 'Skriv',
+            'heading' => 'Rubrik',
             'italic' => 'Kursiv',
             'link' => 'Länk',
             'ordered_list' => 'Nummerlista',
-            'preview' => 'Förhandsgranska',
+            'redo' => 'Gör om',
             'strike' => 'Genomstruken',
+            'table' => 'Tabell',
+            'undo' => 'Ångra',
         ],
 
     ],
@@ -244,6 +247,10 @@ return [
 
             'add' => [
                 'label' => 'Lägg till i :label',
+            ],
+
+            'add_between' => [
+                'label' => 'Infoga mellan',
             ],
 
             'delete' => [
@@ -259,7 +266,7 @@ return [
             ],
 
             'move_down' => [
-                'label' => 'Flytta ned',
+                'label' => 'Flytta ner',
             ],
 
             'move_up' => [
@@ -319,6 +326,7 @@ return [
             'ordered_list' => 'Nummerlista',
             'redo' => 'Gör om',
             'strike' => 'Genomstruken',
+            'underline' => 'Understruken',
             'undo' => 'Ångra',
         ],
 
@@ -338,6 +346,28 @@ return [
 
                         'create' => [
                             'label' => 'Skapa',
+                        ],
+
+                        'create_another' => [
+                            'label' => 'Skapa & skapa en till',
+                        ],
+
+                    ],
+
+                ],
+
+            ],
+
+            'edit_option' => [
+
+                'modal' => [
+
+                    'heading' => 'Redigera',
+
+                    'actions' => [
+
+                        'save' => [
+                            'label' => 'Spara',
                         ],
 
                     ],

--- a/packages/infolists/resources/lang/sv/components.php
+++ b/packages/infolists/resources/lang/sv/components.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+
+    'text_entry' => [
+        'more_list_items' => 'och :count till',
+    ],
+
+];

--- a/packages/notifications/resources/lang/sv/database.php
+++ b/packages/notifications/resources/lang/sv/database.php
@@ -4,7 +4,7 @@ return [
 
     'modal' => [
 
-        'heading' => 'Notiser',
+        'heading' => 'Aviseringar',
 
         'actions' => [
 
@@ -19,8 +19,8 @@ return [
         ],
 
         'empty' => [
-            'heading' => 'Inga notiser här',
-            'description' => 'Kolla igen lite senare',
+            'heading' => 'Inga aviseringar',
+            'description' => 'Kolla igen lite senare.',
         ],
 
     ],

--- a/packages/notifications/resources/lang/sv/database.php
+++ b/packages/notifications/resources/lang/sv/database.php
@@ -4,7 +4,7 @@ return [
 
     'modal' => [
 
-        'heading' => 'Aviseringar',
+        'heading' => 'Notiser',
 
         'actions' => [
 
@@ -19,7 +19,7 @@ return [
         ],
 
         'empty' => [
-            'heading' => 'Inga aviseringar',
+            'heading' => 'Inga notiser',
             'description' => 'Kolla igen lite senare.',
         ],
 

--- a/packages/panels/resources/lang/sv/layout.php
+++ b/packages/panels/resources/lang/sv/layout.php
@@ -37,15 +37,15 @@ return [
         'theme_switcher' => [
 
             'dark' => [
-                'label' => 'Använd mörkt läge',
+                'label' => 'Använd mörkt tema',
             ],
 
             'light' => [
-                'label' => 'Använd ljust läge',
+                'label' => 'Använd ljust tema',
             ],
 
             'system' => [
-                'label' => 'Följ systemets läge',
+                'label' => 'Följ systemets tema',
             ],
 
         ],

--- a/packages/panels/resources/lang/sv/layout.php
+++ b/packages/panels/resources/lang/sv/layout.php
@@ -6,6 +6,10 @@ return [
 
     'actions' => [
 
+        'billing' => [
+            'label' => 'Hantera prenumeration',
+        ],
+
         'logout' => [
             'label' => 'Logga ut',
         ],
@@ -33,11 +37,15 @@ return [
         'theme_switcher' => [
 
             'dark' => [
-                'label' => 'Växla till mörkt läge',
+                'label' => 'Använd mörkt läge',
             ],
 
             'light' => [
-                'label' => 'Växla till ljust läge',
+                'label' => 'Använd ljust läge',
+            ],
+
+            'system' => [
+                'label' => 'Följ systemets läge',
             ],
 
         ],

--- a/packages/panels/resources/lang/sv/layout.php
+++ b/packages/panels/resources/lang/sv/layout.php
@@ -15,7 +15,7 @@ return [
         ],
 
         'open_database_notifications' => [
-            'label' => 'Öppna aviseringar',
+            'label' => 'Öppna notiser',
         ],
 
         'open_user_menu' => [

--- a/packages/panels/resources/lang/sv/pages/auth/edit-profile.php
+++ b/packages/panels/resources/lang/sv/pages/auth/edit-profile.php
@@ -1,0 +1,51 @@
+<?php
+
+return [
+
+    'label' => 'Profil',
+
+    'form' => [
+
+        'email' => [
+            'label' => 'E-postadress',
+        ],
+
+        'name' => [
+            'label' => 'Namn',
+        ],
+
+        'password' => [
+            'label' => 'Nytt lösenord',
+        ],
+
+        'password_confirmation' => [
+            'label' => 'Bekräfta nytt lösenord',
+        ],
+
+        'actions' => [
+
+            'save' => [
+                'label' => 'Spara ändringar',
+            ],
+
+        ],
+
+    ],
+
+    'notifications' => [
+
+        'saved' => [
+            'title' => 'Sparades',
+        ],
+
+    ],
+
+    'actions' => [
+
+        'cancel' => [
+            'label' => 'Avbryt',
+        ],
+
+    ],
+
+];

--- a/packages/panels/resources/lang/sv/pages/auth/edit-profile.php
+++ b/packages/panels/resources/lang/sv/pages/auth/edit-profile.php
@@ -7,7 +7,7 @@ return [
     'form' => [
 
         'email' => [
-            'label' => 'E-postadress',
+            'label' => 'Mejladress',
         ],
 
         'name' => [

--- a/packages/panels/resources/lang/sv/pages/auth/email-verification/email-verification-prompt.php
+++ b/packages/panels/resources/lang/sv/pages/auth/email-verification/email-verification-prompt.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+
+    'title' => 'Verifiera din e-postadress',
+
+    'heading' => 'Verifiera din e-postadress',
+
+    'actions' => [
+
+        'resend_notification' => [
+            'label' => 'Skicka igen',
+        ],
+
+    ],
+
+    'messages' => [
+        'notification_not_received' => 'Inte fått e-postmeddelandet vi skickade?',
+        'notification_sent' => 'Vi skickade ett meddelande till :email med instruktioner på hur du verifierar din e-postadress.',
+    ],
+
+    'notifications' => [
+
+        'notification_resent' => [
+            'title' => 'Vi skickade meddelandet igen.',
+        ],
+
+        'notification_resend_throttled' => [
+            'title' => 'För många försök att skicka igen',
+            'body' => 'Vänligen försök igen om :seconds sekunder.',
+        ],
+
+    ],
+
+];

--- a/packages/panels/resources/lang/sv/pages/auth/email-verification/email-verification-prompt.php
+++ b/packages/panels/resources/lang/sv/pages/auth/email-verification/email-verification-prompt.php
@@ -2,9 +2,9 @@
 
 return [
 
-    'title' => 'Verifiera din e-postadress',
+    'title' => 'Verifiera din mejladress',
 
-    'heading' => 'Verifiera din e-postadress',
+    'heading' => 'Verifiera din mejladress',
 
     'actions' => [
 
@@ -15,8 +15,8 @@ return [
     ],
 
     'messages' => [
-        'notification_not_received' => 'Inte fått e-postmeddelandet vi skickade?',
-        'notification_sent' => 'Vi skickade ett meddelande till :email med instruktioner på hur du verifierar din e-postadress.',
+        'notification_not_received' => 'Inte fått mejlmeddelandet vi skickade?',
+        'notification_sent' => 'Vi skickade ett meddelande till :email med instruktioner på hur du verifierar din mejladress.',
     ],
 
     'notifications' => [

--- a/packages/panels/resources/lang/sv/pages/auth/login.php
+++ b/packages/panels/resources/lang/sv/pages/auth/login.php
@@ -22,7 +22,7 @@ return [
     'form' => [
 
         'email' => [
-            'label' => 'E-postadress',
+            'label' => 'Mejladress',
         ],
 
         'password' => [

--- a/packages/panels/resources/lang/sv/pages/auth/login.php
+++ b/packages/panels/resources/lang/sv/pages/auth/login.php
@@ -4,7 +4,20 @@ return [
 
     'title' => 'Logga in',
 
-    'heading' => 'Logga in på ditt konto',
+    'heading' => 'Logga in',
+
+    'actions' => [
+
+        'register' => [
+            'before' => 'eller',
+            'label' => 'skapa ett konto',
+        ],
+
+        'request_password_reset' => [
+            'label' => 'Glömt ditt lösenord?',
+        ],
+
+    ],
 
     'form' => [
 
@@ -32,14 +45,15 @@ return [
 
     'messages' => [
 
-        'failed' => 'Inloggningen matchar inte våra uppgifter.',
+        'failed' => 'Inloggningsuppgifterna matchar inte våra register.',
 
     ],
 
     'notifications' => [
 
         'throttled' => [
-            'title' => 'För många inloggningsförsök. Vänligen försök igen om :seconds sekunder.',
+            'title' => 'För många inloggningsförsök',
+            'body' => 'Vänligen försök igen om :seconds sekunder.',
         ],
 
     ],

--- a/packages/panels/resources/lang/sv/pages/auth/password-reset/request-password-reset.php
+++ b/packages/panels/resources/lang/sv/pages/auth/password-reset/request-password-reset.php
@@ -1,0 +1,42 @@
+<?php
+
+return [
+
+    'title' => 'Återställ ditt lösenord',
+
+    'heading' => 'Glömt ditt lösenord?',
+
+    'actions' => [
+
+        'login' => [
+            'label' => 'tillbaka till inloggningen',
+        ],
+
+    ],
+
+    'form' => [
+
+        'email' => [
+            'label' => 'E-postadress',
+        ],
+
+        'actions' => [
+
+            'request' => [
+                'label' => 'Skicka e-postmeddelande',
+            ],
+
+        ],
+
+    ],
+
+    'notifications' => [
+
+        'throttled' => [
+            'title' => 'För många förfrågningar',
+            'body' => 'Vänligen försök igen om :seconds sekunder.',
+        ],
+
+    ],
+
+];

--- a/packages/panels/resources/lang/sv/pages/auth/password-reset/request-password-reset.php
+++ b/packages/panels/resources/lang/sv/pages/auth/password-reset/request-password-reset.php
@@ -17,13 +17,13 @@ return [
     'form' => [
 
         'email' => [
-            'label' => 'E-postadress',
+            'label' => 'Mejladress',
         ],
 
         'actions' => [
 
             'request' => [
-                'label' => 'Skicka e-postmeddelande',
+                'label' => 'Skicka mejlmeddelande',
             ],
 
         ],

--- a/packages/panels/resources/lang/sv/pages/auth/password-reset/reset-password.php
+++ b/packages/panels/resources/lang/sv/pages/auth/password-reset/reset-password.php
@@ -9,7 +9,7 @@ return [
     'form' => [
 
         'email' => [
-            'label' => 'E-postadress',
+            'label' => 'Mejladress',
         ],
 
         'password' => [

--- a/packages/panels/resources/lang/sv/pages/auth/password-reset/reset-password.php
+++ b/packages/panels/resources/lang/sv/pages/auth/password-reset/reset-password.php
@@ -1,0 +1,43 @@
+<?php
+
+return [
+
+    'title' => 'Återställ ditt lösenord',
+
+    'heading' => 'Återställ ditt lösenord',
+
+    'form' => [
+
+        'email' => [
+            'label' => 'E-postadress',
+        ],
+
+        'password' => [
+            'label' => 'Lösenord',
+            'validation_attribute' => 'lösenord',
+        ],
+
+        'password_confirmation' => [
+            'label' => 'Bekräfta lösenord',
+        ],
+
+        'actions' => [
+
+            'reset' => [
+                'label' => 'Återställ lösenord',
+            ],
+
+        ],
+
+    ],
+
+    'notifications' => [
+
+        'throttled' => [
+            'title' => 'För många förfrågningar om återställning',
+            'body' => 'Vänligen försök igen om :seconds sekunder.',
+        ],
+
+    ],
+
+];

--- a/packages/panels/resources/lang/sv/pages/auth/register.php
+++ b/packages/panels/resources/lang/sv/pages/auth/register.php
@@ -18,7 +18,7 @@ return [
     'form' => [
 
         'email' => [
-            'label' => 'E-postadress',
+            'label' => 'Mejladress',
         ],
 
         'name' => [

--- a/packages/panels/resources/lang/sv/pages/auth/register.php
+++ b/packages/panels/resources/lang/sv/pages/auth/register.php
@@ -1,0 +1,56 @@
+<?php
+
+return [
+
+    'title' => 'Registrera',
+
+    'heading' => 'Skapa konto',
+
+    'actions' => [
+
+        'login' => [
+            'before' => 'eller',
+            'label' => 'logga in på ditt konto',
+        ],
+
+    ],
+
+    'form' => [
+
+        'email' => [
+            'label' => 'E-postadress',
+        ],
+
+        'name' => [
+            'label' => 'Namn',
+        ],
+
+        'password' => [
+            'label' => 'Lösenord',
+            'validation_attribute' => 'lösenord',
+        ],
+
+        'password_confirmation' => [
+            'label' => 'Bekräfta lösenord',
+        ],
+
+        'actions' => [
+
+            'register' => [
+                'label' => 'Skapa konto',
+            ],
+
+        ],
+
+    ],
+
+    'notifications' => [
+
+        'throttled' => [
+            'title' => 'För många registreringsförsök',
+            'body' => 'Vänligen försök igen om :seconds sekunder.',
+        ],
+
+    ],
+
+];

--- a/packages/panels/resources/lang/sv/pages/tenancy/edit-tenant-profile.php
+++ b/packages/panels/resources/lang/sv/pages/tenancy/edit-tenant-profile.php
@@ -2,30 +2,14 @@
 
 return [
 
-    'title' => 'Redigera :label',
-
-    'breadcrumb' => 'Redigera',
-
     'form' => [
 
         'actions' => [
-
-            'cancel' => [
-                'label' => 'Avbryt',
-            ],
 
             'save' => [
                 'label' => 'Spara ändringar',
             ],
 
-        ],
-
-    ],
-
-    'content' => [
-
-        'tab' => [
-            'label' => 'Redigera',
         ],
 
     ],

--- a/packages/panels/resources/lang/sv/resources/pages/create-record.php
+++ b/packages/panels/resources/lang/sv/resources/pages/create-record.php
@@ -29,7 +29,7 @@ return [
     'notifications' => [
 
         'created' => [
-            'title' => 'Skapad',
+            'title' => 'Skapades',
         ],
 
     ],

--- a/packages/spatie-laravel-settings-plugin/resources/lang/sv/pages/settings-page.php
+++ b/packages/spatie-laravel-settings-plugin/resources/lang/sv/pages/settings-page.php
@@ -17,7 +17,7 @@ return [
     'notifications' => [
 
         'saved' => [
-            'title' => 'Sparad',
+            'title' => 'Sparades',
         ],
 
     ],

--- a/packages/support/resources/lang/sv/components/copyable.php
+++ b/packages/support/resources/lang/sv/components/copyable.php
@@ -3,7 +3,7 @@
 return [
 
     'messages' => [
-        'copied' => 'Kopierad',
+        'copied' => 'Kopierades',
     ],
 
 ];

--- a/packages/support/resources/lang/sv/components/pagination.php
+++ b/packages/support/resources/lang/sv/components/pagination.php
@@ -2,7 +2,7 @@
 
 return [
 
-    'label' => 'Meny för sidnumerering',
+    'label' => 'Sidnavigering',
 
     'overview' => '{1} Visar 1 resultat|[2,*] Visar :first till :last av :total resultat',
 
@@ -10,7 +10,7 @@ return [
 
         'records_per_page' => [
 
-            'label' => 'per sida',
+            'label' => 'Per sida',
 
             'options' => [
                 'all' => 'Alla',

--- a/packages/tables/resources/lang/sv/table.php
+++ b/packages/tables/resources/lang/sv/table.php
@@ -2,6 +2,12 @@
 
 return [
 
+    'column_toggle' => [
+
+        'heading' => 'Kolumner',
+
+    ],
+
     'columns' => [
 
         'text' => [
@@ -18,6 +24,10 @@ return [
 
         'bulk_select_record' => [
             'label' => 'Markera/avmarkera rad :key för massåtgärder.',
+        ],
+
+        'bulk_select_group' => [
+            'label' => 'Markera/avmarkera gruppen :title för massåtgärder.',
         ],
 
         'search' => [
@@ -85,7 +95,11 @@ return [
     ],
 
     'empty' => [
-        'heading' => 'Inga rader hittades',
+
+        'heading' => 'Inga :model',
+
+        'description' => 'Skapa :model för att komma igång.',
+
     ],
 
     'filters' => [
@@ -102,10 +116,12 @@ return [
             ],
 
             'reset' => [
-                'label' => 'Återställ filter',
+                'label' => 'Återställ',
             ],
 
         ],
+
+        'heading' => 'Filter',
 
         'indicator' => 'Aktiva filter',
 
@@ -137,7 +153,7 @@ return [
 
             'group' => [
                 'label' => 'Gruppera',
-                'placeholder' => 'Välj ett fält för gruppering',
+                'placeholder' => 'Gruppera efter',
             ],
 
             'direction' => [


### PR DESCRIPTION
- Sync from all English lang files, to get all missing values
- In places where the original has changed since last PR, I tried to match it

At first I changed the translation from _Notis_ to _Avisering_, but then i found #9046 so I changed it back again. I agree with @tanthammar with using _Notis_ instead. It's not as formal.

Also, I first changed the translation for _Record_ from _Rad_ to _Post_, but I reverted that as well. What do you think about that change, @tanthammar? I think neither feel on point, but I can't come up with something better...