### PR TITLE
Fix: added missing old  param on afterStateUpdated for upload field

### DIFF
--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -195,7 +195,7 @@ class BaseFileUpload extends Field
 
             $this->evaluate($callback, [
                 'state' => $this->isMultiple() ? $state : Arr::first($state ?? []),
-                'old'   => $this->getOldState(),
+                'old' => $this->isMultiple() ? $this->getOldState() : Arr::first($this->getOldState() ?? []),
             ]);
         }
 

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -195,6 +195,7 @@ class BaseFileUpload extends Field
 
             $this->evaluate($callback, [
                 'state' => $this->isMultiple() ? $state : Arr::first($state ?? []),
+                'old'   => $this->getOldState(),
             ]);
         }
 

--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -229,6 +229,19 @@ trait InteractsWithForms
 
     public function updatingInteractsWithForms(string $statePath): void
     {
+        // is it UploadField with 3 part state?
+        $parts = explode(".", $statePath);
+
+        if(count($parts) > 2) {
+            array_pop($parts);
+
+            $newStatePath = implode(".", $parts);
+
+            $uploadedFiles = $this->getFormUploadedFiles($newStatePath);
+
+            $statePath = blank($uploadedFiles) ? $statePath : $newStatePath;
+        }
+
         $this->oldFormState[$statePath] = data_get($this, $statePath);
     }
 

--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -229,25 +229,14 @@ trait InteractsWithForms
 
     public function updatingInteractsWithForms(string $statePath): void
     {
-        // is it UploadField with 3 part state?
-        $parts = explode(".", $statePath);
-
-        if(count($parts) > 2) {
-            array_pop($parts);
-
-            $newStatePath = implode(".", $parts);
-
-            $uploadedFiles = $this->getFormUploadedFiles($newStatePath);
-
-            $statePath = blank($uploadedFiles) ? $statePath : $newStatePath;
-        }
+        $statePath = (string) str($statePath)->before('.');
 
         $this->oldFormState[$statePath] = data_get($this, $statePath);
     }
 
     public function getOldFormState(string $statePath): mixed
     {
-        return $this->oldFormState[$statePath] ?? null;
+        return data_get($this->oldFormState, $statePath);
     }
 
     public function updatedInteractsWithForms(string $statePath): void


### PR DESCRIPTION
As mentioned in issue #9185, for upload field the `old` param is not injected in `afterStateUpdated` callback. I have added `old` param for that function in this way:

The problem with the upload field is that the `$statePath` contains three parts instead of the usual two found in other fields. It appears like this: `data.{field_name}.{some_random_uuid}`, for example, `data.myfile.f0f5612c-a7fd-4333-a0c9-c1b2cc4a58da`. This unique structure complicates tracking the state of the actual field (`data.myfile`).

To address this, I made a fix in the `updatingInteractsWithForms` function. I added logic to check the number of parts in the `statePath`. If it has three parts, I remove the extra part from the `statePath` before saving the state of that field in the `oldFormState` array. Additionally, I check if there is any uploaded data for that field using `$this->getFormUploadedFiles($newStatePath)`.

Since I'm relatively new to Filament core, I would appreciate feedback on whether this is the correct way to resolve the issue. If not, I'm eager to learn and make necessary adjustments.