### PR TITLE
Add smaller avatar sizes

### DIFF
--- a/packages/support/docs/09-blade-components/02-avatar.md
+++ b/packages/support/docs/09-blade-components/02-avatar.md
@@ -27,7 +27,26 @@ Avatars are fully rounded by default, but you may make them square by setting th
 
 ## Setting the size of an avatar
 
-By default, the avatar will be "medium" size. You can make it "large" using the `size` attribute:
+You can change the avatar size using the `size` attribute:
+
+- `xs` _h-5 w-5_
+- `sm` _h-7 w-7_
+- `md` _h-9 w-9_ (default)
+- `lg` _h-10 w-10_
+
+## Set Avatar Size
+
+To change the avatar size, use the `size` attribute. Example:
+
+```blade
+<x-filament::avatar
+    src="https://filamentphp.com/dan.jpg"
+    alt="Dan Harrin"
+    size="lg"
+/>
+```
+
+Here, `size="lg"` sets the avatar to a larger size. Choose the size that fits your design or layout.
 
 ```blade
 <x-filament::avatar

--- a/packages/support/docs/09-blade-components/02-avatar.md
+++ b/packages/support/docs/09-blade-components/02-avatar.md
@@ -34,18 +34,6 @@ You can change the avatar size using the `size` attribute:
 - `md` _h-9 w-9_ (default)
 - `lg` _h-10 w-10_
 
-## Set Avatar Size
-
-To change the avatar size, use the `size` attribute. Example:
-
-```blade
-<x-filament::avatar
-    src="https://filamentphp.com/dan.jpg"
-    alt="Dan Harrin"
-    size="lg"
-/>
-```
-
 Here, `size="lg"` sets the avatar to a larger size. Choose the size that fits your design or layout.
 
 ```blade

--- a/packages/support/resources/views/components/avatar.blade.php
+++ b/packages/support/resources/views/components/avatar.blade.php
@@ -11,6 +11,8 @@
                 'rounded-md' => ! $circular,
                 'fi-circular rounded-full' => $circular,
                 match ($size) {
+                    'xs' => 'h-5 w-5',
+                    'sm' => 'h-7 w-7',
                     'md' => 'h-9 w-9',
                     'lg' => 'h-10 w-10',
                     default => $size,


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

The size `xs` is perfectly suitable for the select component.
This will make it easier to add other sizes without having to build a css.

____

<img width="703" alt="Screenshot 2023-11-10 at 11 16 01" src="https://github.com/filamentphp/filament/assets/142592979/d1961e9a-b0e5-487f-9143-8277c3f194bd">

____

```php
Select::make('user')
    ->native(false)
    ->allowHtml()
    ->options(function () {
        return User::get()
            ->map(fn ($user) => [
                'value' => $user->id,
                'label' => Blade::render(
                    '<x-filament::avatar
                        src="' . filament()->getUserAvatarUrl($user) . '"
                        size="xs"
                        class="inline mr-2"
                    /> ' . $user->name
                )
            ])
            ->pluck('label', 'value');
    });
```