### PR TITLE
Add fix-overflowing-images support to Table ImageColumn

### DIFF
--- a/packages/tables/docs/03-columns/03-icon.md
+++ b/packages/tables/docs/03-columns/03-icon.md
@@ -99,3 +99,17 @@ IconColumn::make('is_featured')
 ```
 
 <AutoScreenshot name="tables/columns/icon/boolean-color" alt="Icon column to display a boolean with custom colors" version="3.x" />
+
+## Wrapping the icons
+
+When displaying multiple icons, they can be set to wrap if they can't fit on one line, using `wrap()`:
+
+```php
+use Filament\Tables\Columns\IconColumn;
+
+IconColumn::make('icon')
+    ->wrap()
+```
+
+Note: the "width" for wrapping is affected by the column label, so you may need to use a shorter or hidden label to wrap more tightly.
+

--- a/packages/tables/docs/03-columns/03-icon.md
+++ b/packages/tables/docs/03-columns/03-icon.md
@@ -100,7 +100,7 @@ IconColumn::make('is_featured')
 
 <AutoScreenshot name="tables/columns/icon/boolean-color" alt="Icon column to display a boolean with custom colors" version="3.x" />
 
-## Wrapping the icons
+## Wrapping multiple icons
 
 When displaying multiple icons, they can be set to wrap if they can't fit on one line, using `wrap()`:
 

--- a/packages/tables/docs/03-columns/04-image.md
+++ b/packages/tables/docs/03-columns/04-image.md
@@ -131,7 +131,7 @@ ImageColumn::make('colleagues.avatar')
 
 ## Wrapping the images
 
-When displaying the table as a Grid, images can be set to wrap if they can't fit on one line, using `wrap()`:
+Images can be set to wrap if they can't fit on one line, by setting `wrap()`:
 
 ```php
 use Filament\Tables\Columns\ImageColumn;

--- a/packages/tables/docs/03-columns/04-image.md
+++ b/packages/tables/docs/03-columns/04-image.md
@@ -129,7 +129,7 @@ ImageColumn::make('colleagues.avatar')
     ->overlap(2)
 ```
 
-## Wrapping the images
+## Wrapping multiple images
 
 Images can be set to wrap if they can't fit on one line, by setting `wrap()`:
 

--- a/packages/tables/docs/03-columns/04-image.md
+++ b/packages/tables/docs/03-columns/04-image.md
@@ -129,6 +129,19 @@ ImageColumn::make('colleagues.avatar')
     ->overlap(2)
 ```
 
+## Wrapping the images
+
+When displaying the table as a Grid, images can be set to wrap if they can't fit on one line, using `wrap()`:
+
+```php
+use Filament\Tables\Columns\ImageColumn;
+
+ImageColumn::make('colleagues.avatar')
+    ->circular()
+    ->stacked()
+    ->wrap()
+```
+
 ## Setting a limit
 
 You may limit the maximum number of images you want to display by passing `limit()`:

--- a/packages/tables/docs/03-columns/04-image.md
+++ b/packages/tables/docs/03-columns/04-image.md
@@ -142,6 +142,8 @@ ImageColumn::make('colleagues.avatar')
     ->wrap()
 ```
 
+Note: the "width" for wrapping is affected by the column label, so you may need to use a shorter or hidden label to wrap more tightly.
+
 ## Setting a limit
 
 You may limit the maximum number of images you want to display by passing `limit()`:

--- a/packages/tables/docs/03-columns/05-color.md
+++ b/packages/tables/docs/03-columns/05-color.md
@@ -52,3 +52,17 @@ ColorColumn::make('color')
     ->copyable()
     ->copyableState(fn (Post $record): string => "Color: {$record->color}")
 ```
+
+## Wrapping multiple color blocks
+
+Color blocks can be set to wrap if they can't fit on one line, by setting `wrap()`:
+
+```php
+use Filament\Tables\Columns\ColorColumn;
+
+ColorColumn::make('color')
+    ->wrap()
+```
+
+Note: the "width" for wrapping is affected by the column label, so you may need to use a shorter or hidden label to wrap more tightly.
+

--- a/packages/tables/resources/views/columns/color-column.blade.php
+++ b/packages/tables/resources/views/columns/color-column.blade.php
@@ -1,9 +1,13 @@
+@php
+    $canWrap = $canWrap();
+@endphp
 <div
     {{
         $attributes
             ->merge($getExtraAttributes(), escape: false)
             ->class([
-                'fi-ta-color flex flex-wrap gap-1.5',
+                'fi-ta-color flex gap-1.5',
+                'flex-wrap' => $canWrap,
                 'px-3 py-4' => ! $isInline(),
             ])
     }}

--- a/packages/tables/resources/views/columns/icon-column.blade.php
+++ b/packages/tables/resources/views/columns/icon-column.blade.php
@@ -1,5 +1,7 @@
 @php
     use Filament\Tables\Columns\IconColumn\IconColumnSize;
+
+    $canWrap = $canWrap();
 @endphp
 
 <div
@@ -7,7 +9,8 @@
         $attributes
             ->merge($getExtraAttributes(), escape: false)
             ->class([
-                'fi-ta-icon flex flex-wrap gap-1.5',
+                'fi-ta-icon flex gap-1.5',
+                'flex-wrap' => $canWrap,
                 'px-3 py-4' => ! $isInline(),
                 'flex-col' => $isListWithLineBreaks(),
             ])

--- a/packages/tables/resources/views/columns/image-column.blade.php
+++ b/packages/tables/resources/views/columns/image-column.blade.php
@@ -7,6 +7,7 @@
     $isStacked = $isStacked();
     $overlap = $isStacked ? ($getOverlap() ?? 2) : null;
     $ring = $isStacked ? ($getRing() ?? 2) : null;
+    $canWrap = $canWrap();
     $height = $getHeight() ?? ($isStacked ? '2rem' : '2.5rem');
     $width = $getWidth() ?? (($isCircular || $isSquare) ? $height : null);
 
@@ -55,6 +56,7 @@
             <div
                 @class([
                     'flex',
+                    'flex-wrap' => $canWrap,
                     match ($overlap) {
                         0 => null,
                         1 => '-space-x-1',
@@ -65,7 +67,7 @@
                         6 => '-space-x-6',
                         7 => '-space-x-7',
                         8 => '-space-x-8',
-                        default => 'gap-x-1.5',
+                        default => 'gap-1.5',
                     },
                 ])
             >

--- a/packages/tables/src/Columns/ColorColumn.php
+++ b/packages/tables/src/Columns/ColorColumn.php
@@ -5,6 +5,7 @@ namespace Filament\Tables\Columns;
 class ColorColumn extends Column
 {
     use Concerns\CanBeCopied;
+    use Concerns\CanWrap;
 
     /**
      * @var view-string

--- a/packages/tables/src/Columns/Concerns/CanWrap.php
+++ b/packages/tables/src/Columns/Concerns/CanWrap.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Filament\Tables\Columns\Concerns;
+
+use Closure;
+
+trait CanWrap
+{
+    protected bool | Closure $wrap = false;
+
+    public function wrap(bool | Closure $condition = true): static
+    {
+        $this->wrap = $condition;
+
+        return $this;
+    }
+
+    public function canWrap(): ?bool
+    {
+        return (bool) $this->evaluate($this->wrap);
+    }
+}

--- a/packages/tables/src/Columns/IconColumn.php
+++ b/packages/tables/src/Columns/IconColumn.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Support\Arrayable;
 
 class IconColumn extends Column
 {
+    use Concerns\CanWrap;
     use Concerns\HasColor {
         getColor as getBaseColor;
     }

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -12,6 +12,8 @@ use Throwable;
 
 class ImageColumn extends Column
 {
+    use Concerns\CanWrap;
+
     /**
      * @var view-string
      */


### PR DESCRIPTION
## Description

Extends #10415 "Fix overflowing images" on infolists (from Filament v3.1.25) by (optionally) adding `flex-wrap` to table image column as well.

While not enabled by default, this PR adds the `->wrap(true)` option to enable the wrapping.

When a table is displayed as a normal table, one will probably want to use limit() instead of wrapping, else images will stack vertically. However, when a table is displayed in a grid, using `wrap(true)` will pleasantly display the images, instead of overflowing out of bounds.

Doesn't interfere with existing `stacked`/`overlay`/`limit`/etc features.

**Grid Table:**

Before:
<img width="667" alt="Screen Shot 2023-12-21 at 1 39 37 PM" src="https://github.com/filamentphp/filament/assets/404472/c4b8dddb-244a-4c5c-9e69-406e2bc69931">

After adding `wrap()`:
<img width="604" alt="Screen Shot 2023-12-21 at 1 39 15 PM" src="https://github.com/filamentphp/filament/assets/404472/ea1d636f-f39b-43f1-b6e4-66256cf8818c">

**Normal Table:**
Before:
<img width="1153" alt="Screen Shot 2023-12-21 at 1 54 27 PM" src="https://github.com/filamentphp/filament/assets/404472/eccdd949-9de8-4056-aac4-a971b4512e6d">

After adding `wrap()` (obviously not everyone will want multiple lines, so they can still use `limit()` instead)
<img width="1089" alt="Screen Shot 2023-12-21 at 1 55 10 PM" src="https://github.com/filamentphp/filament/assets/404472/db8ebd5f-c53d-49d8-b131-cd80b56487d3">

Caveat:
If one adds `wrap()` to a normal row-based table, the images will stack:
<img width="248" alt="Screen Shot 2023-12-21 at 3 09 52 PM" src="https://github.com/filamentphp/filament/assets/404472/cfbe06aa-350a-49f2-8aa3-99f2ef6fa332">


- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

- [x] Make sure code style follows the rest of the codebase.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation updates included
