### PR TITLE
Update infoList documentation

### DIFF
--- a/packages/panels/docs/03-resources/05-viewing-records.md
+++ b/packages/panels/docs/03-resources/05-viewing-records.md
@@ -18,7 +18,7 @@ By default, the View page will display a disabled form with the record's data. I
 use Filament\Infolists;
 use Filament\Infolists\Infolist;
 
-public static function infolist(Infolist $infolist): Infolist
+public function infolist(Infolist $infolist): Infolist
 {
     return $infolist
         ->schema([


### PR DESCRIPTION
In `Filament\Resources\Pages\ViewRecord.php` line 219, `infolist` is not a static method. Copying from the docs causes the IDE to complain that it is 'not compatible' with the method in ViewRecord

![image](https://github.com/filamentphp/filament/assets/5937317/37094ea0-d6b1-45af-bc44-0363d4909266)

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.