### PR TITLE
add reverseBoolean method to Radio field

### DIFF
--- a/packages/forms/src/Components/Radio.php
+++ b/packages/forms/src/Components/Radio.php
@@ -37,6 +37,11 @@ class Radio extends Field implements Contracts\CanDisableOptions
         return $this;
     }
 
+    public function reverseBoolean(?string $trueLabel = null, ?string $falseLabel = null): static
+    {
+        return $this->boolean($falseLabel, $trueLabel);
+    }
+
     public function inline(bool | Closure $condition = true): static
     {
         $this->isInline = $condition;


### PR DESCRIPTION
## Description

Add reverseBoolean() method to Radio field

Often a radio field is used for declarations in the form of:

"I have never drunk drive before"

- Yes
- No

However the database column, is in positive form of "has_drunk_drive_before" which make sense since writing code we often prefer it to be in positive form

the purpose of ->reverseBoolean() is to support this use case.
