### PR TITLE
Prevent nested p tags

### DIFF
--- a/packages/notifications/resources/views/components/body.blade.php
+++ b/packages/notifications/resources/views/components/body.blade.php
@@ -1,5 +1,5 @@
-<p
+<div
     {{ $attributes->class(['fi-no-notification-body overflow-hidden break-words text-sm text-gray-500 dark:text-gray-400']) }}
 >
     {{ $slot }}
-</p>
+</div>


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->
Before this PR, the notification body will try to render the content like below.
```
<p
    {{ $attributes->class(['some-classess']) }}
>
    {{ str($body)->sanitizeHtml()->toHtmlString() }}
</p>

```

Yes, it allows body to be rendered in html format. But when using RichEditor or MarkdownEditor, the content will wrap in `<p>` tag like these.
```
<p><strong>Hello</strong <em>World</em></p>
```
or
```
str('*Hello* **world!**')->markdown() 
# will turn into <p><em>Hello</em> <strong>world!</strong></p>
```

We expected the result will be like
```
<p
    {{ $attributes->class(['some-classess']) }}
>
    <p><em>Hello</em> <strong>world!</strong></p>
</p>

```

But since [Nested p tags are not allowed in HTML](https://stackoverflow.com/questions/46853349/can-i-nest-these-tags), we ended up receive this.
```
<p
    {{ $attributes->class(['some-classess']) }}
> </p>
    <p><em>Hello</em> <strong>world!</strong></p>
<p></p>

```

Change the body `<p>` tag into `<div>` will fix the problem, for now.
```
<div
    {{ $attributes->class(['some-classess']) }}
>
    <p><em>Hello</em> <strong>world!</strong></p>
</div>

```

<!-- Replace this comment with your description. -->

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
