### PR TITLE
Fix using view for page headings

### DIFF
--- a/packages/panels/resources/views/components/header/index.blade.php
+++ b/packages/panels/resources/views/components/header/index.blade.php
@@ -1,9 +1,13 @@
 @props([
     'actions' => [],
     'breadcrumbs' => [],
-    'heading',
-    'subheading' => null,
 ])
+
+@php
+    $heading = $attributes->get('heading');
+    $subheading = $attributes->get('subheading');
+    $attributes = $attributes->except(['heading', 'subheading']);
+@endphp
 
 <header
     {{ $attributes->class(['fi-header flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between']) }}

--- a/packages/panels/resources/views/components/header/index.blade.php
+++ b/packages/panels/resources/views/components/header/index.blade.php
@@ -4,6 +4,7 @@
 ])
 
 @php
+    // These are passed through in the bag otherwise Laravel converts View objects to strings prematurely.
     $heading = $attributes->get('heading');
     $subheading = $attributes->get('subheading');
     $attributes = $attributes->except(['heading', 'subheading']);

--- a/packages/panels/resources/views/components/page/index.blade.php
+++ b/packages/panels/resources/views/components/page/index.blade.php
@@ -32,6 +32,7 @@
             <x-filament-panels::header
                 :actions="$this->getCachedHeaderActions()"
                 :breadcrumbs="filament()->hasBreadcrumbs() ? $this->getBreadcrumbs() : []"
+                {{-- These are passed through in the bag otherwise Laravel converts View objects to strings prematurely --}}
                 :attributes="
                     new \Illuminate\View\ComponentAttributeBag([
                         'heading' => $heading,

--- a/packages/panels/resources/views/components/page/index.blade.php
+++ b/packages/panels/resources/views/components/page/index.blade.php
@@ -32,8 +32,10 @@
             <x-filament-panels::header
                 :actions="$this->getCachedHeaderActions()"
                 :breadcrumbs="filament()->hasBreadcrumbs() ? $this->getBreadcrumbs() : []"
-                :heading="$heading"
-                :subheading="$this->getSubheading()"
+                :attributes="new \Illuminate\View\ComponentAttributeBag([
+                    'heading' => $heading,
+                    'subheading' => $this->getSubheading(),
+                ])"
             />
         @endif
 

--- a/packages/panels/resources/views/components/page/index.blade.php
+++ b/packages/panels/resources/views/components/page/index.blade.php
@@ -32,10 +32,12 @@
             <x-filament-panels::header
                 :actions="$this->getCachedHeaderActions()"
                 :breadcrumbs="filament()->hasBreadcrumbs() ? $this->getBreadcrumbs() : []"
-                :attributes="new \Illuminate\View\ComponentAttributeBag([
-                    'heading' => $heading,
-                    'subheading' => $this->getSubheading(),
-                ])"
+                :attributes="
+                    new \Illuminate\View\ComponentAttributeBag([
+                        'heading' => $heading,
+                        'subheading' => $this->getSubheading(),
+                    ])
+                "
             />
         @endif
 


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

Currently `view()` returned from `getHeading()` or `getSubheading()` gets converted when it's passed as a property from the page Blade view to the header Blade component. The approach in this PR prevents this from happening.

@danharrin, please let me know what you think of this fix and if we need to apply this to more places.

<!-- Replace this comment with your description. -->

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
