### PR TITLE
Fix required validation for concealed select

### DIFF
--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -36,7 +36,7 @@
                 :id="$getId()"
                 :inline-prefix="$isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel))"
                 :inline-suffix="$isSuffixInline && (count($suffixActions) || $suffixIcon || filled($suffixLabel))"
-                :required="$isRequired() && ((bool) $isConcealed())"
+                :required="$isRequired() && (! (bool) $isConcealed())"
                 :attributes="
                     $getExtraInputAttributeBag()
                         ->merge([

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -36,7 +36,7 @@
                 :id="$getId()"
                 :inline-prefix="$isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel))"
                 :inline-suffix="$isSuffixInline && (count($suffixActions) || $suffixIcon || filled($suffixLabel))"
-                :required="$isRequired() && (! (bool) $isConcealed())"
+                :required="$isRequired() && (! $isConcealed())"
                 :attributes="
                     $getExtraInputAttributeBag()
                         ->merge([


### PR DESCRIPTION
Hello, I found problem with concealed select input when I have required select in another tab and save resource then "An invalid form control with name=  is not focusable. " error occurs in console and there is no change of tab with required select and no validation error occurs on input.

After fix in commit. (Same logic like in V2)
App goes to tab with required select and error message occurs like it should.

V2 logic:
@if (! $isConcealed())
    {!! $isRequired() ? 'required' : null !!}
@endif


