### PR TITLE
Pagination with links to the first and last pages

### DIFF
--- a/packages/support/docs/03-icons.md
+++ b/packages/support/docs/03-icons.md
@@ -214,4 +214,8 @@ Alternatively, you may pass an SVG element into the component's slot instead of 
 - `pagination.previous-button.rtl` - Button to go to the previous page (right-to-left direction)
 - `pagination.next-button` - Button to go to the next page
 - `pagination.next-button.rtl` - Button to go to the next page (right-to-left direction)
+- `pagination.first-button` - Button to go to the first page
+- `pagination.first-button.rtl` - Button to go to the first page (right-to-left direction)
+- `pagination.last-button` - Button to go to the last page
+- `pagination.last-button.rtl` - Button to go to the last page (right-to-left direction)
 - `section.collapse-button` - Button to collapse a section

--- a/packages/support/docs/03-icons.md
+++ b/packages/support/docs/03-icons.md
@@ -210,12 +210,12 @@ Alternatively, you may pass an SVG element into the component's slot instead of 
 - `breadcrumbs.separator` - Separator between breadcrumbs
 - `breadcrumbs.separator.rtl` - Separator between breadcrumbs (right-to-left direction)
 - `modal.close-button` - Button to close a modal
-- `pagination.previous-button` - Button to go to the previous page
-- `pagination.previous-button.rtl` - Button to go to the previous page (right-to-left direction)
-- `pagination.next-button` - Button to go to the next page
-- `pagination.next-button.rtl` - Button to go to the next page (right-to-left direction)
 - `pagination.first-button` - Button to go to the first page
 - `pagination.first-button.rtl` - Button to go to the first page (right-to-left direction)
 - `pagination.last-button` - Button to go to the last page
 - `pagination.last-button.rtl` - Button to go to the last page (right-to-left direction)
+- `pagination.next-button` - Button to go to the next page
+- `pagination.next-button.rtl` - Button to go to the next page (right-to-left direction)
+- `pagination.previous-button` - Button to go to the previous page
+- `pagination.previous-button.rtl` - Button to go to the previous page (right-to-left direction)
 - `section.collapse-button` - Button to collapse a section

--- a/packages/support/docs/09-blade-components/02-pagination.md
+++ b/packages/support/docs/09-blade-components/02-pagination.md
@@ -66,6 +66,16 @@ class ListUsers extends Component
     :paginator="$users"
     :page-options="[5, 10, 20, 50, 100, 'all']"
     :current-page-option-property="perPage"
-    :has-first-last-page-links="true"
+/>
+```
+
+## Displaying links to the first and the last page
+
+Extreme links are the first and last page links. You can add them by passing the `extreme-links` attribute to the component:
+
+```blade
+<x-filament::pagination
+    :paginator="$users"
+    extreme-links
 />
 ```

--- a/packages/support/docs/09-blade-components/02-pagination.md
+++ b/packages/support/docs/09-blade-components/02-pagination.md
@@ -66,5 +66,6 @@ class ListUsers extends Component
     :paginator="$users"
     :page-options="[5, 10, 20, 50, 100, 'all']"
     :current-page-option-property="perPage"
+    :has-first-last-page-links="true"
 />
 ```

--- a/packages/support/resources/lang/en/components/pagination.php
+++ b/packages/support/resources/lang/en/components/pagination.php
@@ -22,8 +22,16 @@ return [
 
     'actions' => [
 
+        'first' => [
+            'label' => 'First',
+        ],
+
         'go_to_page' => [
             'label' => 'Go to page :page',
+        ],
+
+        'last' => [
+            'label' => 'Last',
         ],
 
         'next' => [
@@ -32,14 +40,6 @@ return [
 
         'previous' => [
             'label' => 'Previous',
-        ],
-
-        'first' => [
-            'label' => 'First',
-        ],
-
-        'last' => [
-            'label' => 'Last',
         ],
 
     ],

--- a/packages/support/resources/lang/en/components/pagination.php
+++ b/packages/support/resources/lang/en/components/pagination.php
@@ -34,6 +34,14 @@ return [
             'label' => 'Previous',
         ],
 
+        'first' => [
+            'label' => 'First',
+        ],
+
+        'last' => [
+            'label' => 'Last',
+        ],
+
     ],
 
 ];

--- a/packages/support/resources/views/components/pagination/index.blade.php
+++ b/packages/support/resources/views/components/pagination/index.blade.php
@@ -1,8 +1,8 @@
 @props([
+    'currentPageOptionProperty' => 'tableRecordsPerPage',
+    'extremeLinks' => false,
     'paginator',
     'pageOptions' => [],
-    'hasFirstLastPageLinks' => false,
-    'currentPageOptionProperty' => 'tableRecordsPerPage',
 ])
 
 @php
@@ -123,7 +123,7 @@
             class="fi-pagination-items justify-self-end rounded-lg bg-white shadow-sm ring-1 ring-gray-950/10 dark:bg-white/5 dark:ring-white/20"
         >
             @if (! $paginator->onFirstPage())
-                @if($hasFirstLastPageLinks)
+                @if ($extremeLinks)
                     <x-filament::pagination.item
                         :aria-label="__('filament::components/pagination.actions.first.label')"
                         :icon="$isRtl ? 'heroicon-m-chevron-double-right' : 'heroicon-m-chevron-double-left'"
@@ -175,7 +175,7 @@
                     :wire:key="$this->getId() . '.pagination.next'"
                 />
 
-                @if($hasFirstLastPageLinks)
+                @if ($extremeLinks)
                     <x-filament::pagination.item
                         :aria-label="__('filament::components/pagination.actions.last.label')"
                         :icon="$isRtl ? 'heroicon-m-chevron-double-left' : 'heroicon-m-chevron-double-right'"

--- a/packages/support/resources/views/components/pagination/index.blade.php
+++ b/packages/support/resources/views/components/pagination/index.blade.php
@@ -1,6 +1,7 @@
 @props([
     'paginator',
     'pageOptions' => [],
+    'hasFirstLastPageLinks' => false,
     'currentPageOptionProperty' => 'tableRecordsPerPage',
 ])
 
@@ -122,6 +123,18 @@
             class="fi-pagination-items justify-self-end rounded-lg bg-white shadow-sm ring-1 ring-gray-950/10 dark:bg-white/5 dark:ring-white/20"
         >
             @if (! $paginator->onFirstPage())
+                @if($hasFirstLastPageLinks)
+                    <x-filament::pagination.item
+                        :aria-label="__('filament::components/pagination.actions.first.label')"
+                        :icon="$isRtl ? 'heroicon-m-chevron-double-right' : 'heroicon-m-chevron-double-left'"
+                        {{-- @deprecated Use `pagination.previous-button.rtl` instead of `pagination.previous-button` for RTL. --}}
+                        :icon-alias="$isRtl ? ['pagination.first-button.rtl', 'pagination.first-button'] : 'pagination.first-button'"
+                        rel="first"
+                        :wire:click="'gotoPage(1, \'' . $paginator->getPageName() . '\')'"
+                        :wire:key="$this->getId() . '.pagination.first'"
+                    />
+                @endif
+
                 <x-filament::pagination.item
                     :aria-label="__('filament::components/pagination.actions.previous.label')"
                     :icon="$isRtl ? 'heroicon-m-chevron-right' : 'heroicon-m-chevron-left'"
@@ -161,6 +174,18 @@
                     :wire:click="'nextPage(\'' . $paginator->getPageName() . '\')'"
                     :wire:key="$this->getId() . '.pagination.next'"
                 />
+
+                @if($hasFirstLastPageLinks)
+                    <x-filament::pagination.item
+                        :aria-label="__('filament::components/pagination.actions.last.label')"
+                        :icon="$isRtl ? 'heroicon-m-chevron-double-left' : 'heroicon-m-chevron-double-right'"
+                        {{-- @deprecated Use `pagination.previous-button.rtl` instead of `pagination.previous-button` for RTL. --}}
+                        :icon-alias="$isRtl ? ['pagination.last-button.rtl', 'pagination.last-button'] : 'pagination.last-button'"
+                        rel="last"
+                        :wire:click="'gotoPage(' . $paginator->lastPage() . ', \'' . $paginator->getPageName() . '\')'"
+                        :wire:key="$this->getId() . '.pagination.last'"
+                    />
+                @endif
             @endif
         </ol>
     @endif

--- a/packages/tables/docs/10-advanced.md
+++ b/packages/tables/docs/10-advanced.md
@@ -63,9 +63,9 @@ public function table(Table $table): Table
 }
 ```
 
-### Displaying links to the first and the last page
+### Displaying links to the first and the last pagination page
 
-To display links to the first and the last page use the `paginationWithFirstAndLastPageLink()` method:
+To add "extreme" links to the first and the last page using the `extremePaginationLinks()` method:
 
 ```php
 use Filament\Tables\Table;
@@ -73,7 +73,7 @@ use Filament\Tables\Table;
 public function table(Table $table): Table
 {
     return $table
-        ->paginationWithFirstAndLastPageLinks();
+        ->extremePaginationLinks();
 }
 ```
 

--- a/packages/tables/docs/10-advanced.md
+++ b/packages/tables/docs/10-advanced.md
@@ -63,6 +63,20 @@ public function table(Table $table): Table
 }
 ```
 
+### Displaying links to the first and the last page
+
+To display links to the first and the last page use the `paginationWithFirstAndLastPageLink()` method:
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->paginationWithFirstAndLastPageLinks();
+}
+```
+
 ### Using simple pagination
 
 You may use simple pagination by overriding `paginateTableQuery()` method.

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -1226,7 +1226,7 @@
              ((! ($records instanceof \Illuminate\Contracts\Pagination\LengthAwarePaginator)) || $records->total()))
             <x-filament::pagination
                 :page-options="$getPaginationPageOptions()"
-                :has-first-last-page-links="$hasPaginationFirstAndLastPageLinks()"
+                :extreme-links="$hasExtremePaginationLinks()"
                 :paginator="$records"
                 class="fi-ta-pagination px-3 py-3 sm:px-6"
             />

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -1226,6 +1226,7 @@
              ((! ($records instanceof \Illuminate\Contracts\Pagination\LengthAwarePaginator)) || $records->total()))
             <x-filament::pagination
                 :page-options="$getPaginationPageOptions()"
+                :has-first-last-page-links="$hasPaginationFirstAndLastPageLinks()"
                 :paginator="$records"
                 class="fi-ta-pagination px-3 py-3 sm:px-6"
             />

--- a/packages/tables/src/Table/Concerns/CanPaginateRecords.php
+++ b/packages/tables/src/Table/Concerns/CanPaginateRecords.php
@@ -18,6 +18,11 @@ trait CanPaginateRecords
      */
     protected array | Closure | null $paginationPageOptions = null;
 
+    /**
+     * @var bool
+     */
+    protected bool $hasFirstAndLastPageLinks = false;
+
     public function defaultPaginationPageOption(int | string | Closure | null $option): static
     {
         $this->defaultPaginationPageOption = $option;
@@ -57,6 +62,13 @@ trait CanPaginateRecords
         return $this;
     }
 
+    public function paginationWithFirstAndLastPageLinks(bool $condition = true): static
+    {
+        $this->hasFirstAndLastPageLinks = $condition;
+
+        return $this;
+    }
+
     public function getDefaultPaginationPageOption(): int | string | null
     {
         $option = $this->evaluate($this->defaultPaginationPageOption);
@@ -90,5 +102,10 @@ trait CanPaginateRecords
     public function isPaginatedWhileReordering(): bool
     {
         return (bool) $this->evaluate($this->isPaginatedWhileReordering);
+    }
+
+    public function hasPaginationFirstAndLastPageLinks(): bool
+    {
+        return (bool) $this->evaluate($this->hasFirstAndLastPageLinks);
     }
 }

--- a/packages/tables/src/Table/Concerns/CanPaginateRecords.php
+++ b/packages/tables/src/Table/Concerns/CanPaginateRecords.php
@@ -18,10 +18,7 @@ trait CanPaginateRecords
      */
     protected array | Closure | null $paginationPageOptions = null;
 
-    /**
-     * @var bool
-     */
-    protected bool $hasFirstAndLastPageLinks = false;
+    protected bool | Closure $hasExtremePaginationLinks = false;
 
     public function defaultPaginationPageOption(int | string | Closure | null $option): static
     {
@@ -62,9 +59,9 @@ trait CanPaginateRecords
         return $this;
     }
 
-    public function paginationWithFirstAndLastPageLinks(bool $condition = true): static
+    public function extremePaginationLinks(bool | Closure $condition = true): static
     {
-        $this->hasFirstAndLastPageLinks = $condition;
+        $this->hasExtremePaginationLinks = $condition;
 
         return $this;
     }
@@ -104,8 +101,8 @@ trait CanPaginateRecords
         return (bool) $this->evaluate($this->isPaginatedWhileReordering);
     }
 
-    public function hasPaginationFirstAndLastPageLinks(): bool
+    public function hasExtremePaginationLinks(): bool
     {
-        return (bool) $this->evaluate($this->hasFirstAndLastPageLinks);
+        return (bool) $this->evaluate($this->hasExtremePaginationLinks);
     }
 }


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

Possibility to display links to the first and the last pages on pagination.

Table Builder:

```php
use Filament\Tables\Table;

public function table(Table $table): Table
{
    return $table
        ->paginationWithFirstAndLastPageLinks();
}
```

Pagination Blade Component:

```blade
<x-filament::pagination
    :paginator="$users"
    :page-options="[5, 10, 20, 50, 100, 'all']"
    :current-page-option-property="perPage"
    :has-first-last-page-links="true"
/>
```

Icon aliases:

```
- `pagination.first-button` - Button to go to the first page
- `pagination.first-button.rtl` - Button to go to the first page (right-to-left direction)
- `pagination.last-button` - Button to go to the last page
- `pagination.last-button.rtl` - Button to go to the last page (right-to-left direction)
```

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

Before:

![BEFORE](https://github.com/filamentphp/filament/assets/745305/67820294-0715-4a9b-9d6e-2195df4cb8b1)

After:

![AFTER](https://github.com/filamentphp/filament/assets/745305/741e39d0-e00d-4a51-ac9e-11992563f699)

The "go to the first page" link is not showed when you are on the first page, following the same behaviour as the "go to the previous page" link:

![ON THE FIRST PAGE (AFTER)](https://github.com/filamentphp/filament/assets/745305/bc568671-2c86-4698-acdd-350b89c31ba5)

And the same will happen for the "go to the last page" link: it is not showed when you are on the last page.

## To do

To translate strings `filament::components/pagination.actions.first.label` and `filament::components/pagination.actions.last.label` used in pagination item's `aria-label` attribute, as shown below. This PR has them in English only.

```blade
<x-filament::pagination.item
    :aria-label="__('filament::components/pagination.actions.first.label')"
    {{-- ... --}}
/>
```

```blade
<x-filament::pagination.item
    :aria-label="__('filament::components/pagination.actions.last.label')"
    {{-- ... --}}
/>
```

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
