### PR TITLE
Update 02-text.md

### DIFF
--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -80,7 +80,7 @@ TextColumn::make('description')
     ->tooltip(function (TextColumn $column): ?string {
         $state = $column->getState();
 
-        if (strlen($state) <= $column->getLimit()) {
+        if (strlen($state) <= $column->getCharacterLimit()) {
             return null;
         }
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

----

Method `getLimit` not available:
![2023-11-27_16-52](https://github.com/filamentphp/filament/assets/50796878/a3477e75-865d-4eea-b30c-a159c1c28a18)


But if referring [`limit` method](https://github.com/filamentphp/tables/blob/3.x/src/Columns/Concerns/CanFormatState.php#L166
), which sets value to `characterLimit` property, similar method is `getCharacterLimit`

But if you refer to the [`limit`](https://github.com/filamentphp/tables/blob/3.x/src/Columns/Concerns/CanFormatState.php#L166) method, which sets the value of the `characterLimit` property, then the correct method replacement is `getCharacterLimit`.

--- 

**Just a note:** `getLimit` method is available only for `ImageColumn`
- search: https://github.com/search?q=repo%3Afilamentphp%2Ftables%20getLimit&type=code
- `getLimit` reference - https://github.com/filamentphp/tables/blob/04f7051a7c511331f8429e4718e3eed309eb5092/src/Columns/ImageColumn.php#L297
