### PR TITLE
Fix: Tag input TypeError when exiting modal

### DIFF
--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -65,7 +65,7 @@
             @foreach ($getSuggestions() as $suggestion)
                 <template
                     x-bind:key="@js($suggestion)"
-                    x-if="! state.includes(@js($suggestion))"
+                    x-if="state !== undefined && ! state.includes(@js($suggestion))"
                 >
                     <option value="{{ $suggestion }}" />
                 </template>


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.

## Change description
If you have a tag-input field in an action modal, you will get receive a state TypeError when exiting the modal. This change checks if the state is undefined. The change is testet in my local environment and is working. 

<img width="1387" alt="Screenshot 2023-12-09 at 12 54 24" src="https://github.com/filamentphp/filament/assets/8544305/141fae06-acd2-45f9-9175-2219fba650fb">
 
