### PR TITLE
Fix vertical centering of logo

### DIFF
--- a/packages/panels/resources/views/components/logo.blade.php
+++ b/packages/panels/resources/views/components/logo.blade.php
@@ -7,9 +7,9 @@
 
     $getLogoClasses = fn (bool $isDarkMode): string => \Illuminate\Support\Arr::toCssClasses([
         'fi-logo',
-        'inline-flex' => ! $hasDarkModeBrandLogo,
-        'inline-flex dark:hidden' => $hasDarkModeBrandLogo && (! $isDarkMode),
-        'hidden dark:inline-flex' => $hasDarkModeBrandLogo && $isDarkMode,
+        'flex' => ! $hasDarkModeBrandLogo,
+        'flex dark:hidden' => $hasDarkModeBrandLogo && (! $isDarkMode),
+        'hidden dark:flex' => $hasDarkModeBrandLogo && $isDarkMode,
     ]);
 
     $logoStyles = "height: {$brandLogoHeight}";


### PR DESCRIPTION
## Description

Due to the `inline-flex` class, the logo isn't centered correctly. By using the class `flex` instead, the problem is fixed.

## Before and after
![before-after](https://github.com/filamentphp/filament/assets/1169903/8197e419-00b6-443f-a603-2ff7518be96e)




