### PR TITLE
Prevent "outlined" button border from being partially hidden.

### DIFF
--- a/packages/support/resources/views/components/section/index.blade.php
+++ b/packages/support/resources/views/components/section/index.blade.php
@@ -66,7 +66,7 @@
                 } => ! $aside,
             ])
         >
-            <div class="flex items-center gap-3 overflow-hidden">
+            <div class="flex items-center gap-3">
                 @if ($hasIcon)
                     <x-filament::icon
                         :icon="$icon"

--- a/packages/support/resources/views/components/section/index.blade.php
+++ b/packages/support/resources/views/components/section/index.blade.php
@@ -66,7 +66,7 @@
                 } => ! $aside,
             ])
         >
-            <div class="flex items-center gap-3">
+            <div class="flex items-center gap-3 overflow-hidden px-px">
                 @if ($hasIcon)
                     <x-filament::icon
                         :icon="$icon"


### PR DESCRIPTION
## Issue
- Action button borders defined with the `->outlined()` class are partially hidden due to hidden overflow on header.

![image](https://github.com/filamentphp/filament/assets/51721783/5e320bd7-bfd3-4b6c-8b2a-768baee8749c)


## After Change

![image](https://github.com/filamentphp/filament/assets/51721783/6ad4b422-356c-43cd-981d-fb89761d4b69)

## Section Snippet
- Note: this does not include the schema.
```php
return Section::make('Notes')
    ->description('Contact Notes')
    ->icon('heroicon-o-pencil')
    ->headerActions([
        Action::make('Add Note')
            ->label('Add Note')
            ->color('primary-blue')
            ->size(ActionSize::ExtraSmall)
            ->outlined()
            ->modalDescription('Create a new note for this contact.')
            ->icon('heroicon-o-plus')
            ->form([
                Textarea::make('content')
                    ->placeholder('A note about this contact...')
                    ->label('')
                    ->rows(3)
                    ->rules(['required', 'string', 'max:500'])
            ])
            ->action(function ($record, $data) {
                $record->notes()->save(new Note([
                    'content' => $data['content'],
                ]));
            }),
    ])
```