### PR TITLE
fix #8788 - reset activerelationmanager when selected is hidden

### DIFF
--- a/packages/panels/docs/03-resources/04-editing-records.md
+++ b/packages/panels/docs/03-resources/04-editing-records.md
@@ -297,7 +297,7 @@ Here's a basic example of what that view might contain:
 
     @if (count($relationManagers = $this->getRelationManagers()))
         <x-filament-panels::resources.relation-managers
-            :active-manager="$activeRelationManager"
+            :active-manager="$this->activeRelationManager"
             :managers="$relationManagers"
             :owner-record="$record"
             :page-class="static::class"

--- a/packages/panels/docs/03-resources/05-viewing-records.md
+++ b/packages/panels/docs/03-resources/05-viewing-records.md
@@ -122,7 +122,7 @@ Here's a basic example of what that view might contain:
 
     @if (count($relationManagers = $this->getRelationManagers()))
         <x-filament-panels::resources.relation-managers
-            :active-manager="$activeRelationManager"
+            :active-manager="$this->activeRelationManager"
             :managers="$relationManagers"
             :owner-record="$record"
             :page-class="static::class"

--- a/packages/panels/resources/views/resources/pages/edit-record.blade.php
+++ b/packages/panels/resources/views/resources/pages/edit-record.blade.php
@@ -31,7 +31,7 @@
     @if (count($relationManagers))
         <x-filament-panels::resources.relation-managers
             :active-locale="isset($activeLocale) ? $activeLocale : null"
-            :active-manager="$activeRelationManager ?? ($hasCombinedRelationManagerTabsWithContent ? null : array_key_first($relationManagers))"
+            :active-manager="$this->activeRelationManager ?? ($hasCombinedRelationManagerTabsWithContent ? null : array_key_first($relationManagers))"
             :content-tab-label="$this->getContentTabLabel()"
             :managers="$relationManagers"
             :owner-record="$record"

--- a/packages/panels/resources/views/resources/pages/manage-related-records.blade.php
+++ b/packages/panels/resources/views/resources/pages/manage-related-records.blade.php
@@ -19,7 +19,7 @@
     @if (count($relationManagers = $this->getRelationManagers()))
         <x-filament-panels::resources.relation-managers
             :active-locale="isset($activeLocale) ? $activeLocale : null"
-            :active-manager="$activeRelationManager ?? array_key_first($relationManagers)"
+            :active-manager="$this->activeRelationManager ?? array_key_first($relationManagers)"
             :managers="$relationManagers"
             :owner-record="$record"
             :page-class="static::class"

--- a/packages/panels/resources/views/resources/pages/view-record.blade.php
+++ b/packages/panels/resources/views/resources/pages/view-record.blade.php
@@ -25,7 +25,7 @@
     @if (count($relationManagers))
         <x-filament-panels::resources.relation-managers
             :active-locale="isset($activeLocale) ? $activeLocale : null"
-            :active-manager="$activeRelationManager ?? ($hasCombinedRelationManagerTabsWithContent ? null : array_key_first($relationManagers))"
+            :active-manager="$this->activeRelationManager ?? ($hasCombinedRelationManagerTabsWithContent ? null : array_key_first($relationManagers))"
             :content-tab-label="$this->getContentTabLabel()"
             :managers="$relationManagers"
             :owner-record="$record"

--- a/packages/panels/src/Resources/Pages/Concerns/HasRelationManagers.php
+++ b/packages/panels/src/Resources/Pages/Concerns/HasRelationManagers.php
@@ -45,25 +45,19 @@ trait HasRelationManagers
         return $manager;
     }
 
-    public function mountHasRelationManagers(): void
+    public function renderingHasRelationManagers(): void
     {
         $managers = $this->getRelationManagers();
 
-        if (array_key_exists($this->activeRelationManager, $managers) || $this->hasCombinedRelationManagerTabsWithContent()) {
+        if (array_key_exists($this->activeRelationManager, $managers)) {
             return;
         }
 
-        $this->activeRelationManager = array_key_first($this->getRelationManagers()) ?? null;
-    }
-
-    public function renderingHasRelationManagers(View $view): void
-    {
-        $managers = $this->getRelationManagers();
-
-        if (!array_key_exists($this->activeRelationManager, $managers) && !$this->hasCombinedRelationManagerTabsWithContent()) {
-            $this->activeRelationManager = array_key_first($this->getRelationManagers()) ?? null;
-            $view->with('activeRelationManager', $this->activeRelationManager);
+        if ($this->hasCombinedRelationManagerTabsWithContent()) {
+            return;
         }
+
+        $this->activeRelationManager = array_key_first($managers);
     }
 
     public function hasCombinedRelationManagerTabsWithContent(): bool

--- a/packages/panels/src/Resources/Pages/Concerns/HasRelationManagers.php
+++ b/packages/panels/src/Resources/Pages/Concerns/HasRelationManagers.php
@@ -5,6 +5,7 @@ namespace Filament\Resources\Pages\Concerns;
 use Filament\Resources\RelationManagers\RelationGroup;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Resources\RelationManagers\RelationManagerConfiguration;
+use Illuminate\View\View;
 use Livewire\Attributes\Url;
 
 trait HasRelationManagers
@@ -53,6 +54,16 @@ trait HasRelationManagers
         }
 
         $this->activeRelationManager = array_key_first($this->getRelationManagers()) ?? null;
+    }
+
+    public function renderingHasRelationManagers(View $view): void
+    {
+        $managers = $this->getRelationManagers();
+
+        if (!array_key_exists($this->activeRelationManager, $managers) && !$this->hasCombinedRelationManagerTabsWithContent()) {
+            $this->activeRelationManager = array_key_first($this->getRelationManagers()) ?? null;
+            $view->with('activeRelationManager', $this->activeRelationManager);
+        }
     }
 
     public function hasCombinedRelationManagerTabsWithContent(): bool


### PR DESCRIPTION
This PR fixes the bug described in https://github.com/filamentphp/filament/issues/8788 considering @danharrin 's [comment](https://github.com/filamentphp/filament/pull/8790#issuecomment-1763314753)  

After hiding a currently active relation manager, the activeRelationManager is set to the first item and viewdata is updated before rendering.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.

