### PR TITLE
Add panel css selector

### DIFF
--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -62,8 +62,6 @@
             }
         </style>
 
-        @stack('styles')
-
         {{ \Filament\Support\Facades\FilamentView::renderHook('panels::styles.after') }}
 
         @if (! filament()->hasDarkMode())
@@ -93,7 +91,7 @@
     </head>
 
     <body
-        class="fi-body min-h-screen bg-gray-50 font-normal text-gray-950 antialiased dark:bg-gray-950 dark:text-white"
+        class="fi-panel-{{ filament()->getId() }} fi-body min-h-screen bg-gray-50 font-normal text-gray-950 antialiased dark:bg-gray-950 dark:text-white"
     >
         {{ \Filament\Support\Facades\FilamentView::renderHook('panels::body.start') }}
 

--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -62,6 +62,8 @@
             }
         </style>
 
+        @stack('styles')
+
         {{ \Filament\Support\Facades\FilamentView::renderHook('panels::styles.after') }}
 
         @if (! filament()->hasDarkMode())
@@ -91,7 +93,7 @@
     </head>
 
     <body
-        class="fi-panel-{{ filament()->getId() }} fi-body min-h-screen bg-gray-50 font-normal text-gray-950 antialiased dark:bg-gray-950 dark:text-white"
+        class="fi-body fi-panel-{{ filament()->getId() }} min-h-screen bg-gray-50 font-normal text-gray-950 antialiased dark:bg-gray-950 dark:text-white"
     >
         {{ \Filament\Support\Facades\FilamentView::renderHook('panels::body.start') }}
 

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -189,6 +189,11 @@ class FilamentManager
         return $this->getCurrentPanel()->getHomeUrl() ?? $this->getCurrentPanel()->getUrl();
     }
 
+    public function getId(): string
+    {
+        return $this->getCurrentPanel()->getId();
+    }
+
     /**
      * @param  array<mixed>  $parameters
      */

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -189,9 +189,9 @@ class FilamentManager
         return $this->getCurrentPanel()->getHomeUrl() ?? $this->getCurrentPanel()->getUrl();
     }
 
-    public function getId(): string
+    public function getId(): ?string
     {
-        return $this->getCurrentPanel()->getId();
+        return $this->getCurrentPanel()?->getId();
     }
 
     /**


### PR DESCRIPTION
In many cases it makes sense to use a single theme for multiple panels. This PR adds a `fi-panel-panel-id` class to each panel, allowing us to use panel-specific CSS in themes.

I also removed the `@stack('styles')` which I added in [this PR](https://github.com/filamentphp/filament/pull/9455). It doesn't work properly with SPA mode because of persistence issues, so it's just dead code atm.