### PR TITLE
Fix syntax error caused from blank attribute

### DIFF
--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -142,7 +142,7 @@
             <div
                 x-show="isEditorOpen"
                 x-cloak
-                x-on:click.stop
+                x-on:click.stop=""
                 x-trap.noscroll="isEditorOpen"
                 x-on:keydown.escape.window="closeEditor"
                 @class([

--- a/packages/support/resources/views/components/section/index.blade.php
+++ b/packages/support/resources/views/components/section/index.blade.php
@@ -136,7 +136,7 @@
                 <x-filament-actions::actions
                     :actions="$headerActions"
                     :alignment="\Filament\Support\Enums\Alignment::Start"
-                    x-on:click.stop
+                    x-on:click.stop=""
                 />
             @endif
 

--- a/packages/tables/resources/views/columns/checkbox-column.blade.php
+++ b/packages/tables/resources/views/columns/checkbox-column.blade.php
@@ -77,7 +77,7 @@
                     theme: $store.theme,
                 }
         "
-        x-on:click.stop
+        x-on:click.stop=""
         :attributes="
             \Filament\Support\prepare_inherited_attributes($attributes)
                 ->merge($getExtraInputAttributes(), escape: false)

--- a/packages/tables/resources/views/columns/select-column.blade.php
+++ b/packages/tables/resources/views/columns/select-column.blade.php
@@ -72,7 +72,7 @@
                     theme: $store.theme,
                 }
         "
-        x-on:click.stop
+        x-on:click.stop=""
     >
         <x-filament::input.select
             :disabled="$isDisabled"

--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -81,7 +81,7 @@
                     theme: $store.theme,
                 }
         "
-        x-on:click.stop
+        x-on:click.stop=""
     >
         {{-- format-ignore-start --}}
         <x-filament::input


### PR DESCRIPTION
Simple change to fix error when using TextInputColumn in Firefox. 

The issue is when the HTML results in:
```html 
<div class="fi-input-wrp etc" x-on:click.stop="x-on:click.stop">
...
</div>
```

<img width="1296" alt="Screenshot_2023-12-11_at_19 05 30" src="https://github.com/filamentphp/filament/assets/533658/cde34d9c-4cdb-4101-aa12-d7fbf54989d5">
