### PR TITLE
feat: allow dynamically setting the card width on SimplePage

### DIFF
--- a/packages/panels/resources/views/components/layout/simple.blade.php
+++ b/packages/panels/resources/views/components/layout/simple.blade.php
@@ -24,7 +24,7 @@
             <main
                 @class([
                     'fi-simple-main my-16 w-full bg-white px-6 py-12 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 sm:rounded-xl sm:px-12',
-                    match ($maxWidth) {
+                    match ($maxWidth ?? null) {
                         'xs' => 'sm:max-w-xs',
                         'sm' => 'sm:max-w-sm',
                         'md' => 'sm:max-w-md',

--- a/packages/panels/resources/views/components/layout/simple.blade.php
+++ b/packages/panels/resources/views/components/layout/simple.blade.php
@@ -22,7 +22,23 @@
             class="fi-simple-main-ctn flex w-full flex-grow items-center justify-center"
         >
             <main
-                class="fi-simple-main my-16 w-full bg-white px-6 py-12 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 sm:max-w-lg sm:rounded-xl sm:px-12"
+                @class([
+                    'fi-simple-main my-16 w-full bg-white px-6 py-12 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 sm:rounded-xl sm:px-12',
+                    match ($maxWidth) {
+                        'xs' => 'sm:max-w-xs',
+                        'sm' => 'sm:max-w-sm',
+                        'md' => 'sm:max-w-md',
+                        'lg' => 'sm:max-w-lg',
+                        'xl' => 'sm:max-w-xl',
+                        '2xl' => 'sm:max-w-2xl',
+                        '3xl' => 'sm:max-w-3xl',
+                        '4xl' => 'sm:max-w-4xl',
+                        '5xl' => 'sm:max-w-5xl',
+                        '6xl' => 'sm:max-w-6xl',
+                        '7xl' => 'sm:max-w-7xl',
+                        default => 'sm:max-w-lg',
+                    },
+                ])
             >
                 {{ $slot }}
             </main>

--- a/packages/panels/src/Pages/SimplePage.php
+++ b/packages/panels/src/Pages/SimplePage.php
@@ -6,6 +6,20 @@ abstract class SimplePage extends BasePage
 {
     protected static string $layout = 'filament-panels::components.layout.simple';
 
+    protected ?string $maxWidth = null;
+
+    protected function getLayoutData(): array
+    {
+        return [
+            'maxWidth' => $this->getMaxWidth(),
+        ];
+    }
+
+    public function getMaxWidth(): ?string
+    {
+        return $this->maxWidth;
+    }
+
     public function hasLogo(): bool
     {
         return true;


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Currently the card width on the `SimplePage` component is always locked to `lg`. The predecessor of the `SimplePage` component allowed to set this width dynamically, which was very convenient. This PR brings back to feature by adding a `getMaxWidth()` function and a property. I mirrored the implementation for the `getMaxContentWidth()` function.

The only thing I wasn't sure of was where you want to place the default of `lg`. I think it's your policy to put it in Blade like this.

Thanks!