### PR TITLE
add slots to input wrapper component

### DIFF
--- a/packages/support/resources/views/components/input/wrapper.blade.php
+++ b/packages/support/resources/views/components/input/wrapper.blade.php
@@ -9,11 +9,13 @@
     'prefixIcon' => null,
     'prefixIconColor' => 'gray',
     'prefixIconAlias' => null,
+    'prefixSlot' => null,
     'suffix' => null,
     'suffixActions' => [],
     'suffixIcon' => null,
     'suffixIconColor' => 'gray',
     'suffixIconAlias' => null,
+    'suffixSlot' => null,
     'valid' => true,
 ])
 
@@ -28,8 +30,8 @@
         fn (\Filament\Forms\Components\Actions\Action $suffixAction): bool => $suffixAction->isVisible(),
     );
 
-    $hasPrefix = count($prefixActions) || $prefixIcon || filled($prefix);
-    $hasSuffix = count($suffixActions) || $suffixIcon || filled($suffix);
+    $hasPrefix = count($prefixActions) || $prefixIcon || filled($prefix) || $prefixSlot !== null;
+    $hasSuffix = count($suffixActions) || $suffixIcon || filled($suffix) || $suffixSlot !== null;
 
     $hasAlpineDisabledClasses = filled($alpineDisabled);
     $hasAlpineValidClasses = filled($alpineValid);
@@ -157,6 +159,10 @@
                     {{ $prefix }}
                 </span>
             @endif
+
+            @if($prefixSlot !== null)
+                {{$prefixSlot}}
+            @endif
         </div>
     @endif
 
@@ -206,6 +212,10 @@
                         {{ $suffixAction }}
                     @endforeach
                 </div>
+            @endif
+
+            @if($suffixSlot !== null)
+                {{$suffixSlot}}
             @endif
         </div>
     @endif

--- a/packages/support/resources/views/components/input/wrapper.blade.php
+++ b/packages/support/resources/views/components/input/wrapper.blade.php
@@ -2,6 +2,7 @@
     'alpineDisabled' => null,
     'alpineValid' => null,
     'disabled' => false,
+    'end' => null,
     'inlinePrefix' => false,
     'inlineSuffix' => false,
     'prefix' => null,
@@ -9,13 +10,12 @@
     'prefixIcon' => null,
     'prefixIconColor' => 'gray',
     'prefixIconAlias' => null,
-    'prefixSlot' => null,
+    'start' => null,
     'suffix' => null,
     'suffixActions' => [],
     'suffixIcon' => null,
     'suffixIconColor' => 'gray',
     'suffixIconAlias' => null,
-    'suffixSlot' => null,
     'valid' => true,
 ])
 
@@ -30,8 +30,8 @@
         fn (\Filament\Forms\Components\Actions\Action $suffixAction): bool => $suffixAction->isVisible(),
     );
 
-    $hasPrefix = count($prefixActions) || $prefixIcon || filled($prefix) || !\Filament\Support\is_slot_empty($prefixSlot);
-    $hasSuffix = count($suffixActions) || $suffixIcon || filled($suffix) || !\Filament\Support\is_slot_empty($suffixSlot);
+    $hasPrefix = count($prefixActions) || $prefixIcon || filled($prefix);
+    $hasSuffix = count($suffixActions) || $suffixIcon || filled($suffix);
 
     $hasAlpineDisabledClasses = filled($alpineDisabled);
     $hasAlpineValidClasses = filled($alpineValid);
@@ -100,6 +100,8 @@
             ])
     }}
 >
+    {{ $start }}
+    
     @if ($hasPrefix || $hasLoadingIndicator)
         <div
             @if (! $hasPrefix)
@@ -159,10 +161,6 @@
                     {{ $prefix }}
                 </span>
             @endif
-
-            @if(!\Filament\Support\is_slot_empty($prefixSlot))
-                {{$prefixSlot}}
-            @endif
         </div>
     @endif
 
@@ -213,10 +211,8 @@
                     @endforeach
                 </div>
             @endif
-
-            @if(!\Filament\Support\is_slot_empty($suffixSlot))
-                {{$suffixSlot}}
-            @endif
         </div>
     @endif
+
+    {{ $end }}
 </div>

--- a/packages/support/resources/views/components/input/wrapper.blade.php
+++ b/packages/support/resources/views/components/input/wrapper.blade.php
@@ -30,8 +30,8 @@
         fn (\Filament\Forms\Components\Actions\Action $suffixAction): bool => $suffixAction->isVisible(),
     );
 
-    $hasPrefix = count($prefixActions) || $prefixIcon || filled($prefix) || $prefixSlot !== null;
-    $hasSuffix = count($suffixActions) || $suffixIcon || filled($suffix) || $suffixSlot !== null;
+    $hasPrefix = count($prefixActions) || $prefixIcon || filled($prefix) || !\Filament\Support\is_slot_empty($prefixSlot);
+    $hasSuffix = count($suffixActions) || $suffixIcon || filled($suffix) || !\Filament\Support\is_slot_empty($suffixSlot);
 
     $hasAlpineDisabledClasses = filled($alpineDisabled);
     $hasAlpineValidClasses = filled($alpineValid);
@@ -160,7 +160,7 @@
                 </span>
             @endif
 
-            @if($prefixSlot !== null)
+            @if(!\Filament\Support\is_slot_empty($prefixSlot))
                 {{$prefixSlot}}
             @endif
         </div>
@@ -214,7 +214,7 @@
                 </div>
             @endif
 
-            @if($suffixSlot !== null)
+            @if(!\Filament\Support\is_slot_empty($suffixSlot))
                 {{$suffixSlot}}
             @endif
         </div>


### PR DESCRIPTION
This is supposed to reduce duplicate code when developing custom fields.
With this change `x-filament::input.wrapper` can accept two additional slots:

- `x-slot:suffixSlot`
- `x-slot:prefixSlot`

for example this change enables development (without duplicating all the input-wrapper code) of a custom field to suffix a TextField with a select input.

<img width="439" alt="text_field_with_select" src="https://github.com/filamentphp/filament/assets/1621844/895df0c8-87e4-4678-bc16-aaa81f9a3e80">

My implementation allows for affix actions, labels and icons alongside the slot - there might be a discussion to only have one or the other.