### PR TITLE
Enabling Badge Color for Relational Managers

### DIFF
--- a/packages/panels/docs/03-resources/07-relation-managers.md
+++ b/packages/panels/docs/03-resources/07-relation-managers.md
@@ -643,6 +643,93 @@ public function hasCombinedRelationManagerTabsWithContent(): bool
 }
 ```
 
+## Adding badges to relation manager tabs
+
+You can add a badge to a relation manager tab by setting the `$badge` property:
+
+```php
+protected static ?string $badge = 'new';
+```
+
+Alternatively, you can override the `getBadge()` method:
+
+```php
+use Illuminate\Database\Eloquent\Model;
+
+public static function getBadge(Model $ownerRecord, string $pageClass): ?string
+{
+    return static::$badge;
+}
+```
+
+Or, if you are using a [relation group](#grouping-relation-managers), you can use the `badge()` method:
+
+```php
+use Filament\Resources\RelationManagers\RelationGroup;
+
+RelationGroup::make('Contacts', [
+    // ...
+])->badge('new');
+```
+
+### Changing the color of relation manager tab badges
+
+If a badge value is defined, it will display using the primary color by default. To style the badge contextually, set the `$badgeColor` to either `danger`, `gray`, `info`, `primary`, `success` or `warning`:
+
+```php
+protected static ?string $badgeColor = 'danger';
+```
+
+Alternatively, you can override the `getBadgeColor()` method:
+
+```php
+use Illuminate\Database\Eloquent\Model;
+
+public static function getBadgeColor(Model $ownerRecord, string $pageClass): ?string
+{
+    return 'danger';
+}
+```
+
+Or, if you are using a [relation group](#grouping-relation-managers), you can use the `badgeColor()` method:
+
+```php
+use Filament\Resources\RelationManagers\RelationGroup;
+
+RelationGroup::make('Contacts', [
+    // ...
+])->badgeColor('danger');
+```
+
+### Adding a tooltip to relation manager tab badges
+
+If a badge value is defined, you can add a tooltip to it by setting the `$badgeTooltip` property:
+
+```php
+protected static ?string $badgeTooltip = 'There are new posts';
+```
+
+Alternatively, you can override the `getBadgeTooltip()` method:
+
+```php
+use Illuminate\Database\Eloquent\Model;
+
+public static function getBadgeTooltip(Model $ownerRecord, string $pageClass): ?string
+{
+    return 'There are new posts';
+}
+```
+
+Or, if you are using a [relation group](#grouping-relation-managers), you can use the `badgeTooltip()` method:
+
+```php
+use Filament\Resources\RelationManagers\RelationGroup;
+
+RelationGroup::make('Contacts', [
+    // ...
+])->badgeTooltip('There are new posts');
+```
+
 ## Sharing a resource's form and table with a relation manager
 
 You may decide that you want a resource's form and table to be identical to a relation manager's, and subsequently want to reuse the code you previously wrote. This is easy, by calling the `form()` and `table()` methods of the resource from the relation manager:

--- a/packages/panels/resources/views/components/resources/relation-managers.blade.php
+++ b/packages/panels/resources/views/components/resources/relation-managers.blade.php
@@ -47,6 +47,7 @@
                     :active="$activeManager === $tabKey"
                     :badge="filled($tabKey) ? ($isGroup ? $manager->getBadge() : $manager::getBadge($ownerRecord, $pageClass)) : null"
                     :badge-color="filled($tabKey) ? ($isGroup ? $manager->getBadgeColor() : $manager::getBadgeColor($ownerRecord, $pageClass)) : null"
+                    :badge-tooltip="filled($tabKey) ? ($isGroup ? $manager->getBadgeTooltip() : $manager::getBadgeTooltip($ownerRecord, $pageClass)) : null"
                     :icon="filled($tabKey) ? ($isGroup ? $manager->getIcon() : $manager::getIcon($ownerRecord, $pageClass)) : null"
                     :icon-position="filled($tabKey) ? ($isGroup ? $manager->getIconPosition() : $manager::getIconPosition($ownerRecord, $pageClass)) : null"
                     :wire:click="'$set(\'activeRelationManager\', ' . (filled($tabKey) ? ('\'' . $tabKey . '\'') : 'null') . ')'"

--- a/packages/panels/resources/views/components/resources/relation-managers.blade.php
+++ b/packages/panels/resources/views/components/resources/relation-managers.blade.php
@@ -46,6 +46,7 @@
                 <x-filament::tabs.item
                     :active="$activeManager === $tabKey"
                     :badge="filled($tabKey) ? ($isGroup ? $manager->getBadge() : $manager::getBadge($ownerRecord, $pageClass)) : null"
+                    :badge-color="filled($tabKey) ? ($isGroup ? $manager->getBadgeColor() : $manager::getBadgeColor($ownerRecord, $pageClass)) : null"
                     :icon="filled($tabKey) ? ($isGroup ? $manager->getIcon() : $manager::getIcon($ownerRecord, $pageClass)) : null"
                     :icon-position="filled($tabKey) ? ($isGroup ? $manager->getIconPosition() : $manager::getIconPosition($ownerRecord, $pageClass)) : null"
                     :wire:click="'$set(\'activeRelationManager\', ' . (filled($tabKey) ? ('\'' . $tabKey . '\'') : 'null') . ')'"

--- a/packages/panels/src/Resources/RelationManagers/RelationGroup.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationGroup.php
@@ -13,6 +13,10 @@ class RelationGroup extends Component
 
     protected string | Closure | null $badge = null;
 
+    protected string | Closure | null $badgeColor = null;
+
+    protected string | Closure | null $badgeTooltip = null;
+
     protected ?Model $ownerRecord = null;
 
     protected ?string $pageClass = null;
@@ -58,6 +62,20 @@ class RelationGroup extends Component
         return $this;
     }
 
+    public function badgeColor(string | Closure | null $color): static
+    {
+        $this->badgeColor = $color;
+
+        return $this;
+    }
+
+    public function badgeTooltip(string | Closure | null $tooltip): static
+    {
+        $this->badgeTooltip = $tooltip;
+
+        return $this;
+    }
+
     public function getLabel(): string
     {
         return $this->evaluate($this->label);
@@ -97,6 +115,16 @@ class RelationGroup extends Component
     public function getBadge(): ?string
     {
         return $this->evaluate($this->badge);
+    }
+
+    public function getBadgeColor(): ?string
+    {
+        return $this->evaluate($this->badgeColor);
+    }
+
+    public function getBadgeTooltip(): ?string
+    {
+        return $this->evaluate($this->badgeTooltip);
     }
 
     public function getOwnerRecord(): ?Model

--- a/packages/panels/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManager.php
@@ -82,6 +82,8 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
 
     protected static ?string $badge = null;
 
+    protected static ?string $badgeColor = null;
+
     protected static bool $isLazy = true;
 
     public function mount(): void
@@ -147,6 +149,11 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
     public static function getBadge(Model $ownerRecord, string $pageClass): ?string
     {
         return static::$badge;
+    }
+
+    public static function getBadgeColor(Model $ownerRecord, string $pageClass): ?string
+    {
+        return static::$badgeColor;
     }
 
     public static function getTitle(Model $ownerRecord, string $pageClass): string

--- a/packages/panels/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManager.php
@@ -84,6 +84,8 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
 
     protected static ?string $badgeColor = null;
 
+    protected static ?string $badgeTooltip = null;
+
     protected static bool $isLazy = true;
 
     public function mount(): void
@@ -154,6 +156,11 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
     public static function getBadgeColor(Model $ownerRecord, string $pageClass): ?string
     {
         return static::$badgeColor;
+    }
+
+    public static function getBadgeTooltip(Model $ownerRecord, string $pageClass): ?string
+    {
+        return static::$badgeTooltip;
     }
 
     public static function getTitle(Model $ownerRecord, string $pageClass): string

--- a/packages/support/resources/views/components/tabs/item.blade.php
+++ b/packages/support/resources/views/components/tabs/item.blade.php
@@ -7,6 +7,7 @@
     'alpineActive' => null,
     'badge' => null,
     'badgeColor' => null,
+    'badgeTooltip' => null,
     'href' => null,
     'icon' => null,
     'iconColor' => 'gray',
@@ -105,7 +106,7 @@
     @endif
 
     @if (filled($badge))
-        <x-filament::badge :color="$badgeColor" size="sm" class="w-max">
+        <x-filament::badge :color="$badgeColor" :tooltip="$badgeTooltip" size="sm" class="w-max">
             {{ $badge }}
         </x-filament::badge>
     @endif


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

Currently the Relation Manager has the ability to set a badge, but there isn't a way to set the badge color. This PR should now allow setting the badgeColor.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

![CleanShot 2024-01-26 at 13 53 22](https://github.com/filamentphp/filament/assets/1639302/f24d9441-0687-4f4f-91f6-4187877f1a9b)

![CleanShot 2024-01-26 at 13 53 45](https://github.com/filamentphp/filament/assets/1639302/1cdb97a4-bcb8-4425-bf3b-ce51696f6cf1)


## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
