### PR TITLE
[3.x] Tab supports badge color

### DIFF
--- a/packages/forms/docs/04-layout/04-tabs.md
+++ b/packages/forms/docs/04-layout/04-tabs.md
@@ -155,7 +155,6 @@ Tabs::make('Label')
     ->tabs([
         Tabs\Tab::make('Notifications')
             ->badge(5)
-            ->badgeColor('success')
             ->schema([
                 // ...
             ]),
@@ -164,6 +163,23 @@ Tabs::make('Label')
 ```
 
 <AutoScreenshot name="forms/layout/tabs/badges" alt="Tabs with badges" version="3.x" />
+
+If you'd like to change the color for a badge, you can use the `badgeColor()` method:
+
+```php
+use Filament\Forms\Components\Tabs;
+
+Tabs::make('Label')
+    ->tabs([
+        Tabs\Tab::make('Notifications')
+            ->badge(5)
+            ->badgeColor('success')
+            ->schema([
+                // ...
+            ]),
+        // ...
+    ])
+```
 
 ## Using grid columns within a tab
 

--- a/packages/forms/docs/04-layout/04-tabs.md
+++ b/packages/forms/docs/04-layout/04-tabs.md
@@ -155,6 +155,7 @@ Tabs::make('Label')
     ->tabs([
         Tabs\Tab::make('Notifications')
             ->badge(5)
+            ->badgeColor('success')
             ->schema([
                 // ...
             ]),

--- a/packages/forms/resources/views/components/tabs.blade.php
+++ b/packages/forms/resources/views/components/tabs.blade.php
@@ -64,6 +64,7 @@
             <x-filament::tabs.item
                 :alpine-active="'tab === \'' . $tabId . '\''"
                 :badge="$tab->getBadge()"
+                :badge-color="$tab->getBadgeColor()"
                 :icon="$tab->getIcon()"
                 :icon-position="$tab->getIconPosition()"
                 :x-on:click="'tab = \'' . $tabId . '\''"

--- a/packages/forms/src/Components/Tabs/Tab.php
+++ b/packages/forms/src/Components/Tabs/Tab.php
@@ -2,22 +2,21 @@
 
 namespace Filament\Forms\Components\Tabs;
 
-use Closure;
 use Filament\Forms\Components\Component;
 use Filament\Forms\Components\Contracts\CanConcealComponents;
+use Filament\Support\Concerns\HasBadge;
 use Filament\Support\Concerns\HasIcon;
 use Illuminate\Support\Str;
 
 class Tab extends Component implements CanConcealComponents
 {
+    use HasBadge;
     use HasIcon;
 
     /**
      * @var view-string
      */
     protected string $view = 'filament-forms::components.tabs.tab';
-
-    protected string | Closure | null $badge = null;
 
     final public function __construct(string $label)
     {
@@ -33,13 +32,6 @@ class Tab extends Component implements CanConcealComponents
         return $static;
     }
 
-    public function badge(string | Closure | null $badge): static
-    {
-        $this->badge = $badge;
-
-        return $this;
-    }
-
     public function getId(): string
     {
         return $this->getContainer()->getParentComponent()->getId() . '-' . parent::getId() . '-tab';
@@ -51,11 +43,6 @@ class Tab extends Component implements CanConcealComponents
     public function getColumnsConfig(): array
     {
         return $this->columns ?? $this->getContainer()->getColumnsConfig();
-    }
-
-    public function getBadge(): ?string
-    {
-        return $this->evaluate($this->badge);
     }
 
     public function canConcealComponents(): bool

--- a/packages/infolists/docs/04-layout/04-tabs.md
+++ b/packages/infolists/docs/04-layout/04-tabs.md
@@ -155,6 +155,7 @@ Tabs::make('Label')
     ->tabs([
         Tabs\Tab::make('Notifications')
             ->badge(5)
+            ->badgeColor('success')
             ->schema([
                 // ...
             ]),

--- a/packages/infolists/docs/04-layout/04-tabs.md
+++ b/packages/infolists/docs/04-layout/04-tabs.md
@@ -155,7 +155,6 @@ Tabs::make('Label')
     ->tabs([
         Tabs\Tab::make('Notifications')
             ->badge(5)
-            ->badgeColor('success')
             ->schema([
                 // ...
             ]),
@@ -164,6 +163,23 @@ Tabs::make('Label')
 ```
 
 <AutoScreenshot name="infolists/layout/tabs/badges" alt="Tabs with badges" version="3.x" />
+
+If you'd like to change the color for a badge, you can use the `badgeColor()` method:
+
+```php
+use Filament\Infolists\Components\Tabs;
+
+Tabs::make('Label')
+    ->tabs([
+        Tabs\Tab::make('Notifications')
+            ->badge(5)
+            ->badgeColor('success')
+            ->schema([
+                // ...
+            ]),
+        // ...
+    ])
+```
 
 ## Using grid columns within a tab
 

--- a/packages/infolists/resources/views/components/tabs.blade.php
+++ b/packages/infolists/resources/views/components/tabs.blade.php
@@ -50,6 +50,7 @@
             <x-filament::tabs.item
                 :alpine-active="'tab === \'' . $tabId . '\''"
                 :badge="$tab->getBadge()"
+                :badge-color="$tab->getBadgeColor()"
                 :icon="$tab->getIcon()"
                 :icon-position="$tab->getIconPosition()"
                 :x-on:click="'tab = \'' . $tabId . '\''"

--- a/packages/infolists/src/Components/Tabs/Tab.php
+++ b/packages/infolists/src/Components/Tabs/Tab.php
@@ -2,21 +2,20 @@
 
 namespace Filament\Infolists\Components\Tabs;
 
-use Closure;
 use Filament\Infolists\Components\Component;
+use Filament\Support\Concerns\HasBadge;
 use Filament\Support\Concerns\HasIcon;
 use Illuminate\Support\Str;
 
 class Tab extends Component
 {
+    use HasBadge;
     use HasIcon;
 
     /**
      * @var view-string
      */
     protected string $view = 'filament-infolists::components.tabs.tab';
-
-    protected string | Closure | null $badge = null;
 
     final public function __construct(string $label)
     {
@@ -32,13 +31,6 @@ class Tab extends Component
         return $static;
     }
 
-    public function badge(string | Closure | null $badge): static
-    {
-        $this->badge = $badge;
-
-        return $this;
-    }
-
     public function getId(): string
     {
         return $this->getContainer()->getParentComponent()->getId() . '-' . parent::getId() . '-tab';
@@ -50,10 +42,5 @@ class Tab extends Component
     public function getColumnsConfig(): array
     {
         return $this->columns ?? $this->getContainer()->getColumnsConfig();
-    }
-
-    public function getBadge(): ?string
-    {
-        return $this->evaluate($this->badge);
     }
 }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This PR adds support for using `->badgeColor()` in Tab component

<img width="773" alt="image" src="https://github.com/filamentphp/filament/assets/14329460/4e2d658d-6cff-4361-aad4-1b4caa546b7b">
