### PR TITLE
Proposal: Add helper command that fills out version numbers for github issues

### DIFF
--- a/packages/panels/src/Commands/Aliases/MakeIssueCommand.php
+++ b/packages/panels/src/Commands/Aliases/MakeIssueCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Filament\Commands\Aliases;
+
+use Filament\Commands;
+
+class MakeIssueCommand extends Commands\MakeIssueCommand
+{
+    protected $hidden = true;
+
+    protected $signature = 'make:filament-issue';
+}

--- a/packages/panels/src/Commands/Aliases/MakeIssueCommand.php
+++ b/packages/panels/src/Commands/Aliases/MakeIssueCommand.php
@@ -8,5 +8,5 @@ class MakeIssueCommand extends Commands\MakeIssueCommand
 {
     protected $hidden = true;
 
-    protected $signature = 'make:filament-issue';
+    protected $signature = 'filament:issue';
 }

--- a/packages/panels/src/Commands/MakeFilamentVersionPrefilledGithubIssue.php
+++ b/packages/panels/src/Commands/MakeFilamentVersionPrefilledGithubIssue.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class MakeFilamentVersionPrefilledGithubIssue extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'make:filament-issue';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $filament = \Composer\InstalledVersions::getPrettyVersion('filament/filament');
+        $laravel = \Composer\InstalledVersions::getPrettyVersion('laravel/framework');
+        $livewire = \Composer\InstalledVersions::getPrettyVersion('livewire/livewire');
+        $php = \PHP_VERSION;
+
+        $issueTemplate = 'bug_report.yml';
+        $baseGithubUrl = 'https://github.com/filamentphp/filament/issues/new';
+
+        $queryParams = [
+            'template' => $issueTemplate,
+            'package-version' => $filament,
+            'laravel-version' => $laravel,
+            'livewire-version' => $livewire,
+            'php-version' => $php,
+        ];
+
+        $queryString = http_build_query($queryParams);
+
+        $fullUrl = $baseGithubUrl . '?' . $queryString;
+
+        $this->info('Please fill out the issue template at ' . $fullUrl);
+    }
+}

--- a/packages/panels/src/Commands/MakeFilamentVersionPrefilledGithubIssue.php
+++ b/packages/panels/src/Commands/MakeFilamentVersionPrefilledGithubIssue.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Console\Commands;
+namespace Filament\Commands;
 
 use Illuminate\Console\Command;
 

--- a/packages/panels/src/Commands/MakeIssueCommand.php
+++ b/packages/panels/src/Commands/MakeIssueCommand.php
@@ -18,7 +18,7 @@ class MakeIssueCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Generates a link to the Filament issue template with version informations pre-filled.';
+    protected $description = 'Generates a link to the Filament issue page and pre-fills the issue template.';
 
     /**
      * Execute the console command.

--- a/packages/panels/src/Commands/MakeIssueCommand.php
+++ b/packages/panels/src/Commands/MakeIssueCommand.php
@@ -4,7 +4,7 @@ namespace Filament\Commands;
 
 use Illuminate\Console\Command;
 
-class MakeFilamentVersionPrefilledGithubIssue extends Command
+class MakeIssueCommand extends Command
 {
     /**
      * The name and signature of the console command.
@@ -18,7 +18,7 @@ class MakeFilamentVersionPrefilledGithubIssue extends Command
      *
      * @var string
      */
-    protected $description = 'Command description';
+    protected $description = 'Generates a link to the Filament issue template with version informations pre-filled.';
 
     /**
      * Execute the console command.

--- a/packages/panels/src/Commands/MakeIssueCommand.php
+++ b/packages/panels/src/Commands/MakeIssueCommand.php
@@ -23,7 +23,7 @@ class MakeIssueCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle(): void
     {
         $filament = \Composer\InstalledVersions::getPrettyVersion('filament/filament');
         $laravel = \Composer\InstalledVersions::getPrettyVersion('laravel/framework');

--- a/packages/panels/src/Commands/MakeIssueCommand.php
+++ b/packages/panels/src/Commands/MakeIssueCommand.php
@@ -29,7 +29,7 @@ class MakeIssueCommand extends Command
         $filament = InstalledVersions::getPrettyVersion('filament/filament');
         $laravel = InstalledVersions::getPrettyVersion('laravel/framework');
         $livewire = InstalledVersions::getPrettyVersion('livewire/livewire');
-        $php = \PHP_VERSION;
+        $php = PHP_VERSION;
 
         $issueTemplate = 'bug_report.yml';
         $baseGithubUrl = 'https://github.com/filamentphp/filament/issues/new?';

--- a/packages/panels/src/Commands/MakeIssueCommand.php
+++ b/packages/panels/src/Commands/MakeIssueCommand.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Commands;
 
+use Composer\InstalledVersions;
 use Illuminate\Console\Command;
 
 class MakeIssueCommand extends Command
@@ -18,20 +19,20 @@ class MakeIssueCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Generates a link to the Filament issue page and pre-fills the issue template.';
+    protected $description = 'Generates a link to the Filament issue page and pre-fills the version numbers.';
 
     /**
      * Execute the console command.
      */
     public function handle(): void
     {
-        $filament = \Composer\InstalledVersions::getPrettyVersion('filament/filament');
-        $laravel = \Composer\InstalledVersions::getPrettyVersion('laravel/framework');
-        $livewire = \Composer\InstalledVersions::getPrettyVersion('livewire/livewire');
+        $filament = InstalledVersions::getPrettyVersion('filament/filament');
+        $laravel = InstalledVersions::getPrettyVersion('laravel/framework');
+        $livewire = InstalledVersions::getPrettyVersion('livewire/livewire');
         $php = \PHP_VERSION;
 
         $issueTemplate = 'bug_report.yml';
-        $baseGithubUrl = 'https://github.com/filamentphp/filament/issues/new';
+        $baseGithubUrl = 'https://github.com/filamentphp/filament/issues/new?';
 
         $queryParams = [
             'template' => $issueTemplate,
@@ -41,10 +42,21 @@ class MakeIssueCommand extends Command
             'php-version' => $php,
         ];
 
-        $queryString = http_build_query($queryParams);
+        $fullUrl = "{$baseGithubUrl}" . http_build_query($queryParams);
 
-        $fullUrl = $baseGithubUrl . '?' . $queryString;
+        $this->openGithubIssueInBrowser($fullUrl);
+    }
 
-        $this->info('Please fill out the issue template at ' . $fullUrl);
+    public function openGithubIssueInBrowser(string $url): void
+    {
+        if (PHP_OS_FAMILY === 'Darwin') {
+            exec('open "' . $url . '"');
+        }
+        if (PHP_OS_FAMILY === 'Linux') {
+            exec('xdg-open "' . $url . '"');
+        }
+        if (PHP_OS_FAMILY === 'Windows') {
+            exec('start "" "' . $url . '"');
+        }
     }
 }

--- a/packages/panels/src/FilamentServiceProvider.php
+++ b/packages/panels/src/FilamentServiceProvider.php
@@ -108,13 +108,13 @@ class FilamentServiceProvider extends PackageServiceProvider
             Commands\CacheComponentsCommand::class,
             Commands\ClearCachedComponentsCommand::class,
             Commands\MakeClusterCommand::class,
+            Commands\MakeIssueCommand::class,
             Commands\MakePageCommand::class,
             Commands\MakePanelCommand::class,
             Commands\MakeRelationManagerCommand::class,
             Commands\MakeResourceCommand::class,
             Commands\MakeThemeCommand::class,
             Commands\MakeUserCommand::class,
-            Commands\MakeIssueCommand::class,
         ];
 
         $aliases = [];
@@ -122,7 +122,7 @@ class FilamentServiceProvider extends PackageServiceProvider
         foreach ($commands as $command) {
             $class = 'Filament\\Commands\\Aliases\\' . class_basename($command);
 
-            if (!class_exists($class)) {
+            if (! class_exists($class)) {
                 continue;
             }
 

--- a/packages/panels/src/FilamentServiceProvider.php
+++ b/packages/panels/src/FilamentServiceProvider.php
@@ -114,6 +114,7 @@ class FilamentServiceProvider extends PackageServiceProvider
             Commands\MakeResourceCommand::class,
             Commands\MakeThemeCommand::class,
             Commands\MakeUserCommand::class,
+            Commands\MakeIssueCommand::class,
         ];
 
         $aliases = [];
@@ -121,7 +122,7 @@ class FilamentServiceProvider extends PackageServiceProvider
         foreach ($commands as $command) {
             $class = 'Filament\\Commands\\Aliases\\' . class_basename($command);
 
-            if (! class_exists($class)) {
+            if (!class_exists($class)) {
                 continue;
             }
 


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description
Its probably considered a toy more than a tool, but recently I got into submitting issues and amongst other things, filling out version numbers is a little inconvenient. This simple command helps with that.

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

![Screenshot 2024-02-09 211433](https://github.com/filamentphp/filament/assets/11778632/edd826ee-c132-4ba4-9898-6dd42ccc10db)

![Screenshot 2024-02-09 211512](https://github.com/filamentphp/filament/assets/11778632/7c3920ff-f0e7-49ea-88fa-5d65debf4ca9)

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [ ] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
