### PR TITLE
Adding an extra repeater and builder header actions

### DIFF
--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -543,3 +543,28 @@ Repeater::make('members')
 ```
 
 > The `collapseAction()`, `collapseAllAction()`, `expandAction()`, `expandAllAction()` and `reorderAction()` methods do not support confirmation modals, as clicking their buttons does not make the network request that is required to show the modal.
+
+### Adding an extra repeater actions to the header
+
+You can provide an array of additional actions to be displayed in the repeater's header, positioned between the default actions, by utilizing the `extraHeaderActions()` method:
+
+```php
+use Filament\Forms\Components\Actions\Action;
+use Filament\Forms\Components\Repeater;
+ 
+Repeater::make('members')
+    ->schema([
+        // ...
+    ])
+    ->extraHeaderActions([
+        Action::make('reset')
+            ->icon('heroicon-s-arrow-path')
+            ->iconButton()
+            ->color('warning')
+            ->requiresConfirmation()
+            ->action(function () {
+                 // ...
+            }),
+        // ...
+    ])
+```

--- a/packages/forms/docs/03-fields/13-builder.md
+++ b/packages/forms/docs/03-fields/13-builder.md
@@ -351,3 +351,28 @@ Builder::make('content')
 ```
 
 > The `addAction()`, `addBetweenAction()`, `collapseAction()`, `collapseAllAction()`, `expandAction()`, `expandAllAction()` and `reorderAction()` methods do not support confirmation modals, as clicking their buttons does not make the network request that is required to show the modal.
+
+### Adding an extra builder actions to the header
+
+You can provide an array of additional actions to be displayed in the builder's header, positioned between the default actions, by utilizing the `extraHeaderActions()` method:
+
+```php
+use Filament\Forms\Components\Actions\Action;
+use Filament\Forms\Components\Builder;
+ 
+Builder::make('content')
+    ->blocks([
+        // ...
+    ])
+    ->extraHeaderActions([
+        Action::make('reset')
+            ->icon('heroicon-s-arrow-path')
+            ->iconButton()
+            ->color('warning')
+            ->requiresConfirmation()
+            ->action(function () {
+                 // ...
+            }),
+        // ...
+    ])
+```

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -14,6 +14,7 @@
         $moveDownAction = $getAction($getMoveDownActionName());
         $moveUpAction = $getAction($getMoveUpActionName());
         $reorderAction = $getAction($getReorderActionName());
+        $extraHeaderActions = $getAction($getExtraHeaderActionName());
 
         $isAddable = $isAddable();
         $isCloneable = $isCloneable();
@@ -103,12 +104,12 @@
                             })
                         "
                         x-sortable-item="{{ $uuid }}"
-                        class="fi-fo-builder-item rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-white/5 dark:ring-white/10"
+                        class="bg-white shadow-sm fi-fo-builder-item rounded-xl ring-1 ring-gray-950/5 dark:bg-white/5 dark:ring-white/10"
                         x-bind:class="{ 'fi-collapsed overflow-hidden': isCollapsed }"
                     >
                         @if ($isReorderableWithDragAndDrop || $isReorderableWithButtons || $hasBlockLabels || $isCloneable || $isDeletable || $isCollapsible)
                             <div
-                                class="fi-fo-builder-item-header flex items-center gap-x-3 overflow-hidden px-4 py-3"
+                                class="flex items-center px-4 py-3 overflow-hidden fi-fo-builder-item-header gap-x-3"
                             >
                                 @if ($isReorderableWithDragAndDrop || $isReorderableWithButtons)
                                     <ul class="flex items-center gap-x-3">
@@ -151,7 +152,7 @@
 
                                 @if ($isCloneable || $isDeletable || $isCollapsible)
                                     <ul
-                                        class="ms-auto flex items-center gap-x-3"
+                                        class="flex items-center ms-auto gap-x-3"
                                     >
                                         @if ($isCloneable)
                                             <li>
@@ -164,6 +165,12 @@
                                                 {{ $deleteAction(['item' => $uuid]) }}
                                             </li>
                                         @endif
+
+                                        @foreach ($getExtraHeaderActions() as $action)
+                                            <li>
+                                                {{ $action }}
+                                            </li>
+                                        @endforeach
 
                                         @if ($isCollapsible)
                                             <li
@@ -179,7 +186,7 @@
                                                 </div>
 
                                                 <div
-                                                    class="absolute inset-0 rotate-180 transition"
+                                                    class="absolute inset-0 transition rotate-180"
                                                     x-bind:class="{ 'opacity-0 pointer-events-none': ! isCollapsed }"
                                                 >
                                                     {{ $getAction('expand') }}
@@ -193,7 +200,7 @@
 
                         <div
                             x-show="! isCollapsed"
-                            class="fi-fo-builder-item-content border-t border-gray-100 p-4 dark:border-white/10"
+                            class="p-4 border-t border-gray-100 fi-fo-builder-item-content dark:border-white/10"
                         >
                             {{ $item }}
                         </div>
@@ -203,10 +210,10 @@
                         @if ($isAddable && $addBetweenAction->isVisible())
                             <li class="relative -top-2 !mt-0 h-0">
                                 <div
-                                    class="flex w-full justify-center opacity-0 transition duration-75 hover:opacity-100"
+                                    class="flex justify-center w-full transition duration-75 opacity-0 hover:opacity-100"
                                 >
                                     <div
-                                        class="fi-fo-builder-block-picker-ctn rounded-lg bg-white dark:bg-gray-900"
+                                        class="bg-white rounded-lg fi-fo-builder-block-picker-ctn dark:bg-gray-900"
                                     >
                                         <x-filament-forms::builder.block-picker
                                             :action="$addBetweenAction"
@@ -228,7 +235,7 @@
                                 class="relative border-t border-gray-200 dark:border-white/10"
                             >
                                 <span
-                                    class="absolute -top-3 left-3 bg-white px-1 text-sm font-medium dark:bg-gray-900"
+                                    class="absolute px-1 text-sm font-medium bg-white -top-3 left-3 dark:bg-gray-900"
                                 >
                                     {{ $labelBetweenItems }}
                                 </span>

--- a/packages/forms/resources/views/components/repeater.blade.php
+++ b/packages/forms/resources/views/components/repeater.blade.php
@@ -11,6 +11,7 @@
         $moveDownAction = $getAction($getMoveDownActionName());
         $moveUpAction = $getAction($getMoveUpActionName());
         $reorderAction = $getAction($getReorderActionName());
+        $extraHeaderActions = $getAction($getExtraHeaderActionName());
 
         $isAddable = $isAddable();
         $isCloneable = $isCloneable();
@@ -106,12 +107,12 @@
                             x-on:repeater-expand.window="$event.detail === '{{ $statePath }}' && (isCollapsed = false)"
                             x-on:repeater-collapse.window="$event.detail === '{{ $statePath }}' && (isCollapsed = true)"
                             x-sortable-item="{{ $uuid }}"
-                            class="fi-fo-repeater-item rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-white/5 dark:ring-white/10"
+                            class="bg-white shadow-sm fi-fo-repeater-item rounded-xl ring-1 ring-gray-950/5 dark:bg-white/5 dark:ring-white/10"
                             x-bind:class="{ 'fi-collapsed overflow-hidden': isCollapsed }"
                         >
                             @if ($isReorderableWithDragAndDrop || $isReorderableWithButtons || filled($itemLabel) || $isCloneable || $isDeletable || $isCollapsible)
                                 <div
-                                    class="fi-fo-repeater-item-header flex items-center gap-x-3 overflow-hidden px-4 py-3"
+                                    class="flex items-center px-4 py-3 overflow-hidden fi-fo-repeater-item-header gap-x-3"
                                 >
                                     @if ($isReorderableWithDragAndDrop || $isReorderableWithButtons)
                                         <ul class="flex items-center gap-x-3">
@@ -154,7 +155,7 @@
 
                                     @if ($isCloneable || $isDeletable || $isCollapsible)
                                         <ul
-                                            class="ms-auto flex items-center gap-x-3"
+                                            class="flex items-center ms-auto gap-x-3"
                                         >
                                             @if ($isCloneable)
                                                 <li>
@@ -167,6 +168,12 @@
                                                     {{ $deleteAction(['item' => $uuid]) }}
                                                 </li>
                                             @endif
+
+                                            @foreach ($getExtraHeaderActions() as $action)
+                                                <li>
+                                                    {{ $action }}
+                                                </li>
+                                            @endforeach
 
                                             @if ($isCollapsible)
                                                 <li
@@ -182,7 +189,7 @@
                                                     </div>
 
                                                     <div
-                                                        class="absolute inset-0 rotate-180 transition"
+                                                        class="absolute inset-0 transition rotate-180"
                                                         x-bind:class="{ 'opacity-0 pointer-events-none': ! isCollapsed }"
                                                     >
                                                         {{ $getAction('expand') }}
@@ -196,7 +203,7 @@
 
                             <div
                                 x-show="! isCollapsed"
-                                class="fi-fo-repeater-item-content border-t border-gray-100 p-4 dark:border-white/10"
+                                class="p-4 border-t border-gray-100 fi-fo-repeater-item-content dark:border-white/10"
                             >
                                 {{ $item }}
                             </div>
@@ -204,9 +211,9 @@
 
                         @if (! $loop->last)
                             @if ($isAddable && $addBetweenAction->isVisible())
-                                <li class="flex w-full justify-center">
+                                <li class="flex justify-center w-full">
                                     <div
-                                        class="rounded-lg bg-white dark:bg-gray-900"
+                                        class="bg-white rounded-lg dark:bg-gray-900"
                                     >
                                         {{ $addBetweenAction(['afterItem' => $uuid]) }}
                                     </div>
@@ -216,7 +223,7 @@
                                     class="relative border-t border-gray-200 dark:border-white/10"
                                 >
                                     <span
-                                        class="absolute -top-3 left-3 bg-white px-1 text-sm font-medium dark:bg-gray-900"
+                                        class="absolute px-1 text-sm font-medium bg-white -top-3 left-3 dark:bg-gray-900"
                                     >
                                         {{ $labelBetweenItems }}
                                     </span>

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -78,6 +78,10 @@ class Builder extends Field implements Contracts\CanConcealComponents
 
     protected MaxWidth | string | Closure | null $blockPickerWidth = null;
 
+    protected array $cachedExtraHeaderActions;
+
+    protected array $extraHeaderActions = [];
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -106,6 +110,7 @@ class Builder extends Field implements Contracts\CanConcealComponents
             fn (Builder $component): Action => $component->getMoveDownAction(),
             fn (Builder $component): Action => $component->getMoveUpAction(),
             fn (Builder $component): Action => $component->getReorderAction(),
+            fn (Builder $component): array => $component->getExtraHeaderActions(),
         ]);
 
         $this->mutateDehydratedStateUsing(static function (?array $state): array {
@@ -553,6 +558,33 @@ class Builder extends Field implements Contracts\CanConcealComponents
     public function getExpandAllActionName(): string
     {
         return 'expandAll';
+    }
+
+    public function extraHeaderActions(array $actions): static
+    {
+        $this->extraHeaderActions = $actions;
+
+        return $this;
+    }
+
+    public function getExtraHeaderActionName(): string
+    {
+        return 'extra';
+    }
+
+    public function getExtraHeaderActions(): array
+    {
+        if (isset($this->cachedExtraHeaderActions)) {
+            return $this->cachedExtraHeaderActions;
+        }
+
+        $actions = [];
+
+        foreach ($this->evaluate($this->extraHeaderActions) as $action) {
+            $actions[$action->getName()] = $action;
+        }
+
+        return $this->cachedExtraHeaderActions = $actions;
     }
 
     public function truncateBlockLabel(bool | Closure $condition = true): static

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -91,6 +91,10 @@ class Repeater extends Field implements Contracts\CanConcealComponents
 
     protected bool | Closure $isItemLabelTruncated = true;
 
+    protected array $cachedExtraHeaderActions;
+
+    protected array $extraHeaderActions = [];
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -129,6 +133,7 @@ class Repeater extends Field implements Contracts\CanConcealComponents
             fn (Repeater $component): Action => $component->getMoveDownAction(),
             fn (Repeater $component): Action => $component->getMoveUpAction(),
             fn (Repeater $component): Action => $component->getReorderAction(),
+            fn (Repeater $component): array => $component->getExtraHeaderActions(),
         ]);
 
         $this->mutateDehydratedStateUsing(static function (Repeater $component, ?array $state): array {
@@ -570,6 +575,33 @@ class Repeater extends Field implements Contracts\CanConcealComponents
     public function getExpandAllActionName(): string
     {
         return 'expandAll';
+    }
+
+    public function extraHeaderActions(array $actions): static
+    {
+        $this->extraHeaderActions = $actions;
+
+        return $this;
+    }
+
+    public function getExtraHeaderActionName(): string
+    {
+        return 'extra';
+    }
+
+    public function getExtraHeaderActions(): array
+    {
+        if (isset($this->cachedExtraHeaderActions)) {
+            return $this->cachedExtraHeaderActions;
+        }
+
+        $actions = [];
+
+        foreach ($this->evaluate($this->extraHeaderActions) as $action) {
+            $actions[$action->getName()] = $action;
+        }
+
+        return $this->cachedExtraHeaderActions = $actions;
     }
 
     public function addActionLabel(string | Closure | null $label): static


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Same as modals have [the ability to Adding an extra modal action button to the footer](https://filamentphp.com/docs/3.x/actions/modals#adding-an-extra-modal-action-button-to-the-footer)

The Result will be in:

**Repeater**

<img width="732" alt="Screenshot 2023-11-28 at 14 20 06" src="https://github.com/filamentphp/filament/assets/121255432/3a122c7d-9c36-48f6-af35-9a916a4bedff">

**Builder**

<img width="732" alt="Screenshot 2023-11-28 at 14 19 59" src="https://github.com/filamentphp/filament/assets/121255432/9fdd9a6f-ab7e-460c-95d1-818c050d0f56">
