### PR TITLE
Changed edit to save to match the Blade template

### DIFF
--- a/packages/forms/stubs/EditForm.stub
+++ b/packages/forms/stubs/EditForm.stub
@@ -33,7 +33,7 @@ class {{ class }} extends Component implements HasForms
             ->model($this->record);
     }
 
-    public function edit(): void
+    public function save(): void
     {
         $data = $this->form->getState();
 


### PR DESCRIPTION
When I generate the form using `php artisan make:livewire-form DMS/EditDocument --generate`, I get two files - the resource and the Livewire class.

The resource has this code:
```
<form wire:submit="save">
```

The Livewire class has this method:
```
public function edit(): void
```

These don't match and thus don't work out of the box. Can we consolidate this?

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
