### PR TITLE
Fixing radio component translate

### DIFF
--- a/packages/forms/resources/lang/en/components.php
+++ b/packages/forms/resources/lang/en/components.php
@@ -425,5 +425,10 @@ return [
         ],
 
     ],
+    
+    'radio' => [
+        'true' => 'Yes',
+        'false' => 'No',
+    ],
 
 ];

--- a/packages/forms/resources/lang/pt_BR/components.php
+++ b/packages/forms/resources/lang/pt_BR/components.php
@@ -426,4 +426,9 @@ return [
 
     ],
 
+    'radio' => [
+        'true' => 'Sim',
+        'false' => 'Não',
+    ],
+    
 ];

--- a/packages/forms/src/Components/Radio.php
+++ b/packages/forms/src/Components/Radio.php
@@ -31,7 +31,7 @@ class Radio extends Field
         parent::setUp();
     }
 
-    public function boolean(string $trueLabel = null, string $falseLabel = null): static
+    public function boolean(?string $trueLabel = null, ?string $falseLabel = null): static
     {
         $this->options([
             1 => $trueLabel ?? __('filament-forms::components.select.boolean.true'),

--- a/packages/forms/src/Components/Radio.php
+++ b/packages/forms/src/Components/Radio.php
@@ -31,11 +31,11 @@ class Radio extends Field
         parent::setUp();
     }
 
-    public function boolean(string $trueLabel = 'Yes', string $falseLabel = 'No'): static
+    public function boolean(string $trueLabel = null, string $falseLabel = null): static
     {
         $this->options([
-            1 => $trueLabel,
-            0 => $falseLabel,
+            1 => $trueLabel ?? __('filament-forms::components.select.boolean.true'),
+            0 => $falseLabel ?? __('filament-forms::components.select.boolean.false'),
         ]);
 
         return $this;

--- a/packages/forms/src/Components/Radio.php
+++ b/packages/forms/src/Components/Radio.php
@@ -34,8 +34,8 @@ class Radio extends Field
     public function boolean(?string $trueLabel = null, ?string $falseLabel = null): static
     {
         $this->options([
-            1 => $trueLabel ?? __('filament-forms::components.select.boolean.true'),
-            0 => $falseLabel ?? __('filament-forms::components.select.boolean.false'),
+            1 => $trueLabel ?? __('filament-forms::components.radio.true'),
+            0 => $falseLabel ?? __('filament-forms::components.radio.false'),
         ]);
 
         return $this;


### PR DESCRIPTION
Making translation for radio component.

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
