### PR TITLE
Remove unnecessary code duplication

### DIFF
--- a/packages/tables/resources/views/components/filters/dialog.blade.php
+++ b/packages/tables/resources/views/components/filters/dialog.blade.php
@@ -25,7 +25,6 @@
         :slide-over="$triggerAction->isModalSlideOver()"
         :sticky-footer="$triggerAction->isModalFooterSticky()"
         :sticky-header="$triggerAction->isModalHeaderSticky()"
-        :slide-over="$triggerAction->isModalSlideOver()"
         :width="$width"
         wire:key="{{ $this->getId() }}.table.filters"
         {{ $attributes->class(['fi-ta-filters-modal']) }}


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.