### PR TITLE
Change the return type of the getNavigationBadge() method in Resource.php

### DIFF
--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -816,7 +816,7 @@ abstract class Resource
         return static::$navigationLabel ?? static::getTitleCasePluralModelLabel();
     }
 
-    public static function getNavigationBadge(): ?string
+    public static function getNavigationBadge(): ?string | int
     {
         return null;
     }

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -816,7 +816,7 @@ abstract class Resource
         return static::$navigationLabel ?? static::getTitleCasePluralModelLabel();
     }
 
-    public static function getNavigationBadge(): ?string | int
+    public static function getNavigationBadge(): null | string | int
     {
         return null;
     }


### PR DESCRIPTION
When we use declare(strict_types=1) at the beginning of model resource files, and we want to return an integer value in the getNavigationBadge method, we encounter an error related to strict types. To resolve this issue, I added a new return type to address the strict types error.

<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [ ] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
