### PR TITLE
Add max / min validation rules

### DIFF
--- a/packages/forms/docs/05-validation.md
+++ b/packages/forms/docs/05-validation.md
@@ -277,6 +277,22 @@ The field must be a MAC address. [See the Laravel documentation.](https://larave
 Field::make('mac_address')->macAddress()
 ```
 
+### Max
+
+The field must be less than or equal to a maximum value. [See the Laravel documentation.](https://laravel.com/docs/9.x/validation#rule-max)
+
+```php
+Field::make('name')->max(125)
+```
+
+### Min
+
+The field must have a minimum value. [See the Laravel documentation.](https://laravel.com/docs/9.x/validation#rule-min)
+
+```php
+Field::make('name')->min(3)
+```
+
 ### Multiple Of
 
 The field must be a multiple of value. [See the Laravel documentation.](https://laravel.com/docs/validation#multiple-of)

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -240,6 +240,7 @@ trait CanBeValidated
 
         return $this;
     }
+
     public function max(int | Closure $value): static
     {
         $this->rule(static function (Field $component) use ($value) {

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -240,6 +240,23 @@ trait CanBeValidated
 
         return $this;
     }
+    public function max(int | Closure $value): static
+    {
+        $this->rule(static function (Field $component) use ($value) {
+            return 'max:' . $component->evaluate($value);
+        }, static fn (Field $component): bool => filled($component->evaluate($value)));
+
+        return $this;
+    }
+
+    public function min(int | Closure $value): static
+    {
+        $this->rule(static function (Field $component) use ($value) {
+            return 'min:' . $component->evaluate($value);
+        }, static fn (Field $component): bool => filled($component->evaluate($value)));
+
+        return $this;
+    }
 
     public function multipleOf(int | Closure $value): static
     {

--- a/tests/src/Forms/ValidationTest.php
+++ b/tests/src/Forms/ValidationTest.php
@@ -129,6 +129,83 @@ test('fields can be required unless', function () {
         ->toContain('The two field is required unless one is in foo.');
 });
 
+test('fields can have max chars', function () {
+    $rules = [];
+
+    $fieldName = Str::random();
+
+    $component = Livewire::make()->data([$fieldName => 'max chars exceeded']);
+
+    try {
+        ComponentContainer::make($component)
+            ->statePath('data')
+            ->components([
+                $field = (new Field($fieldName))
+                    ->max(3),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+
+        $rules = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    expect($rules)
+        ->toContain('Max');
+});
+
+test('max value as closure', function (){
+    $rules = [];
+
+    $fieldName = Str::random();
+
+    $component = Livewire::make()->data([$fieldName => 'max chars exceeded']);
+
+    try {
+        ComponentContainer::make($component)
+            ->statePath('data')
+            ->components([
+                $field = (new Field($fieldName))
+                    ->max(function () {
+                        return '6';
+                    }),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $rules = $exception->validator->failed()[$field->getStatePath()];
+    }
+
+    expect($rules)
+        ->toHaveKey('Max');
+    expect($rules['Max'][0])
+        ->toBe('6');
+
+});
+
+test('fields can have min chars', function () {
+    $rules = [];
+
+
+    $fieldName = Str::random();
+
+    $component = Livewire::make()->data([$fieldName => 'min chars required']);
+
+    try {
+        ComponentContainer::make($component)
+            ->statePath('data')
+            ->components([
+                $field = (new Field($fieldName))
+                    ->min(30),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+
+        $rules = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    expect($rules)
+        ->toContain('Min');
+});
+
 test('the `in()` rule behaves the same as Laravel\'s', function (?string $input, array | Arrayable | string | Closure $allowed) {
     $filamentFails = [];
 

--- a/tests/src/Forms/ValidationTest.php
+++ b/tests/src/Forms/ValidationTest.php
@@ -153,7 +153,7 @@ test('fields can have max chars', function () {
         ->toContain('Max');
 });
 
-test('max value as closure', function (){
+test('max value as closure', function () {
     $rules = [];
 
     $fieldName = Str::random();
@@ -183,7 +183,6 @@ test('max value as closure', function (){
 
 test('fields can have min chars', function () {
     $rules = [];
-
 
     $fieldName = Str::random();
 


### PR DESCRIPTION
## Description

This pr adds min - max laravel rules to filament field rules

you can now validate the max/min values of a field like

```php
TextInput::make('name')->max(10) //check for max chars allowed
TextInput::make('name')->min(3) // check for min chars allowed
TextInput::make('name')->min(function () use ($calculatedValue) {
                    return $calculatedValue;
                })  

FileUpload::make('avatar')->max(3072) // checks for max size allowed in kb
FileUpload::make('avatar')->min(1024) // checks for max size allowed in kb
```


## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.