### PR TITLE
Support: Add a default 'self' binding that resolves to the current component instance

### DIFF
--- a/packages/support/src/Concerns/EvaluatesClosures.php
+++ b/packages/support/src/Concerns/EvaluatesClosures.php
@@ -100,6 +100,10 @@ trait EvaluatesClosures
      */
     protected function resolveDefaultClosureDependencyForEvaluationByName(string $parameterName): array
     {
+        if ($parameterName == 'self') {
+            return [$this];
+        }
+
         return [];
     }
 


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

This PR provides a default closure dependency name `'self'` that can be used to resolve to `$this` component instance.

The most important use case is components that use the closure dependency system, but don't provide any custom binding. Sometimes we would like to use the current instance, but can't.

For instance there is, AFAIK, currently no way for someone to get the current `Filament\Resources\Components\Tab` instance in its `badge` method to easily reuse the query modification function there.

With this PR, you'd be able to write something like this:

```php
namespace App\Filament\Resources\PlaceResource\Pages;

use App\Enums\PlaceStatus;
use App\Filament\Resources\PlaceResource;
use App\Models\Place;
use Filament\Resources\Components\Tab;

class ListPlaces extends ListRecords
{
    public function getTabs(): array
    {
        return [
            Tab::make('All'),
            Tab::make('Active')
                ->modifyQueryUsing(fn(Builder $query) => $query->whereIn('status', [
                    PlaceStatus::CONSIDERING,
                    PlaceStatus::ACTIVELY_LOOKING,
                    PlaceStatus::OK,
                ]))
                ->badge(fn(Tab $self) => $self->modifyQuery(Place::query())->count()),
        ];
    }
}
```

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

> Will edit the docs website's pages related to parameters resolution

- [ ] Documentation is up-to-date.
