### PR TITLE
Add CSS hook class to group cell

### DIFF
--- a/packages/tables/resources/views/components/selection/group-cell.blade.php
+++ b/packages/tables/resources/views/components/selection/group-cell.blade.php
@@ -1,7 +1,7 @@
 <x-filament-tables::cell
     :attributes="
         \Filament\Support\prepare_inherited_attributes($attributes)
-            ->class(['bg-gray-50 dark:bg-white/5 w-1'])
+            ->class(['fi-ta-group-cell bg-gray-50 dark:bg-white/5 w-1'])
     "
 >
     <div class="px-3">


### PR DESCRIPTION
A small PR that adds `fi-ta-group-cell` hook CSS class to the group cell select box so is possible to style this part. Like pull request https://github.com/filamentphp/filament/pull/8750