### PR TITLE
Fix: Hint icon tooltip

### DIFF
--- a/packages/forms/resources/views/components/placeholder.blade.php
+++ b/packages/forms/resources/views/components/placeholder.blade.php
@@ -9,6 +9,7 @@
     :hint-actions="$getHintActions()"
     :hint-color="$getHintColor()"
     :hint-icon="$getHintIcon()"
+    :hint-icon-tooltip="$getHintIconTooltip()"
     :state-path="$getStatePath()"
 >
     <div


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

The tooltips for the hint icons did not work (underused feature maybe? Because it seems like it has been like this for a while).

After:

![image](https://github.com/filamentphp/filament/assets/10498595/a0d49fc5-52c4-481f-8626-3ae8afc33e49)

Before: No tooltip :)


<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
