### PR TITLE
Fix inline label for placeholder field

### DIFF
--- a/packages/forms/resources/views/components/placeholder.blade.php
+++ b/packages/forms/resources/views/components/placeholder.blade.php
@@ -3,6 +3,7 @@
     :id="$getId()"
     :label="$getLabel()"
     :label-sr-only="$isLabelHidden()"
+    :has-inline-label="$hasInlineLabel()"
     :helper-text="$getHelperText()"
     :hint="$getHint()"
     :hint-actions="$getHintActions()"

--- a/packages/forms/resources/views/components/placeholder.blade.php
+++ b/packages/forms/resources/views/components/placeholder.blade.php
@@ -11,16 +11,20 @@
     :hint-icon="$getHintIcon()"
     :state-path="$getStatePath()"
 >
+    @php
+        $content = $getContent();
+    @endphp
+    
     <div
         {{
             $attributes
                 ->merge($getExtraAttributes(), escape: false)
                 ->class([
                     'fi-fo-placeholder sm:text-sm',
-                    'py-1.5' => $hasInlineLabel() && !$getContent() instanceof \Illuminate\Contracts\Support\Htmlable
+                    'py-1.5' => $hasInlineLabel() && (! $content instanceof \Illuminate\Contracts\Support\Htmlable),
                 ])
         }}
     >
-        {{ $getContent() }}
+        {{ $content }}
     </div>
 </x-dynamic-component>

--- a/packages/forms/resources/views/components/placeholder.blade.php
+++ b/packages/forms/resources/views/components/placeholder.blade.php
@@ -15,7 +15,10 @@
         {{
             $attributes
                 ->merge($getExtraAttributes(), escape: false)
-                ->class(['fi-fo-placeholder sm:text-sm'])
+                ->class([
+                    'fi-fo-placeholder sm:text-sm',
+                    'py-1.5' => $hasInlineLabel() && !$getContent() instanceof \Illuminate\Contracts\Support\Htmlable
+                ])
         }}
     >
         {{ $getContent() }}


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

```php
Placeholder::make('Info')
    ->inlineLabel()
    ->content('Lorem ipsum dolor sit amet')
```

Before:
![image](https://github.com/filamentphp/filament/assets/26832856/aee78410-1193-4fb8-ac3b-a49c27969ba4)

After:
![image](https://github.com/filamentphp/filament/assets/26832856/96dd49cd-8c36-4ae6-932d-f5f53401c529)

> Currently, for plain string content, it is up to the developers how to align the vertical position (since it is much easier than manually setting up inline label). Let me know if there's a suggestion.