### PR TITLE
Update file-upload.css

### DIFF
--- a/packages/forms/resources/css/components/file-upload.css
+++ b/packages/forms/resources/css/components/file-upload.css
@@ -69,5 +69,5 @@
 
 .fi-fo-file-upload-circle-cropper .cropper-view-box,
 .fi-fo-file-upload-circle-cropper .cropper-face {
-    @apply rounded-full;
+    border-radius: 50%;
 }


### PR DESCRIPTION
Update the circle cropper view box and cropper face css to use border-radius of 50% as it's more ideal than tailwinds rounded-full, which uses 9999px when working with circles.

## Description

I've noticed a small issue with this feature involving the CSS.

When using the circle cropper and applying an aspect ratio, for example, 18:25 for the cropper, the circle/oval doesn't make a complete circle/oval due to the fact that the css is using @apply rounded-full; which is essentially: border-radius: 9999px;. This doesn't complete the full "Oval" in this case as shown below:
![image](https://github.com/filamentphp/filament/assets/11856709/776013b5-d342-40d5-ab89-a83d8d7fdf82)

If you update the CSS to use border-radius: 50%; it works as expected with using cropping ratios as show below:
![image](https://github.com/filamentphp/filament/assets/11856709/a51ed799-fe92-478f-94e5-37748fe1442d)

border-radius: 9999px; is great when working with inputs and buttons but we'll need to use border-radius: 50% as we are dealing with circles.

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

- [ ] `composer cs` command has been run.

## Testing

- [ ] Changes have been tested.

## Documentation

- [ ] Documentation is up-to-date.
