### PR TITLE
Restore using HasOneThrough for filters

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -1183,16 +1183,18 @@ class Select extends Field implements Contracts\HasAffixActions, Contracts\HasNe
     {
         if ($relationship instanceof BelongsToMany) {
             return $relationship->getQualifiedRelatedKeyName();
-        } elseif ($relationship instanceof HasOneThrough) {
-            $relatedKeyName = $relationship->getQualifiedForeignKeyName();
-        } elseif ($relationship instanceof \Znck\Eloquent\Relations\BelongsToThrough) {
-            $relatedKeyName = $relationship->getRelated()->getQualifiedKeyName();
-        } else {
-            /** @var BelongsTo $relationship */
-
-            $relatedKeyName = $relationship->getQualifiedOwnerKeyName();
         }
 
-        return $relatedKeyName;
+        if ($relationship instanceof HasOneThrough) {
+            return $relationship->getQualifiedForeignKeyName();
+        }
+
+        if ($relationship instanceof \Znck\Eloquent\Relations\BelongsToThrough) {
+            return $relationship->getRelated()->getQualifiedKeyName();
+        }
+
+        /** @var BelongsTo $relationship */
+
+        return $relationship->getQualifiedOwnerKeyName();
     }
 }

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -829,7 +829,10 @@ class Select extends Field implements Contracts\HasAffixActions, Contracts\HasNe
                 return;
             }
 
-            if ($relationship instanceof \Znck\Eloquent\Relations\BelongsToThrough) {
+            if (
+                ($relationship instanceof HasOneThrough) ||
+                ($relationship instanceof \Znck\Eloquent\Relations\BelongsToThrough)
+            ) {
                 $relatedModel = $relationship->getResults();
 
                 $component->state(


### PR DESCRIPTION
- [ ] Changes have been thoroughly tested to not break existing functionality.
All of the tests are passing.

- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
I'm not sure that supporting different relationship types is documented anywhere. There is no reference to `\Znck\Eloquent\Relations\BelongsToThrough` in the docs.

- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
No visual changes.

As my primary concern is restoring functionality that appears to have been added twice already in #2486 and #5550, I've focused my testing on getting that working.

However, I did notice one area that might need additional work to fully support HasOneThrough, but I'm not really sure how to work on it. The anonymous function starts on line 811, called by `$this->loadStateFromRelationshipsUsing()`.