### PR TITLE
Docs for relation manager: Add missing "?"

### DIFF
--- a/packages/panels/docs/03-resources/07-relation-managers.md
+++ b/packages/panels/docs/03-resources/07-relation-managers.md
@@ -756,7 +756,7 @@ public function table(Table $table): Table
 To set the title of the relation manager, you can use the `$title` property on the relation manager class:
 
 ```php
-protected static string $title = 'Posts';
+protected static ?string $title = 'Posts';
 ```
 
 To set the title of the relation manager dynamically, you can override the `getTitle()` method on the relation manager class:


### PR DESCRIPTION
When copying the example for "Customizing the relation manager title" the following error occurs:

```
Type of ...\RelationManagers\ContributionsRelationManager::$title must be ?string (as in class Filament\Resources\RelationManagers\RelationManager)
```

This just adds the missing "?" before `string` in the docs.