### PR TITLE
Allow individual logout for each of the panels v2

### DIFF
--- a/packages/panels/src/Http/Controllers/Auth/LogoutController.php
+++ b/packages/panels/src/Http/Controllers/Auth/LogoutController.php
@@ -11,13 +11,14 @@ class LogoutController
     {
         Filament::auth()->logout();
 
-        $count = collect(session()->all())->filter(function ($value, $key) {
-            return strpos($key, 'login_') === 0;
-        })->count();
+        $logins = array_filter(
+            array_keys(session()->all()),
+            fn (string $key): bool => str($key)->startsWith('login_'),
+        );
 
-        ($count == 1)
-            ? session()->invalidate()
-            : session()->migrate();        
+        (count($logins) < 2) ?
+            session()->invalidate() :
+            session()->migrate();
         
         session()->regenerateToken();
 

--- a/packages/panels/src/Http/Controllers/Auth/LogoutController.php
+++ b/packages/panels/src/Http/Controllers/Auth/LogoutController.php
@@ -11,8 +11,13 @@ class LogoutController
     {
         Filament::auth()->logout();
 
-        session()->invalidate();
-        session()->regenerateToken();
+        $count = collect(session()->all())->filter(function ($value, $key) {
+            return strpos($key, 'login_') === 0;
+        })->count();
+
+        ($count == 1)
+            ? session()->invalidate()
+            : session()->migrate();        session()->regenerateToken();
 
         return app(LogoutResponse::class);
     }

--- a/packages/panels/src/Http/Controllers/Auth/LogoutController.php
+++ b/packages/panels/src/Http/Controllers/Auth/LogoutController.php
@@ -17,7 +17,9 @@ class LogoutController
 
         ($count == 1)
             ? session()->invalidate()
-            : session()->migrate();        session()->regenerateToken();
+            : session()->migrate();        
+        
+        session()->regenerateToken();
 
         return app(LogoutResponse::class);
     }

--- a/packages/panels/src/Http/Controllers/Auth/LogoutController.php
+++ b/packages/panels/src/Http/Controllers/Auth/LogoutController.php
@@ -19,7 +19,7 @@ class LogoutController
         (count($logins) < 2) ?
             session()->invalidate() :
             session()->migrate();
-        
+
         session()->regenerateToken();
 
         return app(LogoutResponse::class);


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

Since version 3.x allows to manage several panels from the same installation, the lines to destroy the user session when logging out do not make sense.

Because when logging out from one of the panels is done automatically from the rest.

This PR is related with #10372 with a logic to detect if the user has more than one logedin panels
- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
