### PR TITLE
fix the outlined button icon color

### DIFF
--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -117,6 +117,7 @@
         },
         'text-gray-400 dark:text-gray-500' => ($color === 'gray') || ($tag === 'label'),
         'text-white' => ($color !== 'gray') && ($tag !== 'label'),
+        'text-current' => $outlined,
         '[:checked+*>&]:text-white' => $tag === 'label',
     ]);
 

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -116,8 +116,7 @@
             default => $iconSize,
         },
         'text-gray-400 dark:text-gray-500' => ($color === 'gray') || ($tag === 'label'),
-        'text-white' => ($color !== 'gray') && ($tag !== 'label'),
-        'text-current' => $outlined,
+        'text-white' => ($color !== 'gray') && ($tag !== 'label') && ($buttonClasses === $outlined),
         '[:checked+*>&]:text-white' => $tag === 'label',
     ]);
 


### PR DESCRIPTION
## Description

**The Issue:**

<img width="173" alt="Screenshot 2024-01-16 at 15 23 58" src="https://github.com/filamentphp/filament/assets/121255432/35ff0bc6-8580-4685-8f48-7982d6f78de3">


- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

- [x] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.
