### PR TITLE
Fix deprecated enum::tryFrom(null) in PHP 8.3

### DIFF
--- a/packages/actions/resources/views/components/actions.blade.php
+++ b/packages/actions/resources/views/components/actions.blade.php
@@ -18,7 +18,7 @@
         );
 
         if (! $alignment instanceof Alignment) {
-            $alignment = Alignment::tryFrom($alignment) ?? $alignment;
+            $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
         }
     @endphp
 

--- a/packages/forms/resources/views/components/actions.blade.php
+++ b/packages/forms/resources/views/components/actions.blade.php
@@ -4,7 +4,7 @@
     $verticalAlignment = $getVerticalAlignment();
 
     if (! $verticalAlignment instanceof VerticalAlignment) {
-        $verticalAlignment = VerticalAlignment::tryFrom($verticalAlignment) ?? $verticalAlignment;
+        $verticalAlignment = filled($verticalAlignment) ? (VerticalAlignment::tryFrom($verticalAlignment) ?? $verticalAlignment) : null;
     }
 @endphp
 

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -14,7 +14,7 @@
     $alignment = $getAlignment() ?? Alignment::Start;
 
     if (! $alignment instanceof Alignment) {
-        $alignment = Alignment::tryFrom($alignment) ?? $alignment;
+        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
     }
 @endphp
 

--- a/packages/infolists/resources/views/components/actions.blade.php
+++ b/packages/infolists/resources/views/components/actions.blade.php
@@ -4,7 +4,7 @@
     $verticalAlignment = $getVerticalAlignment();
 
     if (! $verticalAlignment instanceof VerticalAlignment) {
-        $verticalAlignment = VerticalAlignment::tryFrom($verticalAlignment) ?? $verticalAlignment;
+        $verticalAlignment = filled($verticalAlignment) ? (VerticalAlignment::tryFrom($verticalAlignment) ?? $verticalAlignment) : null;
     }
 @endphp
 

--- a/packages/infolists/resources/views/components/entry-wrapper/index.blade.php
+++ b/packages/infolists/resources/views/components/entry-wrapper/index.blade.php
@@ -43,7 +43,7 @@
     }
 
     if (! $alignment instanceof Alignment) {
-        $alignment = Alignment::tryFrom($alignment) ?? $alignment;
+        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
     }
 
     $hintActions = array_filter(

--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -25,15 +25,15 @@
 
 @php
     if (! $iconPosition instanceof IconPosition) {
-        $iconPosition = $iconPosition ? IconPosition::tryFrom($iconPosition) : null;
+        $iconPosition = filled($iconPosition) ? (IconPosition::tryFrom($iconPosition) ?? $iconPosition) : null;
     }
 
     if (! $size instanceof ActionSize) {
-        $size = ActionSize::tryFrom($size) ?? $size;
+        $size = filled($size) ? (ActionSize::tryFrom($size) ?? $size) : null;
     }
 
     if (! $iconSize instanceof IconSize) {
-        $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
+        $iconSize = filled($iconSize) ? (IconSize::tryFrom($iconSize) ?? $iconSize) : null;
     }
 
     $isDeletable = count($deleteButton?->attributes->getAttributes() ?? []) > 0;

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -30,11 +30,11 @@
 
 @php
     if (! $iconPosition instanceof IconPosition) {
-        $iconPosition = $iconPosition ? IconPosition::tryFrom($iconPosition) : null;
+        $iconPosition = filled($iconPosition) ? (IconPosition::tryFrom($iconPosition) ?? $iconPosition) : null;
     }
 
     if (! $size instanceof ActionSize) {
-        $size = ActionSize::tryFrom($size) ?? $size;
+        $size = filled($size) ? (ActionSize::tryFrom($size) ?? $size) : null;
     }
 
     $iconSize ??= match ($size) {
@@ -43,7 +43,7 @@
     };
 
     if (! $iconSize instanceof IconSize) {
-        $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
+        $iconSize = filled($iconSize) ? (IconSize::tryFrom($iconSize) ?? $iconSize) : null;
     }
 
     $buttonClasses = \Illuminate\Support\Arr::toCssClasses([

--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -25,7 +25,7 @@
 
 @php
     if (! $size instanceof ActionSize) {
-        $size = ActionSize::tryFrom($size) ?? $size;
+        $size = filled($size) ? (ActionSize::tryFrom($size) ?? $size) : null;
     }
 
     $iconSize ??= match ($size) {
@@ -36,7 +36,7 @@
     };
 
     if (! $iconSize instanceof IconSize) {
-        $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
+        $iconSize = filled($iconSize) ? (IconSize::tryFrom($iconSize) ?? $iconSize) : null;
     }
 
     $buttonClasses = \Illuminate\Support\Arr::toCssClasses([

--- a/packages/support/resources/views/components/link.blade.php
+++ b/packages/support/resources/views/components/link.blade.php
@@ -26,11 +26,11 @@
 
 @php
     if (! $iconPosition instanceof IconPosition) {
-        $iconPosition = $iconPosition ? IconPosition::tryFrom($iconPosition) : null;
+        $iconPosition = filled($iconPosition) ? (IconPosition::tryFrom($iconPosition) ?? $iconPosition) : null;
     }
 
     if (! $size instanceof ActionSize) {
-        $size = ActionSize::tryFrom($size) ?? $size;
+        $size = filled($size) ? (ActionSize::tryFrom($size) ?? $size) : null;
     }
 
     $iconSize ??= match ($size) {
@@ -39,7 +39,7 @@
     };
 
     if (! $iconSize instanceof IconSize) {
-        $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
+        $iconSize = filled($iconSize) ? (IconSize::tryFrom($iconSize) ?? $iconSize) : null;
     }
 
     $linkClasses = \Illuminate\Support\Arr::toCssClasses([

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -31,11 +31,11 @@
 
 @php
     if (! $alignment instanceof Alignment) {
-        $alignment = Alignment::tryFrom($alignment) ?? $alignment;
+        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
     }
 
     if (! $footerActionsAlignment instanceof Alignment) {
-        $footerActionsAlignment = Alignment::tryFrom($footerActionsAlignment) ?? $footerActionsAlignment;
+        $footerActionsAlignment = filled($footerActionsAlignment) ? (Alignment::tryFrom($footerActionsAlignment) ?? $footerActionsAlignment) : null;
     }
 
     if ($width === 'screen') {

--- a/packages/support/resources/views/components/tabs/item.blade.php
+++ b/packages/support/resources/views/components/tabs/item.blade.php
@@ -18,7 +18,7 @@
 
 @php
     if (! $iconPosition instanceof IconPosition) {
-        $iconPosition = $iconPosition ? IconPosition::tryFrom($iconPosition) : null;
+        $iconPosition = filled($iconPosition) ? (IconPosition::tryFrom($iconPosition) ?? $iconPosition) : null;
     }
 
     $hasAlpineActiveClasses = filled($alpineActive);

--- a/packages/tables/resources/views/columns/layout/stack.blade.php
+++ b/packages/tables/resources/views/columns/layout/stack.blade.php
@@ -4,7 +4,7 @@
     $alignment = $getAlignment() ?? Alignment::Start;
 
     if (! $alignment instanceof Alignment) {
-        $alignment = Alignment::tryFrom($alignment) ?? $alignment;
+        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
     }
 @endphp
 

--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -8,7 +8,7 @@
     $alignment = $getAlignment() ?? Alignment::Start;
 
     if (! $alignment instanceof Alignment) {
-        $alignment = Alignment::tryFrom($alignment) ?? $alignment;
+        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
     }
 @endphp
 

--- a/packages/tables/resources/views/components/actions.blade.php
+++ b/packages/tables/resources/views/components/actions.blade.php
@@ -22,7 +22,7 @@
     );
 
     if (! $alignment instanceof Alignment) {
-        $alignment = Alignment::tryFrom($alignment) ?? $alignment;
+        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
     }
 @endphp
 

--- a/packages/tables/resources/views/components/columns/column.blade.php
+++ b/packages/tables/resources/views/components/columns/column.blade.php
@@ -18,7 +18,7 @@
     $url = $column->getUrl();
 
     if (! $alignment instanceof Alignment) {
-        $alignment = Alignment::tryFrom($alignment) ?? $alignment;
+        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
     }
 
     $columnClasses = \Illuminate\Support\Arr::toCssClasses([

--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -13,7 +13,7 @@
     $alignment = $alignment ?? Alignment::Start;
 
     if (! $alignment instanceof Alignment) {
-        $alignment = Alignment::tryFrom($alignment) ?? $alignment;
+        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
     }
 @endphp
 

--- a/packages/tables/resources/views/components/summary/index.blade.php
+++ b/packages/tables/resources/views/components/summary/index.blade.php
@@ -51,7 +51,7 @@
                     $alignment = $column->getAlignment() ?? Alignment::Start;
 
                     if (! $alignment instanceof Alignment) {
-                        $alignment = Alignment::tryFrom($alignment) ?? $alignment;
+                        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
                     }
 
                     $hasColumnHeaderLabel = (! $placeholderColumns) || $column->hasSummary();

--- a/packages/tables/resources/views/components/summary/row.blade.php
+++ b/packages/tables/resources/views/components/summary/row.blade.php
@@ -72,7 +72,7 @@
                 $alignment = $column->getAlignment() ?? Alignment::Start;
 
                 if (! $alignment instanceof Alignment) {
-                    $alignment = Alignment::tryFrom($alignment) ?? $alignment;
+                    $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
                 }
             @endphp
 


### PR DESCRIPTION
Discussed in more detail in the Issue which this fixes: #9706

- [somewhat] Changes have been thoroughly tested to not break existing functionality.
- [n/a] New functionality has been documented or existing documentation has been updated to reflect changes.
- [n/a] Visual changes are explained in the PR description using a screenshot/recording of before and after.

I've tested applying these changes onto an existing project, and it triggers no errors, and no display-problems are noticed.