### PR TITLE
Update Translatable.php

### DIFF
--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Resources\Pages\CreateRecord\Concerns;
 
+use Filament\Facades\Filament;
 use Filament\Resources\Concerns\HasActiveLocaleSwitcher;
 use Filament\Support\Exceptions\Halt;
 use Illuminate\Database\Eloquent\Model;
@@ -124,6 +125,9 @@ trait Translatable
             }
         }
 
+        if ($tenant = Filament::getTenant()) {
+            return $this->associateRecordWithTenant($record, $tenant);
+        }
         $record->save();
 
         return $record;

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
@@ -125,9 +125,13 @@ trait Translatable
             }
         }
 
-        if ($tenant = Filament::getTenant()) {
+        if (
+            static::getResource()::isScopedToTenant() &&
+            ($tenant = Filament::getTenant())
+        ) {
             return $this->associateRecordWithTenant($record, $tenant);
         }
+        
         $record->save();
 
         return $record;


### PR DESCRIPTION
Also save the tenant id when translatable is active.

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
