### PR TITLE
[3.x] Ask for panel ID when installing with `--panels`

### DIFF
--- a/packages/panels/src/Commands/MakePanelCommand.php
+++ b/packages/panels/src/Commands/MakePanelCommand.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Commands;
 
+use Filament\Support\Commands\Concerns\CanGeneratePanels;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
@@ -11,6 +12,7 @@ use function Laravel\Prompts\text;
 class MakePanelCommand extends Command
 {
     use CanManipulateFiles;
+    use CanGeneratePanels;
 
     protected $description = 'Create a new Filament panel';
 
@@ -18,45 +20,9 @@ class MakePanelCommand extends Command
 
     public function handle(): int
     {
-        $id = Str::lcfirst($this->argument('id') ?? text(
-            label: 'What is the ID?',
-            placeholder: 'app',
-            required: true,
-        ));
-
-        $class = (string) str($id)
-            ->studly()
-            ->append('PanelProvider');
-
-        $path = app_path(
-            (string) str($class)
-                ->prepend('Providers/Filament/')
-                ->replace('\\', '/')
-                ->append('.php'),
-        );
-
-        if (! $this->option('force') && $this->checkForCollision([$path])) {
-            return static::INVALID;
+        if (! $this->generatePanel(id: $this->argument('id'), placeholder: 'app', force: $this->option('force'))) {
+            return static::FAILURE;
         }
-
-        $this->copyStubToApp('PanelProvider', $path, [
-            'class' => $class,
-            'directory' => str($id)->studly(),
-            'id' => $id,
-        ]);
-
-        $appConfig = file_get_contents(config_path('app.php'));
-
-        if (! Str::contains($appConfig, "App\\Providers\\Filament\\{$class}::class")) {
-            file_put_contents(config_path('app.php'), str_replace(
-                'App\\Providers\\RouteServiceProvider::class,',
-                "App\\Providers\\Filament\\{$class}::class," . PHP_EOL . '        App\\Providers\\RouteServiceProvider::class,',
-                $appConfig,
-            ));
-        }
-
-        $this->components->info("Filament panel [{$path}] created successfully.");
-        $this->components->warn("We've attempted to register the {$class} in your [config/app.php] file as a service provider.  If you get an error while trying to access your panel then this process has probably failed. You can manually register the service provider by adding it to the [providers] array.");
 
         return static::SUCCESS;
     }

--- a/packages/panels/src/Commands/MakePanelCommand.php
+++ b/packages/panels/src/Commands/MakePanelCommand.php
@@ -5,9 +5,6 @@ namespace Filament\Commands;
 use Filament\Support\Commands\Concerns\CanGeneratePanels;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
 use Illuminate\Console\Command;
-use Illuminate\Support\Str;
-
-use function Laravel\Prompts\text;
 
 class MakePanelCommand extends Command
 {

--- a/packages/support/src/Commands/Concerns/CanGeneratePanels.php
+++ b/packages/support/src/Commands/Concerns/CanGeneratePanels.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Filament\Support\Commands\Concerns;
+
+use Illuminate\Support\Str;
+
+use function Laravel\Prompts\text;
+
+trait CanGeneratePanels
+{
+    use CanManipulateFiles;
+
+    public function generatePanel(?string $id = null, string $default = '', string $placeholder = '', bool $force = false): bool
+    {
+        $id = Str::lcfirst($id ?? text(
+            label: 'What is the ID?',
+            placeholder: $placeholder,
+            default: $default,
+            required: true,
+        ));
+
+        $class = (string) str($id)
+            ->studly()
+            ->append('PanelProvider');
+
+        $path = app_path(
+            (string) str($class)
+                ->prepend('Providers/Filament/')
+                ->replace('\\', '/')
+                ->append('.php'),
+        );
+
+        if (!$force && $this->checkForCollision([$path])) {
+            return false;
+        }
+
+        if ($id === 'admin') {
+            $this->copyStubToApp('AdminPanelProvider', $path);
+        } else {
+            $this->copyStubToApp('PanelProvider', $path, [
+                'class' => $class,
+                'directory' => str($id)->studly(),
+                'id' => $id,
+            ]);
+        }
+
+        $appConfig = file_get_contents(config_path('app.php'));
+
+        if (!Str::contains($appConfig, "App\\Providers\\Filament\\{$class}::class")) {
+            file_put_contents(config_path('app.php'), str_replace(
+                'App\\Providers\\RouteServiceProvider::class,',
+                "App\\Providers\\Filament\\{$class}::class," . PHP_EOL . '        App\\Providers\\RouteServiceProvider::class,',
+                $appConfig,
+            ));
+        }
+
+        $this->components->info("Filament panel [{$path}] created successfully.");
+        $this->components->warn("We've attempted to register the {$class} in your [config/app.php] file as a service provider.  If you get an error while trying to access your panel then this process has probably failed. You can manually register the service provider by adding it to the [providers] array.");
+
+        return true;
+    }
+}

--- a/packages/support/src/Commands/Concerns/CanGeneratePanels.php
+++ b/packages/support/src/Commands/Concerns/CanGeneratePanels.php
@@ -30,7 +30,7 @@ trait CanGeneratePanels
                 ->append('.php'),
         );
 
-        if (!$force && $this->checkForCollision([$path])) {
+        if (! $force && $this->checkForCollision([$path])) {
             return false;
         }
 
@@ -46,7 +46,7 @@ trait CanGeneratePanels
 
         $appConfig = file_get_contents(config_path('app.php'));
 
-        if (!Str::contains($appConfig, "App\\Providers\\Filament\\{$class}::class")) {
+        if (! Str::contains($appConfig, "App\\Providers\\Filament\\{$class}::class")) {
             file_put_contents(config_path('app.php'), str_replace(
                 'App\\Providers\\RouteServiceProvider::class,',
                 "App\\Providers\\Filament\\{$class}::class," . PHP_EOL . '        App\\Providers\\RouteServiceProvider::class,',

--- a/packages/support/src/Commands/InstallCommand.php
+++ b/packages/support/src/Commands/InstallCommand.php
@@ -8,10 +8,8 @@ use Filament\Support\Commands\Concerns\CanManipulateFiles;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 
 use function Laravel\Prompts\confirm;
-use function Laravel\Prompts\text;
 
 class InstallCommand extends Command
 {
@@ -69,7 +67,7 @@ class InstallCommand extends Command
 
     protected function installAdminPanel(): bool
     {
-        if (!class_exists(PanelProvider::class)) {
+        if (! class_exists(PanelProvider::class)) {
             $this->components->error('Please require [filament/filament] before attempting to install the Panel Builder.');
 
             return false;

--- a/packages/support/src/Commands/InstallCommand.php
+++ b/packages/support/src/Commands/InstallCommand.php
@@ -3,6 +3,7 @@
 namespace Filament\Support\Commands;
 
 use Filament\PanelProvider;
+use Filament\Support\Commands\Concerns\CanGeneratePanels;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
@@ -10,10 +11,12 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\text;
 
 class InstallCommand extends Command
 {
     use CanManipulateFiles;
+    use CanGeneratePanels;
 
     protected $signature = 'filament:install {--scaffold} {--actions} {--forms} {--infolists} {--notifications} {--panels} {--tables} {--widgets} {--F|force}';
 
@@ -66,32 +69,13 @@ class InstallCommand extends Command
 
     protected function installAdminPanel(): bool
     {
-        $path = app_path('Providers/Filament/AdminPanelProvider.php');
-
-        if (! $this->option('force') && $this->checkForCollision([$path])) {
-            return true;
-        }
-
-        if (! class_exists(PanelProvider::class)) {
+        if (!class_exists(PanelProvider::class)) {
             $this->components->error('Please require [filament/filament] before attempting to install the Panel Builder.');
 
             return false;
         }
 
-        $this->copyStubToApp('AdminPanelProvider', $path);
-
-        if (! Str::contains($appConfig = file_get_contents(config_path('app.php')), 'App\\Providers\\Filament\\AdminPanelProvider::class')) {
-            file_put_contents(config_path('app.php'), str_replace(
-                'App\\Providers\\RouteServiceProvider::class,',
-                'App\\Providers\\Filament\\AdminPanelProvider::class,' . PHP_EOL . '        App\\Providers\\RouteServiceProvider::class,',
-                $appConfig,
-            ));
-        }
-
-        $this->components->info('Successfully created AdminPanelProvider.php!');
-        $this->components->warn('We\'ve attempted to register the AdminPanelProvider in your [config/app.php] file as a service provider. If you get an error while trying to access your panel then this process has probably failed. You can manually register the service provider by adding it to the [providers] array.');
-
-        return true;
+        return $this->generatePanel(default: 'admin', force: $this->option('force'));
     }
 
     protected function installScaffolding(): void


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This changes how the `filament:install --panels` command behaves slightly and asks for the `id` of the panel, the same way the `make:filament-panel` command does.

When used from the `filament:install` command, it will still default to `admin` and generate the same code but it makes it easier for the developer to use a custom name for the panel by default, without having to generate another panel or manually modify the code it would generate previously.

> NOTE: It still maintains the same behaviour with regards to target directories, where resources/pages/widgets etc are registered from, nothing new there.