### PR TITLE
Fix `getUrl()` for empty panels

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -173,13 +173,13 @@ trait HasRoutes
             $firstGroup = Arr::first($navigation);
 
             if (! $firstGroup) {
-                return null;
+                return url($this->getPath());
             }
 
             $firstItem = Arr::first($firstGroup->getItems());
 
             if (! $firstItem) {
-                return null;
+                return url($this->getPath());
             }
 
             return $firstItem->getUrl();


### PR DESCRIPTION
`getUrl()` doesn't work for empty panels (i.e. panels with just a dashboard) because `$firstGroup` and `$firstItem` are both empty. Is there a reason we return `null` in these cases? 

I've got a couple of monitoring panels which only have a dashboard with widgets and I can't use `$panel->getUrl()` with these. Returning `url($this->getPath())` instead of `null` fixes this.

