### PR TITLE
[3.x] Support presigned upload URLs in FileUpload

### DIFF
--- a/packages/forms/docs/03-fields/09-file-upload.md
+++ b/packages/forms/docs/03-fields/09-file-upload.md
@@ -45,7 +45,7 @@ FileUpload::make('attachment')
 ### Presigned Upload URLs
 
 If you're using a s3-compatible storage provider, you can also enable [presigned uploads](https://docs.aws.amazon.com/AmazonS3/latest/userguide/PresignedUrlUploadObject.html).
-Presigned uploads allow you to upload files directly to s3, without having to go through your server. This can be useful for large files, or if you're using a serverless architecture like Laravel Vapor.
+Presigned uploads allow you to upload files directly to s3, without having to go through your server. This can be useful for large files, or if you're using a serverless architecture like AWS Lambda.
 
 ```php
 FileUpload::make('attachment')

--- a/packages/forms/docs/03-fields/09-file-upload.md
+++ b/packages/forms/docs/03-fields/09-file-upload.md
@@ -34,6 +34,25 @@ FileUpload::make('attachment')
     ->visibility('private')
 ```
 
+If you're using a s3-compatible storage provider, you can use the `s3()` method to set all the appropriate settings:
+
+```php
+FileUpload::make('attachment')
+    ->directory('form-attachments')
+    ->s3(diskName: 's3')
+```
+
+### Presigned Upload URLs
+
+If you're using a s3-compatible storage provider, you can also enable [presigned uploads](https://docs.aws.amazon.com/AmazonS3/latest/userguide/PresignedUrlUploadObject.html).
+Presigned uploads allow you to upload files directly to s3, without having to go through your server. This can be useful for large files, or if you're using a serverless architecture like Laravel Vapor.
+
+```php
+FileUpload::make('attachment')
+    ->directory('form-attachments')
+    ->s3(presigned: true)
+```
+
 > It is the responsibility of the developer to delete these files from the disk if they are removed, as Filament is unaware if they are depended on elsewhere. One way to do this automatically is observing a [model event](https://laravel.com/docs/eloquent#events).
 
 ## Uploading multiple files

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -188,6 +188,7 @@ export default function fileUploadFormComponent({
                                     xhr.setRequestHeader('Content-Type', file.type);
                                     xhr.send(file);
                                 })
+                                .catch(() => error('Failed to request a presigned upload URL'))
 
                             return
                         }

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -155,8 +155,9 @@ export default function fileUploadFormComponent({
                             ).toString(16),
                         )
 
+                        // Handle presigned upload process
                         if(isPresigned) {
-                            const presignedFile = await fetch('/filament/uploads/request-presigned-upload', {
+                            await fetch('/filament/uploads/request-presigned-upload', {
                                 method: 'POST',
                                 headers: {
                                     'Content-Type': 'application/json',
@@ -170,26 +171,28 @@ export default function fileUploadFormComponent({
                                 })
                             })
                                 .then(response => response.json())
-
-                            const xhr = new XMLHttpRequest();
+                                .then(configuration => {
+                                    const xhr = new XMLHttpRequest();
                             
-                            xhr.upload.addEventListener('progress', e => progress(true, Math.round((e.loaded * 100) / e.total), 100));
-                            xhr.addEventListener('error', () => error('Error during upload'));
-                            xhr.addEventListener('abort', () => error('Upload aborted'));
-                            xhr.addEventListener('load', () => {
-                                this.shouldUpdateState = true
-
-                                loadUploadedFileUsing(fileKey, presignedFile.path)
-                                load(fileKey)
-                            });
-
-                            xhr.open('PUT', presignedFile.url, true);
-                            xhr.setRequestHeader('Content-Type', file.type);
-                            xhr.send(file);
+                                    xhr.upload.addEventListener('progress', e => progress(true, Math.round((e.loaded * 100) / e.total), 100));
+                                    xhr.addEventListener('error', () => error('Error during upload'));
+                                    xhr.addEventListener('abort', () => error('Upload aborted'));
+                                    xhr.addEventListener('load', () => {
+                                        this.shouldUpdateState = true
+        
+                                        loadUploadedFileUsing(fileKey, configuration.path)
+                                        load(fileKey)
+                                    });
+        
+                                    xhr.open('PUT', configuration.url, true);
+                                    xhr.setRequestHeader('Content-Type', file.type);
+                                    xhr.send(file);
+                                })
 
                             return
                         }
 
+                        // Handle default upload process
                         uploadUsing(
                             fileKey,
                             file,

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -28,6 +28,7 @@
         ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('file-upload', 'filament/forms') }}"
         x-data="fileUploadFormComponent({
                     acceptedFileTypes: @js($getAcceptedFileTypes()),
+                    diskName: @js($getDiskName()),
                     imageEditorEmptyFillColor: @js($getImageEditorEmptyFillColor()),
                     imageEditorMode: @js($getImageEditorMode()),
                     imageEditorViewportHeight: @js($getImageEditorViewportHeight()),
@@ -57,9 +58,13 @@
                     isDownloadable: @js($isDownloadable()),
                     isMultiple: @js($isMultiple()),
                     isOpenable: @js($isOpenable()),
+                    isPresigned: @js($isPresigned()),
                     isPreviewable: @js($isPreviewable()),
                     isReorderable: @js($isReorderable()),
                     loadingIndicatorPosition: @js($getLoadingIndicatorPosition()),
+                    loadUploadedFileUsing: async (fileKey, filePath) => {
+                        return await $wire.loadFormUploadedFile(@js($statePath), fileKey, filePath)
+                    },
                     locale: @js(app()->getLocale()),
                     panelAspectRatio: @js($getPanelAspectRatio()),
                     panelLayout: @js($getPanelLayout()),

--- a/packages/forms/routes/web.php
+++ b/packages/forms/routes/web.php
@@ -1,0 +1,8 @@
+<?php
+
+use Filament\Forms\Http\Controllers\RequestPresignedUpload;
+use Illuminate\Support\Facades\Route;
+
+Route::post('/filament/uploads/request-presigned-upload', RequestPresignedUpload::class)
+    ->name('filament.uploads.presigned-upload.request')
+    ->middleware(['web', 'auth']);

--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -145,6 +145,13 @@ trait InteractsWithForms
         return null;
     }
 
+    public function loadFormUploadedFile(string $statePath, string $fileKey, string $filePath): void
+    {
+        foreach ($this->getCachedForms() as $form) {
+            $form->loadUploadedFile($statePath, $fileKey, $filePath);
+        }
+    }
+
     public function removeFormUploadedFile(string $statePath, string $fileKey): void
     {
         foreach ($this->getCachedForms() as $form) {

--- a/packages/forms/src/Concerns/SupportsFileUploadFields.php
+++ b/packages/forms/src/Concerns/SupportsFileUploadFields.php
@@ -76,6 +76,29 @@ trait SupportsFileUploadFields
         return false;
     }
 
+    public function loadUploadedFile(string $statePath, string $fileKey, string $filePath): bool
+    {
+        foreach ($this->getComponents() as $component) {
+            if ($component instanceof BaseFileUpload && $component->getStatePath() === $statePath) {
+                $component->loadUploadedFile($fileKey, $filePath);
+
+                return true;
+            }
+
+            foreach ($component->getChildComponentContainers() as $container) {
+                if ($container->isHidden()) {
+                    continue;
+                }
+
+                if ($container->loadUploadedFile($statePath, $fileKey, $filePath)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     /**
      * @param  array<array-key>  $fileKeys
      */

--- a/packages/forms/src/FormsServiceProvider.php
+++ b/packages/forms/src/FormsServiceProvider.php
@@ -18,6 +18,7 @@ class FormsServiceProvider extends PackageServiceProvider
         $package
             ->name('filament-forms')
             ->hasCommands($this->getCommands())
+            ->hasRoute('web')
             ->hasTranslations()
             ->hasViews();
     }

--- a/packages/forms/src/Http/Controllers/RequestPresignedUpload.php
+++ b/packages/forms/src/Http/Controllers/RequestPresignedUpload.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Forms\Http\Controllers;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
@@ -10,7 +11,7 @@ use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 
 class RequestPresignedUpload
 {
-    public function __invoke(Request $request)
+    public function __invoke(Request $request): JsonResponse
     {
         ['disk' => $disk, 'fileName' => $fileName, 'fileType' => $fileType] = $request->validate([
             'disk' => 'required|string',

--- a/packages/forms/src/Http/Controllers/RequestPresignedUpload.php
+++ b/packages/forms/src/Http/Controllers/RequestPresignedUpload.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Filament\Forms\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Features\SupportFileUploads\FileUploadConfiguration;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+
+class RequestPresignedUpload
+{
+    public function __invoke(Request $request)
+    {
+        ['disk' => $disk, 'fileName' => $fileName, 'fileType' => $fileType] = $request->validate([
+            'disk' => 'required|string',
+            'fileName' => 'required|string',
+            'fileType' => 'required|string',
+        ]);
+
+        $fileHashName = TemporaryUploadedFile::generateHashNameWithOriginalNameEmbedded(
+            file: UploadedFile::fake()->create(name: $fileName, mimeType: $fileType)
+        );
+
+        ['url' => $url] = Storage::disk($disk)->temporaryUploadUrl(
+            path: FileUploadConfiguration::path($fileHashName),
+            expiration: now()->addMinutes(FileUploadConfiguration::maxUploadTime()),
+        );
+
+        return response()->json([
+            'path' => $fileHashName,
+            'url' => $url,
+        ], 201);
+    }
+}


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

When using a s3-compatible disk, we don't need to upload the file to the server and then to s3, files can be directly uploaded to the disk, saving unnecessary server processing.

Also, when working on an serverless environment (AWS Lambda using Laravel Vapor for example), there's a hard limit of 6MB for the payload of the request (including files).

This PR adds support presigned uploads using this new api:

```php
FileUpload::make('image')
    ->s3(diskName: 's3', presigned: true)
```

The presigned upload is optional and the new api can be used only as a shortcut to `->disk()` and `->visibility()` if desired.
