### PR TITLE
fix: Stabilize slideover modal

### DIFF
--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -115,7 +115,6 @@
                 'fi-modal-close-overlay fixed inset-0 bg-gray-950/50 dark:bg-gray-950/75',
                 'cursor-pointer' => $closeByClickingAway,
             ])
-            style="will-change: transform"
         ></div>
 
         <div
@@ -147,7 +146,7 @@
                 x-transition:leave="duration-300"
                 @if ($width === MaxWidth::Screen)
                 @elseif ($slideOver)
-                    x-transition:enter-start="translate-x-full rtl:-translate-x-full"
+                    x-transition:enter-start="translate-x-2/3 rtl:-translate-x-2/3"
                     x-transition:enter-end="translate-x-0"
                     x-transition:leave-start="translate-x-0"
                     x-transition:leave-end="translate-x-full rtl:-translate-x-full"


### PR DESCRIPTION
This is an update (part 2) to stabilize the slideover modal to prevent jittery behavior on open. The original commit was reverted. This commit is to find common ground on what would be best as previously discussed. The original commit and all relevant information: #10713 