### PR TITLE
Cross-link Authorization docs

### DIFF
--- a/packages/panels/docs/08-users.md
+++ b/packages/panels/docs/08-users.md
@@ -58,6 +58,10 @@ class User extends Authenticatable implements FilamentUser
 }
 ```
 
+## Authorizing access to Resources
+
+See the [Authorization](resources/getting-started#authorization) in the Resource documentation for controlling access to Resource pages and their data.
+
 ## Setting up user avatars
 
 Out of the box, Filament uses [ui-avatars.com](https://ui-avatars.com) to generate avatars based on a user's name. However, if you user model has an `avatar_url` attribute, that will be used instead. To customize how Filament gets a user's avatar URL, you can implement the `HasAvatar` contract:

--- a/packages/panels/docs/08-users.md
+++ b/packages/panels/docs/08-users.md
@@ -60,7 +60,7 @@ class User extends Authenticatable implements FilamentUser
 
 ## Authorizing access to Resources
 
-See the [Authorization](resources/getting-started#authorization) in the Resource documentation for controlling access to Resource pages and their data.
+See the [Authorization](resources/getting-started#authorization) section in the Resource documentation for controlling access to Resource pages and their data records.
 
 ## Setting up user avatars
 


### PR DESCRIPTION
Just adding a cross-link from the User-Authorization section to the Resource Authorization section, to reduce ambiguity and confusion when using the docs.
