### PR TITLE
Fix table grouping by BackedEnum

### DIFF
--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -367,7 +367,7 @@ class Group extends Component
             ) ?? $query;
         }
 
-        $this->scopeQueryByKey($query, $this->getKey($record));
+        $this->scopeQueryByKey($query, $this->getStringKey($record));
 
         return $query;
     }


### PR DESCRIPTION
## Description

Grouping a table by a backed enum throws the following 

```php
Filament\Tables\Grouping\Group::scopeQueryByKey(): Argument #2 ($key) must be of type string, App\Enums\Region given, called in /vendor/filament/tables/src/Grouping/Group.php on line 370
```

`scopeQueryByKey` expects a string as a key. It seems this bug was i[ntroduced by this commit](https://github.com/filamentphp/filament/commit/9b3815cdf7b9ec328a69104a8162adca19dd3344) about 5 months ago. We did not notice as none of the users used the filter. :)

This PR changes the `getKey()` to `getStringKey()` which resolves this. 

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

- [x] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.

## Documentation

- [ ] Documentation is up-to-date.
