### PR TITLE
Add ability to specify ->delimiter(char) for CSV separator

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -495,6 +495,17 @@ ImportAction::make()
 
 If you are encountering memory issues when importing large CSV files, you may wish to reduce the chunk size.
 
+## Changing the field delimiter
+
+The default delimiter for CSV is the comma (`,`).
+If your import will use a different delimiter, you may call the `delimiter()` method on the action. This also works in conjunction with `example()` when writing a file. NOTE: You must specify only a single character, else an exception will be thrown:
+
+```php
+ImportAction::make()
+    ->importer(ProductImporter::class)
+    ->delimiter(';')
+```
+
 ## Customizing the import job
 
 The default job for processing imports is `Filament\Actions\Imports\Jobs\ImportCsv`. If you want to extend this class and override any of its methods, you may replace the original class in the `register()` method of a service provider:

--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -495,16 +495,17 @@ ImportAction::make()
 
 If you are encountering memory issues when importing large CSV files, you may wish to reduce the chunk size.
 
-## Changing the field delimiter
+## Changing the CSV delimiter
 
-The default delimiter for CSV is the comma (`,`).
-If your import will use a different delimiter, you may call the `delimiter()` method on the action. This also works in conjunction with `example()` when writing a file. NOTE: You must specify only a single character, else an exception will be thrown:
+The default delimiter for CSVs is the comma (`,`). If your import uses a different delimiter, you may call the `csvDelimiter()` method on the action, passing a new one:
 
 ```php
 ImportAction::make()
     ->importer(ProductImporter::class)
-    ->delimiter(';')
+    ->csvDelimiter(';')
 ```
+
+You can only specify a single character, otherwise an exception will be thrown.
 
 ## Customizing the import job
 

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -47,7 +47,7 @@ trait CanImportRecords
 
     protected int | Closure | null $maxRows = null;
 
-    private string | Closure | null $csvDelimiter = null;
+    protected string | Closure | null $csvDelimiter = null;
 
     /**
      * @var array<string, mixed> | Closure
@@ -86,7 +86,7 @@ trait CanImportRecords
 
                     $csvReader = CsvReader::createFromStream($csvStream);
 
-                    if (filled($delimiter = $this->getDelimiter())) {
+                    if (filled($delimiter = $this->getCsvDelimiter())) {
                         $csvReader->setDelimiter($delimiter);
                     }
 
@@ -135,7 +135,7 @@ trait CanImportRecords
 
                     $csvReader = CsvReader::createFromStream($csvStream);
 
-                    if (filled($delimiter = $this->getDelimiter())) {
+                    if (filled($delimiter = $this->getCsvDelimiter())) {
                         $csvReader->setDelimiter($delimiter);
                     }
 
@@ -165,7 +165,7 @@ trait CanImportRecords
 
             $csvReader = CsvReader::createFromStream($csvStream);
 
-            if (filled($delimiter = $this->getDelimiter())) {
+            if (filled($delimiter = $this->getCsvDelimiter())) {
                 $csvReader->setDelimiter($delimiter);
             }
 
@@ -279,7 +279,7 @@ trait CanImportRecords
 
                     $csv = Writer::createFromFileObject(new SplTempFileObject());
 
-                    if (filled($delimiter = $this->getDelimiter())) {
+                    if (filled($delimiter = $this->getCsvDelimiter())) {
                         $csv->setDelimiter($delimiter);
                     }
 
@@ -380,7 +380,7 @@ trait CanImportRecords
         return $this;
     }
 
-    public function delimiter(string | Closure | null $delimiter): static
+    public function csvDelimiter(string | Closure | null $delimiter): static
     {
         $this->csvDelimiter = $delimiter;
 
@@ -413,7 +413,7 @@ trait CanImportRecords
         return $this->evaluate($this->maxRows);
     }
 
-    public function getDelimiter(): ?string
+    public function getCsvDelimiter(): ?string
     {
         return $this->evaluate($this->csvDelimiter);
     }

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -86,8 +86,8 @@ trait CanImportRecords
 
                     $csvReader = CsvReader::createFromStream($csvStream);
 
-                    if (filled($delimiter = $this->getCsvDelimiter())) {
-                        $csvReader->setDelimiter($delimiter);
+                    if (filled($csvDelimiter = $this->getCsvDelimiter())) {
+                        $csvReader->setDelimiter($csvDelimiter);
                     }
 
                     $csvReader->setHeaderOffset(0);
@@ -135,8 +135,8 @@ trait CanImportRecords
 
                     $csvReader = CsvReader::createFromStream($csvStream);
 
-                    if (filled($delimiter = $this->getCsvDelimiter())) {
-                        $csvReader->setDelimiter($delimiter);
+                    if (filled($csvDelimiter = $this->getCsvDelimiter())) {
+                        $csvReader->setDelimiter($csvDelimiter);
                     }
 
                     $csvReader->setHeaderOffset(0);
@@ -165,8 +165,8 @@ trait CanImportRecords
 
             $csvReader = CsvReader::createFromStream($csvStream);
 
-            if (filled($delimiter = $this->getCsvDelimiter())) {
-                $csvReader->setDelimiter($delimiter);
+            if (filled($csvDelimiter = $this->getCsvDelimiter())) {
+                $csvReader->setDelimiter($csvDelimiter);
             }
 
             $csvReader->setHeaderOffset(0);
@@ -279,8 +279,8 @@ trait CanImportRecords
 
                     $csv = Writer::createFromFileObject(new SplTempFileObject());
 
-                    if (filled($delimiter = $this->getCsvDelimiter())) {
-                        $csv->setDelimiter($delimiter);
+                    if (filled($csvDelimiter = $this->getCsvDelimiter())) {
+                        $csv->setDelimiter($csvDelimiter);
                     }
 
                     $csv->insertOne(array_map(

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -47,6 +47,8 @@ trait CanImportRecords
 
     protected int | Closure | null $maxRows = null;
 
+    private string | Closure | null $csvDelimiter = null;
+
     /**
      * @var array<string, mixed> | Closure
      */
@@ -83,6 +85,11 @@ trait CanImportRecords
                     }
 
                     $csvReader = CsvReader::createFromStream($csvStream);
+
+                    if (filled($delimiter = $this->getDelimiter())) {
+                        $csvReader->setDelimiter($delimiter);
+                    }
+
                     $csvReader->setHeaderOffset(0);
 
                     $csvColumns = $csvReader->getHeader();
@@ -127,6 +134,11 @@ trait CanImportRecords
                     }
 
                     $csvReader = CsvReader::createFromStream($csvStream);
+
+                    if (filled($delimiter = $this->getDelimiter())) {
+                        $csvReader->setDelimiter($delimiter);
+                    }
+
                     $csvReader->setHeaderOffset(0);
 
                     $csvColumns = $csvReader->getHeader();
@@ -152,6 +164,11 @@ trait CanImportRecords
             }
 
             $csvReader = CsvReader::createFromStream($csvStream);
+
+            if (filled($delimiter = $this->getDelimiter())) {
+                $csvReader->setDelimiter($delimiter);
+            }
+
             $csvReader->setHeaderOffset(0);
             $csvResults = Statement::create()->process($csvReader);
 
@@ -262,6 +279,10 @@ trait CanImportRecords
 
                     $csv = Writer::createFromFileObject(new SplTempFileObject());
 
+                    if (filled($delimiter = $this->getDelimiter())) {
+                        $csv->setDelimiter($delimiter);
+                    }
+
                     $csv->insertOne(array_map(
                         fn (ImportColumn $column): string => $column->getName(),
                         $columns,
@@ -359,6 +380,13 @@ trait CanImportRecords
         return $this;
     }
 
+    public function delimiter(string | Closure | null $delimiter): static
+    {
+        $this->csvDelimiter = $delimiter;
+
+        return $this;
+    }
+
     /**
      * @return class-string<Importer>
      */
@@ -383,6 +411,11 @@ trait CanImportRecords
     public function getMaxRows(): ?int
     {
         return $this->evaluate($this->maxRows);
+    }
+
+    public function getDelimiter(): ?string
+    {
+        return $this->evaluate($this->csvDelimiter);
     }
 
     /**


### PR DESCRIPTION
Ref: [League CSV docs](https://csv.thephpleague.com/9.0/connections/controls/#the-delimiter-character)

Ref: [Filament Discord discussion](https://discord.com/channels/883083792112300104/1181204479140429905/1181204479140429905)

- [ ] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
