### PR TITLE
Htmlable Form fields' affixes label

### DIFF
--- a/packages/forms/src/Components/Concerns/HasAffixes.php
+++ b/packages/forms/src/Components/Concerns/HasAffixes.php
@@ -5,6 +5,7 @@ namespace Filament\Forms\Components\Concerns;
 use Closure;
 use Filament\Forms\Components\Actions\Action;
 use Filament\Support\Enums\ActionSize;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 
 trait HasAffixes
@@ -19,7 +20,7 @@ trait HasAffixes
      */
     protected array $suffixActions = [];
 
-    protected string | Closure | null $suffixLabel = null;
+    protected string | Htmlable | Closure | null $suffixLabel = null;
 
     /**
      * @var array<Action> | null
@@ -31,7 +32,7 @@ trait HasAffixes
      */
     protected array $prefixActions = [];
 
-    protected string | Closure | null $prefixLabel = null;
+    protected string | Htmlable | Closure | null $prefixLabel = null;
 
     protected string | Closure | null $prefixIcon = null;
 
@@ -51,7 +52,7 @@ trait HasAffixes
 
     protected bool | Closure $isSuffixInline = false;
 
-    public function prefix(string | Closure | null $label, bool | Closure $isInline = false): static
+    public function prefix(string | Htmlable | Closure | null $label, bool | Closure $isInline = false): static
     {
         $this->prefixLabel = $label;
         $this->inlinePrefix($isInline);
@@ -59,7 +60,7 @@ trait HasAffixes
         return $this;
     }
 
-    public function postfix(string | Closure | null $label, bool | Closure $isInline = false): static
+    public function postfix(string | Htmlable | Closure | null $label, bool | Closure $isInline = false): static
     {
         return $this->suffix($label, $isInline);
     }
@@ -106,7 +107,7 @@ trait HasAffixes
         return $this;
     }
 
-    public function suffix(string | Closure | null $label, bool | Closure $isInline = false): static
+    public function suffix(string | Htmlable | Closure | null $label, bool | Closure $isInline = false): static
     {
         $this->suffixLabel = $label;
         $this->inlineSuffix($isInline);
@@ -220,12 +221,12 @@ trait HasAffixes
         return $this->cachedSuffixActions;
     }
 
-    public function getPrefixLabel(): ?string
+    public function getPrefixLabel(): string | Htmlable | null
     {
         return $this->evaluate($this->prefixLabel);
     }
 
-    public function getSuffixLabel(): ?string
+    public function getSuffixLabel(): string | Htmlable | null
     {
         return $this->evaluate($this->suffixLabel);
     }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

usage
```php
Forms\Components\ColorPicker::make('color')
    ->reactive()
    ->hex(),
Forms\Components\TextInput::make('opacity')
    ->reactive()
    ->suffix(fn ($get) => new HtmlString("<div style=\"
    background-color: {$get('color')};
    opacity: {$get('opacity')};
    height: 2rem;
    aspect-ratio: 1;
    border-radius: 8px;
\"></div>")),
```

**before**
![image](https://github.com/filamentphp/filament/assets/67364036/56da0b09-0d18-43bf-805e-f464521bcc93)

**after**
![image](https://github.com/filamentphp/filament/assets/67364036/2ec0e081-ea60-4313-b037-b1c433c70b83)
