### PR TITLE
Prevent white icon when button is "outlined".

### DIFF
--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -116,7 +116,7 @@
             default => $iconSize,
         },
         'text-gray-400 dark:text-gray-500' => ($color === 'gray') || ($tag === 'label'),
-        'text-white' => ($color !== 'gray') && ($tag !== 'label'),
+        'text-white' => ($color !== 'gray') && ($tag !== 'label') && (! $outlined),
         '[:checked+*>&]:text-white' => $tag === 'label',
     ]);
 


### PR DESCRIPTION

## Description
Do not apply "text-white" class to icon if button is outlined.

## Demo
- Before Change
![image](https://github.com/filamentphp/filament/assets/51721783/1a185d92-307b-4ab8-8a4c-480234d58508)

- After Change
![image](https://github.com/filamentphp/filament/assets/51721783/e4eb7c19-0359-436c-b184-a2af30b2d9b7)

## Code for demo
```php
use Filament\Infolists\Components\Actions\Action;

Action::make('Edit Address')
    ->label('Edit Address')
    ->outlined()
    ->color('primary-blue')
    ->size(ActionSize::ExtraSmall)
    ->icon('heroicon-o-pencil')
```

## Note
I do have this custom color registered:

```php
FilamentColor::register([
    'primary-blue' => Color::hex('#0B519D'),
    // ...
])
```