### PR TITLE
Update 05-viewing-records.md

### DIFF
--- a/packages/panels/docs/03-resources/05-viewing-records.md
+++ b/packages/panels/docs/03-resources/05-viewing-records.md
@@ -12,7 +12,7 @@ php artisan make:filament-resource User --view
 
 ## Using an infolist instead of a disabled form
 
-By default, the View page will display a disabled form with the record's data. If you preferred to display the record's data in an "infolist", you can use define an `infolist()` method on the resource class:
+By default, the View page will display a disabled form with the record's data. If you preferred to display the record's data in an "infolist", you can define an `infolist()` method on the resource class:
 
 ```php
 use Filament\Infolists;


### PR DESCRIPTION
Update a typo on the documentation

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [x ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
