### PR TITLE
Allow spatie/invade 2.x

### DIFF
--- a/packages/support/composer.json
+++ b/packages/support/composer.json
@@ -18,7 +18,7 @@
         "livewire/livewire": "^3.0.8",
         "ryangjchandler/blade-capture-directive": "^0.2|^0.3",
         "spatie/color": "^1.5",
-        "spatie/invade": "^1.0",
+        "spatie/invade": "^1.0|^2.0",
         "spatie/laravel-package-tools": "^1.9",
         "symfony/html-sanitizer": "^6.1"
     },

--- a/packages/support/src/Commands/Concerns/CanReadModelSchemas.php
+++ b/packages/support/src/Commands/Concerns/CanReadModelSchemas.php
@@ -44,7 +44,7 @@ trait CanReadModelSchemas
     {
         /** @var Model $modelInstance */
         $modelInstance = app($model);
-        $modelInstanceReflection = new ReflectionClass(invade($modelInstance));
+        $modelInstanceReflection = new ReflectionClass($modelInstance);
         $guessedRelationshipName = str($column->getName())->beforeLast('_id');
         $hasRelationship = $modelInstanceReflection->hasMethod($guessedRelationshipName);
 

--- a/packages/support/src/Commands/Concerns/CanReadModelSchemas.php
+++ b/packages/support/src/Commands/Concerns/CanReadModelSchemas.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use ReflectionClass;
 use ReflectionException;
 use Throwable;
 
@@ -43,13 +44,13 @@ trait CanReadModelSchemas
     {
         /** @var Model $modelInstance */
         $modelInstance = app($model);
-        $modelInstanceReflection = invade($modelInstance);
+        $modelInstanceReflection = new ReflectionClass(invade($modelInstance));
         $guessedRelationshipName = str($column->getName())->beforeLast('_id');
-        $hasRelationship = $modelInstanceReflection->reflected->hasMethod($guessedRelationshipName);
+        $hasRelationship = $modelInstanceReflection->hasMethod($guessedRelationshipName);
 
         if (! $hasRelationship) {
             $guessedRelationshipName = $guessedRelationshipName->camel();
-            $hasRelationship = $modelInstanceReflection->reflected->hasMethod($guessedRelationshipName);
+            $hasRelationship = $modelInstanceReflection->hasMethod($guessedRelationshipName);
         }
 
         if (! $hasRelationship) {
@@ -57,7 +58,7 @@ trait CanReadModelSchemas
         }
 
         try {
-            $type = $modelInstanceReflection->reflected->getMethod($guessedRelationshipName)->getReturnType();
+            $type = $modelInstanceReflection->getMethod($guessedRelationshipName)->getReturnType();
 
             if (
                 (! $type) ||


### PR DESCRIPTION
- [X] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
