### PR TITLE
Allow checking to see if a record can be deleted before deleting

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/04-delete.md
+++ b/packages/actions/docs/07-prebuilt-actions/04-delete.md
@@ -37,6 +37,21 @@ public function table(Table $table): Table
 }
 ```
 
+## Checking if a record is allowed to be deleted
+
+In some cases, you may need to determine if a record can be deleted based on certain conditions. For example, you might want to prevent a user from being deleted if they are the owner of a "Team" model, to avoid integrity constraint violations.
+
+You can use the `deletable()` method to run pre-deletion logic. This method accepts a callback and should return `true` if the record can be deleted, or `false` otherwise.
+
+If the `deletable()` method returns `false`, the deletion process will be skipped and a notification will be displayed to the user. You can customize the title and body of this notification using the `notDeletableNotificationTitle()` and `notDeletableNotificationBody()` methods:
+
+```php
+DeleteAction::make()
+    ->deletable(fn ($record) => $record->teams->isEmpty())
+    ->notDeletableNotificationTitle('Cannot delete user')
+    ->notDeletableNotificationBody(fn ($user) => "You cannot delete {$user->name} because they are the owner of one or more teams."),
+```
+
 ## Redirecting after deleting
 
 You may set up a custom redirect when the form is submitted using the `successRedirectUrl()` method:

--- a/packages/actions/docs/07-prebuilt-actions/06-force-delete.md
+++ b/packages/actions/docs/07-prebuilt-actions/06-force-delete.md
@@ -37,6 +37,21 @@ public function table(Table $table): Table
 }
 ```
 
+## Checking if a record is allowed to be force-deleted
+
+In some cases, you may need to determine if a record can be force-deleted based on certain conditions. For example, you might want to prevent a user from being force-deleted if they are the owner of a "Team" model, to avoid integrity constraint violations.
+
+You can use the `deletable()` method to run pre-deletion logic. This method accepts a callback and should return `true` if the record can be force-deleted, or `false` otherwise.
+
+If the `deletable()` method returns `false`, the deletion process will be skipped and a notification will be displayed to the user. You can customize the title and body of this notification using the `notDeletableNotificationTitle()` and `notDeletableNotificationBody()` methods:
+
+```php
+ForceDeleteAction::make()
+    ->deletable(fn ($record) => $record->teams->isEmpty())
+    ->notDeletableNotificationTitle('Cannot delete user')
+    ->notDeletableNotificationBody(fn ($user) => "You cannot delete {$user->name} because they are the owner of one or more teams."),
+```
+
 ## Redirecting after force-deleting
 
 You may set up a custom redirect when the form is submitted using the `successRedirectUrl()` method:

--- a/packages/actions/src/DeleteAction.php
+++ b/packages/actions/src/DeleteAction.php
@@ -6,57 +6,17 @@ use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Filament\Notifications\Notification;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Concerns\CanDeleteRecords;
 use Filament\Actions\Concerns\CanCustomizeProcess;
 
 class DeleteAction extends Action
 {
     use CanCustomizeProcess;
-
-    protected bool | Closure $deletable = true;
-
-    protected string | Closure $notDeletableNotificationTitle;
-
-    protected string | Closure $notDeletableNotificationBody;
+    use CanDeleteRecords;
 
     public static function getDefaultName(): ?string
     {
         return 'delete';
-    }
-
-    public function deletable(bool | Closure $condition = true): static
-    {
-        $this->deletable = $condition;
-
-        return $this;
-    }
-
-    public function isDeletable(): bool
-    {
-        return (bool) $this->evaluate($this->deletable);
-    }
-
-    public function notDeletableNotificationTitle(string | Closure $notDeletableNotificationTitle): static
-    {
-        $this->notDeletableNotificationTitle = $notDeletableNotificationTitle;
-
-        return $this;
-    }
-
-    public function getNotDeletableNotificationTitle(): string
-    {
-        return $this->evaluate($this->notDeletableNotificationTitle);
-    }
-
-    public function notDeletableNotificationBody(string | Closure $notDeletableNotificationBody): static
-    {
-        $this->notDeletableNotificationBody = $notDeletableNotificationBody;
-
-        return $this;
-    }
-
-    public function getNotDeletableNotificationBody(): string
-    {
-        return $this->evaluate($this->notDeletableNotificationBody);
     }
 
     protected function setUp(): void

--- a/packages/actions/src/DeleteAction.php
+++ b/packages/actions/src/DeleteAction.php
@@ -2,9 +2,7 @@
 
 namespace Filament\Actions;
 
-use Closure;
 use Illuminate\Database\Eloquent\Model;
-use Filament\Notifications\Notification;
 use Filament\Support\Facades\FilamentIcon;
 use Filament\Support\Concerns\CanDeleteRecords;
 use Filament\Actions\Concerns\CanCustomizeProcess;
@@ -51,11 +49,7 @@ class DeleteAction extends Action
 
         $this->action(function (): void {
             if (! $this->isDeletable()) {
-                Notification::make()
-                    ->title($this->getNotDeletableNotificationTitle())
-                    ->body($this->getNotDeletableNotificationBody())
-                    ->danger()
-                    ->send();
+                $this->sendNotDeletableNotification();
 
                 return;
             }

--- a/packages/actions/src/DeleteAction.php
+++ b/packages/actions/src/DeleteAction.php
@@ -12,6 +12,8 @@ class DeleteAction extends Action
     use CanCustomizeProcess;
     use CanDeleteRecords;
 
+    protected bool $recordIsDeletable = true;
+
     public static function getDefaultName(): ?string
     {
         return 'delete';
@@ -22,6 +24,8 @@ class DeleteAction extends Action
         parent::setUp();
 
         $this->label(__('filament-actions::delete.single.label'));
+
+        $this->modalHidden(fn(): bool => ! ($this->recordIsDeletable = $this->isDeletable()));
 
         $this->modalHeading(fn (): string => __('filament-actions::delete.single.modal.heading', ['label' => $this->getRecordTitle()]));
 
@@ -48,7 +52,7 @@ class DeleteAction extends Action
         });
 
         $this->action(function (): void {
-            if (! $this->isDeletable()) {
+            if (! $this->recordIsDeletable) {
                 $this->sendNotDeletableNotification();
 
                 return;

--- a/packages/actions/src/DeleteAction.php
+++ b/packages/actions/src/DeleteAction.php
@@ -12,51 +12,51 @@ class DeleteAction extends Action
 {
     use CanCustomizeProcess;
 
-    protected bool | Closure $allowedToDelete = true;
+    protected bool | Closure $deletable = true;
 
-    protected string | Closure $deleteNotAllowedNotificationTitle;
+    protected string | Closure $notDeletableNotificationTitle;
 
-    protected string | Closure $deleteNotAllowedNotificationBody;
+    protected string | Closure $notDeletableNotificationBody;
 
     public static function getDefaultName(): ?string
     {
         return 'delete';
     }
 
-    public function allowedToDelete(bool | Closure $condition = true): static
+    public function deletable(bool | Closure $condition = true): static
     {
-        $this->allowedToDelete = $condition;
+        $this->deletable = $condition;
 
         return $this;
     }
 
-    public function isAllowedToDelete(): bool
+    public function isDeletable(): bool
     {
-        return (bool) $this->evaluate($this->allowedToDelete);
+        return (bool) $this->evaluate($this->deletable);
     }
 
-    public function deleteNotAllowedNotificationTitle(string | Closure $deleteNotAllowedNotificationTitle): static
+    public function notDeletableNotificationTitle(string | Closure $notDeletableNotificationTitle): static
     {
-        $this->deleteNotAllowedNotificationTitle = $deleteNotAllowedNotificationTitle;
+        $this->notDeletableNotificationTitle = $notDeletableNotificationTitle;
 
         return $this;
     }
 
-    public function getDeletionNotAllowedNotificationTitle(): string
+    public function getNotDeletableNotificationTitle(): string
     {
-        return $this->evaluate($this->deleteNotAllowedNotificationTitle);
+        return $this->evaluate($this->notDeletableNotificationTitle);
     }
 
-    public function deleteNotAllowedNotificationBody(string | Closure $deleteNotAllowedNotificationBody): static
+    public function notDeletableNotificationBody(string | Closure $notDeletableNotificationBody): static
     {
-        $this->deleteNotAllowedNotificationBody = $deleteNotAllowedNotificationBody;
+        $this->notDeletableNotificationBody = $notDeletableNotificationBody;
 
         return $this;
     }
 
-    public function getDeletionNotAllowedNotificationBody(): string
+    public function getNotDeletableNotificationBody(): string
     {
-        return $this->evaluate($this->deleteNotAllowedNotificationBody);
+        return $this->evaluate($this->notDeletableNotificationBody);
     }
 
     protected function setUp(): void
@@ -90,10 +90,10 @@ class DeleteAction extends Action
         });
 
         $this->action(function (): void {
-            if (! $this->isAllowedToDelete()) {
+            if (! $this->isDeletable()) {
                 Notification::make()
-                    ->title($this->getDeletionNotAllowedNotificationTitle())
-                    ->body($this->getDeletionNotAllowedNotificationBody())
+                    ->title($this->getNotDeletableNotificationTitle())
+                    ->body($this->getNotDeletableNotificationBody())
                     ->danger()
                     ->send();
 

--- a/packages/actions/src/ForceDeleteAction.php
+++ b/packages/actions/src/ForceDeleteAction.php
@@ -12,6 +12,8 @@ class ForceDeleteAction extends Action
     use CanCustomizeProcess;
     use CanDeleteRecords;
 
+    protected bool $recordIsDeletable = true;
+
     public static function getDefaultName(): ?string
     {
         return 'forceDelete';
@@ -22,6 +24,8 @@ class ForceDeleteAction extends Action
         parent::setUp();
 
         $this->label(__('filament-actions::force-delete.single.label'));
+
+        $this->modalHidden(fn(): bool => ! ($this->recordIsDeletable = $this->isDeletable()));
 
         $this->modalHeading(fn (): string => __('filament-actions::force-delete.single.modal.heading', ['label' => $this->getRecordTitle()]));
 
@@ -36,7 +40,7 @@ class ForceDeleteAction extends Action
         $this->modalIcon(FilamentIcon::resolve('actions::force-delete-action.modal') ?? 'heroicon-o-trash');
 
         $this->action(function (): void {
-            if (! $this->isDeletable()) {
+            if (! $this->recordIsDeletable) {
                 $this->sendNotDeletableNotification();
 
                 return;

--- a/packages/actions/src/ForceDeleteAction.php
+++ b/packages/actions/src/ForceDeleteAction.php
@@ -5,10 +5,12 @@ namespace Filament\Actions;
 use Filament\Actions\Concerns\CanCustomizeProcess;
 use Filament\Support\Facades\FilamentIcon;
 use Illuminate\Database\Eloquent\Model;
+use Filament\Support\Concerns\CanDeleteRecords;
 
 class ForceDeleteAction extends Action
 {
     use CanCustomizeProcess;
+    use CanDeleteRecords;
 
     public static function getDefaultName(): ?string
     {
@@ -34,6 +36,12 @@ class ForceDeleteAction extends Action
         $this->modalIcon(FilamentIcon::resolve('actions::force-delete-action.modal') ?? 'heroicon-o-trash');
 
         $this->action(function (): void {
+            if (! $this->isDeletable()) {
+                $this->sendNotDeletableNotification();
+
+                return;
+            }
+
             $result = $this->process(static fn (Model $record) => $record->forceDelete());
 
             if (! $result) {

--- a/packages/support/src/Concerns/CanDeleteRecords.php
+++ b/packages/support/src/Concerns/CanDeleteRecords.php
@@ -3,6 +3,7 @@
 namespace Filament\Support\Concerns;
 
 use Closure;
+use Filament\Notifications\Notification;
 
 trait CanDeleteRecords
 {
@@ -46,5 +47,14 @@ trait CanDeleteRecords
     public function getNotDeletableNotificationBody(): string
     {
         return $this->evaluate($this->notDeletableNotificationBody);
+    }
+
+    public function sendNotDeletableNotification(): void
+    {
+        Notification::make()
+            ->title($this->getNotDeletableNotificationTitle())
+            ->body($this->getNotDeletableNotificationBody())
+            ->danger()
+            ->send();
     }
 }

--- a/packages/support/src/Concerns/CanDeleteRecords.php
+++ b/packages/support/src/Concerns/CanDeleteRecords.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Filament\Support\Concerns;
+
+use Closure;
+
+trait CanDeleteRecords
+{
+    protected bool | Closure $deletable = true;
+
+    protected string | Closure | null $notDeletableNotificationTitle = null;
+
+    protected string | Closure  | null $notDeletableNotificationBody = null;
+
+    public function deletable(bool | Closure $condition = true): static
+    {
+        $this->deletable = $condition;
+
+        return $this;
+    }
+
+    public function isDeletable(): bool
+    {
+        return (bool) $this->evaluate($this->deletable);
+    }
+
+    public function notDeletableNotificationTitle(string | Closure $notDeletableNotificationTitle): static
+    {
+        $this->notDeletableNotificationTitle = $notDeletableNotificationTitle;
+
+        return $this;
+    }
+
+    public function getNotDeletableNotificationTitle(): string
+    {
+        return $this->evaluate($this->notDeletableNotificationTitle);
+    }
+
+    public function notDeletableNotificationBody(string | Closure $notDeletableNotificationBody): static
+    {
+        $this->notDeletableNotificationBody = $notDeletableNotificationBody;
+
+        return $this;
+    }
+
+    public function getNotDeletableNotificationBody(): string
+    {
+        return $this->evaluate($this->notDeletableNotificationBody);
+    }
+}

--- a/packages/tables/src/Actions/DeleteAction.php
+++ b/packages/tables/src/Actions/DeleteAction.php
@@ -12,6 +12,8 @@ class DeleteAction extends Action
     use CanCustomizeProcess;
     use CanDeleteRecords;
 
+    protected bool $recordIsDeletable = true;
+
     public static function getDefaultName(): ?string
     {
         return 'delete';
@@ -22,6 +24,8 @@ class DeleteAction extends Action
         parent::setUp();
 
         $this->label(__('filament-actions::delete.single.label'));
+
+        $this->modalHidden(fn(): bool => ! ($this->recordIsDeletable = $this->isDeletable()));
 
         $this->modalHeading(fn (): string => __('filament-actions::delete.single.modal.heading', ['label' => $this->getRecordTitle()]));
 
@@ -46,7 +50,7 @@ class DeleteAction extends Action
         });
 
         $this->action(function (): void {
-            if (! $this->isDeletable()) {
+            if (! $this->recordIsDeletable) {
                 $this->sendNotDeletableNotification();
 
                 return;

--- a/packages/tables/src/Actions/DeleteAction.php
+++ b/packages/tables/src/Actions/DeleteAction.php
@@ -5,10 +5,12 @@ namespace Filament\Tables\Actions;
 use Filament\Actions\Concerns\CanCustomizeProcess;
 use Filament\Support\Facades\FilamentIcon;
 use Illuminate\Database\Eloquent\Model;
+use Filament\Support\Concerns\CanDeleteRecords;
 
 class DeleteAction extends Action
 {
     use CanCustomizeProcess;
+    use CanDeleteRecords;
 
     public static function getDefaultName(): ?string
     {
@@ -44,6 +46,12 @@ class DeleteAction extends Action
         });
 
         $this->action(function (): void {
+            if (! $this->isDeletable()) {
+                $this->sendNotDeletableNotification();
+
+                return;
+            }
+
             $result = $this->process(static fn (Model $record) => $record->delete());
 
             if (! $result) {

--- a/packages/tables/src/Actions/ForceDeleteAction.php
+++ b/packages/tables/src/Actions/ForceDeleteAction.php
@@ -5,10 +5,12 @@ namespace Filament\Tables\Actions;
 use Filament\Actions\Concerns\CanCustomizeProcess;
 use Filament\Support\Facades\FilamentIcon;
 use Illuminate\Database\Eloquent\Model;
+use Filament\Support\Concerns\CanDeleteRecords;
 
 class ForceDeleteAction extends Action
 {
     use CanCustomizeProcess;
+    use CanDeleteRecords;
 
     public static function getDefaultName(): ?string
     {
@@ -36,6 +38,12 @@ class ForceDeleteAction extends Action
         $this->modalIcon(FilamentIcon::resolve('actions::force-delete-action.modal') ?? 'heroicon-o-trash');
 
         $this->action(function (): void {
+            if (! $this->isDeletable()) {
+                $this->sendNotDeletableNotification();
+
+                return;
+            }
+
             $result = $this->process(static fn (Model $record) => $record->forceDelete());
 
             if (! $result) {

--- a/packages/tables/src/Actions/ForceDeleteAction.php
+++ b/packages/tables/src/Actions/ForceDeleteAction.php
@@ -12,6 +12,8 @@ class ForceDeleteAction extends Action
     use CanCustomizeProcess;
     use CanDeleteRecords;
 
+    protected bool $recordIsDeletable = true;
+
     public static function getDefaultName(): ?string
     {
         return 'forceDelete';
@@ -22,6 +24,8 @@ class ForceDeleteAction extends Action
         parent::setUp();
 
         $this->label(__('filament-actions::force-delete.single.label'));
+
+        $this->modalHidden(fn(): bool => ! ($this->recordIsDeletable = $this->isDeletable()));
 
         $this->modalHeading(fn (): string => __('filament-actions::force-delete.single.modal.heading', ['label' => $this->getRecordTitle()]));
 
@@ -38,7 +42,7 @@ class ForceDeleteAction extends Action
         $this->modalIcon(FilamentIcon::resolve('actions::force-delete-action.modal') ?? 'heroicon-o-trash');
 
         $this->action(function (): void {
-            if (! $this->isDeletable()) {
+            if (! $this->recordIsDeletable) {
                 $this->sendNotDeletableNotification();
 
                 return;


### PR DESCRIPTION
Solves: https://x.com/maurozadu/status/1751351926711545863?s=20

Currently there's no clean way to check for integrity constraint violations before deleting a record. Hiding the action can lead to a confusing UX because it's not clear to the user why the delete button is there for some records and not for others. Using `before` works but it means repeatedly creating the same if / else / notification boilerplate.

This PR adds a convenient way of running a check before deletions occur, and showing a customisable notification if it isn't allowed:


```PHP
DeleteAction::make()
    ->deletable(fn ($record) => $record->teams->isEmpty())
    ->notDeletableNotificationTitle('Cannot delete user')
    ->notDeletableNotificationBody(fn ($user) => "You cannot delete {$user->name} because they are the owner of one or more teams."),
```

<img width="303" alt="image" src="https://github.com/filamentphp/filament/assets/5361908/ae8a47aa-ffc6-4b7c-9b24-de4cc7ce9ba7">
