### PR TITLE
DB Notifications: include user_id

### DIFF
--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -79,6 +79,7 @@ class Notification extends ViewComponent implements Arrayable
             'title' => $this->getTitle(),
             'view' => $this->getView(),
             'viewData' => $this->getViewData(),
+            'user_id'=> $this->getAuthUser(),
         ];
     }
 
@@ -309,5 +310,11 @@ class Notification extends ViewComponent implements Arrayable
                 'The notification with the given title was sent'
             );
         }
+    }
+
+    public function getAuthUser()
+    {
+        $user = Auth::user(); // Attempt to get the authenticated user
+        return $user ? $user->id : null; // Return user ID if authenticated, otherwise return null
     }
 }


### PR DESCRIPTION
Quite often I find myself needing to send back a notication/email back to the originator of the first notification.

For example: an Invoice unlock request. Admin then unlocks but needs to alert the originator or the unlock. The one requesting is not always the owner of the Invoice.

This PR stores the user_id of the originator for easy lookup when dealing with the logic of the request.