### PR TITLE
Fix layout break in notification for long words

### DIFF
--- a/packages/notifications/resources/views/components/body.blade.php
+++ b/packages/notifications/resources/views/components/body.blade.php
@@ -1,5 +1,5 @@
 <p
-    {{ $attributes->class(['fi-no-notification-body text-sm text-gray-500 dark:text-gray-400 break-all']) }}
+    {{ $attributes->class(['fi-no-notification-body text-sm text-gray-500 dark:text-gray-400 break-words overflow-hidden']) }}
 >
     {{ $slot }}
 </p>

--- a/packages/notifications/resources/views/components/body.blade.php
+++ b/packages/notifications/resources/views/components/body.blade.php
@@ -1,5 +1,5 @@
 <p
-    {{ $attributes->class(['fi-no-notification-body text-sm text-gray-500 dark:text-gray-400 break-words overflow-hidden']) }}
+    {{ $attributes->class(['fi-no-notification-body overflow-hidden break-words text-sm text-gray-500 dark:text-gray-400']) }}
 >
     {{ $slot }}
 </p>

--- a/packages/notifications/resources/views/components/body.blade.php
+++ b/packages/notifications/resources/views/components/body.blade.php
@@ -1,5 +1,5 @@
 <p
-    {{ $attributes->class(['fi-no-notification-body text-sm text-gray-500 dark:text-gray-400']) }}
+    {{ $attributes->class(['fi-no-notification-body text-sm text-gray-500 dark:text-gray-400 break-all']) }}
 >
     {{ $slot }}
 </p>


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

If the notification text is too long the layout of the notification items breaks, e.g., icons disapear. See screenshot.
![notification-before](https://github.com/filamentphp/filament/assets/9416642/a9bdbb6c-e4d5-4e71-ac25-54da952b221b)

The fix breaks words and therefore fixes the layout. See screenshot.
![notification-fixed](https://github.com/filamentphp/filament/assets/9416642/b1f57469-3c55-4c5b-96b7-2a037f21422b)
