### PR TITLE
Allow Enums in SelectAction

### DIFF
--- a/packages/actions/src/Concerns/HasSelect.php
+++ b/packages/actions/src/Concerns/HasSelect.php
@@ -11,16 +11,16 @@ trait HasSelect
     use HasId;
 
     /**
-     * @var array<string> | Arrayable | string | Closure | null
+     * @var array<string> | Arrayable | string | Closure
      */
-    protected array | Arrayable | string | Closure | null $options = null;
+    protected array | Arrayable | string | Closure $options = [];
 
     protected ?string $placeholder = null;
 
     /**
-     * @param  array<string> | Arrayable | string | Closure | null  $options
+     * @param  array<string> | Arrayable | string | Closure  $options
      */
-    public function options(array | Arrayable | string | Closure | null $options): static
+    public function options(array | Arrayable | string | Closure $options): static
     {
         $this->options = $options;
 

--- a/packages/actions/src/Concerns/HasSelect.php
+++ b/packages/actions/src/Concerns/HasSelect.php
@@ -11,16 +11,16 @@ trait HasSelect
     use HasId;
 
     /**
-     * @var array<string> | Arrayable | string | Closure
+     * @var array<string | array<string>> | Arrayable | string | Closure | null
      */
-    protected array | Arrayable | string | Closure $options = [];
+    protected array | Arrayable | string | Closure | null $options = null;
 
     protected ?string $placeholder = null;
 
     /**
-     * @param  array<string> | Arrayable | Closure  $options
+     * @param  array<string | array<string>> | Arrayable | string | Closure | null  $options
      */
-    public function options(array | Arrayable | Closure $options): static
+    public function options(array | Arrayable | string | Closure | null $options): static
     {
         $this->options = $options;
 
@@ -35,11 +35,11 @@ trait HasSelect
     }
 
     /**
-     * @return array<string>
+     * @return array<string | array<string>>
      */
     public function getOptions(): array
     {
-        $options = $this->evaluate($this->options);
+        $options = $this->evaluate($this->options) ?? [];
 
         $enum = $options;
         if (

--- a/packages/actions/src/Concerns/HasSelect.php
+++ b/packages/actions/src/Concerns/HasSelect.php
@@ -11,14 +11,14 @@ trait HasSelect
     use HasId;
 
     /**
-     * @var array<string | array<string>> | Arrayable | string | Closure | null
+     * @var array<string> | Arrayable | string | Closure | null
      */
     protected array | Arrayable | string | Closure | null $options = null;
 
     protected ?string $placeholder = null;
 
     /**
-     * @param  array<string | array<string>> | Arrayable | string | Closure | null  $options
+     * @param  array<string> | Arrayable | string | Closure | null  $options
      */
     public function options(array | Arrayable | string | Closure | null $options): static
     {
@@ -35,7 +35,7 @@ trait HasSelect
     }
 
     /**
-     * @return array<string | array<string>>
+     * @return array<string>
      */
     public function getOptions(): array
     {


### PR DESCRIPTION
When creating a select action, i expected the options to support the same notation with Enums as the SelectField in the forms package, but it seems that's not the case.

I copied the code from the forms package to the actions package to allow the same usage. Maybe it could be a shared Support trait? Seems to be basically the same :)

Let me know if i should change anything!


