### PR TITLE
Reduce vertical space between sidebar navigation groups

### DIFF
--- a/packages/panels/resources/views/components/sidebar/group.blade.php
+++ b/packages/panels/resources/views/components/sidebar/group.blade.php
@@ -34,7 +34,7 @@
             @endif
 
             <span
-                class="fi-sidebar-group-label flex-1 text-sm font-semibold text-gray-700 dark:text-gray-200"
+                class="fi-sidebar-group-label flex-1 text-sm font-semibold leading-6 text-gray-700 dark:text-gray-200"
             >
                 {{ $label }}
             </span>

--- a/packages/panels/resources/views/components/sidebar/group.blade.php
+++ b/packages/panels/resources/views/components/sidebar/group.blade.php
@@ -48,7 +48,7 @@
                     x-bind:aria-expanded="! $store.sidebar.groupIsCollapsed(label)"
                     x-on:click.stop="$store.sidebar.toggleCollapsedGroup(label)"
                     class="fi-sidebar-group-collapse-button"
-                    x-bind:class="{ 'rotate-180': $store.sidebar.groupIsCollapsed(label) }"
+                    x-bind:class="{ '-rotate-180': $store.sidebar.groupIsCollapsed(label) }"
                 />
             @endif
         </div>

--- a/packages/panels/resources/views/components/sidebar/index.blade.php
+++ b/packages/panels/resources/views/components/sidebar/index.blade.php
@@ -111,7 +111,7 @@
         @endif
 
         @if (filament()->hasNavigation())
-            <ul class="-mx-2 flex flex-col gap-y-7">
+            <ul class="-mx-2 flex flex-col gap-y-1">
                 @foreach ($navigation as $group)
                     <x-filament-panels::sidebar.group
                         :collapsible="$group->isCollapsible()"


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

I notice that when we use `$navigationGroup` there is a lot of space between the groups and this PR aims to reduce that space (check settings and test group)
Before:
![Screenshot from 2023-10-31 16-16-35](https://github.com/filamentphp/filament/assets/28250303/b0082f06-4f0f-4ec2-a29b-58055c32a73a)
After:
![Screenshot from 2023-10-31 16-16-45](https://github.com/filamentphp/filament/assets/28250303/693cdf0a-c00a-4deb-9b76-8deff5f5bdc7)
