### PR TITLE
fix require confirmation

### DIFF
--- a/packages/actions/src/Concerns/CanRequireConfirmation.php
+++ b/packages/actions/src/Concerns/CanRequireConfirmation.php
@@ -12,6 +12,10 @@ trait CanRequireConfirmation
 {
     public function requiresConfirmation(bool | Closure $condition = true): static
     {
+        if (! $this->evaluate($condition)) {
+            return $this;
+        }
+
         $this->modalAlignment(fn (MountableAction $action): ?Alignment => $action->evaluate($condition) ? Alignment::Center : null);
         $this->modalFooterActionsAlignment(fn (MountableAction $action): ?Alignment => $action->evaluate($condition) ? Alignment::Center : null);
         $this->modalIcon(fn (MountableAction $action): ?string => $action->evaluate($condition) ? (FilamentIcon::resolve('actions::modal.confirmation') ?? 'heroicon-o-exclamation-triangle') : null);


### PR DESCRIPTION
- [X] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [X] Visual changes are explained in the PR description using a screenshot/recording of before and after.

### More Info
Even when we pass `false` to `requiresConfirmation` a modal still pops up, which is not an expected behaviour, what do you think?

![Screenshot 2023-12-09 at 12 38 00 AM](https://github.com/filamentphp/filament/assets/37803924/d02abe38-363c-461f-ad84-b692f74f49f3)
