### PR TITLE
Hide pagination options if nr. of records is less than the smallest per page select option

### DIFF
--- a/packages/support/resources/views/components/pagination/index.blade.php
+++ b/packages/support/resources/views/components/pagination/index.blade.php
@@ -7,7 +7,7 @@
 @php
     $isRtl = __('filament-panels::layout.direction') === 'rtl';
     $isSimple = ! $paginator instanceof \Illuminate\Pagination\LengthAwarePaginator;
-	
+
     $smallestPageOption = collect($pageOptions)
         ->filter(fn (int $option) => $option > 0)
         ->sort()

--- a/packages/support/resources/views/components/pagination/index.blade.php
+++ b/packages/support/resources/views/components/pagination/index.blade.php
@@ -9,7 +9,7 @@
     $isSimple = ! $paginator instanceof \Illuminate\Pagination\LengthAwarePaginator;
 
     $smallestPageOption = collect($pageOptions)
-        ->filter(fn (int | string $option) => is_numeric($option)  && $option > 0)
+        ->filter(fn (int | string $option) => is_numeric($option) && $option > 0)
         ->sort()
         ->first();
 @endphp

--- a/packages/support/resources/views/components/pagination/index.blade.php
+++ b/packages/support/resources/views/components/pagination/index.blade.php
@@ -54,7 +54,7 @@
         </span>
     @endif
 
-    @if (count($pageOptions) > 1 && ($isSimple || $paginator->total() > $smallestPageOption))
+    @if (count($pageOptions) > 1 && ($isSimple || ($smallestPageOption || $paginator->total() > $smallestPageOption)))
         <div class="col-start-2 justify-self-center">
             <label class="fi-pagination-records-per-page-select fi-compact">
                 <x-filament::input.wrapper>

--- a/packages/support/resources/views/components/pagination/index.blade.php
+++ b/packages/support/resources/views/components/pagination/index.blade.php
@@ -9,7 +9,7 @@
     $isSimple = ! $paginator instanceof \Illuminate\Pagination\LengthAwarePaginator;
 
     $smallestPageOption = collect($pageOptions)
-        ->filter(fn (int | string $option) => is_numeric($option) && $option > 0)
+        ->filter(fn (int | string $option): bool => is_numeric($option) && ($option > 0))
         ->sort()
         ->first();
 @endphp

--- a/packages/support/resources/views/components/pagination/index.blade.php
+++ b/packages/support/resources/views/components/pagination/index.blade.php
@@ -54,7 +54,7 @@
         </span>
     @endif
 
-    @if (count($pageOptions) > 1 && ($isSimple || ($smallestPageOption || $paginator->total() > $smallestPageOption)))
+    @if ((count($pageOptions) > 1) && ($isSimple || $smallestPageOption || ($paginator->total() > $smallestPageOption)))
         <div class="col-start-2 justify-self-center">
             <label class="fi-pagination-records-per-page-select fi-compact">
                 <x-filament::input.wrapper>

--- a/packages/support/resources/views/components/pagination/index.blade.php
+++ b/packages/support/resources/views/components/pagination/index.blade.php
@@ -7,6 +7,11 @@
 @php
     $isRtl = __('filament-panels::layout.direction') === 'rtl';
     $isSimple = ! $paginator instanceof \Illuminate\Pagination\LengthAwarePaginator;
+	
+    $smallestPageOption = collect($pageOptions)
+        ->filter(fn (int $option) => $option > 0)
+        ->sort()
+        ->first();
 @endphp
 
 <nav
@@ -49,7 +54,7 @@
         </span>
     @endif
 
-    @if (count($pageOptions) > 1)
+    @if (count($pageOptions) > 1 && ($isSimple || $paginator->total() > $smallestPageOption))
         <div class="col-start-2 justify-self-center">
             <label class="fi-pagination-records-per-page-select fi-compact">
                 <x-filament::input.wrapper>

--- a/packages/support/resources/views/components/pagination/index.blade.php
+++ b/packages/support/resources/views/components/pagination/index.blade.php
@@ -9,7 +9,7 @@
     $isSimple = ! $paginator instanceof \Illuminate\Pagination\LengthAwarePaginator;
 	
     $smallestPageOption = collect($pageOptions)
-        ->filter(fn (int $option) => $option > 0)
+        ->filter(fn (int | string $option) => is_numeric($option)  && $option > 0)
         ->sort()
         ->first();
 @endphp


### PR DESCRIPTION
I got a request from a client who found it confusing that the per page select dropdown options were still visible, even if a table had only one or a few records. It was not "clean and logical":

<img width="826" alt="Paginator" src="https://github.com/filamentphp/filament/assets/59207045/dbd9f596-9fc5-462c-985b-a7b300b40c6b">

If there are not many records and the nr. of records is smaller than the , the dropdown to select a nr. of options per page in principle doesn't change anything. 

This PR proposes to remove the dropdown if the nr. of records is smaller than the smallest page option, thus the dropdown having no effect in any situation.

After:

<img width="1150" alt="Table" src="https://github.com/filamentphp/filament/assets/59207045/14295365-4e10-4d70-9212-bcfbd3cd3347">

This PR is only about hiding the dropdown. Things like the nr. of records etc are all not touched.


- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
