### PR TITLE
Forms: Introduce new `ignoreRecord` argument for searchable selects

### DIFF
--- a/packages/forms/docs/03-fields/03-select.md
+++ b/packages/forms/docs/03-fields/03-select.md
@@ -214,7 +214,7 @@ This can be easily be done using the `ignoreRecord` argument.
 use Filament\Forms\Components\Select;
 
 Select::make('parent_id')
-    ->relationship('parent', 'name', ignoreRecord: true)
+    ->relationship(name: 'parent', titleAttribute: 'name', ignoreRecord: true)
 ```
 
 ### Customizing the relationship query

--- a/packages/forms/docs/03-fields/03-select.md
+++ b/packages/forms/docs/03-fields/03-select.md
@@ -208,7 +208,7 @@ Select::make('author_id')
 
 When working with recursive relationships, you will likely want to remove the current record from the set of results.
 
-This can be easily be done using the `ignoreRecord` argument.
+This can be easily be done using the `ignoreRecord` argument:
 
 ```php
 use Filament\Forms\Components\Select;

--- a/packages/forms/docs/03-fields/03-select.md
+++ b/packages/forms/docs/03-fields/03-select.md
@@ -204,6 +204,19 @@ Select::make('author_id')
     ->preload()
 ```
 
+### Excluding the current record
+
+When working with recursive relationships, you will likely want to remove the current record from the set of results.
+
+This can be easily be done using the `ignoreRecord` argument.
+
+```php
+use Filament\Forms\Components\Select;
+
+Select::make('parent_id')
+    ->relationship('parent', 'name', ignoreRecord: true)
+```
+
 ### Customizing the relationship query
 
 You may customize the database query that retrieves options using the third parameter of the `relationship()` method:

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -704,15 +704,19 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
         return $this->evaluate($this->isSearchable) || $this->isMultiple();
     }
 
-    public function relationship(string | Closure | null $name = null, string | Closure | null $titleAttribute = null, ?Closure $modifyQueryUsing = null): static
+    public function relationship(string | Closure | null $name = null, string | Closure | null $titleAttribute = null, ?Closure $modifyQueryUsing = null, bool $ignoreRecord = false): static
     {
         $this->relationship = $name ?? $this->getName();
         $this->relationshipTitleAttribute = $titleAttribute;
 
-        $this->getSearchResultsUsing(static function (Select $component, ?string $search) use ($modifyQueryUsing): array {
+        $this->getSearchResultsUsing(static function (Select $component, ?string $search) use ($modifyQueryUsing, $ignoreRecord): array {
             $relationship = Relation::noConstraints(fn () => $component->getRelationship());
 
             $relationshipQuery = app(RelationshipJoiner::class)->prepareQueryForNoConstraints($relationship);
+
+            if ($ignoreRecord && $record = $component->getRecord()) {
+                $relationshipQuery->where($record->getQualifiedKeyName(), '!=', $record->getKey());
+            }
 
             if ($modifyQueryUsing) {
                 $relationshipQuery = $component->evaluate($modifyQueryUsing, [
@@ -763,7 +767,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
                 ->toArray();
         });
 
-        $this->options(static function (Select $component) use ($modifyQueryUsing): ?array {
+        $this->options(static function (Select $component) use ($modifyQueryUsing, $ignoreRecord): ?array {
             if (($component->isSearchable()) && ! $component->isPreloaded()) {
                 return null;
             }
@@ -771,6 +775,10 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
             $relationship = Relation::noConstraints(fn () => $component->getRelationship());
 
             $relationshipQuery = app(RelationshipJoiner::class)->prepareQueryForNoConstraints($relationship);
+
+            if ($ignoreRecord && $record = $component->getRecord()) {
+                $relationshipQuery->where($record->getQualifiedKeyName(), '!=', $record->getKey());
+            }
 
             if ($modifyQueryUsing) {
                 $relationshipQuery = $component->evaluate($modifyQueryUsing, [

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -714,7 +714,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
 
             $relationshipQuery = app(RelationshipJoiner::class)->prepareQueryForNoConstraints($relationship);
 
-            if ($ignoreRecord && $record = $component->getRecord()) {
+            if ($ignoreRecord && ($record = $component->getRecord())) {
                 $relationshipQuery->where($record->getQualifiedKeyName(), '!=', $record->getKey());
             }
 
@@ -776,7 +776,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
 
             $relationshipQuery = app(RelationshipJoiner::class)->prepareQueryForNoConstraints($relationship);
 
-            if ($ignoreRecord && $record = $component->getRecord()) {
+            if ($ignoreRecord && ($record = $component->getRecord())) {
                 $relationshipQuery->where($record->getQualifiedKeyName(), '!=', $record->getKey());
             }
 


### PR DESCRIPTION
I think this is common enough in applications to add first-party support for it – save some lines of code and tidy things up a little.

When dealing with recursive relationships, e.g. `Page` in a CMS might be the child of another `Page` via a `parent_id` column, you quite often want to prevent selecting the current record as the parent.

The new `ignoreRecord` argument handles this for you by simply excluding the current record from the result set, saving yourself some lines of code that you'd normally write to do this via `modifyQueryUsing`.