### PR TITLE
return null for deprecated `allowsDuplicates`

### DIFF
--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -165,7 +165,7 @@ trait HasRecords
      */
     public function allowsDuplicates(): bool
     {
-        return $this->allowsDuplicates;
+        return null;
     }
 
     /**

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -163,7 +163,7 @@ trait HasRecords
     /**
      * @deprecated Override the `table()` method to configure the table.
      */
-    public function allowsDuplicates(): bool
+    public function allowsDuplicates(): ?bool
     {
         return null;
     }


### PR DESCRIPTION
should fix phpstan errors from this change https://github.com/filamentphp/filament/commit/8e84358e64fe626299c62ce6062f12a0c20fec26

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
