### PR TITLE
fix: typo in HasState trait

### DIFF
--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -231,7 +231,7 @@ trait HasState
 
         $defaultState = $this->getDefaultState();
 
-        $this->state($this->getDefaultState());
+        $this->state($defaultState);
 
         Arr::set($hydratedDefaultState, $statePath, $defaultState);
     }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.

While working on Repeater component fix. I have noticed that default() method is run twice when component is initialised first time. I have traced the culprit to repeated call on Has state trait that component uses.
https://github.com/filamentphp/filament/blob/5b3fc20c7cea7b00bf924dc9b2455c4fca71c30a/packages/forms/src/Components/Concerns/HasState.php#L232-L234

In this Pr i fix the typo as confirmed by @danharrin in this thread:
https://github.com/filamentphp/filament/issues/8874#issuecomment-1837583786