### PR TITLE
Fix to allow state to be maintained with custom notifications

### DIFF
--- a/packages/notifications/src/Collection.php
+++ b/packages/notifications/src/Collection.php
@@ -29,7 +29,7 @@ class Collection extends BaseCollection implements Wireable
     public static function fromLivewire($value): static
     {
         return app(static::class, ['items' => $value])->transform(
-            fn (array $notification): Notification => Notification::fromArray($notification),
+            fn (array $notification): Notification => $notification['type']::fromArray($notification),
         );
     }
 }

--- a/packages/notifications/src/Livewire/Notifications.php
+++ b/packages/notifications/src/Livewire/Notifications.php
@@ -35,7 +35,8 @@ class Notifications extends Component
     public function pullNotificationsFromSession(): void
     {
         foreach (session()->pull('filament.notifications') ?? [] as $notification) {
-            $notification = Notification::fromArray($notification);
+            $notification_class = $notification['type'];
+            $notification = $notification_class::fromArray($notification);
 
             $this->pushNotification($notification);
         }
@@ -47,7 +48,8 @@ class Notifications extends Component
     #[On('notificationSent')]
     public function pushNotificationFromEvent(array $notification): void
     {
-        $notification = Notification::fromArray($notification);
+        $notification_class = $notification['type'];
+        $notification = $notification_class::fromArray($notification);
 
         $this->pushNotification($notification);
     }
@@ -71,7 +73,8 @@ class Notifications extends Component
             return;
         }
 
-        $this->pushNotification(Notification::fromArray($notification));
+        $notification_class = $notification['type'];
+        $this->pushNotification($notification_class::fromArray($notification));
     }
 
     protected function pushNotification(Notification $notification): void

--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -45,6 +45,8 @@ class Notification extends ViewComponent implements Arrayable
      */
     protected array $safeViews = [];
 
+    private string $type;
+
     public function __construct(string $id)
     {
         $this->id($id);
@@ -53,6 +55,7 @@ class Notification extends ViewComponent implements Arrayable
     public static function make(?string $id = null): static
     {
         $static = app(static::class, ['id' => $id ?? Str::orderedUuid()]);
+        $static->type(static::class);
         $static->configure();
 
         return $static;
@@ -79,6 +82,7 @@ class Notification extends ViewComponent implements Arrayable
             'title' => $this->getTitle(),
             'view' => $this->getView(),
             'viewData' => $this->getViewData(),
+            'type' => $this->getType()
         ];
     }
 
@@ -111,6 +115,7 @@ class Notification extends ViewComponent implements Arrayable
         $static->icon($data['icon'] ?? null);
         $static->iconColor($data['iconColor'] ?? $static->getIconColor());
         $static->title($data['title'] ?? null);
+        $static->type($data['type']);
 
         return $static;
     }
@@ -299,5 +304,15 @@ class Notification extends ViewComponent implements Arrayable
         }
 
         Assert::assertSame($expectedNotification->title, $notification);
+    }
+
+    public function type(string $type): void
+    {
+        $this->type = $type;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
     }
 }

--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -82,7 +82,7 @@ class Notification extends ViewComponent implements Arrayable
             'title' => $this->getTitle(),
             'view' => $this->getView(),
             'viewData' => $this->getViewData(),
-            'type' => $this->getType()
+            'type' => $this->getType(),
         ];
     }
 

--- a/tests/src/Notifications/Fixtures/CustomNotification.php
+++ b/tests/src/Notifications/Fixtures/CustomNotification.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Filament\Tests\Notifications\Fixtures;
+
+class CustomNotification extends \Filament\Notifications\Notification
+{
+    protected string $size = 'md';
+
+    public function toArray(): array
+    {
+        return [
+            ...parent::toArray(),
+            'size' => $this->getSize(),
+        ];
+    }
+
+    public static function fromArray(array $data): static
+    {
+        return parent::fromArray($data)->size($data['size']);
+    }
+
+    public function size(string $size): static
+    {
+        $this->size = $size;
+
+        return $this;
+    }
+
+    public function getSize(): string
+    {
+        return $this->size;
+    }
+}

--- a/tests/src/Notifications/NotificationTest.php
+++ b/tests/src/Notifications/NotificationTest.php
@@ -221,3 +221,38 @@ it('can dispatch an event to a component', function () {
     $notification = Notification::make()->actions([$action])->send();
     expect(getLastNotificationAction()->getLivewireClickHandler())->toBe("\$dispatchTo('a_component', 'an_event', JSON.parse('[\\u0022data\\u0022]'))");
 });
+
+it('can send a custom notification', function () {
+
+    \Filament\Tests\Notifications\Fixtures\CustomNotification::make($id = Str::random())
+        ->size('lg')
+        ->send();
+
+    $notifications = session()->get('filament.notifications');
+
+    expect($notifications)
+        ->toBeArray()
+        ->toHaveCount(1);
+
+    $notification = Arr::last($notifications);
+
+    expect($notification)
+        ->toBeArray()
+        ->size->toBe('lg');
+
+    $component = livewire(Notifications::class);
+
+    $component
+        ->dispatch('notificationsSent');
+
+    expect($component->instance()->notifications)
+        ->toBeInstanceOf(Collection::class)
+        ->toHaveCount(1);
+
+    $notification = $component->instance()->notifications->first();
+
+    expect($notification)
+        ->toBeInstanceOf(\Filament\Tests\Notifications\Fixtures\CustomNotification::class)
+        ->getSize()->toBe('lg');
+
+});


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This is a fix for #9268.

Functionality is already documented but docs do not reflect what should be possible. I'm not sure what happened here. It's either a case that it's changed and because there are were no tests for custom notifications, this was missed or something is missing from the docs.

I couldn't see the purpose of the container binding given in the docs also. The tests and my own app run this amend fine without it. Maybe from when the functionality originally worked? Any insight would be appreciated!

As this approach is not tied to one single binding, this could be used to show different custom notifications rather than rely on just one overridden custom class.