### PR TITLE
Add hooks above and below the topbar

### DIFF
--- a/packages/panels/resources/views/components/layout/index.blade.php
+++ b/packages/panels/resources/views/components/layout/index.blade.php
@@ -43,7 +43,11 @@
                 'flex' => filament()->hasTopNavigation() || (! filament()->hasNavigation()),
             ])
         >
+            {{ \Filament\Support\Facades\FilamentView::renderHook('panels::before.topbar') }}
+            
             <x-filament-panels::topbar :navigation="$navigation" />
+
+            {{ \Filament\Support\Facades\FilamentView::renderHook('panels::after.topbar') }}
 
             <main
                 @class([

--- a/packages/panels/resources/views/components/layout/index.blade.php
+++ b/packages/panels/resources/views/components/layout/index.blade.php
@@ -43,11 +43,11 @@
                 'flex' => filament()->hasTopNavigation() || (! filament()->hasNavigation()),
             ])
         >
-            {{ \Filament\Support\Facades\FilamentView::renderHook('panels::before.topbar') }}
+            {{ \Filament\Support\Facades\FilamentView::renderHook('panels::topbar.before') }}
             
             <x-filament-panels::topbar :navigation="$navigation" />
 
-            {{ \Filament\Support\Facades\FilamentView::renderHook('panels::after.topbar') }}
+            {{ \Filament\Support\Facades\FilamentView::renderHook('panels::topbar.after') }}
 
             <main
                 @class([

--- a/packages/support/docs/06-render-hooks.md
+++ b/packages/support/docs/06-render-hooks.md
@@ -74,8 +74,8 @@ FilamentView::registerRenderHook(
 - `panels::styles.before` - Before styles are defined
 - `panels::tenant-menu.after` - After the [tenant menu](../panels/tenancy#customizing-the-tenant-menu)
 - `panels::tenant-menu.before` - Before the [tenant menu](../panels/tenancy#customizing-the-tenant-menu)
-- `panels::before.topbar` - Above the topbar
-- `panels::after.topbar` - Below the topbar
+- `panels::topbar.after` - Below the topbar
+- `panels::topbar.before` - Above the topbar
 - `panels::topbar.end` - End of the topbar container
 - `panels::topbar.start` - Start of the topbar container
 - `panels::user-menu.after` - After the [user menu](../panels/navigation#customizing-the-user-menu)

--- a/packages/support/docs/06-render-hooks.md
+++ b/packages/support/docs/06-render-hooks.md
@@ -74,6 +74,8 @@ FilamentView::registerRenderHook(
 - `panels::styles.before` - Before styles are defined
 - `panels::tenant-menu.after` - After the [tenant menu](../panels/tenancy#customizing-the-tenant-menu)
 - `panels::tenant-menu.before` - Before the [tenant menu](../panels/tenancy#customizing-the-tenant-menu)
+- `panels::before.topbar` - Above the topbar
+- `panels::after.topbar` - Below the topbar
 - `panels::topbar.end` - End of the topbar container
 - `panels::topbar.start` - Start of the topbar container
 - `panels::user-menu.after` - After the [user menu](../panels/navigation#customizing-the-user-menu)


### PR DESCRIPTION
## Description

in my case I prefer to be able to add some custom components above or below the topbar such as **announcement-bar**.

<img width="1719" alt="Screenshot 2023-12-20 at 15 41 52" src="https://github.com/filamentphp/filament/assets/121255432/cacc3ccc-0397-4693-988c-921a0444d546">

<img width="1719" alt="Screenshot 2023-12-20 at 15 42 04" src="https://github.com/filamentphp/filament/assets/121255432/75f0104a-09df-4cef-b5b4-b6be6782b43d">


- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.

## Documentation

- [x] Documentation is up-to-date.
