### PR TITLE
fix: Do not save field relationships when components are disabled

### DIFF
--- a/packages/forms/src/Components/Concerns/BelongsToModel.php
+++ b/packages/forms/src/Components/Concerns/BelongsToModel.php
@@ -15,6 +15,8 @@ trait BelongsToModel
 
     protected ?Closure $saveRelationshipsBeforeChildrenUsing = null;
 
+    protected bool | Closure $shouldSaveRelationshipsWhenDisabled = false;
+
     protected bool | Closure $shouldSaveRelationshipsWhenHidden = false;
 
     public function model(Model | string | Closure | null $model = null): static
@@ -36,6 +38,10 @@ trait BelongsToModel
             return;
         }
 
+        if ((! $this->shouldSaveRelationshipsWhenDisabled()) && $this->isDisabled()) {
+            return;
+        }
+
         if ((! $this->shouldSaveRelationshipsWhenHidden()) && $this->isHidden()) {
             return;
         }
@@ -52,6 +58,10 @@ trait BelongsToModel
         }
 
         if (! ($this->getRecord()?->exists)) {
+            return;
+        }
+
+        if ((! $this->shouldSaveRelationshipsWhenDisabled()) && $this->isDisabled()) {
             return;
         }
 
@@ -99,6 +109,18 @@ trait BelongsToModel
         $this->saveRelationshipsBeforeChildrenUsing = $callback;
 
         return $this;
+    }
+
+    public function saveRelationshipsWhenDisabled(bool | Closure $condition = true): static
+    {
+        $this->shouldSaveRelationshipsWhenDisabled = $condition;
+
+        return $this;
+    }
+
+    public function shouldSaveRelationshipsWhenDisabled(): bool
+    {
+        return (bool) $this->evaluate($this->shouldSaveRelationshipsWhenDisabled);
     }
 
     public function saveRelationshipsWhenHidden(bool | Closure $condition = true): static

--- a/packages/forms/src/Concerns/BelongsToModel.php
+++ b/packages/forms/src/Concerns/BelongsToModel.php
@@ -20,7 +20,13 @@ trait BelongsToModel
         foreach ($this->getComponents(withHidden: true) as $component) {
             $component->saveRelationshipsBeforeChildren();
 
+            $shouldSaveRelationshipsWhenDisabled = $component->shouldSaveRelationshipsWhenDisabled();
+
             foreach ($component->getChildComponentContainers(withHidden: $component->shouldSaveRelationshipsWhenHidden()) as $container) {
+                if ((! $shouldSaveRelationshipsWhenDisabled) && $container->isDisabled()) {
+                    continue;
+                }
+
                 $container->saveRelationships();
             }
 


### PR DESCRIPTION
I think a more predictable default for this behaviour is to not save relationships when components are disabled, in case authorization is being used to prevent a user from being able to change a component. This lines up with the fact that `disabled()` is `dehydrated(false)` by default, which does not save data in most scenarios. You can opt-in to relationships being saved when disabled using `saveRelationshipsWhenDisabled()`.

Fixes #10782.