### PR TITLE
Now allowing defaultSort()'s  argument to be a Closure.

### DIFF
--- a/packages/tables/src/Table/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSortRecords.php
@@ -10,7 +10,7 @@ trait CanSortRecords
 {
     protected ?string $defaultSortColumn = null;
 
-    protected string | Closure | null $defaultSortDirection = null;
+    protected ?string $defaultSortDirection = null;
 
     protected ?Closure $defaultSortQuery = null;
 
@@ -22,6 +22,12 @@ trait CanSortRecords
             $this->defaultSortQuery = $column;
         } else {
             $this->defaultSortColumn = $column;
+        }
+
+        $direction = $this->evaluate($direction);
+
+        if ($direction !== null) {
+            return Str::lower($direction);
         }
 
         $this->defaultSortDirection = $direction;
@@ -62,7 +68,7 @@ trait CanSortRecords
 
     public function getDefaultSortDirection(): ?string
     {
-        return Str::lower($this->evaluate($this->defaultSortDirection));
+        return $this->defaultSortDirection;
     }
 
     public function getDefaultSortQuery(): ?Closure

--- a/packages/tables/src/Table/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSortRecords.php
@@ -27,7 +27,7 @@ trait CanSortRecords
         $direction = $this->evaluate($direction);
 
         if ($direction !== null) {
-            return Str::lower($direction);
+            $direction = Str::lower($direction);
         }
 
         $this->defaultSortDirection = $direction;

--- a/packages/tables/src/Table/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSortRecords.php
@@ -10,7 +10,7 @@ trait CanSortRecords
 {
     protected ?string $defaultSortColumn = null;
 
-    protected ?string $defaultSortDirection = null;
+    protected string | Closure | null $defaultSortDirection = null;
 
     protected ?Closure $defaultSortQuery = null;
 
@@ -22,12 +22,6 @@ trait CanSortRecords
             $this->defaultSortQuery = $column;
         } else {
             $this->defaultSortColumn = $column;
-        }
-
-        $direction = $this->evaluate($direction);
-
-        if ($direction !== null) {
-            $direction = Str::lower($direction);
         }
 
         $this->defaultSortDirection = $direction;
@@ -68,7 +62,13 @@ trait CanSortRecords
 
     public function getDefaultSortDirection(): ?string
     {
-        return $this->defaultSortDirection;
+        $direction = $this->evaluate($this->defaultSortDirection);
+
+        if ($direction !== null) {
+            $direction = Str::lower($direction);
+        }
+
+        return $direction;
     }
 
     public function getDefaultSortQuery(): ?Closure

--- a/packages/tables/src/Table/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSortRecords.php
@@ -10,7 +10,7 @@ trait CanSortRecords
 {
     protected ?string $defaultSortColumn = null;
 
-    protected ?string $defaultSortDirection = null;
+    protected string | Closure | null $defaultSortDirection = null;
 
     protected ?Closure $defaultSortQuery = null;
 
@@ -22,10 +22,6 @@ trait CanSortRecords
             $this->defaultSortQuery = $column;
         } else {
             $this->defaultSortColumn = $column;
-        }
-
-        if ($direction !== null) {
-            $direction = Str::lower($direction);
         }
 
         $this->defaultSortDirection = $direction;
@@ -66,7 +62,7 @@ trait CanSortRecords
 
     public function getDefaultSortDirection(): ?string
     {
-        return $this->evaluate($this->defaultSortDirection);
+        return Str::lower($this->evaluate($this->defaultSortDirection));
     }
 
     public function getDefaultSortQuery(): ?Closure


### PR DESCRIPTION
The `Filament\Tables\Table\Concerns\CanSortRecords` trait's `defaultSort()` method has the following signature:
```php
public function defaultSort(string | Closure | null $column, string | Closure | null $direction = 'asc'): static
```
The `$direction` argument, if not `null`, is passed through `Str::lower()` and then assigned to `$this->defaultSortDirection`, which is a nullable string.

**There is at least one problem**: if a Closure is passed, then `Str::lower()` chokes on it.

![image](https://github.com/filamentphp/filament/assets/53731/b2016366-6047-4d0d-96ed-6ae0bc35312c)

I decided to do the following:

- pass `$direction` through `evaluate()` right away and allow the rest of the code/types to remain as they are currently
- remove the "last minute" call to `evaluate()` in `getDefaultSortDirection()`

All existing tests pass.  No new tests were added.