### PR TITLE
Prepend options to select improving UX

### DIFF
--- a/packages/forms/docs/03-fields/03-select.md
+++ b/packages/forms/docs/03-fields/03-select.md
@@ -532,6 +532,20 @@ Select::make('author_id')
 
 Ensure that you are not lowering the debounce too much, as this may cause the select to become slow and unresponsive due to a high number of network requests to retrieve options from server.
 
+## Prepend options
+
+You can prepend options which appear on the top of the list using the `prependOptions()` method:
+
+```php
+use Filament\Forms\Components\Select;
+
+Select::make('author_id')
+    ->relationship(name: 'author', titleAttribute: 'name')
+    ->prependOptions(['123' => 'Shakespeare ', '456' => 'Tolstoy'])
+```
+
+The method behaves like the ´options()´ method, thus you can also use a closure for more advanced calculations. The option list will not contain duplicates. 
+
 ## Limiting the number of options
 
 You can limit the number of options that are displayed in a searchable select or multi-select using the `optionsLimit()` method. The default is 50:

--- a/packages/forms/src/Components/Concerns/HasOptions.php
+++ b/packages/forms/src/Components/Concerns/HasOptions.php
@@ -47,6 +47,8 @@ trait HasOptions
     }
 
     /**
+     * @param  array<string | array<string>> | Arrayable | string | Closure | null  $opt
+     *
      * @return array<string | array<string>>
      */
     private function getOptionsHelper(array | Arrayable | string | Closure | null $opt): array

--- a/packages/forms/src/Components/Concerns/HasOptions.php
+++ b/packages/forms/src/Components/Concerns/HasOptions.php
@@ -11,7 +11,22 @@ trait HasOptions
     /**
      * @var array<string | array<string>> | Arrayable | string | Closure | null
      */
+    protected array | Arrayable | string | Closure | null $prependedOptions = null;
+
+    /**
+     * @var array<string | array<string>> | Arrayable | string | Closure | null
+     */
     protected array | Arrayable | string | Closure | null $options = null;
+
+    /**
+     * @param  array<string | array<string>> | Arrayable | string | Closure | null  $options
+     */
+    public function prependOptions(array | Arrayable | string | Closure | null $options): static
+    {
+        $this->prependedOptions = $options;
+
+        return $this;
+    }
 
     /**
      * @param  array<string | array<string>> | Arrayable | string | Closure | null  $options
@@ -28,7 +43,15 @@ trait HasOptions
      */
     public function getOptions(): array
     {
-        $options = $this->evaluate($this->options) ?? [];
+        return $this->getOptionsHelper($this->prependedOptions) + $this->getOptionsHelper($this->options);
+    }
+
+    /**
+     * @return array<string | array<string>>
+     */
+    private function getOptionsHelper(array | Arrayable | string | Closure | null $opt): array
+    {
+        $options = $this->evaluate($opt) ?? [];
 
         $enum = $options;
         if (


### PR DESCRIPTION
## Description

In a select field with hundreds of options you want to give the user e.g., the top 5 common/ popular options at the top of the selection list. This PR adds the ability to prepend options to the list. 

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

- [x] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
