### PR TITLE
Rename navigationParentItem variable for clarity

### DIFF
--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -728,9 +728,9 @@ abstract class Resource
         static::$navigationGroup = $group;
     }
 
-    public static function navigationParentItem(?string $parent): void
+    public static function navigationParentItem(?string $item): void
     {
-        static::$navigationParentItem = $parent;
+        static::$navigationParentItem = $item;
     }
 
     public static function getNavigationIcon(): ?string

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -728,9 +728,9 @@ abstract class Resource
         static::$navigationGroup = $group;
     }
 
-    public static function navigationParentItem(?string $group): void
+    public static function navigationParentItem(?string $parent): void
     {
-        static::$navigationParentItem = $group;
+        static::$navigationParentItem = $parent;
     }
 
     public static function getNavigationIcon(): ?string


### PR DESCRIPTION
Minor thing, but as someone who digs through the codebase this confused me. `$group` implies the parent item can only be a group but in reality it can be either a group or an item.