### PR TITLE
Add readOnly method documentation with security note

### DIFF
--- a/packages/forms/docs/03-fields/02-text-input.md
+++ b/packages/forms/docs/03-fields/02-text-input.md
@@ -196,6 +196,23 @@ TextInput::make('amount')
     ->numeric()
 ```
 
+## Making the field read-only
+
+Not to be confused with [disabling the field](getting-started#disabling-a-field), you may make the field "read-only" using the `readonly()` method:
+
+```php
+use Filament\Forms\Components\TextInput;
+
+TextInput::make('name')
+    ->readonly()
+```
+
+There are a few differences, compared to [`disabled()`](getting-started#disabling-a-field):
+
+- When using `readOnly()`, the field will still be sent to the server when the form is submitted. It can be mutated with the browser console, or via JavaScript. You can use [`dehydrated(false)`](advanced#preventing-a-field-from-being-dehydrated) to prevent this.
+- There are no styling changes, such as less opacity, when using `readOnly()`.
+- The field is still focusable when using `readOnly()`.
+
 ## Text input validation
 
 As well as all rules listed on the [validation](../validation) page, there are additional rules that are specific to text inputs.

--- a/packages/forms/docs/03-fields/08-date-time-picker.md
+++ b/packages/forms/docs/03-fields/08-date-time-picker.md
@@ -213,6 +213,25 @@ TimePicker::make('at')
     ->prefixIconColor('success')
 ```
 
+## Making the field read-only
+
+Not to be confused with [disabling the field](getting-started#disabling-a-field), you may make the field "read-only" using the `readonly()` method:
+
+```php
+use Filament\Forms\Components\DatePicker;
+
+DatePicker::make('date_of_birth')
+    ->readonly()
+```
+
+Please note that this setting is only enforced on native date pickers. If you're using the [JavaScript date picker](#enabling-the-javascript-date-picker), you'll need to use [`disabled()`](getting-started#disabling-a-field).
+
+There are a few differences, compared to [`disabled()`](getting-started#disabling-a-field):
+
+- When using `readOnly()`, the field will still be sent to the server when the form is submitted. It can be mutated with the browser console, or via JavaScript. You can use [`dehydrated(false)`](advanced#preventing-a-field-from-being-dehydrated) to prevent this.
+- There are no styling changes, such as less opacity, when using `readOnly()`.
+- The field is still focusable when using `readOnly()`.
+
 ## Date-time picker validation
 
 As well as all rules listed on the [validation](../validation) page, there are additional rules that are specific to date-time pickers.

--- a/packages/forms/docs/03-fields/15-textarea.md
+++ b/packages/forms/docs/03-fields/15-textarea.md
@@ -38,6 +38,23 @@ Textarea::make('description')
     ->autosize()
 ```
 
+## Making the field read-only
+
+Not to be confused with [disabling the field](getting-started#disabling-a-field), you may make the field "read-only" using the `readonly()` method:
+
+```php
+use Filament\Forms\Components\Textarea;
+
+Textarea::make('description')
+    ->readonly()
+```
+
+There are a few differences, compared to [`disabled()`](getting-started#disabling-a-field):
+
+- When using `readOnly()`, the field will still be sent to the server when the form is submitted. It can be mutated with the browser console, or via JavaScript. You can use [`dehydrated(false)`](advanced#preventing-a-field-from-being-dehydrated) to prevent this.
+- There are no styling changes, such as less opacity, when using `readOnly()`.
+- The field is still focusable when using `readOnly()`.
+
 ## Textarea validation
 
 As well as all rules listed on the [validation](../validation) page, there are additional rules that are specific to textareas.

--- a/packages/forms/src/Components/Concerns/CanBeReadOnly.php
+++ b/packages/forms/src/Components/Concerns/CanBeReadOnly.php
@@ -10,10 +10,6 @@ trait CanBeReadOnly
 {
     protected bool | Closure $isReadOnly = false;
 
-    /**
-     * Remember that the input can still be modified on the client side if edited by browser dev tools.
-     * Call `->dehydrated(false)` to prevent this.
-     */
     public function readOnly(bool | Closure $condition = true): static
     {
         $this->isReadOnly = $condition;

--- a/packages/forms/src/Components/Concerns/CanBeReadOnly.php
+++ b/packages/forms/src/Components/Concerns/CanBeReadOnly.php
@@ -10,6 +10,10 @@ trait CanBeReadOnly
 {
     protected bool | Closure $isReadOnly = false;
 
+    /**
+     * Remember that the input can still be modified on the client side if edited by browser dev tools.
+     * Call `->dehydrated(false)` to prevent this.
+     */
     public function readOnly(bool | Closure $condition = true): static
     {
         $this->isReadOnly = $condition;


### PR DESCRIPTION
I find it unintuitive that the readonly method does not call `->dehydrated(false)` automatically, so this adds a note to remind the developer to call it manually.

<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [x] Adding a code comment has no change on functionality.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has not been run as I made the edit using the web UI.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
