### PR TITLE
[Docs] - Added closing backticks to infolist text entry docs

### DIFF
--- a/packages/infolists/docs/03-entries/02-text.md
+++ b/packages/infolists/docs/03-entries/02-text.md
@@ -254,6 +254,7 @@ use Filament\Infolists\Components\TextEntry;
 TextEntry::make('email')
     ->icon('heroicon-m-envelope')
     ->iconColor('primary')
+```
 
 <AutoScreenshot name="infolists/entries/text/icon-color" alt="Text entry with icon in the primary color" version="3.x" />
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Added the missing closing backticks to the documentation, which was causing an odd layout.