### PR TITLE
add should_translate_labels_by_default config

### DIFF
--- a/packages/forms/docs/03-fields/01-getting-started.md
+++ b/packages/forms/docs/03-fields/01-getting-started.md
@@ -63,6 +63,18 @@ TextInput::make('name')
     ->translateLabel() // Equivalent to `label(__('Name'))`
 ```
 
+Also, you can have the label automatically translated [using Laravel's localization features](https://laravel.com/docs/localization) without explicitly calling the `translateLabel()` method on each field by settings the `filament.should_translate_labels_by_default` config key to `true`:
+
+```php
+// config/filament.php
+'should_translate_labels_by_default' => true,
+```
+
+```php
+use Filament\Forms\Components\TextInput;
+
+TextInput::make('name') // Equivalent to `label(__('Name'))` because 'should_translate_labels_by_default' is set to true
+```
 ## Setting an ID
 
 In the same way as labels, field IDs are also automatically determined based on their names. To override a field ID, use the `id()` method:

--- a/packages/forms/src/Components/Concerns/HasLabel.php
+++ b/packages/forms/src/Components/Concerns/HasLabel.php
@@ -48,7 +48,7 @@ trait HasLabel
     {
         $label = $this->evaluate($this->label);
 
-        return (is_string($label) && $this->shouldTranslateLabel) ?
+        return (is_string($label) && ($this->shouldTranslateLabel || config('filament.should_translate_labels_by_default'))) ?
             __($label) :
             $label;
     }

--- a/packages/support/config/filament.php
+++ b/packages/support/config/filament.php
@@ -73,10 +73,10 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Translate Labels By Deafult
+    | Translate Labels By Default
     |--------------------------------------------------------------------------
     |
-    | This determines if labels should be translate by default.
+    | This determines if labels should be translatable by default.
     |
     | Setting this to true makes labels translated, without using
     | 'translateLabel' label method on each form component.

--- a/packages/support/config/filament.php
+++ b/packages/support/config/filament.php
@@ -71,4 +71,16 @@ return [
 
     'livewire_loading_delay' => 'default',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Translate Labels By Deafult
+    |--------------------------------------------------------------------------
+    |
+    | This determines if labels should be translate by default.
+    |
+    | Setting this to true makes labels translated, without using
+    | 'translateLabel' label method on each form component.
+    |
+    */
+    'should_translate_labels_by_default' => false,
 ];

--- a/packages/support/config/filament.php
+++ b/packages/support/config/filament.php
@@ -82,5 +82,6 @@ return [
     | 'translateLabel' label method on each form component.
     |
     */
+    
     'should_translate_labels_by_default' => false,
 ];


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] ~Visual changes are explained in the PR description using a screenshot/recording of before and after.~ (no visual changes)