### PR TITLE
Support custom content width in panel provider

### DIFF
--- a/packages/panels/resources/views/components/layout/index.blade.php
+++ b/packages/panels/resources/views/components/layout/index.blade.php
@@ -44,7 +44,7 @@
             <main
                 @class([
                     'fi-main mx-auto h-full w-full px-4 md:px-6 lg:px-8',
-                    match ($maxContentWidth ??= filament()->getMaxContentWidth() ?? '7xl') {
+                    match ($maxContentWidth ??= (filament()->getMaxContentWidth() ?? '7xl')) {
                         'xl' => 'max-w-xl',
                         '2xl' => 'max-w-2xl',
                         '3xl' => 'max-w-3xl',

--- a/packages/panels/resources/views/components/layout/index.blade.php
+++ b/packages/panels/resources/views/components/layout/index.blade.php
@@ -44,7 +44,7 @@
             <main
                 @class([
                     'fi-main mx-auto h-full w-full px-4 md:px-6 lg:px-8',
-                    match ($maxContentWidth ?? filament()->getMaxContentWidth() ?? '7xl') {
+                    match ($maxContentWidth ??= filament()->getMaxContentWidth() ?? '7xl') {
                         'xl' => 'max-w-xl',
                         '2xl' => 'max-w-2xl',
                         '3xl' => 'max-w-3xl',


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

this change allows custom max width configured in panel to be applied

```php
$panel
      ->maxContentWidth('max-w-7xl 2xl:max-w-full')
```

currently it only fallback to page's `$maxContentWidth` when panel is configured with custom width