### PR TITLE
Fix export download links when in spa mode

### DIFF
--- a/packages/actions/src/Exports/Jobs/ExportCompletion.php
+++ b/packages/actions/src/Exports/Jobs/ExportCompletion.php
@@ -70,10 +70,10 @@ class ExportCompletion implements ShouldQueue
                 fn (Notification $notification) => $notification->actions([
                     NotificationAction::make('download_csv')
                         ->label(__('filament-actions::export.notifications.completed.actions.download_csv.label'))
-                        ->url(route('filament.exports.download', ['export' => $this->export, 'format' => DownloadFileFormat::Csv])),
+                        ->url(route('filament.exports.download', ['export' => $this->export, 'format' => DownloadFileFormat::Csv]), true),
                     NotificationAction::make('download_xlsx')
                         ->label(__('filament-actions::export.notifications.completed.actions.download_xlsx.label'))
-                        ->url(route('filament.exports.download', ['export' => $this->export, 'format' => DownloadFileFormat::Xlsx])),
+                        ->url(route('filament.exports.download', ['export' => $this->export, 'format' => DownloadFileFormat::Xlsx]), true),
                 ]),
             )
             ->sendToDatabase($this->export->user);

--- a/packages/actions/src/Exports/Jobs/ExportCompletion.php
+++ b/packages/actions/src/Exports/Jobs/ExportCompletion.php
@@ -70,10 +70,12 @@ class ExportCompletion implements ShouldQueue
                 fn (Notification $notification) => $notification->actions([
                     NotificationAction::make('download_csv')
                         ->label(__('filament-actions::export.notifications.completed.actions.download_csv.label'))
-                        ->url(route('filament.exports.download', ['export' => $this->export, 'format' => DownloadFileFormat::Csv]), true),
+                        ->url(route('filament.exports.download', ['export' => $this->export, 'format' => DownloadFileFormat::Csv]), shouldOpenInNewTab: true)
+                        ->markAsRead(),
                     NotificationAction::make('download_xlsx')
                         ->label(__('filament-actions::export.notifications.completed.actions.download_xlsx.label'))
-                        ->url(route('filament.exports.download', ['export' => $this->export, 'format' => DownloadFileFormat::Xlsx]), true),
+                        ->url(route('filament.exports.download', ['export' => $this->export, 'format' => DownloadFileFormat::Xlsx]), shouldOpenInNewTab: true)
+                        ->markAsRead(),
                 ]),
             )
             ->sendToDatabase($this->export->user);


### PR DESCRIPTION
## Description

When you click on the export download links, the file content will be shown in the current tab if the site is in SPA mode, because it triggers an XHR request.

The simplest workaround I can think of is to open these links in new tabs which prevents `wire:navigate` from being added to the anchor tag. Most browsers will automatically close the new tab right away, since the files are delivered with a "Content-Disposition: attachment" header.

## Code style

- [x] `composer cs` command has been run.

## Testing

-  [x] Changes have been tested.
