### PR TITLE
Fix - Reverted to the original functionality of markAsRequired() 

### DIFF
--- a/packages/forms/docs/03-fields/01-getting-started.md
+++ b/packages/forms/docs/03-fields/01-getting-started.md
@@ -297,15 +297,6 @@ TextInput::make('name')
     ->markAsRequired(false) // Removes the asterisk
 ```
 
-If your field is not `required()`, but you still wish to show an asterisk `*` you can use `markAsRequired()` too:
-
-```php
-use Filament\Forms\Components\TextInput;
-
-TextInput::make('name')
-    ->markAsRequired()
-```
-
 ## Global settings
 
 If you wish to change the default behaviour of a field globally, then you can call the static `configureUsing()` method inside a service provider's `boot()` method or a middleware. Pass a closure which is able to modify the component. For example, if you wish to make all [checkboxes `inline(false)`](checkbox#positioning-the-label-above), you can do it like so:

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -13,8 +13,7 @@
 
     <span class="text-sm font-medium leading-6 text-gray-950 dark:text-white">
         {{-- Deliberately poor formatting to ensure that the asterisk sticks to the final word in the label. --}}
-        {{ $slot }}@if (($required || $isMarkedAsRequired) && (! $isDisabled))<sup class="text-danger-600 dark:text-danger-400 font-medium">*</sup>
-        @endif
+        {{ $slot }}@if ($required && $isMarkedAsRequired && ! $isDisabled)<sup class="text-danger-600 dark:text-danger-400 font-medium">*</sup>        @endif
     </span>
 
     {{ $suffix }}


### PR DESCRIPTION
## Description
 
After following up on a [comment](https://github.com/filamentphp/filament/pull/10929#issuecomment-1902536951) on  [Pull Request #10929](https://github.com/filamentphp/filament/pull/10929), I reverted to the original code.

I believe what I missed is that markAsRequired() always defaults to true.

I will seek an alternative solution to solve the original challenge in the original pull request.

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
