### PR TITLE
fix collapsing groups on sub navigation pages

### DIFF
--- a/packages/panels/resources/views/components/page/sub-navigation/sidebar.blade.php
+++ b/packages/panels/resources/views/components/page/sub-navigation/sidebar.blade.php
@@ -13,8 +13,8 @@
             :items="$navigationGroup->getItems()"
             :label="$navigationGroup->getLabel()"
             :sidebar-collapsible="false"
+            sub-navigation
             :attributes="\Filament\Support\prepare_inherited_attributes($navigationGroup->getExtraSidebarAttributeBag())"
-            :is-sub-navigation="true"
         />
     @endforeach
 </ul>

--- a/packages/panels/resources/views/components/page/sub-navigation/sidebar.blade.php
+++ b/packages/panels/resources/views/components/page/sub-navigation/sidebar.blade.php
@@ -14,6 +14,7 @@
             :label="$navigationGroup->getLabel()"
             :sidebar-collapsible="false"
             :attributes="\Filament\Support\prepare_inherited_attributes($navigationGroup->getExtraSidebarAttributeBag())"
+            :is-sub-navigation="true"
         />
     @endforeach
 </ul>

--- a/packages/panels/resources/views/components/sidebar/group.blade.php
+++ b/packages/panels/resources/views/components/sidebar/group.blade.php
@@ -4,11 +4,11 @@
     'items' => [],
     'label' => null,
     'sidebarCollapsible' => true,
-    "isSubNavigation" => false,
+    'subNavigation' => false,
 ])
 
 <li
-    x-data="{ label: @js($isSubNavigation ? 'sub-navigation-' . $label : $label) }"
+    x-data="{ label: @js($subNavigation ? "sub_navigation_{$label}" : $label) }"
     data-group-label="{{ $label }}"
     {{ $attributes->class(['fi-sidebar-group flex flex-col gap-y-1']) }}
 >

--- a/packages/panels/resources/views/components/sidebar/group.blade.php
+++ b/packages/panels/resources/views/components/sidebar/group.blade.php
@@ -4,10 +4,11 @@
     'items' => [],
     'label' => null,
     'sidebarCollapsible' => true,
+    "isSubNavigation" => false,
 ])
 
 <li
-    x-data="{ label: @js($label) }"
+    x-data="{ label: @js($isSubNavigation ? 'sub-navigation-' . $label : $label) }"
     data-group-label="{{ $label }}"
     {{ $attributes->class(['fi-sidebar-group flex flex-col gap-y-1']) }}
 >


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

When sub-navigation with collapsible groups is used in both the main sidebar nav and on sub-resource pages, if you have a group that has the same name in both menus they'll both collapse when you toggle either of them.

This change resolves that by adding a flag to the sidebar group generator that prepends sub navigation- to the alpinejs label, so they can be collapsed separately. The flag is set when the menu is being generated from a sub resource.

Before:
![Screenshot 2024-01-20 at 1 17 58 pm](https://github.com/filamentphp/filament/assets/9477420/c5d955ba-82c0-42d5-9a27-2d03239f5501)

After:
![Screenshot 2024-01-20 at 1 18 26 pm](https://github.com/filamentphp/filament/assets/9477420/ad52576f-e238-4710-bce7-17ded329e865)


- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
