### PR TITLE
Adding custom tooltips to navigation badges

### DIFF
--- a/packages/panels/docs/06-navigation.md
+++ b/packages/panels/docs/06-navigation.md
@@ -73,6 +73,15 @@ public static function getNavigationBadgeColor(): ?string
 }
 ```
 
+A custom tooltip for the navigation badge can be returned by `getNavigationBadgeTooltip()`:
+
+```php
+public static function getNavigationBadgeTooltip(): ?string
+{
+    return 'Custom Tooltip';
+}
+```
+
 ## Grouping navigation items
 
 You may group navigation items by specifying a `$navigationGroup` property on a [resource](resources/getting-started) and [custom page](pages):

--- a/packages/panels/docs/06-navigation.md
+++ b/packages/panels/docs/06-navigation.md
@@ -73,12 +73,18 @@ public static function getNavigationBadgeColor(): ?string
 }
 ```
 
-A custom tooltip for the navigation badge can be returned by `getNavigationBadgeTooltip()`:
+A custom tooltip for the navigation badge can be set in `$navigationBadgeTooltip`:
+
+```php
+protected static ?string $navigationBadgeTooltip = 'The number of users';
+```
+
+Or it can be returned from `getNavigationBadgeTooltip()`:
 
 ```php
 public static function getNavigationBadgeTooltip(): ?string
 {
-    return 'Custom Tooltip';
+    return 'The number of users';
 }
 ```
 

--- a/packages/panels/resources/views/components/sidebar/group.blade.php
+++ b/packages/panels/resources/views/components/sidebar/group.blade.php
@@ -73,6 +73,7 @@
                 :active-icon="$item->getActiveIcon()"
                 :badge="$item->getBadge()"
                 :badge-color="$item->getBadgeColor()"
+                :badge-tooltip="$item->getBadgeTooltip()"
                 :child-items="$item->getChildItems()"
                 :first="$loop->first"
                 :grouped="filled($label)"

--- a/packages/panels/resources/views/components/sidebar/item.blade.php
+++ b/packages/panels/resources/views/components/sidebar/item.blade.php
@@ -110,13 +110,6 @@
 
         @if (filled($badge))
             <span
-                @if (filled($badgeTooltip))
-                    x-data="{}"
-                    x-tooltip="{
-                        content: @js($badgeTooltip),
-                        theme: $store.theme,
-                    }"
-                @endif
                 @if ($sidebarCollapsible)
                     x-show="$store.sidebar.isOpen"
                     x-transition:enter="lg:transition lg:delay-100"
@@ -124,7 +117,7 @@
                     x-transition:enter-end="opacity-100"
                 @endif
             >
-                <x-filament::badge :color="$badgeColor">
+                <x-filament::badge :color="$badgeColor" :tooltip="$badgeTooltip">
                     {{ $badge }}
                 </x-filament::badge>
             </span>

--- a/packages/panels/resources/views/components/sidebar/item.blade.php
+++ b/packages/panels/resources/views/components/sidebar/item.blade.php
@@ -4,6 +4,7 @@
     'activeIcon' => null,
     'badge' => null,
     'badgeColor' => null,
+    'badgeTooltip' => null,
     'childItems' => [],
     'first' => false,
     'grouped' => false,

--- a/packages/panels/resources/views/components/sidebar/item.blade.php
+++ b/packages/panels/resources/views/components/sidebar/item.blade.php
@@ -113,7 +113,7 @@
                 @if (filled($badgeTooltip))
                     x-data="{}"
                     x-tooltip="{
-                        content: @js($tooltip),
+                        content: @js($badgeTooltip),
                         theme: $store.theme,
                     }"
                 @endif

--- a/packages/panels/resources/views/components/sidebar/item.blade.php
+++ b/packages/panels/resources/views/components/sidebar/item.blade.php
@@ -133,6 +133,7 @@
                     :active-icon="$childItem->getActiveIcon()"
                     :badge="$childItem->getBadge()"
                     :badge-color="$childItem->getBadgeColor()"
+                    :badge-tooltip="$childItem->getBadgeTooltip()"
                     :first="$loop->first"
                     grouped
                     :icon="$childItem->getIcon()"

--- a/packages/panels/resources/views/components/sidebar/item.blade.php
+++ b/packages/panels/resources/views/components/sidebar/item.blade.php
@@ -109,6 +109,13 @@
 
         @if (filled($badge))
             <span
+                @if (filled($badgeTooltip))
+                    x-data="{}"
+                    x-tooltip="{
+                        content: @js($tooltip),
+                        theme: $store.theme,
+                    }"
+                @endif
                 @if ($sidebarCollapsible)
                     x-show="$store.sidebar.isOpen"
                     x-transition:enter="lg:transition lg:delay-100"

--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -89,6 +89,7 @@
                                         <x-filament::dropdown.list.item
                                             :badge="$item->getBadge()"
                                             :badge-color="$item->getBadgeColor()"
+                                            :badge-tooltip="$item->getBadgeTooltip()"
                                             :color="$isActive ? 'primary' : 'gray'"
                                             :href="$item->getUrl()"
                                             :icon="$isActive ? ($item->getActiveIcon() ?? $icon) : $icon"
@@ -107,6 +108,7 @@
                                     :active-icon="$item->getActiveIcon()"
                                     :badge="$item->getBadge()"
                                     :badge-color="$item->getBadgeColor()"
+                                    :badge-tooltip="$item->getBadgeTooltip()"
                                     :icon="$item->getIcon()"
                                     :should-open-url-in-new-tab="$item->shouldOpenUrlInNewTab()"
                                     :url="$item->getUrl()"

--- a/packages/panels/resources/views/components/topbar/item.blade.php
+++ b/packages/panels/resources/views/components/topbar/item.blade.php
@@ -3,6 +3,7 @@
     'activeIcon' => null,
     'badge' => null,
     'badgeColor' => null,
+    'badgeTooltip' => null,
     'icon' => null,
     'shouldOpenUrlInNewTab' => false,
     'url' => null,
@@ -52,7 +53,7 @@
         </span>
 
         @if (filled($badge))
-            <x-filament::badge :color="$badgeColor" size="sm">
+            <x-filament::badge :color="$badgeColor" :tooltip="$badgeTooltip" size="sm">
                 {{ $badge }}
             </x-filament::badge>
         @endif

--- a/packages/panels/src/Navigation/NavigationItem.php
+++ b/packages/panels/src/Navigation/NavigationItem.php
@@ -28,9 +28,6 @@ class NavigationItem extends Component
      */
     protected string | array | Closure | null $badgeColor = null;
 
-    /**
-     * @var string | string | Closure | null
-     */
     protected string | Closure | null $badgeTooltip = null;
 
     protected bool | Closure $shouldOpenUrlInNewTab = false;
@@ -172,7 +169,7 @@ class NavigationItem extends Component
         return $this->evaluate($this->badgeColor);
     }
 
-    public function getBadgeTooltip(): string | Closure | null
+    public function getBadgeTooltip(): ?string
     {
         return $this->evaluate($this->badgeTooltip);
     }
@@ -200,7 +197,7 @@ class NavigationItem extends Component
 
     public function isVisible(): bool
     {
-        return !$this->isHidden();
+        return ! $this->isHidden();
     }
 
     public function isHidden(): bool
@@ -209,7 +206,7 @@ class NavigationItem extends Component
             return true;
         }
 
-        return !$this->evaluate($this->isVisible);
+        return ! $this->evaluate($this->isVisible);
     }
 
     public function getActiveIcon(): ?string

--- a/packages/panels/src/Navigation/NavigationItem.php
+++ b/packages/panels/src/Navigation/NavigationItem.php
@@ -27,6 +27,8 @@ class NavigationItem extends Component
      * @var string | array{50: string, 100: string, 200: string, 300: string, 400: string, 500: string, 600: string, 700: string, 800: string, 900: string, 950: string} | Closure | null
      */
     protected string | array | Closure | null $badgeColor = null;
+    
+    protected string | array | Closure | null $badgeTooltip = null;
 
     protected bool | Closure $shouldOpenUrlInNewTab = false;
 
@@ -86,6 +88,13 @@ class NavigationItem extends Component
     public function icon(string | Closure | null $icon): static
     {
         $this->icon = $icon;
+
+        return $this;
+    }
+
+    public function tooltip(string | Closure | null $tooltip): static
+    {
+        $this->badgeTooltip = $tooltip;
 
         return $this;
     }
@@ -158,6 +167,11 @@ class NavigationItem extends Component
     public function getBadgeColor(): string | array | null
     {
         return $this->evaluate($this->badgeColor);
+    }
+
+    public function getBadgeTooltip(): string | array | null
+    {
+        return $this->evaluate($this->badgeTooltip);
     }
 
     public function getGroup(): ?string

--- a/packages/panels/src/Navigation/NavigationItem.php
+++ b/packages/panels/src/Navigation/NavigationItem.php
@@ -27,8 +27,11 @@ class NavigationItem extends Component
      * @var string | array{50: string, 100: string, 200: string, 300: string, 400: string, 500: string, 600: string, 700: string, 800: string, 900: string, 950: string} | Closure | null
      */
     protected string | array | Closure | null $badgeColor = null;
-    
-    protected string | array | Closure | null $badgeTooltip = null;
+
+    /**
+     * @var string | string | Closure | null
+     */
+    protected string | Closure | null $badgeTooltip = null;
 
     protected bool | Closure $shouldOpenUrlInNewTab = false;
 
@@ -169,7 +172,7 @@ class NavigationItem extends Component
         return $this->evaluate($this->badgeColor);
     }
 
-    public function getBadgeTooltip(): string | array | null
+    public function getBadgeTooltip(): string | Closure | null
     {
         return $this->evaluate($this->badgeTooltip);
     }
@@ -197,7 +200,7 @@ class NavigationItem extends Component
 
     public function isVisible(): bool
     {
-        return ! $this->isHidden();
+        return !$this->isHidden();
     }
 
     public function isHidden(): bool
@@ -206,7 +209,7 @@ class NavigationItem extends Component
             return true;
         }
 
-        return ! $this->evaluate($this->isVisible);
+        return !$this->evaluate($this->isVisible);
     }
 
     public function getActiveIcon(): ?string

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -167,6 +167,7 @@ abstract class Resource
                 ->activeIcon(static::getActiveNavigationIcon())
                 ->isActiveWhen(fn () => request()->routeIs(static::getRouteBaseName() . '.*'))
                 ->badge(static::getNavigationBadge(), color: static::getNavigationBadgeColor())
+                ->tooltip(static::getNavigationTooltip())
                 ->sort(static::getNavigationSort())
                 ->url(static::getNavigationUrl()),
         ];
@@ -817,6 +818,11 @@ abstract class Resource
     }
 
     public static function getNavigationBadge(): ?string
+    {
+        return null;
+    }
+
+    public static function getNavigationTooltip(): ?string
     {
         return null;
     }

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -65,6 +65,8 @@ abstract class Resource
     protected static ?string $modelLabel = null;
 
     protected static ?string $model = null;
+    
+    protected static ?string $navigationBadgeTooltip = null;
 
     protected static ?string $navigationGroup = null;
 
@@ -824,7 +826,7 @@ abstract class Resource
 
     public static function getNavigationBadgeTooltip(): ?string
     {
-        return null;
+        return static::$navigationBadgeTooltip;
     }
 
     /**

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -167,7 +167,7 @@ abstract class Resource
                 ->activeIcon(static::getActiveNavigationIcon())
                 ->isActiveWhen(fn () => request()->routeIs(static::getRouteBaseName() . '.*'))
                 ->badge(static::getNavigationBadge(), color: static::getNavigationBadgeColor())
-                ->tooltip(static::getNavigationTooltip())
+                ->tooltip(static::getNavigationBadgeTooltip())
                 ->sort(static::getNavigationSort())
                 ->url(static::getNavigationUrl()),
         ];
@@ -822,7 +822,7 @@ abstract class Resource
         return null;
     }
 
-    public static function getNavigationTooltip(): ?string
+    public static function getNavigationBadgeTooltip(): ?string
     {
         return null;
     }

--- a/packages/support/resources/views/components/dropdown/list/item.blade.php
+++ b/packages/support/resources/views/components/dropdown/list/item.blade.php
@@ -5,6 +5,7 @@
 @props([
     'badge' => null,
     'badgeColor' => null,
+    'badgeTooltip' => null,
     'color' => 'gray',
     'disabled' => false,
     'href' => null,
@@ -164,7 +165,7 @@
         </span>
 
         @if (filled($badge))
-            <x-filament::badge :color="$badgeColor" size="sm">
+            <x-filament::badge :color="$badgeColor" :tooltip="$badgeTooltip" size="sm">
                 {{ $badge }}
             </x-filament::badge>
         @endif

--- a/packages/support/src/Concerns/HasBadge.php
+++ b/packages/support/src/Concerns/HasBadge.php
@@ -7,6 +7,8 @@ use Closure;
 trait HasBadge
 {
     protected string | int | float | Closure | null $badge = null;
+    
+    protected string | int | float | Closure | null $badgeTooltip = null;
 
     /**
      * @var string | array{50: string, 100: string, 200: string, 300: string, 400: string, 500: string, 600: string, 700: string, 800: string, 900: string, 950: string} | Closure | null
@@ -43,6 +45,13 @@ trait HasBadge
         return $this;
     }
 
+    public function badgeTooltip(string | array | Closure | null $tooltip): static
+    {
+        $this->badgeTooltip = $tooltip;
+
+        return $this;
+    }
+
     /**
      * @deprecated Use `badgeColor()` instead.
      *
@@ -64,5 +73,10 @@ trait HasBadge
     public function getBadgeColor(): string | array | null
     {
         return $this->evaluate($this->badgeColor);
+    }
+
+    public function getBadgeTooltip(): string | array | null
+    {
+        return $this->evaluate($this->badgeTooltip);
     }
 }

--- a/packages/support/src/Concerns/HasBadge.php
+++ b/packages/support/src/Concerns/HasBadge.php
@@ -7,8 +7,6 @@ use Closure;
 trait HasBadge
 {
     protected string | int | float | Closure | null $badge = null;
-    
-    protected string | int | float | Closure | null $badgeTooltip = null;
 
     /**
      * @var string | array{50: string, 100: string, 200: string, 300: string, 400: string, 500: string, 600: string, 700: string, 800: string, 900: string, 950: string} | Closure | null
@@ -45,13 +43,6 @@ trait HasBadge
         return $this;
     }
 
-    public function badgeTooltip(string | array | Closure | null $tooltip): static
-    {
-        $this->badgeTooltip = $tooltip;
-
-        return $this;
-    }
-
     /**
      * @deprecated Use `badgeColor()` instead.
      *
@@ -73,10 +64,5 @@ trait HasBadge
     public function getBadgeColor(): string | array | null
     {
         return $this->evaluate($this->badgeColor);
-    }
-
-    public function getBadgeTooltip(): string | array | null
-    {
-        return $this->evaluate($this->badgeTooltip);
     }
 }


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

This PR gives the user the ability to add custom tooltips when hovering above navigation badges

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

https://github.com/filamentphp/filament/assets/64212185/c90d5a86-802a-4a19-bc3c-86c6cf87b4b8

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
