### PR TITLE
BP - add missing form translations for toggle and password fields

### DIFF
--- a/packages/forms/resources/lang/fr/components.php
+++ b/packages/forms/resources/lang/fr/components.php
@@ -419,6 +419,31 @@ return [
         'placeholder' => 'Nouveau tag',
     ],
 
+    'text_input' => [
+
+        'actions' => [
+
+            'hide_password' => [
+                'label' => 'Masquer le mot de passe',
+            ],
+
+            'show_password' => [
+                'label' => 'Montrer le mot de passe',
+            ],
+
+        ],
+
+    ],
+
+    'toggle_buttons' => [
+
+        'boolean' => [
+            'true' => 'Oui',
+            'false' => 'Non',
+        ],
+
+    ],
+
     'wizard' => [
 
         'actions' => [


### PR DESCRIPTION
## Description

Adds some missing French translations for form fields after being highlighted in a discord help topic

