### PR TITLE
fix: Markdown Editor initialization in modal

### DIFF
--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -20,11 +20,7 @@
             "
         >
             <div
-                @if (FilamentView::hasSpaMode())
-                    ax-load="visible"
-                @else
-                    ax-load
-                @endif
+                ax-load="visible"
                 ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('markdown-editor', 'filament/forms') }}"
                 x-data="markdownEditorFormComponent({
                             isLiveDebounced: @js($isLiveDebounced()),


### PR DESCRIPTION
## Description

This PR aims to resolve the issue referenced in #10926 and #5972 where the Markdown editor was not properly initializing when opened within a resource-heavy modal. The proposed changes focus on adjusting the initialization process of the markdown editor component to account for the asynchronous and dynamic nature of the modal's content.

### Summary
Users experience a problem where the Markdown editor, when loaded within a modal, fails to display its content immediately. The problem is exacerbated by the resource-intensive nature of the modal, which can delay the rendering and initialization of the editor.

The root cause appears to be linked to the timing of the Markdown editor's initialization in relation to the modal's opening sequence. Components like EasyMDE/CodeMirror, used within the editor, require accurate measurements of their container's dimensions, which can be misreported during the modal's dynamic rendering process.

### Solution Implementation

Implemented `ax-load="visible"` for the Markdown editor within modals. This approach leverages the `IntersectionObserver` to initiate the loading of the editor only when it becomes visible within the modal. The use of `ax-load="visible"` optimizes the initialization of the Markdown editor, particularly in the modal context, by delaying its loading until it is actually in view. This effectively resolves the issue of the editor content not being immediately visible upon modal opening. The rendering of the Markdown Editor is still just as fast as with using the default `ax-load` behavior. This doesn't effect Markdown Editor components that are not located within a modal, or at least it is not noticeable at all.

### Before

[](https://github.com/filamentphp/filament/assets/104294090/3d7070d5-d777-46d7-bf88-451a46d0bf4d)

### After

[](https://github.com/filamentphp/filament/assets/104294090/691e6fdf-836e-451d-b66e-3d0012338520)

### Testing
- [x] Changes have been tested.

- Validated the fix by reproducing the original issue and confirming that the Markdown editor now displays its content as soon as the modal opens.
- Tested in various scenarios, including pages with and without additional Markdown editors, to ensure that the lazy-loading implementation does not adversely affect other components.
- Ensured browser compatibility and responsiveness.
