### PR TITLE
Added deleted_at to columns that should be hidden by default

### DIFF
--- a/packages/tables/src/Commands/Concerns/CanGenerateTables.php
+++ b/packages/tables/src/Commands/Concerns/CanGenerateTables.php
@@ -121,6 +121,7 @@ trait CanGenerateTables
             if (in_array($columnName, [
                 'created_at',
                 'updated_at',
+                'deleted_at',
             ])) {
                 $columnData['toggleable'] = ['isToggledHiddenByDefault' => true];
             }


### PR DESCRIPTION
The deleted_at column should be hidden by default like created/upated_at

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
