### PR TITLE
Update index.blade.php for static positioning

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -260,7 +260,7 @@
                 wire:poll.{{ $pollingInterval }}
             @endif
             @class([
-                'fi-ta-content relative divide-y divide-gray-200 overflow-x-auto dark:divide-white/10 dark:border-t-white/10',
+                'fi-ta-content divide-y divide-gray-200 overflow-x-auto dark:divide-white/10 dark:border-t-white/10',
                 '!border-t-0' => ! $hasHeader,
             ])
         >


### PR DESCRIPTION
Fixes bug where, when the sidebar is collapsed, the tenant dropdown is covered by the table.

## Description

BEFORE:
<img width="421" alt="Screenshot 2023-12-13 at 2 09 53 PM" src="https://github.com/filamentphp/filament/assets/7681836/8b003b66-ff97-419e-b581-2baa20a2b431">

AFTER:
<img width="382" alt="Screenshot 2023-12-13 at 3 19 21 PM" src="https://github.com/filamentphp/filament/assets/7681836/66a0ab84-3c8b-4eec-960c-59c15e50a674">

## Code style

No updates.

## Testing

Not 100% sure how to do this for UI outside of manually clicking around, which I have done.

## Documentation

No updates.