### PR TITLE
Use wire:navigate for create and edit page redirects when SPA mode is enabled

### DIFF
--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -2,17 +2,18 @@
 
 namespace Filament\Resources\Pages;
 
-use Filament\Actions\Action;
-use Filament\Actions\ActionGroup;
-use Filament\Facades\Filament;
 use Filament\Forms\Form;
-use Filament\Notifications\Notification;
-use Filament\Pages\Concerns\InteractsWithFormActions;
-use Filament\Support\Exceptions\Halt;
-use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Support\Str;
+use Filament\Actions\Action;
+use Filament\Facades\Filament;
+use Filament\Actions\ActionGroup;
+use Filament\Support\Exceptions\Halt;
+use Illuminate\Database\Eloquent\Model;
+use Filament\Notifications\Notification;
+use Filament\Support\Facades\FilamentView;
+use Illuminate\Contracts\Support\Htmlable;
+use Filament\Pages\Concerns\InteractsWithFormActions;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
 /**
  * @property Form $form
@@ -25,11 +26,6 @@ class CreateRecord extends Page
      * @var view-string
      */
     protected static string $view = 'filament-panels::resources.pages.create-record';
-
-    /**
-     * @var bool
-     */    
-    protected bool $useWireNavigateForRedirect = false;
 
     public ?Model $record = null;
 
@@ -137,7 +133,14 @@ class CreateRecord extends Page
             return;
         }
 
-        $this->redirect($this->getRedirectUrl(), navigate: $this->useWireNavigateForRedirect);
+        $redirectUrl = $this->getRedirectUrl();
+
+        if (FilamentView::hasSpaMode()) {
+            $isInternalUrl = Str::startsWith($redirectUrl, [config('app.url'), '/']);
+            $this->redirect($redirectUrl, navigate: $isInternalUrl);
+        } else {
+            $this->redirect($redirectUrl);
+        }
     }
 
     protected function getCreatedNotification(): ?Notification

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -26,6 +26,11 @@ class CreateRecord extends Page
      */
     protected static string $view = 'filament-panels::resources.pages.create-record';
 
+    /**
+     * @var bool
+     */    
+    protected bool $useWireNavigateForRedirect = false;
+
     public ?Model $record = null;
 
     /**
@@ -132,7 +137,7 @@ class CreateRecord extends Page
             return;
         }
 
-        $this->redirect($this->getRedirectUrl());
+        $this->redirect($this->getRedirectUrl(), navigate: $this->useWireNavigateForRedirect);
     }
 
     protected function getCreatedNotification(): ?Notification

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -138,7 +138,7 @@ class CreateRecord extends Page
         $redirectUrl = $this->getRedirectUrl();
 
         if (FilamentView::hasSpaMode()) {
-            $this->redirect($redirectUrl, navigate: is_internal_url($redirectUrl));
+            $this->redirect($redirectUrl, navigate: is_app_url($redirectUrl));
         } else {
             $this->redirect($redirectUrl);
         }

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -15,6 +15,8 @@ use Illuminate\Contracts\Support\Htmlable;
 use Filament\Pages\Concerns\InteractsWithFormActions;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
+use function Filament\Support\is_internal_url;
+
 /**
  * @property Form $form
  */
@@ -136,8 +138,7 @@ class CreateRecord extends Page
         $redirectUrl = $this->getRedirectUrl();
 
         if (FilamentView::hasSpaMode()) {
-            $isInternalUrl = Str::startsWith($redirectUrl, [config('app.url'), '/']);
-            $this->redirect($redirectUrl, navigate: $isInternalUrl);
+            $this->redirect($redirectUrl, navigate: is_internal_url($redirectUrl));
         } else {
             $this->redirect($redirectUrl);
         }

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -15,7 +15,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Filament\Pages\Concerns\InteractsWithFormActions;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
-use function Filament\Support\is_internal_url;
+use function Filament\Support\is_app_url;
 
 /**
  * @property Form $form

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -18,7 +18,7 @@ use Filament\Support\Facades\FilamentView;
 use Illuminate\Contracts\Support\Htmlable;
 use Filament\Pages\Concerns\InteractsWithFormActions;
 
-use function Filament\Support\is_internal_url;
+use function Filament\Support\is_app_url;
 
 /**
  * @property Form $form

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -19,6 +19,8 @@ use Filament\Support\Facades\FilamentView;
 use Illuminate\Contracts\Support\Htmlable;
 use Filament\Pages\Concerns\InteractsWithFormActions;
 
+use function Filament\Support\is_internal_url;
+
 /**
  * @property Form $form
  */
@@ -158,8 +160,7 @@ class EditRecord extends Page
 
         if ($shouldRedirect && ($redirectUrl = $this->getRedirectUrl())) {
             if (FilamentView::hasSpaMode()) {
-                $isInternalUrl = Str::startsWith($redirectUrl, [config('app.url'), '/']);
-                $this->redirect($redirectUrl, navigate: $isInternalUrl);
+                $this->redirect($redirectUrl, navigate: is_internal_url($redirectUrl));
             } else {
                 $this->redirect($redirectUrl);
             }

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -3,7 +3,6 @@
 namespace Filament\Resources\Pages;
 
 use Filament\Forms\Form;
-use Illuminate\Support\Str;
 use Filament\Actions\Action;
 use Filament\Actions\ViewAction;
 use Filament\Infolists\Infolist;

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -159,7 +159,7 @@ class EditRecord extends Page
 
         if ($shouldRedirect && ($redirectUrl = $this->getRedirectUrl())) {
             if (FilamentView::hasSpaMode()) {
-                $this->redirect($redirectUrl, navigate: is_internal_url($redirectUrl));
+                $this->redirect($redirectUrl, navigate: is_app_url($redirectUrl));
             } else {
                 $this->redirect($redirectUrl);
             }

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -2,20 +2,22 @@
 
 namespace Filament\Resources\Pages;
 
+use Filament\Forms\Form;
+use Illuminate\Support\Str;
 use Filament\Actions\Action;
+use Filament\Actions\ViewAction;
+use Filament\Infolists\Infolist;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\DeleteAction;
-use Filament\Actions\ForceDeleteAction;
-use Filament\Actions\ReplicateAction;
 use Filament\Actions\RestoreAction;
-use Filament\Actions\ViewAction;
-use Filament\Forms\Form;
-use Filament\Infolists\Infolist;
-use Filament\Notifications\Notification;
-use Filament\Pages\Concerns\InteractsWithFormActions;
+use Filament\Actions\ReplicateAction;
 use Filament\Support\Exceptions\Halt;
-use Illuminate\Contracts\Support\Htmlable;
+use Filament\Actions\ForceDeleteAction;
 use Illuminate\Database\Eloquent\Model;
+use Filament\Notifications\Notification;
+use Filament\Support\Facades\FilamentView;
+use Illuminate\Contracts\Support\Htmlable;
+use Filament\Pages\Concerns\InteractsWithFormActions;
 
 /**
  * @property Form $form
@@ -30,11 +32,6 @@ class EditRecord extends Page
      * @var view-string
      */
     protected static string $view = 'filament-panels::resources.pages.edit-record';
-
-    /**
-     * @var bool
-     */    
-    protected bool $useWireNavigateForRedirect = false;
 
     /**
      * @var array<string, mixed> | null
@@ -160,7 +157,12 @@ class EditRecord extends Page
         $this->getSavedNotification()?->send();
 
         if ($shouldRedirect && ($redirectUrl = $this->getRedirectUrl())) {
-            $this->redirect($redirectUrl, navigate: $this->useWireNavigateForRedirect);
+            if (FilamentView::hasSpaMode()) {
+                $isInternalUrl = Str::startsWith($redirectUrl, [config('app.url'), '/']);
+                $this->redirect($redirectUrl, navigate: $isInternalUrl);
+            } else {
+                $this->redirect($redirectUrl);
+            }
         }
     }
 

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -32,6 +32,11 @@ class EditRecord extends Page
     protected static string $view = 'filament-panels::resources.pages.edit-record';
 
     /**
+     * @var bool
+     */    
+    protected bool $useWireNavigateForRedirect = false;
+
+    /**
      * @var array<string, mixed> | null
      */
     public ?array $data = [];
@@ -155,7 +160,7 @@ class EditRecord extends Page
         $this->getSavedNotification()?->send();
 
         if ($shouldRedirect && ($redirectUrl = $this->getRedirectUrl())) {
-            $this->redirect($redirectUrl);
+            $this->redirect($redirectUrl, navigate: $this->useWireNavigateForRedirect);
         }
     }
 

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -133,10 +133,10 @@ if (! function_exists('Filament\Support\is_slot_empty')) {
     }
 }
 
-if (! function_exists('Filament\Support\is_internal_url')) {
+if (! function_exists('Filament\Support\is_app_url')) {
     function is_internal_url(string $url): bool
     {
-        return Str::startsWith($url, [config('app.url'), '/']);
+        return str($url)->startsWith(request()->root());
     }
 }
 
@@ -147,7 +147,7 @@ if (! function_exists('Filament\Support\generate_href_html')) {
 
         if ($shouldOpenInNewTab) {
             $html .= ' target="_blank"';
-        } elseif (FilamentView::hasSpaMode() && str($url)->startsWith(request()->root())) {
+        } elseif (FilamentView::hasSpaMode() && is_app_url($url)) {
             $html .= ' wire:navigate';
         }
 

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -134,7 +134,7 @@ if (! function_exists('Filament\Support\is_slot_empty')) {
 }
 
 if (! function_exists('Filament\Support\is_app_url')) {
-    function is_internal_url(string $url): bool
+    function is_app_url(string $url): bool
     {
         return str($url)->startsWith(request()->root());
     }

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -133,6 +133,13 @@ if (! function_exists('Filament\Support\is_slot_empty')) {
     }
 }
 
+if (! function_exists('Filament\Support\is_internal_url')) {
+    function is_internal_url(string $url): bool
+    {
+        return Str::startsWith($url, [config('app.url'), '/']);
+    }
+}
+
 if (! function_exists('Filament\Support\generate_href_html')) {
     function generate_href_html(?string $url, bool $shouldOpenInNewTab = false): Htmlable
     {


### PR DESCRIPTION
Adds a property to enable `navigate: true` for create and edit page redirects. [See these Livewire docs](https://livewire.laravel.com/docs/navigate#redirects) for more info.

This should be configurable independently of SPA mode for these pages because we sometimes need to redirect to external URLs (and external URLs don't work when `navigate:` is set to `true`).

Another option could be adding logic to check if the supplied URL is internal or external when SPA mode is enabled but that will add some performance overhead. Not sure if it's worth it, what do you reckon? Maybe better to just allow toggling it with a property.