### PR TITLE
Add down method to import migrations

### DIFF
--- a/packages/actions/database/migrations/create_failed_import_rows_table.php
+++ b/packages/actions/database/migrations/create_failed_import_rows_table.php
@@ -19,4 +19,12 @@ return new class() extends Migration
             $table->timestamps();
         });
     }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('failed_import_rows');
+    }
 };

--- a/packages/actions/database/migrations/create_imports_table.php
+++ b/packages/actions/database/migrations/create_imports_table.php
@@ -24,4 +24,12 @@ return new class() extends Migration
             $table->timestamps();
         });
     }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('imports');
+    }
 };


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Adding down to `create_imports` and `create_failed_import_rows` migrations so the user can rollback when needed.