### PR TITLE
Fix header actions collapsing section header

### DIFF
--- a/packages/support/resources/views/components/section/index.blade.php
+++ b/packages/support/resources/views/components/section/index.blade.php
@@ -136,6 +136,7 @@
                 <x-filament-actions::actions
                     :actions="$headerActions"
                     :alignment="\Filament\Support\Enums\Alignment::End"
+                    x-on:click.stop
                 />
             @endif
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Currently using `->headerActions` with `collapsible` causes the click on the action to toggle de section collapsed state.

Before:

https://github.com/filamentphp/filament/assets/14329460/a2573ad8-1c39-4ca9-a0a2-b36b8edd7213

After: (the modal is outside the captured portion of the screen)

https://github.com/filamentphp/filament/assets/14329460/483aba5a-12a7-4c12-a00c-e81df0f11c54



