### PR TITLE
Add extraAttributes for js assets

### DIFF
--- a/packages/support/docs/02-assets.md
+++ b/packages/support/docs/02-assets.md
@@ -213,6 +213,20 @@ If your JavaScript file was [registered to a plugin](#registering-assets-for-a-p
 </div>
 ```
 
+### Add extra attributes to the `<script>` tag
+
+You may add extra attributes to the `<script>` tag using the `extraAttributes()` method:
+
+```php
+use Filament\Support\Assets\Js;
+use Filament\Support\Facades\FilamentAsset;
+
+FilamentAsset::register([
+    Js::make('custom-script', __DIR__ . '/../../resources/js/custom.js')
+        ->extraAttributes('defer'),
+]);
+```
+
 #### Asynchronous Alpine.js components
 
 <LaracastsBanner

--- a/packages/support/src/Assets/Js.php
+++ b/packages/support/src/Assets/Js.php
@@ -20,6 +20,8 @@ class Js extends Asset
 
     protected string | Htmlable | null $html = null;
 
+    protected string $extraAttributes = '';
+
     public function async(bool $condition = true): static
     {
         $this->isAsync = $condition;
@@ -62,6 +64,13 @@ class Js extends Asset
         return $this;
     }
 
+    public function extraAttributes(string $attributes): static
+    {
+        $this->extraAttributes = $attributes;
+
+        return $this;
+    }
+
     public function isAsync(): bool
     {
         return $this->isAsync;
@@ -96,6 +105,7 @@ class Js extends Asset
         }
 
         $html ??= $this->getSrc();
+        $extraAttributes = $this->extraAttributes;
 
         $async = $this->isAsync() ? 'async' : '';
         $defer = $this->isDeferred() ? 'defer' : '';
@@ -114,6 +124,7 @@ class Js extends Asset
                 {$module}
                 {$navigateOnce}
                 {$navigateTrack}
+                {$extraAttributes}
             ></script>
         ");
     }


### PR DESCRIPTION
Allows doing things like `defer` etc: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attributes. Particularly useful for custom pages.