### PR TITLE
Update pt_PT and pt_BR Translations

### DIFF
--- a/packages/forms/resources/lang/pt_BR/components.php
+++ b/packages/forms/resources/lang/pt_BR/components.php
@@ -184,6 +184,14 @@ return [
                 ],
 
             ],
+            'svg' => [
+
+                'messages' => [
+                    'confirmation' => 'Não é recomendado editar arquivos SVG, pois pode resultar em perda de qualidade ao dimensionar.\n Você tem certeza de que deseja continuar?',
+                    'disabled' => 'A edição de arquivos SVG está desativada, pois pode resultar em perda de qualidade ao dimensionar.',
+                ],
+
+            ],
 
         ],
 
@@ -247,6 +255,10 @@ return [
 
             'add' => [
                 'label' => 'Adicionar em :label',
+            ],
+
+            'add_between' => [
+                'label' => 'Inserir',
             ],
 
             'delete' => [

--- a/packages/forms/resources/lang/pt_BR/components.php
+++ b/packages/forms/resources/lang/pt_BR/components.php
@@ -184,6 +184,7 @@ return [
                 ],
 
             ],
+
             'svg' => [
 
                 'messages' => [

--- a/packages/forms/resources/lang/pt_PT/components.php
+++ b/packages/forms/resources/lang/pt_PT/components.php
@@ -185,6 +185,15 @@ return [
 
             ],
 
+            'svg' => [
+
+                'messages' => [
+                    'confirmation' => 'Não é recomendado editar ficheiros SVG, pois pode resultar em perda de qualidade ao redimensionar.\n Tem a certeza de que deseja continuar?',
+                    'disabled' => 'A edição de ficheiros SVG está desativada, pois pode resultar em perda de qualidade ao redimensionar.',
+                ],
+
+            ],
+
         ],
 
     ],
@@ -247,6 +256,10 @@ return [
 
             'add' => [
                 'label' => 'Adicionar em :label',
+            ],
+
+            'add_between' => [
+                'label' => 'Adicionar entre',
             ],
 
             'delete' => [


### PR DESCRIPTION
Added missing translations for forms package:

- file_upload.editor.svg.messages.confirmation
- file_upload.editor.svg.messages.disabled
- repeater.actions.add_between.label