### PR TITLE
fix: registration evaluation of HasAuth trait

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasAuth.php
+++ b/packages/panels/src/Panel/Concerns/HasAuth.php
@@ -286,7 +286,7 @@ trait HasAuth
      */
     public function getRegistrationRouteAction(): string | Closure | array | null
     {
-        return $this->registrationRouteAction;
+        return $this->evaluate($this->registrationRouteAction);
     }
 
     /**


### PR DESCRIPTION
The getRegistrationRouteAction method is now able to evaluate the closure or value given to it.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
