### PR TITLE
Allow filter modal width to be configurable

### DIFF
--- a/packages/tables/resources/views/components/filters/dialog.blade.php
+++ b/packages/tables/resources/views/components/filters/dialog.blade.php
@@ -26,7 +26,7 @@
         :sticky-footer="$triggerAction->isModalFooterSticky()"
         :sticky-header="$triggerAction->isModalHeaderSticky()"
         :slide-over="$triggerAction->isModalSlideOver()"
-        :width="$width"
+        :width="$triggerAction->getModalWidth()"
         wire:key="{{ $this->getId() }}.table.filters"
         {{ $attributes->class(['fi-ta-filters-modal']) }}
     >


### PR DESCRIPTION
Allows:

```php
->filtersTriggerAction(
    fn (Action $action) => $action
        ->slideOver()
        ->modalWidth('sm'),
);
```

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
