### PR TITLE
[Docs - Select] Order of "multiple()" & "relationship()"

### DIFF
--- a/packages/forms/docs/03-fields/03-select.md
+++ b/packages/forms/docs/03-fields/03-select.md
@@ -159,6 +159,7 @@ Select::make('technologies')
     ->multiple()
     ->relationship(titleAttribute: 'name')
 ```
+> Note that `multiple()` must be called before `relationship()` so that the `dehydrated()` function, which is called in the `relationship()`, is correctly defined.
 
 ### Searching relationship options across multiple columns
 


### PR DESCRIPTION
Mention that it's necessary to define `multiple()` before `relationship()` in the `Select` field
``` 
// ❌
Select::make('users')
    ->relationship('users', 'name')
    ->multiple()

// ✅
Select::make('users')
    ->multiple()
    ->relationship('users', 'name')
```

Because `dehydrated()` is related to `multiple()`
```
// vendor\filament\forms\src\Components\Select.php - Line 984
$this->dehydrated(fn (Select $component): bool => ! $component->isMultiple());
```
