### PR TITLE
Update README.md of Spatie Media Library package

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/README.md
+++ b/packages/spatie-laravel-media-library-plugin/README.md
@@ -68,14 +68,14 @@ The base file upload component also has configuration options for setting the `d
 
 In addition to the behaviour of the normal file upload, Spatie's Media Library also allows users to reorder files.
 
-To enable this behaviour, use the `enableReordering()` method:
+To enable this behaviour, use the `reorderable()` method:
 
 ```php
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 
 SpatieMediaLibraryFileUpload::make('attachments')
     ->multiple()
-    ->enableReordering()
+    ->reorderable()
 ```
 
 You may now drag and drop files into order.


### PR DESCRIPTION
`enableReordering()` is deprecated should be `reorderable()`