### PR TITLE
Select setting the correct data if canSelectPlaceholder is false

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -115,7 +115,16 @@ class Select extends Field implements Contracts\HasAffixActions, Contracts\HasNe
     {
         parent::setUp();
 
-        $this->default(static fn (Select $component): ?array => $component->isMultiple() ? [] : null);
+        $this->default(static function (Select $component): int|array|null {
+            if ($component->isMultiple()) {
+                return [];
+            }
+            if (! $component->canSelectPlaceholder())
+            {
+                return collect($component->getOptions())->keys()->first();
+            }
+            return null;
+        });
 
         $this->afterStateHydrated(static function (Select $component, $state): void {
             if (! $component->isMultiple()) {

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -119,10 +119,12 @@ class Select extends Field implements Contracts\HasAffixActions, Contracts\HasNe
             if ($component->isMultiple()) {
                 return [];
             }
+
             if (! $component->canSelectPlaceholder())
             {
                 return collect($component->getOptions())->keys()->first();
             }
+            
             return null;
         });
 

--- a/tests/src/Forms/FormsTest.php
+++ b/tests/src/Forms/FormsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Form;
 use Filament\Tests\Forms\Fixtures\Livewire;
 use Filament\Tests\TestCase;
@@ -89,6 +90,12 @@ it('can have visible fields on multiple forms', function () {
         ->assertFormFieldIsVisible('visible', 'barForm');
 });
 
+it('sets default value to form select without selectable placeholder', function () {
+    livewire(TestComponentWithSelectForm::class)
+        ->assertFormSet(['select.placeholder' => null])
+        ->assertFormSet(['select.no-placeholder' => 2]);
+});
+
 class TestComponentWithForm extends Livewire
 {
     public function form(Form $form): Form
@@ -162,6 +169,32 @@ class TestComponentWithMultipleForms extends Livewire
 
             TextInput::make('visible'),
         ];
+    }
+
+    public function render(): View
+    {
+        return view('forms.fixtures.form');
+    }
+}
+
+class TestComponentWithSelectForm extends Livewire
+{
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Select::make('select.placeholder')
+                    ->options([
+                        2 => 'Two',
+                        3 => 'Three',
+                    ]),
+                Select::make('select.no-placeholder')
+                    ->selectablePlaceholder(false)
+                    ->options([
+                        2 => 'Two',
+                        3 => 'Three',
+                    ]),
+            ]);
     }
 
     public function render(): View

--- a/tests/src/Forms/FormsTest.php
+++ b/tests/src/Forms/FormsTest.php
@@ -188,6 +188,7 @@ class TestComponentWithSelectForm extends Livewire
                         2 => 'Two',
                         3 => 'Three',
                     ]),
+
                 Select::make('select.no-placeholder')
                     ->selectablePlaceholder(false)
                     ->options([


### PR DESCRIPTION
- [X] Changes have been thoroughly tested to not break existing functionality.
Added additional test

If you create a form with a select on it, and you set the canSelectPlaceholder(false) the first item of the select is selected, but the data is still null. This PR fixes the data to reflect the item being shown on your screen. Normally, you would have to set the default value in your Form component fetching the options again and selecting the first key as default value.