### PR TITLE
Fix inline fields

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -1,30 +1,30 @@
+@php
+    $containers = $getChildComponentContainers();
+    $blockPickerColumns = $getBlockPickerColumns();
+    $blockPickerWidth = $getBlockPickerWidth();
+    $blocks = $getBlocks();
+
+    $addAction = $getAction($getAddActionName());
+    $addBetweenAction = $getAction($getAddBetweenActionName());
+    $cloneAction = $getAction($getCloneActionName());
+    $collapseAllAction = $getAction($getCollapseAllActionName());
+    $expandAllAction = $getAction($getExpandAllActionName());
+    $deleteAction = $getAction($getDeleteActionName());
+    $moveDownAction = $getAction($getMoveDownActionName());
+    $moveUpAction = $getAction($getMoveUpActionName());
+    $reorderAction = $getAction($getReorderActionName());
+
+    $isAddable = $isAddable();
+    $isCloneable = $isCloneable();
+    $isCollapsible = $isCollapsible();
+    $isDeletable = $isDeletable();
+    $isReorderableWithButtons = $isReorderableWithButtons();
+    $isReorderableWithDragAndDrop = $isReorderableWithDragAndDrop();
+
+    $statePath = $getStatePath();
+@endphp
+
 <x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
-    @php
-        $containers = $getChildComponentContainers();
-        $blockPickerColumns = $getBlockPickerColumns();
-        $blockPickerWidth = $getBlockPickerWidth();
-        $blocks = $getBlocks();
-
-        $addAction = $getAction($getAddActionName());
-        $addBetweenAction = $getAction($getAddBetweenActionName());
-        $cloneAction = $getAction($getCloneActionName());
-        $collapseAllAction = $getAction($getCollapseAllActionName());
-        $expandAllAction = $getAction($getExpandAllActionName());
-        $deleteAction = $getAction($getDeleteActionName());
-        $moveDownAction = $getAction($getMoveDownActionName());
-        $moveUpAction = $getAction($getMoveUpActionName());
-        $reorderAction = $getAction($getReorderActionName());
-
-        $isAddable = $isAddable();
-        $isCloneable = $isCloneable();
-        $isCollapsible = $isCollapsible();
-        $isDeletable = $isDeletable();
-        $isReorderableWithButtons = $isReorderableWithButtons();
-        $isReorderableWithDragAndDrop = $isReorderableWithDragAndDrop();
-
-        $statePath = $getStatePath();
-    @endphp
-
     <div
         x-data="{}"
         {{

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -1,12 +1,12 @@
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
-    @php
-        $gridDirection = $getGridDirection() ?? 'column';
-        $isBulkToggleable = $isBulkToggleable();
-        $isDisabled = $isDisabled();
-        $isSearchable = $isSearchable();
-        $statePath = $getStatePath();
-    @endphp
+@php
+    $gridDirection = $getGridDirection() ?? 'column';
+    $isBulkToggleable = $isBulkToggleable();
+    $isDisabled = $isDisabled();
+    $isSearchable = $isSearchable();
+    $statePath = $getStatePath();
+@endphp
 
+<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
     <div
         x-data="{
             areAllCheckboxesChecked: false,

--- a/packages/forms/resources/views/components/checkbox.blade.php
+++ b/packages/forms/resources/views/components/checkbox.blade.php
@@ -1,12 +1,12 @@
+@php
+    $statePath = $getStatePath();
+@endphp
+
 <x-dynamic-component
     :component="$getFieldWrapperView()"
     :field="$field"
     :inline-label-vertical-alignment="\Filament\Support\Enums\VerticalAlignment::Center"
 >
-    @php
-        $statePath = $getStatePath();
-    @endphp
-
     @capture($content)
         <x-filament::input.checkbox
             :error="$errors->has($statePath)"

--- a/packages/forms/resources/views/components/checkbox.blade.php
+++ b/packages/forms/resources/views/components/checkbox.blade.php
@@ -1,4 +1,8 @@
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
+    :inline-label-vertical-alignment="\Filament\Support\Enums\VerticalAlignment::Center"
+>
     @php
         $statePath = $getStatePath();
     @endphp

--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -13,7 +13,11 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
+    :inline-label-vertical-alignment="\Filament\Support\Enums\VerticalAlignment::Center"
+>
     <x-filament::input.wrapper
         :disabled="$isDisabled"
         :inline-prefix="$isPrefixInline"

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -16,7 +16,11 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
+    :inline-label-vertical-alignment="\Filament\Support\Enums\VerticalAlignment::Center"
+>
     <x-filament::input.wrapper
         :disabled="$isDisabled"
         :inline-prefix="$isPrefixInline"

--- a/packages/forms/resources/views/components/field-wrapper/index.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/index.blade.php
@@ -1,3 +1,7 @@
+@php
+    use Filament\Support\Enums\VerticalAlignment;
+@endphp
+
 @props([
     'field' => null,
     'hasInlineLabel' => null,
@@ -9,6 +13,7 @@
     'hintIcon' => null,
     'hintIconTooltip' => null,
     'id' => null,
+    'inlineLabelVerticalAlignment' => VerticalAlignment::Start,
     'isDisabled' => null,
     'isMarkedAsRequired' => null,
     'label' => null,
@@ -56,7 +61,12 @@
     <div
         @class([
             'grid gap-y-2',
-            'sm:grid-cols-3 sm:items-start sm:gap-x-4' => $hasInlineLabel,
+            'sm:grid-cols-3 sm:gap-x-4' => $hasInlineLabel,
+            match ($inlineLabelVerticalAlignment) {
+                VerticalAlignment::Start => 'sm:items-start',
+                VerticalAlignment::Center => 'sm:items-center',
+                VerticalAlignment::End => 'sm:items-end',
+            } => $hasInlineLabel,
         ])
     >
         @if (($label && (! $labelSrOnly)) || $labelPrefix || $labelSuffix || filled($hint) || $hintIcon || count($hintActions))

--- a/packages/forms/resources/views/components/field-wrapper/index.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/index.blade.php
@@ -60,21 +60,17 @@
         ])
     >
         @if (($label && (! $labelSrOnly)) || $labelPrefix || $labelSuffix || filled($hint) || $hintIcon || count($hintActions))
-            <div
-                @class([
-                    'flex items-center justify-between gap-x-3',
-                    'sm:pt-1.5' => $hasInlineLabel,
-                ])
-            >
+            <div class="flex items-center justify-between gap-x-3">
                 @if ($label && (! $labelSrOnly))
                     <x-filament-forms::field-wrapper.label
-                        :for="$id"
                         :error="$hasError"
+                        :for="$id"
                         :is-disabled="$isDisabled"
                         :is-marked-as-required="$isMarkedAsRequired"
                         :prefix="$labelPrefix"
-                        :suffix="$labelSuffix"
                         :required="$required"
+                        :suffix="$labelSuffix"
+                        :attributes="($label instanceof \Illuminate\View\ComponentSlot) ? \Filament\Support\prepare_inherited_attributes($label->attributes) : (new \Illuminate\View\ComponentAttributeBag())"
                     >
                         {{ $label }}
                     </x-filament-forms::field-wrapper.label>

--- a/packages/forms/resources/views/components/field-wrapper/index.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/index.blade.php
@@ -60,7 +60,12 @@
         ])
     >
         @if (($label && (! $labelSrOnly)) || $labelPrefix || $labelSuffix || filled($hint) || $hintIcon || count($hintActions))
-            <div class="flex items-center justify-between gap-x-3">
+            <div
+                @class([
+                    'flex items-center justify-between gap-x-3',
+                    ($label instanceof \Illuminate\View\ComponentSlot) ? $label->attributes->get('class') : null,
+                ])
+            >
                 @if ($label && (! $labelSrOnly))
                     <x-filament-forms::field-wrapper.label
                         :error="$hasError"
@@ -70,7 +75,6 @@
                         :prefix="$labelPrefix"
                         :required="$required"
                         :suffix="$labelSuffix"
-                        :attributes="($label instanceof \Illuminate\View\ComponentSlot) ? \Filament\Support\prepare_inherited_attributes($label->attributes) : (new \Illuminate\View\ComponentAttributeBag())"
                     >
                         {{ $label }}
                     </x-filament-forms::field-wrapper.label>

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -1,29 +1,23 @@
 @php
     use Filament\Support\Enums\Alignment;
     use Filament\Support\Facades\FilamentView;
+
+    $imageCropAspectRatio = $getImageCropAspectRatio();
+    $imageResizeTargetHeight = $getImageResizeTargetHeight();
+    $imageResizeTargetWidth = $getImageResizeTargetWidth();
+    $isAvatar = $isAvatar();
+    $statePath = $getStatePath();
+    $isDisabled = $isDisabled();
+    $hasImageEditor = $hasImageEditor();
+
+    $alignment = $getAlignment() ?? Alignment::Start;
+
+    if (! $alignment instanceof Alignment) {
+        $alignment = Alignment::tryFrom($alignment) ?? $alignment;
+    }
 @endphp
 
-<x-dynamic-component
-    :component="$getFieldWrapperView()"
-    :field="$field"
-    :label-sr-only="$isLabelHidden()"
->
-    @php
-        $imageCropAspectRatio = $getImageCropAspectRatio();
-        $imageResizeTargetHeight = $getImageResizeTargetHeight();
-        $imageResizeTargetWidth = $getImageResizeTargetWidth();
-        $isAvatar = $isAvatar();
-        $statePath = $getStatePath();
-        $isDisabled = $isDisabled();
-        $hasImageEditor = $hasImageEditor();
-
-        $alignment = $getAlignment() ?? Alignment::Start;
-
-        if (! $alignment instanceof Alignment) {
-            $alignment = Alignment::tryFrom($alignment) ?? $alignment;
-        }
-    @endphp
-
+<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
     <div
         @if (FilamentView::hasSpaMode())
             ax-load="visible"

--- a/packages/forms/resources/views/components/key-value.blade.php
+++ b/packages/forms/resources/views/components/key-value.blade.php
@@ -1,16 +1,28 @@
 @php
     use Filament\Support\Facades\FilamentView;
+
+    $debounce = $getLiveDebounce();
+    $hasInlineLabel = $hasInlineLabel();
+    $isAddable = $isAddable();
+    $isDeletable = $isDeletable();
+    $isDisabled = $isDisabled();
+    $isReorderable = $isReorderable();
+    $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
-    @php
-        $debounce = $getLiveDebounce();
-        $isAddable = $isAddable();
-        $isDeletable = $isDeletable();
-        $isDisabled = $isDisabled();
-        $isReorderable = $isReorderable();
-        $statePath = $getStatePath();
-    @endphp
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
+    :has-inline-label="$hasInlineLabel"
+>
+    <x-slot
+        name="label"
+        @class([
+            'sm:pt-1.5' => $hasInlineLabel,
+        ])
+    >
+        {{ $getLabel() }}
+    </x-slot>
 
     <div
         {{

--- a/packages/forms/resources/views/components/placeholder.blade.php
+++ b/packages/forms/resources/views/components/placeholder.blade.php
@@ -1,5 +1,6 @@
 <x-dynamic-component
     :component="$getFieldWrapperView()"
+    :has-inline-label="$hasInlineLabel()"
     :id="$getId()"
     :label="$getLabel()"
     :label-sr-only="$isLabelHidden()"
@@ -14,7 +15,7 @@
         {{
             $attributes
                 ->merge($getExtraAttributes(), escape: false)
-                ->class(['fi-fo-placeholder sm:text-sm'])
+                ->class(['fi-fo-placeholder text-sm leading-6'])
         }}
     >
         {{ $getContent() }}

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -1,12 +1,12 @@
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
-    @php
-        $gridDirection = $getGridDirection() ?? 'column';
-        $id = $getId();
-        $isDisabled = $isDisabled();
-        $isInline = $isInline();
-        $statePath = $getStatePath();
-    @endphp
+@php
+    $gridDirection = $getGridDirection() ?? 'column';
+    $id = $getId();
+    $isDisabled = $isDisabled();
+    $isInline = $isInline();
+    $statePath = $getStatePath();
+@endphp
 
+<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
     <x-filament::grid
         :default="$getColumns('default')"
         :sm="$getColumns('sm')"

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -7,79 +7,67 @@
         $statePath = $getStatePath();
     @endphp
 
-    @capture($content)
-        <x-filament::grid
-            :default="$getColumns('default')"
-            :sm="$getColumns('sm')"
-            :md="$getColumns('md')"
-            :lg="$getColumns('lg')"
-            :xl="$getColumns('xl')"
-            :two-xl="$getColumns('2xl')"
-            :is-grid="! $isInline"
-            :direction="$gridDirection"
-            :attributes="
-                \Filament\Support\prepare_inherited_attributes($attributes)
-                    ->merge($getExtraAttributes(), escape: false)
-                    ->class([
-                        'fi-fo-radio gap-4',
-                        '-mt-4' => (! $isInline) && $gridDirection === 'column',
-                        'flex flex-wrap' => $isInline,
-                    ])
-            "
-        >
-            @foreach ($getOptions() as $value => $label)
-                @php
-                    $shouldOptionBeDisabled = $isDisabled || $isOptionDisabled($value, $label);
-                @endphp
+    <x-filament::grid
+        :default="$getColumns('default')"
+        :sm="$getColumns('sm')"
+        :md="$getColumns('md')"
+        :lg="$getColumns('lg')"
+        :xl="$getColumns('xl')"
+        :two-xl="$getColumns('2xl')"
+        :is-grid="! $isInline"
+        :direction="$gridDirection"
+        :attributes="
+            \Filament\Support\prepare_inherited_attributes($attributes)
+                ->merge($getExtraAttributes(), escape: false)
+                ->class([
+                    'fi-fo-radio gap-4',
+                    '-mt-4' => (! $isInline) && $gridDirection === 'column',
+                    'flex flex-wrap' => $isInline,
+                ])
+        "
+    >
+        @foreach ($getOptions() as $value => $label)
+            @php
+                $shouldOptionBeDisabled = $isDisabled || $isOptionDisabled($value, $label);
+            @endphp
 
-                <div
-                    @class([
-                        'break-inside-avoid pt-4' => (! $isInline) && $gridDirection === 'column',
-                    ])
-                >
-                    <label class="flex gap-x-3">
-                        <input
-                            @disabled($shouldOptionBeDisabled)
-                            id="{{ $id }}-{{ $value }}"
-                            name="{{ $id }}"
-                            type="radio"
-                            value="{{ $value }}"
-                            wire:loading.attr="disabled"
-                            {{ $applyStateBindingModifiers('wire:model') }}="{{ $statePath }}"
-                            {{
-                                $getExtraInputAttributeBag()
-                                    ->class([
-                                        'mt-1 border-none bg-white shadow-sm ring-1 transition duration-75 checked:ring-0 focus:ring-2 focus:ring-offset-0 disabled:bg-gray-50 disabled:text-gray-50 disabled:checked:bg-current disabled:checked:text-gray-400 dark:bg-white/5 dark:disabled:bg-transparent dark:disabled:checked:bg-gray-600',
-                                        'text-primary-600 ring-gray-950/10 focus:ring-primary-600 checked:focus:ring-primary-500/50 dark:text-primary-500 dark:ring-white/20 dark:checked:bg-primary-500 dark:focus:ring-primary-500 dark:checked:focus:ring-primary-400/50 dark:disabled:ring-white/10' => ! $errors->has($statePath),
-                                        'text-danger-600 ring-danger-600 focus:ring-danger-600 checked:focus:ring-danger-500/50 dark:text-danger-500 dark:ring-danger-500 dark:checked:bg-danger-500 dark:focus:ring-danger-500 dark:checked:focus:ring-danger-400/50' => $errors->has($statePath),
-                                    ])
-                            }}
-                        />
+            <div
+                @class([
+                    'break-inside-avoid pt-4' => (! $isInline) && $gridDirection === 'column',
+                ])
+            >
+                <label class="flex gap-x-3">
+                    <input
+                        @disabled($shouldOptionBeDisabled)
+                        id="{{ $id }}-{{ $value }}"
+                        name="{{ $id }}"
+                        type="radio"
+                        value="{{ $value }}"
+                        wire:loading.attr="disabled"
+                        {{ $applyStateBindingModifiers('wire:model') }}="{{ $statePath }}"
+                        {{
+                            $getExtraInputAttributeBag()
+                                ->class([
+                                    'mt-1 border-none bg-white shadow-sm ring-1 transition duration-75 checked:ring-0 focus:ring-2 focus:ring-offset-0 disabled:bg-gray-50 disabled:text-gray-50 disabled:checked:bg-current disabled:checked:text-gray-400 dark:bg-white/5 dark:disabled:bg-transparent dark:disabled:checked:bg-gray-600',
+                                    'text-primary-600 ring-gray-950/10 focus:ring-primary-600 checked:focus:ring-primary-500/50 dark:text-primary-500 dark:ring-white/20 dark:checked:bg-primary-500 dark:focus:ring-primary-500 dark:checked:focus:ring-primary-400/50 dark:disabled:ring-white/10' => ! $errors->has($statePath),
+                                    'text-danger-600 ring-danger-600 focus:ring-danger-600 checked:focus:ring-danger-500/50 dark:text-danger-500 dark:ring-danger-500 dark:checked:bg-danger-500 dark:focus:ring-danger-500 dark:checked:focus:ring-danger-400/50' => $errors->has($statePath),
+                                ])
+                        }}
+                    />
 
-                        <div class="grid text-sm leading-6">
-                            <span
-                                class="font-medium text-gray-950 dark:text-white"
-                            >
-                                {{ $label }}
-                            </span>
+                    <div class="grid text-sm leading-6">
+                        <span class="font-medium text-gray-950 dark:text-white">
+                            {{ $label }}
+                        </span>
 
-                            @if ($hasDescription($value))
-                                <p class="text-gray-500 dark:text-gray-400">
-                                    {{ $getDescription($value) }}
-                                </p>
-                            @endif
-                        </div>
-                    </label>
-                </div>
-            @endforeach
-        </x-filament::grid>
-    @endcapture
-
-    @if ($isInline)
-        <x-slot name="labelSuffix">
-            {{ $content() }}
-        </x-slot>
-    @else
-        {{ $content() }}
-    @endif
+                        @if ($hasDescription($value))
+                            <p class="text-gray-500 dark:text-gray-400">
+                                {{ $getDescription($value) }}
+                            </p>
+                        @endif
+                    </div>
+                </label>
+            </div>
+        @endforeach
+    </x-filament::grid>
 </x-dynamic-component>

--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -1,27 +1,27 @@
+@php
+    $containers = $getChildComponentContainers();
+
+    $addAction = $getAction($getAddActionName());
+    $addBetweenAction = $getAction($getAddBetweenActionName());
+    $cloneAction = $getAction($getCloneActionName());
+    $collapseAllAction = $getAction($getCollapseAllActionName());
+    $expandAllAction = $getAction($getExpandAllActionName());
+    $deleteAction = $getAction($getDeleteActionName());
+    $moveDownAction = $getAction($getMoveDownActionName());
+    $moveUpAction = $getAction($getMoveUpActionName());
+    $reorderAction = $getAction($getReorderActionName());
+
+    $isAddable = $isAddable();
+    $isCloneable = $isCloneable();
+    $isCollapsible = $isCollapsible();
+    $isDeletable = $isDeletable();
+    $isReorderableWithButtons = $isReorderableWithButtons();
+    $isReorderableWithDragAndDrop = $isReorderableWithDragAndDrop();
+
+    $statePath = $getStatePath();
+@endphp
+
 <x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
-    @php
-        $containers = $getChildComponentContainers();
-
-        $addAction = $getAction($getAddActionName());
-        $addBetweenAction = $getAction($getAddBetweenActionName());
-        $cloneAction = $getAction($getCloneActionName());
-        $collapseAllAction = $getAction($getCollapseAllActionName());
-        $expandAllAction = $getAction($getExpandAllActionName());
-        $deleteAction = $getAction($getDeleteActionName());
-        $moveDownAction = $getAction($getMoveDownActionName());
-        $moveUpAction = $getAction($getMoveUpActionName());
-        $reorderAction = $getAction($getReorderActionName());
-
-        $isAddable = $isAddable();
-        $isCloneable = $isCloneable();
-        $isCollapsible = $isCollapsible();
-        $isDeletable = $isDeletable();
-        $isReorderableWithButtons = $isReorderableWithButtons();
-        $isReorderableWithDragAndDrop = $isReorderableWithDragAndDrop();
-
-        $statePath = $getStatePath();
-    @endphp
-
     <div
         x-data="{}"
         {{

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -1,13 +1,11 @@
 @php
     use Filament\Support\Facades\FilamentView;
+
+    $id = $getId();
+    $statePath = $getStatePath();
 @endphp
 
 <x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
-    @php
-        $id = $getId();
-        $statePath = $getStatePath();
-    @endphp
-
     @if ($isDisabled())
         <div
             x-data="{

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -2,6 +2,7 @@
     use Filament\Support\Facades\FilamentView;
 
     $canSelectPlaceholder = $canSelectPlaceholder();
+    $hasInlineLabel = $hasInlineLabel();
     $isDisabled = $isDisabled();
     $isPrefixInline = $isPrefixInline();
     $isSuffixInline = $isSuffixInline();
@@ -14,7 +15,20 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
+    :has-inline-label="$hasInlineLabel"
+>
+    <x-slot
+        name="label"
+        @class([
+            'sm:pt-1.5' => $hasInlineLabel,
+        ])
+    >
+        {{ $getLabel() }}
+    </x-slot>
+
     <x-filament::input.wrapper
         :disabled="$isDisabled"
         :inline-prefix="$isPrefixInline"

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -2,7 +2,6 @@
     use Filament\Support\Facades\FilamentView;
 
     $canSelectPlaceholder = $canSelectPlaceholder();
-    $hasInlineLabel = $hasInlineLabel();
     $isDisabled = $isDisabled();
     $isPrefixInline = $isPrefixInline();
     $isSuffixInline = $isSuffixInline();
@@ -18,17 +17,8 @@
 <x-dynamic-component
     :component="$getFieldWrapperView()"
     :field="$field"
-    :has-inline-label="$hasInlineLabel"
+    :inline-label-vertical-alignment="\Filament\Support\Enums\VerticalAlignment::Center"
 >
-    <x-slot
-        name="label"
-        @class([
-            'sm:pt-1.5' => $hasInlineLabel,
-        ])
-    >
-        {{ $getLabel() }}
-    </x-slot>
-
     <x-filament::input.wrapper
         :disabled="$isDisabled"
         :inline-prefix="$isPrefixInline"

--- a/packages/forms/resources/views/components/simple-repeater.blade.php
+++ b/packages/forms/resources/views/components/simple-repeater.blade.php
@@ -1,23 +1,23 @@
+@php
+    $containers = $getChildComponentContainers();
+
+    $addAction = $getAction($getAddActionName());
+    $cloneAction = $getAction($getCloneActionName());
+    $deleteAction = $getAction($getDeleteActionName());
+    $moveDownAction = $getAction($getMoveDownActionName());
+    $moveUpAction = $getAction($getMoveUpActionName());
+    $reorderAction = $getAction($getReorderActionName());
+
+    $isAddable = $isAddable();
+    $isCloneable = $isCloneable();
+    $isDeletable = $isDeletable();
+    $isReorderableWithButtons = $isReorderableWithButtons();
+    $isReorderableWithDragAndDrop = $isReorderableWithDragAndDrop();
+
+    $statePath = $getStatePath();
+@endphp
+
 <x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
-    @php
-        $containers = $getChildComponentContainers();
-
-        $addAction = $getAction($getAddActionName());
-        $cloneAction = $getAction($getCloneActionName());
-        $deleteAction = $getAction($getDeleteActionName());
-        $moveDownAction = $getAction($getMoveDownActionName());
-        $moveUpAction = $getAction($getMoveUpActionName());
-        $reorderAction = $getAction($getReorderActionName());
-
-        $isAddable = $isAddable();
-        $isCloneable = $isCloneable();
-        $isDeletable = $isDeletable();
-        $isReorderableWithButtons = $isReorderableWithButtons();
-        $isReorderableWithDragAndDrop = $isReorderableWithDragAndDrop();
-
-        $statePath = $getStatePath();
-    @endphp
-
     <div
         x-data="{}"
         {{

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -1,13 +1,25 @@
 @php
     use Filament\Support\Facades\FilamentView;
+
+    $hasInlineLabel = $hasInlineLabel();
+    $id = $getId();
+    $isDisabled = $isDisabled();
+    $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
-    @php
-        $id = $getId();
-        $isDisabled = $isDisabled();
-        $statePath = $getStatePath();
-    @endphp
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
+    :has-inline-label="$hasInlineLabel"
+>
+    <x-slot
+        name="label"
+        @class([
+            'sm:pt-1.5' => $hasInlineLabel,
+        ])
+    >
+        {{ $getLabel() }}
+    </x-slot>
 
     <div
         @if (FilamentView::hasSpaMode())

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -1,6 +1,7 @@
 @php
     $datalistOptions = $getDatalistOptions();
     $extraAlpineAttributes = $getExtraAlpineAttributes();
+    $hasInlineLabel = $hasInlineLabel();
     $id = $getId();
     $isConcealed = $isConcealed();
     $isDisabled = $isDisabled();
@@ -16,7 +17,20 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
+    :has-inline-label="$hasInlineLabel"
+>
+    <x-slot
+        name="label"
+        @class([
+            'sm:pt-1.5' => $hasInlineLabel,
+        ])
+    >
+        {{ $getLabel() }}
+    </x-slot>
+
     <x-filament::input.wrapper
         :disabled="$isDisabled"
         :inline-prefix="$isPrefixInline"

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -1,7 +1,6 @@
 @php
     $datalistOptions = $getDatalistOptions();
     $extraAlpineAttributes = $getExtraAlpineAttributes();
-    $hasInlineLabel = $hasInlineLabel();
     $id = $getId();
     $isConcealed = $isConcealed();
     $isDisabled = $isDisabled();
@@ -20,17 +19,8 @@
 <x-dynamic-component
     :component="$getFieldWrapperView()"
     :field="$field"
-    :has-inline-label="$hasInlineLabel"
+    :inline-label-vertical-alignment="\Filament\Support\Enums\VerticalAlignment::Center"
 >
-    <x-slot
-        name="label"
-        @class([
-            'sm:pt-1.5' => $hasInlineLabel,
-        ])
-    >
-        {{ $getLabel() }}
-    </x-slot>
-
     <x-filament::input.wrapper
         :disabled="$isDisabled"
         :inline-prefix="$isPrefixInline"

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -1,6 +1,7 @@
 @php
     use Filament\Support\Facades\FilamentView;
 
+    $hasInlineLabel = $hasInlineLabel();
     $isConcealed = $isConcealed();
     $rows = $getRows();
     $shouldAutosize = $shouldAutosize();
@@ -9,7 +10,20 @@
     $initialHeight = (($rows ?? 2) * 1.5) + 0.75;
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
+    :has-inline-label="$hasInlineLabel"
+>
+    <x-slot
+        name="label"
+        @class([
+            'sm:pt-1.5' => $hasInlineLabel,
+        ])
+    >
+        {{ $getLabel() }}
+    </x-slot>
+
     <textarea
         @if ($shouldAutosize)
             @if (FilamentView::hasSpaMode())

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -1,4 +1,8 @@
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
+    :inline-label-vertical-alignment="\Filament\Support\Enums\VerticalAlignment::Center"
+>
     @php
         $offColor = $getOffColor() ?? 'gray';
         $onColor = $getOnColor() ?? 'primary';

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -1,14 +1,14 @@
+@php
+    $offColor = $getOffColor() ?? 'gray';
+    $onColor = $getOnColor() ?? 'primary';
+    $statePath = $getStatePath();
+@endphp
+
 <x-dynamic-component
     :component="$getFieldWrapperView()"
     :field="$field"
     :inline-label-vertical-alignment="\Filament\Support\Enums\VerticalAlignment::Center"
 >
-    @php
-        $offColor = $getOffColor() ?? 'gray';
-        $onColor = $getOnColor() ?? 'primary';
-        $statePath = $getStatePath();
-    @endphp
-
     @capture($content)
         <button
             x-data="{

--- a/packages/forms/src/Components/Radio.php
+++ b/packages/forms/src/Components/Radio.php
@@ -51,6 +51,7 @@ class Radio extends Field
     public function inline(bool | Closure $condition = true): static
     {
         $this->isInline = $condition;
+        $this->inlineLabel(fn (Radio $component): ?bool => $component->evaluate($condition) ? true : null);
 
         return $this;
     }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

This PR started with a fix for just the radio component (description below), but I've found more related things to fix regarding form field inline label alignment.

The `inline()` API of the radio button form component currently also sets the label to be inline. This is unexpected, as the dedicated `inlineLabel()` API should control this. This PR updates the radio component to support non-inline label with inline radios. Visually this may be regarded as a breaking change, but to me this is a bug since the current result is unexpected.

### Before

<img width="356" alt="Screenshot 2023-11-26 at 19 51 56" src="https://github.com/filamentphp/filament/assets/44533235/0103d9c2-fed1-4f3d-afe4-79435bf8e5eb">

### After

<img width="226" alt="Screenshot 2023-11-26 at 19 52 28" src="https://github.com/filamentphp/filament/assets/44533235/5fb630bb-8ba5-4d23-9043-49287c8afa6a">
