### PR TITLE
Adding missing callables to grouped ToggleButtons

### DIFF
--- a/packages/forms/resources/views/components/toggle-buttons/grouped.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/grouped.blade.php
@@ -25,6 +25,7 @@
         :attributes="
             \Filament\Support\prepare_inherited_attributes($attributes)
                 ->merge($getExtraAttributes(), escape: false)
+                ->merge($getExtraInputAttributes(), escape: false)
         ">
         
         @foreach ($getOptions() as $value => $label)

--- a/packages/forms/resources/views/components/toggle-buttons/grouped.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/grouped.blade.php
@@ -21,13 +21,12 @@
     </x-slot>
 
     <x-filament::button.group 
-        class="w-max"
         :attributes="
             \Filament\Support\prepare_inherited_attributes($attributes)
                 ->merge($getExtraAttributes(), escape: false)
-                ->merge($getExtraInputAttributes(), escape: false)
-        ">
-        
+                ->class(['w-max'])
+        "
+    >
         @foreach ($getOptions() as $value => $label)
             @php
                 $inputId = "{$id}-{$value}";

--- a/packages/forms/resources/views/components/toggle-buttons/grouped.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/grouped.blade.php
@@ -20,7 +20,13 @@
         {{ $getLabel() }}
     </x-slot>
 
-    <x-filament::button.group class="w-max">
+    <x-filament::button.group 
+        class="w-max"
+        :attributes="
+            \Filament\Support\prepare_inherited_attributes($attributes)
+                ->merge($getExtraAttributes(), escape: false)
+        ">
+        
         @foreach ($getOptions() as $value => $label)
             @php
                 $inputId = "{$id}-{$value}";


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

When using `->extraAtributes(['class' => 'mt-10'])`, the buttons group should have the applied class, but they dont when they are grouped, but do when they are **not** grouped. This PR should fix this issue. Video demo below:


- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.


https://github.com/filamentphp/filament/assets/64212185/d023997c-be97-45cf-9195-1694d1b5684a


## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
