### PR TITLE
MakeIssueCommandAlias not exists.

### DIFF
--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -7,7 +7,6 @@ use Filament\Support\Assets\AssetManager;
 use Filament\Support\Assets\Css;
 use Filament\Support\Assets\Js;
 use Filament\Support\Colors\ColorManager;
-use Filament\Support\Commands\Aliases\MakeIssueCommand as MakeIssueCommandAlias;
 use Filament\Support\Commands\AssetsCommand;
 use Filament\Support\Commands\CheckTranslationsCommand;
 use Filament\Support\Commands\InstallCommand;
@@ -43,7 +42,6 @@ class SupportServiceProvider extends PackageServiceProvider
                 UpgradeCommand::class,
 
                 MakeIssueCommand::class,
-                MakeIssueCommandAlias::class,
             ])
             ->hasConfigFile()
             ->hasTranslations()


### PR DESCRIPTION
In latest release, `MakeIssueCommand` on `Aliases` doesn't exists.

<img width="641" alt="image" src="https://github.com/filamentphp/filament/assets/17238742/d03646ad-45a1-4af1-a2c6-923b5e9c8a59">

So, from service provider, it has been removed also. But the main `MakeIssueCommand` command is present there for `make:filament-issue`