### PR TITLE
Fix refreshFormData with Enum

### DIFF
--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -111,7 +111,7 @@ class EditRecord extends Page
         $updatedData = $this->getRecord()->only($attributes);
 
         $transformedData = array_map(
-            fn($value) => is_a($value, \BackedEnum::class) ? $value->value : $value,
+            fn ($value) => is_a($value, \BackedEnum::class) ? $value->value : $value,
             $updatedData
         );
 

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -18,6 +18,7 @@ use Filament\Support\Facades\FilamentIcon;
 use Filament\Support\Facades\FilamentView;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 
 use function Filament\Support\is_app_url;
 
@@ -108,16 +109,9 @@ class EditRecord extends Page
      */
     protected function refreshFormData(array $attributes): void
     {
-        $updatedData = $this->getRecord()->only($attributes);
-
-        $transformedData = array_map(
-            fn ($value) => is_a($value, \BackedEnum::class) ? $value->value : $value,
-            $updatedData
-        );
-
         $this->data = [
             ...$this->data,
-            ...$transformedData,
+            ...Arr::only($this->getRecord()->attributesToArray(), $attributes),
         ];
     }
 

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -108,9 +108,16 @@ class EditRecord extends Page
      */
     protected function refreshFormData(array $attributes): void
     {
+        $updatedData = $this->getRecord()->only($attributes);
+
+        $transformedData = array_map(
+            fn($value) => is_a($value, \BackedEnum::class) ? $value->value : $value,
+            $updatedData
+        );
+
         $this->data = [
             ...$this->data,
-            ...$this->getRecord()->only($attributes),
+            ...$transformedData,
         ];
     }
 

--- a/packages/panels/src/Resources/Pages/ViewRecord.php
+++ b/packages/panels/src/Resources/Pages/ViewRecord.php
@@ -13,6 +13,7 @@ use Filament\Infolists\Infolist;
 use Filament\Pages\Concerns\InteractsWithFormActions;
 use Filament\Support\Facades\FilamentIcon;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Arr;
 
 /**
  * @property Form $form
@@ -106,7 +107,7 @@ class ViewRecord extends Page
     {
         $this->data = [
             ...$this->data,
-            ...$this->getRecord()->only($attributes),
+            ...Arr::only($this->getRecord()->attributesToArray(), $attributes),
         ];
     }
 


### PR DESCRIPTION
## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

If you use refreshFormData on values that are cast as Enums in the Model, the enum will be loaded instead of its value, which will cause a problem when submitting the form.

My PR fixes this problem by iterating through the values to refresh and taking ->value in the case of an Enum.

The solution is certainly not perfect for Filament's framework.

I'll let the experts correct this properly :)

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

- [x] `composer cs` command has been run.

## Testing

See my previous comment for this.

- [ ] Changes have been tested.
