### PR TITLE
Add h-full utility class to fi-fo-wizard-header-step-separator

### DIFF
--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -216,7 +216,7 @@
                 @if (! $loop->last)
                     <div
                         aria-hidden="true"
-                        class="fi-fo-wizard-header-step-separator absolute end-0 hidden w-5 md:block"
+                        class="fi-fo-wizard-header-step-separator absolute end-0 hidden h-full w-5 md:block"
                     >
                         <svg
                             fill="none"


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

**Before:**

<img width="696" alt="Screenshot 2023-12-13 at 17 18 47" src="https://github.com/filamentphp/filament/assets/121255432/b36cee95-4d5b-4e77-9726-012ead51c7d3">


**After:**

<img width="696" alt="Screenshot 2023-12-13 at 17 19 18" src="https://github.com/filamentphp/filament/assets/121255432/d6fcd17b-7030-47af-82c7-2f32c93024b4">


## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.

## Documentation

- [x] Documentation is up-to-date.
