### PR TITLE
Updated Hungarian translations

### DIFF
--- a/packages/actions/resources/lang/hu/associate.php
+++ b/packages/actions/resources/lang/hu/associate.php
@@ -25,7 +25,7 @@ return [
                 ],
 
                 'associate_another' => [
-                    'label' => 'Társítás és új társítása',
+                    'label' => 'Mentés és új társítása',
                 ],
 
             ],

--- a/packages/actions/resources/lang/hu/attach.php
+++ b/packages/actions/resources/lang/hu/attach.php
@@ -25,7 +25,7 @@ return [
                 ],
 
                 'attach_another' => [
-                    'label' => 'Csatolás és új csatolása',
+                    'label' => 'Mentés és új csatolása',
                 ],
 
             ],

--- a/packages/actions/resources/lang/hu/create.php
+++ b/packages/actions/resources/lang/hu/create.php
@@ -13,11 +13,11 @@ return [
             'actions' => [
 
                 'create' => [
-                    'label' => 'Hozzáadás',
+                    'label' => 'Létrehozás',
                 ],
 
                 'create_another' => [
-                    'label' => 'Hozzáadás és új hozzáadása',
+                    'label' => 'Mentés és új létrehozása',
                 ],
 
             ],
@@ -27,7 +27,7 @@ return [
         'notifications' => [
 
             'created' => [
-                'title' => 'Hozzáadva',
+                'title' => 'Létrehozva',
             ],
 
         ],

--- a/packages/actions/resources/lang/hu/dissociate.php
+++ b/packages/actions/resources/lang/hu/dissociate.php
@@ -4,16 +4,16 @@ return [
 
     'single' => [
 
-        'label' => 'Szétválasztás',
+        'label' => 'Lecsatolás',
 
         'modal' => [
 
-            'heading' => ':label szétválasztása',
+            'heading' => ':label lecstolása',
 
             'actions' => [
 
                 'dissociate' => [
-                    'label' => 'Szétválasztás',
+                    'label' => 'Lecsatolás',
                 ],
 
             ],
@@ -23,7 +23,7 @@ return [
         'notifications' => [
 
             'dissociated' => [
-                'title' => 'Szétválasztva',
+                'title' => 'Lecsatolva',
             ],
 
         ],
@@ -32,16 +32,16 @@ return [
 
     'multiple' => [
 
-        'label' => 'Kijelöltek szétválasztása',
+        'label' => 'Kijelöltek lecsatolása',
 
         'modal' => [
 
-            'heading' => 'Kijelölt :label szétválasztása',
+            'heading' => 'Kijelölt :label lecsatolása',
 
             'actions' => [
 
                 'dissociate' => [
-                    'label' => 'Kijelöltek szétválasztása',
+                    'label' => 'Kijelöltek lecsatolása',
                 ],
 
             ],
@@ -51,7 +51,7 @@ return [
         'notifications' => [
 
             'dissociated' => [
-                'title' => 'Szétválasztva',
+                'title' => 'Lecsatolva',
             ],
 
         ],

--- a/packages/actions/resources/lang/hu/modal.php
+++ b/packages/actions/resources/lang/hu/modal.php
@@ -2,7 +2,7 @@
 
 return [
 
-    'confirmation' => 'Biztos, hogy végre akarod hajtani?',
+    'confirmation' => 'Biztos, hogy ezt akarod csinálni?',
 
     'actions' => [
 
@@ -15,7 +15,7 @@ return [
         ],
 
         'submit' => [
-            'label' => 'Végrehajtás',
+            'label' => 'Beküldés',
         ],
 
     ],

--- a/packages/forms/resources/lang/hu/components.php
+++ b/packages/forms/resources/lang/hu/components.php
@@ -7,7 +7,7 @@ return [
         'actions' => [
 
             'clone' => [
-                'label' => 'Másolás',
+                'label' => 'Duplikálás',
             ],
 
             'add' => [
@@ -15,7 +15,7 @@ return [
             ],
 
             'add_between' => [
-                'label' => 'Beillesztés közé',
+                'label' => 'Beillesztés blokkok közé',
             ],
 
             'delete' => [
@@ -35,19 +35,19 @@ return [
             ],
 
             'collapse' => [
-                'label' => 'Becsuk',
+                'label' => 'Becsukás',
             ],
 
             'expand' => [
-                'label' => 'Kibont',
+                'label' => 'Kibontás',
             ],
 
             'collapse_all' => [
-                'label' => 'Becsuk mindent',
+                'label' => 'Összes becsukása',
             ],
 
             'expand_all' => [
-                'label' => 'Kibont mindent',
+                'label' => 'Összes kibontása',
             ],
 
         ],
@@ -81,11 +81,11 @@ return [
                 ],
 
                 'drag_crop' => [
-                    'label' => 'Kijelölés mód',
+                    'label' => 'Méretrevágási mód',
                 ],
 
                 'drag_move' => [
-                    'label' => 'Mozgatás mód',
+                    'label' => 'Mozgatási mód',
                 ],
 
                 'flip_horizontal' => [
@@ -125,7 +125,7 @@ return [
                 ],
 
                 'set_aspect_ratio' => [
-                    'label' => 'Állítsa be a képarányt :ratio értékre',
+                    'label' => 'Képarány beállítása :ratio értékre',
                 ],
 
                 'save' => [
@@ -154,7 +154,7 @@ return [
                 ],
 
                 'rotation' => [
-                    'label' => 'Forgatás',
+                    'label' => 'Elforgatás',
                     'unit' => 'fok',
                 ],
 
@@ -185,6 +185,15 @@ return [
 
             ],
 
+            'svg' => [
+
+                'messages' => [
+                    'confirmation' => 'Az SVG fájlok szerkesztése nem ajánlott, mivel minőségromláshoz vezethet az átméretezés során.\n Biztosan szeretnéd folytatni?',
+                    'disabled' => 'Az SVG fájlok szerkesztése nem engedélyezett, mivel minőségromláshoz vezethet az átméretezés során.',
+                ],
+
+            ],
+
         ],
 
     ],
@@ -202,7 +211,7 @@ return [
             ],
 
             'reorder' => [
-                'label' => 'Sor újrarendezése',
+                'label' => 'Sor mozgatása',
             ],
 
         ],
@@ -233,10 +242,10 @@ return [
             'italic' => 'Dőlt',
             'link' => 'Hivatkozás',
             'ordered_list' => 'Számozott lista',
-            'redo' => 'Előre',
+            'redo' => 'Visszaállítás',
             'strike' => 'Áthúzott',
             'table' => 'Táblázat',
-            'undo' => 'Vissza',
+            'undo' => 'Visszavonás',
         ],
 
     ],
@@ -254,7 +263,7 @@ return [
             ],
 
             'clone' => [
-                'label' => 'Másolás',
+                'label' => 'Duplikálás',
             ],
 
             'reorder' => [
@@ -270,19 +279,19 @@ return [
             ],
 
             'collapse' => [
-                'label' => 'Becsuk',
+                'label' => 'Becsukás',
             ],
 
             'expand' => [
-                'label' => 'Kibont',
+                'label' => 'Kibontás',
             ],
 
             'collapse_all' => [
-                'label' => 'Becsuk mindent',
+                'label' => 'Összes becsukása',
             ],
 
             'expand_all' => [
-                'label' => 'Kibont mindent',
+                'label' => 'Összes kibontása',
             ],
 
         ],
@@ -320,10 +329,10 @@ return [
             'italic' => 'Dőlt',
             'link' => 'Hivatkozás',
             'ordered_list' => 'Számozott lista',
-            'redo' => 'Előre',
+            'redo' => 'Visszaállítás',
             'strike' => 'Áthúzott',
             'underline' => 'Alázhúzott',
-            'undo' => 'Vissza',
+            'undo' => 'Visszavonás',
         ],
 
     ],
@@ -336,7 +345,7 @@ return [
 
                 'modal' => [
 
-                    'heading' => 'Új opció hozzáadása',
+                    'heading' => 'Új elem hozzáadása',
 
                     'actions' => [
 
@@ -345,7 +354,7 @@ return [
                         ],
 
                         'create_another' => [
-                            'label' => 'Hozzáadás és másik hozzáadása',
+                            'label' => 'Mentés és új hozzáadása',
                         ],
 
                     ],
@@ -385,7 +394,7 @@ return [
 
         'no_search_results_message' => 'Nincs találat',
 
-        'placeholder' => 'Válassz...',
+        'placeholder' => 'Válassz ki egy elemet',
 
         'searching_message' => 'Keresés...',
 

--- a/packages/notifications/resources/lang/hu/database.php
+++ b/packages/notifications/resources/lang/hu/database.php
@@ -19,8 +19,8 @@ return [
         ],
 
         'empty' => [
-            'heading' => 'Nincs értesítés',
-            'description' => 'Kérjük, hogy ellenőrizd később.',
+            'heading' => 'Nincsenek értesítések',
+            'description' => 'Kérjük, hogy nézz vissza később.',
         ],
 
     ],

--- a/packages/panels/resources/lang/hu/layout.php
+++ b/packages/panels/resources/lang/hu/layout.php
@@ -7,7 +7,7 @@ return [
     'actions' => [
 
         'billing' => [
-            'label' => 'Előfizetésem kezelése',
+            'label' => 'Előfizetések kezelése',
         ],
 
         'logout' => [
@@ -19,17 +19,17 @@ return [
         ],
 
         'open_user_menu' => [
-            'label' => 'felhasználói menü',
+            'label' => 'Felhasználói menü',
         ],
 
         'sidebar' => [
 
             'collapse' => [
-                'label' => 'Oldalsáv becsukása',
+                'label' => 'Oldalsáv elrejtése',
             ],
 
             'expand' => [
-                'label' => 'Oldalsáv kinyitása',
+                'label' => 'Oldalsáv megjelenítése',
             ],
 
         ],
@@ -45,7 +45,7 @@ return [
             ],
 
             'system' => [
-                'label' => 'Rendszer alapján',
+                'label' => 'Rendszertéma követése',
             ],
 
         ],

--- a/packages/panels/resources/lang/hu/pages/auth/edit-profile.php
+++ b/packages/panels/resources/lang/hu/pages/auth/edit-profile.php
@@ -43,7 +43,7 @@ return [
     'actions' => [
 
         'cancel' => [
-            'label' => 'vissza',
+            'label' => 'Mégsem',
         ],
 
     ],

--- a/packages/panels/resources/lang/hu/pages/auth/email-verification/email-verification-prompt.php
+++ b/packages/panels/resources/lang/hu/pages/auth/email-verification/email-verification-prompt.php
@@ -9,7 +9,7 @@ return [
     'actions' => [
 
         'resend_notification' => [
-            'label' => 'Újra küldés',
+            'label' => 'Újraküldés',
         ],
 
     ],

--- a/packages/panels/resources/lang/hu/pages/auth/login.php
+++ b/packages/panels/resources/lang/hu/pages/auth/login.php
@@ -4,7 +4,7 @@ return [
 
     'title' => 'Bejelentkezés',
 
-    'heading' => 'Bejelentkezés a fiókba',
+    'heading' => 'Jelentkezz be a fiókodba',
 
     'actions' => [
 
@@ -52,8 +52,8 @@ return [
     'notifications' => [
 
         'throttled' => [
-            'title' => 'Túl sok próbálkozás',
-            'body' => 'Kérjük, próbálja meg újra :second másodperc múlva.',
+            'title' => 'Túl sok bejelentkezési kísérlet',
+            'body' => 'Kérjük, próbáld meg újra :second másodperc múlva.',
         ],
 
     ],

--- a/packages/panels/resources/lang/hu/pages/auth/password-reset/request-password-reset.php
+++ b/packages/panels/resources/lang/hu/pages/auth/password-reset/request-password-reset.php
@@ -34,7 +34,7 @@ return [
 
         'throttled' => [
             'title' => 'Túl sok próbálkozás',
-            'body' => 'Kérjük, próbálja meg újra :second másodperc múlva.',
+            'body' => 'Kérjük, próbáld meg újra :second másodperc múlva.',
         ],
 
     ],

--- a/packages/panels/resources/lang/hu/pages/auth/password-reset/reset-password.php
+++ b/packages/panels/resources/lang/hu/pages/auth/password-reset/reset-password.php
@@ -35,7 +35,7 @@ return [
 
         'throttled' => [
             'title' => 'Túl sok visszaállítási kísérlet',
-            'body' => 'Kérjük, próbálja meg újra :second másodperc múlva.',
+            'body' => 'Kérjük, próbáld meg újra :second másodperc múlva.',
         ],
 
     ],

--- a/packages/panels/resources/lang/hu/pages/auth/register.php
+++ b/packages/panels/resources/lang/hu/pages/auth/register.php
@@ -4,13 +4,13 @@ return [
 
     'title' => 'Regisztráció',
 
-    'heading' => 'Regisztráció',
+    'heading' => 'Regisztrálj új fiókot',
 
     'actions' => [
 
         'login' => [
             'before' => 'vagy',
-            'label' => 'jelentkezzen be a fiókjába',
+            'label' => 'jelentkezz be a fiókodba',
         ],
 
     ],
@@ -48,7 +48,7 @@ return [
 
         'throttled' => [
             'title' => 'Túl sok regisztrációs kísérlet',
-            'body' => 'Kérjük, próbálja meg újra :second másodperc múlva.',
+            'body' => 'Kérjük, próbáld meg újra :second másodperc múlva.',
         ],
 
     ],

--- a/packages/panels/resources/lang/hu/resources/pages/create-record.php
+++ b/packages/panels/resources/lang/hu/resources/pages/create-record.php
@@ -19,7 +19,7 @@ return [
             ],
 
             'create_another' => [
-                'label' => 'Mentés és újabb hozzáadás',
+                'label' => 'Mentés és új létrehozása',
             ],
 
         ],

--- a/packages/panels/resources/lang/hu/resources/pages/edit-record.php
+++ b/packages/panels/resources/lang/hu/resources/pages/edit-record.php
@@ -4,7 +4,7 @@ return [
 
     'title' => ':label szerkesztése',
 
-    'breadcrumb' => 'Szerkeszt',
+    'breadcrumb' => 'Szerkesztés',
 
     'form' => [
 

--- a/packages/panels/resources/lang/hu/widgets/account-widget.php
+++ b/packages/panels/resources/lang/hu/widgets/account-widget.php
@@ -10,6 +10,6 @@ return [
 
     ],
 
-    'welcome' => 'Üdv',
+    'welcome' => 'Üdvözlünk',
 
 ];

--- a/packages/spatie-laravel-settings-plugin/resources/lang/hu/pages/settings-page.php
+++ b/packages/spatie-laravel-settings-plugin/resources/lang/hu/pages/settings-page.php
@@ -7,7 +7,7 @@ return [
         'actions' => [
 
             'save' => [
-                'label' => 'Mentés',
+                'label' => 'Változtatások mentése',
             ],
 
         ],

--- a/packages/tables/resources/lang/hu/table.php
+++ b/packages/tables/resources/lang/hu/table.php
@@ -19,17 +19,17 @@ return [
     'fields' => [
 
         'bulk_select_page' => [
-            'label' => 'Az összes elem kiválasztása vagy megszüntetése tömeges műveletekhez.',
+            'label' => 'Az összes elem kijelölése vagy a kijelölés megszüntetése csoportos műveletekhez.',
         ],
 
         'bulk_select_record' => [
-            'label' => ':key elem kiválasztása vagy megszüntetése tömeges műveletekhez.',
+            'label' => ':key elem kijelölése vagy a kijelölés megszüntetése csoportos műveletekhez.',
         ],
 
         'search' => [
             'label' => 'Keresés',
             'placeholder' => 'Keresés',
-            'indicator' => 'Keres',
+            'indicator' => 'Keress',
         ],
 
     ],
@@ -65,11 +65,11 @@ return [
     'actions' => [
 
         'disable_reordering' => [
-            'label' => 'Sorba rendezés befejezése',
+            'label' => 'Átrendezés befejezése',
         ],
 
         'enable_reordering' => [
-            'label' => 'Sorba rendezés',
+            'label' => 'Átrendezés',
         ],
 
         'filter' => [
@@ -77,11 +77,11 @@ return [
         ],
 
         'group' => [
-            'label' => 'Csoport',
+            'label' => 'Csoportosítás',
         ],
 
         'open_bulk_actions' => [
-            'label' => 'Műveletek',
+            'label' => 'Csoportos műveletek',
         ],
 
         'toggle_columns' => [
@@ -92,9 +92,9 @@ return [
 
     'empty' => [
 
-        'heading' => 'Nincs találat',
+        'heading' => 'Nincs megjeleníthető elem',
 
-        'description' => 'Hozzon létre egy újat a kezdéshez.',
+        'description' => 'Hozz létre egy újat a kezdéshez.',
 
     ],
 
@@ -103,16 +103,16 @@ return [
         'actions' => [
 
             'remove' => [
-                'label' => 'Szűrés megszűntetése',
+                'label' => 'Szűrő megszűntetése',
             ],
 
             'remove_all' => [
-                'label' => 'Összes szűrés megszűntetése',
-                'tooltip' => 'Összes szűrés megszűntetése',
+                'label' => 'Az összes szűrő megszűntetése',
+                'tooltip' => 'Az összes szűrő megszűntetése',
             ],
 
             'reset' => [
-                'label' => 'Alaphelyzet',
+                'label' => 'Visszaállítása',
             ],
 
         ],
@@ -135,7 +135,7 @@ return [
 
             'only_trashed' => 'Csak a törölt elemek',
 
-            'with_trashed' => 'Törölt elemekkel',
+            'with_trashed' => 'Törölt elemekkel együtt',
 
             'without_trashed' => 'Törölt elemek nélkül',
 
@@ -167,7 +167,7 @@ return [
 
     ],
 
-    'reorder_indicator' => 'Fogd meg és mozgasd a sorrendezéshez.',
+    'reorder_indicator' => 'Kattints az elemekre és mozgasd őket az átrendezéshez.',
 
     'selection_indicator' => [
 
@@ -176,7 +176,7 @@ return [
         'actions' => [
 
             'select_all' => [
-                'label' => 'Kijelöli mind a(z) :count elemet',
+                'label' => 'Mind a(z) :count elem kijelölése',
             ],
 
             'deselect_all' => [
@@ -192,7 +192,7 @@ return [
         'fields' => [
 
             'column' => [
-                'label' => 'Rendezve',
+                'label' => 'Rendezés',
             ],
 
             'direction' => [


### PR DESCRIPTION
- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

I use filament for applications in my native language (hungarian) and I have found the translations to be quite inconsistent, especially with the use of formal and informal language features (with my changes I opted to use informal everywhere), and also pretty odd in terms of word use for any native speaker. This PR fixes these issues, fixes some typos in the lang files and adds missing translations as well.