### PR TITLE
Corrected link to docs for media library plugin

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/README.md
+++ b/packages/spatie-laravel-media-library-plugin/README.md
@@ -36,7 +36,7 @@ SpatieMediaLibraryFileUpload::make('avatar')
 
 The media library file upload supports all the customization options of the [original file upload component](https://filamentphp.com/docs/forms/fields/file-upload).
 
-> The field will automatically load and save its uploads to your model. To set this functionality up, **you must also follow the instructions set out in the [field relationships](https://filamentphp.com/docs/forms/getting-started#field-relationships) section**. If you're using a [panel](../panels), you can skip this step.
+> The field will automatically load and save its uploads to your model. To set this functionality up, **you must also follow the instructions set out in the [setting a form model](https://filamentphp.com/docs/forms/adding-a-form-to-a-livewire-component#setting-a-form-model) section**. If you're using a [panel](../panels), you can skip this step.
 
 ### Passing a collection
 


### PR DESCRIPTION
The link for guidance on setting up the model outside of panels was still the 2.x specific page. 

Updated to the correct url for 3.x.