### PR TITLE
Add German translation for text column actions collapse/expand list

### DIFF
--- a/packages/tables/resources/lang/de/table.php
+++ b/packages/tables/resources/lang/de/table.php
@@ -11,6 +11,12 @@ return [
     'columns' => [
 
         'text' => [
+
+            'actions' => [
+                'collapse_list' => ':count weniger anzeigen',
+                'expand_list' => ':count weitere anzeigen',
+            ],
+
             'more_list_items' => 'und :count weitere',
         ],
 


### PR DESCRIPTION

<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

When using the `expandableLimitedList` [modifier](https://filamentphp.com/docs/3.x/tables/columns/text#expanding-the-limited-list) on a TextColumn in a Filament app with German locale, the list actions to collapse and expand the list are not translated to German.

This PR adds the missing short keys for these actions to the German table language file.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

Before:
![image](https://github.com/filamentphp/filament/assets/834914/bc63a972-6081-4ae8-8eb7-137f89da90f1)
![image](https://github.com/filamentphp/filament/assets/834914/5e83c12a-eb8e-453c-adcf-9b05bf578973)

After:
![image](https://github.com/filamentphp/filament/assets/834914/f1927b0e-f149-462e-9a45-4ff38939810c)
![image](https://github.com/filamentphp/filament/assets/834914/36f0507f-b5ea-45f1-bda9-c780422716c9)

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
