### PR TITLE
Fixed: Addressed $loop->iteration placement outside loops and correct…

### DIFF
--- a/packages/infolists/resources/views/components/image-entry.blade.php
+++ b/packages/infolists/resources/views/components/image-entry.blade.php
@@ -11,10 +11,15 @@
         $height = $getHeight() ?? ($isStacked ? '2.5rem' : '8rem');
         $width = $getWidth() ?? (($isCircular || $isSquare) ? $height : null);
 
+        $stateCount = count($state);
+        $limitedStateCount = count($limitedState);
+
         $defaultImageUrl = $getDefaultImageUrl();
 
-        if ((! count($limitedState)) && filled($defaultImageUrl)) {
+        if ((! $limitedStateCount) && filled($defaultImageUrl)) {
             $limitedState = [null];
+
+            $limitedStateCount = 1;
         }
 
         $ringClasses = \Illuminate\Support\Arr::toCssClasses([
@@ -29,7 +34,7 @@
             },
         ]);
 
-        $hasLimitedRemainingText = $hasLimitedRemainingText();
+        $hasLimitedRemainingText = $hasLimitedRemainingText() && ($limitedStateCount < $stateCount);
         $isLimitedRemainingTextSeparate = $isLimitedRemainingTextSeparate();
 
         $limitedRemainingTextSizeClasses = match ($getLimitedRemainingTextSize()) {
@@ -50,7 +55,7 @@
                 ])
         }}
     >
-        @if (count($limitedState))
+        @if ($limitedStateCount)
             <div
                 @class([
                     'flex flex-wrap',
@@ -86,7 +91,7 @@
                     />
                 @endforeach
 
-                @if ($hasLimitedRemainingText && ($loop->iteration < count($limitedState)) && (! $isLimitedRemainingTextSeparate) && $isCircular)
+                @if ($hasLimitedRemainingText && (! $isLimitedRemainingTextSeparate) && $isCircular)
                     <div
                         style="
                             @if ($height) height: {{ $height }}; @endif
@@ -104,20 +109,20 @@
                         ])
                     >
                         <span class="-ms-0.5">
-                            +{{ count($state) - count($limitedState) }}
+                            +{{ $stateCount - $limitedStateCount }}
                         </span>
                     </div>
                 @endif
             </div>
 
-            @if ($hasLimitedRemainingText && ($loop->iteration < count($limitedState)) && ($isLimitedRemainingTextSeparate || (! $isCircular)))
+            @if ($hasLimitedRemainingText && ($isLimitedRemainingTextSeparate || (! $isCircular)))
                 <div
                     @class([
                         'font-medium text-gray-500 dark:text-gray-400',
                         $limitedRemainingTextSizeClasses,
                     ])
                 >
-                    +{{ count($state) - count($limitedState) }}
+                    +{{ $stateCount - $limitedStateCount }}
                 </div>
             @endif
         @elseif (($placeholder = $getPlaceholder()) !== null)

--- a/packages/tables/resources/views/columns/image-column.blade.php
+++ b/packages/tables/resources/views/columns/image-column.blade.php
@@ -10,10 +10,15 @@
     $height = $getHeight() ?? ($isStacked ? '2rem' : '2.5rem');
     $width = $getWidth() ?? (($isCircular || $isSquare) ? $height : null);
 
+    $countState = count($state);
+    $countLimitedState = count($limitedState);
+
     $defaultImageUrl = $getDefaultImageUrl();
 
-    if ((! count($limitedState)) && filled($defaultImageUrl)) {
+    if ((! $countLimitedState) && filled($defaultImageUrl)) {
         $limitedState = [null];
+
+        $countLimitedState = 1;
     }
 
     $ringClasses = \Illuminate\Support\Arr::toCssClasses([
@@ -50,7 +55,7 @@
             ])
     }}
 >
-    @if (count($limitedState))
+    @if ($countLimitedState)
         <div class="flex items-center gap-x-2.5">
             <div
                 @class([
@@ -88,7 +93,7 @@
                     />
                 @endforeach
 
-                @if ($hasLimitedRemainingText && ($loop->iteration < count($limitedState)) && (! $isLimitedRemainingTextSeparate) && $isCircular)
+                @if ($hasLimitedRemainingText && ($countLimitedState < $countState) && (! $isLimitedRemainingTextSeparate) && $isCircular)
                     <div
                         style="
                             @if ($height) height: {{ $height }}; @endif
@@ -106,20 +111,20 @@
                         ])
                     >
                         <span class="-ms-0.5">
-                            +{{ count($state) - count($limitedState) }}
+                            +{{ $countState - $countLimitedState }}
                         </span>
                     </div>
                 @endif
             </div>
 
-            @if ($hasLimitedRemainingText && ($loop->iteration < count($limitedState)) && ($isLimitedRemainingTextSeparate || (! $isCircular)))
+            @if ($hasLimitedRemainingText && ($countLimitedState < $countState) && ($isLimitedRemainingTextSeparate || (! $isCircular)))
                 <div
                     @class([
                         'font-medium text-gray-500 dark:text-gray-400',
                         $limitedRemainingTextSizeClasses,
                     ])
                 >
-                    +{{ count($state) - count($limitedState) }}
+                    +{{ $countState - $countLimitedState }}
                 </div>
             @endif
         </div>

--- a/packages/tables/resources/views/columns/image-column.blade.php
+++ b/packages/tables/resources/views/columns/image-column.blade.php
@@ -10,15 +10,15 @@
     $height = $getHeight() ?? ($isStacked ? '2rem' : '2.5rem');
     $width = $getWidth() ?? (($isCircular || $isSquare) ? $height : null);
 
-    $countState = count($state);
-    $countLimitedState = count($limitedState);
+    $stateCount = count($state);
+    $limitedStateCount = count($limitedState);
 
     $defaultImageUrl = $getDefaultImageUrl();
 
-    if ((! $countLimitedState) && filled($defaultImageUrl)) {
+    if ((! $limitedStateCount) && filled($defaultImageUrl)) {
         $limitedState = [null];
 
-        $countLimitedState = 1;
+        $limitedStateCount = 1;
     }
 
     $ringClasses = \Illuminate\Support\Arr::toCssClasses([
@@ -33,7 +33,7 @@
         },
     ]);
 
-    $hasLimitedRemainingText = $hasLimitedRemainingText();
+    $hasLimitedRemainingText = $hasLimitedRemainingText() && ($limitedStateCount < $stateCount);
     $isLimitedRemainingTextSeparate = $isLimitedRemainingTextSeparate();
 
     $limitedRemainingTextSizeClasses = match ($getLimitedRemainingTextSize()) {
@@ -55,7 +55,7 @@
             ])
     }}
 >
-    @if ($countLimitedState)
+    @if ($limitedStateCount)
         <div class="flex items-center gap-x-2.5">
             <div
                 @class([
@@ -93,7 +93,7 @@
                     />
                 @endforeach
 
-                @if ($hasLimitedRemainingText && ($countLimitedState < $countState) && (! $isLimitedRemainingTextSeparate) && $isCircular)
+                @if ($hasLimitedRemainingText && (! $isLimitedRemainingTextSeparate) && $isCircular)
                     <div
                         style="
                             @if ($height) height: {{ $height }}; @endif
@@ -111,20 +111,20 @@
                         ])
                     >
                         <span class="-ms-0.5">
-                            +{{ $countState - $countLimitedState }}
+                            +{{ $stateCount - $limitedStateCount }}
                         </span>
                     </div>
                 @endif
             </div>
 
-            @if ($hasLimitedRemainingText && ($countLimitedState < $countState) && ($isLimitedRemainingTextSeparate || (! $isCircular)))
+            @if ($hasLimitedRemainingText && ($isLimitedRemainingTextSeparate || (! $isCircular)))
                 <div
                     @class([
                         'font-medium text-gray-500 dark:text-gray-400',
                         $limitedRemainingTextSizeClasses,
                     ])
                 >
-                    +{{ $countState - $countLimitedState }}
+                    +{{ $stateCount - $limitedStateCount }}
                 </div>
             @endif
         </div>


### PR DESCRIPTION
When using limitedRemainingText and no remaining image is present,

we currently display +0, which is not ideal. Instead, if the number of images exceeds the set limit, for example, if we have 5 images and the limit is set to 3, we should display +2.

Additionally, to address a performance issue, we are currently using count($limitedState) in 6 instances and count($state) in 2 instances.
To avoid duplication, I have created separate variables

Note: We have $loop->iteration in 2 lines of code, but these lines are not within a loop. Additionally, there is a minor structural problem which has been corrected as expected.

<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [ ] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
