### PR TITLE
Fix: Ensure relationship existence before parsing relation value

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Infolists/Components/SpatieMediaLibraryImageEntry.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Infolists/Components/SpatieMediaLibraryImageEntry.php
@@ -45,10 +45,8 @@ class SpatieMediaLibraryImageEntry extends ImageEntry
             return null;
         }
 
-        $relationshipName = $this->getRelationshipName();
-
-        if (filled($relationshipName)) {
-            $record = $record->getRelationValue($relationshipName);
+        if ($this->hasRelationship($record)) {
+            $record = $record->getRelationValue($this->getRelationshipName());
         }
 
         /** @var ?Media $media */


### PR DESCRIPTION
## Description

This PR fixes to ensure relationship existence before parsing relation value in SpatieMediaLibraryImageEntry component.

