### PR TITLE
Allow dropdowns to be fixed

### DIFF
--- a/packages/support/resources/views/components/dropdown/index.blade.php
+++ b/packages/support/resources/views/components/dropdown/index.blade.php
@@ -6,7 +6,7 @@
     'teleport' => false,
     'trigger' => null,
     'width' => null,
-    'fixed' => true,
+    'fixed' => false,
 ])
 
 <div

--- a/packages/support/resources/views/components/dropdown/index.blade.php
+++ b/packages/support/resources/views/components/dropdown/index.blade.php
@@ -6,6 +6,7 @@
     'teleport' => false,
     'trigger' => null,
     'width' => null,
+    'fixed' => true,
 ])
 
 <div
@@ -42,7 +43,9 @@
             wire:key="{{ $attributes->get('wire:key') }}.panel"
         @endif
         @class([
-            'fi-dropdown-panel absolute z-10 w-screen divide-y divide-gray-100 rounded-lg bg-white shadow-lg ring-1 ring-gray-950/5 transition dark:divide-white/5 dark:bg-gray-900 dark:ring-white/10',
+            'fi-dropdown-panel z-10 w-screen divide-y divide-gray-100 rounded-lg bg-white shadow-lg ring-1 ring-gray-950/5 transition dark:divide-white/5 dark:bg-gray-900 dark:ring-white/10',
+            'fixed' => $fixed,
+            'absolute' => ! $fixed,
             match ($width) {
                 'xs' => 'max-w-xs',
                 'sm' => 'max-w-sm',


### PR DESCRIPTION
Currently the dropdown panel is positioned with `absolute` for `x-float`. However when using a dropdown inside of a dropdown, this causes the nested dropdown panel to get positioned based on a parent container instead of the viewport. This causes the position to be off in certain instances:

Example 1: The nested panel flips up even though there is viewport space below, becuase the table "parent" is smaller than the panel. 
![Screenshot_2023-11-04_at_10 20 52_AM](https://github.com/filamentphp/filament/assets/6097099/a24d8866-d6b3-47f4-9e39-19b9f98d4b83)

This is even a bigger issue when the panel is taller than the viewport as the navbar covers it up.
![image](https://github.com/filamentphp/filament/assets/6097099/6fc1fedb-e8ea-48b5-8d30-59a9d862d71d)


Example 2: The nested panel shifts to the left because it's tied with the table. This pushes the panel offscreen causing scrolling.
![Screenshot 2023-11-04 at 10 15 55 AM](https://github.com/filamentphp/filament/assets/6097099/c0291a1a-b484-4eb3-baf5-40631b52b7f9)

This PR allows a dropdown to be positioned with `fixed` instead of `absolute`. The default continues to be `absolute` to avoid breaking changes. This is one of the recommended strategies by floating-ui: https://floating-ui.com/docs/misc#clipping

With fixed the above issues are resolved:

![Screenshot_2023-11-04_at_10 37 24_AM](https://github.com/filamentphp/filament/assets/6097099/f52bd85d-bdd6-4727-ae4b-4938b8f8b0cf)
![Screenshot_2023-11-04_at_10 37 41_AM](https://github.com/filamentphp/filament/assets/6097099/69c8a4df-e668-456e-8c1e-aa9bb3b0427b)



- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
