### PR TITLE
Docs: Add quick reference for Blade icon usage

### DIFF
--- a/packages/support/docs/03-icons.md
+++ b/packages/support/docs/03-icons.md
@@ -8,6 +8,14 @@ Icons are used throughout the entire Filament UI to visually communicate core pa
 
 They have a website where you can [search all the available icons](https://blade-ui-kit.com/blade-icons?set=1#search) from various Blade Icons packages. Each package contains a different icon set that you can choose from.
 
+### Blade Usage
+
+You can use the Filament Icon component to render icons from your custom Blade views.
+
+```blade
+<x-filament::icon icon="heroicon-o-check-circle" />
+```
+
 ## Using custom SVGs as icons
 
 The [Blade Icons](https://github.com/blade-ui-kit/blade-icons) package allows you to register custom SVGs as icons. This is useful if you want to use your own custom icons in Filament.


### PR DESCRIPTION

## Abstract

Adds a line users can quickly copy to use the Blade icon component

```blade
<x-filament::icon icon="heroicon-o-check-circle" />
```
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [x] No code changes

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] No code changes


## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] No code changes


## Documentation


- [x] Documentation is up-to-date.
