### PR TITLE
Docs: Update variable name to match example

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -293,7 +293,7 @@ use App\Models\Product;
 
 ImportColumn::make('sku')
     ->fillRecordUsing(function (Product $record, string $state): void {
-        $record->state = strtoupper($state);
+        $record->sku = strtoupper($state);
     })
 ```
 

--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -292,7 +292,7 @@ If you want to customize how column state is filled into a record, you can pass 
 use App\Models\Product;
 
 ImportColumn::make('sku')
-    ->fillUsing(function (Product $record, string $state): void {
+    ->fillRecordUsing(function (Product $record, string $state): void {
         $record->state = strtoupper($state);
     })
 ```

--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -293,7 +293,7 @@ use App\Models\Product;
 
 ImportColumn::make('sku')
     ->fillUsing(function (Product $record, string $state): void {
-        $product->state = strtoupper($state);
+        $record->state = strtoupper($state);
     })
 ```
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

On the new import documentation in the [Customizing how a column is filled into a record](https://filamentphp.com/docs/3.x/actions/prebuilt-actions/import#customizing-how-a-column-is-filled-into-a-record) section, the `$product` variable would be undefined in this example. 
