### PR TITLE
Fix sorting indicator with wrapHeader

### DIFF
--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -57,7 +57,7 @@
                 :alias="$activelySorted && $sortDirection === 'asc' ? 'tables::header-cell.sort-asc-button' : 'tables::header-cell.sort-desc-button'"
                 :icon="$activelySorted && $sortDirection === 'asc' ? 'heroicon-m-chevron-up' : 'heroicon-m-chevron-down'"
                 @class([
-                    'fi-ta-header-cell-sort-icon h-5 w-5 transition duration-75',
+                    'fi-ta-header-cell-sort-icon h-5 w-5 flex-shrink-0 transition duration-75',
                     'text-gray-950 dark:text-white' => $activelySorted,
                     'text-gray-400 dark:text-gray-500 group-hover:text-gray-500 group-focus-visible:text-gray-500 dark:group-hover:text-gray-400 dark:group-focus-visible:text-gray-400' => ! $activelySorted,
                 ])

--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -57,7 +57,7 @@
                 :alias="$activelySorted && $sortDirection === 'asc' ? 'tables::header-cell.sort-asc-button' : 'tables::header-cell.sort-desc-button'"
                 :icon="$activelySorted && $sortDirection === 'asc' ? 'heroicon-m-chevron-up' : 'heroicon-m-chevron-down'"
                 @class([
-                    'fi-ta-header-cell-sort-icon h-5 w-5 flex-shrink-0 transition duration-75',
+                    'fi-ta-header-cell-sort-icon h-5 w-5 shrink-0 transition duration-75',
                     'text-gray-950 dark:text-white' => $activelySorted,
                     'text-gray-400 dark:text-gray-500 group-hover:text-gray-500 group-focus-visible:text-gray-500 dark:group-hover:text-gray-400 dark:group-focus-visible:text-gray-400' => ! $activelySorted,
                 ])


### PR DESCRIPTION
## Description
Fix sorting indicator when wrapHeader is used.

Before:
![Screenshot 2023-12-28 at 1 31 59 PM](https://github.com/filamentphp/filament/assets/6097099/ed0943c5-0849-4757-9178-c0175971c73f)

After:
![Screenshot 2023-12-28 at 1 32 27 PM](https://github.com/filamentphp/filament/assets/6097099/35268242-40c7-4713-946e-cf5118fa4a6e)

- [X] Visual changes (if any) are shown using screenshots/recordings of before and after.
- [X] `composer cs` command has been run.
- [X] Changes have been tested.
- [ ] Documentation is up-to-date.
