### PR TITLE
Add panel colors getter

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasColors.php
+++ b/packages/panels/src/Panel/Concerns/HasColors.php
@@ -21,6 +21,9 @@ trait HasColors
         return $this;
     }
 
+    /**
+     * @return array<string, array{50: string, 100: string, 200: string, 300: string, 400: string, 500: string, 600: string, 700: string, 800: string, 900: string, 950: string} | string>
+     */
     public function getColors(): array
     {
         return $this->colors;

--- a/packages/panels/src/Panel/Concerns/HasColors.php
+++ b/packages/panels/src/Panel/Concerns/HasColors.php
@@ -20,4 +20,9 @@ trait HasColors
 
         return $this;
     }
+
+    public function getColors(): array
+    {
+        return $this->colors;
+    }
 }


### PR DESCRIPTION
I've been trying to sync the styling of some stand-alone pages with a panel. Getting the colors has been challenging. This will allow us to get the panel then call `$panel->getColors()` to retrieve the colors (like we already can with the font, brand logo etc).