### PR TITLE
Use span instead of div for badges

### DIFF
--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -17,7 +17,7 @@
     'keyBindings' => null,
     'loadingIndicator' => true,
     'size' => ActionSize::Medium,
-    'tag' => 'div',
+    'tag' => 'span',
     'target' => null,
     'tooltip' => null,
     'type' => 'button',


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

Currently, badges without link or action use the `<div>` tag.
However, this causes issues when using badges in paragraphs as those don't allow divs as child.
This PR fixes the issue by using the `<span>` tag for badges so they can be used in places like page subheadings.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
