### PR TITLE
Fix: standardizes pt_br strings

### DIFF
--- a/packages/panels/resources/lang/pt_BR/resources/pages/view-record.php
+++ b/packages/panels/resources/lang/pt_BR/resources/pages/view-record.php
@@ -2,14 +2,14 @@
 
 return [
 
-    'title' => 'Mostrar :label',
+    'title' => 'Visualizar :label',
 
-    'breadcrumb' => 'Mostrar',
+    'breadcrumb' => 'Visualizar',
 
     'content' => [
 
         'tab' => [
-            'label' => 'Mostrar',
+            'label' => 'Visualizar',
         ],
 
     ],


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

In some places the term 'Visualizar' is used and in others 'Mostrar'. Both are synonymous, but in Brazilian Portuguese, the term 'Visualizar' makes more sense, or at least, is more used in web applications.

It would be like using View and Show in English. There is no completely wrong choice, but if you choose a one, you must keep it.

## Code style

Didn't affect any style.

## Testing

- [x] Changes have been tested.

## Documentation

There is no new functionality or changes on existing functionality.

- [x] Documentation is up-to-date.
