### PR TITLE
Fix tags input duplicate tags on rehydration

### DIFF
--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -10,12 +10,10 @@
     <div
         ax-load
         ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('tags-input', 'filament/forms') }}"
-        x-init="function() {
-            return tagsInputFormComponent({
-                state: $wire.{{ $applyStateBindingModifiers("\$entangle('{$statePath}')") }},
-                splitKeys: @js($splitKeys),
-            })
-        }"
+        x-init="() => tagsInputFormComponent({
+            state: $wire.{{ $applyStateBindingModifiers("\$entangle('{$statePath}')") }},
+            splitKeys: @js($splitKeys),
+        })"
         x-ignore
         {{
             $attributes

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -10,10 +10,12 @@
     <div
         ax-load
         ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('tags-input', 'filament/forms') }}"
-        x-data="tagsInputFormComponent({
-                    state: $wire.{{ $applyStateBindingModifiers("\$entangle('{$statePath}')") }},
-                    splitKeys: @js($splitKeys),
-                })"
+        x-init="function() {
+            return tagsInputFormComponent({
+                state: $wire.{{ $applyStateBindingModifiers("\$entangle('{$statePath}')") }},
+                splitKeys: @js($splitKeys),
+            })
+        }"
         x-ignore
         {{
             $attributes


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.


This fixes a bug in the Tags Input component where duplicate tags were created during rehydration. The issue arose from the immediate initialization of the Alpine.js component's state in the x-data attribute, leading to conflicts with Livewire's rehydration.

The solution delays the Alpine.js component initialization until after the DOM update by using x-init.

