### PR TITLE
feat: Select relationship title attribute based on query expression

### DIFF
--- a/packages/forms/docs/03-fields/03-select.md
+++ b/packages/forms/docs/03-fields/03-select.md
@@ -235,6 +235,19 @@ Select::make('author_id')
     ->relationship(name: 'author', titleAttribute: 'full_name')
 ```
 
+Or you can use `Illuminate\Database\Query\Expression` to do the same thing:
+
+```php
+use Filament\Forms\Components\Select;
+use Illuminate\Database\Query\Expression;
+
+Select::make('author_id')
+    ->relationship(
+        name: 'author',
+        titleAttribute: new Expression('concat(first_name, \' \', last_name) as full_name'),
+    )
+```
+
 Alternatively, you can use the `getOptionLabelFromRecordUsing()` method to transform an option's Eloquent model into a label:
 
 ```php


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

**The issue:**
I want to sort my users by full name, without creating virtual column in database.

**Solution:**
Allow to specify titleAttribute of forms/Select component, using query expression:

```php
use Filament\Forms\Components\Select;
use Illuminate\Database\Query\Expression;

Select::make('author_id')
    ->relationship(
        name: 'author',
        titleAttribute: new Expression('concat(first_name, \' \', last_name) as full_name'),
    )
```

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
