### PR TITLE
Allow relationship filters using custom keys

### DIFF
--- a/packages/tables/src/Filters/Concerns/HasRelationship.php
+++ b/packages/tables/src/Filters/Concerns/HasRelationship.php
@@ -5,6 +5,9 @@ namespace Filament\Tables\Filters\Concerns;
 use Closure;
 use Filament\Support\Services\RelationshipJoiner;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\Relation;
 
 trait HasRelationship
@@ -91,5 +94,28 @@ trait HasRelationship
         }
 
         return $relationshipQuery;
+    }
+
+    public function getRelationshipKey(): ?string
+    {
+        $relationship = $this->getRelationship();
+
+        if ($relationship instanceof BelongsToMany) {
+            return $relationship->getQualifiedRelatedKeyName();
+        }
+
+        if ($relationship instanceof HasManyThrough) {
+            return $relationship->getQualifiedForeignKeyName();
+        }
+
+        if ($relationship instanceof \Znck\Eloquent\Relations\BelongsToThrough) {
+            $keyColumn = $relationship->getRelated()->getQualifiedKeyName();
+        }
+
+        if ($relationship instanceof BelongsTo) {
+            return $relationship->getQualifiedOwnerKeyName();
+        }
+
+        return null;
     }
 }

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -5,6 +5,7 @@ namespace Filament\Tables\Filters;
 use Closure;
 use Filament\Forms\Components\Select;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 
 class SelectFilter extends BaseFilter
@@ -81,7 +82,11 @@ class SelectFilter extends BaseFilter
 
             if ($filter->queriesRelationships()) {
                 $label = $filter->getRelationshipQuery()
-                    ->whereKey($state['value'])
+                    ->when(
+                        $this->getRelationshipKey(),
+                        fn($query) => $query->where($this->getRelationshipKey(), $state['value']),
+                        fn($query) => $query->whereKey($state['value'])
+                    )
                     ->first()
                     ?->getAttributeValue($filter->getRelationshipTitleAttribute());
             } else {
@@ -153,7 +158,12 @@ class SelectFilter extends BaseFilter
                     ]) ?? $query;
                 }
 
-                return $query->whereKey($values);
+                return $query
+                    ->when(
+                        $this->getRelationshipKey(),
+                        fn($query) => $query->where($this->getRelationshipKey(), $values),
+                        fn($query) => $query->whereKey($values)
+                    );
             },
         );
     }


### PR DESCRIPTION
## Description

When using relationships that do not rely on primary keys, the select filter `->relationship` method still uses the primary key to filter instead of the defined foreign key. This PR reintroduces a method that was present in 2.x that gets the related key based on the relationship type, and when present uses that one instead of the primary key to filter.

- [X] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

command run, but not commited changes to tests not touched by this PR

- [X] `composer cs` command has been run.

## Testing

We tested this in `BelongsTo` relationship types.

- [X] Changes have been tested.

## Documentation


- [X] Documentation is up-to-date.
