### PR TITLE
Deprecated message when passing null value to Str::lower() method

### DIFF
--- a/packages/tables/src/Table/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSortRecords.php
@@ -24,7 +24,11 @@ trait CanSortRecords
             $this->defaultSortColumn = $column;
         }
 
-        $this->defaultSortDirection = Str::lower($direction);
+        if ($direction !== null) {
+            $direction = Str::lower($direction);
+        }
+        
+        $this->defaultSortDirection = $direction;
 
         return $this;
     }


### PR DESCRIPTION
Hello,

A little PR to get rid of a deprecated message when calling Str:lower with a null value since it only accepts string values (see [PHP docs](https://www.php.net/manual/en/function.mb-strtolower.php)).

![image](https://github.com/filamentphp/filament/assets/8366863/db470d90-8c34-403c-bff4-fcfa73931292)

