### PR TITLE
feat: Make the ID of the record unique

### DIFF
--- a/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
+++ b/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
@@ -74,7 +74,7 @@ class PrepareCsvExport implements ShouldQueue
             $recordsCount = count($records);
 
             if (($totalRows + $recordsCount) > $this->export->total_rows) {
-                $records = array_slice(array_unique($records), 0, $this->export->total_rows - $totalRows);
+                $records = array_slice($records, 0, $this->export->total_rows - $totalRows);
                 $recordsCount = count($records);
             }
 
@@ -111,6 +111,7 @@ class PrepareCsvExport implements ShouldQueue
         $chunkKeySize = $this->chunkSize * 10;
 
         $baseQuery = $query->toBase();
+        $baseQuery->distinct($qualifiedKeyName);
 
         /** @phpstan-ignore-next-line */
         $baseQueryOrders = $baseQuery->orders ?? [];

--- a/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
+++ b/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
@@ -74,7 +74,7 @@ class PrepareCsvExport implements ShouldQueue
             $recordsCount = count($records);
 
             if (($totalRows + $recordsCount) > $this->export->total_rows) {
-                $records = array_slice($records, 0, $this->export->total_rows - $totalRows);
+                $records = array_slice(array_unique($records), 0, $this->export->total_rows - $totalRows);
                 $recordsCount = count($records);
             }
 


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description
This modification pertains to the export of intermediate tables. 
Exporting the resource page and the intermediate table may not be recommended.

In the case of the intermediate table where there are multiple records with the same key (in this image, item_id: 1 corresponds to three records), we are ensuring uniqueness to avoid multiple executions of item_id: 1 within the chunk.

![スクリーンショット 2024-02-06 2 18 37](https://github.com/filamentphp/filament/assets/28666304/b296946c-8c25-4111-866e-6b1f89c65c61)

The image shows the results when the chunk is set to 2.
|before|after|
|---|---|
|![スクリーンショット 2024-02-06 2 32 37](https://github.com/filamentphp/filament/assets/28666304/d99a826c-8e5f-4076-b4fc-2493cec2a167)|![スクリーンショット 2024-02-06 2 32 16](https://github.com/filamentphp/filament/assets/28666304/53bdd1a3-d252-468e-89c5-2d53d9bbfb0c)|



<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [ ] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
