### PR TITLE
Fix: do not lazy load brand logo

### DIFF
--- a/packages/panels/resources/views/components/logo.blade.php
+++ b/packages/panels/resources/views/components/logo.blade.php
@@ -29,7 +29,6 @@
     @elseif (filled($logo))
         <img
             alt="{{ $brandName }}"
-            loading="lazy"
             src="{{ $logo }}"
             {{
                 $attributes


### PR DESCRIPTION
## Description

I noticed on Safari that the logo/navigation would flicker when navigating through a panel (I do have caching etc enabled). On Chrome the effect was less impactful, but I still could reproduce it a few times randomly.

https://github.com/filamentphp/filament/assets/59207045/4ee2358c-a146-403b-8cd4-db8b49cac08b

I noticed that the brand logo uses the `loading="lazy"` attribute, but the goal of lazy loading is to [Defer loading of the resource until it reaches a calculated distance from the viewport](https://web.dev/articles/browser-level-image-lazy-loading). Since the logo is pretty much always immediately in view, I think the `loading="lazy"` is pointless and actually reduces the UX experience.

Sidenote: love the top-navigation, very beautiful 💛
