### PR TITLE
Set table column width

### DIFF
--- a/packages/tables/docs/03-columns/01-getting-started.md
+++ b/packages/tables/docs/03-columns/01-getting-started.md
@@ -527,6 +527,28 @@ TextColumn::make('name')
     ->wrapHeader()
 ```
 
+## Controlling the width of columns
+
+By default, columns will take up as much space as they need. You may allow some columns to consume more space than others by using the `grow()` method:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('name')
+    ->grow()
+```
+
+Alternatively, you can define a width for the column, which is passed to the header cell using the `style` attribute, so you can use any valid CSS value:
+
+```php
+use Filament\Tables\Columns\IconColumn;
+
+IconColumn::make('is_paid')
+    ->label('Paid')
+    ->boolean()
+    ->width('1%')
+```
+
 ## Grouping columns
 
 You group multiple columns together underneath a single heading using a `ColumnGroup` object:

--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -17,7 +17,7 @@ TextColumn::make('title')
 
 ## Displaying as a "badge"
 
-By default, text is quite plain and has no background color. You can make it appear as a "badge" instead using the `badge()` method. A great use case for this is with statuses, where may want to display a badge with a [color](#customizing-the-color) that matches the status:
+By default, the text is quite plain and has no background color. You can make it appear as a "badge" instead using the `badge()` method. A great use case for this is with statuses, where may want to display a badge with a [color](#customizing-the-color) that matches the status:
 
 ```php
 use Filament\Tables\Columns\TextColumn;
@@ -326,17 +326,6 @@ TextColumn::make('email')
 ```
 
 <AutoScreenshot name="tables/columns/text/icon-color" alt="Text column with icon in the primary color" version="3.x" />
-
-## Customizing the column width
-
-To control the width of a column, you may use the `columnWidth()` method:
-
-```php
-use Filament\Tables\Columns\TextColumn;
-
-TextColumn::make('id')
-    ->columnWidth('1%')
-```
 
 ## Customizing the text size
 

--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -327,6 +327,17 @@ TextColumn::make('email')
 
 <AutoScreenshot name="tables/columns/text/icon-color" alt="Text column with icon in the primary color" version="3.x" />
 
+## Customizing the column width
+
+To control the width of a column, you may use the `columnWidth()` method:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('id')
+    ->columnWidth('1%')
+```
+
 ## Customizing the text size
 
 Text columns have small font size by default, but you may change this to `TextColumnSize::ExtraSmall`, `TextColumnSize::Medium`, or `TextColumnSize::Large`.

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -811,6 +811,10 @@
                         @endif
 
                         @foreach ($columns as $column)
+                            @php
+                                $columnWidth = $column->getWidth();
+                            @endphp
+
                             <x-filament-tables::header-cell
                                 :actively-sorted="$getSortColumn() === $column->getName()"
                                 :alignment="$column->getAlignment()"
@@ -822,9 +826,12 @@
                                     \Filament\Support\prepare_inherited_attributes($column->getExtraHeaderAttributeBag())
                                         ->class([
                                             'fi-table-header-cell-' . str($column->getName())->camel()->kebab(),
-                                            'w-full' => $column->canGrow(default: false),
+                                            'w-full' => blank($columnWidth) && $column->canGrow(default: false),
                                             '[&:not(:first-of-type)]:border-s [&:not(:last-of-type)]:border-e border-gray-200 dark:border-white/5' => $column->getGroup(),
                                             $getHiddenClasses($column),
+                                        ])
+                                        ->style([
+                                            'width' => $columnWidth,
                                         ])
                                 "
                             >

--- a/packages/tables/src/Columns/Column.php
+++ b/packages/tables/src/Columns/Column.php
@@ -40,6 +40,7 @@ class Column extends ViewComponent
     use Concerns\HasRecord;
     use Concerns\HasRowLoopObject;
     use Concerns\HasTooltip;
+    use Concerns\HasWidth;
     use Concerns\InteractsWithTableQuery;
     use Conditionable;
     use HasAlignment;

--- a/packages/tables/src/Columns/Concerns/HasWidth.php
+++ b/packages/tables/src/Columns/Concerns/HasWidth.php
@@ -4,8 +4,12 @@ namespace Filament\Tables\Columns\Concerns;
 
 trait HasWidth
 {
-    public function columnWidth(int|string $width): static
+    public function columnWidth(int | string $width): static
     {
+        if (is_int($width)) {
+            $width = "{$width}px";
+        }
+
         $this->extraHeaderAttributes[] = ['style' => 'width: ' . $width];
 
         return $this;

--- a/packages/tables/src/Columns/Concerns/HasWidth.php
+++ b/packages/tables/src/Columns/Concerns/HasWidth.php
@@ -2,16 +2,27 @@
 
 namespace Filament\Tables\Columns\Concerns;
 
+use Closure;
+
 trait HasWidth
 {
-    public function columnWidth(int | string $width): static
+    protected int | string | Closure | null $width = null;
+
+    public function width(int | string | Closure | null $width): static
     {
+        $this->width = $width;
+
+        return $this;
+    }
+
+    public function getWidth(): ?string
+    {
+        $width = $this->evaluate($this->width);
+
         if (is_int($width)) {
             $width = "{$width}px";
         }
 
-        $this->extraHeaderAttributes[] = ['style' => 'width: ' . $width];
-
-        return $this;
+        return $width;
     }
 }

--- a/packages/tables/src/Columns/Concerns/HasWidth.php
+++ b/packages/tables/src/Columns/Concerns/HasWidth.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Filament\Tables\Columns\Concerns;
+
+trait HasWidth
+{
+    public function columnWidth(int|string $width): static
+    {
+        $this->extraHeaderAttributes[] = ['style' => 'width: ' . $width];
+
+        return $this;
+    }
+}


### PR DESCRIPTION
## Description

Let's set the width of a table column using `﻿->columnWidth()`.

It adds `['style' => 'width: ' . $width]` to the `$extraHeaderAttributes`

## Code style

- [x] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.

## Documentation

- [x] Documentation is up-to-date.
