### PR TITLE
Re-order state formatting

### DIFF
--- a/packages/infolists/src/Components/Concerns/CanFormatState.php
+++ b/packages/infolists/src/Components/Concerns/CanFormatState.php
@@ -209,13 +209,13 @@ trait CanFormatState
 
     public function formatState(mixed $state): mixed
     {
-        if ($state instanceof LabelInterface) {
-            $state = $state->getLabel();
-        }
-
         $state = $this->evaluate($this->formatStateUsing ?? $state, [
             'state' => $state,
         ]);
+
+        if ($state instanceof LabelInterface) {
+            $state = $state->getLabel();
+        }
 
         if ($characterLimit = $this->getCharacterLimit()) {
             $state = Str::limit($state, $characterLimit, $this->getCharacterLimitEnd());

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -209,13 +209,13 @@ trait CanFormatState
 
     public function formatState(mixed $state): mixed
     {
-        if ($state instanceof LabelInterface) {
-            $state = $state->getLabel();
-        }
-
         $state = $this->evaluate($this->formatStateUsing ?? $state, [
             'state' => $state,
         ]);
+
+        if ($state instanceof LabelInterface) {
+            $state = $state->getLabel();
+        }
 
         if ($characterLimit = $this->getCharacterLimit()) {
             $state = Str::limit($state, $characterLimit, $this->getCharacterLimitEnd());


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Infolist entries and table columns can be formatted using `formatStateUsing()`. In v3 when using enums, often they will implement interfaces such as `HasLabel` and `HasColor` so that they can be automatically formatted. Sometimes, custom formatting is required however. It would be nice to still get the enum in the closure instead of its label string.

I know we still have access to `$record`, however, this isn't applicable when the entry/column is responsible for displaying an array of enum cases. The evaluated closure receives the item, not the entire array, due to it being executed inside a `@foreach` loop in the corresponding view. I like this behaviour.

This change would mean that existing uses of `formatStateUsing()` may receive a different type and break functionality. Alternatively, another parameter could be injected into the closure, such as `$hasLabel`, `$original` or `$labelable`, for example.