### PR TITLE
Hide group selection when needed

### DIFF
--- a/packages/tables/docs/08-grouping.md
+++ b/packages/tables/docs/08-grouping.md
@@ -333,9 +333,7 @@ use Filament\Tables\Table;
 public function table(Table $table): Table
 {
     return $table
-        ->groups([
-            // ...
-        ])
+		->defaultGroup('status');
         ->groupSelectionVisible(false);
 }
 ```

--- a/packages/tables/docs/08-grouping.md
+++ b/packages/tables/docs/08-grouping.md
@@ -322,3 +322,20 @@ public function table(Table $table): Table
         ->groupsInDropdownOnDesktop();
 }
 ```
+
+## Hiding the group selection
+
+You can disable the groups selection by using the `->groupSelectionVisible()` method:
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->groups([
+            // ...
+        ])
+        ->groupSelectionVisible(false);
+}
+```

--- a/packages/tables/docs/08-grouping.md
+++ b/packages/tables/docs/08-grouping.md
@@ -306,9 +306,9 @@ public function table(Table $table): Table
 }
 ```
 
-## Enabling the groups dropdown on desktop
+## Using the grouping settings dropdown on desktop
 
-By default, the groups dropdown will only be shown on mobile devices. On desktop devices, the group select field is in the header of the time. You can enable the dropdown on desktop devices too by using the `groupsInDropdownOnDesktop()` method:
+By default, the grouping settings dropdown will only be shown on mobile devices. On desktop devices, the grouping settings are in the header of the time. You can enable the dropdown on desktop devices too by using the `groupingSettingsInDropdownOnDesktop()` method:
 
 ```php
 use Filament\Tables\Table;
@@ -319,13 +319,13 @@ public function table(Table $table): Table
         ->groups([
             // ...
         ])
-        ->groupsInDropdownOnDesktop();
+        ->groupingSettingsInDropdownOnDesktop();
 }
 ```
 
-## Hiding the group selection
+## Hiding the grouping settings
 
-You can disable the groups selection by using the `->groupSelectionVisible()` method:
+You can hide the grouping settings interface using the `groupingSettingsHidden()` method:
 
 ```php
 use Filament\Tables\Table;
@@ -334,6 +334,6 @@ public function table(Table $table): Table
 {
     return $table
 		->defaultGroup('status');
-        ->groupSelectionVisible(false);
+        ->groupingSettingsHidden();
 }
 ```

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -30,6 +30,7 @@
         fn (\Filament\Tables\Actions\BulkAction | \Filament\Tables\Actions\ActionGroup $action): bool => $action->isVisible(),
     );
     $groups = $getGroups();
+    $isGroupSelectionVisible = count($groups) && (! $isGroupSelectionHidden());
     $description = $getDescription();
     $isGroupsOnly = $isGroupsOnly() && $group;
     $isReorderable = $isReorderable();
@@ -48,8 +49,8 @@
     $hasFiltersAboveContentCollapsible = $hasFilters && ($filtersLayout === FiltersLayout::AboveContentCollapsible);
     $hasFiltersBelowContent = $hasFilters && ($filtersLayout === FiltersLayout::BelowContent);
     $hasColumnToggleDropdown = $hasToggleableColumns();
-    $hasHeader = $header || $heading || $description || ($headerActions && (! $isReordering)) || $isReorderable || count($groups) || $isGlobalSearchVisible || $hasFilters || count($filterIndicators) || $hasColumnToggleDropdown;
-    $hasHeaderToolbar = $isReorderable || count($groups) || $isGlobalSearchVisible || $hasFiltersDialog || $hasColumnToggleDropdown;
+    $hasHeader = $header || $heading || $description || ($headerActions && (! $isReordering)) || $isReorderable || $isGroupSelectionVisible || $isGlobalSearchVisible || $hasFilters || count($filterIndicators) || $hasColumnToggleDropdown;
+    $hasHeaderToolbar = $isReorderable || $isGroupSelectionVisible || $isGlobalSearchVisible || $hasFiltersDialog || $hasColumnToggleDropdown;
     $pluralModelLabel = $getPluralModelLabel();
     $records = $isLoaded ? $getRecords() : null;
     $allSelectableRecordsCount = ($isSelectionEnabled && $isLoaded) ? $getAllSelectableRecordsCount() : null;
@@ -181,7 +182,7 @@
 
                     {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.grouping-selector.before', scopes: static::class) }}
 
-                    @if (count($groups) && $isGroupSelectionVisible())
+                    @if ($isGroupSelectionVisible)
                         <x-filament-tables::groups
                             :dropdown-on-desktop="$areGroupsInDropdownOnDesktop()"
                             :groups="$groups"

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -30,7 +30,7 @@
         fn (\Filament\Tables\Actions\BulkAction | \Filament\Tables\Actions\ActionGroup $action): bool => $action->isVisible(),
     );
     $groups = $getGroups();
-    $isGroupSelectionVisible = count($groups) && (! $isGroupSelectionHidden());
+    $areGroupingSettingsVisible = count($groups) && (! $areGroupingSettingsHidden());
     $description = $getDescription();
     $isGroupsOnly = $isGroupsOnly() && $group;
     $isReorderable = $isReorderable();
@@ -49,8 +49,8 @@
     $hasFiltersAboveContentCollapsible = $hasFilters && ($filtersLayout === FiltersLayout::AboveContentCollapsible);
     $hasFiltersBelowContent = $hasFilters && ($filtersLayout === FiltersLayout::BelowContent);
     $hasColumnToggleDropdown = $hasToggleableColumns();
-    $hasHeader = $header || $heading || $description || ($headerActions && (! $isReordering)) || $isReorderable || $isGroupSelectionVisible || $isGlobalSearchVisible || $hasFilters || count($filterIndicators) || $hasColumnToggleDropdown;
-    $hasHeaderToolbar = $isReorderable || $isGroupSelectionVisible || $isGlobalSearchVisible || $hasFiltersDialog || $hasColumnToggleDropdown;
+    $hasHeader = $header || $heading || $description || ($headerActions && (! $isReordering)) || $isReorderable || $areGroupingSettingsVisible || $isGlobalSearchVisible || $hasFilters || count($filterIndicators) || $hasColumnToggleDropdown;
+    $hasHeaderToolbar = $isReorderable || $areGroupingSettingsVisible || $isGlobalSearchVisible || $hasFiltersDialog || $hasColumnToggleDropdown;
     $pluralModelLabel = $getPluralModelLabel();
     $records = $isLoaded ? $getRecords() : null;
     $allSelectableRecordsCount = ($isSelectionEnabled && $isLoaded) ? $getAllSelectableRecordsCount() : null;
@@ -182,9 +182,9 @@
 
                     {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.grouping-selector.before', scopes: static::class) }}
 
-                    @if ($isGroupSelectionVisible)
+                    @if ($areGroupingSettingsVisible)
                         <x-filament-tables::groups
-                            :dropdown-on-desktop="$areGroupsInDropdownOnDesktop()"
+                            :dropdown-on-desktop="$areGroupingSettingsInDropdownOnDesktop()"
                             :groups="$groups"
                             :trigger-action="$getGroupRecordsTriggerAction()"
                         />

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -181,7 +181,7 @@
 
                     {{ \Filament\Support\Facades\FilamentView::renderHook('tables::toolbar.grouping-selector.before', scopes: static::class) }}
 
-                    @if (count($groups))
+                    @if (count($groups) && $isGroupSelectionVisible())
                         <x-filament-tables::groups
                             :dropdown-on-desktop="$areGroupsInDropdownOnDesktop()"
                             :groups="$groups"

--- a/packages/tables/src/Table/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Table/Concerns/CanGroupRecords.php
@@ -19,9 +19,9 @@ trait CanGroupRecords
 
     protected bool | Closure $isGroupsOnly = false;
 
-    protected bool | Closure $areGroupsInDropdownOnDesktop = false;
+    protected bool | Closure $areGroupingSettingsInDropdownOnDesktop = false;
 
-	protected bool | Closure $isGroupSelectionHidden = false;
+	protected bool | Closure $areGroupingSettingsHidden = false;
 
     protected ?Closure $modifyGroupRecordsTriggerActionUsing = null;
 
@@ -32,16 +32,26 @@ trait CanGroupRecords
         return $this;
     }
 
-    public function groupsInDropdownOnDesktop(bool | Closure $condition = true): static
+    public function groupingSettingsInDropdownOnDesktop(bool | Closure $condition = true): static
     {
-        $this->areGroupsInDropdownOnDesktop = $condition;
+        $this->areGroupingSettingsInDropdownOnDesktop = $condition;
 
         return $this;
     }
 
-	public function groupSelectionHidden(bool | Closure $condition = true): static
+    /**
+     * @deprecated Use the `groupingSettingsInDropdownOnDesktop()` method instead.
+     */
+    public function groupsInDropdownOnDesktop(bool | Closure $condition = true): static
     {
-        $this->isGroupSelectionHidden = $condition;
+        $this->groupingSettingsInDropdownOnDesktop($condition);
+
+        return $this;
+    }
+
+	public function groupingSettingsHidden(bool | Closure $condition = true): static
+    {
+        $this->areGroupingSettingsHidden = $condition;
 
         return $this;
     }
@@ -110,14 +120,14 @@ trait CanGroupRecords
         return $this->getGroup($defaultGroup->getId()) !== null;
     }
 
-    public function areGroupsInDropdownOnDesktop(): bool
+    public function areGroupingSettingsInDropdownOnDesktop(): bool
     {
-        return (bool) $this->evaluate($this->areGroupsInDropdownOnDesktop);
+        return (bool) $this->evaluate($this->areGroupingSettingsInDropdownOnDesktop);
     }
 
-    public function isGroupSelectionHidden(): bool
+    public function areGroupingSettingsHidden(): bool
     {
-        return (bool) $this->evaluate($this->isGroupSelectionHidden);
+        return (bool) $this->evaluate($this->areGroupingSettingsHidden);
     }
 
     public function getDefaultGroup(): ?Group

--- a/packages/tables/src/Table/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Table/Concerns/CanGroupRecords.php
@@ -21,7 +21,7 @@ trait CanGroupRecords
 
     protected bool | Closure $areGroupsInDropdownOnDesktop = false;
 
-	protected bool|\Closure $isGroupSelectionVisible = true;
+	protected bool | Closure $isGroupSelectionHidden = false;
 
     protected ?Closure $modifyGroupRecordsTriggerActionUsing = null;
 
@@ -39,9 +39,9 @@ trait CanGroupRecords
         return $this;
     }
 
-	public function groupSelectionVisible(bool|\Closure $condition = true): static
+	public function groupSelectionHidden(bool | Closure $condition = true): static
     {
-        $this->isGroupSelectionVisible = $condition;
+        $this->isGroupSelectionHidden = $condition;
 
         return $this;
     }
@@ -115,9 +115,9 @@ trait CanGroupRecords
         return (bool) $this->evaluate($this->areGroupsInDropdownOnDesktop);
     }
 
-    public function isGroupSelectionVisible(): bool
+    public function isGroupSelectionHidden(): bool
     {
-        return (bool) $this->evaluate($this->isGroupSelectionVisible);
+        return (bool) $this->evaluate($this->isGroupSelectionHidden);
     }
 
     public function getDefaultGroup(): ?Group

--- a/packages/tables/src/Table/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Table/Concerns/CanGroupRecords.php
@@ -21,7 +21,7 @@ trait CanGroupRecords
 
     protected bool | Closure $areGroupingSettingsInDropdownOnDesktop = false;
 
-	protected bool | Closure $areGroupingSettingsHidden = false;
+    protected bool | Closure $areGroupingSettingsHidden = false;
 
     protected ?Closure $modifyGroupRecordsTriggerActionUsing = null;
 
@@ -49,7 +49,7 @@ trait CanGroupRecords
         return $this;
     }
 
-	public function groupingSettingsHidden(bool | Closure $condition = true): static
+    public function groupingSettingsHidden(bool | Closure $condition = true): static
     {
         $this->areGroupingSettingsHidden = $condition;
 

--- a/packages/tables/src/Table/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Table/Concerns/CanGroupRecords.php
@@ -21,6 +21,8 @@ trait CanGroupRecords
 
     protected bool | Closure $areGroupsInDropdownOnDesktop = false;
 
+	protected bool|\Closure $isGroupSelectionVisible = true;
+
     protected ?Closure $modifyGroupRecordsTriggerActionUsing = null;
 
     public function groupRecordsTriggerAction(?Closure $callback): static
@@ -33,6 +35,13 @@ trait CanGroupRecords
     public function groupsInDropdownOnDesktop(bool | Closure $condition = true): static
     {
         $this->areGroupsInDropdownOnDesktop = $condition;
+
+        return $this;
+    }
+
+	public function groupSelectionVisible(bool|\Closure $condition = true): static
+    {
+        $this->isGroupSelectionVisible = $condition;
 
         return $this;
     }
@@ -104,6 +113,11 @@ trait CanGroupRecords
     public function areGroupsInDropdownOnDesktop(): bool
     {
         return (bool) $this->evaluate($this->areGroupsInDropdownOnDesktop);
+    }
+
+    public function isGroupSelectionVisible(): bool
+    {
+        return (bool) $this->evaluate($this->isGroupSelectionVisible);
     }
 
     public function getDefaultGroup(): ?Group


### PR DESCRIPTION

This pull request adds the ->groupSelectionVisible method to exclude the Group Selection from the table output. This makes sense especially when only one group or ->defaultGroup() is used.

Example:

```php
use Filament\Tables\Table;

public function table(Table $table): Table
{
    return $table
	->defaultGroup('status');
        ->groupSelectionVisible(false);
}
```

Screenshot:
<img width="1081" alt="Screenshot-2023-11-18 at 12 50 10@2x" src="https://github.com/filamentphp/filament/assets/789541/5efe80f3-1a5f-475e-b7f6-8d7df5a8f2ce">
