### PR TITLE
fix: Recursively attach relationship with pivot ID

### DIFF
--- a/packages/tables/src/Actions/AssociateAction.php
+++ b/packages/tables/src/Actions/AssociateAction.php
@@ -223,6 +223,7 @@ class AssociateAction extends Action
                 });
             }
 
+            $relationCountHash = $relationship->getRelationCountHash(false);
             $relationshipQuery
                 ->whereDoesntHave($table->getInverseRelationship(), function (Builder $query) use ($relationship): Builder {
                     if ($relationship instanceof MorphMany) {
@@ -240,7 +241,7 @@ class AssociateAction extends Action
                     return $query->where(
                         // https://github.com/filamentphp/filament/issues/8067
                         $relationship->getParent()->getTable() === $relationship->getRelated()->getTable() ?
-                            $relationship->getParent()->getKeyName() :
+                            ($relationCountHash.'.'.$relationship->getParent()->getKeyName()) :
                             $relationship->getParent()->getQualifiedKeyName(),
                         $relationship->getParent()->getKey(),
                     );

--- a/packages/tables/src/Actions/AssociateAction.php
+++ b/packages/tables/src/Actions/AssociateAction.php
@@ -225,7 +225,10 @@ class AssociateAction extends Action
 
             $relationCountHash = $relationship->getRelationCountHash(false);
             $relationshipQuery
-                ->whereDoesntHave($table->getInverseRelationship(), function (Builder $query) use ($relationship): Builder {
+                ->whereDoesntHave($table->getInverseRelationship(), function (Builder $query) use (
+                    $relationCountHash,
+                    $relationship
+                ): Builder {
                     if ($relationship instanceof MorphMany) {
                         return $query
                             ->where(

--- a/packages/tables/src/Actions/AssociateAction.php
+++ b/packages/tables/src/Actions/AssociateAction.php
@@ -241,7 +241,7 @@ class AssociateAction extends Action
                     return $query->where(
                         // https://github.com/filamentphp/filament/issues/8067
                         $relationship->getParent()->getTable() === $relationship->getRelated()->getTable() ?
-                            ($relationCountHash.'.'.$relationship->getParent()->getKeyName()) :
+                            ($relationCountHash . '.' . $relationship->getParent()->getKeyName()) :
                             $relationship->getParent()->getQualifiedKeyName(),
                         $relationship->getParent()->getKey(),
                     );

--- a/packages/tables/src/Actions/AssociateAction.php
+++ b/packages/tables/src/Actions/AssociateAction.php
@@ -223,7 +223,8 @@ class AssociateAction extends Action
                 });
             }
 
-            $relationCountHash = $relationship->getRelationCountHash(false);
+            $relationCountHash = $relationship->getRelationCountHash(incrementJoinCount: false);
+            
             $relationshipQuery
                 ->whereDoesntHave($table->getInverseRelationship(), function (Builder $query) use (
                     $relationCountHash,

--- a/packages/tables/src/Actions/AssociateAction.php
+++ b/packages/tables/src/Actions/AssociateAction.php
@@ -245,7 +245,7 @@ class AssociateAction extends Action
                     return $query->where(
                         // https://github.com/filamentphp/filament/issues/8067
                         $relationship->getParent()->getTable() === $relationship->getRelated()->getTable() ?
-                            ($relationCountHash . '.' . $relationship->getParent()->getKeyName()) :
+                            "{$relationCountHash}.{$relationship->getParent()->getKeyName()}" :
                             $relationship->getParent()->getQualifiedKeyName(),
                         $relationship->getParent()->getKey(),
                     );

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -227,15 +227,17 @@ class AttachAction extends Action
                 });
             }
 
+            $relationCountHash = $relationship->getRelationCountHash(false);
             $relationshipQuery
                 ->when(
-                    ! $table->allowsDuplicates(),
-                    fn (Builder $query): Builder => $query->whereDoesntHave(
+                    !$table->allowsDuplicates(),
+                    fn(Builder $query): Builder => $query->whereDoesntHave(
                         $table->getInverseRelationship(),
-                        fn (Builder $query): Builder => $query->where(
-                            // https://github.com/filamentphp/filament/issues/8067
+
+                        fn(Builder $query): Builder => $query->where(
+                        // https://github.com/filamentphp/filament/issues/8067
                             $relationship->getParent()->getTable() === $relationship->getRelated()->getTable() ?
-                                $relationship->getParent()->getKeyName() :
+                                ($relationCountHash.'.'.$relationship->getParent()->getKeyName()) :
                                 $relationship->getParent()->getQualifiedKeyName(),
                             $relationship->getParent()->getKey(),
                         ),

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -233,7 +233,6 @@ class AttachAction extends Action
                     ! $table->allowsDuplicates(),
                     fn (Builder $query): Builder => $query->whereDoesntHave(
                         $table->getInverseRelationship(),
-
                         fn (Builder $query): Builder => $query->where(
                             // https://github.com/filamentphp/filament/issues/8067
                             $relationship->getParent()->getTable() === $relationship->getRelated()->getTable() ?

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -230,12 +230,12 @@ class AttachAction extends Action
             $relationCountHash = $relationship->getRelationCountHash(false);
             $relationshipQuery
                 ->when(
-                    !$table->allowsDuplicates(),
-                    fn(Builder $query): Builder => $query->whereDoesntHave(
+                    ! $table->allowsDuplicates(),
+                    fn (Builder $query): Builder => $query->whereDoesntHave(
                         $table->getInverseRelationship(),
 
-                        fn(Builder $query): Builder => $query->where(
-                        // https://github.com/filamentphp/filament/issues/8067
+                        fn (Builder $query): Builder => $query->where(
+                            // https://github.com/filamentphp/filament/issues/8067
                             $relationship->getParent()->getTable() === $relationship->getRelated()->getTable() ?
                                 ($relationCountHash.'.'.$relationship->getParent()->getKeyName()) :
                                 $relationship->getParent()->getQualifiedKeyName(),

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -237,7 +237,7 @@ class AttachAction extends Action
                         fn (Builder $query): Builder => $query->where(
                             // https://github.com/filamentphp/filament/issues/8067
                             $relationship->getParent()->getTable() === $relationship->getRelated()->getTable() ?
-                                ($relationCountHash . '.' . $relationship->getParent()->getKeyName()) :
+                                "{$relationCountHash}.{$relationship->getParent()->getKeyName()}" :
                                 $relationship->getParent()->getQualifiedKeyName(),
                             $relationship->getParent()->getKey(),
                         ),

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -227,7 +227,8 @@ class AttachAction extends Action
                 });
             }
 
-            $relationCountHash = $relationship->getRelationCountHash(false);
+            $relationCountHash = $relationship->getRelationCountHash(incrementJoinCount: false);
+            
             $relationshipQuery
                 ->when(
                     ! $table->allowsDuplicates(),

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -230,14 +230,13 @@ class AttachAction extends Action
             $relationCountHash = $relationship->getRelationCountHash(false);
             $relationshipQuery
                 ->when(
-                    !$table->allowsDuplicates(),
-                    fn(Builder $query): Builder => $query->whereDoesntHave(
+                    ! $table->allowsDuplicates(),
+                    fn (Builder $query): Builder => $query->whereDoesntHave(
                         $table->getInverseRelationship(),
-
-                        fn(Builder $query): Builder => $query->where(
-                        // https://github.com/filamentphp/filament/issues/8067
+                        fn (Builder $query): Builder => $query->where(
+                            // https://github.com/filamentphp/filament/issues/8067
                             $relationship->getParent()->getTable() === $relationship->getRelated()->getTable() ?
-                                ($relationCountHash.'.'.$relationship->getParent()->getKeyName()) :
+                                ($relationCountHash . '.' . $relationship->getParent()->getKeyName()) :
                                 $relationship->getParent()->getQualifiedKeyName(),
                             $relationship->getParent()->getKey(),
                         ),


### PR DESCRIPTION
## Description

An error occurs due to the incrementing ID in the pivot table while trying to Attach a record via the AttachAction.

Fixes https://github.com/filamentphp/filament/issues/10568

Impact:
This issue may affect applications that rely on self-referential relationships with incrementing IDs in pivot tables.

Reproduction repository:
https://github.com/dennisvandalen/filament-recursive-attach-relationship-with-id

## Code style

- [x] `composer cs` command has been run.

## Testing

- [x] Changes have been manually tested.

## Documentation

No new features.