### PR TITLE
Load `az` locale from FilePond

### DIFF
--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -664,6 +664,7 @@ export default function fileUploadFormComponent({
 }
 
 import ar from 'filepond/locale/ar-ar'
+import az from 'filepond/locale/az-az'
 import cs from 'filepond/locale/cs-cz'
 import da from 'filepond/locale/da-dk'
 import de from 'filepond/locale/de-de'
@@ -690,6 +691,7 @@ import zh_TW from 'filepond/locale/zh-tw'
 
 const locales = {
     ar,
+    az,
     cs,
     da,
     de,


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
