### PR TITLE
change page $maxContentWidth type to accept enum

### DIFF
--- a/packages/panels/src/Events/Auth/Registered.php
+++ b/packages/panels/src/Events/Auth/Registered.php
@@ -11,7 +11,8 @@ class Registered
 
     public function __construct(
         protected Authenticatable $user,
-    ) {}
+    ) {
+    }
 
     public function getUser(): Authenticatable
     {

--- a/packages/panels/src/Pages/BasePage.php
+++ b/packages/panels/src/Pages/BasePage.php
@@ -35,7 +35,7 @@ abstract class BasePage extends Component implements HasActions, HasForms, HasIn
 
     public static ?Closure $reportValidationErrorUsing = null;
 
-    protected ?string $maxContentWidth = null;
+    protected MaxWidth | string | null $maxContentWidth = null;
 
     public static string | Alignment $formActionsAlignment = Alignment::Start;
 


### PR DESCRIPTION
**This is a breaking change. Consider it in v3.2 or v4**

<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

Currently `maxContentWidth` is `?string` and not able to pass `MaxWidth` enum

**current**
`protected ?string $maxContentWidth = 'full';`

workaround to use enum will be `protected ?string $maxContentWidth = MaxWidth::Full->value;`

**after**
`protected MaxWidth | string | null $maxContentWidth = MaxWidth::Full;`

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->
**Breaking change**
- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
