### PR TITLE
Use wire:navigate when redirecting

### DIFF
--- a/packages/actions/src/Concerns/CanRedirect.php
+++ b/packages/actions/src/Concerns/CanRedirect.php
@@ -4,6 +4,7 @@ namespace Filament\Actions\Concerns;
 
 use Closure;
 use Filament\Support\Facades\FilamentView;
+
 use function Filament\Support\is_app_url;
 
 trait CanRedirect

--- a/packages/actions/src/Concerns/CanRedirect.php
+++ b/packages/actions/src/Concerns/CanRedirect.php
@@ -3,6 +3,7 @@
 namespace Filament\Actions\Concerns;
 
 use Closure;
+use Filament\Support\Facades\FilamentView;
 
 trait CanRedirect
 {
@@ -34,7 +35,7 @@ trait CanRedirect
 
     public function redirect(string | Closure $url): void
     {
-        $this->getLivewire()->redirect($this->evaluate($url));
+        $this->getLivewire()->redirect($this->evaluate($url), navigate: FilamentView::hasSpaMode());
     }
 
     public function failureRedirectUrl(string | Closure | null $url): static

--- a/packages/actions/src/Concerns/CanRedirect.php
+++ b/packages/actions/src/Concerns/CanRedirect.php
@@ -4,6 +4,7 @@ namespace Filament\Actions\Concerns;
 
 use Closure;
 use Filament\Support\Facades\FilamentView;
+use function Filament\Support\is_app_url;
 
 trait CanRedirect
 {
@@ -35,7 +36,9 @@ trait CanRedirect
 
     public function redirect(string | Closure $url): void
     {
-        $this->getLivewire()->redirect($this->evaluate($url), navigate: FilamentView::hasSpaMode());
+        $url = $this->evaluate($url);
+
+        $this->getLivewire()->redirect($url, navigate: FilamentView::hasSpaMode() && is_app_url($url));
     }
 
     public function failureRedirectUrl(string | Closure | null $url): static

--- a/packages/panels/src/Pages/Auth/EditProfile.php
+++ b/packages/panels/src/Pages/Auth/EditProfile.php
@@ -16,6 +16,7 @@ use Filament\Pages\SimplePage;
 use Filament\Panel;
 use Filament\Support\Enums\Alignment;
 use Filament\Support\Exceptions\Halt;
+use Filament\Support\Facades\FilamentView;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
@@ -23,6 +24,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Validation\Rules\Password;
+use function Filament\Support\is_app_url;
 
 /**
  * @property Form $form
@@ -147,7 +149,7 @@ class EditProfile extends SimplePage
         $this->getSavedNotification()?->send();
 
         if ($redirectUrl = $this->getRedirectUrl()) {
-            $this->redirect($redirectUrl);
+            $this->redirect($redirectUrl, navigate: FilamentView::hasSpaMode() && is_app_url($redirectUrl));
         }
     }
 

--- a/packages/panels/src/Pages/Auth/EditProfile.php
+++ b/packages/panels/src/Pages/Auth/EditProfile.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Validation\Rules\Password;
+
 use function Filament\Support\is_app_url;
 
 /**

--- a/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
+++ b/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
@@ -11,6 +11,7 @@ use Filament\Pages\Concerns;
 use Filament\Pages\Page;
 use Filament\Panel;
 use Filament\Support\Exceptions\Halt;
+use Filament\Support\Facades\FilamentView;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
@@ -19,6 +20,7 @@ use Illuminate\Support\Facades\Route;
 use Livewire\Attributes\Locked;
 
 use function Filament\authorize;
+use function Filament\Support\is_app_url;
 
 /**
  * @property Form $form
@@ -132,7 +134,7 @@ abstract class EditTenantProfile extends Page
         $this->getSavedNotification()?->send();
 
         if ($redirectUrl = $this->getRedirectUrl()) {
-            $this->redirect($redirectUrl);
+            $this->redirect($redirectUrl, navigate: FilamentView::hasSpaMode() && is_app_url($redirectUrl));
         }
     }
 

--- a/packages/panels/src/Pages/Tenancy/RegisterTenant.php
+++ b/packages/panels/src/Pages/Tenancy/RegisterTenant.php
@@ -11,6 +11,7 @@ use Filament\Pages\Concerns\InteractsWithFormActions;
 use Filament\Pages\SimplePage;
 use Filament\Panel;
 use Filament\Support\Exceptions\Halt;
+use Filament\Support\Facades\FilamentView;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
@@ -18,6 +19,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Route;
 
 use function Filament\authorize;
+use function Filament\Support\is_app_url;
 
 /**
  * @property Form $form
@@ -101,7 +103,7 @@ abstract class RegisterTenant extends SimplePage
         }
 
         if ($redirectUrl = $this->getRedirectUrl()) {
-            $this->redirect($redirectUrl);
+            $this->redirect($redirectUrl, navigate: FilamentView::hasSpaMode() && is_app_url($redirectUrl));
         }
     }
 

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -107,11 +107,7 @@ class CreateRecord extends Page
 
         $redirectUrl = $this->getRedirectUrl();
 
-        if (FilamentView::hasSpaMode()) {
-            $this->redirect($redirectUrl, navigate: is_app_url($redirectUrl));
-        } else {
-            $this->redirect($redirectUrl);
-        }
+        $this->redirect($redirectUrl, navigate: FilamentView::hasSpaMode() && is_app_url($redirectUrl));
     }
 
     protected function getCreatedNotification(): ?Notification

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -148,11 +148,7 @@ class EditRecord extends Page
         $this->getSavedNotification()?->send();
 
         if ($shouldRedirect && ($redirectUrl = $this->getRedirectUrl())) {
-            if (FilamentView::hasSpaMode()) {
-                $this->redirect($redirectUrl, navigate: is_app_url($redirectUrl));
-            } else {
-                $this->redirect($redirectUrl);
-            }
+            $this->redirect($redirectUrl, navigate: FilamentView::hasSpaMode() && is_app_url($redirectUrl));
         }
     }
 

--- a/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
+++ b/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
@@ -9,6 +9,7 @@ use Filament\Forms\Form;
 use Filament\Notifications\Notification;
 use Filament\Support\Exceptions\Halt;
 use Filament\Support\Facades\FilamentView;
+
 use function Filament\Support\is_app_url;
 
 /**

--- a/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
+++ b/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
@@ -8,6 +8,8 @@ use Filament\Forms\ComponentContainer;
 use Filament\Forms\Form;
 use Filament\Notifications\Notification;
 use Filament\Support\Exceptions\Halt;
+use Filament\Support\Facades\FilamentView;
+use function Filament\Support\is_app_url;
 
 /**
  * @property ComponentContainer $form
@@ -78,7 +80,7 @@ class SettingsPage extends Page
         $this->getSavedNotification()?->send();
 
         if ($redirectUrl = $this->getRedirectUrl()) {
-            $this->redirect($redirectUrl);
+            $this->redirect($redirectUrl, navigate: FilamentView::hasSpaMode() && is_app_url($redirectUrl));
         }
     }
 


### PR DESCRIPTION
## Description

When you edit a resource, click the delete button, and confirm you are redirected using a full page redirect. This PR will set `navigate` to `true` based on `FilamentView::hasSpaMode()`.


## Testing
- [x] Changes have been tested.