### PR TITLE
Fix to enable `data-` attributes to be parsed correctly

### DIFF
--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -101,7 +101,7 @@ if (! function_exists('Filament\Support\prepare_inherited_attributes')) {
 
         $attributes->setAttributes(
             collect($originalAttributes)
-                ->filter(fn ($value, string $name): bool => ! str($name)->startsWith('x-', 'data-'))
+                ->filter(fn ($value, string $name): bool => ! str($name)->startsWith(['x-', 'data-']))
                 ->mapWithKeys(fn ($value, string $name): array => [Str::camel($name) => $value])
                 ->merge($originalAttributes)
                 ->all(),

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -101,8 +101,7 @@ if (! function_exists('Filament\Support\prepare_inherited_attributes')) {
 
         $attributes->setAttributes(
             collect($originalAttributes)
-                ->filter(fn ($value, string $name): bool => ! str($name)->startsWith('x-'))
-                ->filter(fn ($value, string $name): bool => ! str($name)->startsWith('data-'))
+                ->filter(fn ($value, string $name): bool => ! str($name)->startsWith('x-', 'data-'))
                 ->mapWithKeys(fn ($value, string $name): array => [Str::camel($name) => $value])
                 ->merge($originalAttributes)
                 ->all(),

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -102,6 +102,7 @@ if (! function_exists('Filament\Support\prepare_inherited_attributes')) {
         $attributes->setAttributes(
             collect($originalAttributes)
                 ->filter(fn ($value, string $name): bool => ! str($name)->startsWith('x-'))
+                ->filter(fn ($value, string $name): bool => ! str($name)->startsWith('data-'))
                 ->mapWithKeys(fn ($value, string $name): array => [Str::camel($name) => $value])
                 ->merge($originalAttributes)
                 ->all(),

--- a/tests/src/Support/helpersTest.php
+++ b/tests/src/Support/helpersTest.php
@@ -16,7 +16,7 @@ it('will prepare attributes', function () {
     ]);
 });
 
-it('will prepare alpine attributes', function () {
+it('will prepare Alpine attributes', function () {
     $bag = new ComponentAttributeBag([
         'x-data' => '{foo:bar}',
     ]);

--- a/tests/src/Support/helpersTest.php
+++ b/tests/src/Support/helpersTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\View\ComponentAttributeBag;
+use function Filament\Support\prepare_inherited_attributes;
+
+it('will prepare attributes', function() {
+    $bag = new ComponentAttributeBag([
+        'style' => 'color:red'
+    ]);
+
+    $attributes = prepare_inherited_attributes($bag);
+
+    expect($attributes->getAttributes())->toBe([
+        'style' => 'color:red'
+    ]);
+});
+
+it('will prepare alpine attributes', function() {
+    $bag = new ComponentAttributeBag([
+        'x-data' => '{foo:bar}'
+    ]);
+
+    $attributes = prepare_inherited_attributes($bag);
+
+    expect($attributes->getAttributes())->toBe([
+        'x-data' => '{foo:bar}'
+    ]);
+});
+
+it('will prepare data attributes', function() {
+    $bag = new ComponentAttributeBag([
+        'data-foo' => 'bar'
+    ]);
+
+    $attributes = prepare_inherited_attributes($bag);
+
+    expect($attributes->getAttributes())->toBe([
+        'data-foo' => 'bar'
+    ]);
+});

--- a/tests/src/Support/helpersTest.php
+++ b/tests/src/Support/helpersTest.php
@@ -1,40 +1,41 @@
 <?php
 
 use Illuminate\View\ComponentAttributeBag;
+
 use function Filament\Support\prepare_inherited_attributes;
 
-it('will prepare attributes', function() {
+it('will prepare attributes', function () {
     $bag = new ComponentAttributeBag([
-        'style' => 'color:red'
+        'style' => 'color:red',
     ]);
 
     $attributes = prepare_inherited_attributes($bag);
 
     expect($attributes->getAttributes())->toBe([
-        'style' => 'color:red'
+        'style' => 'color:red',
     ]);
 });
 
-it('will prepare alpine attributes', function() {
+it('will prepare alpine attributes', function () {
     $bag = new ComponentAttributeBag([
-        'x-data' => '{foo:bar}'
+        'x-data' => '{foo:bar}',
     ]);
 
     $attributes = prepare_inherited_attributes($bag);
 
     expect($attributes->getAttributes())->toBe([
-        'x-data' => '{foo:bar}'
+        'x-data' => '{foo:bar}',
     ]);
 });
 
-it('will prepare data attributes', function() {
+it('will prepare data attributes', function () {
     $bag = new ComponentAttributeBag([
-        'data-foo' => 'bar'
+        'data-foo' => 'bar',
     ]);
 
     $attributes = prepare_inherited_attributes($bag);
 
     expect($attributes->getAttributes())->toBe([
-        'data-foo' => 'bar'
+        'data-foo' => 'bar',
     ]);
 });


### PR DESCRIPTION
## Description

Currently the following results in two attributes being output on the target element. One being incorrect:
```
TextInput('something')
   ->extraAttributes(['data-foo' => 'bar']);

//Results in...
<div...
   datafoo='bar'
   data-foo='bar'
>
```

PR includes tests for basic html attributes, alpine attributes and data attributes.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

Before PR:
![image](https://github.com/filamentphp/filament/assets/1583366/fead3f51-e76e-4fcc-bfab-8658299772ac)

After PR:
![image](https://github.com/filamentphp/filament/assets/1583366/316cc024-418a-44ae-9d71-ffad29697e94)

- [ ] `composer cs` command has been run.
- [x] Changes have been tested.
- [ ] Documentation is up-to-date.
