### PR TITLE
Add CSS classes to sidebar based on label

### DIFF
--- a/packages/forms/resources/views/component-container.blade.php
+++ b/packages/forms/resources/views/component-container.blade.php
@@ -9,34 +9,34 @@
     :x-data="$isRoot ? '{}' : null"
     :x-on:form-validation-error.window="
         $isRoot ? ('if ($event.detail.livewireId !== ' . Js::from($this->getId()) . ') {
-                    return
-                }
+                            return
+                        }
 
-                $nextTick(() => {
-                    error = $el.querySelector(\'[data-validation-error]\')
+                        $nextTick(() => {
+                            error = $el.querySelector(\'[data-validation-error]\')
 
-                    if (! error) {
-                        return
-                    }
+                            if (! error) {
+                                return
+                            }
 
-                    elementToExpand = error
+                            elementToExpand = error
 
-                    while (elementToExpand) {
-                        elementToExpand.dispatchEvent(new CustomEvent(\'expand\'))
+                            while (elementToExpand) {
+                                elementToExpand.dispatchEvent(new CustomEvent(\'expand\'))
 
-                        elementToExpand = elementToExpand.parentNode
-                    }
+                                elementToExpand = elementToExpand.parentNode
+                            }
 
-                    setTimeout(
-                        () =>
-                            error.closest(\'[data-field-wrapper]\').scrollIntoView({
-                                behavior: \'smooth\',
-                                block: \'start\',
-                                inline: \'start\',
-                            }),
-                        200,
-                    )
-                })') : null
+                            setTimeout(
+                                () =>
+                                    error.closest(\'[data-field-wrapper]\').scrollIntoView({
+                                        behavior: \'smooth\',
+                                        block: \'start\',
+                                        inline: \'start\',
+                                    }),
+                                200,
+                            )
+                        })') : null
     "
     :default="$getColumns('default')"
     :sm="$getColumns('sm')"

--- a/packages/panels/resources/views/components/sidebar/item.blade.php
+++ b/packages/panels/resources/views/components/sidebar/item.blade.php
@@ -23,6 +23,7 @@
     {{
         $attributes->class([
             'fi-sidebar-item',
+            'fi-sidebar-item-' . str($slot)->slug(),
             // @deprecated `fi-sidebar-item-active` has been replaced by `fi-active`.
             'fi-active fi-sidebar-item-active' => $active,
             'flex flex-col gap-y-1' => $active || $activeChildItems,


### PR DESCRIPTION
## Description

I was looking for a way to apply some custom CSS to a certain item in the navigation to make it stand out more (an onboarding page). I noticed there wasn't really a good way to target a specific navigation item using CSS classes.

This PR automatically sluggifies the navigation item label and adds that as a class. It will generate classes like this:

```
fi-sidebar-item-onboarding
fi-sidebar-item-tasks
...
```

Thanks!
