### PR TITLE
Bugfix panel assets

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasAssets.php
+++ b/packages/panels/src/Panel/Concerns/HasAssets.php
@@ -17,7 +17,7 @@ trait HasAssets
      */
     public function assets(array $assets, string $package = 'app'): static
     {
-        $this->assets[$package][] = [
+        $this->assets[$package] = [
             ...($this->assets[$package] ?? []),
             ...$assets,
         ];


### PR DESCRIPTION
## Description
Fix a small bug when using `$panel->assets` (https://github.com/filamentphp/filament/pull/10954) that would cause a multi-dimension array to be created.
