### PR TITLE
Update 08-users.md with missing semicolon

### DIFF
--- a/packages/panels/docs/08-users.md
+++ b/packages/panels/docs/08-users.md
@@ -50,7 +50,7 @@ class User extends Authenticatable implements FilamentUser
     public function canAccessPanel(Panel $panel): bool
     {
         if ($panel->getId() === 'admin') {
-            return str_ends_with($this->email, '@yourdomain.com') && $this->hasVerifiedEmail()
+            return str_ends_with($this->email, '@yourdomain.com') && $this->hasVerifiedEmail();
         }
 
         return true;


### PR DESCRIPTION
Missing semi colon at end of line in docs.

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
