### PR TITLE
Panels: Add new Panel::route() helper for generating routes

### DIFF
--- a/packages/forms/resources/views/component-container.blade.php
+++ b/packages/forms/resources/views/component-container.blade.php
@@ -9,34 +9,34 @@
     :x-data="$isRoot ? '{}' : null"
     :x-on:form-validation-error.window="
         $isRoot ? ('if ($event.detail.livewireId !== ' . Js::from($this->getId()) . ') {
+                return
+            }
+
+            $nextTick(() => {
+                error = $el.querySelector(\'[data-validation-error]\')
+
+                if (! error) {
                     return
                 }
 
-                $nextTick(() => {
-                    error = $el.querySelector(\'[data-validation-error]\')
+                elementToExpand = error
 
-                    if (! error) {
-                        return
-                    }
+                while (elementToExpand) {
+                    elementToExpand.dispatchEvent(new CustomEvent(\'expand\'))
 
-                    elementToExpand = error
+                    elementToExpand = elementToExpand.parentNode
+                }
 
-                    while (elementToExpand) {
-                        elementToExpand.dispatchEvent(new CustomEvent(\'expand\'))
-
-                        elementToExpand = elementToExpand.parentNode
-                    }
-
-                    setTimeout(
-                        () =>
-                            error.closest(\'[data-field-wrapper]\').scrollIntoView({
-                                behavior: \'smooth\',
-                                block: \'start\',
-                                inline: \'start\',
-                            }),
-                        200,
-                    )
-                })') : null
+                setTimeout(
+                    () =>
+                        error.closest(\'[data-field-wrapper]\').scrollIntoView({
+                            behavior: \'smooth\',
+                            block: \'start\',
+                            inline: \'start\',
+                        }),
+                    200,
+                )
+        })') : null
     "
     :default="$getColumns('default')"
     :sm="$getColumns('sm')"

--- a/packages/forms/resources/views/component-container.blade.php
+++ b/packages/forms/resources/views/component-container.blade.php
@@ -9,34 +9,34 @@
     :x-data="$isRoot ? '{}' : null"
     :x-on:form-validation-error.window="
         $isRoot ? ('if ($event.detail.livewireId !== ' . Js::from($this->getId()) . ') {
-            return
-        }
+                    return
+                }
 
-        $nextTick(() => {
-            error = $el.querySelector(\'[data-validation-error]\')
+                $nextTick(() => {
+                    error = $el.querySelector(\'[data-validation-error]\')
 
-            if (! error) {
-                return
-            }
+                    if (! error) {
+                        return
+                    }
 
-            elementToExpand = error
+                    elementToExpand = error
 
-            while (elementToExpand) {
-                elementToExpand.dispatchEvent(new CustomEvent(\'expand\'))
+                    while (elementToExpand) {
+                        elementToExpand.dispatchEvent(new CustomEvent(\'expand\'))
 
-                elementToExpand = elementToExpand.parentNode
-            }
+                        elementToExpand = elementToExpand.parentNode
+                    }
 
-            setTimeout(
-                () =>
-                    error.closest(\'[data-field-wrapper]\').scrollIntoView({
-                        behavior: \'smooth\',
-                        block: \'start\',
-                        inline: \'start\',
-                    }),
-                200,
-            )
-        })') : null
+                    setTimeout(
+                        () =>
+                            error.closest(\'[data-field-wrapper]\').scrollIntoView({
+                                behavior: \'smooth\',
+                                block: \'start\',
+                                inline: \'start\',
+                            }),
+                        200,
+                    )
+                })') : null
     "
     :default="$getColumns('default')"
     :sm="$getColumns('sm')"

--- a/packages/panels/src/Pages/Page.php
+++ b/packages/panels/src/Pages/Page.php
@@ -73,11 +73,11 @@ abstract class Page extends BasePage
 
     public static function getRouteName(?string $panel = null): string
     {
-        $panel ??= Filament::getCurrentPanel()->getId();
+        $panel = $panel ? Filament::getPanel($panel) : Filament::getCurrentPanel();
 
-        return (string) str(static::getSlug())
+        return $panel->generateRouteName((string) str(static::getSlug())
             ->replace('/', '.')
-            ->prepend("filament.{$panel}.pages.");
+            ->prepend('pages.'));
     }
 
     /**

--- a/packages/panels/src/Panel/Concerns/HasAuth.php
+++ b/packages/panels/src/Panel/Concerns/HasAuth.php
@@ -165,7 +165,7 @@ trait HasAuth
 
     public function getEmailVerificationPromptRouteName(): string
     {
-        return "filament.{$this->getId()}.auth.email-verification.prompt";
+        return $this->generateRouteName('auth.email-verification.prompt');
     }
 
     public function getEmailVerifiedMiddleware(): string
@@ -215,7 +215,7 @@ trait HasAuth
     public function getVerifyEmailUrl(MustVerifyEmail | Model | Authenticatable $user, array $parameters = []): string
     {
         return URL::temporarySignedRoute(
-            "filament.{$this->getId()}.auth.email-verification.verify",
+            $this->generateRouteName('auth.email-verification.verify'),
             now()->addMinutes(config('auth.verification.expire', 60)),
             [
                 'id' => $user->getKey(),
@@ -231,7 +231,7 @@ trait HasAuth
     public function getResetPasswordUrl(string $token, CanResetPassword | Model | Authenticatable $user, array $parameters = []): string
     {
         return URL::signedRoute(
-            "filament.{$this->getId()}.auth.password-reset.reset",
+            $this->generateRouteName('auth.password-reset.reset'),
             [
                 'email' => $user->getEmailForPasswordReset(),
                 'token' => $token,

--- a/packages/panels/src/Panel/Concerns/HasAuth.php
+++ b/packages/panels/src/Panel/Concerns/HasAuth.php
@@ -182,7 +182,7 @@ trait HasAuth
             return null;
         }
 
-        return route("filament.{$this->getId()}.auth.login", $parameters);
+        return $this->route('auth.login', $parameters);
     }
 
     /**
@@ -194,7 +194,7 @@ trait HasAuth
             return null;
         }
 
-        return route("filament.{$this->getId()}.auth.register", $parameters);
+        return $this->route('auth.register', $parameters);
     }
 
     /**
@@ -206,7 +206,7 @@ trait HasAuth
             return null;
         }
 
-        return route("filament.{$this->getId()}.auth.password-reset.request", $parameters);
+        return $this->route('auth.password-reset.request', $parameters);
     }
 
     /**
@@ -249,7 +249,7 @@ trait HasAuth
             return null;
         }
 
-        return route("filament.{$this->getId()}.auth.profile", $parameters);
+        return $this->route('auth.profile', $parameters);
     }
 
     /**
@@ -257,7 +257,7 @@ trait HasAuth
      */
     public function getLogoutUrl(array $parameters = []): string
     {
-        return route("filament.{$this->getId()}.auth.logout", $parameters);
+        return $this->route('auth.logout', $parameters);
     }
 
     public function getEmailVerifiedMiddlewareName(): string

--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -88,7 +88,12 @@ trait HasRoutes
 
     public function route(string $name, mixed $parameters = [], bool $absolute = true): string
     {
-        return route("filament.{$this->getId()}.{$name}", $parameters, $absolute);
+        return route($this->generateRouteName($name), $parameters, $absolute);
+    }
+
+    public function generateRouteName(string $name): string
+    {
+        return "filament.{$this->getId()}.{$name}";
     }
 
     public function getRoutes(): ?Closure

--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -86,6 +86,11 @@ trait HasRoutes
         return $this;
     }
 
+    public function route(string $name, mixed $parameters = [], bool $absolute = true): string
+    {
+        return route("filament.{$this->getId()}.{$name}", $parameters, $absolute);
+    }
+
     public function getRoutes(): ?Closure
     {
         return $this->routes;

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -180,13 +180,10 @@ trait HasTenancy
             return null;
         }
 
-        return route(
-            "filament.{$this->getId()}.tenant.billing",
-            [
-                'tenant' => $tenant,
-                ...$parameters,
-            ],
-        );
+        return $this->route('tenant.billing', [
+            'tenant' => $tenant,
+            ...$parameters,
+        ]);
     }
 
     /**
@@ -198,7 +195,7 @@ trait HasTenancy
             return null;
         }
 
-        return route("filament.{$this->getId()}.tenant.profile", $parameters);
+        return $this->route('tenant.profile', $parameters);
     }
 
     /**
@@ -210,7 +207,7 @@ trait HasTenancy
             return null;
         }
 
-        return route("filament.{$this->getId()}.tenant.registration", $parameters);
+        return $this->route('tenant.registration', $parameters);
     }
 
     public function hasTenantMenu(): bool

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -564,11 +564,11 @@ abstract class Resource
 
     public static function getRouteBaseName(?string $panel = null): string
     {
-        $panel ??= Filament::getCurrentPanel()->getId();
+        $panel = $panel ? Filament::getPanel($panel) : Filament::getCurrentPanel();
 
-        return (string) str(static::getSlug())
+        return $panel->generateRouteName((string) str(static::getSlug())
             ->replace('/', '.')
-            ->prepend("filament.{$panel}.resources.");
+            ->prepend('resources.'));
     }
 
     public static function getRecordRouteKeyName(): ?string


### PR DESCRIPTION
## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

You can register routes for a panel using the `$panel->routes(function () { ... })` method, but generating route URIs is tedious because the names are prefixed with `filament.{$panel->getId()}`. 

This new `$panel->route(...)` helper has the same signature as Laravel's own `route()` helper but makes it easier to generate the URLs themselves.

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
