### PR TITLE
Amending `assertColumnExists` to accept `Closure` to test configuration

### DIFF
--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -117,7 +117,7 @@ namespace Livewire\Features\SupportTesting {
 
         public function assertCanNotRenderTableColumn(string $name): static {}
 
-        public function assertTableColumnExists(string $name): static {}
+        public function assertTableColumnExists(string $name, ?\Closure $checkColumnUsing = null): static {}
 
         public function assertTableColumnVisible(string $name): static {}
 

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -3,6 +3,7 @@
 namespace Livewire\Features\SupportTesting {
 
     use Illuminate\Support\Collection;
+    use Closure;
 
     class Testable {
         public function mountTableAction(string $name, $record = null): static {}
@@ -117,7 +118,7 @@ namespace Livewire\Features\SupportTesting {
 
         public function assertCanNotRenderTableColumn(string $name): static {}
 
-        public function assertTableColumnExists(string $name, ?\Closure $checkColumnUsing = null): static {}
+        public function assertTableColumnExists(string $name, ?Closure $checkColumnUsing = null, $record = null): static {}
 
         public function assertTableColumnVisible(string $name): static {}
 

--- a/packages/tables/docs/12-testing.md
+++ b/packages/tables/docs/12-testing.md
@@ -175,18 +175,17 @@ it('has an author column', function () {
 });
 ```
 
-You can pass an additional `Closure` with a record's model or key to check the configuration of a column:
+You can pass an additional function, alongside a record's model instance or key, to check the configuration of a column. The function will pass in the column instance, and you should return a boolean based on if the check passed:
 
 ```php
 use function Pest\Livewire\livewire;
 use Filament\Tables\Columns\TextColumn;
-use App\Models\Post;
 
 it('has an author column', function () {
     $post = Post::factory()->create();
     
     livewire(PostResource\Pages\ListPosts::class)
-        ->assertTableColumnExists('author', function (TextColumn $column) {
+        ->assertTableColumnExists('author', function (TextColumn $column): bool {
             return $column->isSortable();
         }, $post);
 });
@@ -609,6 +608,7 @@ To ensure an action or bulk action has the correct URL traits, you can use `asse
 
 ```php
 use function Pest\Livewire\livewire;
+
 it('links to the correct Filament sites', function () {
     $post = Post::factory()->create();
 

--- a/packages/tables/docs/12-testing.md
+++ b/packages/tables/docs/12-testing.md
@@ -175,6 +175,19 @@ it('has an author column', function () {
 });
 ```
 
+You can pass an additional `Closure` to check the configuration of a column:
+```php
+use function Pest\Livewire\livewire;
+use \Filament\Tables\Columns\TextColumn;
+
+it('has an author column', function () {
+    livewire(PostResource\Pages\ListPosts::class)
+        ->assertTableColumnExists(`author`, function(TextColumn $column) {
+            return $column->isSortable();
+        });
+});
+```
+
 ### Authorization
 
 To ensure that a particular user cannot see a column, you can use the `assertTableColumnVisible()` and `assertTableColumnHidden()` methods:

--- a/packages/tables/docs/12-testing.md
+++ b/packages/tables/docs/12-testing.md
@@ -186,7 +186,7 @@ it('has an author column', function () {
     
     livewire(PostResource\Pages\ListPosts::class)
         ->assertTableColumnExists('author', function (TextColumn $column): bool {
-            return $column->isSortable();
+            return $column->getDescriptionBelow() === $post->subtitle;
         }, $post);
 });
 ```

--- a/packages/tables/docs/12-testing.md
+++ b/packages/tables/docs/12-testing.md
@@ -175,16 +175,18 @@ it('has an author column', function () {
 });
 ```
 
-You can pass an additional `Closure` to check the configuration of a column:
+You can pass an additional `Closure` with a record's model or key to check the configuration of a column:
 ```php
 use function Pest\Livewire\livewire;
-use \Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Columns\TextColumn;
+use App\Models\Post;
 
 it('has an author column', function () {
+    $post = \App\Models\Post::factory()->create();
     livewire(PostResource\Pages\ListPosts::class)
         ->assertTableColumnExists(`author`, function(TextColumn $column) {
             return $column->isSortable();
-        });
+        }, $post);
 });
 ```
 

--- a/packages/tables/docs/12-testing.md
+++ b/packages/tables/docs/12-testing.md
@@ -176,15 +176,17 @@ it('has an author column', function () {
 ```
 
 You can pass an additional `Closure` with a record's model or key to check the configuration of a column:
+
 ```php
 use function Pest\Livewire\livewire;
 use Filament\Tables\Columns\TextColumn;
 use App\Models\Post;
 
 it('has an author column', function () {
-    $post = \App\Models\Post::factory()->create();
+    $post = Post::factory()->create();
+    
     livewire(PostResource\Pages\ListPosts::class)
-        ->assertTableColumnExists(`author`, function(TextColumn $column) {
+        ->assertTableColumnExists('author', function (TextColumn $column) {
             return $column->isSortable();
         }, $post);
 });

--- a/packages/tables/docs/12-testing.md
+++ b/packages/tables/docs/12-testing.md
@@ -175,7 +175,7 @@ it('has an author column', function () {
 });
 ```
 
-You can pass an additional function, alongside a record's model instance or key, to check the configuration of a column. The function will pass in the column instance, and you should return a boolean based on if the check passed:
+You may pass a function as an additional argument in order to assert that a column passes a given "truth test". This is useful for asserting that a column has a specific configuration. You can also pass in a record as the third parameter, which is useful if your check is dependant on which table row is being rendered:
 
 ```php
 use function Pest\Livewire\livewire;

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -60,7 +60,7 @@ class TestsColumns
 
     public function assertTableColumnExists(): Closure
     {
-        return function (string $name): static {
+        return function (string $name, ?Closure $checkColumnUsing = null): static {
             $column = $this->instance()->getTable()->getColumn($name);
 
             $livewireClass = $this->instance()::class;
@@ -70,6 +70,13 @@ class TestsColumns
                 $column,
                 message: "Failed asserting that a table column with name [{$name}] exists on the [{$livewireClass}] component.",
             );
+
+            if ($checkColumnUsing) {
+                Assert::assertTrue(
+                    $checkColumnUsing($column),
+                    "Failed asserting that a field with the name [{$name}] and provided configuration exists on the [{$livewireClass}] component."
+                );
+            }
 
             return $this;
         };

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -60,7 +60,7 @@ class TestsColumns
 
     public function assertTableColumnExists(): Closure
     {
-        return function (string $name, ?Closure $checkColumnUsing = null): static {
+        return function (string $name, ?Closure $checkColumnUsing = null, $record = null): static {
             $column = $this->instance()->getTable()->getColumn($name);
 
             $livewireClass = $this->instance()::class;
@@ -71,7 +71,15 @@ class TestsColumns
                 message: "Failed asserting that a table column with name [{$name}] exists on the [{$livewireClass}] component.",
             );
 
-            if ($checkColumnUsing) {
+            if($record) {
+                if (! ($record instanceof Model)) {
+                    $record = $this->instance()->getTableRecord($record);
+                }
+
+                $column->record($record);
+            }
+
+            if ($checkColumnUsing && $column->getRecord()) {
                 Assert::assertTrue(
                     $checkColumnUsing($column),
                     "Failed asserting that a field with the name [{$name}] and provided configuration exists on the [{$livewireClass}] component."

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -71,7 +71,7 @@ class TestsColumns
                 message: "Failed asserting that a table column with name [{$name}] exists on the [{$livewireClass}] component.",
             );
 
-            if($record) {
+            if ($record) {
                 if (! ($record instanceof Model)) {
                     $record = $this->instance()->getTableRecord($record);
                 }

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -82,7 +82,7 @@ class TestsColumns
             if ($checkColumnUsing && $column->getRecord()) {
                 Assert::assertTrue(
                     $checkColumnUsing($column),
-                    "Failed asserting that a field with the name [{$name}] and provided configuration exists on the [{$livewireClass}] component."
+                    "Failed asserting that a column with the name [{$name}] and provided configuration exists on the [{$livewireClass}] component."
                 );
             }
 

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -164,3 +164,20 @@ it('can state whether a select column has options', function () {
         ->assertTableSelectColumnHasOptions('with_options', ['red' => 'Red', 'blue' => 'Blue'], $post)
         ->assertTableSelectColumnDoesNotHaveOptions('with_options', ['one' => 'One', 'two' => 'Two'], $post);
 });
+
+it('can assert that a column exists with the given configuration', function () {
+    $post = Post::factory()->create();
+
+    livewire(PostsTable::class)
+        ->assertTableColumnExists('title', function(\Filament\Tables\Columns\TextColumn $column) {
+            return $column->isSortable() && $column->isSearchable();
+        });
+
+    $this->expectException('PHPUnit\Framework\ExpectationFailedException');
+    $this->expectExceptionMessage('Failed asserting that a field with the name [title] and provided configuration exists on the ['.PostsTable::class.'] component');
+
+    livewire(PostsTable::class)
+        ->assertTableColumnExists('title', function(\Filament\Tables\Columns\TextColumn $column) {
+            return $column->isTime();
+        });
+});

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -166,7 +166,7 @@ it('can state whether a select column has options', function () {
 });
 
 it('can assert that a column exists with the given configuration', function () {
-    $post_published = Post::factory()->create([
+    $publishedPost = Post::factory()->create([
         'is_published' => true,
     ]);
 
@@ -175,23 +175,23 @@ it('can assert that a column exists with the given configuration', function () {
             return $column->isSortable() &&
                 $column->isSearchable() &&
                 $column->getPrefix() == 'published';
-        }, $post_published);
+        }, $publishedPost);
 
-    $post_unpublished = Post::factory()->create([
+    $unpublishedPost = Post::factory()->create([
         'is_published' => false,
     ]);
 
     livewire(PostsTable::class)
         ->assertTableColumnExists('title2', function (Filament\Tables\Columns\TextColumn $column) {
             return $column->getPrefix() == 'unpublished';
-        }, $post_unpublished);
+        }, $unpublishedPost);
 
     $this->expectException('PHPUnit\Framework\ExpectationFailedException');
-    $this->expectExceptionMessage('Failed asserting that a field with the name [title] and provided configuration exists on the [' . PostsTable::class . '] component');
+    $this->expectExceptionMessage('Failed asserting that a column with the name [title] and provided configuration exists on the [' . PostsTable::class . '] component');
 
     livewire(PostsTable::class)
         ->assertTableColumnExists('title', function (Filament\Tables\Columns\TextColumn $column) {
             return $column->isTime();
-        }, $post_published);
+        }, $publishedPost);
 
 });

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -166,12 +166,25 @@ it('can state whether a select column has options', function () {
 });
 
 it('can assert that a column exists with the given configuration', function () {
-    $post = Post::factory()->create();
+    $post_published = Post::factory()->create([
+        'is_published' => true
+    ]);
 
     livewire(PostsTable::class)
-        ->assertTableColumnExists('title', function (Filament\Tables\Columns\TextColumn $column) {
-            return $column->isSortable() && $column->isSearchable();
-        });
+        ->assertTableColumnExists('title2', function(Filament\Tables\Columns\TextColumn $column) {
+            return $column->isSortable() &&
+                $column->isSearchable() &&
+                $column->getPrefix() == 'published';
+        }, $post_published);
+
+    $post_unpublished = Post::factory()->create([
+        'is_published' => false
+    ]);
+
+    livewire(PostsTable::class)
+        ->assertTableColumnExists('title2', function(Filament\Tables\Columns\TextColumn $column) {
+            return $column->getPrefix() == 'unpublished';
+        }, $post_unpublished);
 
     $this->expectException('PHPUnit\Framework\ExpectationFailedException');
     $this->expectExceptionMessage('Failed asserting that a field with the name [title] and provided configuration exists on the [' . PostsTable::class . '] component');
@@ -179,5 +192,6 @@ it('can assert that a column exists with the given configuration', function () {
     livewire(PostsTable::class)
         ->assertTableColumnExists('title', function (Filament\Tables\Columns\TextColumn $column) {
             return $column->isTime();
-        });
+        }, $post_published);
+
 });

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -169,15 +169,15 @@ it('can assert that a column exists with the given configuration', function () {
     $post = Post::factory()->create();
 
     livewire(PostsTable::class)
-        ->assertTableColumnExists('title', function(\Filament\Tables\Columns\TextColumn $column) {
+        ->assertTableColumnExists('title', function (Filament\Tables\Columns\TextColumn $column) {
             return $column->isSortable() && $column->isSearchable();
         });
 
     $this->expectException('PHPUnit\Framework\ExpectationFailedException');
-    $this->expectExceptionMessage('Failed asserting that a field with the name [title] and provided configuration exists on the ['.PostsTable::class.'] component');
+    $this->expectExceptionMessage('Failed asserting that a field with the name [title] and provided configuration exists on the [' . PostsTable::class . '] component');
 
     livewire(PostsTable::class)
-        ->assertTableColumnExists('title', function(\Filament\Tables\Columns\TextColumn $column) {
+        ->assertTableColumnExists('title', function (Filament\Tables\Columns\TextColumn $column) {
             return $column->isTime();
         });
 });

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -167,22 +167,22 @@ it('can state whether a select column has options', function () {
 
 it('can assert that a column exists with the given configuration', function () {
     $post_published = Post::factory()->create([
-        'is_published' => true
+        'is_published' => true,
     ]);
 
     livewire(PostsTable::class)
-        ->assertTableColumnExists('title2', function(Filament\Tables\Columns\TextColumn $column) {
+        ->assertTableColumnExists('title2', function (Filament\Tables\Columns\TextColumn $column) {
             return $column->isSortable() &&
                 $column->isSearchable() &&
                 $column->getPrefix() == 'published';
         }, $post_published);
 
     $post_unpublished = Post::factory()->create([
-        'is_published' => false
+        'is_published' => false,
     ]);
 
     livewire(PostsTable::class)
-        ->assertTableColumnExists('title2', function(Filament\Tables\Columns\TextColumn $column) {
+        ->assertTableColumnExists('title2', function (Filament\Tables\Columns\TextColumn $column) {
             return $column->getPrefix() == 'unpublished';
         }, $post_unpublished);
 

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -83,6 +83,10 @@ class PostsTable extends Component implements HasForms, Tables\Contracts\HasTabl
                         'red' => 'Red',
                         'blue' => 'Blue',
                     ]),
+                Tables\Columns\TextColumn::make('title2')
+                    ->sortable()
+                    ->searchable()
+                    ->prefix(fn($record) => $record->is_published ? 'published' : 'unpublished')
             ])
             ->filters([
                 Tables\Filters\Filter::make('is_published')

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -86,7 +86,7 @@ class PostsTable extends Component implements HasForms, Tables\Contracts\HasTabl
                 Tables\Columns\TextColumn::make('title2')
                     ->sortable()
                     ->searchable()
-                    ->prefix(fn ($record) => $record->is_published ? 'published' : 'unpublished'),
+                    ->prefix(fn (Post $record): string => $record->is_published ? 'published' : 'unpublished'),
             ])
             ->filters([
                 Tables\Filters\Filter::make('is_published')

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -86,7 +86,7 @@ class PostsTable extends Component implements HasForms, Tables\Contracts\HasTabl
                 Tables\Columns\TextColumn::make('title2')
                     ->sortable()
                     ->searchable()
-                    ->prefix(fn($record) => $record->is_published ? 'published' : 'unpublished')
+                    ->prefix(fn ($record) => $record->is_published ? 'published' : 'unpublished'),
             ])
             ->filters([
                 Tables\Filters\Filter::make('is_published')


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

The PR changes `assertColumnExists` to behave like `assertFormFieldExists` where a closure can be passed to assert the configuration of a column. This will avoid adding numerous assertions targetting specific attributes of a column with a more open approach and, potentially, in v4, allow the removal of superfluous assertions such as `assertTableColumnHasDescription`.