### PR TITLE
only show DB notifications icon when user has notifications

### DIFF
--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -127,7 +127,7 @@
             {{ \Filament\Support\Facades\FilamentView::renderHook('panels::global-search.after') }}
 
             @if (filament()->auth()->check())
-                @if (filament()->hasDatabaseNotifications())
+                @if (filament()->hasDatabaseNotifications() && count(auth()->user()->notifications))
                     @livewire(Filament\Livewire\DatabaseNotifications::class, ['lazy' => true])
                 @endif
 


### PR DESCRIPTION
Previously the DB notifications icon was always shown, even if there are no notifications: icon with badge (0). The icon should only be shown to indicate action is expected from the user.

With this change the notifications icon is only shown if the user has notifications, either read or unread. 

When pressing "mark all as read" the icon remains, with badge (0). The user can still access old notifications.

When pressing "clear" all notifications disappear, as well as the icon (on the next refresh). That's as expected, as there are no notifications to access.

<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
