### PR TITLE
Utility injection in CanBeValidated@rules

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -420,7 +420,7 @@ trait CanBeValidated
     /**
      * @param  string | array<mixed>  $rules
      */
-    public function rules(Closure | string | array $rules, bool | Closure $condition = true): static
+    public function rules(string | array | Closure $rules, bool | Closure $condition = true): static
     {
         $rules = $this->evaluate($rules);
         

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -420,8 +420,10 @@ trait CanBeValidated
     /**
      * @param  string | array<mixed>  $rules
      */
-    public function rules(string | array $rules, bool | Closure $condition = true): static
+    public function rules(Closure | string | array $rules, bool | Closure $condition = true): static
     {
+        $rules = $this->evaluate($rules);
+        
         if (is_string($rules)) {
             $rules = explode('|', $rules);
         }


### PR DESCRIPTION
## Description

This pr aims to allow utility injection in CanBeValidated@rules, since I need it for a couple of edge cases (I need to make the same db query for a bunch of custom rules, so that by using utility injection on every single rule, that would be repeated). It is working well in my tests, if it pass your further scrutiny let me know if I should somehow mention this feature in the docs as well ([here](https://filamentphp.com/docs/3.x/forms/validation#custom-rules)).
Thanks.

## Code style

- [x ] `composer cs` command has been run.

## Testing

- [ x] Changes have been tested.

## Documentation

- [ ] Documentation is up-to-date.
