### PR TITLE
Add the ability to customize both nextAction and previousAction actio…

### DIFF
--- a/packages/actions/src/Concerns/HasForm.php
+++ b/packages/actions/src/Concerns/HasForm.php
@@ -71,6 +71,8 @@ trait HasForm
                     ->startOnStep($this->getWizardStartStep())
                     ->cancelAction($this->getModalCancelAction())
                     ->submitAction($this->getModalSubmitAction())
+                    ->nextAction(fn () => $this->getWizardNextAction())
+                    ->previousAction(fn () => $this->getWizardPreviousAction())
                     ->skippable($this->isWizardSkippable())
                     ->disabled($this->isFormDisabled()),
             ];

--- a/packages/actions/src/Concerns/HasForm.php
+++ b/packages/actions/src/Concerns/HasForm.php
@@ -65,17 +65,21 @@ trait HasForm
         }
 
         if (is_array($modifiedForm) && $this->isWizard()) {
-            $modifiedForm = [
-                Wizard::make($modifiedForm)
-                    ->contained(false)
-                    ->startOnStep($this->getWizardStartStep())
-                    ->cancelAction($this->getModalCancelAction())
-                    ->submitAction($this->getModalSubmitAction())
-                    ->nextAction(fn () => $this->getWizardNextAction())
-                    ->previousAction(fn () => $this->getWizardPreviousAction())
-                    ->skippable($this->isWizardSkippable())
-                    ->disabled($this->isFormDisabled()),
-            ];
+            $wizard = Wizard::make($modifiedForm)
+                ->contained(false)
+                ->startOnStep($this->getWizardStartStep())
+                ->cancelAction($this->getModalCancelAction())
+                ->submitAction($this->getModalSubmitAction())
+                ->skippable($this->isWizardSkippable())
+                ->disabled($this->isFormDisabled());
+
+            if ($this->modifyWizardUsing) {
+                $this->evaluate($this->modifyWizardUsing, [
+                    'wizard' => $wizard,
+                ]) ?? $wizard;
+            }
+
+            $modifiedForm = [$wizard];
         }
 
         if (is_array($modifiedForm)) {

--- a/packages/actions/src/Concerns/HasWizard.php
+++ b/packages/actions/src/Concerns/HasWizard.php
@@ -3,9 +3,7 @@
 namespace Filament\Actions\Concerns;
 
 use Closure;
-use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\Wizard\Step;
-use Filament\Support\Enums\IconPosition;
 
 trait HasWizard
 {
@@ -15,9 +13,7 @@ trait HasWizard
 
     protected int | Closure $wizardStartStep = 1;
 
-    protected ?Closure $modifyNextActionUsing = null;
-
-    protected ?Closure $modifyPreviousActionUsing = null;
+    protected ?Closure $modifyWizardUsing = null;
 
     /**
      * @param  array<Step> | Closure  $steps
@@ -54,66 +50,11 @@ trait HasWizard
         return (bool) $this->evaluate($this->isWizardSkippable);
     }
 
-    public function getWizardStartStep(): int
+    public function modifyWizardUsing(?Closure $callback): static
     {
-        return $this->evaluate($this->wizardStartStep);
-    }
-
-    public function getWizardNextAction(): Action
-    {
-        $action = Action::make($this->getNextActionName())
-            ->label(__('filament-forms::components.wizard.actions.next_step.label'))
-            ->iconPosition(IconPosition::After)
-            ->livewireClickHandlerEnabled(false)
-            ->button();
-
-        if ($this->modifyNextActionUsing) {
-            $action = $this->evaluate($this->modifyNextActionUsing, [
-                'action' => $action,
-            ]) ?? $action;
-        }
-
-        return $action;
-    }
-
-    public function nextAction($callback): static
-    {
-        $this->modifyNextActionUsing = $callback;
+        $this->isWizard = true;
+        $this->modifyWizardUsing = $callback;
 
         return $this;
-    }
-
-    public function getNextActionName(): string
-    {
-        return 'next';
-    }
-
-        public function getWizardPreviousAction(): Action
-    {
-        $action = Action::make($this->getPreviousActionName())
-            ->label(__('filament-forms::components.wizard.actions.previous_step.label'))
-            ->color('gray')
-            ->livewireClickHandlerEnabled(false)
-            ->button();
-
-        if ($this->modifyPreviousActionUsing) {
-            $action = $this->evaluate($this->modifyPreviousActionUsing, [
-                'action' => $action,
-            ]) ?? $action;
-        }
-
-        return $action;
-    }
-
-    public function previousAction(?Closure $callback): static
-    {
-        $this->modifyPreviousActionUsing = $callback;
-
-        return $this;
-    }
-
-    public function getPreviousActionName(): string
-    {
-        return 'previous';
     }
 }

--- a/packages/actions/src/Concerns/HasWizard.php
+++ b/packages/actions/src/Concerns/HasWizard.php
@@ -3,7 +3,9 @@
 namespace Filament\Actions\Concerns;
 
 use Closure;
+use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\Wizard\Step;
+use Filament\Support\Enums\IconPosition;
 
 trait HasWizard
 {
@@ -12,6 +14,10 @@ trait HasWizard
     protected bool | Closure $isWizardSkippable = false;
 
     protected int | Closure $wizardStartStep = 1;
+
+    protected ?Closure $modifyNextActionUsing = null;
+
+    protected ?Closure $modifyPreviousActionUsing = null;
 
     /**
      * @param  array<Step> | Closure  $steps
@@ -51,5 +57,63 @@ trait HasWizard
     public function getWizardStartStep(): int
     {
         return $this->evaluate($this->wizardStartStep);
+    }
+
+    public function getWizardNextAction(): Action
+    {
+        $action = Action::make($this->getNextActionName())
+            ->label(__('filament-forms::components.wizard.actions.next_step.label'))
+            ->iconPosition(IconPosition::After)
+            ->livewireClickHandlerEnabled(false)
+            ->button();
+
+        if ($this->modifyNextActionUsing) {
+            $action = $this->evaluate($this->modifyNextActionUsing, [
+                'action' => $action,
+            ]) ?? $action;
+        }
+
+        return $action;
+    }
+
+    public function nextAction($callback): static
+    {
+        $this->modifyNextActionUsing = $callback;
+
+        return $this;
+    }
+
+    public function getNextActionName(): string
+    {
+        return 'next';
+    }
+
+        public function getWizardPreviousAction(): Action
+    {
+        $action = Action::make($this->getPreviousActionName())
+            ->label(__('filament-forms::components.wizard.actions.previous_step.label'))
+            ->color('gray')
+            ->livewireClickHandlerEnabled(false)
+            ->button();
+
+        if ($this->modifyPreviousActionUsing) {
+            $action = $this->evaluate($this->modifyPreviousActionUsing, [
+                'action' => $action,
+            ]) ?? $action;
+        }
+
+        return $action;
+    }
+
+    public function previousAction(?Closure $callback): static
+    {
+        $this->modifyPreviousActionUsing = $callback;
+
+        return $this;
+    }
+
+    public function getPreviousActionName(): string
+    {
+        return 'previous';
     }
 }


### PR DESCRIPTION
- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.

Related to #10162

**The final result:**

```
<?php

namespace App\Filament\Pages;

use Filament\Actions\Action;
use Filament\Forms\Components\Actions\Action as FormAction;
use Filament\Forms\Components\Wizard\Step;
use Filament\Pages\Page;
use Filament\Support\Enums\MaxWidth;

class Test extends Page
{
    protected static ?string $navigationIcon = 'heroicon-o-document-text';

    protected static string $view = 'filament.pages.test';

    protected function deleteAction(): Action
    {
        return Action::make('delete')
            ->requiresConfirmation()
            ->modalWidth(MaxWidth::ExtraLarge)
            ->steps([
                Step::make('Step 1')
                    ->schema([]),
                Step::make('Step 2')
                    ->schema([]),
            ])
            ->nextAction(
                fn (FormAction $action) => $action
                    ->label('Next step')
                    ->color('success')
                    ->icon('heroicon-s-arrow-long-right'),
            )
            ->previousAction(
                fn (FormAction $action) => $action
                    ->label('Back step')
                    ->color('danger')
                    ->icon('heroicon-s-arrow-long-left'),
            );
    }
}
```

**Live Preview:**


https://github.com/filamentphp/filament/assets/121255432/503c962a-9c12-4432-844a-29180fbe11bc

