### PR TITLE
fix search case sensitive with json column in spatie translatable

### DIFF
--- a/packages/spatie-laravel-translatable-plugin/src/SpatieLaravelTranslatableContentDriver.php
+++ b/packages/spatie-laravel-translatable-plugin/src/SpatieLaravelTranslatableContentDriver.php
@@ -123,7 +123,7 @@ class SpatieLaravelTranslatableContentDriver implements TranslatableContentDrive
         return $query->{$whereClause}(
             generate_search_column_expression($column, $isCaseInsensitivityForced, $databaseConnection),
             'like',
-            "%{$search}%",
+            (string) str($search)->wrap('%'),
         );
     }
 }

--- a/packages/spatie-laravel-translatable-plugin/src/SpatieLaravelTranslatableContentDriver.php
+++ b/packages/spatie-laravel-translatable-plugin/src/SpatieLaravelTranslatableContentDriver.php
@@ -117,13 +117,13 @@ class SpatieLaravelTranslatableContentDriver implements TranslatableContentDrive
 
         $column = match ($databaseConnection->getDriverName()) {
             'pgsql' => "{$column}->>'{$this->activeLocale}'",
-            default => "json_extract({$column}, \"$.{$this->activeLocale}\")",
+            default => "lower(json_extract({$column}, \"$.{$this->activeLocale}\"))",
         };
 
         return $query->{$whereClause}(
             generate_search_column_expression($column, $isCaseInsensitivityForced, $databaseConnection),
             'like',
-            "%{$search}%",
+            '%' . strtolower($search) . '%',
         );
     }
 }

--- a/packages/spatie-laravel-translatable-plugin/src/SpatieLaravelTranslatableContentDriver.php
+++ b/packages/spatie-laravel-translatable-plugin/src/SpatieLaravelTranslatableContentDriver.php
@@ -117,13 +117,13 @@ class SpatieLaravelTranslatableContentDriver implements TranslatableContentDrive
 
         $column = match ($databaseConnection->getDriverName()) {
             'pgsql' => "{$column}->>'{$this->activeLocale}'",
-            default => "lower(json_extract({$column}, \"$.{$this->activeLocale}\"))",
+            default => "json_extract({$column}, \"$.{$this->activeLocale}\")",
         };
 
         return $query->{$whereClause}(
             generate_search_column_expression($column, $isCaseInsensitivityForced, $databaseConnection),
             'like',
-            '%' . strtolower($search) . '%',
+            "%{$search}%",
         );
     }
 }

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -174,7 +174,7 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
 
         $isSearchForcedCaseInsensitive ??= match ($driverName) {
             'pgsql' => true,
-            default => false,
+            default => str($column)->contains('json_extract('),
         };
 
         if ($isSearchForcedCaseInsensitive) {
@@ -188,8 +188,7 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
         }
 
         if (
-            str($column)->contains('(') || // This checks if the column name probably contains a raw expression like `json_extract()`.
-            $isSearchForcedCaseInsensitive ||
+            str($column)->contains('(') || // This checks if the column name probably contains a raw expression like `lower()` or `json_extract()`.
             filled($collation)
         ) {
             return new Expression($column);

--- a/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
@@ -76,7 +76,7 @@ trait InteractsWithTableQuery
 
         $isSearchForcedCaseInsensitive = $this->isSearchForcedCaseInsensitive();
 
-        $search = generate_search_term_expression($search, $isSearchForcedCaseInsensitive, $databaseConnection);
+        $nonTranslatableSearch = generate_search_term_expression($search, $isSearchForcedCaseInsensitive, $databaseConnection);
 
         $translatableContentDriver = $this->getLivewire()->makeFilamentTranslatableContentDriver();
 
@@ -92,12 +92,12 @@ trait InteractsWithTableQuery
                         $this->getRelationshipName(),
                         generate_search_column_expression($searchColumn, $isSearchForcedCaseInsensitive, $databaseConnection),
                         'like',
-                        "%{$search}%",
+                        "%{$nonTranslatableSearch}%",
                     ),
                     fn (EloquentBuilder $query): EloquentBuilder => $query->{$whereClause}(
                         generate_search_column_expression($searchColumn, $isSearchForcedCaseInsensitive, $databaseConnection),
                         'like',
-                        "%{$search}%",
+                        "%{$nonTranslatableSearch}%",
                     ),
                 ),
             );


### PR DESCRIPTION
## Description

when searching in mysql with `json_extract` it's always case sensitive.
adding `lower` for the data and the searched term, will return correct results.

this only happens when using spatie translatable plugin.

>not sure if it should be the default behavior or if there is better way, let me know.

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

- [ ] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.

## Documentation

- [ ] Documentation is up-to-date.
