### PR TITLE
Add stack('styles') to base.blade.php

### DIFF
--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -51,8 +51,6 @@
 
         @filamentStyles
 
-        @stack('styles')
-
         {{ filament()->getTheme()->getHtml() }}
         {{ filament()->getFontHtml() }}
 
@@ -63,6 +61,8 @@
                 --collapsed-sidebar-width: {{ filament()->getCollapsedSidebarWidth() }};
             }
         </style>
+
+        @stack('styles')
 
         {{ \Filament\Support\Facades\FilamentView::renderHook('panels::styles.after') }}
 

--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -50,6 +50,9 @@
         </style>
 
         @filamentStyles
+
+        @stack('styles')
+
         {{ filament()->getTheme()->getHtml() }}
         {{ filament()->getFontHtml() }}
 


### PR DESCRIPTION
There are times when you want to tweak the styling of one specific panel page using a custom view. In these cases, modifying the overall theme CSS isn't an option. Using `@push('styles')` is the best way to do it:

```
// custom-list-records.blade.php

@push('styles')
    <style>
        .fi-ta-ctn {
            background: none !important;
            border: none !important;
            box-shadow: none !important;
        }
    </style>
@endpush

<x-filament-panels::page
    @class([
        'fi-resource-list-records-page',
        'fi-resource-' . str_replace('/', '-', $this->getResource()::getSlug()),
    ])
>
    <div class="flex flex-col gap-y-6">
        <x-filament-panels::resources.tabs />

        {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.table.before', scopes: $this->getRenderHookScopes()) }}

        {{ $this->table }}

        {{ \Filament\Support\Facades\FilamentView::renderHook('panels::resource.pages.list-records.table.after', scopes: $this->getRenderHookScopes()) }}
    </div>
</x-filament-panels::page>
```

Using `@push` and `@stack` to add styles to the `<head>` is a lot cleaner than adding inline CSS in the `<body>` of custom views. I've put `@stack('styles')` under `@filamentStyles` so any custom styling takes precedence.