### PR TITLE
Allow markAsRequired() to be used independently of required() to denote a required field.

### DIFF
--- a/packages/forms/docs/03-fields/01-getting-started.md
+++ b/packages/forms/docs/03-fields/01-getting-started.md
@@ -297,6 +297,16 @@ TextInput::make('name')
     ->markAsRequired(false) // Removes the asterisk
 ```
 
+If you wish to use [other rules](validation#other-rules), but still show an asterisk `*`, such as in the case of using 'required' with `rules()`, you can do it like so:
+
+```php
+use Filament\Forms\Components\TextInput;
+
+TextInput::make('name')
+    ->rules(['required']) // Adds validation to ensure the field is required
+    ->markAsRequired() // Includes the asterisk
+```
+
 ## Global settings
 
 If you wish to change the default behaviour of a field globally, then you can call the static `configureUsing()` method inside a service provider's `boot()` method or a middleware. Pass a closure which is able to modify the component. For example, if you wish to make all [checkboxes `inline(false)`](checkbox#positioning-the-label-above), you can do it like so:

--- a/packages/forms/docs/03-fields/01-getting-started.md
+++ b/packages/forms/docs/03-fields/01-getting-started.md
@@ -297,14 +297,13 @@ TextInput::make('name')
     ->markAsRequired(false) // Removes the asterisk
 ```
 
-If you wish to use [other rules](validation#other-rules), but still show an asterisk `*`, such as in the case of using 'required' with `rules()`, you can do it like so:
+If your field is not `required()`, but you still wish to show an asterisk `*` you can use `markAsRequired()` too:
 
 ```php
 use Filament\Forms\Components\TextInput;
 
 TextInput::make('name')
-    ->rules(['required']) // Adds validation to ensure the field is required
-    ->markAsRequired() // Includes the asterisk
+    ->markAsRequired()
 ```
 
 ## Global settings

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -13,7 +13,7 @@
 
     <span class="text-sm font-medium leading-6 text-gray-950 dark:text-white">
         {{-- Deliberately poor formatting to ensure that the asterisk sticks to the final word in the label. --}}
-        {{ $slot }}@if ($required && $isMarkedAsRequired && ! $isDisabled || ! $required && $isMarkedAsRequired && ! $isDisabled)<sup class="text-danger-600 dark:text-danger-400 font-medium">*</sup>
+        {{ $slot }}@if (($required || $isMarkedAsRequired) && (! $isDisabled))<sup class="text-danger-600 dark:text-danger-400 font-medium">*</sup>
         @endif
     </span>
 

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -13,7 +13,7 @@
 
     <span class="text-sm font-medium leading-6 text-gray-950 dark:text-white">
         {{-- Deliberately poor formatting to ensure that the asterisk sticks to the final word in the label. --}}
-        {{ $slot }}@if ($required && $isMarkedAsRequired && ! $isDisabled)<sup class="text-danger-600 dark:text-danger-400 font-medium">*</sup>
+        {{ $slot }}@if ($required && $isMarkedAsRequired && ! $isDisabled || ! $required && $isMarkedAsRequired && ! $isDisabled)<sup class="text-danger-600 dark:text-danger-400 font-medium">*</sup>
         @endif
     </span>
 


### PR DESCRIPTION
## Description

Allow markAsRequired() to be used independent of required()

In scenarios where a red asterisk must be present to denote a required field, but `->rules(['required'])` is being used instead of `->required()`, using `->markAsRequired()` will generate the red asterisk.

Example:

```php
TextInput::make('sample')
    ->rules(['required'])
    ->markAsRequired()
```

Currently, only `->markAsRequired(false)` has the effect of removing the asterisk when paired with `->required(),` but `->markAsRequired()` or `->markAsRequired(true)` have no effect even when paired with `->required()`.

This change is helpful in cases where a project ignores browser-side error handling in favor of Laravel validation, and the author wants to display a required asterisk without having to fall back on solutions such as using a `label()` that generates an HtmlString that includes a div with styling classes and an asterisk.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

Original code without proposed changes:

```php
TextInput::make('sample')
    ->rules(['required'])
    ->markAsRequired()
```

<img width="369" alt="image" src="https://github.com/filamentphp/filament/assets/1270019/19321c7b-f30f-4359-a60b-d0bb999698ce">

With Proposed changes:

```php
TextInput::make('sample')
    ->rules(['required'])
    ->markAsRequired()
```

<img width="364" alt="image" src="https://github.com/filamentphp/filament/assets/1270019/8713965f-2721-4a2e-8e54-d64eeea2f04f">


## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
