### PR TITLE
fix: pt_BR translations

### DIFF
--- a/packages/actions/resources/lang/pt_BR/create.php
+++ b/packages/actions/resources/lang/pt_BR/create.php
@@ -4,7 +4,7 @@ return [
 
     'single' => [
 
-        'label' => 'Adicionar :label',
+        'label' => 'Criar :label',
 
         'modal' => [
 


### PR DESCRIPTION
"Adicionar" means "Add" while "Criar" means "Create" which better represents the action.