### PR TITLE
Adds hook class for prose content

### DIFF
--- a/packages/infolists/resources/views/components/text-entry.blade.php
+++ b/packages/infolists/resources/views/components/text-entry.blade.php
@@ -118,7 +118,7 @@
                                 $weight = $getWeight($state);
 
                                 $proseClasses = \Illuminate\Support\Arr::toCssClasses([
-                                    'fi-in-prose prose max-w-none dark:prose-invert [&>*:first-child]:mt-0 [&>*:last-child]:mb-0',
+                                    'fi-in-text-item-prose prose max-w-none dark:prose-invert [&>*:first-child]:mt-0 [&>*:last-child]:mb-0',
                                     'pt-2' => ! $isLabelHidden(),
                                     match ($size) {
                                         TextEntrySize::ExtraSmall, 'xs' => 'prose-xs',

--- a/packages/infolists/resources/views/components/text-entry.blade.php
+++ b/packages/infolists/resources/views/components/text-entry.blade.php
@@ -118,7 +118,7 @@
                                 $weight = $getWeight($state);
 
                                 $proseClasses = \Illuminate\Support\Arr::toCssClasses([
-                                    'prose max-w-none dark:prose-invert [&>*:first-child]:mt-0 [&>*:last-child]:mb-0',
+                                    'fi-in-prose prose max-w-none dark:prose-invert [&>*:first-child]:mt-0 [&>*:last-child]:mb-0',
                                     'pt-2' => ! $isLabelHidden(),
                                     match ($size) {
                                         TextEntrySize::ExtraSmall, 'xs' => 'prose-xs',


### PR DESCRIPTION
## Description

I extensively use filament outside the panel builder within my app and started to refactor a lot of my components using filament (mostly infolist builder).

Today I discovered the `prose` method, which is awesome! However, it does not quite fit the style of my app, since I [modified it](https://tailwindcss.com/docs/typography-plugin#element-modifiers) a bit.

Would be great to have a dedicated hook, to apply changes to.


- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

- [x] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.

Adding an empty selector does not make any changes.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.

My changes do not add new functionality, however the `prose` method is not documented yet.