### PR TITLE
Htmlable filter indicator label

### DIFF
--- a/packages/tables/src/Filters/Concerns/HasIndicators.php
+++ b/packages/tables/src/Filters/Concerns/HasIndicators.php
@@ -60,7 +60,7 @@ trait HasIndicators
         return $indicators;
     }
 
-    public function getIndicator(): Indicator | string
+    public function getIndicator(): Indicator | string | Htmlable
     {
         $state = $this->getState();
 

--- a/packages/tables/src/Filters/Concerns/HasIndicators.php
+++ b/packages/tables/src/Filters/Concerns/HasIndicators.php
@@ -5,14 +5,15 @@ namespace Filament\Tables\Filters\Concerns;
 use Closure;
 use Filament\Tables\Filters\Indicator;
 use Illuminate\Support\Arr;
+use Illuminate\Contracts\Support\Htmlable;
 
 trait HasIndicators
 {
     protected string | Closure | null $indicateUsing = null;
 
-    protected Indicator | string | Closure | null $indicator = null;
+    protected Indicator | string | Htmlable | Closure | null $indicator = null;
 
-    public function indicator(Indicator | string | Closure | null $indicator): static
+    public function indicator(Indicator | string | Htmlable | Closure | null $indicator): static
     {
         $this->indicator = $indicator;
 

--- a/packages/tables/src/Filters/Indicator.php
+++ b/packages/tables/src/Filters/Indicator.php
@@ -55,14 +55,14 @@ class Indicator extends Component
         return (bool) $this->evaluate($this->isRemovable);
     }
 
-    public function removeField(string | Htmlable | Closure | null $name): static
+    public function removeField(string | Closure | null $name): static
     {
         $this->removeField = $name;
 
         return $this;
     }
 
-    public function getRemoveField(): string | Htmlable | null
+    public function getRemoveField(): ?string
     {
         return $this->evaluate($this->removeField);
     }

--- a/packages/tables/src/Filters/Indicator.php
+++ b/packages/tables/src/Filters/Indicator.php
@@ -5,6 +5,7 @@ namespace Filament\Tables\Filters;
 use Closure;
 use Filament\Support\Components\Component;
 use Filament\Support\Concerns\HasColor;
+use Illuminate\Contracts\Support\Htmlable;
 
 class Indicator extends Component
 {
@@ -12,7 +13,7 @@ class Indicator extends Component
 
     protected bool | Closure $isRemovable = true;
 
-    protected string | Closure $label;
+    protected string | Htmlable | Closure $label;
 
     protected string | Closure | null $removeField = null;
 
@@ -20,24 +21,24 @@ class Indicator extends Component
 
     protected string $evaluationIdentifier = 'indicator';
 
-    final public function __construct(string | Closure $label)
+    final public function __construct(string | Htmlable | Closure $label)
     {
         $this->label($label);
     }
 
-    public static function make(string | Closure $label): static
+    public static function make(string | Htmlable | Closure $label): static
     {
         return app(static::class, ['label' => $label]);
     }
 
-    public function label(string | Closure $label): static
+    public function label(string | Htmlable | Closure $label): static
     {
         $this->label = $label;
 
         return $this;
     }
 
-    public function getLabel(): string
+    public function getLabel(): string | Htmlable
     {
         return $this->evaluate($this->label);
     }
@@ -54,14 +55,14 @@ class Indicator extends Component
         return (bool) $this->evaluate($this->isRemovable);
     }
 
-    public function removeField(string | Closure | null $name): static
+    public function removeField(string | Htmlable | Closure | null $name): static
     {
         $this->removeField = $name;
 
         return $this;
     }
 
-    public function getRemoveField(): ?string
+    public function getRemoveField(): string | Htmlable | null
     {
         return $this->evaluate($this->removeField);
     }


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

Allowing `Filament\Tables\Filters\Indicator` to be labeled with `Illuminate\Support\HtmlString`, i.e.:

```php
\Filament\Tables\Filters\Indicator::make('field')->label(new \Illuminate\Support\HtmlString('<span class="custom-class">Indicator lable</span>'))
```

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
