### PR TITLE
Add Czech translations for Spatie Settings

### DIFF
--- a/packages/spatie-laravel-settings-plugin/resources/lang/cs/pages/settings-page.php
+++ b/packages/spatie-laravel-settings-plugin/resources/lang/cs/pages/settings-page.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+
+    'form' => [
+
+        'actions' => [
+
+            'save' => [
+                'label' => 'Uložit',
+            ],
+
+        ],
+
+    ],
+
+    'notifications' => [
+
+        'saved' => [
+            'title' => 'Uloženo',
+        ],
+
+    ],
+
+];

--- a/packages/spatie-laravel-settings-plugin/resources/lang/cs/pages/settings-page.php
+++ b/packages/spatie-laravel-settings-plugin/resources/lang/cs/pages/settings-page.php
@@ -7,7 +7,7 @@ return [
         'actions' => [
 
             'save' => [
-                'label' => 'Uložit',
+                'label' => 'Uložit změny',
             ],
 
         ],


### PR DESCRIPTION
This PR adds Czech translations for the Spatie Settings plugin. 

**Changes**:
  - 'Save' button label translation added.
  - 'Saved' notification translation added.