### PR TITLE
fix: afterStateUpdated() not executing for batched requests

### DIFF
--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -90,7 +90,7 @@ trait HasState
     public function callAfterStateUpdated(): static
     {
         foreach ($this->afterStateUpdated as $callback) {
-            $runId = spl_object_id($callback) . md5(json_encode($this->getState()));;
+            $runId = spl_object_id($callback) . md5(json_encode($this->getState()));
 
             if (store($this)->has('executedAfterStateUpdatedCallbacks', iKey: $runId)) {
                 continue;

--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -90,15 +90,15 @@ trait HasState
     public function callAfterStateUpdated(): static
     {
         foreach ($this->afterStateUpdated as $callback) {
-            $callbackId = spl_object_id($callback);
+            $runId = spl_object_id($callback) . md5(json_encode($this->getState()));;
 
-            if (store($this)->has('executedAfterStateUpdatedCallbacks', iKey: $callbackId)) {
+            if (store($this)->has('executedAfterStateUpdatedCallbacks', iKey: $runId)) {
                 continue;
             }
 
             $this->callAfterStateUpdatedHook($callback);
 
-            store($this)->push('executedAfterStateUpdatedCallbacks', value: $callbackId, iKey: $callbackId);
+            store($this)->push('executedAfterStateUpdatedCallbacks', value: $runId, iKey: $runId);
         }
 
         return $this;


### PR DESCRIPTION
Fixes #10660.

Livewire batched requests was not running `afterStateUpdated()` more than once per batch instead of per request