### PR TITLE
Add custom class for top bar expand and collapse buttons

### DIFF
--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -27,7 +27,7 @@
                 x-on:click="$store.sidebar.open()"
                 x-show="! $store.sidebar.isOpen"
                 @class([
-                    'fi-topbar-open-sidebar-button',
+                    'fi-topbar-open-sidebar-btn',
                     'lg:hidden' => (! filament()->isSidebarFullyCollapsibleOnDesktop()) || filament()->isSidebarCollapsibleOnDesktop(),
                 ])
             />

--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -27,6 +27,7 @@
                 x-on:click="$store.sidebar.open()"
                 x-show="! $store.sidebar.isOpen"
                 @class([
+                    'fi-topbar-open-sidebar-button',
                     'lg:hidden' => (! filament()->isSidebarFullyCollapsibleOnDesktop()) || filament()->isSidebarCollapsibleOnDesktop(),
                 ])
             />
@@ -41,7 +42,7 @@
                 x-data="{}"
                 x-on:click="$store.sidebar.close()"
                 x-show="$store.sidebar.isOpen"
-                class="lg:hidden"
+                class="fi-topbar-close-sidebar-button lg:hidden"
             />
         @endif
 

--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -42,7 +42,7 @@
                 x-data="{}"
                 x-on:click="$store.sidebar.close()"
                 x-show="$store.sidebar.isOpen"
-                class="fi-topbar-close-sidebar-button lg:hidden"
+                class="fi-topbar-close-sidebar-btn lg:hidden"
             />
         @endif
 


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

I want to be able to add some custom css styles for expand and collapse buttons but I face an issue that only one custom class exist for both Expand, Collapse and Open notifications buttons `fi-icon-btn`

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
