### PR TITLE
fix: Repeatable entry clone

### DIFF
--- a/packages/forms/src/Concerns/Cloneable.php
+++ b/packages/forms/src/Concerns/Cloneable.php
@@ -23,7 +23,7 @@ trait Cloneable
     public function getClone(): static
     {
         $clone = clone $this;
-        $clone->flushCachedStatePath();
+        $clone->flushCachedAbsoluteStatePath();
         $clone->cloneComponents();
 
         return $clone;

--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -9,7 +9,7 @@ trait HasState
 {
     protected ?string $statePath = null;
 
-    protected string $cachedFullStatePath;
+    protected string $cachedAbsoluteStatePath;
 
     public function callAfterStateHydrated(): void
     {
@@ -227,8 +227,8 @@ trait HasState
 
     public function getStatePath(bool $isAbsolute = true): string
     {
-        if (isset($this->cachedFullStatePath)) {
-            return $this->cachedFullStatePath;
+        if (isset($this->cachedAbsoluteStatePath)) {
+            return $this->cachedAbsoluteStatePath;
         }
 
         $pathComponents = [];
@@ -241,11 +241,11 @@ trait HasState
             $pathComponents[] = $statePath;
         }
 
-        return $this->cachedFullStatePath = implode('.', $pathComponents);
+        return $this->cachedAbsoluteStatePath = implode('.', $pathComponents);
     }
 
-    protected function flushCachedStatePath(): void
+    protected function flushCachedAbsoluteStatePath(): void
     {
-        unset($this->cachedFullStatePath);
+        unset($this->cachedAbsoluteStatePath);
     }
 }

--- a/packages/infolists/src/Components/Concerns/Cloneable.php
+++ b/packages/infolists/src/Components/Concerns/Cloneable.php
@@ -2,12 +2,27 @@
 
 namespace Filament\Infolists\Components\Concerns;
 
+use Filament\Infolists\Components\Component;
+
 trait Cloneable
 {
+    protected function cloneChildComponents(): static
+    {
+        if (is_array($this->childComponents)) {
+            $this->childComponents = array_map(
+                fn (Component $component): Component => $component->getClone(),
+                $this->childComponents,
+            );
+        }
+
+        return $this;
+    }
+
     public function getClone(): static
     {
         $clone = clone $this;
-        $clone->flushCachedStatePath();
+        $clone->flushCachedAbsoluteStatePath();
+        $clone->cloneChildComponents();
 
         return $clone;
     }

--- a/packages/infolists/src/Components/Concerns/HasState.php
+++ b/packages/infolists/src/Components/Concerns/HasState.php
@@ -20,7 +20,7 @@ trait HasState
 
     protected bool | Closure $isDistinctList = false;
 
-    protected string $cachedFullStatePath;
+    protected string $cachedAbsoluteStatePath;
 
     public function getStateUsing(mixed $callback): static
     {
@@ -117,8 +117,8 @@ trait HasState
 
     public function getStatePath(bool $isAbsolute = true): string
     {
-        if (isset($this->cachedFullStatePath)) {
-            return $this->cachedFullStatePath;
+        if (isset($this->cachedAbsoluteStatePath)) {
+            return $this->cachedAbsoluteStatePath;
         }
 
         $pathComponents = [];
@@ -131,7 +131,7 @@ trait HasState
             $pathComponents[] = $this->statePath;
         }
 
-        return $this->cachedFullStatePath = implode('.', $pathComponents);
+        return $this->cachedAbsoluteStatePath = implode('.', $pathComponents);
     }
 
     public function getStateFromRecord(Model $record): mixed
@@ -167,8 +167,8 @@ trait HasState
         return $state->all();
     }
 
-    protected function flushCachedStatePath(): void
+    protected function flushCachedAbsoluteStatePath(): void
     {
-        unset($this->cachedFullStatePath);
+        unset($this->cachedAbsoluteStatePath);
     }
 }

--- a/packages/infolists/src/Concerns/Cloneable.php
+++ b/packages/infolists/src/Concerns/Cloneable.php
@@ -18,7 +18,7 @@ trait Cloneable
     public function getClone(): static
     {
         $clone = clone $this;
-        $clone->flushCachedStatePath();
+        $clone->flushCachedAbsoluteStatePath();
         $clone->cloneComponents();
 
         return $clone;

--- a/packages/infolists/src/Concerns/HasState.php
+++ b/packages/infolists/src/Concerns/HasState.php
@@ -16,7 +16,7 @@ trait HasState
      */
     protected ?array $state = null;
 
-    protected string $cachedFullStatePath;
+    protected string $cachedAbsoluteStatePath;
 
     /**
      * @param  array<string, mixed> | null  $state
@@ -44,8 +44,8 @@ trait HasState
 
     public function getStatePath(bool $isAbsolute = true): string
     {
-        if (isset($this->cachedFullStatePath)) {
-            return $this->cachedFullStatePath;
+        if (isset($this->cachedAbsoluteStatePath)) {
+            return $this->cachedAbsoluteStatePath;
         }
 
         $pathComponents = [];
@@ -58,7 +58,7 @@ trait HasState
             $pathComponents[] = $statePath;
         }
 
-        return $this->cachedFullStatePath = implode('.', $pathComponents);
+        return $this->cachedAbsoluteStatePath = implode('.', $pathComponents);
     }
 
     /**
@@ -90,8 +90,8 @@ trait HasState
         return $this->getParentComponent()?->getRecord();
     }
 
-    protected function flushCachedStatePath(): void
+    protected function flushCachedAbsoluteStatePath(): void
     {
-        unset($this->cachedFullStatePath);
+        unset($this->cachedAbsoluteStatePath);
     }
 }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Fixes #6964.