### PR TITLE
Graceful handling of deleted export dirs

### DIFF
--- a/packages/actions/src/Exports/Downloaders/CsvDownloader.php
+++ b/packages/actions/src/Exports/Downloaders/CsvDownloader.php
@@ -11,13 +11,18 @@ class CsvDownloader implements Downloader
     public function __invoke(Export $export): StreamedResponse
     {
         $disk = $export->getFileDisk();
+        $directory = $export->getFileDirectory();
 
-        return response()->streamDownload(function () use ($disk, $export) {
-            echo $disk->get($export->getFileDirectory() . DIRECTORY_SEPARATOR . 'headers.csv');
+        if (! $disk->exists($directory)) {
+            abort(419);
+        }
+
+        return response()->streamDownload(function () use ($disk, $directory) {
+            echo $disk->get($directory . DIRECTORY_SEPARATOR . 'headers.csv');
 
             flush();
 
-            foreach ($disk->files($export->getFileDirectory()) as $file) {
+            foreach ($disk->files($directory) as $file) {
                 if (str($file)->endsWith('headers.csv')) {
                     continue;
                 }

--- a/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
+++ b/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
@@ -15,10 +15,15 @@ class XlsxDownloader implements Downloader
     public function __invoke(Export $export): StreamedResponse
     {
         $disk = $export->getFileDisk();
+        $directory = $export->getFileDirectory();
+
+        if (! $disk->exists($directory)) {
+            abort(419);
+        }
 
         $fileName = $export->file_name . '.xlsx';
 
-        if ($disk->exists($filePath = $export->getFileDirectory() . DIRECTORY_SEPARATOR . $fileName)) {
+        if ($disk->exists($filePath = $directory . DIRECTORY_SEPARATOR . $fileName)) {
             return $disk->download($filePath);
         }
 
@@ -36,12 +41,12 @@ class XlsxDownloader implements Downloader
             }
         };
 
-        return response()->streamDownload(function () use ($disk, $export, $fileName, $writer, $writeRowsFromFile) {
+        return response()->streamDownload(function () use ($disk, $directory, $fileName, $writer, $writeRowsFromFile) {
             $writer->openToBrowser($fileName);
 
-            $writeRowsFromFile($export->getFileDirectory() . DIRECTORY_SEPARATOR . 'headers.csv');
+            $writeRowsFromFile($directory . DIRECTORY_SEPARATOR . 'headers.csv');
 
-            foreach ($disk->files($export->getFileDirectory()) as $file) {
+            foreach ($disk->files($directory) as $file) {
                 if (str($file)->endsWith('headers.csv')) {
                     continue;
                 }


### PR DESCRIPTION
You often need to automate cleanups in a multi-tenant environment to keep disk space under control. I'm running a scheduled job to delete export folders older than x days.

Currently when the user clicks a download link for an export with a deleted folder:

- The csv export returns a file of 0 bytes
- The xlsx export fails with a server error 

This PR aborts with 419 "Page expired" when the export directory has been deleted. IMHO 419 is a better choice than 404 here because it makes it clear to the user what's going on. 404 implies that something's broken, 419 implies that the export has just "expired".