### PR TITLE
Eager load grouped by relations

### DIFF
--- a/packages/tables/src/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Concerns/CanGroupRecords.php
@@ -53,6 +53,8 @@ trait CanGroupRecords
             return $query;
         }
 
+        $group->applyEagerLoading($query);
+
         return $group->orderQuery($query, $this->getTableGroupingDirection() ?? 'asc');
     }
 }

--- a/packages/tables/src/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Concerns/CanGroupRecords.php
@@ -55,6 +55,8 @@ trait CanGroupRecords
 
         $group->applyEagerLoading($query);
 
-        return $group->orderQuery($query, $this->getTableGroupingDirection() ?? 'asc');
+        $group->orderQuery($query, $this->getTableGroupingDirection() ?? 'asc');
+
+        return $query;
     }
 }

--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -8,7 +8,6 @@ use Closure;
 use DateTimeInterface;
 use Filament\Support\Components\Component;
 use Filament\Support\Contracts\HasLabel as LabelInterface;
-use Filament\Tables\Columns\Concerns\InteractsWithTableQuery;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
@@ -18,8 +17,6 @@ use Illuminate\Support\Arr;
 
 class Group extends Component
 {
-    use InteractsWithTableQuery;
-
     protected ?string $column;
 
     protected ?Closure $getDescriptionFromRecordUsing = null;
@@ -456,5 +453,20 @@ class Group extends Component
     public function isDate(): bool
     {
         return $this->isDate;
+    }
+
+    public function applyEagerLoading(EloquentBuilder $query): EloquentBuilder
+    {
+        if (! $this->getRelationship($query->getModel())) {
+            return $query;
+        }
+
+        $relationshipName = $this->getRelationshipName();
+
+        if (array_key_exists($relationshipName, $query->getEagerLoads())) {
+            return $query;
+        }
+
+        return $query->with([$relationshipName]);
     }
 }

--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -8,6 +8,7 @@ use Closure;
 use DateTimeInterface;
 use Filament\Support\Components\Component;
 use Filament\Support\Contracts\HasLabel as LabelInterface;
+use Filament\Tables\Columns\Concerns\InteractsWithTableQuery;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
@@ -17,6 +18,8 @@ use Illuminate\Support\Arr;
 
 class Group extends Component
 {
+    use InteractsWithTableQuery;
+
     protected ?string $column;
 
     protected ?Closure $getDescriptionFromRecordUsing = null;


### PR DESCRIPTION
## Description

This pr eager loads the table relations when the relation is used in [grouping by](https://filamentphp.com/docs/3.x/tables/grouping#grouping-by-a-relationship-attribute), it fixes this reported [issue](https://github.com/filamentphp/filament/issues/10580)


```php
public static function table(Table $table): Table
    {
        return $table
            ->defaultGroup('category.name')
            ->columns([
                Tables\Columns\TextColumn::make('title')
                    ->searchable(),
            ])
    }
```

Queries Before this pr
<img width="1512" alt="image" src="https://github.com/filamentphp/filament/assets/33787232/3197d7ae-0f1f-4af2-aaa0-3bd5824337fb">

Queries after 
<img width="1512" alt="image" src="https://github.com/filamentphp/filament/assets/33787232/4b0568f8-35bc-4863-adb6-9727b346d69d">


let me know please what you think, and thank you guys for creating such a brilliant project ❤️ 🚀 


