### PR TITLE
Add extraBodyAttributes for pages

### DIFF
--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -1,5 +1,5 @@
 @props([
-    'livewire',
+    'livewire' => null,
 ])
 
 <!DOCTYPE html>
@@ -23,7 +23,7 @@
         @endif
 
         <title>
-            {{ filled($title = strip_tags($livewire->getTitle())) ? "{$title} - " : null }}
+            {{ filled($title = strip_tags(($livewire ?? null)?->getTitle() ?? '')) ? "{$title} - " : null }}
             {{ filament()->getBrandName() }}
         </title>
 
@@ -115,7 +115,7 @@
     <body
         {{
             $attributes
-                ->merge($livewire->getExtraBodyAttributes(), escape: false)
+                ->merge(($livewire ?? null)?->getExtraBodyAttributes() ?? [], escape: false)
                 ->class([
                     'fi-body',
                     'fi-panel-' . filament()->getId(),

--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -113,7 +113,21 @@
     </head>
 
     <body
-        class="fi-body fi-panel-{{ filament()->getId() }} min-h-screen bg-gray-50 font-normal text-gray-950 antialiased dark:bg-gray-950 dark:text-white"
+        {{
+            $attributes
+                ->merge($livewire->getExtraBodyAttributes(), escape: false)
+                ->class([
+                    'fi-body',
+                    'fi-panel-' . filament()->getId(),
+                    'min-h-screen',
+                    'bg-gray-50',
+                    'font-normal',
+                    'text-gray-950',
+                    'antialiased',
+                    'dark:bg-gray-950',
+                    'dark:text-white'
+                ])
+        }}
     >
         {{ \Filament\Support\Facades\FilamentView::renderHook('panels::body.start') }}
 

--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -119,13 +119,7 @@
                 ->class([
                     'fi-body',
                     'fi-panel-' . filament()->getId(),
-                    'min-h-screen',
-                    'bg-gray-50',
-                    'font-normal',
-                    'text-gray-950',
-                    'antialiased',
-                    'dark:bg-gray-950',
-                    'dark:text-white'
+                    'min-h-screen bg-gray-50 font-normal text-gray-950 antialiased dark:bg-gray-950 dark:text-white',
                 ])
         }}
     >

--- a/packages/panels/src/Pages/BasePage.php
+++ b/packages/panels/src/Pages/BasePage.php
@@ -38,7 +38,7 @@ abstract class BasePage extends Component implements HasActions, HasForms, HasIn
     protected ?string $maxContentWidth = null;
 
     /**
-     * @var array<string, scalar>
+     * @var array<mixed>
      */
     protected array $extraBodyAttributes = [];
 
@@ -82,7 +82,7 @@ abstract class BasePage extends Component implements HasActions, HasForms, HasIn
     }
 
     /**
-     * @return array<string, scalar>
+     * @return array<mixed>
      */
     public function getExtraBodyAttributes(): array
     {

--- a/packages/panels/src/Pages/BasePage.php
+++ b/packages/panels/src/Pages/BasePage.php
@@ -37,6 +37,11 @@ abstract class BasePage extends Component implements HasActions, HasForms, HasIn
 
     protected ?string $maxContentWidth = null;
 
+    /**
+     * @var array<string, scalar>
+     */
+    protected array $extraBodyAttributes = [];
+
     public static string | Alignment $formActionsAlignment = Alignment::Start;
 
     public static bool $formActionsAreSticky = false;
@@ -74,6 +79,14 @@ abstract class BasePage extends Component implements HasActions, HasForms, HasIn
     public function getMaxContentWidth(): MaxWidth | string | null
     {
         return $this->maxContentWidth;
+    }
+
+    /**
+     * @return array<string, scalar>
+     */
+    public function getExtraBodyAttributes(): array
+    {
+        return $this->extraBodyAttributes;
     }
 
     /**


### PR DESCRIPTION
Currently there's no easy way to target custom pages with CSS. This PR adds an `extraBodyAttributes` property / method to the base page allowing us to add classes, Alpine directives etc. to the `<body>` tag. It opens the door for much heavier customization and hacking of custom pages.