### PR TITLE
In ImageColumn's ring method: incorrect type string, should be int

### DIFF
--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -277,7 +277,7 @@ class ImageColumn extends Column
         return $this->evaluate($this->overlap);
     }
 
-    public function ring(string | Closure | null $ring): static
+    public function ring(int | Closure | null $ring): static
     {
         $this->ring = $ring;
 


### PR DESCRIPTION
In the ImageColumn's ring method, we mistakenly have string | Closure | null $ring instead of the correct int | Closure | null $ring. However, the correct type declaration int | Closure | null $ring is present in the constant

<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [ ] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
