### PR TITLE
Make url optional for local font provider

### DIFF
--- a/packages/panels/src/FontProviders/LocalFontProvider.php
+++ b/packages/panels/src/FontProviders/LocalFontProvider.php
@@ -10,7 +10,7 @@ class LocalFontProvider implements Contracts\FontProvider
     public function getHtml(string $family, ?string $url = null): Htmlable
     {
         if (blank($url)) {
-            return HtmlString('');
+            return new HtmlString('');
         }
 
         return new HtmlString("

--- a/packages/panels/src/FontProviders/LocalFontProvider.php
+++ b/packages/panels/src/FontProviders/LocalFontProvider.php
@@ -4,14 +4,13 @@ namespace Filament\FontProviders;
 
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\HtmlString;
-use InvalidArgumentException;
 
 class LocalFontProvider implements Contracts\FontProvider
 {
     public function getHtml(string $family, ?string $url = null): Htmlable
     {
         if (blank($url)) {
-            return HtmlString("");
+            return HtmlString('');
         }
 
         return new HtmlString("

--- a/packages/panels/src/FontProviders/LocalFontProvider.php
+++ b/packages/panels/src/FontProviders/LocalFontProvider.php
@@ -11,7 +11,7 @@ class LocalFontProvider implements Contracts\FontProvider
     public function getHtml(string $family, ?string $url = null): Htmlable
     {
         if (blank($url)) {
-            throw new InvalidArgumentException('The local font\'s CSS URL must be specified.');
+            return HtmlString("");
         }
 
         return new HtmlString("


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Currently the `url` attribute is required if you use the local font provider, which is problematic if you have already defined your `font-family` in your theme stylesheet using this method: https://filamentphp.com/docs/3.x/panels/themes#creating-a-custom-theme

This PR makes it optional to pass the url if you need to use a separate css to define your `font-family`.