### PR TITLE
use empty string as fallback when calling $record->getAttributeValue()

### DIFF
--- a/packages/tables/src/Table/Concerns/HasRecords.php
+++ b/packages/tables/src/Table/Concerns/HasRecords.php
@@ -112,7 +112,7 @@ trait HasRecords
                 Model::class => $record,
                 $record::class => $record,
             ],
-        ) ?? $record->getAttributeValue($this->getRecordTitleAttribute() ?? '') ?? $this->getModelLabel();
+        ) ?? (($titleAttribute = $this->getRecordTitleAttribute()) ? $record->getAttributeValue($titleAttribute) : null) ?? $this->getModelLabel();
 
         if ($title instanceof HasLabel) {
             return $title->getLabel();

--- a/packages/tables/src/Table/Concerns/HasRecords.php
+++ b/packages/tables/src/Table/Concerns/HasRecords.php
@@ -112,7 +112,7 @@ trait HasRecords
                 Model::class => $record,
                 $record::class => $record,
             ],
-        ) ?? $record->getAttributeValue($this->getRecordTitleAttribute()) ?? $this->getModelLabel();
+        ) ?? $record->getAttributeValue($this->getRecordTitleAttribute() ?? '') ?? $this->getModelLabel();
 
         if ($title instanceof HasLabel) {
             return $title->getLabel();

--- a/packages/tables/src/Table/Concerns/HasRecords.php
+++ b/packages/tables/src/Table/Concerns/HasRecords.php
@@ -112,7 +112,13 @@ trait HasRecords
                 Model::class => $record,
                 $record::class => $record,
             ],
-        ) ?? (($titleAttribute = $this->getRecordTitleAttribute()) ? $record->getAttributeValue($titleAttribute) : null) ?? $this->getModelLabel();
+        );
+        
+        if (filled($titleAttribute = $this->getRecordTitleAttribute())) {
+            $title ??= $record->getAttributeValue($titleAttribute);
+        }
+
+        $title ??= $this->getModelLabel();
 
         if ($title instanceof HasLabel) {
             return $title->getLabel();


### PR DESCRIPTION
`$record->getAttributeValue()` requires a string according to Laravel's code: https://github.com/laravel/framework/blob/7d26bfb23fbc2d82adb095d4c6c28fe7f2e4bc4b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L481-L490

However: `getRecordTitleAttribute` returns an optional string. This results in an error for `getAttributeValue()` when `getRecordTitleAttribute()` returned null.

Therefore: use empty string as fallback when calling `$record->getAttributeValue()`

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
