### PR TITLE
Added ability to customize default panel route slugs

### DIFF
--- a/packages/panels/docs/09-configuration.md
+++ b/packages/panels/docs/09-configuration.md
@@ -209,3 +209,30 @@ public function panel(Panel $panel): Panel
         ], isPersistent: true);
 }
 ```
+
+## Changing the default slugs
+
+Filament uses sensible English slugs by default when registering its routes. These can be changed by setting them in their respective config methods. 
+
+```php
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->tenantBillingProvider(slug: 'abrechnung')
+        ->login(slug: 'einloggen')
+        ->passwordReset(
+            requestSlug: 'anfragen',
+            resetSlug: 'zuruecksetzen',
+            prefix: 'passwort-ruecksetzung'
+        )
+        ->registration(slug: 'registrieren')
+        ->emailVerification(
+            promptSlug: 'auffordern',
+            verifySlug: 'verifizieren',
+            prefix: 'email-verifizierung'
+        );
+}
+```

--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -29,22 +29,25 @@ Route::name('filament.')
 
                         Route::name('auth.')->group(function () use ($panel) {
                             if ($panel->hasLogin()) {
-                                Route::get('/login', $panel->getLoginRouteAction())->name('login');
+                                Route::get($panel->getLoginRouteSlug(), $panel->getLoginRouteAction())
+                                    ->name('login');
                             }
 
                             if ($panel->hasPasswordReset()) {
                                 Route::name('password-reset.')
-                                    ->prefix('/password-reset')
+                                    ->prefix($panel->getResetPasswordRoutePrefix())
                                     ->group(function () use ($panel) {
-                                        Route::get('/request', $panel->getRequestPasswordResetRouteAction())->name('request');
-                                        Route::get('/reset', $panel->getResetPasswordRouteAction())
+                                        Route::get($panel->getRequestPasswordResetRouteSlug(), $panel->getRequestPasswordResetRouteAction())
+                                            ->name('request');
+                                        Route::get($panel->getResetPasswordRouteSlug(), $panel->getResetPasswordRouteAction())
                                             ->middleware(['signed'])
                                             ->name('reset');
                                     });
                             }
 
                             if ($panel->hasRegistration()) {
-                                Route::get('/register', $panel->getRegistrationRouteAction())->name('register');
+                                Route::get($panel->getRegistrationRouteSlug(), $panel->getRegistrationRouteAction())
+                                    ->name('register');
                             }
                         });
 
@@ -69,10 +72,11 @@ Route::name('filament.')
 
                                 if ($panel->hasEmailVerification()) {
                                     Route::name('auth.email-verification.')
-                                        ->prefix('/email-verification')
+                                        ->prefix($panel->getEmailVerificationRoutePrefix())
                                         ->group(function () use ($panel) {
-                                            Route::get('/prompt', $panel->getEmailVerificationPromptRouteAction())->name('prompt');
-                                            Route::get('/verify/{id}/{hash}', EmailVerificationController::class)
+                                            Route::get($panel->getEmailVerificationPromptRouteSlug(), $panel->getEmailVerificationPromptRouteAction())
+                                                ->name('prompt');
+                                            Route::get($panel->getEmailVerificationVerifyRouteSlug('/{id}/{hash}'), EmailVerificationController::class)
                                                 ->middleware(['signed', 'throttle:6,1'])
                                                 ->name('verify');
                                         });
@@ -96,7 +100,7 @@ Route::name('filament.')
 
                                         Route::name('tenant.')->group(function () use ($panel): void {
                                             if ($panel->hasTenantBilling()) {
-                                                Route::get('/billing', $panel->getTenantBillingProvider()->getRouteAction())
+                                                Route::get($panel->getTenantBillingRouteSlug(), $panel->getTenantBillingProvider()->getRouteAction())
                                                     ->name('billing');
                                             }
 

--- a/packages/panels/src/Panel/Concerns/HasAuth.php
+++ b/packages/panels/src/Panel/Concerns/HasAuth.php
@@ -15,6 +15,7 @@ use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
 
 trait HasAuth
 {
@@ -25,6 +26,12 @@ trait HasAuth
      */
     protected string | Closure | array | null $emailVerificationRouteAction = null;
 
+    protected string $emailVerificationPromptRouteSlug = 'prompt';
+
+    protected string $emailVerificationVerifyRouteSlug = 'verify';
+
+    protected string $emailVerificationRoutePrefix = 'email-verification';
+
     protected bool $isEmailVerificationRequired = false;
 
     /**
@@ -32,20 +39,30 @@ trait HasAuth
      */
     protected string | Closure | array | null $loginRouteAction = null;
 
+    protected string $loginRouteSlug = 'login';
+
     /**
      * @var string | Closure | array<class-string, string> | null
      */
     protected string | Closure | array | null $registrationRouteAction = null;
+
+    protected string $registrationRouteSlug = 'register';
 
     /**
      * @var string | Closure | array<class-string, string> | null
      */
     protected string | Closure | array | null $requestPasswordResetRouteAction = null;
 
+    protected string $requestPasswordResetRouteSlug = 'request';
+
     /**
      * @var string | Closure | array<class-string, string> | null
      */
     protected string | Closure | array | null $resetPasswordRouteAction = null;
+
+    protected string $resetPasswordRouteSlug = 'reset';
+
+    protected string $resetPasswordRoutePrefix = 'password-reset';
 
     protected ?string $profilePage = null;
 
@@ -56,10 +73,14 @@ trait HasAuth
     /**
      * @param  string | Closure | array<class-string, string> | null  $promptAction
      */
-    public function emailVerification(string | Closure | array | null $promptAction = EmailVerificationPrompt::class, bool $isRequired = true): static
+    public function emailVerification(string | Closure | array | null $promptAction = EmailVerificationPrompt::class, bool $isRequired = true, string $promptSlug = 'prompt', string $verifySlug = 'verify', string $prefix = 'email-verification'): static
     {
         $this->emailVerificationRouteAction = $promptAction;
         $this->requiresEmailVerification($isRequired);
+
+        $this->emailVerificationPromptRouteSlug = $promptSlug;
+        $this->emailVerificationVerifyRouteSlug = $verifySlug;
+        $this->emailVerificationRoutePrefix = $prefix;
 
         return $this;
     }
@@ -81,9 +102,10 @@ trait HasAuth
     /**
      * @param  string | Closure | array<class-string, string> | null  $action
      */
-    public function login(string | Closure | array | null $action = Login::class): static
+    public function login(string | Closure | array | null $action = Login::class, string $slug = 'login'): static
     {
         $this->loginRouteAction = $action;
+        $this->loginRouteSlug = $slug;
 
         return $this;
     }
@@ -92,10 +114,15 @@ trait HasAuth
      * @param  string | Closure | array<class-string, string> | null  $requestAction
      * @param  string | Closure | array<class-string, string> | null  $resetAction
      */
-    public function passwordReset(string | Closure | array | null $requestAction = RequestPasswordReset::class, string | Closure | array | null $resetAction = ResetPassword::class): static
+    public function passwordReset(string | Closure | array | null $requestAction = RequestPasswordReset::class, string | Closure | array | null $resetAction = ResetPassword::class, string $requestSlug = 'request', string $resetSlug = 'reset', string $prefix = 'password-reset'): static
     {
         $this->requestPasswordResetRouteAction = $requestAction;
         $this->resetPasswordRouteAction = $resetAction;
+
+        $this->requestPasswordResetRouteSlug = $requestSlug;
+        $this->resetPasswordRouteSlug = $resetSlug;
+
+        $this->resetPasswordRoutePrefix = $prefix;
 
         return $this;
     }
@@ -103,9 +130,10 @@ trait HasAuth
     /**
      * @param  string | Closure | array<class-string, string> | null  $action
      */
-    public function registration(string | Closure | array | null $action = Register::class): static
+    public function registration(string | Closure | array | null $action = Register::class, string $slug = 'register'): static
     {
         $this->registrationRouteAction = $action;
+        $this->registrationRouteSlug = $slug;
 
         return $this;
     }
@@ -273,12 +301,32 @@ trait HasAuth
         return $this->emailVerificationRouteAction;
     }
 
+    public function getEmailVerificationPromptRouteSlug(): string
+    {
+        return Str::start($this->emailVerificationPromptRouteSlug, '/');
+    }
+
+    public function getEmailVerificationVerifyRouteSlug(string $suffix): string
+    {
+        return Str::start($this->emailVerificationVerifyRouteSlug, '/') . $suffix;
+    }
+
+    public function getEmailVerificationRoutePrefix(): string
+    {
+        return Str::start($this->emailVerificationRoutePrefix, '/');
+    }
+
     /**
      * @return string | Closure | array<class-string, string> | null
      */
     public function getLoginRouteAction(): string | Closure | array | null
     {
         return $this->loginRouteAction;
+    }
+
+    public function getLoginRouteSlug(): string
+    {
+        return Str::start($this->loginRouteSlug, '/');
     }
 
     /**
@@ -289,6 +337,11 @@ trait HasAuth
         return $this->registrationRouteAction;
     }
 
+    public function getRegistrationRouteSlug(): string
+    {
+        return Str::start($this->registrationRouteSlug, '/');
+    }
+
     /**
      * @return string | Closure | array<class-string, string> | null
      */
@@ -297,12 +350,27 @@ trait HasAuth
         return $this->requestPasswordResetRouteAction;
     }
 
+    public function getRequestPasswordResetRouteSlug(): string
+    {
+        return Str::start($this->requestPasswordResetRouteSlug, '/');
+    }
+
     /**
      * @return string | Closure | array<class-string, string> | null
      */
     public function getResetPasswordRouteAction(): string | Closure | array | null
     {
         return $this->resetPasswordRouteAction;
+    }
+
+    public function getResetPasswordRouteSlug(): string
+    {
+        return Str::start($this->resetPasswordRouteSlug, '/');
+    }
+
+    public function getResetPasswordRoutePrefix(): string
+    {
+        return Str::start($this->resetPasswordRoutePrefix, '/');
     }
 
     public function hasEmailVerification(): bool

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -7,10 +7,13 @@ use Filament\Billing\Providers\Contracts\Provider as BillingProvider;
 use Filament\Navigation\MenuItem;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Str;
 
 trait HasTenancy
 {
     protected ?BillingProvider $tenantBillingProvider = null;
+
+    protected string $tenantBillingRouteSlug = 'billing';
 
     protected bool | Closure $hasTenantMenu = true;
 
@@ -76,9 +79,10 @@ trait HasTenancy
         return $this;
     }
 
-    public function tenantBillingProvider(?BillingProvider $provider): static
+    public function tenantBillingProvider(?BillingProvider $provider, string $slug = 'billing'): static
     {
         $this->tenantBillingProvider = $provider;
+        $this->tenantBillingRouteSlug = $slug;
 
         return $this;
     }
@@ -135,6 +139,11 @@ trait HasTenancy
     public function getTenantBillingProvider(): ?BillingProvider
     {
         return $this->tenantBillingProvider;
+    }
+
+    public function getTenantBillingRouteSlug(): string
+    {
+        return Str::start($this->tenantBillingRouteSlug, '/');
     }
 
     public function getTenantProfilePage(): ?string

--- a/tests/src/Models/User.php
+++ b/tests/src/Models/User.php
@@ -28,7 +28,7 @@ class User extends Authenticatable implements FilamentUser, HasTenants, MustVeri
 
     public function canAccessPanel(Panel $panel): bool
     {
-        return $panel->getId() === 'admin';
+        return in_array($panel->getId(), ['admin', 'slugs']);
     }
 
     public function posts(): HasMany

--- a/tests/src/Panels/Auth/EmailVerification/EmailVerificationPromptTest.php
+++ b/tests/src/Panels/Auth/EmailVerification/EmailVerificationPromptTest.php
@@ -18,6 +18,23 @@ it('can render page', function () {
 
     $this->actingAs($userToVerify);
 
+    expect(Filament::getEmailVerificationPromptUrl())->toEndWith('/email-verification/prompt');
+
+    $this->get(Filament::getEmailVerificationPromptUrl())
+        ->assertSuccessful();
+});
+
+it('can render page with a custom slug', function () {
+    Filament::setCurrentPanel(Filament::getPanel('slugs'));
+
+    expect(Filament::getEmailVerificationPromptUrl())->toEndWith('/email-verification-test/prompt-test');
+
+    $userToVerify = User::factory()->create([
+        'email_verified_at' => null,
+    ]);
+
+    $this->actingAs($userToVerify);
+
     $this->get(Filament::getEmailVerificationPromptUrl())
         ->assertSuccessful();
 });

--- a/tests/src/Panels/Auth/EmailVerification/EmailVerificationTest.php
+++ b/tests/src/Panels/Auth/EmailVerification/EmailVerificationTest.php
@@ -23,6 +23,26 @@ it('can verify an email', function () {
         ->hasVerifiedEmail()->toBeTrue();
 });
 
+it('can verify an email with a custom slug', function () {
+    Filament::setCurrentPanel(Filament::getPanel('slugs'));
+
+    $userToVerify = User::factory()->create([
+        'email_verified_at' => null,
+    ]);
+
+    expect($userToVerify)
+        ->hasVerifiedEmail()->toBeFalse()
+        ->and(Filament::getVerifyEmailUrl($userToVerify))->toContain('/email-verification-test/verify-test/');
+
+    $this
+        ->actingAs($userToVerify)
+        ->get(Filament::getVerifyEmailUrl($userToVerify))
+        ->assertRedirect(Filament::getUrl());
+
+    expect($userToVerify->refresh())
+        ->hasVerifiedEmail()->toBeTrue();
+});
+
 it('cannot verify an email when signed in as another user', function () {
     $userToVerify = User::factory()->create([
         'email_verified_at' => null,

--- a/tests/src/Panels/Auth/LoginTest.php
+++ b/tests/src/Panels/Auth/LoginTest.php
@@ -11,6 +11,17 @@ use function Filament\Tests\livewire;
 uses(TestCase::class);
 
 it('can render page', function () {
+    expect(Filament::getLoginUrl())->toEndWith('/login');
+
+    $this->get(Filament::getLoginUrl())
+        ->assertSuccessful();
+});
+
+it('can render page with a custom slug', function () {
+    Filament::setCurrentPanel(Filament::getPanel('slugs'));
+
+    expect(Filament::getLoginUrl())->toEndWith('/login-test');
+
     $this->get(Filament::getLoginUrl())
         ->assertSuccessful();
 });

--- a/tests/src/Panels/Auth/PasswordReset/RequestPasswordResetTest.php
+++ b/tests/src/Panels/Auth/PasswordReset/RequestPasswordResetTest.php
@@ -12,6 +12,17 @@ use function Filament\Tests\livewire;
 uses(TestCase::class);
 
 it('can render page', function () {
+    expect(Filament::getRequestPasswordResetUrl())->toEndWith('/password-reset/request');
+
+    $this->get(Filament::getRequestPasswordResetUrl())
+        ->assertSuccessful();
+});
+
+it('can render page with a custom slug', function () {
+    Filament::setCurrentPanel(Filament::getPanel('slugs'));
+
+    expect(Filament::getRequestPasswordResetUrl())->toEndWith('/password-reset-test/request-test');
+
     $this->get(Filament::getRequestPasswordResetUrl())
         ->assertSuccessful();
 });

--- a/tests/src/Panels/Auth/PasswordReset/ResetPasswordTest.php
+++ b/tests/src/Panels/Auth/PasswordReset/ResetPasswordTest.php
@@ -17,10 +17,30 @@ it('can render page', function () {
     $userToResetPassword = User::factory()->make();
     $token = Password::createToken($userToResetPassword);
 
-    $this->get(Filament::getResetPasswordUrl(
+    $url = Filament::getResetPasswordUrl(
         $token,
         $userToResetPassword,
-    ))->assertSuccessful();
+    );
+
+    expect($url)->toContain('/password-reset/reset?');
+
+    $this->get($url)->assertSuccessful();
+});
+
+it('can render page with a custom slug', function () {
+    Filament::setCurrentPanel(Filament::getPanel('slugs'));
+
+    $userToResetPassword = User::factory()->make();
+    $token = Password::createToken($userToResetPassword);
+
+    $url = Filament::getResetPasswordUrl(
+        $token,
+        $userToResetPassword,
+    );
+
+    expect($url)->toContain('/password-reset-test/reset-test?');
+
+    $this->get($url)->assertSuccessful();
 });
 
 it('can reset password', function () {

--- a/tests/src/Panels/Auth/RegisterTest.php
+++ b/tests/src/Panels/Auth/RegisterTest.php
@@ -13,6 +13,17 @@ use function Filament\Tests\livewire;
 uses(TestCase::class);
 
 it('can render page', function () {
+    expect(Filament::getRegistrationUrl())->toEndWith('/register');
+
+    $this->get(Filament::getRegistrationUrl())
+        ->assertSuccessful();
+});
+
+it('can render page with a custom slug', function () {
+    Filament::setCurrentPanel(Filament::getPanel('slugs'));
+
+    expect(Filament::getRegistrationUrl())->toEndWith('/register-test');
+
     $this->get(Filament::getRegistrationUrl())
         ->assertSuccessful();
 });

--- a/tests/src/SlugsPanelProvider.php
+++ b/tests/src/SlugsPanelProvider.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Filament\Tests;
+
+use Filament\Http\Middleware\Authenticate;
+use Filament\Http\Middleware\DisableBladeIconComponents;
+use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Panel;
+use Filament\PanelProvider;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Session\Middleware\AuthenticateSession;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
+
+class SlugsPanelProvider extends PanelProvider
+{
+    public function panel(Panel $panel): Panel
+    {
+        return $panel
+            ->id('slugs')
+            ->path('slugs')
+            ->login(slug: 'login-test')
+            ->passwordReset(
+                requestSlug: 'request-test',
+                resetSlug: 'reset-test',
+                prefix: 'password-reset-test'
+            )
+            ->registration(slug: 'register-test')
+            ->emailVerification(
+                promptSlug: 'prompt-test',
+                verifySlug: 'verify-test',
+                prefix: 'email-verification-test'
+            )
+            ->resources([])
+            ->pages([])
+            ->middleware([
+                EncryptCookies::class,
+                AddQueuedCookiesToResponse::class,
+                StartSession::class,
+                AuthenticateSession::class,
+                ShareErrorsFromSession::class,
+                VerifyCsrfToken::class,
+                SubstituteBindings::class,
+                DisableBladeIconComponents::class,
+                DispatchServingFilamentEvent::class,
+            ])
+            ->authMiddleware([
+                Authenticate::class,
+            ]);
+    }
+}

--- a/tests/src/TestCase.php
+++ b/tests/src/TestCase.php
@@ -43,6 +43,7 @@ abstract class TestCase extends BaseTestCase
             WidgetsServiceProvider::class,
             AdminPanelProvider::class,
             CustomPanelProvider::class,
+            SlugsPanelProvider::class,
         ];
     }
 


### PR DESCRIPTION
## Description

Currently the default slugs, like auth and billing, are hardcoded and cannot be changed. For the majority of apps this is probably fine, but for apps in languages other than English this can be a bit of an annoyance. This PR fixes this by making them configurable.

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after. (**Not applicable**)

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
