### PR TITLE
Added red color to notifications number badge

### DIFF
--- a/packages/panels/resources/views/components/topbar/database-notifications-trigger.blade.php
+++ b/packages/panels/resources/views/components/topbar/database-notifications-trigger.blade.php
@@ -1,6 +1,7 @@
 <x-filament::icon-button
     :badge="$unreadNotificationsCount"
     color="gray"
+    badgeColor="{{ $unreadNotificationsCount > 0 ? 'danger' : 'primary' }}"
     icon="heroicon-o-bell"
     icon-alias="panels::topbar.open-database-notifications-button"
     icon-size="lg"


### PR DESCRIPTION
Hey, I'm thinking about something like this.

If we had some type of configuration so that users could customize the color of their badge when no notifications are present, and also when there are notifications.

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
