### PR TITLE
Fixes MorphToSelect afterStateUpdated, reactive and lazy.

### DIFF
--- a/packages/forms/src/Components/MorphToSelect.php
+++ b/packages/forms/src/Components/MorphToSelect.php
@@ -57,7 +57,10 @@ class MorphToSelect extends Component
                 ))
                 ->required($isRequired)
                 ->reactive()
-                ->afterStateUpdated(fn (Closure $set) => $set($keyColumn, null)),
+                ->afterStateUpdated(function (Closure $set) use ($keyColumn) {
+                    $set($keyColumn, null);
+                    $this->callAfterStateUpdated();
+                }),
             Select::make($keyColumn)
                 ->label($selectedType?->getLabel())
                 ->disableLabel()
@@ -74,7 +77,11 @@ class MorphToSelect extends Component
                 ->loadingMessage($this->getLoadingMessage())
                 ->allowHtml($this->isHtmlAllowed())
                 ->optionsLimit($this->getOptionsLimit())
-                ->preload($this->isPreloaded()),
+                ->preload($this->isPreloaded())
+                ->reactive($this->isReactive())
+                ->afterStateUpdated(function () {
+                    $this->callAfterStateUpdated();
+                }),
         ];
     }
 

--- a/packages/forms/src/Concerns/HasStateBindingModifiers.php
+++ b/packages/forms/src/Concerns/HasStateBindingModifiers.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Forms\Concerns;
 
+use Closure;
 use Filament\Forms\Components\Component;
 use Illuminate\Support\Str;
 
@@ -11,15 +12,23 @@ trait HasStateBindingModifiers
 
     protected string | int | null $debounce = null;
 
-    public function reactive(): static
+    public function reactive(bool | Closure $condition = true): static
     {
+        if ($condition === false) {
+            return $this;
+        }
+
         $this->stateBindingModifiers([]);
 
         return $this;
     }
 
-    public function lazy(): static
+    public function lazy(bool | Closure $condition = true): static
     {
+        if ($condition === false) {
+            return $this;
+        }
+
         $this->stateBindingModifiers(['lazy']);
 
         return $this;

--- a/packages/forms/src/Concerns/HasStateBindingModifiers.php
+++ b/packages/forms/src/Concerns/HasStateBindingModifiers.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Forms\Concerns;
 
-use Closure;
 use Filament\Forms\Components\Component;
 use Illuminate\Support\Str;
 
@@ -12,24 +11,20 @@ trait HasStateBindingModifiers
 
     protected string | int | null $debounce = null;
 
-    public function reactive(bool | Closure $condition = true): static
+    public function reactive(bool $condition = true): static
     {
-        if ($condition === false) {
-            return $this;
+        if ($condition) {
+            $this->stateBindingModifiers([]);
         }
-
-        $this->stateBindingModifiers([]);
 
         return $this;
     }
 
-    public function lazy(bool | Closure $condition = true): static
+    public function lazy(bool $condition = true): static
     {
-        if ($condition === false) {
-            return $this;
+        if ($condition) {
+            $this->stateBindingModifiers(['lazy']);
         }
-
-        $this->stateBindingModifiers(['lazy']);
 
         return $this;
     }


### PR DESCRIPTION
Adds support for lazy and reactive dynamic implementations

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
