### PR TITLE
Fix custom notification object

### DIFF
--- a/packages/notifications/docs/05-customizing-notifications.md
+++ b/packages/notifications/docs/05-customizing-notifications.md
@@ -70,7 +70,7 @@ namespace App\Notifications;
 
 use Filament\Notifications\Notification as BaseNotification;
 
-class CustomNotification extends BaseNotification
+class Notification extends BaseNotification
 {
     protected string $size = 'md';
 
@@ -104,10 +104,10 @@ class CustomNotification extends BaseNotification
 Next, you should bind your custom `Notification` class into the container inside a service provider's `boot()` method:
 
 ```php
-use App\Notifications\CustomNotification;
+use App\Notifications\Notification;
 use Filament\Notifications\Notification as BaseNotification;
 
-$this->app->bind(BaseNotification::class, CustomNotification::class);
+$this->app->bind(BaseNotification::class, Notification::class);
 ```
 
 You can now use your custom `Notification` class in the same way as you would with the default `Notification` object.

--- a/packages/notifications/docs/05-customizing-notifications.md
+++ b/packages/notifications/docs/05-customizing-notifications.md
@@ -70,7 +70,7 @@ namespace App\Notifications;
 
 use Filament\Notifications\Notification as BaseNotification;
 
-class Notification extends BaseNotification
+class CustomNotification extends BaseNotification
 {
     protected string $size = 'md';
 
@@ -84,7 +84,7 @@ class Notification extends BaseNotification
 
     public static function fromArray(array $data): static
     {
-        return parent::fromArray()->size($data['size']);
+        return parent::fromArray($data)->size($data['size']);
     }
 
     public function size(string $size): static
@@ -104,10 +104,10 @@ class Notification extends BaseNotification
 Next, you should bind your custom `Notification` class into the container inside a service provider's `boot()` method:
 
 ```php
-use App\Notifications\Notification;
+use App\Notifications\CustomNotification;
 use Filament\Notifications\Notification as BaseNotification;
 
-$this->app->bind(BaseNotification::class, Notification::class);
+$this->app->bind(BaseNotification::class, CustomNotification::class);
 ```
 
 You can now use your custom `Notification` class in the same way as you would with the default `Notification` object.

--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -89,8 +89,14 @@ class Notification extends ViewComponent implements Arrayable
     {
         $static = static::make($data['id'] ?? Str::random());
 
-        if (is_subclass_of($static::class, self::class) && get_called_class() === self::class) {
-            $static = $static::fromArray($data);
+        // If the container constructs an instance of child class
+        // instead of the current class, we should run `fromArray()`
+        // on the child class instead.
+        if (
+            ($static::class !== self::class) &&
+            (get_called_class() === self::class)
+        ) {
+            return $static::fromArray($data);
         }
 
         $static->actions(

--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -89,7 +89,7 @@ class Notification extends ViewComponent implements Arrayable
     {
         $static = static::make($data['id'] ?? Str::random());
 
-        if (is_subclass_of($static, self::class) && get_called_class() === self::class) {
+        if (is_subclass_of($static::class, self::class) && get_called_class() === self::class) {
             $static = $static::fromArray($data);
         }
 

--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -88,6 +88,11 @@ class Notification extends ViewComponent implements Arrayable
     public static function fromArray(array $data): static
     {
         $static = static::make($data['id'] ?? Str::random());
+
+        if (is_subclass_of($static, self::class) && get_called_class() === self::class) {
+            $static = $static::fromArray($data);
+        }
+
         $static->actions(
             array_map(
                 fn (array $action): Action | ActionGroup => match (array_key_exists('actions', $action)) {

--- a/tests/src/Notifications/Fixtures/CustomNotification.php
+++ b/tests/src/Notifications/Fixtures/CustomNotification.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Filament\Tests\Notifications\Fixtures;
+
+class CustomNotification extends \Filament\Notifications\Notification
+{
+    protected string $size = 'md';
+
+    public function toArray(): array
+    {
+        return [
+            ...parent::toArray(),
+            'size' => $this->getSize(),
+        ];
+    }
+
+    public static function fromArray(array $data): static
+    {
+        return parent::fromArray($data)->size($data['size']);
+    }
+
+    public function size(string $size): static
+    {
+        $this->size = $size;
+
+        return $this;
+    }
+
+    public function getSize(): string
+    {
+        return $this->size;
+    }
+}


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

closes #9268 

when recreating the notification object from array, `Notification` class resolved the correct `CustomNotification` but the `CustomNotification::fromArray` is not called again. this PR fixes that by checking if the notification object resolved from container is custom and its called from `Notification` class to ensure its only called once and prevent infinite loop


another approach would be in livewire\Notifications to resolved the notification object but that would have multiple useless instance created and more code changes that I not able to test