### PR TITLE
Add Spanish (es) missing translations - radio bool

### DIFF
--- a/packages/forms/resources/lang/es/components.php
+++ b/packages/forms/resources/lang/es/components.php
@@ -250,6 +250,15 @@ return [
 
     ],
 
+    'radio' => [
+
+        'boolean' => [
+            'true' => 'Sí',
+            'false' => 'No',
+        ],
+
+    ],
+
     'repeater' => [
 
         'actions' => [


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Translations for *form component radio* boolean texts.