### PR TITLE
Fix nested Repeater Eager Loading

### DIFF
--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1038,6 +1038,12 @@ class Repeater extends Field implements Contracts\CanConcealComponents
 
         $relatedKeyName = $relationship->getRelated()->getKeyName();
 
+        if(!is_null($relationship->getParent()->{$this->statePath})){
+            return $this->cachedExistingRecords = $relationship->getParent()->{$this->statePath}->mapWithKeys(
+                fn (Model $item): array => ["record-{$item[$relatedKeyName]}" => $item],
+            );
+        }
+        
         return $this->cachedExistingRecords = $relationshipQuery->get()->mapWithKeys(
             fn (Model $item): array => ["record-{$item[$relatedKeyName]}" => $item],
         );


### PR DESCRIPTION
Checks if the relationship is already eagerly loaded, returning itself to avoid querying the database again and causing an N+1 query problem.

Issue/Bug description: https://github.com/filamentphp/filament/issues/9776

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
