### PR TITLE
Fix overflowing images

### DIFF
--- a/packages/infolists/resources/views/components/image-entry.blade.php
+++ b/packages/infolists/resources/views/components/image-entry.blade.php
@@ -53,7 +53,7 @@
         @if (count($limitedState))
             <div
                 @class([
-                    'flex',
+                    'flex flex-wrap',
                     match ($overlap) {
                         0 => null,
                         1 => '-space-x-1',
@@ -64,7 +64,7 @@
                         6 => '-space-x-6',
                         7 => '-space-x-7',
                         8 => '-space-x-8',
-                        default => 'gap-x-1.5',
+                        default => 'gap-1.5',
                     },
                 ])
             >


### PR DESCRIPTION
## Description

This PR addresses an issue where multiple images displayed through `SpatieMediaLibraryImageEntry` were overflowing the container. To fix this, I have added `﻿flex-wrap` to allow the images to wrap within the container and prevented them from overflowing. Additionally, I have replaced ﻿`gap-x-1.5` with `﻿gap-1.5` to adjust the horizontal spacing between the images.

- [x] Visual changes

Before:
![screenshot-1](https://github.com/filamentphp/filament/assets/44904418/ccf096d7-f1e3-4a91-a4e1-68e358002bcb)
After:
![screenshot-2](https://github.com/filamentphp/filament/assets/44904418/4d5b817b-8f9f-4e5c-9f3f-c813d2c8352c)


## Code style

- [ ] `composer cs` command has been run.

## Testing

This Pull Request, focused on visual changes, does not require any modifications to the tests.

- [ ] Changes have been tested.

## Documentation

There is no need to change documentation.

- [x] Documentation is up-to-date.
