### PR TITLE
Update `component-container.blade.php`: use `let` for block-scope variable assignment in `form-validation-error` listener

### DIFF
--- a/packages/forms/resources/views/component-container.blade.php
+++ b/packages/forms/resources/views/component-container.blade.php
@@ -13,13 +13,13 @@
             }
 
             $nextTick(() => {
-                error = $el.querySelector(\'[data-validation-error]\')
+                let error = $el.querySelector(\'[data-validation-error]\')
 
                 if (! error) {
                     return
                 }
 
-                elementToExpand = error
+                let elementToExpand = error
 
                 while (elementToExpand) {
                     elementToExpand.dispatchEvent(new CustomEvent(\'expand\'))


### PR DESCRIPTION
## Description

This PR updates the `form-validation-error` listener in `component-container.blade.php` to use `let` for block-scope variable assignment.

This fixes the error `TypeError: error is null` when validation fails with multiple forms on the page, as otherwise variables `error` and `elementToExpand` are globally assigned (which should generally be avoided).

<!-- Replace this comment with your description. -->

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [ ] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
