### PR TITLE
fix: remove failed at check

### DIFF
--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -203,10 +203,6 @@ trait CanImportRecords
             Bus::batch($importJobs->all())
                 ->allowFailures()
                 ->finally(function () use ($import) {
-                    if ($import->failed_at) {
-                        return;
-                    }
-
                     $import->touch('completed_at');
 
                     if (! $import->user instanceof Authenticatable) {


### PR DESCRIPTION
Using CSV import action in combination with strict models (`Model::shouldBeStrict(! $this->app->isProduction());`) fails, because the Import model does not have a `failed_at` attribute.


After removing this line, the success notification later on is being send. I'm not sure if there needs to be another way to check if the import failed?

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
