### PR TITLE
Adjusting rules checking user input against a list of allowed values

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -75,7 +75,7 @@ trait CanBeValidated
     /**
      * @param  array<scalar> | Arrayable | string | Closure  $values
      */
-    public function doesntStartWith(array | Arrayable | string | Closure $values): static
+    public function doesntStartWith(array | Arrayable | string | Closure $values, bool | Closure $condition = true): static
     {
         $this->rule(static function (Field $component) use ($values) {
             $values = $component->evaluate($values);
@@ -89,15 +89,7 @@ trait CanBeValidated
             }
 
             return 'doesnt_start_with:' . $values;
-        }, static function (Field $component) use ($values): bool {
-            $values = $component->evaluate($values);
-
-            if ($values instanceof Arrayable) {
-                $values = $values->toArray();
-            }
-
-            return is_array($values) ? count($values) : filled($values);
-        });
+        }, $condition);
 
         return $this;
     }
@@ -105,7 +97,7 @@ trait CanBeValidated
     /**
      * @param  array<scalar> | Arrayable | string | Closure  $values
      */
-    public function doesntEndWith(array | Arrayable | string | Closure $values): static
+    public function doesntEndWith(array | Arrayable | string | Closure $values, bool | Closure $condition = true): static
     {
         $this->rule(static function (Field $component) use ($values) {
             $values = $component->evaluate($values);
@@ -119,15 +111,7 @@ trait CanBeValidated
             }
 
             return 'doesnt_end_with:' . $values;
-        }, static function (Field $component) use ($values): bool {
-            $values = $component->evaluate($values);
-
-            if ($values instanceof Arrayable) {
-                $values = $values->toArray();
-            }
-
-            return is_array($values) ? count($values) : filled($values);
-        });
+        }, $condition);
 
         return $this;
     }
@@ -135,7 +119,7 @@ trait CanBeValidated
     /**
      * @param  array<scalar> | Arrayable | string | Closure  $values
      */
-    public function endsWith(array | Arrayable | string | Closure $values): static
+    public function endsWith(array | Arrayable | string | Closure $values, bool | Closure $condition = true): static
     {
         $this->rule(static function (Field $component) use ($values) {
             $values = $component->evaluate($values);
@@ -149,15 +133,7 @@ trait CanBeValidated
             }
 
             return 'ends_with:' . $values;
-        }, static function (Field $component) use ($values): bool {
-            $values = $component->evaluate($values);
-
-            if ($values instanceof Arrayable) {
-                $values = $values->toArray();
-            }
-
-            return is_array($values) ? count($values) : filled($values);
-        });
+        }, $condition);
 
         return $this;
     }
@@ -203,7 +179,7 @@ trait CanBeValidated
     /**
      * @param  array<scalar> | Arrayable | string | Closure  $values
      */
-    public function in(array | Arrayable | string | Closure $values): static
+    public function in(array | Arrayable | string | Closure $values, bool | Closure $condition = true): static
     {
         $this->rule(static function (Field $component) use ($values) {
             $values = $component->evaluate($values);
@@ -217,15 +193,7 @@ trait CanBeValidated
             }
 
             return Rule::in($values);
-        }, static function (Field $component) use ($values): bool {
-            $values = $component->evaluate($values);
-
-            if ($values instanceof Arrayable) {
-                $values = $values->toArray();
-            }
-
-            return is_array($values) ? count($values) : filled($values);
-        });
+        }, $condition);
 
         return $this;
     }
@@ -277,7 +245,7 @@ trait CanBeValidated
     /**
      * @param  array<scalar> | Arrayable | string | Closure  $values
      */
-    public function notIn(array | Arrayable | string | Closure $values): static
+    public function notIn(array | Arrayable | string | Closure $values, bool | Closure $condition = true): static
     {
         $this->rule(static function (Field $component) use ($values) {
             $values = $component->evaluate($values);
@@ -291,15 +259,7 @@ trait CanBeValidated
             }
 
             return Rule::notIn($values);
-        }, static function (Field $component) use ($values): bool {
-            $values = $component->evaluate($values);
-
-            if ($values instanceof Arrayable) {
-                $values = $values->toArray();
-            }
-
-            return is_array($values) ? count($values) : filled($values);
-        });
+        }, $condition);
 
         return $this;
     }
@@ -406,7 +366,7 @@ trait CanBeValidated
     /**
      * @param  array<scalar> | Arrayable | string | Closure  $values
      */
-    public function startsWith(array | Arrayable | string | Closure $values): static
+    public function startsWith(array | Arrayable | string | Closure $values, bool | Closure $condition = true): static
     {
         $this->rule(static function (Field $component) use ($values) {
             $values = $component->evaluate($values);
@@ -420,15 +380,7 @@ trait CanBeValidated
             }
 
             return 'starts_with:' . $values;
-        }, static function (Field $component) use ($values): bool {
-            $values = $component->evaluate($values);
-
-            if ($values instanceof Arrayable) {
-                $values = $values->toArray();
-            }
-
-            return is_array($values) ? count($values) : filled($values);
-        });
+        }, $condition);
 
         return $this;
     }

--- a/tests/src/Forms/ValidationTest.php
+++ b/tests/src/Forms/ValidationTest.php
@@ -4,7 +4,9 @@ use Filament\Forms\ComponentContainer;
 use Filament\Forms\Components\Field;
 use Filament\Tests\Forms\Fixtures\Livewire;
 use Filament\Tests\TestCase;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 
 uses(TestCase::class);
@@ -125,4 +127,796 @@ test('fields can be required unless', function () {
 
     expect($errors)
         ->toContain('The two field is required unless one is in foo.');
+});
+
+/* ----- in() ----- */
+test('the in() rule api works like passing laravel\'s `Rule::in()` as a custom rule', function (?string $input, array | Arrayable | string | Closure $allowed) {
+    $filamentFails = [];
+
+    $laravelFails = [];
+
+    $fieldName = Str::random();
+
+    $component = Livewire::make()->data([$fieldName => $input]);
+
+    try {
+        ComponentContainer::make($component)
+            ->statePath('data')
+            ->components([
+                $field = (new Field($fieldName))
+                    ->in($allowed),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $filamentFails = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    try {
+        ComponentContainer::make($component)
+            ->statePath('data')
+            ->components([
+                $field = (new Field($fieldName))
+                    ->rule(Rule::in($allowed instanceof Closure
+                        ? $allowed()
+                        : $allowed)),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $laravelFails = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    expect($filamentFails)
+        ->toBe($laravelFails);
+})->with([
+    [
+        'input' => 'foo',
+        'allowed' => ['bar'],
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => collect(['bar']),
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => 'bar',
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => fn () => (fn () => 'bar'),
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => [],
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => collect([]),
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => '',
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => fn () => (fn () => null),
+    ],
+    [
+        'input' => null,
+        'allowed' => [],
+    ],
+    [
+        'input' => null,
+        'allowed' => collect([]),
+    ],
+    [
+        'input' => null,
+        'allowed' => '',
+    ],
+    [
+        'input' => null,
+        'allowed' => fn () => (fn () => null),
+    ],
+    [
+        'input' => '',
+        'allowed' => [],
+    ],
+    [
+        'input' => '',
+        'allowed' => collect([]),
+    ],
+    [
+        'input' => '',
+        'allowed' => '',
+    ],
+    [
+        'input' => '',
+        'allowed' => fn () => (fn () => null),
+    ],
+]);
+
+test('the in() rule can be conditionally validated', function () {
+    $fails = [];
+
+    $fieldName = Str::random();
+
+    try {
+        ComponentContainer::make(Livewire::make()->data([$fieldName => 'foo']))
+            ->statePath('data')
+            ->components([
+                $field = (new Field($fieldName))
+                    ->in(['bar'], false),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $fails = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    expect($fails)
+        ->toBeEmpty();
+});
+
+/* ----- notIn() ----- */
+test('the notIn() rule api works like passing laravel\'s `Rule::notIn()` as a custom rule', function (?string $input, array | Arrayable | string | Closure $allowed) {
+    $filamentFails = [];
+
+    $laravelFails = [];
+
+    $fieldName = Str::random();
+
+    $component = Livewire::make()->data([$fieldName => $input]);
+
+    try {
+        ComponentContainer::make($component)
+            ->statePath('data')
+            ->components([
+                $field = (new Field($fieldName))
+                    ->notIn($allowed),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $filamentFails = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    try {
+        ComponentContainer::make($component)
+            ->statePath('data')
+            ->components([
+                $field = (new Field($fieldName))
+                    ->rule(Rule::notIn($allowed instanceof Closure
+                        ? $allowed()
+                        : $allowed)),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $laravelFails = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    expect($filamentFails)
+        ->toBe($laravelFails);
+})->with([
+    [
+        'input' => 'foo',
+        'allowed' => ['bar'],
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => collect(['bar']),
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => 'bar',
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => fn () => (fn () => 'bar'),
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => [],
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => collect([]),
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => '',
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => fn () => (fn () => null),
+    ],
+    [
+        'input' => null,
+        'allowed' => [],
+    ],
+    [
+        'input' => null,
+        'allowed' => collect([]),
+    ],
+    [
+        'input' => null,
+        'allowed' => '',
+    ],
+    [
+        'input' => null,
+        'allowed' => fn () => (fn () => null),
+    ],
+    [
+        'input' => '',
+        'allowed' => [],
+    ],
+    [
+        'input' => '',
+        'allowed' => collect([]),
+    ],
+    [
+        'input' => '',
+        'allowed' => '',
+    ],
+    [
+        'input' => '',
+        'allowed' => fn () => (fn () => null),
+    ],
+]);
+
+test('the notIn rule can be conditionally validated', function () {
+    $fails = [];
+
+    $fieldName = Str::random();
+
+    try {
+        ComponentContainer::make(Livewire::make()->data([$fieldName => 'foo']))
+            ->statePath('data')
+            ->components([
+                $field = (new Field($fieldName))
+                    ->notIn(['bar'], false),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $fails = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    expect($fails)
+        ->toBeEmpty();
+});
+
+/* ----- startsWith() ----- */
+test('the startsWith() rule api works like passing laravel\'s `starts_with:` as a custom rule', function (?string $input, array | Arrayable | string | Closure $allowed) {
+    $filamentFails = [];
+
+    $laravelFails = [];
+
+    $fieldName = Str::random();
+
+    $component = Livewire::make()->data([$fieldName => $input]);
+
+    try {
+        ComponentContainer::make($component)
+            ->statePath('data')
+            ->components([
+                $field = (new Field($fieldName))
+                    ->startsWith($allowed),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $filamentFails = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    $field = (new Field($fieldName));
+
+    $allowed = $field->evaluate($allowed);
+
+    if ($allowed instanceof Arrayable) {
+        $allowed = $allowed->toArray();
+    }
+
+    if (is_array($allowed)) {
+        $allowed = implode(',', $allowed);
+    }
+
+    try {
+        ComponentContainer::make($component)
+            ->statePath('data')
+            ->components([
+                $field->rule('starts_with:' . $allowed),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $laravelFails = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    expect($filamentFails)
+        ->toBe($laravelFails);
+})->with([
+    [
+        'input' => 'foo',
+        'allowed' => ['bar'],
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => collect(['bar']),
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => 'bar',
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => fn () => (fn () => 'bar'),
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => [],
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => collect([]),
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => '',
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => fn () => (fn () => null),
+    ],
+    [
+        'input' => null,
+        'allowed' => [],
+    ],
+    [
+        'input' => null,
+        'allowed' => collect([]),
+    ],
+    [
+        'input' => null,
+        'allowed' => '',
+    ],
+    [
+        'input' => null,
+        'allowed' => fn () => (fn () => null),
+    ],
+    [
+        'input' => '',
+        'allowed' => [],
+    ],
+    [
+        'input' => '',
+        'allowed' => collect([]),
+    ],
+    [
+        'input' => '',
+        'allowed' => '',
+    ],
+    [
+        'input' => '',
+        'allowed' => fn () => (fn () => null),
+    ],
+]);
+
+test('the startsWith rule can be conditionally validated', function () {
+    $fails = [];
+
+    $fieldName = Str::random();
+
+    try {
+        ComponentContainer::make(Livewire::make()->data([$fieldName => 'foo']))
+            ->statePath('data')
+            ->components([
+                $field = (new Field($fieldName))
+                    ->startsWith(['bar'], false),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $fails = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    expect($fails)
+        ->toBeEmpty();
+});
+
+/* ----- doesntStartWith() ----- */
+test('the doesntStartWith() rule api works like passing laravel\'s `doesnt_start_with:` as a custom rule', function (?string $input, array | Arrayable | string | Closure $allowed) {
+    $filamentFails = [];
+
+    $laravelFails = [];
+
+    $fieldName = Str::random();
+
+    $component = Livewire::make()->data([$fieldName => $input]);
+
+    try {
+        ComponentContainer::make($component)
+            ->statePath('data')
+            ->components([
+                $field = (new Field($fieldName))
+                    ->doesntStartWith($allowed),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $filamentFails = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    $field = (new Field($fieldName));
+
+    $allowed = $field->evaluate($allowed);
+
+    if ($allowed instanceof Arrayable) {
+        $allowed = $allowed->toArray();
+    }
+
+    if (is_array($allowed)) {
+        $allowed = implode(',', $allowed);
+    }
+
+    try {
+        ComponentContainer::make($component)
+            ->statePath('data')
+            ->components([
+                $field->rule('doesnt_start_with:' . $allowed),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $laravelFails = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    expect($filamentFails)
+        ->toBe($laravelFails);
+})->with([
+    [
+        'input' => 'foo',
+        'allowed' => ['bar'],
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => collect(['bar']),
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => 'bar',
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => fn () => (fn () => 'bar'),
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => [],
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => collect([]),
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => '',
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => fn () => (fn () => null),
+    ],
+    [
+        'input' => null,
+        'allowed' => [],
+    ],
+    [
+        'input' => null,
+        'allowed' => collect([]),
+    ],
+    [
+        'input' => null,
+        'allowed' => '',
+    ],
+    [
+        'input' => null,
+        'allowed' => fn () => (fn () => null),
+    ],
+    [
+        'input' => '',
+        'allowed' => [],
+    ],
+    [
+        'input' => '',
+        'allowed' => collect([]),
+    ],
+    [
+        'input' => '',
+        'allowed' => '',
+    ],
+    [
+        'input' => '',
+        'allowed' => fn () => (fn () => null),
+    ],
+]);
+
+test('the doesntStartWith rule can be conditionally validated', function () {
+    $fails = [];
+
+    $fieldName = Str::random();
+
+    try {
+        ComponentContainer::make(Livewire::make()->data([$fieldName => 'foo']))
+            ->statePath('data')
+            ->components([
+                $field = (new Field($fieldName))
+                    ->doesntStartWith(['bar'], false),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $fails = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    expect($fails)
+        ->toBeEmpty();
+});
+
+/* ----- endsWith() ----- */
+test('the endsWith() rule api works like passing laravel\'s `ends_with:` as a custom rule', function (?string $input, array | Arrayable | string | Closure $allowed) {
+    $filamentFails = [];
+
+    $laravelFails = [];
+
+    $fieldName = Str::random();
+
+    $component = Livewire::make()->data([$fieldName => $input]);
+
+    try {
+        ComponentContainer::make($component)
+            ->statePath('data')
+            ->components([
+                $field = (new Field($fieldName))
+                    ->endsWith($allowed),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $filamentFails = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    $field = (new Field($fieldName));
+
+    $allowed = $field->evaluate($allowed);
+
+    if ($allowed instanceof Arrayable) {
+        $allowed = $allowed->toArray();
+    }
+
+    if (is_array($allowed)) {
+        $allowed = implode(',', $allowed);
+    }
+
+    try {
+        ComponentContainer::make($component)
+            ->statePath('data')
+            ->components([
+                $field->rule('ends_with:' . $allowed),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $laravelFails = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    expect($filamentFails)
+        ->toBe($laravelFails);
+})->with([
+    [
+        'input' => 'foo',
+        'allowed' => ['bar'],
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => collect(['bar']),
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => 'bar',
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => fn () => (fn () => 'bar'),
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => [],
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => collect([]),
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => '',
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => fn () => (fn () => null),
+    ],
+    [
+        'input' => null,
+        'allowed' => [],
+    ],
+    [
+        'input' => null,
+        'allowed' => collect([]),
+    ],
+    [
+        'input' => null,
+        'allowed' => '',
+    ],
+    [
+        'input' => null,
+        'allowed' => fn () => (fn () => null),
+    ],
+    [
+        'input' => '',
+        'allowed' => [],
+    ],
+    [
+        'input' => '',
+        'allowed' => collect([]),
+    ],
+    [
+        'input' => '',
+        'allowed' => '',
+    ],
+    [
+        'input' => '',
+        'allowed' => fn () => (fn () => null),
+    ],
+]);
+
+test('the endsWith rule can be conditionally validated', function () {
+    $fails = [];
+
+    $fieldName = Str::random();
+
+    try {
+        ComponentContainer::make(Livewire::make()->data([$fieldName => 'foo']))
+            ->statePath('data')
+            ->components([
+                $field = (new Field($fieldName))
+                    ->endsWith(['bar'], false),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $fails = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    expect($fails)
+        ->toBeEmpty();
+});
+
+/* ----- doesntEndWith() ----- */
+test('the doesntEndWith() rule api works like passing laravel\'s `doesnt_end_with:` as a custom rule', function (?string $input, array | Arrayable | string | Closure $allowed) {
+    $filamentFails = [];
+
+    $laravelFails = [];
+
+    $fieldName = Str::random();
+
+    $component = Livewire::make()->data([$fieldName => $input]);
+
+    try {
+        ComponentContainer::make($component)
+            ->statePath('data')
+            ->components([
+                $field = (new Field($fieldName))
+                    ->doesntEndWith($allowed),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $filamentFails = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    $field = (new Field($fieldName));
+
+    $allowed = $field->evaluate($allowed);
+
+    if ($allowed instanceof Arrayable) {
+        $allowed = $allowed->toArray();
+    }
+
+    if (is_array($allowed)) {
+        $allowed = implode(',', $allowed);
+    }
+
+    try {
+        ComponentContainer::make($component)
+            ->statePath('data')
+            ->components([
+                $field->rule('doesnt_end_with:' . $allowed),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $laravelFails = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    expect($filamentFails)
+        ->toBe($laravelFails);
+})->with([
+    [
+        'input' => 'foo',
+        'allowed' => ['bar'],
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => collect(['bar']),
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => 'bar',
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => fn () => (fn () => 'bar'),
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => [],
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => collect([]),
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => '',
+    ],
+    [
+        'input' => 'foo',
+        'allowed' => fn () => (fn () => null),
+    ],
+    [
+        'input' => null,
+        'allowed' => [],
+    ],
+    [
+        'input' => null,
+        'allowed' => collect([]),
+    ],
+    [
+        'input' => null,
+        'allowed' => '',
+    ],
+    [
+        'input' => null,
+        'allowed' => fn () => (fn () => null),
+    ],
+    [
+        'input' => '',
+        'allowed' => [],
+    ],
+    [
+        'input' => '',
+        'allowed' => collect([]),
+    ],
+    [
+        'input' => '',
+        'allowed' => '',
+    ],
+    [
+        'input' => '',
+        'allowed' => fn () => (fn () => null),
+    ],
+]);
+
+test('the doesntEndWith rule can be conditionally validated', function () {
+    $fails = [];
+
+    $fieldName = Str::random();
+
+    try {
+        ComponentContainer::make(Livewire::make()->data([$fieldName => 'foo']))
+            ->statePath('data')
+            ->components([
+                $field = (new Field($fieldName))
+                    ->doesntEndWith(['bar'], false),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $fails = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    expect($fails)
+        ->toBeEmpty();
 });

--- a/tests/src/Forms/ValidationTest.php
+++ b/tests/src/Forms/ValidationTest.php
@@ -129,8 +129,7 @@ test('fields can be required unless', function () {
         ->toContain('The two field is required unless one is in foo.');
 });
 
-/* ----- in() ----- */
-test('the in() rule api works like passing laravel\'s `Rule::in()` as a custom rule', function (?string $input, array | Arrayable | string | Closure $allowed) {
+test('the `in()` rule behaves the same as Laravel\'s', function (?string $input, array | Arrayable | string | Closure $allowed) {
     $filamentFails = [];
 
     $laravelFails = [];
@@ -234,7 +233,7 @@ test('the in() rule api works like passing laravel\'s `Rule::in()` as a custom r
     ],
 ]);
 
-test('the in() rule can be conditionally validated', function () {
+test('the `in()` rule can be conditionally validated', function () {
     $fails = [];
 
     $fieldName = Str::random();
@@ -255,8 +254,7 @@ test('the in() rule can be conditionally validated', function () {
         ->toBeEmpty();
 });
 
-/* ----- notIn() ----- */
-test('the notIn() rule api works like passing laravel\'s `Rule::notIn()` as a custom rule', function (?string $input, array | Arrayable | string | Closure $allowed) {
+test('the `notIn()` rule behaves the same as Laravel\'s', function (?string $input, array | Arrayable | string | Closure $allowed) {
     $filamentFails = [];
 
     $laravelFails = [];
@@ -360,7 +358,7 @@ test('the notIn() rule api works like passing laravel\'s `Rule::notIn()` as a cu
     ],
 ]);
 
-test('the notIn rule can be conditionally validated', function () {
+test('the `notIn()` rule can be conditionally validated', function () {
     $fails = [];
 
     $fieldName = Str::random();
@@ -381,8 +379,7 @@ test('the notIn rule can be conditionally validated', function () {
         ->toBeEmpty();
 });
 
-/* ----- startsWith() ----- */
-test('the startsWith() rule api works like passing laravel\'s `starts_with:` as a custom rule', function (?string $input, array | Arrayable | string | Closure $allowed) {
+test('the `startsWith()` rule behaves the same as Laravel\'s', function (?string $input, array | Arrayable | string | Closure $allowed) {
     $filamentFails = [];
 
     $laravelFails = [];
@@ -495,7 +492,7 @@ test('the startsWith() rule api works like passing laravel\'s `starts_with:` as 
     ],
 ]);
 
-test('the startsWith rule can be conditionally validated', function () {
+test('the `startsWith()` rule can be conditionally validated', function () {
     $fails = [];
 
     $fieldName = Str::random();
@@ -516,8 +513,7 @@ test('the startsWith rule can be conditionally validated', function () {
         ->toBeEmpty();
 });
 
-/* ----- doesntStartWith() ----- */
-test('the doesntStartWith() rule api works like passing laravel\'s `doesnt_start_with:` as a custom rule', function (?string $input, array | Arrayable | string | Closure $allowed) {
+test('the `doesntStartWith()` rule behaves the same as Laravel\'s', function (?string $input, array | Arrayable | string | Closure $allowed) {
     $filamentFails = [];
 
     $laravelFails = [];
@@ -630,7 +626,7 @@ test('the doesntStartWith() rule api works like passing laravel\'s `doesnt_start
     ],
 ]);
 
-test('the doesntStartWith rule can be conditionally validated', function () {
+test('the `doesntStartWith()` rule can be conditionally validated', function () {
     $fails = [];
 
     $fieldName = Str::random();
@@ -651,8 +647,7 @@ test('the doesntStartWith rule can be conditionally validated', function () {
         ->toBeEmpty();
 });
 
-/* ----- endsWith() ----- */
-test('the endsWith() rule api works like passing laravel\'s `ends_with:` as a custom rule', function (?string $input, array | Arrayable | string | Closure $allowed) {
+test('the `endsWith()` rule behaves the same as Laravel\'s', function (?string $input, array | Arrayable | string | Closure $allowed) {
     $filamentFails = [];
 
     $laravelFails = [];
@@ -765,7 +760,7 @@ test('the endsWith() rule api works like passing laravel\'s `ends_with:` as a cu
     ],
 ]);
 
-test('the endsWith rule can be conditionally validated', function () {
+test('the `endsWith()` rule can be conditionally validated', function () {
     $fails = [];
 
     $fieldName = Str::random();
@@ -786,8 +781,7 @@ test('the endsWith rule can be conditionally validated', function () {
         ->toBeEmpty();
 });
 
-/* ----- doesntEndWith() ----- */
-test('the doesntEndWith() rule api works like passing laravel\'s `doesnt_end_with:` as a custom rule', function (?string $input, array | Arrayable | string | Closure $allowed) {
+test('the `doesntEndWith()` rule behaves the same as Laravel\'s', function (?string $input, array | Arrayable | string | Closure $allowed) {
     $filamentFails = [];
 
     $laravelFails = [];
@@ -900,7 +894,7 @@ test('the doesntEndWith() rule api works like passing laravel\'s `doesnt_end_wit
     ],
 ]);
 
-test('the doesntEndWith rule can be conditionally validated', function () {
+test('the `doesntEndWith()` rule can be conditionally validated', function () {
     $fails = [];
 
     $fieldName = Str::random();


### PR DESCRIPTION
## template

- [ ] Changes have been thoroughly tested to not break existing functionality.
  -> indeed it does change the validation functionality 
- [x] New functionality has been documented or existing documentation has been updated to reflect changes. 
  -> no changes needed
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
  -> no visual changes

## context

https://discord.com/channels/883083792112300104/1174699150420476014

after taking a look into the implementation of filaments fluent rule api's, i recognized there are some more rules that have the same behaviour like the `->in()` rule: 

```
->notIn()
->startsWith()
->doesntStartWith()
->endsWith()
->doesntEndWith()
```

please note that i've adjusted all of these rules in this PR. 

## background

my idea was that all of these rules should have the exact same behaviour like passing their laravel's equivalent into a custom rule, e.g.

``` php
// user input: 'foo'
->in([])               // fails
->rule(Rule::in([])    // fails
```

whereas the current implementation works like this:

``` php
// user input: 'foo'
->in([])               // passes, since it's conditionally skipped
->rule(Rule::in([])    // fails
```

### conditionally skipping

laravel's Rule::in() also fails if I allow `null` while the input is anything other than `null` or `''`. to gain the same behavior in filament's fluent api but at the same time add the ability to conditionally skip the validation, I thought the easiest way is to add a second parameter inspired by most of the other rules. 

i've specified my idea of the whole behaviour in `tests/src/Forms/ValidationTest.php`