### PR TITLE
[Docs - Field] Order of "disabled()" & "relationship()"

### DIFF
--- a/packages/forms/docs/03-fields/01-getting-started.md
+++ b/packages/forms/docs/03-fields/01-getting-started.md
@@ -238,7 +238,7 @@ Toggle::make('is_admin')
     ->dehydrated()
 ```
 
-> When using `disabled()` with `relationship()`, ensure that `disabled()` is defined before `relationship()`. This ensures that the `dehydrated()` function, called within `relationship()`, is not overridden by the one called in `disabled(...)`.
+> When using `disabled()` with `relationship()`, ensure that `disabled()` is called before `relationship()`. This ensures that the `dehydrated()` call from within `relationship()` is not overridden by call from `disabled()`.
 
 > If you choose to dehydrate the field, a skilled user could still edit the field's value by manipulating Livewire's JavaScript.
 

--- a/packages/forms/docs/03-fields/01-getting-started.md
+++ b/packages/forms/docs/03-fields/01-getting-started.md
@@ -237,7 +237,8 @@ Toggle::make('is_admin')
     ->disabled()
     ->dehydrated()
 ```
-> When using `disabled($someCondition)` with `relationship()`, ensure that `disabled(...)` is defined before `relationship()`. This ensures that the `dehydrated()` function, called within `relationship()`, is not overridden by the one called in `disabled(...)`.
+
+> When using `disabled()` with `relationship()`, ensure that `disabled()` is defined before `relationship()`. This ensures that the `dehydrated()` function, called within `relationship()`, is not overridden by the one called in `disabled(...)`.
 
 > If you choose to dehydrate the field, a skilled user could still edit the field's value by manipulating Livewire's JavaScript.
 

--- a/packages/forms/docs/03-fields/01-getting-started.md
+++ b/packages/forms/docs/03-fields/01-getting-started.md
@@ -238,8 +238,6 @@ Toggle::make('is_admin')
     ->dehydrated()
 ```
 
-> When using `disabled()` with `relationship()`, ensure that `disabled()` is called before `relationship()`. This ensures that the `dehydrated()` call from within `relationship()` is not overridden by call from `disabled()`.
-
 > If you choose to dehydrate the field, a skilled user could still edit the field's value by manipulating Livewire's JavaScript.
 
 ### Hiding a field

--- a/packages/forms/docs/03-fields/01-getting-started.md
+++ b/packages/forms/docs/03-fields/01-getting-started.md
@@ -237,6 +237,7 @@ Toggle::make('is_admin')
     ->disabled()
     ->dehydrated()
 ```
+> When using `disabled($someCondition)` with `relationship()`, ensure that `disabled(...)` is defined before `relationship()`. This ensures that the `dehydrated()` function, called within `relationship()`, is not overridden by the one called in `disabled(...)`.
 
 > If you choose to dehydrate the field, a skilled user could still edit the field's value by manipulating Livewire's JavaScript.
 

--- a/packages/forms/docs/03-fields/03-select.md
+++ b/packages/forms/docs/03-fields/03-select.md
@@ -160,6 +160,16 @@ Select::make('technologies')
     ->relationship(titleAttribute: 'name')
 ```
 
+> When using `disabled()` with `relationship()`, ensure that `disabled()` is called before `relationship()`. This ensures that the `dehydrated()` call from within `relationship()` is not overridden by the call from `disabled()`.
+
+```php
+use Filament\Forms\Components\Select;
+
+Select::make('technologies')
+    ->disabled()
+    ->relationship(titleAttribute: 'name')
+```
+
 ### Searching relationship options across multiple columns
 
 By default, if the select is also searchable, Filament will return search results for the relationship based on the title column of the relationship. If you'd like to search across multiple columns, you can pass an array of columns to the `searchable()` method:

--- a/packages/forms/docs/03-fields/03-select.md
+++ b/packages/forms/docs/03-fields/03-select.md
@@ -160,12 +160,13 @@ Select::make('technologies')
     ->relationship(titleAttribute: 'name')
 ```
 
-> When using `disabled()` with `relationship()`, ensure that `disabled()` is called before `relationship()`. This ensures that the `dehydrated()` call from within `relationship()` is not overridden by the call from `disabled()`.
+When using `disabled()` with `multiple()` and `relationship()`, ensure that `disabled()` is called before `relationship()`. This ensures that the `dehydrated()` call from within `relationship()` is not overridden by the call from `disabled()`:
 
 ```php
 use Filament\Forms\Components\Select;
 
 Select::make('technologies')
+    ->multiple()
     ->disabled()
     ->relationship(titleAttribute: 'name')
 ```

--- a/packages/forms/docs/03-fields/06-checkbox-list.md
+++ b/packages/forms/docs/03-fields/06-checkbox-list.md
@@ -177,7 +177,7 @@ CheckboxList::make('technologies')
     ->relationship(titleAttribute: 'name')
 ```
 
-> When using `disabled()` with `relationship()`, ensure that `disabled()` is called before `relationship()`. This ensures that the `dehydrated()` call from within `relationship()` is not overridden by the call from `disabled()`.
+When using `disabled()` with `relationship()`, ensure that `disabled()` is called before `relationship()`. This ensures that the `dehydrated()` call from within `relationship()` is not overridden by the call from `disabled()`:
 
 ```php
 use Filament\Forms\Components\CheckboxList;

--- a/packages/forms/docs/03-fields/06-checkbox-list.md
+++ b/packages/forms/docs/03-fields/06-checkbox-list.md
@@ -177,6 +177,16 @@ CheckboxList::make('technologies')
     ->relationship(titleAttribute: 'name')
 ```
 
+> When using `disabled()` with `relationship()`, ensure that `disabled()` is called before `relationship()`. This ensures that the `dehydrated()` call from within `relationship()` is not overridden by the call from `disabled()`.
+
+```php
+use Filament\Forms\Components\CheckboxList;
+
+CheckboxList::make('technologies')
+    ->disabled()
+    ->relationship(titleAttribute: 'name')
+```
+
 ### Customizing the relationship query
 
 You may customize the database query that retrieves options using the `modifyOptionsQueryUsing` parameter of the `relationship()` method:

--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -219,6 +219,19 @@ Repeater::make('qualifications')
     ])
 ```
 
+> When using `disabled()` with `relationship()`, ensure that `disabled()` is called before `relationship()`. This ensures that the `dehydrated()` call from within `relationship()` is not overridden by the call from `disabled()`.
+
+```php
+use Filament\Forms\Components\Repeater;
+
+Repeater::make('qualifications')
+    ->disabled()
+    ->relationship()
+    ->schema([
+        // ...
+    ])
+```
+
 ### Reordering items in a relationship
 
 By default, [reordering](#reordering-items) relationship repeater items is disabled. This is because your related model needs an `sort` column to store the order of related records. To enable reordering, you may use the `orderColumn()` method, passing in a name of the column on your related model to store the order in:

--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -219,7 +219,7 @@ Repeater::make('qualifications')
     ])
 ```
 
-> When using `disabled()` with `relationship()`, ensure that `disabled()` is called before `relationship()`. This ensures that the `dehydrated()` call from within `relationship()` is not overridden by the call from `disabled()`.
+When using `disabled()` with `relationship()`, ensure that `disabled()` is called before `relationship()`. This ensures that the `dehydrated()` call from within `relationship()` is not overridden by the call from `disabled()`:
 
 ```php
 use Filament\Forms\Components\Repeater;


### PR DESCRIPTION
Mention that it's necessary to define `disabled()` before `relationship()`.
```
// ❌
SomeField::make('users')
    ->relationship('users', 'name')
    ->disabled()

// ✅
SomeField::make('users')
    ->disabled()
    ->relationship('users', 'name')
```

Because `dehydrated()` in `relationship()` will be overrided by the one in `disabled()`
```
// vendor\filament\forms\src\Components\Concerns\CanBeDisabled.php - Line 17
$this->dehydrated(fn (Component $component): bool => ! $component->evaluate($condition));
```


