### PR TITLE
fix: Stabilize slideover modal to prevent jitteriness on open

### DIFF
--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -115,7 +115,6 @@
                 'fi-modal-close-overlay fixed inset-0 bg-gray-950/50 dark:bg-gray-950/75',
                 'cursor-pointer' => $closeByClickingAway,
             ])
-            style="will-change: transform"
         ></div>
 
         <div
@@ -143,14 +142,14 @@
                     x-on:keydown.window.escape="close()"
                 @endif
                 x-show="isShown"
-                x-transition:enter="duration-300"
-                x-transition:leave="duration-300"
+                x-transition:enter="transition ease-out duration-300"
+                x-transition:leave="transition ease-in duration-300"
                 @if ($width === MaxWidth::Screen)
                 @elseif ($slideOver)
-                    x-transition:enter-start="translate-x-full rtl:-translate-x-full"
+                    x-transition:enter-start="translate-x-1/2 rtl:-translate-x-1/2"
                     x-transition:enter-end="translate-x-0"
                     x-transition:leave-start="translate-x-0"
-                    x-transition:leave-end="translate-x-full rtl:-translate-x-full"
+                    x-transition:leave-end="translate-x-1/2 rtl:-translate-x-1/2"
                 @else
                     x-transition:enter-start="scale-95"
                     x-transition:enter-end="scale-100"


### PR DESCRIPTION
This pull request addresses an issue with the slideover modal where it exhibited jittery and shaky behavior upon opening. This would be more pronounced based on the browser you were using and whether it utilized hardware-acceleration. The goal was to ensure a smooth, stable transition when the modal is activated. This issue was also mentioned here #4319, in which that video is what it looks like on Chrome. The video below is what it looks like using Firefox.

### Key Changes
**Transition Property Adjustment:** Modified the transition properties of the slideover modal. Previously, the `translate-x-full` property was used, which caused the modal to slide more than necessary, leading to an unstable appearance. This has been adjusted to a more appropriate value that maintains the visual integrity of the sliding effect without causing instability.

**CSS Refinement and Removal of `will-change`:** Reviewed and refined the CSS associated with the modal to eliminate any conflicting styles or properties that could contribute to the jitteriness. Importantly, the `will-change: transform` property was removed from the outer div of the modal. This change was made because the `transform` CSS properties were not being utilized on this element, and `will-change: transform` does not affect the children of an element. This adjustment helps ensure that browser rendering optimizations are correctly applied where actually needed.

**Cross-Browser Consistency:** Ensured that the changes provide a consistent experience across different browsers and devices.

These changes result in a more fluid user experience when interacting with the slideover modal, enhancing the overall usability and visual appeal of the interface.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

### Before

[SlideoverBefore](https://github.com/filamentphp/filament/assets/104294090/06b0c94c-1cf8-4e55-be31-a6e8918c21cb)

### After

[SlideoverAfter](https://github.com/filamentphp/filament/assets/104294090/9b475913-8d6e-4465-9d4a-0360bc0c69ab)




## Testing

- [x] Changes have been tested.
