### PR TITLE
making default widgets not lazy by default

### DIFF
--- a/packages/panels/src/Widgets/AccountWidget.php
+++ b/packages/panels/src/Widgets/AccountWidget.php
@@ -6,6 +6,8 @@ class AccountWidget extends Widget
 {
     protected static ?int $sort = -3;
 
+    protected static bool $isLazy = false;
+
     /**
      * @var view-string
      */

--- a/packages/panels/src/Widgets/FilamentInfoWidget.php
+++ b/packages/panels/src/Widgets/FilamentInfoWidget.php
@@ -6,6 +6,8 @@ class FilamentInfoWidget extends Widget
 {
     protected static ?int $sort = -2;
 
+    protected static bool $isLazy = false;
+
     /**
      * @var view-string
      */


### PR DESCRIPTION
Added $isLazy property to AccountWidget and FilamentInfoWidget and make it false.

default widgets do not seem to be lazy loaded as they have very minimal information and no need for an extra request for loading them...