### PR TITLE
Improvement of translation management

### DIFF
--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/Concerns/HasTranslatableFormWithExistingRecordData.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/Concerns/HasTranslatableFormWithExistingRecordData.php
@@ -20,7 +20,7 @@ trait HasTranslatableFormWithExistingRecordData
             $translatedData = [];
 
             foreach ($translatableAttributes as $attribute) {
-                $translatedData[$attribute] = $record->getTranslation($attribute, $locale, false);
+                $translatedData[$attribute] = $record->getTranslation($attribute, $locale, useFallbackLocale: false);
             }
 
             if ($locale !== $this->activeLocale) {

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/Concerns/HasTranslatableFormWithExistingRecordData.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/Concerns/HasTranslatableFormWithExistingRecordData.php
@@ -20,7 +20,7 @@ trait HasTranslatableFormWithExistingRecordData
             $translatedData = [];
 
             foreach ($translatableAttributes as $attribute) {
-                $translatedData[$attribute] = $record->getTranslation($attribute, $locale);
+                $translatedData[$attribute] = $record->getTranslation($attribute, $locale, false);
             }
 
             if ($locale !== $this->activeLocale) {

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
@@ -78,6 +78,8 @@ trait Translatable
             return;
         }
 
+        $this->resetValidation();
+
         $translatableAttributes = static::getResource()::getTranslatableAttributes();
 
         $this->otherLocaleData[$this->oldActiveLocale] = Arr::only($this->data, $translatableAttributes);

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
@@ -85,8 +85,7 @@ trait Translatable
             return;
         }
 
-        $this->form->getLivewire()->resetValidation();
-
+        $this->resetValidation();
 
         $translatableAttributes = static::getResource()::getTranslatableAttributes();
 

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
@@ -85,6 +85,9 @@ trait Translatable
             return;
         }
 
+        $this->form->getLivewire()->resetValidation();
+
+
         $translatableAttributes = static::getResource()::getTranslatableAttributes();
 
         $this->otherLocaleData[$this->oldActiveLocale] = Arr::only($this->data, $translatableAttributes);

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
@@ -34,7 +34,15 @@ trait Translatable
 
         $originalData = $this->data;
 
+        $existingLocales = null;
+
         foreach ($this->otherLocaleData as $locale => $localeData) {
+            $existingLocales ??= collect($translatableAttributes)
+                ->map(fn (string $attribute): array => array_keys($record->getTranslations($attribute)))
+                ->flatten()
+                ->unique()
+                ->all();
+
             $this->data = [
                 ...$this->data,
                 ...$localeData,
@@ -43,7 +51,13 @@ trait Translatable
             try {
                 $this->form->validate();
             } catch (ValidationException $exception) {
-                continue;
+                if (! array_key_exists($locale, $existingLocales)) {
+                    continue;
+                }
+
+                $this->setActiveLocale($locale);
+
+                throw $exception;
             }
 
             $localeData = $this->mutateFormDataBeforeSave($localeData);
@@ -65,18 +79,10 @@ trait Translatable
         $this->oldActiveLocale = $this->activeLocale;
     }
 
-    public function updatedActiveLocale(string $newActiveLocale): void
+    public function updatedActiveLocale(): void
     {
         if (blank($this->oldActiveLocale)) {
             return;
-        }
-
-        try {
-            $this->form->getLivewire()->resetValidation();
-        } catch (ValidationException $exception) {
-            $this->activeLocale = $this->oldActiveLocale;
-
-            throw $exception;
         }
 
         $translatableAttributes = static::getResource()::getTranslatableAttributes();
@@ -89,5 +95,12 @@ trait Translatable
         ];
 
         unset($this->otherLocaleData[$this->activeLocale]);
+    }
+
+    public function setActiveLocale(string $locale): void
+    {
+        $this->updatingActiveLocale();
+        $this->activeLocale = $locale;
+        $this->updatedActiveLocale();
     }
 }

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/EditRecord/Concerns/Translatable.php
@@ -72,7 +72,7 @@ trait Translatable
         }
 
         try {
-            $this->form->validate();
+            $this->form->getLivewire()->resetValidation();
         } catch (ValidationException $exception) {
             $this->activeLocale = $this->oldActiveLocale;
 

--- a/packages/spatie-laravel-translatable-plugin/src/SpatieLaravelTranslatableContentDriver.php
+++ b/packages/spatie-laravel-translatable-plugin/src/SpatieLaravelTranslatableContentDriver.php
@@ -104,7 +104,7 @@ class SpatieLaravelTranslatableContentDriver implements TranslatableContentDrive
         }
 
         foreach ($record->getTranslatableAttributes() as $attribute) {
-            $attributes[$attribute] = $record->getTranslation($attribute, $this->activeLocale);
+            $attributes[$attribute] = $record->getTranslation($attribute, $this->activeLocale, useFallbackLocale: false);
         }
 
         return $attributes;


### PR DESCRIPTION
This Pull Request improves the current logic of `filamentphp/spatie-laravel-translatable-plugin` in three ways:

1. Currently, the fallback value is returned for missing translations. Additionally, this fallback value is saved as a translation during the update process. This results as having the model translated in all languages, as it was purposefully translated. But it's not. When I save my entry with French selected via the language selector, I expect to only edit the French version, not to inject the fallback translation into all other missing translations.
This current behavior also prevents the development of a "missing translations" system, since the fallback value is saved.  

2. Furthermore, the form is validated when changing languages via the language selector. Again, wanting to change languages does not mean "wanting to save." I might want to check what translations I have in Italian to implement them in Spanish, for example. Currently, this is not possible as Filament attempts to validate upon language change.  

3.  Considering the above two points, I believe the language selector should only be an action for **displaying** the form in the desired language, and only impacting the selected language.

This logic is implemented in Statamic CMS and many others.

With this PR:
- The field is no longer populated with the fallback value. If there is no translation, the field will remain empty, as it should.
- Validation is no longer executed during a language change. It will always occur upon form submission though.