### PR TITLE
Fix/remove hardcoded npm package

### DIFF
--- a/packages/panels/docs/11-themes.md
+++ b/packages/panels/docs/11-themes.md
@@ -122,6 +122,7 @@ php artisan make:filament-theme admin
 ```
 
 By default, this command will use NPM to install dependencies. If you want to use a different package manager, you can use the `--pm` option:
+
 ```bash
 php artisan make:filament-theme --pm=bun
 ````

--- a/packages/panels/docs/11-themes.md
+++ b/packages/panels/docs/11-themes.md
@@ -121,8 +121,7 @@ If you have multiple panels, you can specify the panel you want to create a them
 php artisan make:filament-theme admin
 ```
 
-By default, command will use node package manager with npm. If you want to use different package manager use `--pm` option:
-
+By default, this command will use NPM to install dependencies. If you want to use a different package manager, you can use the `--pm` option:
 ```bash
 php artisan make:filament-theme --pm=bun
 ````

--- a/packages/panels/docs/11-themes.md
+++ b/packages/panels/docs/11-themes.md
@@ -121,6 +121,12 @@ If you have multiple panels, you can specify the panel you want to create a them
 php artisan make:filament-theme admin
 ```
 
+By default, command will use node package manager with npm. If you want to use different package manager use `--pm` option:
+
+```bash
+php artisan make:filament-theme --pm=bun
+````
+
 The command will create a CSS file and Tailwind Configuration file in the `/resources/css/filament` directory. You can then customize the theme by editing these files. It will also give you instructions on how to compile the theme and register it in Filament. **Please follow the instructions in the command to complete the setup process:**
 
 ```

--- a/packages/panels/src/Commands/Aliases/MakeThemeCommand.php
+++ b/packages/panels/src/Commands/Aliases/MakeThemeCommand.php
@@ -8,5 +8,5 @@ class MakeThemeCommand extends Commands\MakeThemeCommand
 {
     protected $hidden = true;
 
-    protected $signature = 'filament:theme {panel?} {--F|force}';
+    protected $signature = 'filament:theme {panel?} {--pm=} {--F|force}';
 }

--- a/packages/panels/src/Commands/MakeThemeCommand.php
+++ b/packages/panels/src/Commands/MakeThemeCommand.php
@@ -17,7 +17,7 @@ class MakeThemeCommand extends Command
 
     protected $description = 'Create a new Filament panel theme';
 
-    protected $signature = 'make:filament-theme {panel?} {packet-manager?} {--F|force} {--P|packet-manager=npm}';
+    protected $signature = 'make:filament-theme {panel?} {packet-manager?} {--F|force}';
 
     public function handle(): int
     {

--- a/packages/panels/src/Commands/MakeThemeCommand.php
+++ b/packages/panels/src/Commands/MakeThemeCommand.php
@@ -23,7 +23,7 @@ class MakeThemeCommand extends Command
     {
         $pm = $this->option('pm') ?? 'npm';
 
-        exec($pm . ' -v', $pmVersion, $pmVersionExistCode);
+        exec("${$pm} -v", $pmVersion, $pmVersionExistCode);
 
         if ($pmVersionExistCode !== 0) {
             $this->error('Node.js is not installed. Please install before continuing.');
@@ -33,7 +33,10 @@ class MakeThemeCommand extends Command
 
         $this->info("Using {$pm} v{$pmVersion[0]}");
 
-        $installCommand = $pm === 'yarn' ? 'yarn add' : "{$pm} install";
+        $installCommand = match($pm) {
+            'yarn' => 'yarn add',
+            default => "{$pm} install",
+        };
 
         exec("{$installCommand} tailwindcss @tailwindcss/forms @tailwindcss/typography postcss autoprefixer --save-dev");
 
@@ -63,9 +66,9 @@ class MakeThemeCommand extends Command
         $tailwindConfigFilePath = resource_path("css/filament/{$panelId}/tailwind.config.js");
 
         if (! $this->option('force') && $this->checkForCollision([
-                $cssFilePath,
-                $tailwindConfigFilePath,
-            ])) {
+            $cssFilePath,
+            $tailwindConfigFilePath,
+        ])) {
             return static::INVALID;
         }
 

--- a/packages/panels/src/Commands/MakeThemeCommand.php
+++ b/packages/panels/src/Commands/MakeThemeCommand.php
@@ -23,7 +23,7 @@ class MakeThemeCommand extends Command
     {
         $pm = $this->option('pm') ?? 'npm';
 
-        exec("$pm -v", $pmVersion, $pmVersionExistCode);
+        exec("{$pm} -v", $pmVersion, $pmVersionExistCode);
 
         if ($pmVersionExistCode !== 0) {
             $this->error('Node.js is not installed. Please install before continuing.');

--- a/packages/panels/src/Commands/MakeThemeCommand.php
+++ b/packages/panels/src/Commands/MakeThemeCommand.php
@@ -23,7 +23,7 @@ class MakeThemeCommand extends Command
     {
         $pm = $this->option('pm') ?? 'npm';
 
-        exec("${$pm} -v", $pmVersion, $pmVersionExistCode);
+        exec("$pm -v", $pmVersion, $pmVersionExistCode);
 
         if ($pmVersionExistCode !== 0) {
             $this->error('Node.js is not installed. Please install before continuing.');

--- a/packages/panels/src/Commands/MakeThemeCommand.php
+++ b/packages/panels/src/Commands/MakeThemeCommand.php
@@ -33,7 +33,9 @@ class MakeThemeCommand extends Command
 
         $this->info("Using {$pm} v{$pmVersion[0]}");
 
-        exec("{$pm} install tailwindcss @tailwindcss/forms @tailwindcss/typography postcss autoprefixer --save-dev");
+        $installCommand = $pm === 'yarn' ? 'yarn add' : "{$pm} install";
+
+        exec("{$installCommand} tailwindcss @tailwindcss/forms @tailwindcss/typography postcss autoprefixer --save-dev");
 
         $panel = $this->argument('panel');
 

--- a/packages/panels/src/Commands/MakeThemeCommand.php
+++ b/packages/panels/src/Commands/MakeThemeCommand.php
@@ -17,21 +17,23 @@ class MakeThemeCommand extends Command
 
     protected $description = 'Create a new Filament panel theme';
 
-    protected $signature = 'make:filament-theme {panel?} {--F|force}';
+    protected $signature = 'make:filament-theme {panel?} {packet-manager?} {--F|force} {--P|packet-manager=npm}';
 
     public function handle(): int
     {
-        exec('npm -v', $npmVersion, $npmVersionExistCode);
+        $pm = $this->argument('packet-manager') ?? 'npm';
 
-        if ($npmVersionExistCode !== 0) {
+        exec($pm . ' -v', $pmVersion, $pmVersionExistCode);
+
+        if ($pmVersionExistCode !== 0) {
             $this->error('Node.js is not installed. Please install before continuing.');
 
             return static::FAILURE;
         }
 
-        $this->info("Using NPM v{$npmVersion[0]}");
+        $this->info("Using {$pm} v{$pmVersion[0]}");
 
-        exec('npm install tailwindcss @tailwindcss/forms @tailwindcss/typography postcss autoprefixer --save-dev');
+        exec("{$pm} install tailwindcss @tailwindcss/forms @tailwindcss/typography postcss autoprefixer --save-dev");
 
         $panel = $this->argument('panel');
 
@@ -59,9 +61,9 @@ class MakeThemeCommand extends Command
         $tailwindConfigFilePath = resource_path("css/filament/{$panelId}/tailwind.config.js");
 
         if (! $this->option('force') && $this->checkForCollision([
-            $cssFilePath,
-            $tailwindConfigFilePath,
-        ])) {
+                $cssFilePath,
+                $tailwindConfigFilePath,
+            ])) {
             return static::INVALID;
         }
 
@@ -108,7 +110,7 @@ class MakeThemeCommand extends Command
         $this->components->bulletList([
             "First, add a new item to the `input` array of `vite.config.js`: `resources/css/filament/{$panelId}/theme.css`.",
             "Next, register the theme in the {$panelId} panel provider using `->viteTheme('resources/css/filament/{$panelId}/theme.css')`",
-            'Finally, run `npm run build` to compile the theme.',
+            "Finally, run `{$pm} run build` to compile the theme.",
         ]);
 
         return static::SUCCESS;

--- a/packages/panels/src/Commands/MakeThemeCommand.php
+++ b/packages/panels/src/Commands/MakeThemeCommand.php
@@ -17,11 +17,11 @@ class MakeThemeCommand extends Command
 
     protected $description = 'Create a new Filament panel theme';
 
-    protected $signature = 'make:filament-theme {panel?} {packet-manager?} {--F|force}';
+    protected $signature = 'make:filament-theme {panel?} {--pm=} {--F|force}';
 
     public function handle(): int
     {
-        $pm = $this->argument('packet-manager') ?? 'npm';
+        $pm = $this->option('pm') ?? 'npm';
 
         exec($pm . ' -v', $pmVersion, $pmVersionExistCode);
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Current make:filament-theme command had hardcoded npm package giving no possibility to use other package managers such as yarn or bun. This PR adds a new --pm option to the command which will let user to enter what package manager command should use.

Example usage:
`php artisan make:filament-theme admin --pm=bun`
`php artisan make:filament-theme admin --pm=yarn`