### PR TITLE
Update manage-issue.yml

### DIFF
--- a/.github/workflows/manage-issue.yml
+++ b/.github/workflows/manage-issue.yml
@@ -158,7 +158,7 @@ jobs:
                 Hey @${user}! We're sorry to hear that you've hit this issue. 💛
             `.trim()
 
-            const NO_REPRO_URL = ((! url) || (! url.includes('https://github.com/')) || (url.includes('https://github.com/filamentphp')))
+            const NO_REPRO_URL = ((! url) || (! url.includes('https://github.com/')) || (url.includes('https://github.com/filamentphp') && (! url.includes('https://github.com/filamentphp/demo'))))
             const NO_REPRO_STEPS = reproSteps.length < 25
 
             if (NO_REPRO_URL || NO_REPRO_STEPS) {

--- a/.github/workflows/manage-issue.yml
+++ b/.github/workflows/manage-issue.yml
@@ -158,7 +158,7 @@ jobs:
                 Hey @${user}! We're sorry to hear that you've hit this issue. 💛
             `.trim()
 
-            const NO_REPRO_URL = ((! url.includes('https://github.com/')) || url.includes('https://github.com/filamentphp/') || url === 'https://github.com/filamentphp') && (! url.includes('https://github.com/filamentphp/demo'))
+            const NO_REPRO_URL = ((! url) || (! url.includes('https://github.com/')) || (url.includes('https://github.com/filamentphp')))
             const NO_REPRO_STEPS = reproSteps.length < 25
 
             if (NO_REPRO_URL || NO_REPRO_STEPS) {


### PR DESCRIPTION
Url can be null as defined in https://github.com/filamentphp/filament/blob/9f2f63a611594dedc97130cf5a08eebb38ba7e07/.github/workflows/manage-issue.yml#L34

Because of that, its causing errors while evaluating NO_REPRO_URL further down in the code, see action log:
https://github.com/filamentphp/filament/actions/runs/7005326321

This PR fixes the evaluation by adding a check wether `url` is not falsy.

Also fixes the checks for repro urls under `filamentphp` org to avoid urls like:
https://github.com/filamentphp/filament/issues/9838

```js
const url = 'https://github.com/filamentphp/demo'

// before
((! url.includes('https://github.com/')) || url.includes('https://github.com/filamentphp/') || url === 'https://github.com/filamentphp') && (! url.includes('https://github.com/filamentphp/demo')) // false

// after
((! url) || (! url.includes('https://github.com/')) || (url.includes('https://github.com/filamentphp'))) // true
```