### PR TITLE
- Remove inlineLabel() call from inline() in Radio; Issue #9994

### DIFF
--- a/packages/forms/src/Components/Radio.php
+++ b/packages/forms/src/Components/Radio.php
@@ -40,7 +40,6 @@ class Radio extends Field implements Contracts\CanDisableOptions
     public function inline(bool | Closure $condition = true): static
     {
         $this->isInline = $condition;
-        $this->inlineLabel(fn (Radio $component): ?bool => $component->evaluate($condition) ? true : null);
 
         return $this;
     }


### PR DESCRIPTION
## Description

- Remove inlineLabel() call from inline() in Radio; Issue #9994

- [x] `composer cs` command has been run.
