### PR TITLE
feat: add `FilamentAsset::registerCssVariables`

### DIFF
--- a/packages/support/docs/02-assets.md
+++ b/packages/support/docs/02-assets.md
@@ -141,6 +141,24 @@ FilamentAsset::register([
 ]);
 ```
 
+### Registering CSS variables
+
+Sometimes, you may wish to use dynamic data from the backend in CSS files. To do this, you can use the `FilamentAsset::registerCssVariables()` method in the `boot()` method of a service provider:
+
+```php
+use Filament\Support\Facades\FilamentAsset;
+
+FilamentAsset::registerCssVariables([
+    'background-image' => asset('images/background.jpg'),
+]);
+```
+
+Now, you can access these variables from any CSS file:
+
+```css
+background-image: var(--background-image);
+```
+
 ## Registering JavaScript files
 
 To register a JavaScript file with the asset system, use the `FilamentAsset::register()` method in the `boot()` method of a service provider. You must pass in an array of `Js` objects, which each represents a JavaScript file that should be registered in the asset system.

--- a/packages/support/src/Assets/AssetManager.php
+++ b/packages/support/src/Assets/AssetManager.php
@@ -29,6 +29,11 @@ class AssetManager
     protected array $styles = [];
 
     /**
+     * @var array<string, array<string, mixed>>
+     */
+    protected array $cssVariables = [];
+
+    /**
      * @var array<string, Theme>
      */
     protected array $themes = [];
@@ -59,6 +64,17 @@ class AssetManager
         $this->scriptData[$package] = [
             ...($this->scriptData[$package] ?? []),
             ...$data,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $variables
+     */
+    public function registerCssVariables(array $variables, ?string $package = null): void
+    {
+        $this->cssVariables[$package] = [
+            ...($this->cssVariables[$package] ?? []),
+            ...$variables,
         ];
     }
 
@@ -196,10 +212,36 @@ class AssetManager
 
     /**
      * @param  array<string> | null  $packages
+     * @return array<string, mixed>
+     */
+    public function getCssVariables(?array $packages = null): array
+    {
+        $variables = [];
+
+        foreach ($this->cssVariables as $package => $packageVariables) {
+            if (
+                ($packages !== null) &&
+                ($package !== null) &&
+                (! in_array($package, $packages))
+            ) {
+                continue;
+            }
+
+            $variables = [
+                ...$variables,
+                ...$packageVariables,
+            ];
+        }
+
+        return $variables;
+    }
+
+    /**
+     * @param  array<string> | null  $packages
      */
     public function renderStyles(?array $packages = null): string
     {
-        $variables = [];
+        $variables = $this->getCssVariables($packages);
 
         foreach (FilamentColor::getColors() as $name => $shades) {
             foreach ($shades as $shade => $color) {

--- a/packages/support/src/Facades/FilamentAsset.php
+++ b/packages/support/src/Facades/FilamentAsset.php
@@ -48,4 +48,14 @@ class FilamentAsset extends Facade
             $assetManager->registerScriptData($data, $package);
         });
     }
+
+    /**
+     * @param  array<string, mixed>  $variables
+     */
+    public static function registerCssVariables(array $variables, ?string $package = null): void
+    {
+        static::resolved(function (AssetManager $assetManager) use ($variables, $package) {
+            $assetManager->registerCssVariables($variables, $package);
+        });
+    }
 }


### PR DESCRIPTION
Using this method, you can use dynamic data from the backend in CSS files. It is basically the CSS counterpart of (and based on) `FilamentAsset::registerScriptData`.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

### Use-case
I'd like to add a dynamic background-image to the login page(s), based on the day of the month, time of the day, weather or just random, you name it. Currently there is only a "hacky" way by adding a CSS file using a URL that points to a controller that dynamically generates the CSS. From a caching perspective this isn't ideal, although there are probably "hacks" to make that cacheable. When I can add a dynamic CSS variable, I can create one static (cacheable) CSS file that uses that variable for the background-image, without any "hacks".