### PR TITLE
ProhibitX validation rules

### DIFF
--- a/packages/forms/docs/05-validation.md
+++ b/packages/forms/docs/05-validation.md
@@ -309,6 +309,30 @@ The field value must be empty. [See the Laravel documentation.](https://laravel.
 Field::make('name')->prohibited()
 ```
 
+### Prohibited If
+
+The field must be empty _only if_ the other specified field has any of the given values. [See the Laravel documentation.](https://laravel.com/docs/validation#rule-prohibited-if)
+
+```php
+Field::make('name')->prohibitedIf('field', 'value')
+```
+
+### Prohibited Unless
+
+The field must be empty _unless_ the other specified field has any of the given values. [See the Laravel documentation.](https://laravel.com/docs/validation#rule-prohibited-unless)
+
+```php
+Field::make('name')->prohibitedUnless('field', 'value')
+```
+
+### Prohibits
+
+If the field is not empty, all other specified fields must be empty. [See the Laravel documentation.](https://laravel.com/docs/validation#rule-prohibits)
+
+```php
+Field::make('name')->prohibits('field,another_field')
+```
+
 ### Required
 
 The field value must not be empty. [See the Laravel documentation.](https://laravel.com/docs/validation#rule-required)

--- a/packages/forms/docs/05-validation.md
+++ b/packages/forms/docs/05-validation.md
@@ -330,7 +330,9 @@ Field::make('name')->prohibitedUnless('field', 'value')
 If the field is not empty, all other specified fields must be empty. [See the Laravel documentation.](https://laravel.com/docs/validation#rule-prohibits)
 
 ```php
-Field::make('name')->prohibits('field,another_field')
+Field::make('name')->prohibits('field')
+
+Field::make('name')->prohibits(['field', 'another_field'])
 ```
 
 ### Required

--- a/packages/forms/docs/05-validation.md
+++ b/packages/forms/docs/05-validation.md
@@ -311,7 +311,7 @@ Field::make('name')->prohibited()
 
 ### Prohibited If
 
-The field must be empty _only if_ the other specified field has any of the given values. [See the Laravel documentation.](https://laravel.com/docs/validation#rule-prohibited-if)
+The field must be empty *only if* the other specified field has any of the given values. [See the Laravel documentation.](https://laravel.com/docs/validation#rule-prohibited-if)
 
 ```php
 Field::make('name')->prohibitedIf('field', 'value')
@@ -319,7 +319,7 @@ Field::make('name')->prohibitedIf('field', 'value')
 
 ### Prohibited Unless
 
-The field must be empty _unless_ the other specified field has any of the given values. [See the Laravel documentation.](https://laravel.com/docs/validation#rule-prohibited-unless)
+The field must be empty *unless* the other specified field has any of the given values. [See the Laravel documentation.](https://laravel.com/docs/validation#rule-prohibited-unless)
 
 ```php
 Field::make('name')->prohibitedUnless('field', 'value')

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -339,9 +339,12 @@ trait CanBeValidated
         return $this->multiFieldValueComparisonRule('prohibited_unless', $statePath, $stateValues, $isStatePathAbsolute);
     }
 
-    public function prohibits(string | Closure $statePath, bool $isStatePathAbsolute = false): static
+    /**
+     * @param  array<string> | string | Closure  $statePaths
+     */
+    public function prohibits(array | string | Closure $statePaths, bool $isStatePathAbsolute = false): static
     {
-        return $this->fieldComparisonRule('prohibits', $statePath, $isStatePathAbsolute);
+        return $this->multiFieldComparisonRule('prohibits', $statePaths, $isStatePathAbsolute);
     }
 
     public function required(bool | Closure $condition = true): static

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -329,6 +329,21 @@ trait CanBeValidated
         return $this;
     }
 
+    public function prohibitedIf(string | Closure $statePath, mixed $stateValues, bool $isStatePathAbsolute = false): static
+    {
+        return $this->multiFieldValueComparisonRule('prohibited_if', $statePath, $stateValues, $isStatePathAbsolute);
+    }
+
+    public function prohibitedUnless(string | Closure $statePath, mixed $stateValues, bool $isStatePathAbsolute = false): static
+    {
+        return $this->multiFieldValueComparisonRule('prohibited_unless', $statePath, $stateValues, $isStatePathAbsolute);
+    }
+
+    public function prohibits(string | Closure $statePath, bool $isStatePathAbsolute = false): static
+    {
+        return $this->fieldComparisonRule('prohibits', $statePath, $isStatePathAbsolute);
+    }
+
     public function required(bool | Closure $condition = true): static
     {
         $this->isRequired = $condition;


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] ~Visual changes are explained in the PR description using a screenshot/recording of before and after.~ (not applicable)

Adds & documents the following validation rules:
- `->prohibitedIf('field', 'value')`
- `->prohibitedUnless('field', 'value')`
- `->prohibits('field')`
