### PR TITLE
Fix modal cancel action

### DIFF
--- a/packages/actions/src/Concerns/CanOpenModal.php
+++ b/packages/actions/src/Concerns/CanOpenModal.php
@@ -436,6 +436,10 @@ trait CanOpenModal
                 default => $color,
             });
 
+        if ($this->evaluate($this->modalSubmitAction, ['action' => $action]) === true) {
+            return $action;
+        }
+
         if ($this->modalSubmitAction !== null) {
             $action = $this->evaluate($this->modalSubmitAction, ['action' => $action]) ?? $action;
         }
@@ -453,6 +457,10 @@ trait CanOpenModal
             ->label($this->getModalCancelActionLabel())
             ->close()
             ->color('gray');
+
+        if ($this->evaluate($this->modalCancelAction, ['action' => $action]) === true) {
+            return $action;
+        }
 
         if ($this->modalCancelAction !== null) {
             $action = $this->evaluate($this->modalCancelAction, ['action' => $action]) ?? $action;


### PR DESCRIPTION
## Description

### current behaviour

I'm writing an Action and I wanted the cancel button to be shown conditionally: 

```php
Action::make('delete')
    ->form([
        TextInput::make('input')
    ])
    ->modalCancelAction(fn () => $condition)
    ->action(fn () => null);
```

if `$condition` is `false` everything works as expected and the submit button is hidden, but if `$condition` is `true` i get this error:

> Filament\Actions\MountableAction::getModalCancelAction(): Return value must be of type ?Filament\Actions\StaticAction, true returned

### expected behaviour

I expected the method to return the default cancel action.

--- 

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after. 

--> no visual changes

## Code style

- [x] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.

## Documentation

- [x] Documentation is up-to-date.
