### PR TITLE
feat: add exampleHeader for importer

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -446,6 +446,13 @@ ImportColumn::make('sku')
     ->example('ABC123')
 ```
 
+You can customize the header of the example file using the `exampleHeader()` function.
+
+```php
+ImportColumn::make('sku')
+    ->exampleHeader('SKU')
+```
+
 ## Using a custom user model
 
 By default, the `imports` table has a `user_id` column. That column is constrained to the `users` table:

--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -449,6 +449,8 @@ ImportColumn::make('sku')
 By default, the name of the column is used in the header of the example CSV. You can customize the header per-column using `exampleHeader()`:
 
 ```php
+use Filament\Actions\Imports\ImportColumn;
+
 ImportColumn::make('sku')
     ->exampleHeader('SKU')
 ```

--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -446,7 +446,7 @@ ImportColumn::make('sku')
     ->example('ABC123')
 ```
 
-You can customize the header of the example file using the `exampleHeader()` function.
+By default, the name of the column is used in the header of the example CSV. You can customize the header per-column using `exampleHeader()`:
 
 ```php
 ImportColumn::make('sku')

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -304,7 +304,7 @@ trait CanImportRecords
                     }
 
                     $csv->insertOne(array_map(
-                        fn (ImportColumn $column): string => $column->getName(),
+                        fn (ImportColumn $column): string => $column->getExampleHeader() ?? $column->getName(),
                         $columns,
                     ));
 

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -304,7 +304,7 @@ trait CanImportRecords
                     }
 
                     $csv->insertOne(array_map(
-                        fn (ImportColumn $column): string => $column->getExampleHeader() ?? $column->getName(),
+                        fn (ImportColumn $column): string => $column->getExampleHeader(),
                         $columns,
                     ));
 

--- a/packages/actions/src/Imports/ImportColumn.php
+++ b/packages/actions/src/Imports/ImportColumn.php
@@ -52,6 +52,8 @@ class ImportColumn extends Component
 
     protected mixed $example = null;
 
+    protected ?string $exampleHeader = null;
+
     protected string | Closure | null $relationship = null;
 
     /**
@@ -104,6 +106,13 @@ class ImportColumn extends Component
     public function example(mixed $example): static
     {
         $this->example = $example;
+
+        return $this;
+    }
+
+    public function exampleHeader(string $exampleHeader): static
+    {
+        $this->exampleHeader = $exampleHeader;
 
         return $this;
     }
@@ -284,6 +293,11 @@ class ImportColumn extends Component
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function getExampleHeader(): ?string
+    {
+        return $this->exampleHeader;
     }
 
     /**

--- a/packages/actions/src/Imports/ImportColumn.php
+++ b/packages/actions/src/Imports/ImportColumn.php
@@ -52,7 +52,7 @@ class ImportColumn extends Component
 
     protected mixed $example = null;
 
-    protected ?string $exampleHeader = null;
+    protected string | Closure | null $exampleHeader = null;
 
     protected string | Closure | null $relationship = null;
 
@@ -110,9 +110,9 @@ class ImportColumn extends Component
         return $this;
     }
 
-    public function exampleHeader(string $exampleHeader): static
+    public function exampleHeader(string | Closure | null $header): static
     {
-        $this->exampleHeader = $exampleHeader;
+        $this->exampleHeader = $header;
 
         return $this;
     }
@@ -297,7 +297,7 @@ class ImportColumn extends Component
 
     public function getExampleHeader(): ?string
     {
-        return $this->exampleHeader;
+        return $this->evaluate($this->exampleHeader);
     }
 
     /**

--- a/packages/actions/src/Imports/ImportColumn.php
+++ b/packages/actions/src/Imports/ImportColumn.php
@@ -295,9 +295,9 @@ class ImportColumn extends Component
         return $this->name;
     }
 
-    public function getExampleHeader(): ?string
+    public function getExampleHeader(): string
     {
-        return $this->evaluate($this->exampleHeader);
+        return $this->evaluate($this->exampleHeader) ?? $this->getName();
     }
 
     /**


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description
This PR adds functionality to customize the headers of import examples.(#11165)

|not use | use exampleHeader|
|--|--|
|![スクリーンショット 2024-02-06 3 26 34](https://github.com/filamentphp/filament/assets/28666304/a6c340a6-a644-4878-8a3f-c70bac933223)result: ![スクリーンショット 2024-02-06 3 24 39](https://github.com/filamentphp/filament/assets/28666304/e33a7dc2-7c5e-42cb-a956-36c1be547542)|![スクリーンショット 2024-02-06 3 24 00](https://github.com/filamentphp/filament/assets/28666304/9609d0f2-1a0e-47de-992c-fdf868811af3)result: ![スクリーンショット 2024-02-06 3 24 53](https://github.com/filamentphp/filament/assets/28666304/1b6a3d19-0f21-497d-8f61-8c939c7217e7)


<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [ ] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
