### PR TITLE
Ability to add Helper Text to Import Column

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -104,19 +104,6 @@ ImportColumn::make('sku')
     ->label('SKU')
 ```
 
-## Adding helper text below the import column
-
-Sometimes, you may wish to provide extra information for the import column before validation.
-
-The `helperText()` method is used to add helper text:
-
-```php
-use Filament\Forms\Components\TextInput;
-
-ImportColumn::make('skus')
-    ->helperText('A comma-separated list of SKUs.')
-```
-
 ### Requiring an importer column to be mapped to a CSV column
 
 You can call the `requiredMapping()` method to make a column required to be mapped to a column in the CSV. Columns that are required in the database should be required to be mapped:
@@ -331,6 +318,18 @@ ImportColumn::make('sku')
     ->fillRecordUsing(function (Product $record, string $state): void {
         $record->sku = strtoupper($state);
     })
+```
+
+### Adding helper text below the import column
+
+Sometimes, you may wish to provide extra information for the user before validation. You can do this by adding `helperText()` to a column, which gets displayed below the mapping select:
+
+```php
+use Filament\Forms\Components\TextInput;
+
+ImportColumn::make('skus')
+    ->array(',')
+    ->helperText('A comma-separated list of SKUs.')
 ```
 
 ## Updating existing records when importing

--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -104,6 +104,19 @@ ImportColumn::make('sku')
     ->label('SKU')
 ```
 
+## Adding helper text below the import column
+
+Sometimes, you may wish to provide extra information for the import column before validation.
+
+The `helperText()` method is used to add helper text:
+
+```php
+use Filament\Forms\Components\TextInput;
+
+ImportColumn::make('skus')
+    ->helperText('A comma-separated list of SKUs.')
+```
+
 ### Requiring an importer column to be mapped to a CSV column
 
 You can call the `requiredMapping()` method to make a column required to be mapped to a column in the CSV. Columns that are required in the database should be required to be mapped:

--- a/packages/actions/src/Imports/ImportColumn.php
+++ b/packages/actions/src/Imports/ImportColumn.php
@@ -3,6 +3,7 @@
 namespace Filament\Actions\Imports;
 
 use Closure;
+use Filament\Forms\Components\Concerns\HasHelperText;
 use Filament\Forms\Components\Select;
 use Filament\Support\Components\Component;
 use Illuminate\Database\Eloquent\Model;
@@ -13,6 +14,8 @@ use Illuminate\Support\Str;
 
 class ImportColumn extends Component
 {
+    use HasHelperText;
+
     protected string $name;
 
     protected string | Closure | null $label = null;
@@ -88,7 +91,8 @@ class ImportColumn extends Component
         return Select::make($this->getName())
             ->label($this->getLabel())
             ->placeholder(__('filament-actions::import.modal.form.columns.placeholder'))
-            ->required($this->isMappingRequired());
+            ->required($this->isMappingRequired())
+            ->helperText($this->getHelperText());
     }
 
     public function name(string $name): static

--- a/packages/actions/src/Imports/ImportColumn.php
+++ b/packages/actions/src/Imports/ImportColumn.php
@@ -3,9 +3,9 @@
 namespace Filament\Actions\Imports;
 
 use Closure;
-use Filament\Forms\Components\Concerns\HasHelperText;
 use Filament\Forms\Components\Select;
 use Filament\Support\Components\Component;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -14,8 +14,6 @@ use Illuminate\Support\Str;
 
 class ImportColumn extends Component
 {
-    use HasHelperText;
-
     protected string $name;
 
     protected string | Closure | null $label = null;
@@ -73,6 +71,8 @@ class ImportColumn extends Component
 
     protected string $evaluationIdentifier = 'column';
 
+    protected string | Htmlable | Closure | null $helperText = null;
+
     final public function __construct(string $name)
     {
         $this->name($name);
@@ -92,7 +92,7 @@ class ImportColumn extends Component
             ->label($this->getLabel())
             ->placeholder(__('filament-actions::import.modal.form.columns.placeholder'))
             ->required($this->isMappingRequired())
-            ->helperText($this->getHelperText());
+            ->helperText($this->helperText);
     }
 
     public function name(string $name): static
@@ -134,6 +134,13 @@ class ImportColumn extends Component
     {
         $this->isNumeric = $condition;
         $this->decimalPlaces = $decimalPlaces;
+
+        return $this;
+    }
+
+    public function helperText(string | Htmlable | Closure | null $text): static
+    {
+        $this->helperText = $text;
 
         return $this;
     }


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

This PR introduces an optional method for adding `helperText()` to `ImportColumn`. This functionality is particularly useful for providing instructions prior to validation.

```php
ImportColumn::make('associated_skus')
                ->label('Associated SKUs')
                ->requiredMapping()
                ->helperText('Comma separated list of SKUs')
```

<img width="566" alt="Screenshot 2024-02-15 at 9 47 21 PM" src="https://github.com/filamentphp/filament/assets/17038330/9f5f1d93-fa34-4d1b-bb91-18eb519bb367">



<!-- Replace this comment with your description. -->

- [X] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [X] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [X] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [X] Documentation is up-to-date.
