### PR TITLE
Fix: Optional MorphToSelect does not set key column to null

### DIFF
--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -36,6 +36,8 @@ trait HasState
 
     protected bool | Closure $isDehydrated = true;
 
+    protected bool | Closure $isDehydratedWhenHidden = false;
+
     protected ?string $statePath = null;
 
     protected string $cachedAbsoluteStatePath;
@@ -131,6 +133,13 @@ trait HasState
     public function dehydrated(bool | Closure $condition = true): static
     {
         $this->isDehydrated = $condition;
+
+        return $this;
+    }
+
+    public function dehydratedWhenHidden(bool | Closure $condition = true): static
+    {
+        $this->isDehydratedWhenHidden = $condition;
 
         return $this;
     }
@@ -430,6 +439,20 @@ trait HasState
     public function isDehydrated(): bool
     {
         return (bool) $this->evaluate($this->isDehydrated);
+    }
+
+    public function isDehydratedWhenHidden(): bool
+    {
+        return (bool) $this->evaluate($this->isDehydratedWhenHidden);
+    }
+
+    public function isHiddenAndNotDehydrated(): bool
+    {
+        if (! $this->isHidden()) {
+            return false;
+        }
+
+        return ! $this->isDehydratedWhenHidden();
     }
 
     public function getGetCallback(): Get

--- a/packages/forms/src/Components/MorphToSelect.php
+++ b/packages/forms/src/Components/MorphToSelect.php
@@ -99,6 +99,28 @@ class MorphToSelect extends Component
         ];
     }
 
+    /**
+     * @param  array<string, mixed>  $state
+     */
+    public function dehydrateState(array &$state, bool $isDehydrated = true): void
+    {
+        parent::dehydrateState($state, $isDehydrated);
+
+        if ($this->isRequired()) {
+            return;
+        }
+
+        $relationship = $this->getRelationship();
+        $typeColumn = $relationship->getMorphType();
+        $keyColumn = $relationship->getForeignKeyName();
+
+        $statePath = $this->getStatePath();
+
+        if (blank(data_get($state, "{$statePath}.{$typeColumn}"))) {
+            data_set($state, "{$statePath}.{$keyColumn}", null);
+        }
+    }
+
     public function optionsLimit(int | Closure $limit): static
     {
         $this->optionsLimit = $limit;

--- a/packages/forms/src/Components/MorphToSelect.php
+++ b/packages/forms/src/Components/MorphToSelect.php
@@ -78,8 +78,9 @@ class MorphToSelect extends Component
                 ->options($selectedType?->getOptionsUsing)
                 ->getSearchResultsUsing($selectedType?->getSearchResultsUsing)
                 ->getOptionLabelUsing($selectedType?->getOptionLabelUsing)
-                ->required($isRequired)
-                ->hidden(! $selectedType)
+                ->required(filled($selectedType))
+                ->hidden(blank($selectedType))
+                ->dehydratedWhenHidden()
                 ->searchable($this->isSearchable())
                 ->searchDebounce($this->getSearchDebounce())
                 ->searchPrompt($this->getSearchPrompt())
@@ -97,28 +98,6 @@ class MorphToSelect extends Component
                     $this->callAfterStateUpdated();
                 }),
         ];
-    }
-
-    /**
-     * @param  array<string, mixed>  $state
-     */
-    public function dehydrateState(array &$state, bool $isDehydrated = true): void
-    {
-        parent::dehydrateState($state, $isDehydrated);
-
-        if ($this->isRequired()) {
-            return;
-        }
-
-        $relationship = $this->getRelationship();
-        $typeColumn = $relationship->getMorphType();
-        $keyColumn = $relationship->getForeignKeyName();
-
-        $statePath = $this->getStatePath();
-
-        if (blank(data_get($state, "{$statePath}.{$typeColumn}"))) {
-            data_set($state, "{$statePath}.{$keyColumn}", null);
-        }
     }
 
     public function optionsLimit(int | Closure $limit): static

--- a/packages/forms/src/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Concerns/CanBeValidated.php
@@ -3,6 +3,7 @@
 namespace Filament\Forms\Concerns;
 
 use Filament\Forms\Components;
+use Filament\Forms\Components\Component;
 
 trait CanBeValidated
 {
@@ -13,7 +14,11 @@ trait CanBeValidated
     {
         $attributes = [];
 
-        foreach ($this->getComponents() as $component) {
+        foreach ($this->getComponents(withHidden: true) as $component) {
+            if ($component->isHiddenAndNotDehydrated()) {
+                continue;
+            }
+
             if ($component instanceof Components\Contracts\HasValidationRules) {
                 $component->dehydrateValidationAttributes($attributes);
             }
@@ -40,7 +45,11 @@ trait CanBeValidated
     {
         $messages = [];
 
-        foreach ($this->getComponents() as $component) {
+        foreach ($this->getComponents(withHidden: true) as $component) {
+            if ($component->isHiddenAndNotDehydrated()) {
+                continue;
+            }
+
             if ($component instanceof Components\Contracts\HasValidationRules) {
                 $component->dehydrateValidationMessages($messages);
             }
@@ -67,7 +76,11 @@ trait CanBeValidated
     {
         $rules = [];
 
-        foreach ($this->getComponents() as $component) {
+        foreach ($this->getComponents(withHidden: true) as $component) {
+            if ($component->isHiddenAndNotDehydrated()) {
+                continue;
+            }
+
             if ($component instanceof Components\Contracts\HasValidationRules) {
                 $component->dehydrateValidationRules($rules);
             }
@@ -92,7 +105,10 @@ trait CanBeValidated
      */
     public function validate(): array
     {
-        if (! count($this->getComponents())) {
+        if (! count(array_filter(
+            $this->getComponents(withHidden: true),
+            fn (Component $component): bool => ! $component->isHiddenAndNotDehydrated(),
+        ))) {
             return [];
         }
 

--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -70,8 +70,8 @@ trait HasState
      */
     public function dehydrateState(array &$state = [], bool $isDehydrated = true): array
     {
-        foreach ($this->getComponents() as $component) {
-            if ($component->isHidden()) {
+        foreach ($this->getComponents(withHidden: true) as $component) {
+            if ($component->isHiddenAndNotDehydrated()) {
                 continue;
             }
 
@@ -87,8 +87,8 @@ trait HasState
      */
     public function mutateDehydratedState(array &$state = []): array
     {
-        foreach ($this->getComponents() as $component) {
-            if ($component->isHidden()) {
+        foreach ($this->getComponents(withHidden: true) as $component) {
+            if ($component->isHiddenAndNotDehydrated()) {
                 continue;
             }
 
@@ -130,8 +130,8 @@ trait HasState
      */
     public function mutateStateForValidation(array &$state = []): array
     {
-        foreach ($this->getComponents() as $component) {
-            if ($component->isHidden()) {
+        foreach ($this->getComponents(withHidden: true) as $component) {
+            if ($component->isHiddenAndNotDehydrated()) {
                 continue;
             }
 

--- a/tests/src/Forms/StateTest.php
+++ b/tests/src/Forms/StateTest.php
@@ -440,6 +440,123 @@ test('components can be excluded from state dehydration if their parent componen
         ->dehydrateState()->toBe([]);
 });
 
+test('hidden components are excluded from state dehydration', function () {
+    $container = ComponentContainer::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            (new Component())
+                ->statePath(Str::random())
+                ->default(Str::random())
+                ->hidden(),
+        ])
+        ->fill();
+
+    expect($container)
+        ->dehydrateState()->toBe([]);
+});
+
+test('hidden components are excluded from state dehydration if their parent component is', function () {
+    $container = ComponentContainer::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            (new Component())
+                ->hidden()
+                ->schema([
+                    (new Component())
+                        ->statePath(Str::random())
+                        ->default(Str::random()),
+                ]),
+        ])
+        ->fill();
+
+    expect($container)
+        ->dehydrateState()->toBe([]);
+});
+
+test('hidden components are excluded from state dehydration except if they are marked as dehydrated', function () {
+    $container = ComponentContainer::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            (new Component())
+                ->statePath(Str::random())
+                ->default(Str::random())
+                ->hidden()
+                ->dehydratedWhenHidden(),
+        ])
+        ->fill();
+
+    expect($container)
+        ->dehydrateState()->not()->toBe([]);
+});
+
+test('disabled components are excluded from state dehydration', function () {
+    $container = ComponentContainer::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            (new Component())
+                ->statePath(Str::random())
+                ->default(Str::random())
+                ->disabled(),
+        ])
+        ->fill();
+
+    expect($container)
+        ->dehydrateState()->toBe([]);
+});
+
+test('disabled components are excluded from state dehydration if their parent component is', function () {
+    $container = ComponentContainer::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            (new Component())
+                ->disabled()
+                ->schema([
+                    (new Component())
+                        ->statePath(Str::random())
+                        ->default(Str::random()),
+                ]),
+        ])
+        ->fill();
+
+    expect($container)
+        ->dehydrateState()->toBe([]);
+});
+
+test('disabled components are excluded from state dehydration except if they are marked as dehydrated', function () {
+    $container = ComponentContainer::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            (new Component())
+                ->statePath(Str::random())
+                ->default(Str::random())
+                ->disabled()
+                ->dehydrated(),
+        ])
+        ->fill();
+
+    expect($container)
+        ->dehydrateState()->not()->toBe([]);
+});
+
+test('disabled components are excluded from state dehydration if their parent component is disabled and not marked as dehydrated', function () {
+    $container = ComponentContainer::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            (new Component())
+                ->disabled()
+                ->schema([
+                    (new Component())
+                        ->statePath(Str::random())
+                        ->default(Str::random())
+                        ->dehydrated(),
+                ]),
+        ])
+        ->fill();
+
+    expect($container)
+        ->dehydrateState()->toBe([]);
+});
+
 test('dehydrated state can be mutated', function () {
     $container = ComponentContainer::make(Livewire::make())
         ->statePath('data')


### PR DESCRIPTION
## Description

I have an optional MorphToSelect field:
```php
MorphToSelect::make('morphable')
    ->types([
        MorphToSelect\Type::make(MorphType1::class)
            ->titleAttribute('name'),
        MorphToSelect\Type::make(MorphType2::class)
            ->titleAttribute('name'),
        MorphToSelect\Type::make(MorphType3::class)
            ->titleAttribute('name'),
    ]),
```
When I set the type field back to "Select an option" and save the `morphable_id` column is still set even though the morphable_type is set to null.

This PR adds an override of the `dehydrateState()` method that manually sets the "key" column to null if the field is not required

## Code style

- [x] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.

## Documentation

- [x] Documentation is up-to-date.
