### PR TITLE
Add filament register event

### DIFF
--- a/packages/panels/src/Events/Auth/Registered.php
+++ b/packages/panels/src/Events/Auth/Registered.php
@@ -2,27 +2,14 @@
 
 namespace Filament\Events\Auth;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Queue\SerializesModels;
 
 class Registered
 {
     use SerializesModels;
 
-    /**
-     * The authenticated user.
-     *
-     * @var \Illuminate\Contracts\Auth\Authenticatable
-     */
-    public $user;
-
-    /**
-     * Create a new event instance.
-     *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
-     * @return void
-     */
-    public function __construct($user)
-    {
-        $this->user = $user;
-    }
+    public function __construct(
+        readonly public Authenticatable $user,
+    ) {}
 }

--- a/packages/panels/src/Events/Auth/Registered.php
+++ b/packages/panels/src/Events/Auth/Registered.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Filament\Events\Auth;
+
+use Illuminate\Queue\SerializesModels;
+
+class Registered
+{
+    use SerializesModels;
+
+    /**
+     * The authenticated user.
+     *
+     * @var \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public $user;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @return void
+     */
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+}

--- a/packages/panels/src/Events/Auth/Registered.php
+++ b/packages/panels/src/Events/Auth/Registered.php
@@ -10,6 +10,11 @@ class Registered
     use SerializesModels;
 
     public function __construct(
-        readonly public Authenticatable $user,
+        protected Authenticatable $user,
     ) {}
+
+    public function getUser(): Authenticatable
+    {
+        return $this->user;
+    }
 }

--- a/packages/panels/src/Pages/Auth/Register.php
+++ b/packages/panels/src/Pages/Auth/Register.php
@@ -7,6 +7,7 @@ use DanHarrin\LivewireRateLimiting\WithRateLimiting;
 use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
+use Filament\Events\Auth\Registered;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Component;
 use Filament\Forms\Components\TextInput;
@@ -76,6 +77,8 @@ class Register extends SimplePage
         $data = $this->form->getState();
 
         $user = $this->getUserModel()::create($data);
+
+        event(new Registered($user));
 
         $this->sendEmailVerificationNotification($user);
 

--- a/tests/src/Panels/Auth/RegisterTest.php
+++ b/tests/src/Panels/Auth/RegisterTest.php
@@ -1,10 +1,12 @@
 <?php
 
+use Filament\Events\Auth\Registered;
 use Filament\Facades\Filament;
 use Filament\Notifications\Auth\VerifyEmail;
 use Filament\Pages\Auth\Register;
 use Filament\Tests\Models\User;
 use Filament\Tests\TestCase;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Str;
 
@@ -19,6 +21,7 @@ it('can render page', function () {
 
 it('can register', function () {
     Notification::fake();
+    Event::fake();
 
     $this->assertGuest();
 
@@ -37,6 +40,7 @@ it('can register', function () {
         ->assertRedirect(Filament::getUrl());
 
     Notification::assertSentTimes(VerifyEmail::class, expectedCount: 1);
+    Event::assertDispatched(Registered::class);
 
     $this->assertAuthenticated();
 
@@ -48,6 +52,7 @@ it('can register', function () {
 
 it('can register and redirect user to their intended URL', function () {
     Notification::fake();
+    Event::fake();
 
     session()->put('url.intended', $intendedUrl = Str::random());
 
@@ -68,6 +73,7 @@ it('can register and redirect user to their intended URL', function () {
 
 it('can throttle registration attempts', function () {
     Notification::fake();
+    Event::fake();
 
     $this->assertGuest();
 
@@ -90,6 +96,7 @@ it('can throttle registration attempts', function () {
     }
 
     Notification::assertSentTimes(VerifyEmail::class, expectedCount: 2);
+    Event::assertDispatchedTimes(Registered::class, times: 2);
 
     livewire(Register::class)
         ->fillForm([
@@ -103,6 +110,7 @@ it('can throttle registration attempts', function () {
         ->assertNoRedirect();
 
     Notification::assertSentTimes(VerifyEmail::class, expectedCount: 2);
+    Event::assertDispatchedTimes(Registered::class, times: 2);
 
     $this->assertGuest();
 });


### PR DESCRIPTION
## Description

This pull request will reintroduce the "Registered" event upon registration, which was removed in [this pull request](https://github.com/filamentphp/filament/pull/9875/files). It does not utilize the default Laravel "Registered" event, but instead uses an event in the Filament namespace.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
