### PR TITLE
Panel Domain Routing

### DIFF
--- a/packages/panels/docs/11-tenancy.md
+++ b/packages/panels/docs/11-tenancy.md
@@ -677,6 +677,57 @@ public function panel(Panel $panel): Panel
 
 Before, the URL structure was `/admin/1` for tenant 1. Now, it is `/admin/team/1`.
 
+## Using a domain to identify the tenant
+
+When using a tenant, you might want to use domain or subdomain routing like `admin.example.com/posts` instead of a route prefix like `/admin/posts` . You can do that with the `tenantDomain()` method, alongside the `tenant()` configuration method:
+
+```php
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->tenant(Team::class)
+        ->tenantDomain('{tenant}.example.com', , slugAttribute: 'slug');
+}
+```
+
+You can even use full domains for the routing:
+
+```php
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->tenant(Team::class)
+        ->tenantDomain('{tenant}', , slugAttribute: 'domain');
+}
+```
+
+Remember that the model itself should also be updated to use the correct `getRouteKeyName()` method or similar, and that the model field name should contain a valid domain host, like `example.com` or `subdomain.example.com`. if you are using a full domain routing instead of the previous subdomain routing example.
+
+```php
+<?php
+
+namespace App\Models;
+
+use Filament\Models\Contracts\HasCurrentTenantLabel;
+use Illuminate\Database\Eloquent\Model;
+
+class Team extends Model
+{
+    // ...
+    
+    public function getRouteKeyName(): string
+    {
+        return 'domain';
+    }
+}
+```
+
 ## Disabling tenancy for a resource
 
 By default, all resources within a panel with tenancy will be scoped to the current tenant. If you have resources that are shared between tenants, you can disable tenancy for them by setting the `$isScopedToTenant` static property to `false` on the resource class:

--- a/packages/panels/docs/11-tenancy.md
+++ b/packages/panels/docs/11-tenancy.md
@@ -679,7 +679,7 @@ Before, the URL structure was `/admin/1` for tenant 1. Now, it is `/admin/team/1
 
 ## Using a domain to identify the tenant
 
-When using a tenant, you might want to use domain or subdomain routing like `admin.example.com/posts` instead of a route prefix like `/admin/posts` . You can do that with the `tenantDomain()` method, alongside the `tenant()` configuration method:
+When using a tenant, you might want to use domain or subdomain routing like `team1.example.com/posts` instead of a route prefix like `/team1/posts` . You can do that with the `tenantDomain()` method, alongside the `tenant()` configuration method. The `tenant` argument name is followed by a colon `:` and then the attribute you wish to resolve that part of the domain using, like the `slug` attribute:
 
 ```php
 use Filament\Panel;
@@ -689,11 +689,11 @@ public function panel(Panel $panel): Panel
     return $panel
         // ...
         ->tenant(Team::class)
-        ->tenantDomain('{tenant}.example.com', , slugAttribute: 'slug');
+        ->tenantDomain('{tenant:slug}.example.com');
 }
 ```
 
-You can even use full domains for the routing:
+In the above examples, the tenants live on subdomains of the main app domain. You may also set the system up to resolve the entire domain from the tenant as well:
 
 ```php
 use Filament\Panel;
@@ -703,30 +703,11 @@ public function panel(Panel $panel): Panel
     return $panel
         // ...
         ->tenant(Team::class)
-        ->tenantDomain('{tenant}', , slugAttribute: 'domain');
+        ->tenantDomain('{tenant:domain}');
 }
 ```
 
-Remember that the model itself should also be updated to use the correct `getRouteKeyName()` method or similar, and that the model field name should contain a valid domain host, like `example.com` or `subdomain.example.com`. if you are using a full domain routing instead of the previous subdomain routing example.
-
-```php
-<?php
-
-namespace App\Models;
-
-use Filament\Models\Contracts\HasCurrentTenantLabel;
-use Illuminate\Database\Eloquent\Model;
-
-class Team extends Model
-{
-    // ...
-    
-    public function getRouteKeyName(): string
-    {
-        return 'domain';
-    }
-}
-```
+In this example, the `domain` attribute should contain a valid domain host, like `example.com` or `subdomain.example.com`.
 
 ## Disabling tenancy for a resource
 

--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -126,18 +126,24 @@ Route::name('filament.')
                                             $resource::registerRoutes($panel);
                                         }
                                     });
-
                             });
 
                         if ($hasTenancy) {
-                            Route::middleware($panel->getTenantMiddleware())
-                                ->prefix((($tenantRoutePrefix) ? "{$tenantRoutePrefix}/" : '') . '{tenant' . (($tenantSlugAttribute) ? ":{$tenantSlugAttribute}" : '') . '}')
+                            $route = Route::middleware($panel->getTenantMiddleware())
+                                ->prefix((($tenantRoutePrefix) ? "{$tenantRoutePrefix}/" : '') . '{tenant' . (($tenantSlugAttribute) ? ":{$tenantSlugAttribute}" : '') . '}');
+
+                            if ($tenantDomain) {
+                                $route->domain($tenantDomain);
+                            }
+
+                            $route
                                 ->group(function () use ($panel): void {
                                     if ($routes = $panel->getTenantRoutes()) {
                                         $routes($panel);
                                     }
                                 });
                         }
+
                     });
             }
         }

--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -129,11 +129,15 @@ Route::name('filament.')
                             });
 
                         if ($hasTenancy) {
-                            $route = Route::middleware($panel->getTenantMiddleware())
-                                ->prefix((($tenantRoutePrefix) ? "{$tenantRoutePrefix}/" : '') . '{tenant' . (($tenantSlugAttribute) ? ":{$tenantSlugAttribute}" : '') . '}');
+
+                            $prefix = (($tenantRoutePrefix) ? "{$tenantRoutePrefix}/" : '') . '{tenant' . (($tenantSlugAttribute) ? ":{$tenantSlugAttribute}" : '') . '}';
+
+                            $route = Route::middleware($panel->getTenantMiddleware());
 
                             if ($tenantDomain) {
                                 $route->domain($tenantDomain);
+                            } else {
+                                $route->prefix($prefix);
                             }
 
                             $route

--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -53,7 +53,7 @@ Route::name('filament.')
                         });
 
                         Route::middleware($panel->getAuthMiddleware())
-                            ->group(function () use ($panel, $hasTenancy, $tenantRoutePrefix, $tenantDomain, $tenantSlugAttribute): void {
+                            ->group(function () use ($panel, $hasTenancy, $tenantDomain, $tenantRoutePrefix, $tenantSlugAttribute): void {
                                 if ($routes = $panel->getAuthenticatedRoutes()) {
                                     $routes($panel);
                                 }

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -19,6 +19,8 @@ trait HasTenancy
 
     protected ?string $tenantRoutePrefix = null;
 
+    protected ?string $tenantDomain = null;
+
     protected ?string $tenantModel = null;
 
     protected ?string $tenantProfilePage = null;
@@ -75,6 +77,14 @@ trait HasTenancy
     public function tenantRoutePrefix(?string $prefix): static
     {
         $this->tenantRoutePrefix = $prefix;
+
+        return $this;
+    }
+
+    public function tenantDomain(?string $domain, ?string $slugAttribute): static
+    {
+        $this->tenantDomain = $domain;
+        $this->tenantSlugAttribute = $slugAttribute;
 
         return $this;
     }
@@ -140,6 +150,16 @@ trait HasTenancy
     public function getTenantRoutePrefix(): ?string
     {
         return $this->tenantRoutePrefix;
+    }
+
+    public function hasTenantDomain(): bool
+    {
+        return filled($this->getTenantDomain());
+    }
+
+    public function getTenantDomain(): ?string
+    {
+        return $this->tenantDomain;
     }
 
     public function getTenantBillingProvider(): ?BillingProvider

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -81,10 +81,9 @@ trait HasTenancy
         return $this;
     }
 
-    public function tenantDomain(?string $domain, ?string $slugAttribute = null): static
+    public function tenantDomain(?string $domain): static
     {
         $this->tenantDomain = $domain;
-        $this->tenantSlugAttribute = $slugAttribute ?? $this->tenantSlugAttribute ?? 'domain';
 
         return $this;
     }

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -81,10 +81,10 @@ trait HasTenancy
         return $this;
     }
 
-    public function tenantDomain(?string $domain, ?string $slugAttribute): static
+    public function tenantDomain(?string $domain, ?string $slugAttribute = null): static
     {
         $this->tenantDomain = $domain;
-        $this->tenantSlugAttribute = $slugAttribute;
+        $this->tenantSlugAttribute = $slugAttribute ?? $this->tenantSlugAttribute ?? 'domain';
 
         return $this;
     }

--- a/tests/database/factories/DomainTeamFactory.php
+++ b/tests/database/factories/DomainTeamFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Filament\Tests\Database\Factories;
+
+use Filament\Tests\Models\DomainTeam;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class DomainTeamFactory extends Factory
+{
+    protected $model = DomainTeam::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->company(),
+            'domain' => $this->faker->domainName(),
+        ];
+    }
+}

--- a/tests/database/migrations/create_domain_teams_table.php
+++ b/tests/database/migrations/create_domain_teams_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('domain_teams', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('domain');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('domain_teams');
+    }
+};

--- a/tests/src/DomainTenancyPanelProvider.php
+++ b/tests/src/DomainTenancyPanelProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Filament\Tests;
+
+use Filament\Http\Middleware\Authenticate;
+use Filament\Http\Middleware\DisableBladeIconComponents;
+use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Http\Middleware\IdentifyTenant;
+use Filament\Panel;
+use Filament\PanelProvider;
+use Filament\Tests\Models\DomainTeam;
+use Filament\Tests\Panels\Fixtures\Resources\PostCategoryResource;
+use Filament\Tests\Panels\Fixtures\Resources\PostResource;
+use Filament\Tests\Panels\Fixtures\Resources\ProductResource;
+use Filament\Tests\Panels\Fixtures\Resources\UserResource;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Session\Middleware\AuthenticateSession;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
+
+class DomainTenancyPanelProvider extends PanelProvider
+{
+    public function panel(Panel $panel): Panel
+    {
+        return $panel
+            ->id('domain-tenancy')
+            ->tenant(DomainTeam::class)
+            ->tenantDomain('{tenant}', 'domain')
+            ->login()
+            ->registration()
+            ->passwordReset()
+            ->emailVerification()
+            ->resources([
+                PostResource::class,
+                PostCategoryResource::class,
+                ProductResource::class,
+                UserResource::class,
+            ])
+            ->pages([
+
+            ])
+            ->middleware([
+                EncryptCookies::class,
+                AddQueuedCookiesToResponse::class,
+                StartSession::class,
+                AuthenticateSession::class,
+                ShareErrorsFromSession::class,
+                VerifyCsrfToken::class,
+                SubstituteBindings::class,
+                DisableBladeIconComponents::class,
+                DispatchServingFilamentEvent::class,
+                IdentifyTenant::class,
+            ])
+            ->authMiddleware([
+                Authenticate::class,
+            ]);
+    }
+}

--- a/tests/src/DomainTenancyPanelProvider.php
+++ b/tests/src/DomainTenancyPanelProvider.php
@@ -32,7 +32,7 @@ class DomainTenancyPanelProvider extends PanelProvider
             ->id('domain-tenancy')
             ->path('/domain-tenancy')
             ->tenant(DomainTeam::class)
-            ->tenantDomain('{tenant}', 'domain')
+            ->tenantDomain('{tenant:domain}')
             ->login()
             ->registration()
             ->passwordReset()

--- a/tests/src/DomainTenancyPanelProvider.php
+++ b/tests/src/DomainTenancyPanelProvider.php
@@ -6,9 +6,12 @@ use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
 use Filament\Http\Middleware\IdentifyTenant;
+use Filament\Pages;
 use Filament\Panel;
 use Filament\PanelProvider;
+use Filament\Tests\Actions\Fixtures\Pages\Actions;
 use Filament\Tests\Models\DomainTeam;
+use Filament\Tests\Panels\Fixtures\Pages\Settings;
 use Filament\Tests\Panels\Fixtures\Resources\PostCategoryResource;
 use Filament\Tests\Panels\Fixtures\Resources\PostResource;
 use Filament\Tests\Panels\Fixtures\Resources\ProductResource;
@@ -27,6 +30,7 @@ class DomainTenancyPanelProvider extends PanelProvider
     {
         return $panel
             ->id('domain-tenancy')
+            ->path('/domain-tenancy')
             ->tenant(DomainTeam::class)
             ->tenantDomain('{tenant}', 'domain')
             ->login()
@@ -40,7 +44,9 @@ class DomainTenancyPanelProvider extends PanelProvider
                 UserResource::class,
             ])
             ->pages([
-
+                Pages\Dashboard::class,
+                Actions::class,
+                Settings::class,
             ])
             ->middleware([
                 EncryptCookies::class,

--- a/tests/src/Models/DomainTeam.php
+++ b/tests/src/Models/DomainTeam.php
@@ -16,9 +16,4 @@ class DomainTeam extends Model
     {
         return DomainTeamFactory::new();
     }
-
-    public function getRouteKeyName()
-    {
-        return 'domain';
-    }
 }

--- a/tests/src/Models/DomainTeam.php
+++ b/tests/src/Models/DomainTeam.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Filament\Tests\Models;
+
+use Filament\Tests\Database\Factories\DomainTeamFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DomainTeam extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected static function newFactory()
+    {
+        return DomainTeamFactory::new();
+    }
+
+    public function getRouteKeyName()
+    {
+        return 'domain';
+    }
+}

--- a/tests/src/Panels/Tenancy/ResolveTenantTest.php
+++ b/tests/src/Panels/Tenancy/ResolveTenantTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Filament\Facades\Filament;
+use Filament\Tests\Models\DomainTeam;
+use Filament\Tests\Models\Team;
+use Filament\Tests\Panels\Pages\TestCase;
+use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Facades\Route;
+
+uses(TestCase::class);
+
+it('resolves the tenant correctly from the route', function () {
+    $team = Team::factory()->create();
+
+    $panel = Filament::getPanel('tenancy');
+    Filament::setCurrentPanel($panel);
+    Filament::setTenant($team);
+
+    $routeName = 'filament.tenancy.resources.posts.index';
+    $route = Route::getRoutes()->getByName($routeName);
+
+    $request = Request::create(route($routeName, [
+        'tenant' => $team,
+    ]));
+
+    $request->setRouteResolver(fn () => $route->bind($request));
+
+    $resolvedTenant = $panel->getTenant($team->getKey());
+    expect($resolvedTenant)->toBeSameModel($team);
+});
+
+it('resolves the tenant correctly using domain', function () {
+    $team = DomainTeam::factory()->create();
+    $panel = Filament::getPanel('domain-tenancy');
+
+    Filament::setCurrentPanel($panel);
+    Filament::setTenant($team);
+
+    $routeName = 'filament.domain-tenancy.resources.posts.index';
+    $route = Route::getRoutes()->getByName($routeName);
+
+    $request = Request::create(route($routeName, [
+        'tenant' => $team,
+    ]));
+
+    expect($request->fullUrl())->toStartWith('http://' . $team->domain);
+
+    $request->setRouteResolver(fn () => $route->bind($request));
+
+    $resolvedTenant = $panel->getTenant($team->getRouteKey());
+    expect($resolvedTenant)->toBeSameModel($team);
+});

--- a/tests/src/TenancyPanelProvider.php
+++ b/tests/src/TenancyPanelProvider.php
@@ -6,9 +6,12 @@ use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
 use Filament\Http\Middleware\IdentifyTenant;
+use Filament\Pages;
 use Filament\Panel;
 use Filament\PanelProvider;
+use Filament\Tests\Actions\Fixtures\Pages\Actions;
 use Filament\Tests\Models\Team;
+use Filament\Tests\Panels\Fixtures\Pages\Settings;
 use Filament\Tests\Panels\Fixtures\Resources\PostCategoryResource;
 use Filament\Tests\Panels\Fixtures\Resources\PostResource;
 use Filament\Tests\Panels\Fixtures\Resources\ProductResource;
@@ -40,7 +43,9 @@ class TenancyPanelProvider extends PanelProvider
                 UserResource::class,
             ])
             ->pages([
-
+                Pages\Dashboard::class,
+                Actions::class,
+                Settings::class,
             ])
             ->middleware([
                 EncryptCookies::class,

--- a/tests/src/TenancyPanelProvider.php
+++ b/tests/src/TenancyPanelProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Filament\Tests;
+
+use Filament\Http\Middleware\Authenticate;
+use Filament\Http\Middleware\DisableBladeIconComponents;
+use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Http\Middleware\IdentifyTenant;
+use Filament\Panel;
+use Filament\PanelProvider;
+use Filament\Tests\Models\Team;
+use Filament\Tests\Panels\Fixtures\Resources\PostCategoryResource;
+use Filament\Tests\Panels\Fixtures\Resources\PostResource;
+use Filament\Tests\Panels\Fixtures\Resources\ProductResource;
+use Filament\Tests\Panels\Fixtures\Resources\UserResource;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Session\Middleware\AuthenticateSession;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
+
+class TenancyPanelProvider extends PanelProvider
+{
+    public function panel(Panel $panel): Panel
+    {
+        return $panel
+            ->id('tenancy')
+            ->path('tenancy')
+            ->tenant(Team::class)
+            ->login()
+            ->registration()
+            ->passwordReset()
+            ->emailVerification()
+            ->resources([
+                PostResource::class,
+                PostCategoryResource::class,
+                ProductResource::class,
+                UserResource::class,
+            ])
+            ->pages([
+
+            ])
+            ->middleware([
+                EncryptCookies::class,
+                AddQueuedCookiesToResponse::class,
+                StartSession::class,
+                AuthenticateSession::class,
+                ShareErrorsFromSession::class,
+                VerifyCsrfToken::class,
+                SubstituteBindings::class,
+                DisableBladeIconComponents::class,
+                DispatchServingFilamentEvent::class,
+                IdentifyTenant::class,
+            ])
+            ->authMiddleware([
+                Authenticate::class,
+            ]);
+    }
+}

--- a/tests/src/TestCase.php
+++ b/tests/src/TestCase.php
@@ -44,6 +44,8 @@ abstract class TestCase extends BaseTestCase
             AdminPanelProvider::class,
             CustomPanelProvider::class,
             SlugsPanelProvider::class,
+            TenancyPanelProvider::class,
+            DomainTenancyPanelProvider::class,
         ];
     }
 


### PR DESCRIPTION
## Description

Expanding on the concept of [Multi Tenancy](https://filamentphp.com/docs/3.x/panels/tenancy), i've tried to implement support for domain or subdomain based routing using [Laravel's Subdomain Roting](https://laravel.com/docs/10.x/routing#route-group-subdomain-routing).

The idea is to provide a configurable sudomain (or even domain) setup to identify the tenant.
Will post here the updated docs to better explain the new options:

When using a tenant, you might want to use domain or subdomain routing like `admin.example.com/posts` instead of a route prefix like `/admin/posts` . You can do that with the `tenantDomain()` method, alongside the `tenant()` configuration method:

```php
use Filament\Panel;

public function panel(Panel $panel): Panel
{
    return $panel
        // ...
        ->tenant(Team::class)
        ->tenantDomain('{tenant}.example.com', , slugAttribute: 'slug');
}
```

You can even use full domains for the routing:

```php
use Filament\Panel;

public function panel(Panel $panel): Panel
{
    return $panel
        // ...
        ->tenant(Team::class)
        ->tenantDomain('{tenant}', , slugAttribute: 'domain');
}
```

Remember that the model itself should also be updated to use the correct `getRouteKeyName()` method or similar, and that the model field name should contain a valid domain host, like `example.com` or `subdomain.example.com`. if you are using a full domain routing instead of the previous subdomain routing example.

- [X] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

- [X] `composer cs` command has been run.

## Testing

- [X] Changes have been tested.

## Documentation

- [X] Documentation is up-to-date.
