### PR TITLE
Make action group dropdown offset customizable

### DIFF
--- a/packages/actions/docs/05-grouping-actions.md
+++ b/packages/actions/docs/05-grouping-actions.md
@@ -91,3 +91,14 @@ ActionGroup::make([
 ])
     ->maxHeight('400px')
 ```
+
+### Controlling the dropdown offset
+
+You may control the offset of the dropdown using the `dropdownOffset()` method, by default the offset is set to `8`.
+
+```php
+ActionGroup::make([
+    // Array of actions
+])
+    ->dropdownOffset(16)
+```

--- a/packages/actions/docs/05-grouping-actions.md
+++ b/packages/actions/docs/05-grouping-actions.md
@@ -92,7 +92,7 @@ ActionGroup::make([
     ->maxHeight('400px')
 ```
 
-### Controlling the dropdown offset
+## Controlling the dropdown offset
 
 You may control the offset of the dropdown using the `dropdownOffset()` method, by default the offset is set to `8`.
 

--- a/packages/actions/resources/views/components/group.blade.php
+++ b/packages/actions/resources/views/components/group.blade.php
@@ -5,9 +5,9 @@
     'button' => false,
     'color' => null,
     'dropdownMaxHeight' => null,
+    'dropdownOffset' => null,
     'dropdownPlacement' => null,
     'dropdownWidth' => null,
-    'dropdownOffset' => 8,
     'dynamicComponent' => null,
     'group' => null,
     'icon' => null,
@@ -27,9 +27,9 @@
             ->badgeColor($badgeColor)
             ->color($color)
             ->dropdownMaxHeight($dropdownMaxHeight)
+            ->dropdownOffset($dropdownOffset)
             ->dropdownPlacement($dropdownPlacement)
             ->dropdownWidth($dropdownWidth)
-            ->dropdownOffset($dropdownOffset)
             ->icon($icon)
             ->iconPosition($iconPosition)
             ->iconSize($iconSize)
@@ -94,9 +94,9 @@
 
     <x-filament::dropdown
         :max-height="$group->getDropdownMaxHeight()"
+        :offset="$group->getDropdownOffset()"
         :placement="$group->getDropdownPlacement() ?? 'bottom-start'"
         :width="$group->getDropdownWidth()"
-        :offset="$group->getDropdownOffset()"
         teleport
     >
         <x-slot name="trigger">

--- a/packages/actions/resources/views/components/group.blade.php
+++ b/packages/actions/resources/views/components/group.blade.php
@@ -7,6 +7,7 @@
     'dropdownMaxHeight' => null,
     'dropdownPlacement' => null,
     'dropdownWidth' => null,
+    'dropdownOffset' => 8,
     'dynamicComponent' => null,
     'group' => null,
     'icon' => null,
@@ -28,6 +29,7 @@
             ->dropdownMaxHeight($dropdownMaxHeight)
             ->dropdownPlacement($dropdownPlacement)
             ->dropdownWidth($dropdownWidth)
+            ->dropdownOffset($dropdownOffset)
             ->icon($icon)
             ->iconPosition($iconPosition)
             ->iconSize($iconSize)
@@ -94,6 +96,7 @@
         :max-height="$group->getDropdownMaxHeight()"
         :placement="$group->getDropdownPlacement() ?? 'bottom-start'"
         :width="$group->getDropdownWidth()"
+        :offset="$group->getDropdownOffset()"
         teleport
     >
         <x-slot name="trigger">

--- a/packages/actions/src/Concerns/HasDropdown.php
+++ b/packages/actions/src/Concerns/HasDropdown.php
@@ -13,7 +13,7 @@ trait HasDropdown
 
     protected string | Closure | null $dropdownMaxHeight = null;
 
-    protected int | Closure | null $dropdownOffset = 8;
+    protected int | Closure | null $dropdownOffset = null;
 
     protected MaxWidth | string | Closure | null $dropdownWidth = null;
 

--- a/packages/actions/src/Concerns/HasDropdown.php
+++ b/packages/actions/src/Concerns/HasDropdown.php
@@ -13,9 +13,10 @@ trait HasDropdown
 
     protected string | Closure | null $dropdownMaxHeight = null;
 
+    protected int | Closure | null $dropdownOffset = 8;
+
     protected MaxWidth | string | Closure | null $dropdownWidth = null;
 
-    protected int | Closure $dropdownOffset = 8;
 
     public function dropdown(bool | Closure $condition = true): static
     {
@@ -38,16 +39,16 @@ trait HasDropdown
         return $this;
     }
 
-    public function dropdownWidth(MaxWidth | string | Closure | null $width): static
+    public function dropdownOffset(int | Closure | null $offset): static
     {
-        $this->dropdownWidth = $width;
+        $this->dropdownOffset = $offset;
 
         return $this;
     }
 
-    public function dropdownOffset(int | Closure $offset): static
+    public function dropdownWidth(MaxWidth | string | Closure | null $width): static
     {
-        $this->dropdownOffset = $offset;
+        $this->dropdownWidth = $width;
 
         return $this;
     }
@@ -62,14 +63,14 @@ trait HasDropdown
         return $this->evaluate($this->dropdownMaxHeight);
     }
 
+    public function getDropdownOffset(): ?int
+    {
+        return $this->evaluate($this->dropdownOffset);
+    }
+
     public function getDropdownWidth(): MaxWidth | string | null
     {
         return $this->evaluate($this->dropdownWidth);
-    }
-
-    public function getDropdownOffset(): int
-    {
-        return $this->evaluate($this->dropdownOffset);
     }
 
     public function hasDropdown(): bool

--- a/packages/actions/src/Concerns/HasDropdown.php
+++ b/packages/actions/src/Concerns/HasDropdown.php
@@ -15,6 +15,8 @@ trait HasDropdown
 
     protected MaxWidth | string | Closure | null $dropdownWidth = null;
 
+    protected int | Closure $dropdownOffset = 8;
+
     public function dropdown(bool | Closure $condition = true): static
     {
         $this->hasDropdown = $condition;
@@ -43,6 +45,13 @@ trait HasDropdown
         return $this;
     }
 
+    public function dropdownOffset(int | Closure $offset): static
+    {
+        $this->dropdownOffset = $offset;
+
+        return $this;
+    }
+
     public function getDropdownPlacement(): ?string
     {
         return $this->evaluate($this->dropdownPlacement);
@@ -56,6 +65,11 @@ trait HasDropdown
     public function getDropdownWidth(): MaxWidth | string | null
     {
         return $this->evaluate($this->dropdownWidth);
+    }
+
+    public function getDropdownOffset(): int
+    {
+        return $this->evaluate($this->dropdownOffset);
     }
 
     public function hasDropdown(): bool

--- a/packages/notifications/src/Actions/ActionGroup.php
+++ b/packages/notifications/src/Actions/ActionGroup.php
@@ -22,6 +22,7 @@ class ActionGroup extends BaseActionGroup implements Arrayable
             'dropdownMaxHeight' => $this->getDropdownMaxHeight(),
             'dropdownPlacement' => $this->getDropdownPlacement(),
             'dropdownWidth' => $this->getDropdownWidth(),
+            'dropdownOffset' => $this->getDropdownOffset(),
             'extraAttributes' => $this->getExtraAttributes(),
             'hasDropdown' => $this->hasDropdown(),
             'icon' => $this->getIcon(),
@@ -65,6 +66,7 @@ class ActionGroup extends BaseActionGroup implements Arrayable
         $static->dropdownMaxHeight($data['dropdownMaxHeight'] ?? null);
         $static->dropdownPlacement($data['dropdownPlacement'] ?? null);
         $static->dropdownWidth($data['dropdownWidth'] ?? null);
+        $static->dropdownOffset($data['dropdownOffset'] ?? null);
         $static->extraAttributes($data['extraAttributes'] ?? []);
         $static->icon($data['icon'] ?? null);
         $static->iconPosition($data['iconPosition'] ?? null);

--- a/packages/notifications/src/Actions/ActionGroup.php
+++ b/packages/notifications/src/Actions/ActionGroup.php
@@ -20,9 +20,9 @@ class ActionGroup extends BaseActionGroup implements Arrayable
             'actions' => collect($this->getActions())->toArray(),
             'color' => $this->getColor(),
             'dropdownMaxHeight' => $this->getDropdownMaxHeight(),
+            'dropdownOffset' => $this->getDropdownOffset(),
             'dropdownPlacement' => $this->getDropdownPlacement(),
             'dropdownWidth' => $this->getDropdownWidth(),
-            'dropdownOffset' => $this->getDropdownOffset(),
             'extraAttributes' => $this->getExtraAttributes(),
             'hasDropdown' => $this->hasDropdown(),
             'icon' => $this->getIcon(),
@@ -64,9 +64,9 @@ class ActionGroup extends BaseActionGroup implements Arrayable
         $static->color($data['color'] ?? null);
         $static->dropdown($data['hasDropdown'] ?? false);
         $static->dropdownMaxHeight($data['dropdownMaxHeight'] ?? null);
+        $static->dropdownOffset($data['dropdownOffset'] ?? null);
         $static->dropdownPlacement($data['dropdownPlacement'] ?? null);
         $static->dropdownWidth($data['dropdownWidth'] ?? null);
-        $static->dropdownOffset($data['dropdownOffset'] ?? null);
         $static->extraAttributes($data['extraAttributes'] ?? []);
         $static->icon($data['icon'] ?? null);
         $static->iconPosition($data['iconPosition'] ?? null);


### PR DESCRIPTION
No visual changes, as we keep the default dropdown offset of 8 and just allow that to be changed.

`HasDropdown` now has the `dropdownOffset` and `getDropdownOffset` methods. And inside the Action Group blade component `group.blade.php` we pass that prop to the underlying dropdown which already supports an `offset` prop that wasn't being utilised. 

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
