### PR TITLE
Update CreateRecord/.../Translatable.php

### DIFF
--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
@@ -114,11 +114,11 @@ trait Translatable
 
         $translatableAttributes = $record->getTranslatableAttributes();
 
-        // Fill non-translatable data
-        $record->fill(Arr::except(Arr::first($data), $translatableAttributes));
-
-        // Fill translatable data
         foreach ($data as $locale => $localeData) {
+            if ($locale === $this->activeLocale) {
+                $record->fill(Arr::except($localeData, $translatableAttributes));
+            }
+            
             $localeData = Arr::only(
                 $localeData,
                 app(static::getModel())->getTranslatableAttributes(),

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
@@ -119,12 +119,7 @@ trait Translatable
                 $record->fill(Arr::except($localeData, $translatableAttributes));
             }
             
-            $localeData = Arr::only(
-                $localeData,
-                app(static::getModel())->getTranslatableAttributes(),
-            );
-
-            foreach ($localeData as $key => $value) {
+            foreach (Arr::only($localeData, $translatableAttributes) as $key => $value) {
                 $record->setTranslation($key, $locale, $value);
             }
         }

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
@@ -119,12 +119,6 @@ trait Translatable
 
         // Fill translatable data
         foreach ($data as $locale => $localeData) {
-            if ($locale === $this->activeLocale) {
-                $localeData = Arr::only(
-                    $localeData,
-                    app(static::getModel())->getTranslatableAttributes(),
-                );
-            }
             $localeData = Arr::only(
                 $localeData,
                 app(static::getModel())->getTranslatableAttributes(),

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
@@ -114,8 +114,10 @@ trait Translatable
 
         $translatableAttributes = $record->getTranslatableAttributes();
 
+        // Fill non-translatable data
         $record->fill(Arr::except(Arr::first($data), $translatableAttributes));
 
+        // Fill translatable data
         foreach ($data as $locale => $localeData) {
             if ($locale === $this->activeLocale) {
                 $localeData = Arr::only(
@@ -123,6 +125,10 @@ trait Translatable
                     app(static::getModel())->getTranslatableAttributes(),
                 );
             }
+            $localeData = Arr::only(
+                $localeData,
+                app(static::getModel())->getTranslatableAttributes(),
+            );
 
             foreach ($localeData as $key => $value) {
                 $record->setTranslation($key, $locale, $value);


### PR DESCRIPTION
# Error Link
https://flareapp.io/share/95JwJerm

# Description of the problem (solved)
When using `mutateFormDataBeforeCreate` and we have values for different languages, the error appears.

# Steps to reproduce the solved problem
1. Create a resource with translation
2. Add translatable columns to the model
3. Add some data using `mutateFormDataBeforeCreate`
4. Create new record (must fill more than one language data, so the error appears)
=> The error will appears