### PR TITLE
Fixed front-end crush if title contains double quotes.

### DIFF
--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -137,7 +137,7 @@
                     'disabled' => $disabled,
                     'title' => $label,
                     'type' => $type,
-                ], escape: false)
+                ], escape: true)
                 ->class([$buttonClasses])
                 ->style([$buttonStyles])
         }}
@@ -201,7 +201,7 @@
             $attributes
                 ->merge([
                     'title' => $label,
-                ], escape: false)
+                ], escape: true)
                 ->class([$buttonClasses])
                 ->style([$buttonStyles])
         }}

--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -135,8 +135,10 @@
             $attributes
                 ->merge([
                     'disabled' => $disabled,
-                    'title' => $label,
                     'type' => $type,
+                ], escape: false)
+                ->merge([
+                    'title' => $label,
                 ], escape: true)
                 ->class([$buttonClasses])
                 ->style([$buttonStyles])


### PR DESCRIPTION
I make groups in a table and found that when I switch pagination, the table stops working with an error.

```
Uncaught DOMException: Failed to execute 'setAttribute' on 'Element': '#2"' is not a valid attribute name.
    at HTMLButtonElement.newSetAttribute [as setAttribute] (http://localhost:8000/livewire/livewire.js?id=2f6e5d4d:6520:25)
    at patchAttributes (http://localhost:8000/livewire/livewire.js?id=2f6e5d4d:6284:17)
    at patch (http://localhost:8000/livewire/livewire.js?id=2f6e5d4d:6239:9)
    at patchChildren (http://localhost:8000/livewire/livewire.js?id=2f6e5d4d:6393:9)
    at patchChildren (http://localhost:8000/livewire/livewire.js?id=2f6e5d4d:6346:11)
    at patchChildren (http://localhost:8000/livewire/livewire.js?id=2f6e5d4d:6346:11)
    at patch (http://localhost:8000/livewire/livewire.js?id=2f6e5d4d:6242:7)
    at patchChildren (http://localhost:8000/livewire/livewire.js?id=2f6e5d4d:6393:9)
    at patch (http://localhost:8000/livewire/livewire.js?id=2f6e5d4d:6242:7)
    at patchChildren (http://localhost:8000/livewire/livewire.js?id=2f6e5d4d:6393:9)
```

I'm using code like this.

```
Group::make('theme.day.id')
     ->label('Day')
     ->titlePrefixedWithLabel(false)
     ->getTitleFromRecordUsing(fn (Section $record): string => 'Course "' . $record->theme->day->course->title . '". Day #' . $record->theme->day->number)
     ->collapsible()
```

And the double quote characters in the title and icon are not escaped and false attributes are generated for the element.

![image](https://github.com/filamentphp/filament/assets/5977764/24930ff3-35a3-46aa-a0bd-2f2b22d49a6f)
