### PR TITLE
Improving Table performance by caching eloquent queries

### DIFF
--- a/packages/tables/src/Concerns/CachesQueries.php
+++ b/packages/tables/src/Concerns/CachesQueries.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Filament\Tables\Concerns;
+
+use Closure;
+use Filament\Resources\Pages\ListRecords;
+use Illuminate\Support\Facades\Cache;
+
+trait CachesQueries
+{
+    protected bool $shouldCacheQueries = false;
+
+    protected int $keepCachedQueriesForSeconds = 600;
+
+    public function cacheQueries(bool $cache = true): static
+    {
+        $this->shouldCacheQueries = $cache;
+
+        return $this;
+    }
+
+    public function isCachingQueries(): bool
+    {
+        return $this->shouldCacheQueries;
+    }
+
+    public function keepCacheFor(int $seconds): static
+    {
+        $this->keepCachedQueriesForSeconds = $seconds;
+
+        return $this;
+    }
+
+    public function isKeepingCacheFor(): int
+    {
+        return $this->keepCachedQueriesForSeconds;
+    }
+
+    protected function getCacheTag(): string
+    {
+        return $this instanceof ListRecords
+            ? $this->getId()
+            : $this->getLivewire()->getId();
+    }
+
+    protected function remember(string $key, Closure $callback): mixed
+    {
+        return $this->isCachingQueries()
+            ? Cache::tags([$this->getCacheTag()])
+                ->remember(
+                    key: $key,
+                    ttl: now()->addSeconds($this->keepCachedQueriesForSeconds),
+                    callback: $callback
+                )
+            : $callback();
+    }
+
+    public function flushCache(): bool
+    {
+        return $this->isCachingQueries() && Cache::tags([$this->getCacheTag()])->flush();
+    }
+}

--- a/packages/tables/src/Concerns/CachesQueries.php
+++ b/packages/tables/src/Concerns/CachesQueries.php
@@ -3,7 +3,6 @@
 namespace Filament\Tables\Concerns;
 
 use Illuminate\Contracts\Pagination\CursorPaginator;
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Cache;

--- a/packages/tables/src/Concerns/CachesQueries.php
+++ b/packages/tables/src/Concerns/CachesQueries.php
@@ -2,8 +2,10 @@
 
 namespace Filament\Tables\Concerns;
 
-use Closure;
-use Filament\Resources\Pages\ListRecords;
+use Illuminate\Contracts\Pagination\CursorPaginator;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Contracts\Pagination\Paginator;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Cache;
 
 trait CachesQueries
@@ -38,13 +40,12 @@ trait CachesQueries
 
     protected function getCacheTag(): string
     {
-        return $this instanceof ListRecords
-            ? $this->getId()
-            : $this->getLivewire()->getId();
+        return $this->getId();
     }
 
-    protected function remember(string $key, Closure $callback): mixed
+    protected function remember(string $key, \Closure $callback): mixed
     {
+        /** @var \Closure(): Paginator|CursorPaginator|Collection  $callback */
         return $this->isCachingQueries()
             ? Cache::tags([$this->getCacheTag()])
                 ->remember(

--- a/packages/tables/src/Concerns/CanPaginateRecords.php
+++ b/packages/tables/src/Concerns/CanPaginateRecords.php
@@ -6,11 +6,11 @@ use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
-use Illuminate\Support\Facades\Cache;
 
 trait CanPaginateRecords
 {
     use CachesQueries;
+
     /**
      * @var int | string | null
      */
@@ -38,7 +38,8 @@ trait CanPaginateRecords
                 $perPage === 'all' ? $query->count() : $perPage,
                 ['*'],
                 $this->getTablePaginationPageName()
-            ));
+            )
+        );
 
         return $records->onEachSide(0);
     }

--- a/packages/tables/src/Concerns/CanPaginateRecords.php
+++ b/packages/tables/src/Concerns/CanPaginateRecords.php
@@ -9,8 +9,6 @@ use Illuminate\Pagination\LengthAwarePaginator;
 
 trait CanPaginateRecords
 {
-    use CachesQueries;
-
     /**
      * @var int | string | null
      */
@@ -30,10 +28,12 @@ trait CanPaginateRecords
     protected function paginateTableQuery(Builder $query): Paginator | CursorPaginator
     {
         $perPage = $this->getTableRecordsPerPage();
+        /** @var string $sql phpstan thinks `->toRawSql()` returns a Builder 🤷🏻 */
+        $sql = $query->toRawSql();
 
         /** @var LengthAwarePaginator $records */
         $records = $this->remember(
-            key: md5($query->toRawSql() . $perPage),
+            key: md5($sql . $perPage),
             callback: fn () => $query->paginate(
                 $perPage === 'all' ? $query->count() : $perPage,
                 ['*'],

--- a/packages/tables/src/Concerns/HasActions.php
+++ b/packages/tables/src/Concerns/HasActions.php
@@ -108,6 +108,8 @@ trait HasActions
             ]);
 
             $result = $action->callAfter() ?? $result;
+
+            $this->flushCache();
         } catch (Halt $exception) {
             return null;
         } catch (Cancel $exception) {
@@ -168,6 +170,7 @@ trait HasActions
 
         if (filled($record) && ($action->getRecord() === null)) {
             $this->unmountTableAction();
+            $this->flushCache();
 
             return null;
         }

--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -79,6 +79,8 @@ trait HasBulkActions
             ]);
 
             $result = $action->callAfter() ?? $result;
+
+            $this->flushCache();
         } catch (Halt $exception) {
             return null;
         } catch (Cancel $exception) {

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -14,6 +14,8 @@ use function Livewire\invade;
 
 trait HasRecords
 {
+    use CachesQueries;
+
     /**
      * @deprecated Override the `table()` method to configure the table.
      */
@@ -94,7 +96,9 @@ trait HasRecords
             (! $this->getTable()->isPaginated()) ||
             ($this->isTableReordering() && (! $this->getTable()->isPaginatedWhileReordering()))
         ) {
-            return $setRecordLocales($this->cachedTableRecords = $this->hydratePivotRelationForTableRecords($query->get()));
+            $records = $this->remember(md5($query->toRawSql()), fn () => $query->get());
+
+            return $setRecordLocales($this->cachedTableRecords = $this->hydratePivotRelationForTableRecords($records));
         }
 
         return $setRecordLocales($this->cachedTableRecords = $this->hydratePivotRelationForTableRecords($this->paginateTableQuery($query)));

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -14,8 +14,6 @@ use function Livewire\invade;
 
 trait HasRecords
 {
-    use CachesQueries;
-
     /**
      * @deprecated Override the `table()` method to configure the table.
      */
@@ -96,7 +94,9 @@ trait HasRecords
             (! $this->getTable()->isPaginated()) ||
             ($this->isTableReordering() && (! $this->getTable()->isPaginatedWhileReordering()))
         ) {
-            $records = $this->remember(md5($query->toRawSql()), fn () => $query->get());
+            /** @var string $sql phpstan thinks `->toRawSql()` returns a Builder 🤷🏻 */
+            $sql = $query->toRawSql();
+            $records = $this->remember(md5($sql), fn () => $query->get());
 
             return $setRecordLocales($this->cachedTableRecords = $this->hydratePivotRelationForTableRecords($records));
         }

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -14,6 +14,7 @@ use Livewire\WithPagination;
 
 trait InteractsWithTable
 {
+    use CachesQueries;
     use CanBeStriped;
     use CanDeferLoading;
     use CanGroupRecords;


### PR DESCRIPTION
## Description

### The "problem"
In a ListRecords page, every time an Action is clicked the database query is re-executed.
(In fact this happens every time Livewire "talks" to the server)
A single action with a form seems to trigger the exact same query to the DB at least 3 times (4 times if it requires confirmation).

With high number of records and/or complex queries (e.g. where the sorting is done on a related table column) this has a significant impact in the user experience.

### Proposed solution
This PR aims to improve the performance by leveraging Laravel's cache and avoid extra queries.

#### How it works:
- this feature must be enabled explicitly by setting `protected bool $shouldCacheQueries = true;` in any Page that extends `ListRecords`
- cache key is defined by the query's SQL
- cache is tagged using the Component's id.
- queries are cached by a default of 600 seconds
- cache is flushed anytime an Action executes successfully, to reflect changes in the table.

#### Notes:
- This solution relies on a cache driver that supports tagging, such as Redis.
- If not available, queries are simply not cached.
- If enabled without this support, will throw an exception.

I'd love to get some feedback, **even if only to kick-off a discussion on how to improve such scenarios.**

## Code style

- [X] `composer cs` command has been run.

## Testing

- [X] Changes have been tested.

## Documentation

- [ Not yet ] Documentation is up-to-date.
