### PR TITLE
Customize form fields validation message

### DIFF
--- a/packages/forms/docs/05-validation.md
+++ b/packages/forms/docs/05-validation.md
@@ -506,6 +506,20 @@ use Filament\Forms\Components\TextInput;
 TextInput::make('name')->validationAttribute('full name')
 ```
 
+## Validation messages
+
+By default Laravel's validation error message is used. To customize the error messages, use the `validationMessages()` method:
+
+```php
+use Filament\Forms\Components\TextInput;
+
+TextInput::make('email')
+    ->unique(// ...)
+    ->validationMessages([
+        'unique' => 'The :attribute has already been registered.',
+    ])
+```
+
 ## Sending validation notifications
 
 If you want to send a notification when validation error occurs, you may do so by using the `onValidationError()` method on your Livewire component:

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -27,7 +27,7 @@ trait CanBeValidated
      * @var array<string, string | Closure>
      */
     protected array $validationMessages = [];
-    
+
     protected string | Closure | null $validationAttribute = null;
 
     public function activeUrl(bool | Closure $condition = true): static
@@ -543,7 +543,6 @@ trait CanBeValidated
         return $this;
     }
 
-    
     /**
      * @param  array<string, string | Closure>  $messages
      */
@@ -575,14 +574,14 @@ trait CanBeValidated
     public function getValidationMessages(): array
     {
         $messages = [];
-        
+
         foreach ($this->validationMessages as $rule => $message) {
             $messages[] = $this->evaluate($message);
         }
 
         return array_filter($messages);
     }
-    
+
     /**
      * @return array<mixed>
      */
@@ -618,7 +617,7 @@ trait CanBeValidated
             $rules[$statePath] = $componentMessages;
         }
     }
-    
+
     /**
      * @param  array<string, array<mixed>>  $rules
      */

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -576,7 +576,7 @@ trait CanBeValidated
         $messages = [];
 
         foreach ($this->validationMessages as $rule => $message) {
-            $messages[] = $this->evaluate($message);
+            $messages[$rule] = $this->evaluate($message);
         }
 
         return array_filter($messages);
@@ -614,7 +614,9 @@ trait CanBeValidated
         $statePath = $this->getStatePath();
 
         if (count($componentMessages = $this->getValidationMessages())) {
-            $rules[$statePath] = $componentMessages;
+            foreach ($componentMessages as $rule => $message) {
+                $rules["{$statePath}.{$rule}"] = $message;
+            }
         }
     }
 

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -607,15 +607,15 @@ trait CanBeValidated
     }
 
     /**
-     * @param  array<string, array<string, string>>  $rules
+     * @param  array<string, array<string, string>>  $messages
      */
-    public function dehydrateValidationMessages(array &$rules): void
+    public function dehydrateValidationMessages(array &$messages): void
     {
         $statePath = $this->getStatePath();
 
         if (count($componentMessages = $this->getValidationMessages())) {
             foreach ($componentMessages as $rule => $message) {
-                $rules["{$statePath}.{$rule}"] = $message;
+                $messages["{$statePath}.{$rule}"] = $message;
             }
         }
     }

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -23,6 +23,11 @@ trait CanBeValidated
      */
     protected array $rules = [];
 
+    /**
+     * @var array<string, string | Closure>
+     */
+    protected array $validationMessages = [];
+    
     protected string | Closure | null $validationAttribute = null;
 
     public function activeUrl(bool | Closure $condition = true): static
@@ -538,6 +543,17 @@ trait CanBeValidated
         return $this;
     }
 
+    
+    /**
+     * @param  array<string, string | Closure>  $messages
+     */
+    public function validationMessages(array $messages): static
+    {
+        $this->validationMessages = $messages;
+
+        return $this;
+    }
+
     public function getRegexPattern(): ?string
     {
         return $this->evaluate($this->regexPattern);
@@ -553,6 +569,20 @@ trait CanBeValidated
         return $this->evaluate($this->validationAttribute) ?? Str::lcfirst($this->getLabel());
     }
 
+    /**
+     * @return array<string, string>
+     */
+    public function getValidationMessages(): array
+    {
+        $messages = [];
+        
+        foreach ($this->validationMessages as $rule => $message) {
+            $messages[] = $this->evaluate($message);
+        }
+
+        return array_filter($messages);
+    }
+    
     /**
      * @return array<mixed>
      */
@@ -577,6 +607,18 @@ trait CanBeValidated
         return $rules;
     }
 
+    /**
+     * @param  array<string, array<string, string>>  $rules
+     */
+    public function dehydrateValidationMessages(array &$rules): void
+    {
+        $statePath = $this->getStatePath();
+
+        if (count($componentMessages = $this->getValidationMessages())) {
+            $rules[$statePath] = $componentMessages;
+        }
+    }
+    
     /**
      * @param  array<string, array<mixed>>  $rules
      */

--- a/packages/forms/src/Components/Contracts/HasValidationRules.php
+++ b/packages/forms/src/Components/Contracts/HasValidationRules.php
@@ -10,6 +10,11 @@ interface HasValidationRules
     public function dehydrateValidationAttributes(array &$attributes): void;
 
     /**
+     * @param  array<string, array<string, string>>  $rules
+     */
+    public function dehydrateValidationMessages(array &$messages): void;
+
+    /**
      * @param  array<string, array<mixed>>  $rules
      */
     public function dehydrateValidationRules(array &$rules): void;

--- a/packages/forms/src/Components/Contracts/HasValidationRules.php
+++ b/packages/forms/src/Components/Contracts/HasValidationRules.php
@@ -10,7 +10,7 @@ interface HasValidationRules
     public function dehydrateValidationAttributes(array &$attributes): void;
 
     /**
-     * @param  array<string, array<string, string>>  $rules
+     * @param  array<string, array<string, string>>  $messages
      */
     public function dehydrateValidationMessages(array &$messages): void;
 

--- a/packages/forms/src/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Concerns/CanBeValidated.php
@@ -34,7 +34,7 @@ trait CanBeValidated
     }
 
     /**
-     * @return array<string, array<string, string>>
+     * @return array<string, string>>
      */
     public function getValidationMessages(): array
     {

--- a/packages/forms/src/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Concerns/CanBeValidated.php
@@ -34,7 +34,7 @@ trait CanBeValidated
     }
 
     /**
-     * @return array<string, string>>
+     * @return array<string, string>
      */
     public function getValidationMessages(): array
     {

--- a/packages/forms/src/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Concerns/CanBeValidated.php
@@ -33,7 +33,6 @@ trait CanBeValidated
         return $attributes;
     }
 
-    
     /**
      * @return array<string, array<string, string>>
      */
@@ -60,7 +59,7 @@ trait CanBeValidated
 
         return $messages;
     }
-    
+
     /**
      * @return array<string, array<mixed>>
      */

--- a/packages/forms/src/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Concerns/CanBeValidated.php
@@ -33,6 +33,34 @@ trait CanBeValidated
         return $attributes;
     }
 
+    
+    /**
+     * @return array<string, array<string, string>>
+     */
+    public function getValidationMessages(): array
+    {
+        $messages = [];
+
+        foreach ($this->getComponents() as $component) {
+            if ($component instanceof Components\Contracts\HasValidationRules) {
+                $component->dehydrateValidationMessages($messages);
+            }
+
+            foreach ($component->getChildComponentContainers() as $container) {
+                if ($container->isHidden()) {
+                    continue;
+                }
+
+                $messages = [
+                    ...$messages,
+                    ...$container->getValidationMessages(),
+                ];
+            }
+        }
+
+        return $messages;
+    }
+    
     /**
      * @return array<string, array<mixed>>
      */
@@ -75,6 +103,6 @@ trait CanBeValidated
             return [];
         }
 
-        return $this->getLivewire()->validate($rules, [], $this->getValidationAttributes());
+        return $this->getLivewire()->validate($rules, $this->getValidationMessages(), $this->getValidationAttributes());
     }
 }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.


```php
Forms\Components\TextInput::make('reference')
      ->label('Invoice / Reference No.')
      ->unique(ignoreRecord: true, modifyRuleUsing: function (Unique $rule, $get) {
          return // ...
      })
      ->validationMessages([
          'unique' => fn ($get) => 'The :attribute already registered.',
      ])
```

Before
![image](https://github.com/filamentphp/filament/assets/67364036/6dc275de-025b-47c4-b3a5-5b4e5b03d339)

After
![image](https://github.com/filamentphp/filament/assets/67364036/51afdce4-17fb-4c5b-a168-97fb6989ec3f)

