### PR TITLE
Update Hungarian translation

### DIFF
--- a/packages/tables/resources/lang/hu/table.php
+++ b/packages/tables/resources/lang/hu/table.php
@@ -103,16 +103,16 @@ return [
         'actions' => [
 
             'remove' => [
-                'label' => 'Szűrő megszűntetése',
+                'label' => 'Szűrő megszüntetése',
             ],
 
             'remove_all' => [
-                'label' => 'Az összes szűrő megszűntetése',
-                'tooltip' => 'Az összes szűrő megszűntetése',
+                'label' => 'Az összes szűrő megszüntetése',
+                'tooltip' => 'Az összes szűrő megszüntetése',
             ],
 
             'reset' => [
-                'label' => 'Visszaállítása',
+                'label' => 'Visszaállítás',
             ],
 
         ],


### PR DESCRIPTION
'megszűntetése' does not exist in the language, only 'megszüntetése'
'Visszaállítása' translates to 'it's reset', the proper translation for 'reset' is 'visszaállítás'

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
