### PR TITLE
Missing mount function in the infolist example

### DIFF
--- a/packages/infolists/docs/07-adding-an-infolist-to-a-livewire-component.md
+++ b/packages/infolists/docs/07-adding-an-infolist-to-a-livewire-component.md
@@ -50,6 +50,13 @@ Next, add a method to the Livewire component which accepts an `$infolist` object
 ```php
 use Filament\Infolists\Infolist;
 
+public Product $product;
+
+public function mount(Product $product): void
+{
+    $this->product = $product;
+}
+
 public function productInfolist(Infolist $infolist): Infolist
 {
     return $infolist


### PR DESCRIPTION
There is a missing mount function in the example. It took me an hour to find the solution, and I don't want others to waste their time on this.

<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [ ] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
