### PR TITLE
Docs: Add `titleAttribute` to Select example

### DIFF
--- a/packages/forms/docs/03-fields/03-select.md
+++ b/packages/forms/docs/03-fields/03-select.md
@@ -237,6 +237,7 @@ use Illuminate\Database\Eloquent\Model;
 Select::make('author_id')
     ->relationship(
         name: 'author',
+        titleAttribute: 'name',
         modifyQueryUsing: fn (Builder $query) => $query->orderBy('first_name')->orderBy('last_name'),
     )
     ->getOptionLabelFromRecordUsing(fn (Model $record) => "{$record->first_name} {$record->last_name}")

--- a/packages/forms/docs/03-fields/03-select.md
+++ b/packages/forms/docs/03-fields/03-select.md
@@ -237,7 +237,7 @@ use Illuminate\Database\Eloquent\Model;
 Select::make('author_id')
     ->relationship(
         name: 'author',
-        titleAttribute: 'name',
+        titleAttribute: 'full_name',
         modifyQueryUsing: fn (Builder $query) => $query->orderBy('first_name')->orderBy('last_name'),
     )
     ->getOptionLabelFromRecordUsing(fn (Model $record) => "{$record->first_name} {$record->last_name}")


### PR DESCRIPTION
This PR adds `titleAttribute` to the documentation select example as `titleAttribute` is required.

![Screenshot 2023-11-28 at 4 15 26 PM](https://github.com/filamentphp/filament/assets/17038330/3371202d-ffd1-4c27-a312-0454c7ec52de)