### PR TITLE
fix: Live filters

### DIFF
--- a/packages/forms/src/Concerns/HasStateBindingModifiers.php
+++ b/packages/forms/src/Concerns/HasStateBindingModifiers.php
@@ -59,11 +59,11 @@ trait HasStateBindingModifiers
 
     public function applyStateBindingModifiers(string $expression, bool $isOptimisticallyLive = true): string
     {
-        $entangled = str($expression)->contains('entangle');
+        $entangled = str($expression)->is('$entangle(*)');
 
         $modifiers = $this->getStateBindingModifiers(withBlur: ! $entangled, withDebounce: ! $entangled, isOptimisticallyLive: $isOptimisticallyLive);
 
-        if (str($expression)->is('$entangle(*)')) {
+        if ($entangled) {
             return (string) str($expression)->replaceLast(
                 ')',
                 in_array('live', $modifiers) ? ', true)' : ', false)',
@@ -110,11 +110,11 @@ trait HasStateBindingModifiers
         }
 
         if ($this instanceof Component) {
-            return $this->getContainer()->getStateBindingModifiers();
+            return $this->getContainer()->getStateBindingModifiers($withBlur, $withDebounce, $isOptimisticallyLive);
         }
 
         if ($this->getParentComponent()) {
-            return $this->getParentComponent()->getStateBindingModifiers();
+            return $this->getParentComponent()->getStateBindingModifiers($withBlur, $withDebounce, $isOptimisticallyLive);
         }
 
         return [];

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -32,7 +32,7 @@ trait HasFilters
             ->columns($this->getTable()->getFiltersFormColumns())
             ->model($this->getTable()->getModel())
             ->statePath($this->getTable()->hasDeferredFilters() ? 'tableDeferredFilters' : 'tableFilters')
-            ->when(! $this->getTable()->hasDeferredFilters(), fn (Form $form) => $form->live(onBlur: true));
+            ->when(! $this->getTable()->hasDeferredFilters(), fn (Form $form) => $form->live());
     }
 
     public function updatedTableFilters(): void


### PR DESCRIPTION
In v3.2, we made all filters affect the table content on blur, instead of immediately. However, some fields do not have full support for blur, so we are reverting this change for now.

Fixes #10819.