### PR TITLE
Adding assertions to verify that a notification was not sent

### DIFF
--- a/packages/notifications/.stubs.php
+++ b/packages/notifications/.stubs.php
@@ -6,6 +6,7 @@ namespace Livewire\Features\SupportTesting {
 
     class Testable {
         public function assertNotified(Notification | string $notification = null): static {}
+        
         public function assertNotNotified(Notification | string $notification = null): static {}
     }
 

--- a/packages/notifications/.stubs.php
+++ b/packages/notifications/.stubs.php
@@ -6,6 +6,7 @@ namespace Livewire\Features\SupportTesting {
 
     class Testable {
         public function assertNotified(Notification | string $notification = null): static {}
+        public function assertNotNotified(Notification | string $notification = null): static {}
     }
 
 }

--- a/packages/notifications/docs/06-testing.md
+++ b/packages/notifications/docs/06-testing.md
@@ -63,31 +63,23 @@ it('sends a notification', function () {
         );
 });
 ```
-Conversely, you can test if a notification was not sent:
+
+Conversely, you can assert that a notification was not sent:
+
 ```php
 use Filament\Notifications\Notification;
 use function Pest\Livewire\livewire;
 
 it('does not send a notification', function () {
     livewire(CreatePost::class)
-        ->assertNotNotified();
-```
-You can test that a notification was not sent with a given title:
-```php
-it('does not send a notification', function () {
-    livewire(CreatePost::class)
-        ->assertNotNotified('Unable to create post');
-});
-```
-Or with a given notification object:
-```php
-it('does not send a notification', function () {
-    livewire(CreatePost::class)
+        ->assertNotNotified()
+        // or
+        ->assertNotNotified('Unable to create post')
+        // or
         ->assertNotified(
             Notification::make()
                 ->danger()
                 ->title('Unable to create post')
                 ->body('Something went wrong.'),
         );
-});
 ```

--- a/packages/notifications/docs/06-testing.md
+++ b/packages/notifications/docs/06-testing.md
@@ -63,3 +63,31 @@ it('sends a notification', function () {
         );
 });
 ```
+Conversely, you can test if a notification was not sent:
+```php
+use Filament\Notifications\Notification;
+use function Pest\Livewire\livewire;
+
+it('does not send a notification', function () {
+    livewire(CreatePost::class)
+        ->assertNotNotified();
+```
+You can test that a notification was not sent with a given title:
+```php
+it('does not send a notification', function () {
+    livewire(CreatePost::class)
+        ->assertNotNotified('Unable to create post');
+});
+```
+Or with a given notification object:
+```php
+it('does not send a notification', function () {
+    livewire(CreatePost::class)
+        ->assertNotified(
+            Notification::make()
+                ->danger()
+                ->title('Unable to create post')
+                ->body('Something went wrong.'),
+        );
+});
+```

--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -311,4 +311,47 @@ class Notification extends ViewComponent implements Arrayable
 
         Assert::assertSame($expectedNotification->title, $notification);
     }
+
+    public static function assertNotNotified(Notification | string | null $notification = null): void
+    {
+        $notificationsLivewireComponent = new Notifications();
+        $notificationsLivewireComponent->mount();
+        $notifications = $notificationsLivewireComponent->notifications;
+
+        $expectedNotification = null;
+
+        Assert::assertIsArray($notifications->toArray());
+
+        if (is_string($notification)) {
+            $expectedNotification = $notifications->first(fn (Notification $mountedNotification): bool => $mountedNotification->title === $notification);
+        }
+
+        if ($notification instanceof Notification) {
+            $expectedNotification = $notifications->first(fn (Notification $mountedNotification, string $key): bool => $mountedNotification->id === $key);
+        }
+
+        if (blank($notification)) {
+            return;
+        }
+
+        //Assert::assertNull($expectedNotification, 'A notification was sent');
+
+        if ($notification instanceof Notification) {
+            Assert::assertNotSame(
+                collect($expectedNotification)->except(['id'])->toArray(),
+                collect($notification->toArray())->except(['id'])->toArray(),
+                'The notification with the given configration was sent'
+            );
+
+            return;
+        }
+
+        if($expectedNotification instanceof Notification) {
+            Assert::assertNotSame(
+                $expectedNotification->title,
+                $notification,
+                'The notification with the given title was sent'
+            );
+        }
+    }
 }

--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -346,7 +346,7 @@ class Notification extends ViewComponent implements Arrayable
             return;
         }
 
-        if($expectedNotification instanceof Notification) {
+        if ($expectedNotification instanceof Notification) {
             Assert::assertNotSame(
                 $expectedNotification->title,
                 $notification,

--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -334,8 +334,6 @@ class Notification extends ViewComponent implements Arrayable
             return;
         }
 
-        //Assert::assertNull($expectedNotification, 'A notification was sent');
-
         if ($notification instanceof Notification) {
             Assert::assertNotSame(
                 collect($expectedNotification)->except(['id'])->toArray(),

--- a/packages/notifications/src/Testing/TestsNotifications.php
+++ b/packages/notifications/src/Testing/TestsNotifications.php
@@ -22,4 +22,13 @@ class TestsNotifications
             return $this;
         };
     }
+
+    public function assertNotNotified(): Closure
+    {
+        return function (Notification | string | null $notification = null): static {
+            Notification::assertNotNotified($notification);
+
+            return $this;
+        };
+    }
 }

--- a/tests/src/Actions/ActionTest.php
+++ b/tests/src/Actions/ActionTest.php
@@ -265,3 +265,40 @@ test('can assert that notifications are sent in any order', function () {
         ->callAction('two-notifications')
         ->assertNotified('Third notification');
 });
+
+it('will assert that a notification was not sent', function () {
+
+    livewire(Actions::class)
+        ->callAction('does-not-show-notification')
+        ->assertNotNotified();
+
+    livewire(Actions::class)
+        ->callAction('shows-notification-with-id')
+        ->assertNotNotified(
+            Notification::make()
+                ->title('An incorrect notification')
+                ->success()
+        );
+
+    livewire(Actions::class)
+        ->callAction('shows-notification-with-id')
+        ->assertNotNotified('An incorrect notification');
+
+    $this->expectException('PHPUnit\Framework\ExpectationFailedException');
+    $this->expectExceptionMessage('The notification with the given configration was sent');
+
+    livewire(Actions::class)
+        ->callAction('shows-notification-with-id')
+        ->assertNotNotified(
+            Notification::make()
+                ->title('A notification')
+                ->success()
+        );
+
+    $this->expectException('PHPUnit\Framework\ExpectationFailedException');
+    $this->expectExceptionMessage('The notification with the given title was sent');
+
+    livewire(Actions::class)
+        ->callAction('shows-notification-with-id')
+        ->assertNotNotified('A notification');
+});


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

adding assertion of `assertNotNotified` to complement `assertNotified` to ensure that a notification is not triggered if some logic dictates.
