### PR TITLE
Allow unlabelled navigation groups

### DIFF
--- a/packages/panels/src/Navigation/NavigationGroup.php
+++ b/packages/panels/src/Navigation/NavigationGroup.php
@@ -22,6 +22,8 @@ class NavigationGroup extends Component
 
     protected string | Closure | null $label = null;
 
+    protected bool | Closure | null $hideLabel = null;
+
     final public function __construct(string | Closure | null $label = null)
     {
         $this->label($label);
@@ -75,6 +77,13 @@ class NavigationGroup extends Component
         return $this;
     }
 
+    public function hideLabel(bool | Closure | null $condition = true): static
+    {
+        $this->hideLabel = $condition;
+
+        return $this;
+    }
+
     public function getIcon(): ?string
     {
         $icon = $this->evaluate($this->icon);
@@ -97,6 +106,11 @@ class NavigationGroup extends Component
     public function getLabel(): ?string
     {
         return $this->evaluate($this->label);
+    }
+
+    public function hasHiddenLabel(): bool
+    {
+        return (bool) $this->evaluate($this->hideLabel);
     }
 
     public function isCollapsed(): bool

--- a/packages/panels/src/Navigation/NavigationGroup.php
+++ b/packages/panels/src/Navigation/NavigationGroup.php
@@ -22,7 +22,7 @@ class NavigationGroup extends Component
 
     protected string | Closure | null $label = null;
 
-    protected bool | Closure | null $hideLabel = null;
+    protected bool | Closure $isLabelHidden = false;
 
     final public function __construct(string | Closure | null $label = null)
     {
@@ -77,9 +77,9 @@ class NavigationGroup extends Component
         return $this;
     }
 
-    public function hideLabel(bool | Closure | null $condition = true): static
+    public function hiddenLabel(bool | Closure $condition = true): static
     {
-        $this->hideLabel = $condition;
+        $this->isLabelHidden = $condition;
 
         return $this;
     }
@@ -108,9 +108,9 @@ class NavigationGroup extends Component
         return $this->evaluate($this->label);
     }
 
-    public function hasHiddenLabel(): bool
+    public function isLabelHidden(): bool
     {
-        return (bool) $this->evaluate($this->hideLabel);
+        return (bool) $this->evaluate($this->isLabelHidden);
     }
 
     public function isCollapsed(): bool

--- a/packages/panels/src/Panel/Concerns/HasNavigation.php
+++ b/packages/panels/src/Panel/Concerns/HasNavigation.php
@@ -175,7 +175,7 @@ trait HasNavigation
                 return $sort;
             })
             ->map(function (NavigationGroup $group): NavigationGroup {
-                if ($group->hasHiddenLabel()) {
+                if ($group->isLabelHidden()) {
                     $group->label('');
                 }
 

--- a/packages/panels/src/Panel/Concerns/HasNavigation.php
+++ b/packages/panels/src/Panel/Concerns/HasNavigation.php
@@ -178,6 +178,7 @@ trait HasNavigation
                 if ($group->hasHiddenLabel()) {
                     $group->label('');
                 }
+
                 return $group;
             })
             ->all();

--- a/packages/panels/src/Panel/Concerns/HasNavigation.php
+++ b/packages/panels/src/Panel/Concerns/HasNavigation.php
@@ -174,6 +174,12 @@ trait HasNavigation
 
                 return $sort;
             })
+            ->map(function (NavigationGroup $group): NavigationGroup {
+                if ($group->hasHiddenLabel()) {
+                    $group->label('');
+                }
+                return $group;
+            })
             ->all();
     }
 


### PR DESCRIPTION
Currently, standalone (ungrouped) nav items are always at the top of the menu: https://github.com/filamentphp/filament/blob/b8882ecaed8a9c00b76c4f25fb7c1e033fc5ef99/packages/panels/src/Panel/Concerns/HasNavigation.php#L150
```
            ->sortBy(function (NavigationGroup $group, ?string $groupIndex): int {
                if (blank($group->getLabel())) {
                    return -1;
                }
```
And groups are always displayed underneath. 

This limits the possibilities for navigation customization. For example, you can't mix it up like this:
<img width="1851" alt="image" src="https://github.com/filamentphp/filament/assets/5361908/2ccc44a8-da1f-4b8b-8654-310b6acf4d32">

The order in the above example is:

```
Home (item)
Store (group)
Apps (group)
Finances (item)
Marketing (group)
Feedback (item)
Resolution center (item)
```

This PR adds a `->hideLabel()` method for groups which allows groups of top level items to be positioned anywhere in the menu without looking like a group. It would be cleaner to refactor the overall sorting concept but I think it would be a BC. This was the best workaround I could think of.

With this PR, this is now possible:

<img width="364" alt="image" src="https://github.com/filamentphp/filament/assets/5361908/4871838e-3b60-49b1-9842-10a5d1f5b485">