### PR TITLE
Hide filter indicator bar

### DIFF
--- a/packages/tables/docs/04-filters/06-layout.md
+++ b/packages/tables/docs/04-filters/06-layout.md
@@ -93,23 +93,6 @@ public function table(Table $table): Table
 
 <AutoScreenshot name="tables/filters/above-content" alt="Table with filters above content" version="3.x" />
 
-## Hiding the filter indicator bar
-
-To hide the active filters indicator bar, you may use: 
-
-```php
-use Filament\Tables\Table;
-
-public function table(Table $table): Table
-{
-    return $table
-        ->filters([
-            // ...
-        ])
-        ->hideFilterIndicators();
-}
-```
-
 ### Allowing filters above the table content to be collapsed
 
 To allow the filters above the table content to be collapsed, you may use:
@@ -144,3 +127,20 @@ public function table(Table $table): Table
 ```
 
 <AutoScreenshot name="tables/filters/below-content" alt="Table with filters below content" version="3.x" />
+
+## Hiding the filter indicators
+
+To hide the active filters indicators above the table, you may use `hiddenFilterIndicators()`:
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->filters([
+            // ...
+        ])
+        ->hiddenFilterIndicators();
+}
+```

--- a/packages/tables/docs/04-filters/06-layout.md
+++ b/packages/tables/docs/04-filters/06-layout.md
@@ -93,6 +93,23 @@ public function table(Table $table): Table
 
 <AutoScreenshot name="tables/filters/above-content" alt="Table with filters above content" version="3.x" />
 
+## Hiding the filter indicator bar
+
+To hide the active filters indicator bar, you may use: 
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->filters([
+            // ...
+        ])
+        ->hideFilterIndicators();
+}
+```
+
 ### Allowing filters above the table content to be collapsed
 
 To allow the filters above the table content to be collapsed, you may use:

--- a/packages/tables/src/Table/Concerns/HasFilterIndicators.php
+++ b/packages/tables/src/Table/Concerns/HasFilterIndicators.php
@@ -2,19 +2,20 @@
 
 namespace Filament\Tables\Table\Concerns;
 
+use Closure;
 use Filament\Tables\Filters\BaseFilter;
 use Filament\Tables\Filters\Indicator;
 
 trait HasFilterIndicators
 {
-    protected ?bool $hideFilterIndicators = null;
+    protected bool | Closure $areFilterIndicatorsHidden = false;
 
     /**
      * @return array<Indicator>
      */
     public function getFilterIndicators(): array
     {
-        if ($this->hideFilterIndicators) {
+        if ($this->evaluate($this->areFilterIndicatorsHidden)) {
             return [];
         }
 
@@ -38,9 +39,9 @@ trait HasFilterIndicators
         ];
     }
 
-    public function hideFilterIndicators(?bool $condition = true): static
+    public function hiddenFilterIndicators(bool | Closure $condition = true): static
     {
-        $this->hideFilterIndicators = $condition;
+        $this->areFilterIndicatorsHidden = $condition;
 
         return $this;
     }

--- a/packages/tables/src/Table/Concerns/HasFilterIndicators.php
+++ b/packages/tables/src/Table/Concerns/HasFilterIndicators.php
@@ -7,11 +7,17 @@ use Filament\Tables\Filters\Indicator;
 
 trait HasFilterIndicators
 {
+    protected ?bool $hideFilterIndicators = null;
+
     /**
      * @return array<Indicator>
      */
     public function getFilterIndicators(): array
     {
+        if ($this->hideFilterIndicators) {
+            return [];
+        }
+
         return [
             ...($this->hasSearch() ? [$this->getSearchIndicator()] : []),
             ...$this->getColumnSearchIndicators(),
@@ -30,5 +36,12 @@ trait HasFilterIndicators
                 [],
             ),
         ];
+    }
+
+    public function hideFilterIndicators(?bool $condition = true): static
+    {
+        $this->hideFilterIndicators = $condition;
+
+        return $this;
     }
 }


### PR DESCRIPTION
The active filters bar is sometimes redundant. Eg. when filters are displayed above the table, the state of each filter is already visible.

This adds a method which allows it to be disabled.

Without `->hideFilterIndicators` (active filters shown in 2 places):
<img width="679" alt="image" src="https://github.com/filamentphp/filament/assets/5361908/3f1756e6-80ed-426d-bb3b-e4a8b018be63">

With `->hideFilterIndicators`:
<img width="683" alt="image" src="https://github.com/filamentphp/filament/assets/5361908/a992f308-eaca-451d-ba44-8367601e2d5f">
