### PR TITLE
Update 08-import.md

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -361,7 +361,7 @@ The import action can render extra form components that the user can interact wi
 ```php
 use Filament\Forms\Components\Checkbox;
 
-public function getOptionsFormComponents(): array
+public static function getOptionsFormComponents(): array
 {
     return [
         Checkbox::make('update_existing')


### PR DESCRIPTION
As the parent function is static this one should also be

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
