### PR TITLE
Specify name for dispatched job batches within the Exporter & Importer classes

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -612,6 +612,19 @@ public function getJobTags(): array
 
 If you'd like to customize the tags that are applied to jobs of a certain importer, you may override this method in your importer class.
 
+### Customizing the import job batch name
+
+By default, the import system doesn't define any name for the job batches.
+
+```php
+public function getJobBatchName(): ?string
+{
+    return null;
+}
+```
+
+If you'd like to customize the name that are applied to job batches of a certain importer, you may override this method in your importer class.
+
 ## Customizing import validation messages
 
 The import system will automatically validate the CSV file before it is imported. If there are any errors, the user will be shown a list of them, and the import will not be processed. If you'd like to override any default validation messages, you may do so by overriding the `getValidationMessages()` method on your importer class:

--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -614,16 +614,14 @@ If you'd like to customize the tags that are applied to jobs of a certain import
 
 ### Customizing the import job batch name
 
-By default, the import system doesn't define any name for the job batches.
+By default, the import system doesn't define any name for the job batches. If you'd like to customize the name that is applied to job batches of a certain importer, you may override the `getJobBatchName()` method in your importer class:
 
 ```php
 public function getJobBatchName(): ?string
 {
-    return null;
+    return 'product-import';
 }
 ```
-
-If you'd like to customize the name that are applied to job batches of a certain importer, you may override this method in your importer class.
 
 ## Customizing import validation messages
 

--- a/packages/actions/docs/07-prebuilt-actions/09-export.md
+++ b/packages/actions/docs/07-prebuilt-actions/09-export.md
@@ -579,6 +579,19 @@ public function getJobTags(): array
 
 If you'd like to customize the tags that are applied to jobs of a certain exporter, you may override this method in your exporter class.
 
+### Customizing the export job batch name
+
+By default, the export system doesn't define any name for the job batches.
+
+```php
+public function getJobBatchName(): ?string
+{
+    return null;
+}
+```
+
+If you'd like to customize the name that are applied to job batches of a certain exporter, you may override this method in your exporter class.
+
 ## Authorization
 
 By default, only the user who started the export may download files that get generated. If you'd like to customize the authorization logic, you may create an `ExportPolicy` class, and [register it in your `AuthServiceProvider`](https://laravel.com/docs/10.x/authorization#registering-policies):

--- a/packages/actions/docs/07-prebuilt-actions/09-export.md
+++ b/packages/actions/docs/07-prebuilt-actions/09-export.md
@@ -581,16 +581,14 @@ If you'd like to customize the tags that are applied to jobs of a certain export
 
 ### Customizing the export job batch name
 
-By default, the export system doesn't define any name for the job batches.
+By default, the export system doesn't define any name for the job batches. If you'd like to customize the name that is applied to job batches of a certain exporter, you may override the `getJobBatchName()` method in your exporter class:
 
 ```php
 public function getJobBatchName(): ?string
 {
-    return null;
+    return 'product-export';
 }
 ```
-
-If you'd like to customize the name that are applied to job batches of a certain exporter, you may override this method in your exporter class.
 
 ## Authorization
 

--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -174,6 +174,7 @@ trait CanExportRecords
             $job = $action->getJob();
             $jobQueue = $exporter->getJobQueue();
             $jobConnection = $exporter->getJobConnection();
+            $jobBatchName = $exporter->getJobBatchName();
 
             // We do not want to send the loaded user relationship to the queue in job payloads,
             // in case it contains attributes that are not serializable, such as binary columns.
@@ -201,6 +202,10 @@ trait CanExportRecords
                     ->when(
                         filled($jobConnection),
                         fn (PendingBatch $batch) => $batch->onConnection($jobConnection),
+                    )
+                    ->when(
+                        filled($jobBatchName),
+                        fn (PendingBatch $batch) => $batch->name($jobBatchName),
                     )
                     ->allowFailures(),
                 ...(($hasXlsx && (! $hasCsv)) ? [$makeCreateXlsxFileJob()] : []),

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -238,6 +238,10 @@ trait CanImportRecords
                     filled($jobConnection = $importer->getJobConnection()),
                     fn (PendingBatch $batch) => $batch->onConnection($jobConnection),
                 )
+                ->when(
+                    filled($jobBatchName = $importer->getJobBatchName()),
+                    fn (PendingBatch $batch) => $batch->name($jobBatchName),
+                )
                 ->finally(function () use ($import) {
                     $import->touch('completed_at');
 

--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -105,6 +105,11 @@ abstract class Exporter
         return null;
     }
 
+    public function getJobBatchName(): ?string
+    {
+        return null;
+    }
+
     /**
      * @return array<ExportColumn>
      */

--- a/packages/actions/src/Imports/Importer.php
+++ b/packages/actions/src/Imports/Importer.php
@@ -264,6 +264,11 @@ abstract class Importer
         return null;
     }
 
+    public function getJobBatchName(): ?string
+    {
+        return null;
+    }
+
     /**
      * @return array<ImportColumn>
      */


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

Implemented the functionality to specify a name for dispatched job batches within the Exporter & Importer classes. This enhancement facilitates streamlined tracking of job batches in Laravel Horizon.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
