### PR TITLE
Can use Apply button for filters (need help)

### DIFF
--- a/packages/tables/docs/04-filters/01-getting-started.md
+++ b/packages/tables/docs/04-filters/01-getting-started.md
@@ -154,6 +154,18 @@ TernaryFilter::make('trashed')
     ]))
 ```
 
+## Use Apply filters button
+
+By default, every filter update will run its corresponding query instantly. However, you may use `useApplyFiltersButton()` method to prevent all queries until user clicks the `Apply filters` button:
+
+```php
+$table
+    ->filters([
+        // ...
+    ])
+    ->useApplyFiltersButton();
+```
+
 ## Customizing the filters trigger action
 
 To customize the filters trigger buttons, you may use the `filtersTriggerAction()` method, passing a closure that returns an action. All methods that are available to [customize action trigger buttons](../../actions/trigger-button) can be used:

--- a/packages/tables/resources/lang/en/table.php
+++ b/packages/tables/resources/lang/en/table.php
@@ -113,6 +113,10 @@ return [
 
         'actions' => [
 
+            'apply' => [
+                'label' => 'Apply filters',
+            ],
+
             'remove' => [
                 'label' => 'Remove filter',
             ],

--- a/packages/tables/resources/lang/id/table.php
+++ b/packages/tables/resources/lang/id/table.php
@@ -106,6 +106,10 @@ return [
 
         'actions' => [
 
+            'apply' => [
+                'label' => 'Terapkan filter',
+            ],
+
             'remove' => [
                 'label' => 'Hapus filter',
             ],

--- a/packages/tables/resources/views/components/filters/index.blade.php
+++ b/packages/tables/resources/views/components/filters/index.blade.php
@@ -10,33 +10,81 @@
             {{ __('filament-tables::table.filters.heading') }}
         </h4>
 
-        <x-filament::link
-            :attributes="
-                \Filament\Support\prepare_inherited_attributes(
-                    new \Illuminate\View\ComponentAttributeBag([
-                        'color' => 'danger',
-                        'tag' => 'button',
-                        'wire:click' => 'resetTableFiltersForm',
-                        'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => '',
-                        'wire:target' => 'tableFilters,resetTableFiltersForm',
-                    ])
-                )
-            "
-        >
-            {{ __('filament-tables::table.filters.actions.reset.label') }}
-        </x-filament::link>
+        @unless ($this->table->hasApplyFiltersButton())
+            <x-filament::link
+                :attributes="
+                    \Filament\Support\prepare_inherited_attributes(
+                        new \Illuminate\View\ComponentAttributeBag([
+                            'color' => 'danger',
+                            'tag' => 'button',
+                            'wire:click' => 'resetTableFiltersForm',
+                            'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => '',
+                            'wire:target' => 'tableFilters,resetTableFiltersForm',
+                        ])
+                    )
+                "
+            >
+                {{ __('filament-tables::table.filters.actions.reset.label') }}
+            </x-filament::link>
 
-        <x-filament::loading-indicator
-            :attributes="
-                \Filament\Support\prepare_inherited_attributes(
-                    new \Illuminate\View\ComponentAttributeBag([
-                        'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
-                        'wire:target' => 'tableFilters,resetTableFiltersForm',
-                    ])
-                )->class(['h-5 w-5 text-gray-400 dark:text-gray-500'])
-            "
-        />
+            <x-filament::loading-indicator
+                :attributes="
+                    \Filament\Support\prepare_inherited_attributes(
+                        new \Illuminate\View\ComponentAttributeBag([
+                            'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
+                            'wire:target' => 'tableFilters,resetTableFiltersForm',
+                        ])
+                    )->class(['h-5 w-5 text-gray-400 dark:text-gray-500'])
+                "
+            />
+        @endunless
     </div>
 
     {{ $form }}
+
+    @if ($this->table->hasApplyFiltersButton())
+        <div class="flex items-center justify-end gap-4">
+            <x-filament::link
+                :attributes="
+                    \Filament\Support\prepare_inherited_attributes(
+                        new \Illuminate\View\ComponentAttributeBag([
+                            'color' => 'danger',
+                            'tag' => 'button',
+                            'wire:click' => 'resetTableFiltersForm',
+                            'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => '',
+                            'wire:target' => 'resetTableFiltersForm',
+                        ])
+                    )
+                "
+            >
+                {{ __('filament-tables::table.filters.actions.reset.label') }}
+            </x-filament::link>
+
+            <x-filament::loading-indicator
+                :attributes="
+                    \Filament\Support\prepare_inherited_attributes(
+                        new \Illuminate\View\ComponentAttributeBag([
+                            'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
+                            'wire:target' => 'resetTableFiltersForm',
+                        ])
+                    )->class(['h-5 w-5 text-gray-400 dark:text-gray-500'])
+                "
+            />
+
+            <x-filament::button
+                :attributes="
+                    \Filament\Support\prepare_inherited_attributes(
+                        new \Illuminate\View\ComponentAttributeBag([
+                            'tag' => 'button',
+                            'size' => 'sm',
+                            'wire:click' => 'submitTableFiltersForm',
+                            'wire:target' => 'submitTableFiltersForm',
+                        ])
+                    )
+                "
+            >
+                {{ __('filament-tables::table.filters.actions.apply.label') }}
+            </x-filament::button>
+        </div>
+    @endif
 </div>

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -23,12 +23,17 @@ trait HasFilters
             return $this->getForm('tableFiltersForm');
         }
 
-        return $this->makeForm()
+        $form = $this->makeForm()
             ->schema($this->getTableFiltersFormSchema())
             ->columns($this->getTable()->getFiltersFormColumns())
             ->model($this->getTable()->getModel())
-            ->statePath('tableFilters')
-            ->live();
+            ->statePath('tableFilters');
+
+        if ($this->table->hasApplyFiltersButton()) {
+            return $form;
+        }
+
+        return $form->live();
     }
 
     public function updatedTableFilters(): void
@@ -97,6 +102,11 @@ trait HasFilters
     {
         $this->getTableFiltersForm()->fill();
 
+        $this->updatedTableFilters();
+    }
+
+    public function submitTableFiltersForm(): void
+    {
         $this->updatedTableFilters();
     }
 

--- a/packages/tables/src/Table/Concerns/HasFilters.php
+++ b/packages/tables/src/Table/Concerns/HasFilters.php
@@ -111,7 +111,7 @@ trait HasFilters
         return $this;
     }
 
-    public function useApplyFilterButton(bool | Closure $condition = true): static
+    public function useApplyFiltersButton(bool | Closure $condition = true): static
     {
         $this->hasApplyFiltersButton = $condition;
 

--- a/packages/tables/src/Table/Concerns/HasFilters.php
+++ b/packages/tables/src/Table/Concerns/HasFilters.php
@@ -158,11 +158,7 @@ trait HasFilters
         if ($this->hasApplyFiltersButton()) {
             $filterActions[] = Action::make('applyFilters')
                 ->label(__('filament-tables::table.filters.actions.apply.label'))
-                ->action(function (Action $action) {
-                    $this->submitTableFiltersForm();
-
-                    $action->livewireClickHandlerEnabled();
-                });
+                ->action('submitTableFiltersForm');
         }
 
         $action = Action::make('openFilters')


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

This is to enable "Apply filters" button so that any filter update will not trigger any query until we click "Apply filters". I'm thinking this is important (at least for me) to work with tables that frequently need multiple filters applied.


https://github.com/filamentphp/filament/assets/26832856/bcaefcbd-98f5-40b4-929c-1a4504888456


- Still not sure about the namings, currently it is `$table->useApplyFiltersButton()`.
- I need help to make the action closes the modal/dropdown after it is run.
- Corrections and suggestions are absolutely welcome.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
