### PR TITLE
Update max content width options

### DIFF
--- a/packages/panels/docs/04-pages.md
+++ b/packages/panels/docs/04-pages.md
@@ -296,7 +296,7 @@ This example assumes you have a Blade view at `resources/views/filament/settings
 
 ## Customizing the maximum content width
 
-By default, Filament will restrict the width of the content on the page, so it doesn't become too wide on large screens. To change this, you may override the `getMaxContentWidth()` method. Options correspond to [Tailwind's max-width scale](https://tailwindcss.com/docs/max-width). The options are `ExtraSmall`, `Small`, `Medium`, `Large`, `ExtraLarge`, `TwoExtraLarge`, `ThreeExtraLarge`, `FourExtraLarge`, `FiveExtraLarge`, `SixExtraLarge`, `SevenExtraLarge`, `Prose`, `ScreenSmall`, `ScreenMedium`, `ScreenLarge`, `ScreenExtraLarge`, `ScreenTwoExtraLarge` and `Full`. The default is `SevenExtraLarge`:
+By default, Filament will restrict the width of the content on the page, so it doesn't become too wide on large screens. To change this, you may override the `getMaxContentWidth()` method. Options correspond to [Tailwind's max-width scale](https://tailwindcss.com/docs/max-width). The options are `Zero`, `None`, `ExtraSmall`, `Small`, `Medium`, `Large`, `ExtraLarge`, `TwoExtraLarge`, `ThreeExtraLarge`, `FourExtraLarge`, `FiveExtraLarge`, `SixExtraLarge`, `SevenExtraLarge`, `Full`, `MinContent`, `MaxContent`, `FitContent`,  `Prose`, `ScreenSmall`, `ScreenMedium`, `ScreenLarge`, `ScreenExtraLarge` and `ScreenTwoExtraLarge`. The default is `SevenExtraLarge`:
 
 ```php
 use Filament\Support\Enums\MaxWidth;

--- a/packages/panels/docs/04-pages.md
+++ b/packages/panels/docs/04-pages.md
@@ -296,7 +296,7 @@ This example assumes you have a Blade view at `resources/views/filament/settings
 
 ## Customizing the maximum content width
 
-By default, Filament will restrict the width of the content on the page, so it doesn't become too wide on large screens. To change this, you may override the `getMaxContentWidth()` method. Options correspond to [Tailwind's max-width scale](https://tailwindcss.com/docs/max-width). The options are `Zero`, `None`, `ExtraSmall`, `Small`, `Medium`, `Large`, `ExtraLarge`, `TwoExtraLarge`, `ThreeExtraLarge`, `FourExtraLarge`, `FiveExtraLarge`, `SixExtraLarge`, `SevenExtraLarge`, `Full`, `MinContent`, `MaxContent`, `FitContent`,  `Prose`, `ScreenSmall`, `ScreenMedium`, `ScreenLarge`, `ScreenExtraLarge` and `ScreenTwoExtraLarge`. The default is `SevenExtraLarge`:
+By default, Filament will restrict the width of the content on the page, so it doesn't become too wide on large screens. To change this, you may override the `getMaxContentWidth()` method. Options correspond to [Tailwind's max-width scale](https://tailwindcss.com/docs/max-width). The options are `ExtraSmall`, `Small`, `Medium`, `Large`, `ExtraLarge`, `TwoExtraLarge`, `ThreeExtraLarge`, `FourExtraLarge`, `FiveExtraLarge`, `SixExtraLarge`, `SevenExtraLarge`, `Full`, `MinContent`, `MaxContent`, `FitContent`,  `Prose`, `ScreenSmall`, `ScreenMedium`, `ScreenLarge`, `ScreenExtraLarge` and `ScreenTwoExtraLarge`. The default is `SevenExtraLarge`:
 
 ```php
 use Filament\Support\Enums\MaxWidth;

--- a/packages/panels/docs/09-configuration.md
+++ b/packages/panels/docs/09-configuration.md
@@ -100,7 +100,7 @@ public function panel(Panel $panel): Panel
 
 ## Customizing the maximum content width
 
-By default, Filament will restrict the width of the content on the page, so it doesn't become too wide on large screens. To change this, you may override the `getMaxContentWidth()` method. Options correspond to [Tailwind's max-width scale](https://tailwindcss.com/docs/max-width). The options are `ExtraSmall`, `Small`, `Medium`, `Large`, `ExtraLarge`, `TwoExtraLarge`, `ThreeExtraLarge`, `FourExtraLarge`, `FiveExtraLarge`, `SixExtraLarge`, `SevenExtraLarge`, `Full`, `MinContent`, `MaxContent`, `FitContent`,  `Prose`, `ScreenSmall`, `ScreenMedium`, `ScreenLarge`, `ScreenExtraLarge` and `ScreenTwoExtraLarge`. The default is `SevenExtraLarge`:
+By default, Filament will restrict the width of the content on the page, so it doesn't become too wide on large screens. To change this, you may use the `maxContentWidth()` method. Options correspond to [Tailwind's max-width scale](https://tailwindcss.com/docs/max-width). The options are `ExtraSmall`, `Small`, `Medium`, `Large`, `ExtraLarge`, `TwoExtraLarge`, `ThreeExtraLarge`, `FourExtraLarge`, `FiveExtraLarge`, `SixExtraLarge`, `SevenExtraLarge`, `Full`, `MinContent`, `MaxContent`, `FitContent`,  `Prose`, `ScreenSmall`, `ScreenMedium`, `ScreenLarge`, `ScreenExtraLarge` and `ScreenTwoExtraLarge`. The default is `SevenExtraLarge`:
 
 ```php
 use Filament\Panel;

--- a/packages/panels/docs/09-configuration.md
+++ b/packages/panels/docs/09-configuration.md
@@ -100,7 +100,7 @@ public function panel(Panel $panel): Panel
 
 ## Customizing the maximum content width
 
-By default, Filament will restrict the width of the content on the page, so it doesn't become too wide on large screens. To change this, you may override the `getMaxContentWidth()` method. Options correspond to [Tailwind's max-width scale](https://tailwindcss.com/docs/max-width). The options are `Zero`, `None`, `ExtraSmall`, `Small`, `Medium`, `Large`, `ExtraLarge`, `TwoExtraLarge`, `ThreeExtraLarge`, `FourExtraLarge`, `FiveExtraLarge`, `SixExtraLarge`, `SevenExtraLarge`, `Full`, `MinContent`, `MaxContent`, `FitContent`,  `Prose`, `ScreenSmall`, `ScreenMedium`, `ScreenLarge`, `ScreenExtraLarge` and `ScreenTwoExtraLarge`. The default is `SevenExtraLarge`:
+By default, Filament will restrict the width of the content on the page, so it doesn't become too wide on large screens. To change this, you may override the `getMaxContentWidth()` method. Options correspond to [Tailwind's max-width scale](https://tailwindcss.com/docs/max-width). The options are `ExtraSmall`, `Small`, `Medium`, `Large`, `ExtraLarge`, `TwoExtraLarge`, `ThreeExtraLarge`, `FourExtraLarge`, `FiveExtraLarge`, `SixExtraLarge`, `SevenExtraLarge`, `Full`, `MinContent`, `MaxContent`, `FitContent`,  `Prose`, `ScreenSmall`, `ScreenMedium`, `ScreenLarge`, `ScreenExtraLarge` and `ScreenTwoExtraLarge`. The default is `SevenExtraLarge`:
 
 ```php
 use Filament\Panel;

--- a/packages/panels/docs/09-configuration.md
+++ b/packages/panels/docs/09-configuration.md
@@ -100,7 +100,7 @@ public function panel(Panel $panel): Panel
 
 ## Customizing the maximum content width
 
-By default, Filament will restrict the width of the content on a page, so it doesn't become too wide on large screens. To change this, you may use the `maxContentWidth()` method. Options correspond to [Tailwind's max-width scale](https://tailwindcss.com/docs/max-width). The options are `ExtraSmall`, `Small`, `Medium`, `Large`, `ExtraLarge`, `TwoExtraLarge`, `ThreeExtraLarge`, `FourExtraLarge`, `FiveExtraLarge`, `SixExtraLarge`, `SevenExtraLarge`, `Prose`, `ScreenSmall`, `ScreenMedium`, `ScreenLarge`, `ScreenExtraLarge`, `ScreenTwoExtraLarge` and `Full`. The default is `SevenExtraLarge`:
+By default, Filament will restrict the width of the content on the page, so it doesn't become too wide on large screens. To change this, you may override the `getMaxContentWidth()` method. Options correspond to [Tailwind's max-width scale](https://tailwindcss.com/docs/max-width). The options are `Zero`, `None`, `ExtraSmall`, `Small`, `Medium`, `Large`, `ExtraLarge`, `TwoExtraLarge`, `ThreeExtraLarge`, `FourExtraLarge`, `FiveExtraLarge`, `SixExtraLarge`, `SevenExtraLarge`, `Full`, `MinContent`, `MaxContent`, `FitContent`,  `Prose`, `ScreenSmall`, `ScreenMedium`, `ScreenLarge`, `ScreenExtraLarge` and `ScreenTwoExtraLarge`. The default is `SevenExtraLarge`:
 
 ```php
 use Filament\Panel;

--- a/packages/panels/resources/views/components/layout/index.blade.php
+++ b/packages/panels/resources/views/components/layout/index.blade.php
@@ -46,7 +46,32 @@
             <main
                 @class([
                     'fi-main mx-auto h-full w-full px-4 md:px-6 lg:px-8',
-                    $maxContentWidth?->value ?? (filament()->getMaxContentWidth() ?? MaxWidth::SevenExtraLarge)->value,
+                    match ($maxContentWidth ??= (filament()->getMaxContentWidth() ?? MaxWidth::SevenExtraLarge)) {
+                        MaxWidth::Zero, '0' => 'max-w-0',
+                        MaxWidth::None, 'none' => 'max-w-none',
+                        MaxWidth::ExtraSmall, 'xs' => 'max-w-xs',
+                        MaxWidth::Small, 'sm' => 'max-w-sm',
+                        MaxWidth::Medium, 'md' => 'max-w-md',
+                        MaxWidth::Large, 'lg' => 'max-w-lg',
+                        MaxWidth::ExtraLarge, 'xl' => 'max-w-xl',
+                        MaxWidth::TwoExtraLarge, '2xl' => 'max-w-2xl',
+                        MaxWidth::ThreeExtraLarge, '3xl' => 'max-w-3xl',
+                        MaxWidth::FourExtraLarge, '4xl' => 'max-w-4xl',
+                        MaxWidth::FiveExtraLarge, '5xl' => 'max-w-5xl',
+                        MaxWidth::SixExtraLarge, '6xl' => 'max-w-6xl',
+                        MaxWidth::SevenExtraLarge, '7xl' => 'max-w-7xl',
+                        MaxWidth::Full, 'full' => 'max-w-full',
+                        MaxWidth::MinContent, 'min' => 'max-w-min',
+                        MaxWidth::MaxContent, 'max' => 'max-w-max',
+                        MaxWidth::FitContent, 'fit' => 'max-w-fit',
+                        MaxWidth::Prose, 'prose' => 'max-w-prose',
+                        MaxWidth::ScreenSmall, 'screen-sm' => 'max-w-screen-sm',
+                        MaxWidth::ScreenMedium, 'screen-md' => 'max-w-screen-md',
+                        MaxWidth::ScreenLarge, 'screen-lg' => 'max-w-screen-lg',
+                        MaxWidth::ScreenExtraLarge, 'screen-xl' => 'max-w-screen-xl',
+                        MaxWidth::ScreenTwoExtraLarge, 'screen-2xl' => 'max-w-screen-2xl',
+                        default => $maxContentWidth,
+                    },
                 ])
             >
                 {{ \Filament\Support\Facades\FilamentView::renderHook('panels::content.start') }}

--- a/packages/panels/resources/views/components/layout/index.blade.php
+++ b/packages/panels/resources/views/components/layout/index.blade.php
@@ -46,23 +46,7 @@
             <main
                 @class([
                     'fi-main mx-auto h-full w-full px-4 md:px-6 lg:px-8',
-                    match ($maxContentWidth ??= (filament()->getMaxContentWidth() ?? MaxWidth::SevenExtraLarge)) {
-                        MaxWidth::ExtraLarge, 'xl' => 'max-w-xl',
-                        MaxWidth::TwoExtraLarge, '2xl' => 'max-w-2xl',
-                        MaxWidth::ThreeExtraLarge, '3xl' => 'max-w-3xl',
-                        MaxWidth::FourExtraLarge, '4xl' => 'max-w-4xl',
-                        MaxWidth::FiveExtraLarge, '5xl' => 'max-w-5xl',
-                        MaxWidth::SixExtraLarge, '6xl' => 'max-w-6xl',
-                        MaxWidth::SevenExtraLarge, '7xl' => 'max-w-7xl',
-                        MaxWidth::Prose, 'prose' => 'max-w-prose',
-                        MaxWidth::ScreenSmall, 'screen-sm' => 'max-w-screen-sm',
-                        MaxWidth::ScreenMedium, 'screen-md' => 'max-w-screen-md',
-                        MaxWidth::ScreenLarge, 'screen-lg' => 'max-w-screen-lg',
-                        MaxWidth::ScreenExtraLarge, 'screen-xl' => 'max-w-screen-xl',
-                        MaxWidth::ScreenTwoExtraLarge, 'screen-2xl' => 'max-w-screen-2xl',
-                        MaxWidth::Full, 'full' => 'max-w-full',
-                        default => $maxContentWidth,
-                    },
+                    $maxContentWidth?->value ?? (filament()->getMaxContentWidth() ?? MaxWidth::SevenExtraLarge)->value,
                 ])
             >
                 {{ \Filament\Support\Facades\FilamentView::renderHook('panels::content.start') }}

--- a/packages/panels/resources/views/components/layout/index.blade.php
+++ b/packages/panels/resources/views/components/layout/index.blade.php
@@ -47,8 +47,6 @@
                 @class([
                     'fi-main mx-auto h-full w-full px-4 md:px-6 lg:px-8',
                     match ($maxContentWidth ??= (filament()->getMaxContentWidth() ?? MaxWidth::SevenExtraLarge)) {
-                        MaxWidth::Zero, '0' => 'max-w-0',
-                        MaxWidth::None, 'none' => 'max-w-none',
                         MaxWidth::ExtraSmall, 'xs' => 'max-w-xs',
                         MaxWidth::Small, 'sm' => 'max-w-sm',
                         MaxWidth::Medium, 'md' => 'max-w-md',

--- a/packages/support/src/Enums/MaxWidth.php
+++ b/packages/support/src/Enums/MaxWidth.php
@@ -45,4 +45,6 @@ enum MaxWidth
     case ScreenExtraLarge;
 
     case ScreenTwoExtraLarge;
+
+    case Screen;
 }

--- a/packages/support/src/Enums/MaxWidth.php
+++ b/packages/support/src/Enums/MaxWidth.php
@@ -2,51 +2,51 @@
 
 namespace Filament\Support\Enums;
 
-enum MaxWidth: string
+enum MaxWidth
 {
-    case Zero = 'max-w-0';
+    case Zero;
 
-    case None = 'max-w-none';
+    case None;
 
-    case ExtraSmall = 'max-w-xs';
+    case ExtraSmall;
 
-    case Small  = 'max-w-sm';
+    case Small;
 
-    case Medium = 'max-w-md';
+    case Medium;
 
-    case Large = 'max-w-lg';
+    case Large;
 
-    case ExtraLarge = 'max-w-xl';
+    case ExtraLarge;
 
-    case TwoExtraLarge = 'max-w-2xl';
+    case TwoExtraLarge;
 
-    case ThreeExtraLarge = 'max-w-3xl';
+    case ThreeExtraLarge;
 
-    case FourExtraLarge = 'max-w-4xl';
+    case FourExtraLarge;
 
-    case FiveExtraLarge = 'max-w-5xl';
+    case FiveExtraLarge;
 
-    case SixExtraLarge = 'max-w-6xl';
+    case SixExtraLarge;
 
-    case SevenExtraLarge = 'max-w-7xl';
+    case SevenExtraLarge;
 
-    case Full = 'max-w-full';
+    case Full;
 
-    case MinContent = 'max-w-min';
+    case MinContent;
 
-    case MaxContent = 'max-w-max';
+    case MaxContent;
 
-    case FitContent = 'max-w-fit';
+    case FitContent;
 
-    case Prose = 'max-w-prose';
+    case Prose;
 
-    case ScreenSmall = 'max-w-screen-sm';
+    case ScreenSmall;
 
-    case ScreenMedium = 'max-w-screen-md';
+    case ScreenMedium;
 
-    case ScreenLarge = 'max-w-screen-lg';
+    case ScreenLarge;
 
-    case ScreenExtraLarge = 'max-w-screen-xl';
+    case ScreenExtraLarge;
 
-    case ScreenTwoExtraLarge = 'max-w-screen-2xl';
+    case ScreenTwoExtraLarge;
 }

--- a/packages/support/src/Enums/MaxWidth.php
+++ b/packages/support/src/Enums/MaxWidth.php
@@ -2,43 +2,51 @@
 
 namespace Filament\Support\Enums;
 
-enum MaxWidth
+enum MaxWidth: string
 {
-    case ExtraSmall;
+    case Zero = 'max-w-0';
 
-    case Small;
+    case None = 'max-w-none';
 
-    case Medium;
+    case ExtraSmall = 'max-w-xs';
 
-    case Large;
+    case Small  = 'max-w-sm';
 
-    case ExtraLarge;
+    case Medium = 'max-w-md';
 
-    case TwoExtraLarge;
+    case Large = 'max-w-lg';
 
-    case ThreeExtraLarge;
+    case ExtraLarge = 'max-w-xl';
 
-    case FourExtraLarge;
+    case TwoExtraLarge = 'max-w-2xl';
 
-    case FiveExtraLarge;
+    case ThreeExtraLarge = 'max-w-3xl';
 
-    case SixExtraLarge;
+    case FourExtraLarge = 'max-w-4xl';
 
-    case SevenExtraLarge;
+    case FiveExtraLarge = 'max-w-5xl';
 
-    case Prose;
+    case SixExtraLarge = 'max-w-6xl';
 
-    case Screen;
+    case SevenExtraLarge = 'max-w-7xl';
 
-    case ScreenSmall;
+    case Full = 'max-w-full';
 
-    case ScreenMedium;
+    case MinContent = 'max-w-min';
 
-    case ScreenLarge;
+    case MaxContent = 'max-w-max';
 
-    case ScreenExtraLarge;
+    case FitContent = 'max-w-fit';
 
-    case ScreenTwoExtraLarge;
+    case Prose = 'max-w-prose';
 
-    case Full;
+    case ScreenSmall = 'max-w-screen-sm';
+
+    case ScreenMedium = 'max-w-screen-md';
+
+    case ScreenLarge = 'max-w-screen-lg';
+
+    case ScreenExtraLarge = 'max-w-screen-xl';
+
+    case ScreenTwoExtraLarge = 'max-w-screen-2xl';
 }

--- a/packages/support/src/Enums/MaxWidth.php
+++ b/packages/support/src/Enums/MaxWidth.php
@@ -4,10 +4,6 @@ namespace Filament\Support\Enums;
 
 enum MaxWidth
 {
-    case Zero;
-
-    case None;
-
     case ExtraSmall;
 
     case Small;


### PR DESCRIPTION
Updated the maximum content width options and the corresponding Filament's documentation. Added `Zero`, `None`, `MinContent`, `MaxContent`, `FitContent` to the MaxWidth Enum options and made adjustments in the system to match these changes. This enhancement provides more width options to accommodate varying screen sizes and improve the user interface layout on larger screens.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
