### PR TITLE
Improve UX of forms builder/repeater with `collapsible()`

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -123,7 +123,7 @@
                                             x-on:click.stop="isCollapsed = !isCollapsed"
                                         @endif
                                         @class([
-                                            'text-sm font-medium text-gray-950 dark:text-white',
+                                            'text-sm font-medium text-gray-950 dark:text-white flex-grow',
                                             'truncate' => $isBlockLabelTruncated(),
                                             'cursor-pointer select-none' => $isCollapsible,
                                         ])

--- a/packages/forms/resources/views/components/repeater/index.blade.php
+++ b/packages/forms/resources/views/components/repeater/index.blade.php
@@ -127,7 +127,7 @@
                                                 x-on:click.stop="isCollapsed = !isCollapsed"
                                             @endif
                                             @class([
-                                                'text-sm font-medium text-gray-950 dark:text-white',
+                                                'text-sm font-medium text-gray-950 dark:text-white flex-grow',
                                                 'truncate' => $isItemLabelTruncated(),
                                                 'cursor-pointer select-none' => $isCollapsible,
                                             ])


### PR DESCRIPTION
When using the repeater/builder with `collapsible()` clicking the label toggles the collapsed/expanded status. However, as an end user I'd assume the label *and* empty space is clickable to toggle this, and that clicking the buttons of course would do their own thing.

<img width="808" alt="301461780-7d6750e9-e391-46ae-bc9d-d81deae7e8cf" src="https://github.com/filamentphp/filament/assets/3736774/70f56b5e-b220-4149-85f9-2fb19be634bb">

Adding a simple `flex-grow` on the element containing the label does the trick.
