### PR TITLE
Correction of the gap property in the navigation group

### DIFF
--- a/packages/panels/resources/views/components/sidebar/index.blade.php
+++ b/packages/panels/resources/views/components/sidebar/index.blade.php
@@ -113,7 +113,7 @@
         @endif
 
         @if (filament()->hasNavigation())
-            <ul class="-mx-2 flex flex-col gap-y-7">
+            <ul class="-mx-2 flex flex-col gap-y-1">
                 @foreach ($navigation as $group)
                     <x-filament-panels::sidebar.group
                         :collapsible="$group->isCollapsible()"


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

I noticed that the spacing between navigation groups, which was fixed in #9387, has reverted.

I reverted it with this fix, but is there a specific reason for this? 
If there is no issue, please merge this pull request and reapply the fix from #9387.

Modified Commits: 
![スクリーンショット 2023-12-12 2 28 57](https://github.com/filamentphp/filament/assets/28666304/d96ab7e1-3c20-4b9a-ac5b-a371703fab89)


before:
![スクリーンショット 2023-12-12 2 26 52](https://github.com/filamentphp/filament/assets/28666304/f8834721-9a31-4d9d-90a7-82cc62204dc0)

after:
![スクリーンショット 2023-12-12 2 26 25](https://github.com/filamentphp/filament/assets/28666304/e104eda9-93bf-491a-bd56-1e1411350e2b)


- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
