### PR TITLE
Bugfix: Check if resource is scoped to tenant when using spatie/laravel-translatable plugin

### DIFF
--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Resources\Pages\CreateRecord\Concerns;
 
+use Filament\Facades\Filament;
 use Filament\Resources\Concerns\HasActiveLocaleSwitcher;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
@@ -61,6 +62,13 @@ trait Translatable
         }
 
         $this->data = $originalData;
+
+        if (
+            static::getResource()::isScopedToTenant() &&
+            ($tenant = Filament::getTenant())
+        ) {
+            return $this->associateRecordWithTenant($record, $tenant);
+        }
 
         $record->save();
 


### PR DESCRIPTION
## Issue

When using the spatie-laravel-translatable plugin within a resource that is scoped to a tenant the record creation method was missing a check for that thus resulting in an error when saving a resource. This PR adds that check and fixes that issue.
