### PR TITLE
Improve sticky form actions behavior

### DIFF
--- a/packages/panels/resources/views/components/form/actions.blade.php
+++ b/packages/panels/resources/views/components/form/actions.blade.php
@@ -9,7 +9,7 @@
         @if ($this->areFormActionsSticky())
             x-data="{
                 isSticky: false,
-                evaluatePageScrollPosition() {
+                evaluatePageScrollPosition: function () {
                     this.isSticky = window.pageYOffset > 0
                 },
             }"

--- a/packages/panels/resources/views/components/form/actions.blade.php
+++ b/packages/panels/resources/views/components/form/actions.blade.php
@@ -8,10 +8,13 @@
     <div
         @if ($this->areFormActionsSticky())
             x-data="{
+        
                 isSticky: false,
+        
                 evaluatePageScrollPosition: function () {
                     this.isSticky = window.pageYOffset > 0
                 },
+        
             }"
             x-init="evaluatePageScrollPosition"
             x-on:scroll.window="evaluatePageScrollPosition"

--- a/packages/panels/resources/views/components/form/actions.blade.php
+++ b/packages/panels/resources/views/components/form/actions.blade.php
@@ -9,6 +9,7 @@
         @if ($this->areFormActionsSticky())
             x-data="{
                 isSticky: false,
+
                 evaluatePageScrollPosition: function () {
                     this.isSticky = window.pageYOffset > 0
                 },

--- a/packages/panels/resources/views/components/form/actions.blade.php
+++ b/packages/panels/resources/views/components/form/actions.blade.php
@@ -18,14 +18,14 @@
             x-init="evaluatePageScrollPosition"
             x-intersect.threshold.100="isPinned = true"
             x-on:scroll.window="evaluatePageScrollPosition"
-            x-bind:style="{
-                bottom: '-1px',
-            }"
             x-bind:class="{
                 'transform bg-white shadow-lg ring-1 ring-gray-950/5 transition dark:bg-gray-900 dark:ring-white/10 md:rounded-t-xl -mx-4 md:mx-0':
                     isSticky,
                 'fi-sticky sticky p-4':
                     true,
+            }"
+            x-bind:style="{
+                bottom: '-1px',
             }"
         @endif
         class="fi-form-actions"

--- a/packages/panels/resources/views/components/form/actions.blade.php
+++ b/packages/panels/resources/views/components/form/actions.blade.php
@@ -9,11 +9,8 @@
         @if ($this->areFormActionsSticky())
             x-data="{
                 isSticky: false,
-
-                evaluatePageScrollPosition: function () {
-                    this.isSticky =
-                        document.body.scrollHeight >=
-                        window.scrollY + window.innerHeight * 2
+                evaluatePageScrollPosition() {
+                    this.isSticky = window.pageYOffset > 0
                 },
             }"
             x-init="evaluatePageScrollPosition"

--- a/packages/panels/resources/views/components/form/actions.blade.php
+++ b/packages/panels/resources/views/components/form/actions.blade.php
@@ -10,11 +10,19 @@
             x-data="{
                 isSticky: false,
 
+                getInitialPosition: function () {
+                    this.initialPosition = $el.getBoundingClientRect().top + window.scrollY;
+                },
+
                 evaluatePageScrollPosition: function () {
-                    this.isSticky = window.pageYOffset > 0
+                    var currentScroll = window.scrollY;
+                    var initialPosition = this.initialPosition;
+
+                    this.isSticky = (currentScroll >= initialPosition) ? false : true;
+                    
                 },
             }"
-            x-init="evaluatePageScrollPosition"
+            x-init="getInitialPosition"
             x-on:scroll.window="evaluatePageScrollPosition"
             x-bind:class="{
                 'fi-sticky sticky bottom-0 -mx-4 transform bg-white p-4 shadow-lg ring-1 ring-gray-950/5 transition dark:bg-gray-900 dark:ring-white/10 md:bottom-4 md:rounded-xl':

--- a/packages/panels/resources/views/components/form/actions.blade.php
+++ b/packages/panels/resources/views/components/form/actions.blade.php
@@ -8,7 +8,6 @@
     <div
         @if ($this->areFormActionsSticky())
             x-data="{
-        
                 isSticky: false,
                 evaluatePageScrollPosition: function () {
                     this.isSticky = window.pageYOffset > 0

--- a/packages/panels/resources/views/components/form/actions.blade.php
+++ b/packages/panels/resources/views/components/form/actions.blade.php
@@ -12,7 +12,6 @@
                 evaluatePageScrollPosition: function () {
                     this.isSticky = window.pageYOffset > 0
                 },
-        
             }"
             x-init="evaluatePageScrollPosition"
             x-on:scroll.window="evaluatePageScrollPosition"

--- a/packages/panels/resources/views/components/form/actions.blade.php
+++ b/packages/panels/resources/views/components/form/actions.blade.php
@@ -10,7 +10,6 @@
             x-data="{
         
                 isSticky: false,
-        
                 evaluatePageScrollPosition: function () {
                     this.isSticky = window.pageYOffset > 0
                 },

--- a/packages/panels/resources/views/components/form/actions.blade.php
+++ b/packages/panels/resources/views/components/form/actions.blade.php
@@ -7,26 +7,25 @@
 @if (count($actions))
     <div
         @if ($this->areFormActionsSticky())
-            x-data="{
+        x-data="{
                 isSticky: false,
-
-                getInitialPosition: function () {
-                    this.initialPosition = $el.getBoundingClientRect().top + window.scrollY;
-                },
-
+                isPinned: false,
                 evaluatePageScrollPosition: function () {
-                    var currentScroll = window.scrollY;
-                    var initialPosition = this.initialPosition;
-
-                    this.isSticky = (currentScroll >= initialPosition) ? false : true;
-                    
+                    this.isSticky = (this.isPinned == false && window.scrollY >= 0);
+                    this.isPinned = $el.getBoundingClientRect().bottom <= window.innerHeight;
                 },
             }"
-            x-init="getInitialPosition"
+            x-init="evaluatePageScrollPosition"
+            x-intersect.threshold.100="isPinned = true"
             x-on:scroll.window="evaluatePageScrollPosition"
+            x-bind:style="{
+                bottom: '-1px',
+            }"
             x-bind:class="{
-                'fi-sticky sticky bottom-0 -mx-4 transform bg-white p-4 shadow-lg ring-1 ring-gray-950/5 transition dark:bg-gray-900 dark:ring-white/10 md:bottom-4 md:rounded-xl':
+                'transform bg-white shadow-lg ring-1 ring-gray-950/5 transition dark:bg-gray-900 dark:ring-white/10 md:rounded-t-xl -mx-4 md:mx-0':
                     isSticky,
+                'fi-sticky sticky p-4':
+                    true,
             }"
         @endif
         class="fi-form-actions"


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

In the actual code the sticky form actions are not always showing when scrolling, it only works staring for a certain page length, I used a repeater in the video to show you that.

https://github.com/filamentphp/filament/assets/993307/4c4b9765-8070-48c7-86c1-7f65f3f51b25

I changed the code a little bit to make the sticky form actions beavior more consistent

https://github.com/filamentphp/filament/assets/993307/14aa6824-5d91-448f-b0cd-3e63b0be7afd




