### PR TITLE
Return empty array if there is no more tabsdata on the refs object

### DIFF
--- a/packages/forms/resources/views/components/tabs.blade.php
+++ b/packages/forms/resources/views/components/tabs.blade.php
@@ -14,7 +14,7 @@
             if (! this.$refs.tabsData) {
                 return []
             }
-             
+
             return JSON.parse(this.$refs.tabsData.value)
         },
 

--- a/packages/forms/resources/views/components/tabs.blade.php
+++ b/packages/forms/resources/views/components/tabs.blade.php
@@ -11,6 +11,10 @@
         tab: @if ($isTabPersisted() && filled($persistenceId = $getId())) $persist(null).as('tabs-{{ $persistenceId }}') @else null @endif,
 
         getTabs: function () {
+            if (! this.$refs.tabsData) {
+                return []
+            }
+             
             return JSON.parse(this.$refs.tabsData.value)
         },
 


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

When having some tabs in a modal, it still executes the succeeded callback in the commit hook when closing the modal, but since the tabs are not in the DOM anymore the whole app breaks.