### PR TITLE
Allow infolist modal to infolist action

### DIFF
--- a/packages/infolists/src/Components/Actions/Action.php
+++ b/packages/infolists/src/Components/Actions/Action.php
@@ -79,4 +79,9 @@ class Action extends MountableAction
 
         return $action->component($this->getInfolistComponent());
     }
+
+    public function getInfolistName(): string
+    {
+        return 'mountedInfolistActionInfoList';
+    }
 }

--- a/packages/infolists/src/Components/Actions/Action.php
+++ b/packages/infolists/src/Components/Actions/Action.php
@@ -82,6 +82,6 @@ class Action extends MountableAction
 
     public function getInfolistName(): string
     {
-        return 'mountedInfolistActionInfoList';
+        return 'mountedInfolistActionsInfolist';
     }
 }


### PR DESCRIPTION
- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

With the current version of Filament, and the situation below, the action does not execute:
```
use Filament\Infolists\Components\TextEntry;
use Filament\Infolists\Components\Actions\Action;
use Filament\Resources\Resource;
use Filament\Infolists\Infolist;

class ProjectResource as Resource
{
     // ...

     public static function infolist(Infolist $infolist): Infolist
     {
          return $infolist
               ->schema([
                    TextEntry::make('description')
                         ->suffixAction(Action::make('revisions')
                              ->infolist(fn ($infolist, $record) => $infolist
                                   ->record($record)
                                   ->schema([...]))
               ])
     }

     // ...
}
```

Perhaps there is a grounded reason for why it is not possible to have an action inside an infolist with a modal that displays another infolist, but I guess then `Filament\Infolists\Components\Actions\Action` should have the `infolist()` function.

The reason it was not working, is that the `getInfolistName()` function inside `Filament\Infolists\Components\Actions\Action` is not set, and therefore, `getInfolist()` will return `null`.