### PR TITLE
Mark current top navigation dropdown item as active

### DIFF
--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -83,14 +83,15 @@
                                     @foreach ($group->getItems() as $item)
                                         @php
                                             $icon = $item->getIcon();
+                                            $isActive = $item->isActive();
                                         @endphp
 
                                         <x-filament::dropdown.list.item
-                                            :active="$item->isActive()"
                                             :badge="$item->getBadge()"
                                             :badge-color="$item->getBadgeColor()"
+                                            :color="$isActive ? 'primary' : 'gray'"
                                             :href="$item->getUrl()"
-                                            :icon="$item->isActive() ? ($item->getActiveIcon() ?? $icon) : $icon"
+                                            :icon="$isActive ? ($item->getActiveIcon() ?? $icon) : $icon"
                                             tag="a"
                                             :target="$item->shouldOpenUrlInNewTab() ? '_blank' : null"
                                         >

--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -86,6 +86,7 @@
                                         @endphp
 
                                         <x-filament::dropdown.list.item
+                                            :active="$item->isActive()"
                                             :badge="$item->getBadge()"
                                             :badge-color="$item->getBadgeColor()"
                                             :href="$item->getUrl()"

--- a/packages/support/resources/views/components/dropdown/list/item.blade.php
+++ b/packages/support/resources/views/components/dropdown/list/item.blade.php
@@ -17,6 +17,7 @@
     'tag' => 'button',
     'target' => null,
     'tooltip' => null,
+    'active' => false,
 ])
 
 @php
@@ -51,10 +52,8 @@
             IconSize::Large, 'lg' => 'h-6 w-6',
             default => $iconSize,
         },
-        match ($color) {
-            'gray' => 'text-gray-400 dark:text-gray-500',
-            default => 'text-custom-500 dark:text-custom-400',
-        },
+        'text-gray-400 dark:text-gray-500' => ! $active,
+        'text-primary-600 dark:text-primary-400' => $active,
     ]);
 
     $iconStyles = \Illuminate\Support\Arr::toCssStyles([
@@ -69,10 +68,8 @@
 
     $labelClasses = \Illuminate\Support\Arr::toCssClasses([
         'fi-dropdown-list-item-label flex-1 truncate text-start',
-        match ($color) {
-            'gray' => 'text-gray-700 dark:text-gray-200',
-            default => 'text-custom-600 dark:text-custom-400 ',
-        },
+        'text-primary-600 dark:text-primary-500' => $active,
+        'text-gray-700 dark:text-gray-200' => ! $active,
     ]);
 
     $labelStyles = \Illuminate\Support\Arr::toCssStyles([

--- a/packages/support/resources/views/components/dropdown/list/item.blade.php
+++ b/packages/support/resources/views/components/dropdown/list/item.blade.php
@@ -17,7 +17,6 @@
     'tag' => 'button',
     'target' => null,
     'tooltip' => null,
-    'active' => false,
 ])
 
 @php
@@ -52,8 +51,10 @@
             IconSize::Large, 'lg' => 'h-6 w-6',
             default => $iconSize,
         },
-        'text-gray-400 dark:text-gray-500' => ! $active,
-        'text-primary-600 dark:text-primary-400' => $active,
+        match ($color) {
+            'gray' => 'text-gray-400 dark:text-gray-500',
+            default => 'text-custom-500 dark:text-custom-400',
+        },
     ]);
 
     $iconStyles = \Illuminate\Support\Arr::toCssStyles([
@@ -68,8 +69,10 @@
 
     $labelClasses = \Illuminate\Support\Arr::toCssClasses([
         'fi-dropdown-list-item-label flex-1 truncate text-start',
-        'text-primary-600 dark:text-primary-500' => $active,
-        'text-gray-700 dark:text-gray-200' => ! $active,
+        match ($color) {
+            'gray' => 'text-gray-700 dark:text-gray-200',
+            default => 'text-custom-600 dark:text-custom-400 ',
+        },
     ]);
 
     $labelStyles = \Illuminate\Support\Arr::toCssStyles([


### PR DESCRIPTION
Currently, the top bar navigation doesn't show the active dropdown menu item when you are on the current page. This fixes it.

![CleanShot 2024-01-24 at 14 09 19](https://github.com/filamentphp/filament/assets/1639302/72b5dccb-ad91-4b75-aa8d-8776d1be49d6)
