### PR TITLE
Add option to remove default constraint operators'

### DIFF
--- a/packages/tables/docs/04-filters/04-query-builder.md
+++ b/packages/tables/docs/04-filters/04-query-builder.md
@@ -352,19 +352,43 @@ TextConstraint::make('author')
 Each constraint type has a set of default operators, which you can customize by using the `operators()`method:
 
 ```php
+use Filament\Tables\Filters\QueryBuilder\Constraints\Operators\IsFilledOperator;
 use Filament\Tables\Filters\QueryBuilder\Constraints\TextConstraint;
-use Tables\Filters\QueryBuilder\Constraints\TextConstraint\Operators\EqualsOperator;
 
 TextConstraint::make('author')
     ->relationship(name: 'author', titleAttribute: 'name')
     ->operators([
-        EqualsOperator::make() // or a custom operator
-    ], keepDefault: true)
+        IsFilledOperator::make(),
+    ])
 ```
 
-This will add the `EqualsOperator` to the existing/default operators.
+This will remove all operators, and register the `EqualsOperator`.
 
-If you'd like to remove the default operators and show only the EqualsOperator, use `keepDefault: false`.
+If you'd like to add an operator to the end of the list, use `pushOperators()` instead:
+
+```php
+use Filament\Tables\Filters\QueryBuilder\Constraints\Operators\IsFilledOperator;
+use Filament\Tables\Filters\QueryBuilder\Constraints\TextConstraint;
+
+TextConstraint::make('author')
+    ->relationship(name: 'author', titleAttribute: 'name')
+    ->pushOperators([
+        IsFilledOperator::class,
+    ])
+```
+
+If you'd like to add an operator to the start of the list, use `unshiftOperators()` instead:
+
+```php
+use Filament\Tables\Filters\QueryBuilder\Constraints\Operators\IsFilledOperator;
+use Filament\Tables\Filters\QueryBuilder\Constraints\TextConstraint;
+
+TextConstraint::make('author')
+    ->relationship(name: 'author', titleAttribute: 'name')
+    ->unshiftOperators([
+        IsFilledOperator::class,
+    ])
+```
 
 ## Creating custom constraints
 

--- a/packages/tables/docs/04-filters/04-query-builder.md
+++ b/packages/tables/docs/04-filters/04-query-builder.md
@@ -347,6 +347,25 @@ TextConstraint::make('author')
     ->icon('heroicon-m-user')
 ```
 
+## Overriding the default operators
+
+Each constraint type has a set of default operators, which you can customize by using the `operators()`method:
+
+```php
+use Filament\Tables\Filters\QueryBuilder\Constraints\TextConstraint;
+use Tables\Filters\QueryBuilder\Constraints\TextConstraint\Operators\EqualsOperator;
+
+TextConstraint::make('author')
+    ->relationship(name: 'author', titleAttribute: 'name')
+    ->operators([
+        EqualsOperator::make() // or a custom operator
+    ], keepDefault: true)
+```
+
+This will add the `EqualsOperator` to the existing/default operators.
+
+If you'd like to remove the default operators and show only the EqualsOperator, use `keepDefault: false`.
+
 ## Creating custom constraints
 
 Custom constraints can be created "inline" with other constraints using the `Constraint::make()` method. You should also pass an [icon](#customizing-the-constraint-icon) to the `icon()` method:

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/Concerns/HasOperators.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/Concerns/HasOperators.php
@@ -37,8 +37,12 @@ trait HasOperators
     /**
      * @param  array<class-string<Operator> | Operator>  $operators
      */
-    public function operators(array $operators): static
+    public function operators(array $operators, bool $keepDefault = true): static
     {
+        if (! $keepDefault) {
+            $this->operators = [];
+        }
+        
         foreach ($operators as $operator) {
             if (is_string($operator)) {
                 $operator = $operator::make();

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/Concerns/HasOperators.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/Concerns/HasOperators.php
@@ -37,12 +37,19 @@ trait HasOperators
     /**
      * @param  array<class-string<Operator> | Operator>  $operators
      */
-    public function operators(array $operators, bool $keepDefault = true): static
+    public function operators(array $operators): static
     {
-        if (! $keepDefault) {
-            $this->operators = [];
-        }
-        
+        $this->operators = [];
+        $this->pushOperators($operators);
+
+        return $this;
+    }
+
+    /**
+     * @param  array<class-string<Operator> | Operator>  $operators
+     */
+    public function pushOperators(array $operators): static
+    {
         foreach ($operators as $operator) {
             if (is_string($operator)) {
                 $operator = $operator::make();


### PR DESCRIPTION
- [X] Changes have been thoroughly tested to not break existing functionality.
- [X] New functionality has been documented or existing documentation has been updated to reflect changes.
- [n.a.] Visual changes are explained in the PR description using a screenshot/recording of before and after.
