### PR TITLE
Fix nested Repeater Eager Loading

### DIFF
--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1031,6 +1031,14 @@ class Repeater extends Field implements Contracts\CanConcealComponents
             return $this->cachedExistingRecords = $this->getRecord()->{$relationshipName}->mapWithKeys(
                 fn (Model $item): array => ["record-{$item[$relatedKeyName]}" => $item],
             );
+        } elseif (
+            $this->getModelInstance()->relationLoaded($relationshipName) &&
+            (! $this->modifyRelationshipQueryUsing) &&
+            filled($orderColumn)
+        ){
+            return $this->cachedExistingRecords = $this->getRecord()->{$relationshipName}->sortBy($orderColumn)->mapWithKeys(
+                fn (Model $item): array => ["record-{$item[$relatedKeyName]}" => $item],
+            );
         }
         
         $relationshipQuery = $relationship->getQuery();

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1024,21 +1024,14 @@ class Repeater extends Field implements Contracts\CanConcealComponents
 
         if (
             $this->getModelInstance()->relationLoaded($relationshipName) &&
-            (! $this->modifyRelationshipQueryUsing) &&
-            blank($orderColumn)
+            (! $this->modifyRelationshipQueryUsing)
             
         ) {
-            return $this->cachedExistingRecords = $this->getRecord()->{$relationshipName}->mapWithKeys(
-                fn (Model $item): array => ["record-{$item[$relatedKeyName]}" => $item],
-            );
-        } elseif (
-            $this->getModelInstance()->relationLoaded($relationshipName) &&
-            (! $this->modifyRelationshipQueryUsing) &&
-            filled($orderColumn)
-        ){
-            return $this->cachedExistingRecords = $this->getRecord()->{$relationshipName}->sortBy($orderColumn)->mapWithKeys(
-                fn (Model $item): array => ["record-{$item[$relatedKeyName]}" => $item],
-            );
+            return $this->cachedExistingRecords = $this->getRecord()->getRelationValue($relationshipName)
+                ->when(filled($orderColumn), fn (Collection $records) => $records->sortBy($orderColumn))
+                ->mapWithKeys(
+                    fn (Model $item): array => ["record-{$item[$relatedKeyName]}" => $item],
+                );
         }
         
         $relationshipQuery = $relationship->getQuery();

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1017,9 +1017,9 @@ class Repeater extends Field implements Contracts\CanConcealComponents
         }
 
         $relationship = $this->getRelationship();
+        $relatedKeyName = $relationship->getRelated()->getKeyName();
 
         $relationshipName = $this->getRelationshipName();
-        $relatedKeyName = $relationship->getRelated()->getKeyName();
         $orderColumn = $this->getOrderColumn();
 
         if (

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1038,6 +1038,12 @@ class Repeater extends Field implements Contracts\CanConcealComponents
 
         $relatedKeyName = $relationship->getRelated()->getKeyName();
 
+        if(!is_null($relationship->getParent()->{$this->statePath})){
+            return $this->cachedExistingRecords = $relationship->getParent()->{$this->statePath}->mapWithKeys(
+                fn (Model $item): array => ["record-{$item[$relatedKeyName]}" => $item],
+            );
+        }
+        
         return $this->cachedExistingRecords = $relationshipQuery->get()->mapWithKeys(
             fn (Model $item): array => ["record-{$item[$relatedKeyName]}" => $item],
         );


### PR DESCRIPTION
Checks if the relationship is already eagerly loaded, returning itself to avoid querying the database again and causing an N+1 query problem.

Issue/Bug Description: https://github.com/filamentphp/filament/issues/9776

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
