### PR TITLE
feature: Allow table searches to include phrases when wrapped in doub…

### DIFF
--- a/packages/tables/src/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Concerns/CanSearchRecords.php
@@ -108,7 +108,10 @@ trait CanSearchRecords
      */
     protected function extractTableSearchWords(string $search): array
     {
-        return $search === '' ? [''] : str_getcsv(preg_replace('/\s+/', ' ', $search), ' ');
+        return array_filter(
+            str_getcsv(preg_replace('/\s+/', ' ', $search), ' '),
+            fn ($word): bool => filled($word),
+        );
     }
 
     protected function applyGlobalSearchToTableQuery(Builder $query): Builder

--- a/packages/tables/src/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Concerns/CanSearchRecords.php
@@ -108,7 +108,7 @@ trait CanSearchRecords
      */
     protected function extractTableSearchWords(string $search): array
     {
-        return explode(' ', preg_replace('/\s+/', ' ', $search));
+        return $search === '' ? [''] : str_getcsv(preg_replace('/\s+/', ' ', $search), ' ');
     }
 
     protected function applyGlobalSearchToTableQuery(Builder $query): Builder

--- a/tests/src/Tables/Concerns/CanSearchRecordsTest.php
+++ b/tests/src/Tables/Concerns/CanSearchRecordsTest.php
@@ -30,8 +30,8 @@ it('can extract the search into words using whitespace', function () {
     $this->assertSame(['phrase one', 'test', 'number 2'],
         $trait->extractTableSearchWords('"phrase one"   test  "number   2"'));
 
-    // an empty search string should return array containing empty string ['']
-    $this->assertSame([''], $trait->extractTableSearchWords(''));
+    // an empty search string should return an empty array
+    $this->assertSame([], $trait->extractTableSearchWords(''));
 });
 
 it('can trim the search query', function () {

--- a/tests/src/Tables/Concerns/CanSearchRecordsTest.php
+++ b/tests/src/Tables/Concerns/CanSearchRecordsTest.php
@@ -15,11 +15,23 @@ it('can extract the search into words using whitespace', function () {
     };
 
     assertCount(1, $trait->extractTableSearchWords('test'));
-
     assertCount(2, $trait->extractTableSearchWords('testy test'));
     assertCount(2, $trait->extractTableSearchWords('testy   test'));
     assertCount(2, $trait->extractTableSearchWords("testy \t \n \r  test"));
     assertCount(3, $trait->extractTableSearchWords('testy   tasty   test'));
+
+    // test count when string contains phrases
+    assertCount(1, $trait->extractTableSearchWords('"phrase one"'));
+    assertCount(3, $trait->extractTableSearchWords('"phrase one" test "number 2"'));
+    // test word/phrase split content, *within double quotes multiple adjacent spaces are compressed to single space.
+    $this->assertSame(['test', 'phrase one'],
+        $trait->extractTableSearchWords('test   "phrase    one"'));
+
+    $this->assertSame(['phrase one', 'test', 'number 2'],
+        $trait->extractTableSearchWords('"phrase one"   test  "number   2"'));
+
+    // an empty search string should return array containing empty string ['']
+    $this->assertSame([''], $trait->extractTableSearchWords(''));
 });
 
 it('can trim the search query', function () {
@@ -42,4 +54,7 @@ it('can trim the search query', function () {
 
     $trait->tableSearch = null;
     $this->assertNull($trait->getTableSearch());
+
+    $trait->tableSearch = '  testy "test phrase" ';
+    $this->assertSame('testy "test phrase"', $trait->getTableSearch());
 });


### PR DESCRIPTION
When searching in tables the search previously broke each word separately on spaces between them. However sometimes that generates an unexpected large number of results, especially when search is enabled for multiple columns. By adding the ability to not break words up on spaces **when** they are within double quotes, we can have better search results.  So a search for `"Jane Doe"` will do a single search for the entire phrase `Jane Doe`. You can also mix them, so if in search bar you type `treatment "Jane Doe"` the system would search for both `treatment` and `Jane Doe`.

The old system used `explode()` which returned an array containing an empty string `['']` if the search string was an empty string. The new method uses `str_getcsv()` which returns an array containing null `[null]` so to ensure it was compatible, I wrapped so if the search string was empty it just returned `['']` without running the `str_getcsv()`. This should make it so it does not break any existing functionality. I added tests to confirm, which I ran before and after making the change from `explode()` to `str_getcsv()`. Then I also added tests that the string is not split on spaces within the double quotes. `" "`. When testing in a laravel installation, it worked and it even let me search for a single space `" "` now and it finds records that contain at least one space.

I did not update documentation as I didn't see any documentation about how the search is divided up already on each space and so I was unsure if and where you would want this.

There are no visual changes, you just wrap phrases in double quotes `"` in the table search input field. If you type in "Jane Doe" you will see a single search tag appear with quotes `Search: "Jane Doe"`. 

If you would like documentation updated, please let me know where and I'll add it.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
