### PR TITLE
Feature/save belongs to relations without having to set fillable

### DIFF
--- a/packages/forms/src/Components/Concerns/BelongsToModel.php
+++ b/packages/forms/src/Components/Concerns/BelongsToModel.php
@@ -34,7 +34,7 @@ trait BelongsToModel
             return;
         }
 
-        if ($this->getRecord() === null || (!$this->getRecord()?->exists && !$this->getRecord()?->isDirty())) {
+        if ($this->getRecord() === null || (! $this->getRecord()?->exists && ! $this->getRecord()?->isDirty())) {
             return;
         }
 

--- a/packages/forms/src/Components/Concerns/BelongsToModel.php
+++ b/packages/forms/src/Components/Concerns/BelongsToModel.php
@@ -34,7 +34,7 @@ trait BelongsToModel
             return;
         }
 
-        if (! ($this->getRecord()?->exists)) {
+        if ($this->getRecord() === null || (!$this->getRecord()?->exists && !$this->getRecord()?->isDirty())) {
             return;
         }
 

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -15,8 +15,8 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
-
 use ReflectionClass;
+
 use function Filament\Support\is_app_url;
 
 /**
@@ -165,7 +165,7 @@ class CreateRecord extends Page
     }
 
     /**
-     * @param array<string, mixed> $data
+     * @param  array<string, mixed>  $data
      */
     protected function filterRelationships(Model $record, array $data): array
     {
@@ -181,6 +181,7 @@ class CreateRecord extends Page
             }
         }
         $relations = array_diff($relations, $record->getFillable());
+
         return array_diff_key($data, array_fill_keys($relations, true));
     }
 

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -21,8 +21,8 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Arr;
-
 use ReflectionClass;
+
 use function Filament\Support\is_app_url;
 
 /**
@@ -189,11 +189,12 @@ class EditRecord extends Page
     protected function handleRecordUpdate(Model $record, array $data): Model
     {
         $record->update($this->filterRelationships($record, $data));
+
         return $record;
     }
 
     /**
-     * @param array<string, mixed> $data
+     * @param  array<string, mixed>  $data
      */
     protected function filterRelationships(Model $record, array $data): array
     {
@@ -209,6 +210,7 @@ class EditRecord extends Page
             }
         }
         $relations = array_diff($relations, $record->getFillable());
+
         return array_diff_key($data, array_fill_keys($relations, true));
     }
 


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

When using Select fields with belongsTo relations, we had to set the relation field as $fillable in the Model or had to set the whole Model as Unguarded.

With minor changes to the CreateRecord and EditRecord, we are now able to automatically use the belongsTo relation when saving the record and we filter out the possible relations in the data array if they are not existing in the fillable array.

Example:

The model `Project.php` has the relation company and only set the `name` attribute as fillable
```php
class Project extends Model
{

    protected $fillable = [
        'name',
    ];

    public function company(): BelongsTo
    {
        return $this->belongsTo(Company::class);
    }
}
```

The `ProjectResource` has the following form with a Select Field `company`
```php
    public static function form(Form $form): Form
    {
        return self::sidebarForm($form, [
            Select::make('company')
                ->relationship(name: 'company', titleAttribute: 'name')
                ->preload()
                ->searchable(),
            TextInput::make('name')
                ->required(),
        ]);
    }
```

The Select field is using the relation registered in the model. In the current situation, when creating a new record using this example form and Model, would throw an Exception: `Add fillable property [company] to allow mass assignment on [App\Models\Project].`.

With this implementation the relation is used to save the model and relation attributes will be filtered out of the data array just before filling the model on create/edit.

For now, this implementation if primary working with belongsTo relationships and will also fix the issue https://github.com/filamentphp/filament/issues/11204 as intended.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
