### PR TITLE
Add mask to TextInputColumn

### DIFF
--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -3,7 +3,6 @@
 
     $isDisabled = $isDisabled();
     $state = $getState();
-    $type = $getType();
     $mask = $getMask();
 
     $alignment = $getAlignment() ?? Alignment::Start;
@@ -14,6 +13,8 @@
 
     if (filled($mask)) {
         $type = 'text';
+    } else {
+        $type = $getType();
     }
 @endphp
 

--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -4,11 +4,16 @@
     $isDisabled = $isDisabled();
     $state = $getState();
     $type = $getType();
+    $mask = $getMask();
 
     $alignment = $getAlignment() ?? Alignment::Start;
 
     if (! $alignment instanceof Alignment) {
         $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
+    }
+
+    if (filled($mask)) {
+        $type = 'text';
     }
 @endphp
 
@@ -115,6 +120,7 @@
 
                                 isLoading = false
                             ',
+                            'x-mask' . ($mask instanceof \Filament\Support\RawJs ? ':dynamic' : '') => filled($mask) ? $mask : null,
                         ])
                         ->class([
                             match ($alignment) {

--- a/packages/tables/src/Columns/TextInputColumn.php
+++ b/packages/tables/src/Columns/TextInputColumn.php
@@ -6,6 +6,7 @@ use Closure;
 use Filament\Forms\Components\Concerns\HasExtraInputAttributes;
 use Filament\Forms\Components\Concerns\HasInputMode;
 use Filament\Forms\Components\Concerns\HasStep;
+use Filament\Support\RawJs;
 use Filament\Tables\Columns\Contracts\Editable;
 
 class TextInputColumn extends Column implements Editable
@@ -20,6 +21,8 @@ class TextInputColumn extends Column implements Editable
      * @var view-string
      */
     protected string $view = 'filament-tables::columns.text-input-column';
+
+    protected string | RawJs | Closure | null $mask = null;
 
     protected string | Closure | null $type = null;
 
@@ -40,5 +43,17 @@ class TextInputColumn extends Column implements Editable
     public function getType(): string
     {
         return $this->evaluate($this->type) ?? 'text';
+    }
+
+    public function mask(string | RawJs | Closure | null $mask): static
+    {
+        $this->mask = $mask;
+
+        return $this;
+    }
+
+    public function getMask(): string | RawJs | null
+    {
+        return $this->evaluate($this->mask);
     }
 }


### PR DESCRIPTION
This is a super simple addition to TextInputColumn that adds support for `mask()`.

The only thing I didn't do since this is duplicate code from `TextInput` would be to extract it out to a trait like `HasMask` or something. But I can if you'd like.