### PR TITLE
Update table column affix helpers to support Htmlables

### DIFF
--- a/packages/infolists/src/Components/Concerns/CanFormatState.php
+++ b/packages/infolists/src/Components/Concerns/CanFormatState.php
@@ -6,10 +6,9 @@ use Closure;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
 use Filament\Support\Contracts\HasLabel as LabelInterface;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
-use Illuminate\Support\Stringable;
 
 use function Filament\Support\format_money;
 use function Filament\Support\format_number;
@@ -26,9 +25,9 @@ trait CanFormatState
 
     protected string | Closure | null $wordLimitEnd = null;
 
-    protected string | Closure | null $prefix = null;
+    protected string | Htmlable | Closure | null $prefix = null;
 
-    protected string | Closure | null $suffix = null;
+    protected string | Htmlable | Closure | null $suffix = null;
 
     protected string | Closure | null $timezone = null;
 
@@ -179,14 +178,14 @@ trait CanFormatState
         return $this;
     }
 
-    public function prefix(string | Closure | null $prefix): static
+    public function prefix(string | Htmlable | Closure | null $prefix): static
     {
         $this->prefix = $prefix;
 
         return $this;
     }
 
-    public function suffix(string | Closure | null $suffix): static
+    public function suffix(string | Htmlable | Closure | null $suffix): static
     {
         $this->suffix = $suffix;
 
@@ -209,9 +208,16 @@ trait CanFormatState
 
     public function formatState(mixed $state): mixed
     {
+        $isHtml = $this->isHtml();
+
         $state = $this->evaluate($this->formatStateUsing ?? $state, [
             'state' => $state,
         ]);
+
+        if ($state instanceof Htmlable) {
+            $isHtml = true;
+            $state = $state->toHtml();
+        }
 
         if ($state instanceof LabelInterface) {
             $state = $state->getLabel();
@@ -225,23 +231,39 @@ trait CanFormatState
             $state = Str::words($state, $wordLimit, $this->getWordLimitEnd());
         }
 
-        if (filled($prefix = $this->getPrefix())) {
+        if ($isHtml && $this->isMarkdown()) {
+            $state = Str::markdown($state);
+        }
+
+        $prefix = $this->getPrefix();
+        $suffix = $this->getSuffix();
+
+        if (
+            (($prefix instanceof Htmlable) || ($suffix instanceof Htmlable)) &&
+            (! $isHtml)
+        ) {
+            $isHtml = true;
+            $state = e($state);
+        }
+
+        if (filled($prefix)) {
+            if ($prefix instanceof Htmlable) {
+                $prefix = $prefix->toHtml();
+            }
+
             $state = $prefix . $state;
         }
 
-        if (filled($suffix = $this->getSuffix())) {
+        if (filled($suffix)) {
+            if ($suffix instanceof Htmlable) {
+                $suffix = $suffix->toHtml();
+            }
+
             $state = $state . $suffix;
         }
 
-        if ($state instanceof HtmlString) {
-            return $state;
-        }
-
-        if ($this->isHtml()) {
-            return str($state)
-                ->when($this->isMarkdown(), fn (Stringable $stringable) => $stringable->markdown())
-                ->sanitizeHtml()
-                ->toHtmlString();
+        if ($isHtml) {
+            return str($state)->sanitizeHtml()->toHtmlString();
         }
 
         return $state;
@@ -277,12 +299,12 @@ trait CanFormatState
         return $this->evaluate($this->isHtml) || $this->isMarkdown() || $this->isProse();
     }
 
-    public function getPrefix(): ?string
+    public function getPrefix(): string | Htmlable | null
     {
         return $this->evaluate($this->prefix);
     }
 
-    public function getSuffix(): ?string
+    public function getSuffix(): string | Htmlable | null
     {
         return $this->evaluate($this->suffix);
     }

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -286,12 +286,12 @@ trait CanFormatState
         return $this->evaluate($this->isHtml) || $this->isMarkdown();
     }
 
-    public function getPrefix(): null | string | Htmlable
+    public function getPrefix(): string | Htmlable | null
     {
         return $this->evaluate($this->prefix);
     }
 
-    public function getSuffix(): null | string | Htmlable
+    public function getSuffix(): string | Htmlable | null
     {
         return $this->evaluate($this->suffix);
     }

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -6,6 +6,7 @@ use Closure;
 use Filament\Support\Contracts\HasLabel as LabelInterface;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
@@ -26,9 +27,9 @@ trait CanFormatState
 
     protected string | Closure | null $wordLimitEnd = null;
 
-    protected string | Closure | null $prefix = null;
+    protected string | Htmlable | Closure | null $prefix = null;
 
-    protected string | Closure | null $suffix = null;
+    protected string | Htmlable | Closure | null $suffix = null;
 
     protected string | Closure | null $timezone = null;
 
@@ -179,14 +180,14 @@ trait CanFormatState
         return $this;
     }
 
-    public function prefix(string | Closure | null $prefix): static
+    public function prefix(string | Htmlable | Closure | null $prefix): static
     {
         $this->prefix = $prefix;
 
         return $this;
     }
 
-    public function suffix(string | Closure | null $suffix): static
+    public function suffix(string | Htmlable | Closure | null $suffix): static
     {
         $this->suffix = $suffix;
 
@@ -227,10 +228,18 @@ trait CanFormatState
 
         if (filled($prefix = $this->getPrefix())) {
             $state = $prefix . $state;
+
+            if ($prefix instanceof Htmlable) {
+                $this->isHtml = true;
+            }
         }
 
         if (filled($suffix = $this->getSuffix())) {
             $state = $state . $suffix;
+
+            if ($suffix instanceof Htmlable) {
+                $this->isHtml = true;
+            }
         }
 
         if ($state instanceof HtmlString) {
@@ -277,12 +286,12 @@ trait CanFormatState
         return $this->evaluate($this->isHtml) || $this->isMarkdown();
     }
 
-    public function getPrefix(): ?string
+    public function getPrefix(): null | string | Htmlable
     {
         return $this->evaluate($this->prefix);
     }
 
-    public function getSuffix(): ?string
+    public function getSuffix(): null | string | Htmlable
     {
         return $this->evaluate($this->suffix);
     }


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

Updates the `TableColumn` `->prefix()` and  `->suffix()` helpers support `Htmlables` like `HtmlStrings`.

```php
Tables\Columns\TextColumn::make('name')
  ->suffix(function (Project $record): ?HtmlString {
      return $record->isActive()
        ? new HtmlString('<span class="text-green-500">Active</span>') 
        : null;
  })
```

Fixes https://github.com/filamentphp/filament/discussions/9729 and https://www.answeroverflow.com/m/1154022222118256700


- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.
 
![image](https://github.com/filamentphp/filament/assets/95144705/ecf6593d-701a-4d70-8389-05ebb80cf400)

![image](https://github.com/filamentphp/filament/assets/95144705/c874f332-7c87-48e9-bc8f-2a9f56d394b5)


## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
