### PR TITLE
fix for ImageColumn to accept Base64 image `data:image`

### DIFF
--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -142,7 +142,7 @@ class ImageColumn extends Column
 
     public function getImageUrl(?string $state = null): ?string
     {
-        if (filter_var($state, FILTER_VALIDATE_URL) !== false || str($state)->startsWith('data:')) {
+        if ((filter_var($state, FILTER_VALIDATE_URL) !== false) || str($state)->startsWith('data:')) {
             return $state;
         }
 

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -142,7 +142,7 @@ class ImageColumn extends Column
 
     public function getImageUrl(?string $state = null): ?string
     {
-        if (filter_var($state, FILTER_VALIDATE_URL) !== false) {
+        if (filter_var($state, FILTER_VALIDATE_URL) !== false || str($state)->startsWith('data:')) {
             return $state;
         }
 


### PR DESCRIPTION
- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

this will allow images to be Base64 images. if they stored in DB for example
`data:image/png;base64,iVBORw0KGgoAAAANSUhE.....`

the validation `filter_var ` will return false, and filament will continue to try to get the image from the disk

