### PR TITLE
fix summerize count

### DIFF
--- a/packages/tables/src/Columns/Summarizers/Count.php
+++ b/packages/tables/src/Columns/Summarizers/Count.php
@@ -37,7 +37,7 @@ class Count extends Summarizer
 
         $state = [];
 
-        foreach ($query->clone()->pluck($attribute)->uniqueStrict() as $value) {
+        foreach ($query->clone()->distinct()->pluck($attribute) as $value) {
             $column->record($this->getQuery()->getModel()->setAttribute($attribute, $value));
             $columnState = $column->getState();
             $color = json_encode($column->getColor($columnState));

--- a/packages/tables/src/Columns/Summarizers/Count.php
+++ b/packages/tables/src/Columns/Summarizers/Count.php
@@ -37,7 +37,7 @@ class Count extends Summarizer
 
         $state = [];
 
-        foreach ($query->clone()->pluck($attribute) as $value) {
+        foreach ($query->clone()->pluck($attribute)->uniqueStrict() as $value) {
             $column->record($this->getQuery()->getModel()->setAttribute($attribute, $value));
             $columnState = $column->getState();
             $color = json_encode($column->getColor($columnState));


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

<img width="155" alt="image" src="https://github.com/filamentphp/filament/assets/25253808/78476e0e-2666-49b1-b997-9655e24b9d88">

As you can see, this page has 4 green ticks and 6 x marks, but filament miscount to 4x4 ticks and 6x6 marks
This PR is to fix this by looping the values that need to be counted only once

<img width="155" alt="image" src="https://github.com/filamentphp/filament/assets/25253808/c1b40f5c-f617-4f6c-ae6d-674e252ad093">