### PR TITLE
Add 2xl icon column size

### DIFF
--- a/packages/infolists/docs/03-entries/03-icon.md
+++ b/packages/infolists/docs/03-entries/03-icon.md
@@ -44,7 +44,7 @@ In the function, `$state` is the value of the entry, and `$record` can be used t
 
 ## Customizing the size
 
-The default icon size is `IconEntrySize::Large`, but you may customize the size to be either `IconEntrySize::ExtraSmall`, `IconEntrySize::Small`, `IconEntrySize::Medium` or `IconEntrySize::ExtraLarge`:
+The default icon size is `IconEntrySize::Large`, but you may customize the size to be either `IconEntrySize::ExtraSmall`, `IconEntrySize::Small`, `IconEntrySize::Medium`, `IconEntrySize::ExtraLarge` or `IconEntrySize::ExtraExtraLarge`:
 
 ```php
 use Filament\Infolists\Components\IconEntry;

--- a/packages/infolists/resources/views/components/icon-entry.blade.php
+++ b/packages/infolists/resources/views/components/icon-entry.blade.php
@@ -30,6 +30,7 @@
                                 IconEntrySize::Medium, 'md' => 'fi-in-icon-item-size-md h-5 w-5',
                                 IconEntrySize::Large, 'lg' => 'fi-in-icon-item-size-lg h-6 w-6',
                                 IconEntrySize::ExtraLarge, 'xl' => 'fi-in-icon-item-size-xl h-7 w-7',
+                                IconEntrySize::ExtraExtraLarge, '2xl' => 'fi-in-icon-item-size-2xl h-8 w-8',                                
                                 default => $size,
                             },
                             match ($color) {

--- a/packages/infolists/src/Components/IconEntry/IconEntrySize.php
+++ b/packages/infolists/src/Components/IconEntry/IconEntrySize.php
@@ -13,4 +13,6 @@ enum IconEntrySize
     case Large;
 
     case ExtraLarge;
+
+    case ExtraExtraLarge;
 }

--- a/packages/tables/docs/03-columns/03-icon.md
+++ b/packages/tables/docs/03-columns/03-icon.md
@@ -44,7 +44,7 @@ In the function, `$state` is the value of the column, and `$record` can be used 
 
 ## Customizing the size
 
-The default icon size is `IconColumnSize::Large`, but you may customize the size to be either `IconColumnSize::ExtraSmall`, `IconColumnSize::Small`, `IconColumnSize::Medium` or `IconColumnSize::ExtraLarge`:
+The default icon size is `IconColumnSize::Large`, but you may customize the size to be either `IconColumnSize::ExtraSmall`, `IconColumnSize::Small`, `IconColumnSize::Medium`, `IconColumnSize::ExtraLarge` or `IconColumnSize::ExtraExtraLarge`:
 
 ```php
 use Filament\Tables\Columns\IconColumn;

--- a/packages/tables/resources/views/columns/icon-column.blade.php
+++ b/packages/tables/resources/views/columns/icon-column.blade.php
@@ -31,6 +31,7 @@
                             IconColumnSize::Medium, 'md' => 'fi-ta-icon-item-size-md h-5 w-5',
                             IconColumnSize::Large, 'lg' => 'fi-ta-icon-item-size-lg h-6 w-6',
                             IconColumnSize::ExtraLarge, 'xl' => 'fi-ta-icon-item-size-xl h-7 w-7',
+                            IconColumnSize::ExtraExtraLarge, '2xl' => 'fi-ta-icon-item-size-2xl h-8 w-8',
                             default => $size,
                         },
                         match ($color) {

--- a/packages/tables/src/Columns/IconColumn/IconColumnSize.php
+++ b/packages/tables/src/Columns/IconColumn/IconColumnSize.php
@@ -13,4 +13,6 @@ enum IconColumnSize
     case Large;
 
     case ExtraLarge;
+
+    case ExtraExtraLarge;
 }


### PR DESCRIPTION
Sometimes you want larger icons for things like categories when using a card layout.