### PR TITLE
Support tags color in `TagsInput`

### DIFF
--- a/packages/forms/docs/03-fields/14-tags-input.md
+++ b/packages/forms/docs/03-fields/14-tags-input.md
@@ -85,6 +85,28 @@ TagsInput::make('percentages')
     ->tagSuffix('%')
 ```
 
+## Reordering tags
+
+You can allow the user to reorder tags within the field using the `reorderable()` method:
+
+```php
+use Filament\Forms\Components\TagsInput;
+
+TagsInput::make('tags')
+    ->reorderable()
+```
+
+## Changing the color of tags
+
+You can change the color of the tags by passing a color to the `color()` method. It may be either `danger`, `gray`, `info`, `primary`, `success` or `warning`:
+
+```php
+use Filament\Forms\Components\TagsInput;
+
+TagsInput::make('tags')
+    ->color('danger')
+```
+
 ## Tags validation
 
 You may add validation rules for each tag by passing an array of rules to the `nestedRecursiveRules()` method:
@@ -97,26 +119,4 @@ TagsInput::make('tags')
         'min:3',
         'max:255',
     ])
-```
-
-## Reordering tags
-
-You can allow the user to reorder tags within the field using the `reorderable()` method:
-
-```php
-use Filament\Forms\Components\TagsInput;
-
-TagsInput::make('tags')
-    ->reorderable()
-```
-
-## Changing tag color
-
-You can change the color of the tags by passing a color to the `color()` method:
-
-```php
-use Filament\Forms\Components\TagsInput;
-
-TagsInput::make('tags')
-    ->color('purple')
 ```

--- a/packages/forms/docs/03-fields/14-tags-input.md
+++ b/packages/forms/docs/03-fields/14-tags-input.md
@@ -109,3 +109,25 @@ use Filament\Forms\Components\TagsInput;
 TagsInput::make('tags')
     ->reorderable()
 ```
+
+## Changing tag color
+
+You can change the color of the tags by passing a color to the `color()` method:
+
+```php
+use Filament\Forms\Components\TagsInput;
+
+TagsInput::make('tags')
+    ->color('purple')
+```
+
+## Inline input
+
+You can change the input to be inline by using the `inlineInput()` method:
+
+```php
+use Filament\Forms\Components\TagsInput;
+
+TagsInput::make('tags')
+    ->inlineInput()
+```

--- a/packages/forms/docs/03-fields/14-tags-input.md
+++ b/packages/forms/docs/03-fields/14-tags-input.md
@@ -120,14 +120,3 @@ use Filament\Forms\Components\TagsInput;
 TagsInput::make('tags')
     ->color('purple')
 ```
-
-## Inline input
-
-You can change the input to be inline by using the `inlineInput()` method:
-
-```php
-use Filament\Forms\Components\TagsInput;
-
-TagsInput::make('tags')
-    ->inlineInput()
-```

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -6,6 +6,7 @@
     $isDisabled = $isDisabled();
     $isReorderable = $isReorderable();
     $statePath = $getStatePath();
+    $isInlineInput = $getInlineInput();
 @endphp
 
 <x-dynamic-component

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -47,7 +47,7 @@
             x-ignore
             {{ $getExtraAlpineAttributeBag() }}
         >
-            @if(!$isInlineInput)
+            @if (! $isInlineInput)
                 <x-filament::input
                     autocomplete="off"
                     :autofocus="$isAutofocused()"
@@ -67,7 +67,7 @@
                         x-bind:key="@js($suggestion)"
                         x-if="! state.includes(@js($suggestion))"
                     >
-                        <option value="{{ $suggestion }}"/>
+                        <option value="{{ $suggestion }}" />
                     </template>
                 @endforeach
             </datalist>
@@ -77,13 +77,16 @@
                     '[&_.fi-badge-delete-button]:hidden' => $isDisabled,
                 ])
             >
-                <div wire:ignore x-data="{inline: {{ $isInlineInput ? 'true' : 'false' }}}">
+                <div
+                    wire:ignore
+                    x-data="{ inline: {{ $isInlineInput ? 'true' : 'false' }} }"
+                >
                     <template x-cloak x-if="state?.length || inline">
                         <div
                             @if ($isReorderable)
                                 x-on:end.stop="reorderTags($event)"
-                            x-sortable
-                            data-sortable-animation-duration="{{ $getReorderAnimationDuration() }}"
+                                x-sortable
+                                data-sortable-animation-duration="{{ $getReorderAnimationDuration() }}"
                             @endif
                             @class([
                                 'flex w-full flex-wrap gap-1.5 p-2',
@@ -119,7 +122,7 @@
                                 </x-filament::badge>
                             </template>
 
-                            @if($isInlineInput)
+                            @if ($isInlineInput)
                                 <x-filament::input
                                     autocomplete="off"
                                     :autofocus="$isAutofocused()"
@@ -135,7 +138,6 @@
                                     ])
                                 />
                             @endif
-
                         </div>
                     </template>
                 </div>

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -7,6 +7,7 @@
     $isReorderable = $isReorderable();
     $statePath = $getStatePath();
     $isInlineInput = $getInlineInput();
+    $color = $getColor();
 @endphp
 
 <x-dynamic-component
@@ -98,6 +99,7 @@
                                     @class([
                                         'cursor-move' => $isReorderable,
                                     ])
+                                    :color="$color"
                                 >
                                     {{ $getTagPrefix() }}
 

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -1,13 +1,13 @@
 @php
     use Filament\Support\Facades\FilamentView;
 
+    $color = $getColor();
     $hasInlineLabel = $hasInlineLabel();
     $id = $getId();
     $isDisabled = $isDisabled();
+    $isInlineInput = $getInlineInput();
     $isReorderable = $isReorderable();
     $statePath = $getStatePath();
-    $isInlineInput = $getInlineInput();
-    $color = $getColor();
 @endphp
 
 <x-dynamic-component
@@ -99,12 +99,12 @@
                                 class="hidden"
                             >
                                 <x-filament::badge
+                                    :color="$color"
                                     :x-bind:x-sortable-item="$isReorderable ? 'index' : null"
                                     :x-sortable-handle="$isReorderable ? '' : null"
                                     @class([
                                         'cursor-move' => $isReorderable,
                                     ])
-                                    :color="$color"
                                 >
                                     {{ $getTagPrefix() }}
 

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -74,9 +74,7 @@
                     '[&_.fi-badge-delete-button]:hidden' => $isDisabled,
                 ])
             >
-                <div
-                    wire:ignore
-                >
+                <div wire:ignore>
                     <template x-cloak x-if="state?.length">
                         <div
                             @if ($isReorderable)

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -47,17 +47,19 @@
             x-ignore
             {{ $getExtraAlpineAttributeBag() }}
         >
-            <x-filament::input
-                autocomplete="off"
-                :autofocus="$isAutofocused()"
-                :disabled="$isDisabled"
-                :id="$id"
-                :list="$id . '-suggestions'"
-                :placeholder="$getPlaceholder()"
-                type="text"
-                x-bind="input"
-                :attributes="\Filament\Support\prepare_inherited_attributes($getExtraInputAttributeBag())"
-            />
+            @if(!$isInlineInput)
+                <x-filament::input
+                    autocomplete="off"
+                    :autofocus="$isAutofocused()"
+                    :disabled="$isDisabled"
+                    :id="$id"
+                    :list="$id . '-suggestions'"
+                    :placeholder="$getPlaceholder()"
+                    type="text"
+                    x-bind="input"
+                    :attributes="\Filament\Support\prepare_inherited_attributes($getExtraInputAttributeBag())"
+                />
+            @endif
 
             <datalist id="{{ $id }}-suggestions">
                 @foreach ($getSuggestions() as $suggestion)
@@ -65,7 +67,7 @@
                         x-bind:key="@js($suggestion)"
                         x-if="! state.includes(@js($suggestion))"
                     >
-                        <option value="{{ $suggestion }}" />
+                        <option value="{{ $suggestion }}"/>
                     </template>
                 @endforeach
             </datalist>
@@ -75,13 +77,13 @@
                     '[&_.fi-badge-delete-button]:hidden' => $isDisabled,
                 ])
             >
-                <div wire:ignore>
-                    <template x-cloak x-if="state?.length">
+                <div wire:ignore x-data="{inline: {{ $isInlineInput ? 'true' : 'false' }}}">
+                    <template x-cloak x-if="state?.length || inline">
                         <div
                             @if ($isReorderable)
                                 x-on:end.stop="reorderTags($event)"
-                                x-sortable
-                                data-sortable-animation-duration="{{ $getReorderAnimationDuration() }}"
+                            x-sortable
+                            data-sortable-animation-duration="{{ $getReorderAnimationDuration() }}"
                             @endif
                             @class([
                                 'flex w-full flex-wrap gap-1.5 p-2',
@@ -116,6 +118,24 @@
                                     ></x-slot>
                                 </x-filament::badge>
                             </template>
+
+                            @if($isInlineInput)
+                                <x-filament::input
+                                    autocomplete="off"
+                                    :autofocus="$isAutofocused()"
+                                    :disabled="$isDisabled"
+                                    :id="$id"
+                                    :list="$id . '-suggestions'"
+                                    :placeholder="$getPlaceholder()"
+                                    type="text"
+                                    x-bind="input"
+                                    :attributes="\Filament\Support\prepare_inherited_attributes($getExtraInputAttributeBag())"
+                                    @class([
+                                        'flex-1 min-w-fit',
+                                    ])
+                                />
+                            @endif
+
                         </div>
                     </template>
                 </div>

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -5,7 +5,6 @@
     $hasInlineLabel = $hasInlineLabel();
     $id = $getId();
     $isDisabled = $isDisabled();
-    $isInlineInput = $getInlineInput();
     $isReorderable = $isReorderable();
     $statePath = $getStatePath();
 @endphp
@@ -47,19 +46,17 @@
             x-ignore
             {{ $getExtraAlpineAttributeBag() }}
         >
-            @if (! $isInlineInput)
-                <x-filament::input
-                    autocomplete="off"
-                    :autofocus="$isAutofocused()"
-                    :disabled="$isDisabled"
-                    :id="$id"
-                    :list="$id . '-suggestions'"
-                    :placeholder="$getPlaceholder()"
-                    type="text"
-                    x-bind="input"
-                    :attributes="\Filament\Support\prepare_inherited_attributes($getExtraInputAttributeBag())"
-                />
-            @endif
+            <x-filament::input
+                autocomplete="off"
+                :autofocus="$isAutofocused()"
+                :disabled="$isDisabled"
+                :id="$id"
+                :list="$id . '-suggestions'"
+                :placeholder="$getPlaceholder()"
+                type="text"
+                x-bind="input"
+                :attributes="\Filament\Support\prepare_inherited_attributes($getExtraInputAttributeBag())"
+            />
 
             <datalist id="{{ $id }}-suggestions">
                 @foreach ($getSuggestions() as $suggestion)
@@ -79,9 +76,8 @@
             >
                 <div
                     wire:ignore
-                    x-data="{ inline: {{ $isInlineInput ? 'true' : 'false' }} }"
                 >
-                    <template x-cloak x-if="state?.length || inline">
+                    <template x-cloak x-if="state?.length">
                         <div
                             @if ($isReorderable)
                                 x-on:end.stop="reorderTags($event)"
@@ -121,24 +117,6 @@
                                     ></x-slot>
                                 </x-filament::badge>
                             </template>
-
-                            @if ($isInlineInput)
-                                <x-filament::input
-                                    autocomplete="off"
-                                    :autofocus="$isAutofocused()"
-                                    :disabled="$isDisabled"
-                                    :id="$id"
-                                    :list="$id . '-suggestions'"
-                                    :placeholder="$getPlaceholder()"
-                                    type="text"
-                                    x-bind="input"
-                                    :attributes="\Filament\Support\prepare_inherited_attributes($getExtraInputAttributeBag())"
-                                    @class([
-                                        'flex-1 min-w-fit',
-                                    ])
-                                    style="padding: 0px !important;"
-                                />
-                            @endif
                         </div>
                     </template>
                 </div>

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -136,6 +136,7 @@
                                     @class([
                                         'flex-1 min-w-fit',
                                     ])
+                                    style="padding: 0px !important;"
                                 />
                             @endif
                         </div>

--- a/packages/forms/src/Components/TagsInput.php
+++ b/packages/forms/src/Components/TagsInput.php
@@ -3,6 +3,7 @@
 namespace Filament\Forms\Components;
 
 use Closure;
+use Filament\Support\Concerns\HasColor;
 use Filament\Support\Concerns\HasExtraAlpineAttributes;
 use Filament\Support\Concerns\HasReorderAnimationDuration;
 use Illuminate\Contracts\Support\Arrayable;
@@ -14,6 +15,7 @@ class TagsInput extends Field implements Contracts\HasNestedRecursiveValidationR
     use Concerns\HasPlaceholder;
     use HasExtraAlpineAttributes;
     use HasReorderAnimationDuration;
+    use HasColor;
 
     /**
      * @var view-string

--- a/packages/forms/src/Components/TagsInput.php
+++ b/packages/forms/src/Components/TagsInput.php
@@ -13,9 +13,9 @@ class TagsInput extends Field implements Contracts\HasNestedRecursiveValidationR
     use Concerns\HasExtraInputAttributes;
     use Concerns\HasNestedRecursiveValidationRules;
     use Concerns\HasPlaceholder;
+    use HasColor;
     use HasExtraAlpineAttributes;
     use HasReorderAnimationDuration;
-    use HasColor;
 
     /**
      * @var view-string
@@ -40,7 +40,7 @@ class TagsInput extends Field implements Contracts\HasNestedRecursiveValidationR
 
     protected string | Closure | null $tagSuffix = null;
 
-    protected bool | null $inlineInput = false;
+    protected ?bool $inlineInput = false;
 
     protected function setUp(): void
     {
@@ -171,7 +171,7 @@ class TagsInput extends Field implements Contracts\HasNestedRecursiveValidationR
         return (bool) $this->evaluate($this->isReorderable);
     }
 
-    public function inlineInput(bool | null $inlineInput = true): static
+    public function inlineInput(?bool $inlineInput = true): static
     {
         $this->inlineInput = $inlineInput;
 

--- a/packages/forms/src/Components/TagsInput.php
+++ b/packages/forms/src/Components/TagsInput.php
@@ -40,8 +40,6 @@ class TagsInput extends Field implements Contracts\HasNestedRecursiveValidationR
 
     protected string | Closure | null $tagSuffix = null;
 
-    protected ?bool $inlineInput = false;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -169,17 +167,5 @@ class TagsInput extends Field implements Contracts\HasNestedRecursiveValidationR
     public function isReorderable(): bool
     {
         return (bool) $this->evaluate($this->isReorderable);
-    }
-
-    public function inlineInput(?bool $inlineInput = true): static
-    {
-        $this->inlineInput = $inlineInput;
-
-        return $this;
-    }
-
-    public function getInlineInput(): bool
-    {
-        return (bool) $this->evaluate($this->inlineInput);
     }
 }

--- a/packages/forms/src/Components/TagsInput.php
+++ b/packages/forms/src/Components/TagsInput.php
@@ -38,6 +38,8 @@ class TagsInput extends Field implements Contracts\HasNestedRecursiveValidationR
 
     protected string | Closure | null $tagSuffix = null;
 
+    protected bool | null $inlineInput = false;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -165,5 +167,17 @@ class TagsInput extends Field implements Contracts\HasNestedRecursiveValidationR
     public function isReorderable(): bool
     {
         return (bool) $this->evaluate($this->isReorderable);
+    }
+
+    public function inlineInput(bool | null $inlineInput = true): static
+    {
+        $this->inlineInput = $inlineInput;
+
+        return $this;
+    }
+
+    public function getInlineInput(): bool
+    {
+        return (bool) $this->evaluate($this->inlineInput);
     }
 }


### PR DESCRIPTION
## Description

This PR introduces two new feature for TagsInput component, the `->color()` method (HasColor Trait) to change the color of the tags/badges and the method `->inlineInput()` to make the input inline, after the badges/tags.

- [X] Visual changes (if any) are shown using screenshots/recordings of before and after.

**Before:**
![tagsinput_before](https://github.com/filamentphp/filament/assets/32993233/ca1ff694-cdf8-4696-b8ef-53dcb535e592)

**After:**
![tagsinput_after](https://github.com/filamentphp/filament/assets/32993233/20caad1c-1218-4626-9a5c-2a5867778b57)

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [X] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [X] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [X] Documentation is up-to-date.
