### PR TITLE
Improve Sub-Navigation Styling

### DIFF
--- a/packages/panels/resources/views/components/page/index.blade.php
+++ b/packages/panels/resources/views/components/page/index.blade.php
@@ -84,7 +84,7 @@
                     </x-filament::input.wrapper>
 
                     <div
-                        class="hidden rounded-xl bg-white p-2 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 md:block"
+                        class="hidden md:block"
                     >
                         @foreach ($subNavigation as $subNavigationGroup)
                             <x-filament-panels::sidebar.group


### PR DESCRIPTION
This is a small PR to try to improve the sub-navigation styling. Currently, it looks a bit "clunky". This looks to bring it in line with the Filament styling.

BEFORE
<img width="1453" alt="image" src="https://github.com/filamentphp/filament/assets/647407/e5322a18-78fd-4c36-9c65-4037c20747bc">


AFTER
<img width="1454" alt="image" src="https://github.com/filamentphp/filament/assets/647407/62b50b95-dea2-4281-8693-b29dbac9a512">
