### PR TITLE
feat: implement possibilty to apply or not tenant relationship on res…

### DIFF
--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -172,10 +172,11 @@ class CreateRecord extends Page
     protected function handleRecordCreation(array $data): Model
     {
         $record = new ($this->getModel())($data);
-        
-        $tenant = Filament::getTenant();
 
-        if ($tenant && static::getResource()::isScopedToTenant()) {
+        if (
+            static::getResource()::isScopedToTenant() &&
+            ($tenant = Filament::getTenant())
+        ) {
             return $this->associateRecordWithTenant($record, $tenant);
         }
 

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -172,9 +172,10 @@ class CreateRecord extends Page
     protected function handleRecordCreation(array $data): Model
     {
         $record = new ($this->getModel())($data);
+        
         $tenant = Filament::getTenant();
 
-        if ($tenant && static::getResource()::shouldApplyTenantRelationship()) {
+        if ($tenant && static::getResource()::isScopedToTenant()) {
             return $this->associateRecordWithTenant($record, $tenant);
         }
 

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -172,8 +172,9 @@ class CreateRecord extends Page
     protected function handleRecordCreation(array $data): Model
     {
         $record = new ($this->getModel())($data);
+        $tenant = Filament::getTenant();
 
-        if ($tenant = Filament::getTenant()) {
+        if ($tenant && static::getResource()::shouldApplyTenantRelationship()) {
             return $this->associateRecordWithTenant($record, $tenant);
         }
 

--- a/packages/panels/src/Resources/Pages/ListRecords.php
+++ b/packages/panels/src/Resources/Pages/ListRecords.php
@@ -115,7 +115,7 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
             ->modelLabel($this->getModelLabel() ?? static::getResource()::getModelLabel())
             ->form(fn (Form $form): Form => $this->form($form->columns(2)));
 
-        if ($action instanceof CreateAction) {
+        if (($action instanceof CreateAction) && static::getResource()::isScopedToTenant()) {
             $action->relationship(($tenant = Filament::getTenant()) ? fn (): Relation => static::getResource()::getTenantRelationship($tenant) : null);
         }
 

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -86,6 +86,8 @@ abstract class Resource
 
     protected static ?string $slug = null;
 
+    protected static bool $shouldApplyTenantRelationship = true;
+
     protected static ?string $tenantOwnershipRelationshipName = null;
 
     protected static ?string $tenantRelationshipName = null;
@@ -307,8 +309,9 @@ abstract class Resource
     public static function getEloquentQuery(): Builder
     {
         $query = static::getModel()::query();
+        $tenant = Filament::getTenant();
 
-        if ($tenant = Filament::getTenant()) {
+        if ($tenant && static::shouldApplyTenantRelationship()) {
             static::scopeEloquentQueryToTenant($query, $tenant);
         }
 
@@ -745,6 +748,11 @@ abstract class Resource
     public static function isDiscovered(): bool
     {
         return static::$isDiscovered;
+    }
+
+    public static function shouldApplyTenantRelationship(): bool
+    {
+        return static::$shouldApplyTenantRelationship;
     }
 
     public static function getTenantOwnershipRelationshipName(): string

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -86,7 +86,7 @@ abstract class Resource
 
     protected static ?string $slug = null;
 
-    protected static bool $shouldApplyTenantRelationship = true;
+    protected static bool $isScopedToTenant = true;
 
     protected static ?string $tenantOwnershipRelationshipName = null;
 
@@ -311,7 +311,7 @@ abstract class Resource
         $query = static::getModel()::query();
         $tenant = Filament::getTenant();
 
-        if ($tenant && static::shouldApplyTenantRelationship()) {
+        if ($tenant && static::isScopedToTenant()) {
             static::scopeEloquentQueryToTenant($query, $tenant);
         }
 
@@ -750,9 +750,9 @@ abstract class Resource
         return static::$isDiscovered;
     }
 
-    public static function shouldApplyTenantRelationship(): bool
+    public static function isScopedToTenant(): bool
     {
-        return static::$shouldApplyTenantRelationship;
+        return static::$isScopedToTenant;
     }
 
     public static function getTenantOwnershipRelationshipName(): string

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -309,9 +309,11 @@ abstract class Resource
     public static function getEloquentQuery(): Builder
     {
         $query = static::getModel()::query();
-        $tenant = Filament::getTenant();
 
-        if ($tenant && static::isScopedToTenant()) {
+        if (
+            static::isScopedToTenant() &&
+            ($tenant = Filament::getTenant())
+        ) {
             static::scopeEloquentQueryToTenant($query, $tenant);
         }
 


### PR DESCRIPTION
Hello, some of us using multi tenancy want to have resources shared between tenants without having a tenant relation. I propose the possibility of enabling/disabling the default apply of the tenant notion on queries.

By default `$shouldApplyTenantRelationship` is at `true` to avoid any breaking change.

[Discord related help topic](https://discord.com/channels/883083792112300104/1142037309986975845/1142037309986975845)

TODO: update documentation

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
