### PR TITLE
Fix empty action modal caused by validation exception

### DIFF
--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -11,6 +11,7 @@ use Filament\Support\Exceptions\Cancel;
 use Filament\Support\Exceptions\Halt;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Validation\ValidationException;
 use InvalidArgumentException;
 
 use function Livewire\store;
@@ -89,6 +90,10 @@ trait InteractsWithActions
         } catch (Halt $exception) {
             return null;
         } catch (Cancel $exception) {
+        } catch (ValidationException $exception) {
+            $this->unmountAction();
+
+            throw $exception;
         }
 
         $action->resetArguments();

--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -92,10 +92,17 @@ trait InteractsWithActions
         } catch (Cancel $exception) {
         } catch (ValidationException $exception) {
             if (! $this->mountedActionShouldOpenModal()) {
+                $action->resetArguments();
+                $action->resetFormData();
+
                 $this->unmountAction();
             }
 
             throw $exception;
+        }
+
+        if (store($this)->has('redirect')) {
+            return $result;
         }
 
         $action->resetArguments();
@@ -107,10 +114,6 @@ trait InteractsWithActions
             $action->clearRecordAfter();
 
             return null;
-        }
-
-        if (store($this)->has('redirect')) {
-            return $result;
         }
 
         $this->unmountAction();

--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -91,7 +91,9 @@ trait InteractsWithActions
             return null;
         } catch (Cancel $exception) {
         } catch (ValidationException $exception) {
-            $this->unmountAction();
+            if (! $this->mountedActionShouldOpenModal()) {
+                $this->unmountAction();
+            }
 
             throw $exception;
         }

--- a/packages/forms/src/Concerns/HasFormComponentActions.php
+++ b/packages/forms/src/Concerns/HasFormComponentActions.php
@@ -9,6 +9,7 @@ use Filament\Forms\Form;
 use Filament\Support\Exceptions\Cancel;
 use Filament\Support\Exceptions\Halt;
 use Illuminate\Support\Arr;
+use Illuminate\Validation\ValidationException;
 
 use function Livewire\store;
 
@@ -80,14 +81,23 @@ trait HasFormComponentActions
         } catch (Halt $exception) {
             return null;
         } catch (Cancel $exception) {
-        }
+        } catch (ValidationException $exception) {
+            if (! $this->mountedFormComponentActionShouldOpenModal()) {
+                $action->resetArguments();
+                $action->resetFormData();
 
-        $action->resetArguments();
-        $action->resetFormData();
+                $this->unmountFormComponentAction();
+            }
+
+            throw $exception;
+        }
 
         if (store($this)->has('redirect')) {
             return $result;
         }
+
+        $action->resetArguments();
+        $action->resetFormData();
 
         $this->unmountFormComponentAction();
 

--- a/packages/infolists/src/Concerns/InteractsWithInfolists.php
+++ b/packages/infolists/src/Concerns/InteractsWithInfolists.php
@@ -13,6 +13,7 @@ use Filament\Infolists\Infolist;
 use Filament\Support\Exceptions\Cancel;
 use Filament\Support\Exceptions\Halt;
 use Filament\Tables\Contracts\HasTable;
+use Illuminate\Validation\ValidationException;
 
 use function Livewire\store;
 
@@ -120,14 +121,23 @@ trait InteractsWithInfolists
         } catch (Halt $exception) {
             return null;
         } catch (Cancel $exception) {
-        }
+        } catch (ValidationException $exception) {
+            if (! $this->mountedInfolistActionShouldOpenModal()) {
+                $action->resetArguments();
+                $action->resetFormData();
 
-        $action->resetArguments();
-        $action->resetFormData();
+                $this->unmountInfolistAction();
+            }
+
+            throw $exception;
+        }
 
         if (store($this)->has('redirect')) {
             return $result;
         }
+
+        $action->resetArguments();
+        $action->resetFormData();
 
         $this->unmountInfolistAction();
 

--- a/packages/tables/src/Concerns/HasActions.php
+++ b/packages/tables/src/Concerns/HasActions.php
@@ -9,6 +9,7 @@ use Filament\Support\Exceptions\Halt;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\ActionGroup;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Validation\ValidationException;
 
 use function Livewire\store;
 
@@ -84,14 +85,23 @@ trait HasActions
         } catch (Halt $exception) {
             return null;
         } catch (Cancel $exception) {
-        }
+        } catch (ValidationException $exception) {
+            if (! $this->mountedTableActionShouldOpenModal()) {
+                $action->resetArguments();
+                $action->resetFormData();
 
-        $action->resetArguments();
-        $action->resetFormData();
+                $this->unmountTableAction();
+            }
+
+            throw $exception;
+        }
 
         if (store($this)->has('redirect')) {
             return $result;
         }
+
+        $action->resetArguments();
+        $action->resetFormData();
 
         $this->unmountTableAction();
 

--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
+use Illuminate\Validation\ValidationException;
 
 use function Livewire\store;
 
@@ -79,19 +80,25 @@ trait HasBulkActions
         } catch (Halt $exception) {
             return null;
         } catch (Cancel $exception) {
+        } catch (ValidationException $exception) {
+            if (! $this->mountedTableBulkActionShouldOpenModal()) {
+                $action->resetArguments();
+                $action->resetFormData();
+
+                $this->unmountTableBulkAction();
+            }
+
+            throw $exception;
         }
 
         if (store($this)->has('redirect')) {
             return $result;
         }
 
-        $this->mountedTableBulkAction = null;
-        $this->selectedTableRecords = [];
-
         $action->resetArguments();
         $action->resetFormData();
 
-        $this->closeTableBulkActionModal();
+        $this->unmountTableBulkAction();
 
         return $result;
     }
@@ -179,6 +186,14 @@ trait HasBulkActions
             $action->getModalContentFooter() ||
             $action->getInfolist() ||
             $this->mountedTableBulkActionHasForm();
+    }
+
+    public function unmountTableBulkAction(): void
+    {
+        $this->mountedTableBulkAction = null;
+        $this->selectedTableRecords = [];
+
+        $this->closeTableBulkActionModal();
     }
 
     public function mountedTableBulkActionHasForm(): bool


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

When triggering an action on a page with a form, it's common to first validate its state.

Often, this is the first check that happens and will be contained in the `->action()` closure, or a function it calls.

For actions that don't have a modal/form, the `callMountedAction` call happens automatically, therefore the validation exception should be caught here (and of course rethrown so it can be handled by Livewire).

If it occurs, and the action doesn't open a modal, it's safe to assume that the validation exception occurred on the base page, or a previous modal. If that is the case it can be unmounted.

This should address https://github.com/filamentphp/filament/issues/7909, https://github.com/filamentphp/filament/issues/8522.

This may need to be added in `HasFormComponentActions`. Additional logic may need to be added to ensure the exception happened in the previous action (if actions are chained) or the base page.