### PR TITLE
fix: Use Laravel's email verification request

### DIFF
--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -72,8 +72,8 @@ Route::name('filament.')
                                         ->prefix('/email-verification')
                                         ->group(function () use ($panel) {
                                             Route::get('/prompt', $panel->getEmailVerificationPromptRouteAction())->name('prompt');
-                                            Route::get('/verify', EmailVerificationController::class)
-                                                ->middleware(['signed'])
+                                            Route::get('/verify/{id}/{hash}', EmailVerificationController::class)
+                                                ->middleware(['signed', 'throttle:6,1'])
                                                 ->name('verify');
                                         });
                                 }

--- a/packages/panels/src/Http/Controllers/Auth/EmailVerificationController.php
+++ b/packages/panels/src/Http/Controllers/Auth/EmailVerificationController.php
@@ -6,17 +6,13 @@ use Filament\Facades\Filament;
 use Filament\Http\Responses\Auth\Contracts\EmailVerificationResponse;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Foundation\Auth\EmailVerificationRequest;
 
 class EmailVerificationController
 {
-    public function __invoke(): EmailVerificationResponse
+    public function __invoke(EmailVerificationRequest $request): EmailVerificationResponse
     {
-        /** @var MustVerifyEmail $user */
-        $user = Filament::auth()->user();
-
-        if ((! $user->hasVerifiedEmail()) && $user->markEmailAsVerified()) {
-            event(new Verified($user));
-        }
+        $request->fulfill();
 
         return app(EmailVerificationResponse::class);
     }

--- a/tests/src/Panels/Auth/EmailVerification/EmailVerificationTest.php
+++ b/tests/src/Panels/Auth/EmailVerification/EmailVerificationTest.php
@@ -22,3 +22,24 @@ it('can verify an email', function () {
     expect($userToVerify->refresh())
         ->hasVerifiedEmail()->toBeTrue();
 });
+
+it('cannot verify an email when signed in as another user', function () {
+    $userToVerify = User::factory()->create([
+        'email_verified_at' => null,
+    ]);
+
+    $anotherUser = User::factory()->create([
+        'email_verified_at' => null,
+    ]);
+
+    expect($anotherUser)
+        ->hasVerifiedEmail()->toBeFalse();
+
+    $this
+        ->actingAs($anotherUser)
+        ->get(Filament::getVerifyEmailUrl($userToVerify))
+        ->assertForbidden();
+
+    expect($anotherUser->refresh())
+        ->hasVerifiedEmail()->toBeFalse();
+});


### PR DESCRIPTION
Now, Filament uses Laravel's built-in email verification request authorization, to ensure that the currently authenticated user is the one that received the verification URL.