### PR TITLE
Correction of indentation during file creation.

### DIFF
--- a/packages/support/src/Commands/Concerns/CanIndentStrings.php
+++ b/packages/support/src/Commands/Concerns/CanIndentStrings.php
@@ -9,7 +9,7 @@ trait CanIndentStrings
         return implode(
             PHP_EOL,
             array_map(
-                fn (string $line) => $line === '' ? '' : str_repeat('    ', $level) . "{$line}",
+                fn (string $line) => ($line !== '') ? (str_repeat('    ', $level) . "{$line}") : '',
                 explode(PHP_EOL, $string),
             ),
         );

--- a/packages/support/src/Commands/Concerns/CanIndentStrings.php
+++ b/packages/support/src/Commands/Concerns/CanIndentStrings.php
@@ -9,7 +9,7 @@ trait CanIndentStrings
         return implode(
             PHP_EOL,
             array_map(
-                fn (string $line) => str_repeat('    ', $level) . "{$line}",
+                fn (string $line) => $line === '' ? '' : str_repeat('    ', $level) . "{$line}",
                 explode(PHP_EOL, $string),
             ),
         );


### PR DESCRIPTION
- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

When creating resource files, the indentation is not consistent, and manual corrections are required each time. 
I have made a fix to address this issue.

I have conducted the verification as follows.


```bash
php artisan make:filament-resource Customer
```
|before|after|
|---|---|
|![スクリーンショット 2023-11-07 2 10 51](https://github.com/filamentphp/filament/assets/28666304/39698097-2a8c-49ca-8ffb-6af52e9bd9d2)|![スクリーンショット 2023-11-07 2 12 29](https://github.com/filamentphp/filament/assets/28666304/0703462a-92c7-4562-b26d-39c2d8435fda)|

```bash
php artisan make:filament-resource Customer --soft-deletes
```
|before|after|
|---|---|
|![スクリーンショット 2023-11-07 2 14 46](https://github.com/filamentphp/filament/assets/28666304/d0ca593a-4826-431a-8fd7-6bc57f64588d)|![スクリーンショット 2023-11-07 2 15 56](https://github.com/filamentphp/filament/assets/28666304/be62a4ad-80c7-469f-b486-2fa081fd5788)|

Please confirm.