### PR TITLE
improved handling of rare morph relationship scenarios

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -17,6 +17,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Exists;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 class Select extends Field implements Contracts\HasNestedRecursiveValidationRules
 {
@@ -623,9 +625,26 @@ class Select extends Field implements Contracts\HasNestedRecursiveValidationRule
             static fn (Select $component): bool => ! $component->isMultiple(),
         );
 
-        $this->saveRelationshipsUsing(static function (Select $component, Model $record, $state) {
+       $this->saveRelationshipsUsing(static function (Select $component, Model $record, $state) {
             if ($component->isMultiple()) {
-                $component->getRelationship()->sync($state ?? []);
+
+                if ($component->getRelationship() instanceof MorphToMany) {
+                    $currentRelationshipName = $component->getRelationshipName();
+                    $table = $component->getRelationship()->getTable();
+                    $morphType = $component->getRelationship()->getMorphType();
+                    $morphClass = $component->getRelationship()->getMorphClass();
+                    $foreignPivotKey = $component->getRelationship()->getForeignPivotKeyName();
+                    $relatedPivotKey = $component->getRelationship()->getRelatedPivotKeyName();
+                    foreach ($record->$currentRelationshipName as $category) {
+                        DB::table($table)->where($morphType, '=', $morphClass)->where($foreignPivotKey, $record->id)->where($relatedPivotKey, $category->id)->delete();
+                    }
+                    foreach ($state as $sta) {
+                        $component->getRelationship()->attach($sta);
+                    }
+                } else {
+                    $component->getRelationship()->sync($state ?? []);
+                }
+
 
                 return;
             }


### PR DESCRIPTION
Refactor save function to enhance support for uncommon scenarios in morph relationships

In certain rare scenarios involving multiple morph relationships with the same model, specifically when dealing with customized queries, the existing save function needed modification to ensure robust handling. For instance, consider the case where a model, such as 'Product,' has a morph-to-many relationship with categories, but with distinct query conditions for different category subsets, like 'Gaming Categories' and 'Tech Categories.' This commit addresses these complexities, providing a more versatile and resilient solution for managing diverse morph relationships within the application.

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
