### PR TITLE
Globally disable default tenancy scope in a panel

### DIFF
--- a/packages/panels/docs/10-tenancy.md
+++ b/packages/panels/docs/10-tenancy.md
@@ -653,20 +653,20 @@ By default, all resources within a panel with tenancy will be scoped to the curr
 protected static bool $isScopedToTenant = false;
 ```
 
-## Disabling tenancy scope for all resources
+### Disabling tenancy for all resources
 
-If you wish to manually customize tenancy scope for all resources you can disable it globally in your panel provider.
+If you wish to opt-in to tenancy for each resource instead of opting-out, you can call `Resource::scopeToTenant(false)` inside a service provider's `boot()` method or a middleware:
 
 ```php
-use App\Models\Team;
-use Filament\Panel;
+use Filament\Resources\Resource;
 
-public function panel(Panel $panel): Panel
-{
-    return $panel
-        // ...
-        ->tenant(Team::class, applyResourceScope:false);
-}
+Resource::scopeToTenant(false);
+```
+
+Now, you can opt-in to tenancy for each resource by setting the `$isScopedToTenant` static property to `true` on a resource class:
+
+```php
+protected static bool $isScopedToTenant = true;
 ```
 
 ## Tenancy security

--- a/packages/panels/docs/10-tenancy.md
+++ b/packages/panels/docs/10-tenancy.md
@@ -653,6 +653,22 @@ By default, all resources within a panel with tenancy will be scoped to the curr
 protected static bool $isScopedToTenant = false;
 ```
 
+## Disabling tenancy scope for all resource
+
+If you wish to manually customize tenancy scope for your resources you can disable it globally in your panel provider.
+
+```php
+use App\Models\Team;
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->tenant(Team::class, applyResourceScope:false);
+}
+```
+
 ## Tenancy security
 
 It's important to understand the security implications of multi-tenancy and how to properly implement it. If implemented partially or incorrectly, data belonging to one tenant may be exposed to another tenant. Filament provides a set of tools to help you implement multi-tenancy in your application, but it is up to you to understand how to use them. Filament does not provide any guarantees about the security of your application. It is your responsibility to ensure that your application is secure.

--- a/packages/panels/docs/10-tenancy.md
+++ b/packages/panels/docs/10-tenancy.md
@@ -653,9 +653,9 @@ By default, all resources within a panel with tenancy will be scoped to the curr
 protected static bool $isScopedToTenant = false;
 ```
 
-## Disabling tenancy scope for all resource
+## Disabling tenancy scope for all resources
 
-If you wish to manually customize tenancy scope for your resources you can disable it globally in your panel provider.
+If you wish to manually customize tenancy scope for all resources you can disable it globally in your panel provider.
 
 ```php
 use App\Models\Team;

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -364,11 +364,6 @@ class FilamentManager
         return $this->getCurrentPanel()->getTenantModel();
     }
 
-    public function shouldApplyTenantResourceScope():bool
-    {
-        return $this->getCurrentPanel()->shouldApplyTenantResourceScope();
-    }
-
     public function getTenantName(Model $tenant): string
     {
         if ($tenant instanceof HasName) {

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -364,6 +364,11 @@ class FilamentManager
         return $this->getCurrentPanel()->getTenantModel();
     }
 
+    public function shouldApplyTenantResourceScope():bool
+    {
+        return $this->getCurrentPanel()->shouldApplyTenantResourceScope();
+    }
+
     public function getTenantName(Model $tenant): string
     {
         if ($tenant instanceof HasName) {

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -23,8 +23,6 @@ trait HasTenancy
 
     protected ?string $tenantOwnershipRelationshipName = null;
 
-    protected bool $tenantApplyResourceScope = true;
-
     /**
      * @var array<MenuItem>
      */
@@ -52,12 +50,11 @@ trait HasTenancy
         return $this;
     }
 
-    public function tenant(?string $model, ?string $slugAttribute = null, ?string $ownershipRelationship = null, bool $applyResourceScope=true): static
+    public function tenant(?string $model, ?string $slugAttribute = null, ?string $ownershipRelationship = null): static
     {
         $this->tenantModel = $model;
         $this->tenantSlugAttribute = $slugAttribute;
         $this->tenantOwnershipRelationshipName = $ownershipRelationship;
-        $this->tenantApplyResourceScope = $applyResourceScope;
         return $this;
     }
 
@@ -231,10 +228,5 @@ trait HasTenancy
         return (string) str($this->getTenantModel())
             ->classBasename()
             ->camel();
-    }
-
-    public function shouldApplyTenantResourceScope():bool
-    {
-        return $this->tenantApplyResourceScope;
     }
 }

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -55,6 +55,7 @@ trait HasTenancy
         $this->tenantModel = $model;
         $this->tenantSlugAttribute = $slugAttribute;
         $this->tenantOwnershipRelationshipName = $ownershipRelationship;
+        
         return $this;
     }
 

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -23,6 +23,8 @@ trait HasTenancy
 
     protected ?string $tenantOwnershipRelationshipName = null;
 
+    protected bool $tenantApplyResourceScope = true;
+
     /**
      * @var array<MenuItem>
      */
@@ -50,12 +52,12 @@ trait HasTenancy
         return $this;
     }
 
-    public function tenant(?string $model, ?string $slugAttribute = null, ?string $ownershipRelationship = null): static
+    public function tenant(?string $model, ?string $slugAttribute = null, ?string $ownershipRelationship = null, bool $applyResourceScope=true): static
     {
         $this->tenantModel = $model;
         $this->tenantSlugAttribute = $slugAttribute;
         $this->tenantOwnershipRelationshipName = $ownershipRelationship;
-
+        $this->tenantApplyResourceScope = $applyResourceScope;
         return $this;
     }
 
@@ -229,5 +231,10 @@ trait HasTenancy
         return (string) str($this->getTenantModel())
             ->classBasename()
             ->camel();
+    }
+
+    public function shouldApplyTenantResourceScope():bool
+    {
+        return $this->tenantApplyResourceScope;
     }
 }

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -311,6 +311,7 @@ abstract class Resource
         $query = static::getModel()::query();
 
         if (
+            Filament::shouldApplyTenantResourceScope() &&
             static::isScopedToTenant() &&
             ($tenant = Filament::getTenant())
         ) {

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -311,7 +311,6 @@ abstract class Resource
         $query = static::getModel()::query();
 
         if (
-            Filament::shouldApplyTenantResourceScope() &&
             static::isScopedToTenant() &&
             ($tenant = Filament::getTenant())
         ) {
@@ -751,6 +750,11 @@ abstract class Resource
     public static function isDiscovered(): bool
     {
         return static::$isDiscovered;
+    }
+
+    public static function scopeToTenant(bool $condition = true): void
+    {
+        static::$isScopedToTenant = $condition;
     }
 
     public static function isScopedToTenant(): bool


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Added a  `$applyResourceScope` parameter to the `tenant` panel function. Setting it to false will prevent the default resources's tenancy scope to be applied ignoring the `$isScopedToTenant` property. 

This allows a bit more flexibility when dealing with global scope applied through middleware.

