### PR TITLE
fix: isMarkedAsRequired should be false by default

### DIFF
--- a/packages/forms/resources/views/components/field-wrapper/index.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/index.blade.php
@@ -15,7 +15,6 @@
     'id' => null,
     'inlineLabelVerticalAlignment' => VerticalAlignment::Start,
     'isDisabled' => null,
-    'isMarkedAsRequired' => null,
     'label' => null,
     'labelPrefix' => null,
     'labelSrOnly' => null,
@@ -36,10 +35,9 @@
         $hintIconTooltip ??= $field->getHintIconTooltip();
         $id ??= $field->getId();
         $isDisabled ??= $field->isDisabled();
-        $isMarkedAsRequired ??= $field->isMarkedAsRequired();
         $label ??= $field->getLabel();
         $labelSrOnly ??= $field->isLabelHidden();
-        $required ??= $field->isRequired();
+        $required ??= $field->isMarkedAsRequired();
         $statePath ??= $field->getStatePath();
     }
 
@@ -79,8 +77,7 @@
                 @if ($label && (! $labelSrOnly))
                     <x-filament-forms::field-wrapper.label
                         :for="$id"
-                        :is-disabled="$isDisabled"
-                        :is-marked-as-required="$isMarkedAsRequired"
+                        :disabled="$isDisabled"
                         :prefix="$labelPrefix"
                         :required="$required"
                         :suffix="$labelSuffix"

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -1,6 +1,5 @@
 @props([
-    'isDisabled' => false,
-    'isMarkedAsRequired' => false,
+    'disabled' => false,
     'prefix' => null,
     'required' => false,
     'suffix' => null,
@@ -13,7 +12,7 @@
 
     <span class="text-sm font-medium leading-6 text-gray-950 dark:text-white">
         {{-- Deliberately poor formatting to ensure that the asterisk sticks to the final word in the label. --}}
-        {{ $slot }}@if (($required || $isMarkedAsRequired) && (! $isDisabled))<sup class="text-danger-600 dark:text-danger-400 font-medium">*</sup>
+        {{ $slot }}@if ($required && (! $disabled))<sup class="text-danger-600 dark:text-danger-400 font-medium">*</sup>
         @endif
     </span>
 

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -1,6 +1,6 @@
 @props([
     'isDisabled' => false,
-    'isMarkedAsRequired' => true,
+    'isMarkedAsRequired' => false,
     'prefix' => null,
     'required' => false,
     'suffix' => null,

--- a/packages/forms/src/Components/Concerns/CanBeMarkedAsRequired.php
+++ b/packages/forms/src/Components/Concerns/CanBeMarkedAsRequired.php
@@ -6,9 +6,9 @@ use Closure;
 
 trait CanBeMarkedAsRequired
 {
-    protected bool | Closure $isMarkedAsRequired = false;
+    protected bool | Closure | null $isMarkedAsRequired = null;
 
-    public function markAsRequired(bool | Closure $condition = true): static
+    public function markAsRequired(bool | Closure | null $condition = true): static
     {
         $this->isMarkedAsRequired = $condition;
 
@@ -17,6 +17,6 @@ trait CanBeMarkedAsRequired
 
     public function isMarkedAsRequired(): bool
     {
-        return (bool) $this->evaluate($this->isMarkedAsRequired);
+        return $this->evaluate($this->isMarkedAsRequired) ?? $this->isRequired();
     }
 }

--- a/packages/forms/src/Components/Concerns/CanBeMarkedAsRequired.php
+++ b/packages/forms/src/Components/Concerns/CanBeMarkedAsRequired.php
@@ -6,7 +6,7 @@ use Closure;
 
 trait CanBeMarkedAsRequired
 {
-    protected bool | Closure $isMarkedAsRequired = true;
+    protected bool | Closure $isMarkedAsRequired = false;
 
     public function markAsRequired(bool | Closure $condition = true): static
     {


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

Recent update (#10929) improves the logic for showing the asterisk label for fields marked as required. But `isMarkedAsRequired` should be `false` by default for this to work correctly. 

Currently, all fields will show an asterisk unless we explicitly call `markAsRequired(false)` on the form component. 

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
