### PR TITLE
Added the icon position to the action group

### DIFF
--- a/packages/actions/resources/views/components/group.blade.php
+++ b/packages/actions/resources/views/components/group.blade.php
@@ -102,6 +102,7 @@
                 :component="$dynamicComponent"
                 :icon="$group->getIcon()"
                 :icon-size="$group->getIconSize()"
+                :icon-position="$group->getIconPosition()"
                 :label-sr-only="$group->isLabelHidden()"
                 :tooltip="$group->getTooltip()"
                 :attributes="\Filament\Support\prepare_inherited_attributes($attributes)->merge($group->getExtraAttributes(), escape: false)"


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

The action group trigger was missing the icon position. This PR fixed that.