### PR TITLE
feat: Allow columns to be omitted from exports by default.

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/09-export.md
+++ b/packages/actions/docs/07-prebuilt-actions/09-export.md
@@ -113,6 +113,17 @@ ExportColumn::make('sku')
     ->label('SKU')
 ```
 
+### Configuring the default column selection
+
+By default, all columns will be selected when the user is asked which columns they would like to export. You can customize the default selection state for a column with the `enabledByDefault()` method:
+
+```php
+use Filament\Actions\Exports\ExportColumn;
+
+ExportColumn::make('description')
+    ->enabledByDefault(false)
+```
+
 ### Calculated export column state
 
 Sometimes you need to calculate the state of a column, instead of directly reading it from a database column.

--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -81,7 +81,7 @@ trait CanExportRecords
                             Forms\Components\Checkbox::make('isEnabled')
                                 ->label(__('filament-actions::export.modal.form.columns.form.is_enabled.label', ['column' => $column->getName()]))
                                 ->hiddenLabel()
-                                ->default(true)
+                                ->default($column->isEnabledByDefault())
                                 ->live()
                                 ->grow(false),
                             Forms\Components\TextInput::make('label')

--- a/packages/actions/src/Exports/ExportColumn.php
+++ b/packages/actions/src/Exports/ExportColumn.php
@@ -58,9 +58,9 @@ class ExportColumn extends Component
         return $this;
     }
 
-    public function enabledByDefault(bool | Closure $isEnabledByDefault): static
+    public function enabledByDefault(bool | Closure $condition): static
     {
-        $this->isEnabledByDefault = $isEnabledByDefault;
+        $this->isEnabledByDefault = $condition;
 
         return $this;
     }

--- a/packages/actions/src/Exports/ExportColumn.php
+++ b/packages/actions/src/Exports/ExportColumn.php
@@ -77,7 +77,7 @@ class ExportColumn extends Component
 
     public function isEnabledByDefault(): bool
     {
-        return $this->evaluate($this->isEnabledByDefault) ?? true;
+        return (bool) $this->evaluate($this->isEnabledByDefault)
     }
 
     public function getRecord(): ?Model

--- a/packages/actions/src/Exports/ExportColumn.php
+++ b/packages/actions/src/Exports/ExportColumn.php
@@ -22,6 +22,8 @@ class ExportColumn extends Component
 
     protected ?Exporter $exporter = null;
 
+    protected bool | Closure $isEnabledByDefault = true;
+
     final public function __construct(string $name)
     {
         $this->name($name);
@@ -56,6 +58,13 @@ class ExportColumn extends Component
         return $this;
     }
 
+    public function enabledByDefault(bool | Closure $isEnabledByDefault): static
+    {
+        $this->isEnabledByDefault = $isEnabledByDefault;
+
+        return $this;
+    }
+
     public function getName(): string
     {
         return $this->name;
@@ -64,6 +73,11 @@ class ExportColumn extends Component
     public function getExporter(): ?Exporter
     {
         return $this->exporter;
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return $this->evaluate($this->isEnabledByDefault) ?? true;
     }
 
     public function getRecord(): ?Model


### PR DESCRIPTION
## Description

Currently the modal for the new export action has all columns selected by default. In the case where an export includes a column that is only occasionally needed, it would be convenient for it to be _deselected_ by default.

This PR makes a simple modification to `ExportColumn` and `CanSelectRecords`, adding a `$defaultEnabled` property and appropriate methods (there may be a more suitable name for this) to allow the default state of a column to be configured.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

(No visual changes.)

## Code style

- [x] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.

(Changes tested manually.)

## Documentation

- [x] Documentation is up-to-date.
