### PR TITLE
Fix typo in modal sticky header docs

### DIFF
--- a/packages/actions/docs/04-modals.md
+++ b/packages/actions/docs/04-modals.md
@@ -293,7 +293,7 @@ Instead of opening in the center of the screen, the modal content will now slide
 
 ## Making the modal header sticky
 
-The header of a modal scrolls out of view with the modal content when it overflows the modal size. However, slide-overs have a sticky modal that's always visible. You may control this behavior using `stickyModalHeader()`:
+The header of a modal scrolls out of view with the modal content when it overflows the modal size. However, slide-overs have a sticky header that's always visible. You may control this behavior using `stickyModalHeader()`:
 
 ```php
 Action::make('updateAuthor')


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

This PR fixes a typo in the action modal documentation. The typo is located in the sticky header configuration option chapter. The term "sticky modal" doesn't make any sense here. I guess it should called "sticky header",  as in the following chapter about configuring a sticky footer.

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

Not applicable.

- [ ] `composer cs` command has been run.

## Testing

Not applicable.

- [ ] Changes have been tested.

## Documentation

Not applicable.

- [ ] Documentation is up-to-date.
