### PR TITLE
Improve Turkish translation

### DIFF
--- a/packages/actions/resources/lang/tr/create.php
+++ b/packages/actions/resources/lang/tr/create.php
@@ -17,7 +17,7 @@ return [
                 ],
 
                 'create_another' => [
-                    'label' => 'Oluştur ve başka bir tane oluştur',
+                    'label' => 'Oluştur & yeni oluştur',
                 ],
 
             ],

--- a/packages/forms/resources/lang/tr/components.php
+++ b/packages/forms/resources/lang/tr/components.php
@@ -345,7 +345,7 @@ return [
                         ],
 
                         'create_another' => [
-                            'label' => 'Oluştur & başka bir tane oluştur',
+                            'label' => 'Oluştur & yeni oluştur',
                         ],
 
                     ],


### PR DESCRIPTION
It's already translated as "Oluştur & yeni oluştur" in the .../pages/create-record.php directory. This translation has been consistently applied across other sections, making it the best fit for uniformity.