### PR TITLE
Fix syntax error with modal edit forms

### DIFF
--- a/packages/panels/resources/views/components/page/index.blade.php
+++ b/packages/panels/resources/views/components/page/index.blade.php
@@ -116,7 +116,7 @@
         <x-filament-actions::modals />
     @elseif ($this->isTableLoaded() && filled($this->defaultTableAction))
         <div
-            wire:init="mountTableAction(@js($this->defaultTableAction), @if (filled($this->defaultTableActionRecord)) @js($this->defaultTableActionRecord) @elsenull @endif @if (filled($this->defaultTableActionArguments)) , @js($this->defaultTableActionArguments) @endif)"
+            wire:init="mountTableAction(@js($this->defaultTableAction), @if (filled($this->defaultTableActionRecord)) @js($this->defaultTableActionRecord) @else null @endif @if (filled($this->defaultTableActionArguments)) , @js($this->defaultTableActionArguments) @endif)"
         ></div>
     @endif
 


### PR DESCRIPTION
## How to reproduce
Visit the following link & open the browser console
https://demo.filamentphp.com/blog/categories?tableAction=edit&tableActionRecord=6

<img width="567" alt="Screenshot 2024-01-05 at 4 35 41 AM" src="https://github.com/filamentphp/filament/assets/406705/4ab5ffe6-6eca-44ba-b511-0706e9b9b2b8">

<img width="520" alt="Screenshot 2024-01-05 at 4 37 56 AM" src="https://github.com/filamentphp/filament/assets/406705/db7d8a13-d601-42a7-a440-ca98cda6b286">