### PR TITLE
Fix when linking from a panel with tenancy to one without

### DIFF
--- a/packages/panels/src/Pages/Page.php
+++ b/packages/panels/src/Pages/Page.php
@@ -38,7 +38,8 @@ abstract class Page extends BasePage
      */
     public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null): string
     {
-        $parameters['tenant'] ??= ($tenant ?? Filament::getTenant());
+        if ($panel === null || Filament::getPanel($panel)->hasTenancy())
+            $parameters['tenant'] ??= ($tenant ?? Filament::getTenant());
 
         return route(static::getRouteName($panel), $parameters, $isAbsolute);
     }

--- a/packages/panels/src/Pages/Page.php
+++ b/packages/panels/src/Pages/Page.php
@@ -38,8 +38,9 @@ abstract class Page extends BasePage
      */
     public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null): string
     {
-        if ($panel === null || Filament::getPanel($panel)->hasTenancy())
+        if (blank($panel) || Filament::getPanel($panel)->hasTenancy()) {
             $parameters['tenant'] ??= ($tenant ?? Filament::getTenant());
+        }
 
         return route(static::getRouteName($panel), $parameters, $isAbsolute);
     }


### PR DESCRIPTION
When linking from a panel with multitenancy to one without multitenancy it was adding "?tenant=(id)" to the URL, even if I explicitly passed null as the tenant parameter. 

As a temporary workaround I am using route(getRouteName()) which is what getUrl is doing anyway.

This PR provides a solution by only adding the tenancy parameter if you are linking within the same panel, or if the panel you are linking to also has multitenancy.