### PR TITLE
adding header to sidebar dropdown

### DIFF
--- a/packages/panels/resources/views/components/sidebar/group.blade.php
+++ b/packages/panels/resources/views/components/sidebar/group.blade.php
@@ -121,6 +121,12 @@
                 }
             @endphp
 
+            @if (filled($label))
+                <x-filament::dropdown.header>
+                    {{ $label }}
+                </x-filament::dropdown.header>
+            @endif
+
             @foreach ($lists as $list)
                 <x-filament::dropdown.list>
                     @foreach ($list as $item)


### PR DESCRIPTION
## Description

adding header for the dropdown menu for better UX

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

Before:
<img width="1110" alt="Screenshot 2024-02-13 at 1 46 27 AM" src="https://github.com/filamentphp/filament/assets/1952412/4a165291-10b3-46f1-b0b0-0cdb410325f7">

After:
<img width="1110" alt="Screenshot 2024-02-13 at 1 45 40 AM" src="https://github.com/filamentphp/filament/assets/1952412/f9741b6c-5435-4c05-8975-abe6a110a36c">

