### PR TITLE
Fix chartWidget property must not be accessed error

### DIFF
--- a/packages/widgets/src/ChartWidget.php
+++ b/packages/widgets/src/ChartWidget.php
@@ -16,7 +16,7 @@ abstract class ChartWidget extends Widget
     protected ?array $cachedData = null;
 
     #[Locked]
-    public string $dataChecksum;
+    public string $dataChecksum = '';
 
     public ?string $filter = null;
 

--- a/packages/widgets/src/ChartWidget.php
+++ b/packages/widgets/src/ChartWidget.php
@@ -16,7 +16,7 @@ abstract class ChartWidget extends Widget
     protected ?array $cachedData = null;
 
     #[Locked]
-    public string $dataChecksum = '';
+    public ?string $dataChecksum = null;
 
     public ?string $filter = null;
 


### PR DESCRIPTION
Using a chartWidget with `InteractsWithPageTable` throws a `Typed property Filament\Widgets\ChartWidget::$dataChecksum must not be accessed before initialization` error. 

Setting a default value to the property (seems to) fix this (This is one of those livewire things that I don't fully understand). 

Another option that works is:

`public ?string $dataChecksum = null;`

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.
- [ ] `composer cs` command has been run.
- [X] Changes have been tested.
- [ ] Documentation is up-to-date.
