### PR TITLE
Be able to set locale for format money() and numeric() values and make use of Laravel Number helper functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "pestphp/pest-plugin-laravel": "^2.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "v1.10.54",
+        "laravel/framework": ">=10.33",
         "rector/rector": "^0.17",
         "spatie/laravel-medialibrary": "^10.0|^11.0",
         "spatie/laravel-ray": "^1.29",

--- a/packages/forms/docs/01-installation.md
+++ b/packages/forms/docs/01-installation.md
@@ -9,7 +9,7 @@ title: Installation
 Filament requires the following to run:
 
 - PHP 8.1+
-- Laravel v10.0+
+- Laravel v10.33+
 - Livewire v3.0+
 
 > **Livewire v3 is recently released!**<br />

--- a/packages/forms/src/Commands/Concerns/CanGenerateForms.php
+++ b/packages/forms/src/Commands/Concerns/CanGenerateForms.php
@@ -155,6 +155,7 @@ trait CanGenerateForms
                         $parameterValue = match (true) {
                             /** @phpstan-ignore-next-line */
                             is_bool($parameterValue) => $parameterValue ? 'true' : 'false',
+                            /** @phpstan-ignore-next-line */
                             is_null($parameterValue) => 'null',
                             is_numeric($parameterValue) => $parameterValue,
                             default => "'{$parameterValue}'",

--- a/packages/infolists/docs/03-entries/02-text.md
+++ b/packages/infolists/docs/03-entries/02-text.md
@@ -58,8 +58,20 @@ TextEntry::make('created_at')
 
 ## Number formatting
 
-The `numeric()` method allows you to format an entry as a number, using PHP's `number_format()`:
+The `numeric()` method allows you to format an entry as a number.
 
+Using `Number::format()` method from Laravel:
+```php
+use Filament\Infolists\Components\TextEntry;
+
+TextEntry::make('stock')
+    ->numeric(
+        decimalPlaces: 2,
+        locale: 'de',
+    )
+```
+
+To use the traditional PHP's `number_format()`, you should define the `decimalSeparator` attribute:
 ```php
 use Filament\Infolists\Components\TextEntry;
 
@@ -82,6 +94,14 @@ TextEntry::make('price')
     ->money('EUR')
 ```
 
+There is an optional `locale` argument for `money()` to set a locale for the currency formatting.
+```php
+use Filament\Infolists\Components\TextEntry;
+
+TextEntry::make('price')
+    ->money('EUR', locale: 'de')
+```
+
 There is also a `divideBy` argument for `money()` that allows you to divide the original value by a number before formatting it. This could be useful if your database stores the price in cents, for example:
 
 ```php
@@ -89,6 +109,20 @@ use Filament\Infolists\Components\TextEntry;
 
 TextEntry::make('price')
     ->money('EUR', divideBy: 100)
+```
+
+### Globally set the number and currency formatting
+The `money()` and `number()` methods will follow the formatting of the application locale by default. You can override the default number locale globally, which affects how numbers and currency are formatted by subsequent invocations to the Number class's methods:
+```php
+use Illuminate\Support\Number;
+ 
+/**
+ * Bootstrap any application services.
+ */
+public function boot(): void
+{
+    Number::useLocale('de');
+}
 ```
 
 ## Limiting text length

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -46,6 +46,7 @@ class MakePageCommand extends Command
         $resource = null;
         $resourceClass = null;
         $resourcePage = null;
+        $modifyQueryUsing = '';
 
         $resourceInput = $this->option('resource') ?? text(
             label: 'What is the resource you would like to create this in?',
@@ -144,8 +145,6 @@ class MakePageCommand extends Command
                 }
 
                 $tableBulkActions[] = 'Tables\Actions\DeleteBulkAction::make(),';
-
-                $modifyQueryUsing = '';
 
                 if ($hasSoftDeletes) {
                     $modifyQueryUsing .= '->modifyQueryUsing(fn (Builder $query) => $query->withoutGlobalScopes([';
@@ -266,7 +265,7 @@ class MakePageCommand extends Command
             $this->copyStubToApp('ResourceManageRelatedRecordsPage', $path, [
                 'baseResourcePage' => "Filament\\Resources\\Pages\\{$resourcePage}",
                 'baseResourcePageClass' => $resourcePage,
-                'modifyQueryUsing' => filled($modifyQueryUsing ?? null) ? PHP_EOL . $this->indentString($modifyQueryUsing ?? '', 3) : $modifyQueryUsing ?? '',
+                'modifyQueryUsing' => filled($modifyQueryUsing) ? PHP_EOL . $this->indentString($modifyQueryUsing, 3) : $modifyQueryUsing,
                 'namespace' => "{$resourceNamespace}\\{$resource}\\Pages" . ($pageNamespace !== '' ? "\\{$pageNamespace}" : ''),
                 'recordTitleAttribute' => $recordTitleAttribute ?? null,
                 'relationship' => $relationship ?? null,

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -139,7 +139,9 @@ class SupportServiceProvider extends PackageServiceProvider
             return new Stringable(Str::ucwords($this->value));
         });
 
-        Number::useLocale($this->app->getLocale());
+        if (method_exists(Number::class, 'useLocale')) {
+            Number::useLocale($this->app->getLocale());
+        }
 
         if (class_exists(InstalledVersions::class)) {
             $packages = [

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -139,9 +139,7 @@ class SupportServiceProvider extends PackageServiceProvider
             return new Stringable(Str::ucwords($this->value));
         });
 
-        if (method_exists(Number::class, 'useLocale')) {
-            Number::useLocale($this->app->getLocale());
-        }
+        Number::useLocale($this->app->getLocale());
 
         if (class_exists(InstalledVersions::class)) {
             $packages = [

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -21,6 +21,7 @@ use Filament\Support\View\ViewManager;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Number;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Laravel\Octane\Events\RequestReceived;
@@ -137,6 +138,8 @@ class SupportServiceProvider extends PackageServiceProvider
             /** @phpstan-ignore-next-line */
             return new Stringable(Str::ucwords($this->value));
         });
+
+        Number::useLocale($this->app->getLocale());
 
         if (class_exists(InstalledVersions::class)) {
             $packages = [

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -28,7 +28,7 @@ if (! function_exists('Filament\Support\format_money')) {
 
 if (! function_exists('Filament\Support\format_number')) {
 
-    function format_number(float | int $number, $precision = null, ?string $locale = null): string
+    function format_number(float | int $number, ?int $precision = null, ?string $locale = null): string
     {
         return Number::format($number, $precision, null, $locale);
     }

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -8,30 +8,29 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Number;
 use Illuminate\Support\Str;
 use Illuminate\Translation\MessageSelector;
 use Illuminate\View\ComponentAttributeBag;
-use NumberFormatter;
 
 if (! function_exists('Filament\Support\format_money')) {
-    function format_money(float | int $money, string $currency, int $divideBy = 0): string
+
+    function format_money(float | int $money, string $currency, int $divideBy = 0, ?string $locale = null): string
     {
-        $formatter = new NumberFormatter(app()->getLocale(), NumberFormatter::CURRENCY);
 
         if ($divideBy) {
             $money /= $divideBy;
         }
 
-        return $formatter->formatCurrency($money, $currency);
+        return Number::currency($money, $currency, $locale);
     }
 }
 
 if (! function_exists('Filament\Support\format_number')) {
-    function format_number(float | int $number): string
-    {
-        $formatter = new NumberFormatter(app()->getLocale(), NumberFormatter::DECIMAL);
 
-        return $formatter->format($number);
+    function format_number(float | int $number, $precision = null, ?string $locale = null): string
+    {
+        return Number::format($number, $precision, null, $locale);
     }
 }
 

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Number;
 use Illuminate\Support\Str;
 use Illuminate\Translation\MessageSelector;
 use Illuminate\View\ComponentAttributeBag;
+use NumberFormatter;
 
 if (! function_exists('Filament\Support\format_money')) {
 
@@ -22,7 +23,14 @@ if (! function_exists('Filament\Support\format_money')) {
             $money /= $divideBy;
         }
 
-        return Number::currency($money, $currency, $locale);
+        if (method_exists(Number::class, 'currency')) {
+            return Number::currency($money, $currency, $locale);
+        }
+
+        $formatter = new NumberFormatter($locale ?? app()->getLocale(), NumberFormatter::CURRENCY);
+
+        return $formatter->formatCurrency($money, $currency);
+
     }
 }
 
@@ -30,7 +38,16 @@ if (! function_exists('Filament\Support\format_number')) {
 
     function format_number(float | int $number, ?int $precision = null, ?string $locale = null): string
     {
-        return Number::format($number, $precision, null, $locale);
+        if (method_exists(Number::class, 'format')) {
+            return Number::format($number, $precision, null, $locale);
+        }
+
+        $formatter = new NumberFormatter($locale ?? app()->getLocale(), NumberFormatter::DECIMAL);
+        if (! is_null($precision)) {
+            $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
+        }
+
+        return $formatter->format($number, $precision);
     }
 }
 

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -12,7 +12,6 @@ use Illuminate\Support\Number;
 use Illuminate\Support\Str;
 use Illuminate\Translation\MessageSelector;
 use Illuminate\View\ComponentAttributeBag;
-use NumberFormatter;
 
 if (! function_exists('Filament\Support\format_money')) {
 
@@ -23,14 +22,7 @@ if (! function_exists('Filament\Support\format_money')) {
             $money /= $divideBy;
         }
 
-        if (method_exists(Number::class, 'currency')) {
-            return Number::currency($money, $currency, $locale);
-        }
-
-        $formatter = new NumberFormatter($locale ?? app()->getLocale(), NumberFormatter::CURRENCY);
-
-        return $formatter->formatCurrency($money, $currency);
-
+        return Number::currency($money, $currency, $locale);
     }
 }
 
@@ -38,16 +30,7 @@ if (! function_exists('Filament\Support\format_number')) {
 
     function format_number(float | int $number, ?int $precision = null, ?string $locale = null): string
     {
-        if (method_exists(Number::class, 'format')) {
-            return Number::format($number, $precision, null, $locale);
-        }
-
-        $formatter = new NumberFormatter($locale ?? app()->getLocale(), NumberFormatter::DECIMAL);
-        if (! is_null($precision)) {
-            $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
-        }
-
-        return $formatter->format($number, $precision);
+        return Number::format($number, $precision, null, $locale);
     }
 }
 

--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -84,7 +84,21 @@ TextColumn::make('created_at')
 
 ## Number formatting
 
-The `numeric()` method allows you to format a column as a number, using PHP's `number_format()`:
+The `numeric()` method allows you to format a summary as a number.
+
+Using `Number::format()` method from Laravel:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('stock')
+    ->numeric(
+        decimalPlaces: 2,
+        locale: 'de',
+    )
+```
+
+To use the traditional PHP's `number_format()`, you should define the `decimalSeparator` attribute:
 
 ```php
 use Filament\Tables\Columns\TextColumn;
@@ -107,6 +121,13 @@ use Filament\Tables\Columns\TextColumn;
 TextColumn::make('price')
     ->money('EUR')
 ```
+There is an optional `locale` argument for `money()` to set a locale for the currency formatting.
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('price')
+    ->money('EUR', locale: 'de')
+```
 
 There is also a `divideBy` argument for `money()` that allows you to divide the original value by a number before formatting it. This could be useful if your database stores the price in cents, for example:
 
@@ -115,6 +136,20 @@ use Filament\Tables\Columns\TextColumn;
 
 TextColumn::make('price')
     ->money('EUR', divideBy: 100)
+```
+
+### Globally set the number and currency formatting
+The `money()` and `number()` methods will follow the formatting of the application locale by default. You can override the default number locale globally, which affects how numbers and currency are formatted by subsequent invocations to the Number class's methods:
+```php
+use Illuminate\Support\Number;
+ 
+/**
+ * Bootstrap any application services.
+ */
+public function boot(): void
+{
+    Number::useLocale('de');
+}
 ```
 
 ## Limiting text length

--- a/packages/tables/docs/07-summaries.md
+++ b/packages/tables/docs/07-summaries.md
@@ -221,8 +221,22 @@ In this example, the table will calculate how many posts are published.
 
 ### Number formatting
 
-The `numeric()` method allows you to format a summary as a number, using PHP's `number_format()`:
+The `numeric()` method allows you to format a summary as a number.
 
+Using `Number::format()` method from Laravel:
+
+```php
+use Filament\Tables\Columns\Summarizers\Average;
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('rating')
+    ->summarize(Average::make()->numeric(
+        decimalPlaces: 2,
+        locale: 'de',
+    ))
+```
+
+To use the traditional PHP's `number_format()`, you should define the `decimalSeparator` attribute:
 ```php
 use Filament\Tables\Columns\Summarizers\Average;
 use Filament\Tables\Columns\TextColumn;
@@ -247,6 +261,15 @@ TextColumn::make('price')
     ->summarize(Sum::make()->money('EUR'))
 ```
 
+There is an optional `locale` argument for `money()` to set a locale for the currency formatting.
+```php
+use Filament\Tables\Columns\Summarizers\Sum;
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('price')
+    ->summarize(Sum::make()->money('EUR', locale: 'de'))
+```
+
 There is also a `divideBy` argument for `money()` that allows you to divide the original value by a number before formatting it. This could be useful if your database stores the price in cents, for example:
 
 ```php
@@ -256,6 +279,21 @@ use Filament\Tables\Columns\TextColumn;
 TextColumn::make('price')
     ->summarize(Sum::make()->money('EUR', divideBy: 100))
 ```
+
+### Globally set the number and currency formatting
+The `money()` and `number()` methods will follow the formatting of the application locale by default. You can override the default number locale globally, which affects how numbers and currency are formatted by subsequent invocations to the Number class's methods:
+```php
+use Illuminate\Support\Number;
+ 
+/**
+ * Bootstrap any application services.
+ */
+public function boot(): void
+{
+    Number::useLocale('de');
+}
+```
+
 
 ### Limiting text length
 

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -99,28 +99,28 @@ trait CanFormatState
         return $this;
     }
 
-    public function money(string | Closure | null $currency = null, int $divideBy = 0): static
+    public function money(string | Closure | null $currency = null, int $divideBy = 0, string | Closure | null $locale = null): static
     {
         $this->isMoney = true;
 
-        $this->formatStateUsing(static function (TextColumn $column, $state) use ($currency, $divideBy): ?string {
+        $this->formatStateUsing(static function (TextColumn $column, $state) use ($currency, $divideBy, $locale): ?string {
             if (blank($state)) {
                 return null;
             }
 
             $currency = $column->evaluate($currency) ?? Table::$defaultCurrency;
 
-            return format_money($state, $currency, $divideBy);
+            return format_money($state, $currency, $divideBy, $column->evaluate($locale));
         });
 
         return $this;
     }
 
-    public function numeric(int | Closure | null $decimalPlaces = null, string | Closure | null $decimalSeparator = '.', string | Closure | null $thousandsSeparator = ','): static
+    public function numeric(int | Closure | null $decimalPlaces = null, string | Closure | null $decimalSeparator = null, string | Closure | null $thousandsSeparator = null, string | Closure | null $locale = null): static
     {
         $this->isNumeric = true;
 
-        $this->formatStateUsing(static function (TextColumn $column, $state) use ($decimalPlaces, $decimalSeparator, $thousandsSeparator): ?string {
+        $this->formatStateUsing(static function (TextColumn $column, $state) use ($decimalPlaces, $decimalSeparator, $thousandsSeparator, $locale): ?string {
             if (blank($state)) {
                 return null;
             }
@@ -131,6 +131,12 @@ trait CanFormatState
 
             if ($decimalPlaces === null) {
                 return format_number($state);
+            }
+
+            if ($locale !== null ||
+                ($decimalSeparator === null && $thousandsSeparator === null)
+            ) {
+                return format_number($state, $column->evaluate($decimalPlaces), $column->evaluate($locale));
             }
 
             return number_format(


### PR DESCRIPTION
## Description

For multiple projects we want to be able to format the `money()` and `numeric()` methods using a locale, independent from the `app()->getLocale()` configuration. For our customers it's pretty common to have the whole admin interface in the english language but still have the date and currency / number formatting in the local (eg 'de / 'nl') format.

Next to that I want to be able to set the currency and numeric formatting for the whole application or per user session. To support this, but don't break current implementations the default locale fallback is still `app()->getLocale()` and also the traditional PHP's `number_format()` is still supported to cover current implementations and make the impact of the change minimal.

The implementation allows us to use the new `locale` attribute in `money()` and `numeric()` methods. The implementation is making use of the default [Laravel Number helper functions](https://laravel.com/docs/10.x/helpers#numbers-method-list).

## Formatting

### Number formatting

The `numeric()` method allows you to format a summary as a number.

Using `Number::format()` method from Laravel:

```php
use Filament\Tables\Columns\Summarizers\Average;
use Filament\Tables\Columns\TextColumn;

TextColumn::make('rating')
    ->summarize(Average::make()->numeric(
        decimalPlaces: 2,
        locale: 'de',
    ))
```

To use the traditional PHP's `number_format()`, you should define the `decimalSeparator` attribute:
```php
use Filament\Tables\Columns\Summarizers\Average;
use Filament\Tables\Columns\TextColumn;

TextColumn::make('rating')
    ->summarize(Average::make()->numeric(
        decimalPlaces: 0,
        decimalSeparator: '.',
        thousandsSeparator: ',',
    ))
```

### Currency formatting

There is an optional `locale` argument for `money()` to set a locale for the currency formatting.
```php
use Filament\Tables\Columns\Summarizers\Sum;
use Filament\Tables\Columns\TextColumn;

TextColumn::make('price')
    ->summarize(Sum::make()->money('EUR', locale: 'de'))
```


Next to that, it is also possible to set the locale for formatting globally

```php
use Illuminate\Support\Number;
 
/**
 * Bootstrap any application services.
 */
public function boot(): void
{
    Number::useLocale('de');
}

```

For a new Filament 3.4 or 4.x implementation I would suggest to totally move to the Laravel  Number helper functions and also implement `Number::abbreviate()` and `Number::forHumans()` and support more options that the helpers support too. Maybe even remove the decimal symbol support etc.

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
