### PR TITLE
Clarify Handling duplicates

### DIFF
--- a/packages/panels/docs/03-resources/07-relation-managers.md
+++ b/packages/panels/docs/03-resources/07-relation-managers.md
@@ -347,10 +347,16 @@ By default, you will not be allowed to attach a record more than once. This is b
 
 Please ensure that the `id` attribute is listed in the `withPivot()` method of the relationship *and* inverse relationship.
 
-Finally, add the `$allowsDuplicates` property to the relation manager:
+Finally, add the `$allowsDuplicates` property to the relation manager and the `allowDuplicates()` method to the table:
 
 ```php
 protected bool $allowsDuplicates = true;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->allowDuplicates();
+}
 ```
 
 ## Associating and dissociating records

--- a/packages/panels/docs/03-resources/07-relation-managers.md
+++ b/packages/panels/docs/03-resources/07-relation-managers.md
@@ -347,17 +347,14 @@ By default, you will not be allowed to attach a record more than once. This is b
 
 Please ensure that the `id` attribute is listed in the `withPivot()` method of the relationship *and* inverse relationship.
 
-Finally, add the `$allowsDuplicates` property to the relation manager and the `allowDuplicates()` method to the table:
+Finally, add the `allowDuplicates()` method to the table:
 
 ```php
-protected bool $allowsDuplicates = true;
-
 public function table(Table $table): Table
 {
     return $table
         ->allowDuplicates();
 }
-```
 
 ## Associating and dissociating records
 


### PR DESCRIPTION
In order to correctly attach a duplicate record the allowDuplicate() method must be added to the table

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
