### PR TITLE
Correct the sort order for reorderable Spatie Media Library Files when displaying in table or infolist

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Infolists/Components/SpatieMediaLibraryImageEntry.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Infolists/Components/SpatieMediaLibraryImageEntry.php
@@ -83,7 +83,7 @@ class SpatieMediaLibraryImageEntry extends ImageEntry
 
         return $this->getRecord()->getRelationValue('media')
             ->filter(fn (Media $media): bool => blank($collection) || ($media->getAttributeValue('collection_name') === $collection))
-            ->sortBy('order_column')
+            ->sortByDesc('order_column')
             ->map(fn (Media $media): string => $media->uuid)
             ->all();
     }

--- a/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
@@ -85,7 +85,7 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
 
         return $record->getRelationValue('media')
             ->filter(fn (Media $media): bool => blank($collection) || ($media->getAttributeValue('collection_name') === $collection))
-            ->sortBy('order_column')
+            ->sortByDesc('order_column')
             ->map(fn (Media $media): string => $media->uuid)
             ->all();
     }


### PR DESCRIPTION
## Description

Currently when using `SpatieMediaLibraryFileUpload::make()->reorderable()` if you have 3 items will get the following sort order indicated by their `order_column`:

1.  ->   3
2. ->   2
3.  ->   1

When using `SpatieMediaLibraryImageColumn::make()->stacked()` I would expect to see the top item from the form first, but its currently using `sortBy` instead of `sortByDesc` resulting in last item being shown first.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [v] `composer cs` command has been run.

## Testing

- [v] Changes have been tested manually 

## Documentation

no new functionality has been added.
