### PR TITLE
Update base Widget class to support HtmlString placeholder() return types

### DIFF
--- a/packages/widgets/src/Widget.php
+++ b/packages/widgets/src/Widget.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Widgets;
 
+use Illuminate\Support\HtmlString;
 use Illuminate\Contracts\View\View;
 use Livewire\Component;
 
@@ -99,7 +100,7 @@ abstract class Widget extends Component
         return $properties;
     }
 
-    public function placeholder(): View
+    public function placeholder(): View | HtmlString
     {
         return view('filament::components.loading-section', [
             'columnSpan' => $this->getColumnSpan(),

--- a/packages/widgets/src/Widget.php
+++ b/packages/widgets/src/Widget.php
@@ -2,8 +2,8 @@
 
 namespace Filament\Widgets;
 
-use Illuminate\Support\HtmlString;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\HtmlString;
 use Livewire\Component;
 
 abstract class Widget extends Component


### PR DESCRIPTION
Adds a union type so that `HtmlStrings` can be returned from overridden `placeholder()` methods in custom `Widget` classes, making it easier to customize without having to create a view.

```php
public function placeholder(): HtmlString
{
    return new HtmlString('<div>Example</div>');
}
```

<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
