### PR TITLE
Add compact sidebar navigation

### DIFF
--- a/packages/panels/docs/06-navigation.md
+++ b/packages/panels/docs/06-navigation.md
@@ -187,6 +187,21 @@ public function panel(Panel $panel): Panel
 }
 ```
 
+### Using compact sidebar navigation
+
+By default, navigation groups have extra top and bottom padding. You may disable this and make all navigation items evenly spaced using the `compactSidebarNavigation()` method:
+
+```php
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->compactSidebarNavigation();
+}
+```
+
 ## Registering custom navigation items
 
 To register new navigation items, you can use the [configuration](configuration):

--- a/packages/panels/docs/06-navigation.md
+++ b/packages/panels/docs/06-navigation.md
@@ -189,7 +189,7 @@ public function panel(Panel $panel): Panel
 
 ### Using compact sidebar navigation
 
-By default, navigation groups have extra top and bottom padding. You may disable this and make all navigation items evenly spaced using the `compactSidebarNavigation()` method:
+By default, navigation groups have extra top and bottom padding. You may remove this and make all navigation items evenly spaced using the `compactSidebarNavigation()` method:
 
 ```php
 use Filament\Panel;

--- a/packages/panels/resources/views/components/sidebar/index.blade.php
+++ b/packages/panels/resources/views/components/sidebar/index.blade.php
@@ -113,7 +113,7 @@
         @endif
 
         @if (filament()->hasNavigation())
-            <ul class="-mx-2 flex flex-col gap-y-7">
+            <ul class="-mx-2 flex flex-col {{ filament()->hasCompactSidebarNavigation() ? 'gap-y-1' : 'gap-y-7' }}">
                 @foreach ($navigation as $group)
                     <x-filament-panels::sidebar.group
                         :collapsible="$group->isCollapsible()"

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -616,6 +616,11 @@ class FilamentManager
         return $this->getCurrentPanel()->isSidebarFullyCollapsibleOnDesktop();
     }
 
+    public function hasCompactSidebarNavigation(): bool
+    {
+        return $this->getCurrentPanel()->hasCompactSidebarNavigation();
+    }
+
     public function mountNavigation(): void
     {
         $this->getCurrentPanel()->mountNavigation();

--- a/packages/panels/src/Panel/Concerns/HasSidebar.php
+++ b/packages/panels/src/Panel/Concerns/HasSidebar.php
@@ -14,6 +14,8 @@ trait HasSidebar
 
     protected bool $hasCollapsibleNavigationGroups = true;
 
+    protected bool $hasCompactSidebarNavigation = false;
+
     public function sidebarCollapsibleOnDesktop(bool $condition = true): static
     {
         $this->isSidebarCollapsibleOnDesktop = $condition;
@@ -49,6 +51,13 @@ trait HasSidebar
         return $this;
     }
 
+    public function compactSidebarNavigation(bool $condition = true): static
+    {
+        $this->hasCompactSidebarNavigation = $condition;
+
+        return $this;
+    }    
+
     public function getSidebarWidth(): string
     {
         return $this->sidebarWidth;
@@ -73,4 +82,9 @@ trait HasSidebar
     {
         return $this->hasCollapsibleNavigationGroups;
     }
+
+    public function hasCompactSidebarNavigation(): bool
+    {
+        return $this->hasCompactSidebarNavigation;
+    }    
 }


### PR DESCRIPTION
In most admin panels, standalone items and dropdown items look the same and are evenly spaced. Visually a "group" is just a collapsible item with children. For example:
![image](https://github.com/filamentphp/filament/assets/5361908/d93267f7-60ef-4a24-9c6f-8c4c2fe1047e)

This PR adds a `->compactSidebarNavigation()` method which makes the spacing between all items in the sidebar the same regardless of whether it's a group of standalone item.

With `->compactSidebarNavigation()`:
<img width="272" alt="image" src="https://github.com/filamentphp/filament/assets/5361908/04db3e68-0201-4c94-97ba-882bfafeee7f">
<img width="289" alt="image" src="https://github.com/filamentphp/filament/assets/5361908/f9209802-05ed-45da-9200-f986751332ef">

Without `->compactSidebarNavigation()` (the current / default setting):
<img width="285" alt="image" src="https://github.com/filamentphp/filament/assets/5361908/7193d677-1231-4707-b118-fc1fdc3c129d">
<img width="287" alt="image" src="https://github.com/filamentphp/filament/assets/5361908/687970c3-008b-44c5-a9b2-ca6f937d2f99">