### PR TITLE
This change prevents the stretching collapsed elements

### DIFF
--- a/packages/forms/resources/views/components/repeater/index.blade.php
+++ b/packages/forms/resources/views/components/repeater/index.blade.php
@@ -70,7 +70,7 @@
                     :wire:end.stop="'mountFormComponentAction(\'' . $statePath . '\', \'reorder\', { items: $event.target.sortable.toArray() })'"
                     x-sortable
                     :data-sortable-animation-duration="$getReorderAnimationDuration()"
-                    class="gap-4"
+                    class="gap-4 items-start"
                 >
                     @foreach ($containers as $uuid => $item)
                         @php


### PR DESCRIPTION


<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description
This change prevents the stretching of other elements if one or more collapsed elements are open.
This does not change the use of space or save space, but it clarifies the handling of elements
<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->
This
![CleanShot_2024-01-20_at_12 52 42](https://github.com/filamentphp/filament/assets/32259223/9aa95abe-2944-47d1-8e26-5eb360753928)
To
![CleanShot 2024-01-20 at 12 52 42](https://github.com/filamentphp/filament/assets/32259223/5d786ebf-96f6-49b7-bbaa-4792c7fc3d6e)



<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [ ] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
