### PR TITLE
Add iconColor attribute for Dropdown Blade components

### DIFF
--- a/packages/support/docs/09-blade-components/02-dropdown.md
+++ b/packages/support/docs/09-blade-components/02-dropdown.md
@@ -69,6 +69,32 @@ By default, the color of a dropdown item is "gray". You can change it to be `dan
 </x-filament::dropdown.list.item>
 ```
 
+## Changing the icon color of a dropdown item
+
+By default, the icon color of a dropdown item is "gray". You can change it to be `danger`, `info`, `primary`, `success` or `warning` by using the `iconColor` attribute:
+
+```blade
+<x-filament::dropdown.list.item iconColor="danger">
+    Edit
+</x-filament::dropdown.list.item>
+
+<x-filament::dropdown.list.item iconColor="info">
+    Edit
+</x-filament::dropdown.list.item>
+
+<x-filament::dropdown.list.item iconColor="primary">
+    Edit
+</x-filament::dropdown.list.item>
+
+<x-filament::dropdown.list.item iconColor="success">
+    Edit
+</x-filament::dropdown.list.item>
+
+<x-filament::dropdown.list.item iconColor="warning">
+    Edit
+</x-filament::dropdown.list.item>
+```
+
 ## Adding an icon to a dropdown item
 
 You can add an [icon](https://blade-ui-kit.com/blade-icons?set=1#search) to a dropdown item by using the `icon` attribute:

--- a/packages/support/docs/09-blade-components/02-dropdown.md
+++ b/packages/support/docs/09-blade-components/02-dropdown.md
@@ -69,38 +69,38 @@ By default, the color of a dropdown item is "gray". You can change it to be `dan
 </x-filament::dropdown.list.item>
 ```
 
-## Changing the icon color of a dropdown item
-
-By default, the icon color of a dropdown item is "gray". You can change it to be `danger`, `info`, `primary`, `success` or `warning` by using the `iconColor` attribute:
-
-```blade
-<x-filament::dropdown.list.item iconColor="danger">
-    Edit
-</x-filament::dropdown.list.item>
-
-<x-filament::dropdown.list.item iconColor="info">
-    Edit
-</x-filament::dropdown.list.item>
-
-<x-filament::dropdown.list.item iconColor="primary">
-    Edit
-</x-filament::dropdown.list.item>
-
-<x-filament::dropdown.list.item iconColor="success">
-    Edit
-</x-filament::dropdown.list.item>
-
-<x-filament::dropdown.list.item iconColor="warning">
-    Edit
-</x-filament::dropdown.list.item>
-```
-
 ## Adding an icon to a dropdown item
 
 You can add an [icon](https://blade-ui-kit.com/blade-icons?set=1#search) to a dropdown item by using the `icon` attribute:
 
 ```blade
 <x-filament::dropdown.list.item icon="heroicon-m-pencil">
+    Edit
+</x-filament::dropdown.list.item>
+```
+
+### Changing the icon color of a dropdown item
+
+By default, the icon color uses the [same color as the item itself](#changing-the-color-of-a-dropdown-item). You can override it to be `danger`, `info`, `primary`, `success` or `warning` by using the `icon-color` attribute:
+
+```blade
+<x-filament::dropdown.list.item icon="heroicon-m-pencil" icon-color="danger">
+    Edit
+</x-filament::dropdown.list.item>
+
+<x-filament::dropdown.list.item icon="heroicon-m-pencil" icon-color="info">
+    Edit
+</x-filament::dropdown.list.item>
+
+<x-filament::dropdown.list.item icon="heroicon-m-pencil" icon-color="primary">
+    Edit
+</x-filament::dropdown.list.item>
+
+<x-filament::dropdown.list.item icon="heroicon-m-pencil" icon-color="success">
+    Edit
+</x-filament::dropdown.list.item>
+
+<x-filament::dropdown.list.item icon="heroicon-m-pencil" icon-color="warning">
     Edit
 </x-filament::dropdown.list.item>
 ```

--- a/packages/support/resources/views/components/dropdown/list/item.blade.php
+++ b/packages/support/resources/views/components/dropdown/list/item.blade.php
@@ -44,7 +44,7 @@
             alias: 'dropdown.list.item',
         ) => $color !== 'gray',
     ]);
-    
+
     $iconClasses = \Illuminate\Support\Arr::toCssClasses([
         'fi-dropdown-list-item-icon',
         match ($iconSize) {

--- a/packages/support/resources/views/components/dropdown/list/item.blade.php
+++ b/packages/support/resources/views/components/dropdown/list/item.blade.php
@@ -66,7 +66,7 @@
             $iconColor,
             shades: [400, 500],
             alias: 'dropdown.list.item.icon',
-        ) => ($iconColor) !== 'gray',
+        ) => $iconColor !== 'gray',
     ]);
 
     $imageClasses = 'fi-dropdown-list-item-image h-5 w-5 rounded-full bg-cover bg-center';

--- a/packages/support/resources/views/components/dropdown/list/item.blade.php
+++ b/packages/support/resources/views/components/dropdown/list/item.blade.php
@@ -45,6 +45,8 @@
         ) => $color !== 'gray',
     ]);
 
+    $iconColor ??= $color;
+
     $iconClasses = \Illuminate\Support\Arr::toCssClasses([
         'fi-dropdown-list-item-icon',
         match ($iconSize) {
@@ -53,7 +55,7 @@
             IconSize::Large, 'lg' => 'h-6 w-6',
             default => $iconSize,
         },
-        match ($iconColor ?? $color) {
+        match ($iconColor) {
             'gray' => 'text-gray-400 dark:text-gray-500',
             default => 'text-custom-500 dark:text-custom-400',
         },
@@ -61,10 +63,10 @@
 
     $iconStyles = \Illuminate\Support\Arr::toCssStyles([
         \Filament\Support\get_color_css_variables(
-            $iconColor ?? $color,
+            $iconColor,
             shades: [400, 500],
             alias: 'dropdown.list.item.icon',
-        ) => ($iconColor ?? $color) !== 'gray',
+        ) => ($iconColor) !== 'gray',
     ]);
 
     $imageClasses = 'fi-dropdown-list-item-image h-5 w-5 rounded-full bg-cover bg-center';

--- a/packages/support/resources/views/components/dropdown/list/item.blade.php
+++ b/packages/support/resources/views/components/dropdown/list/item.blade.php
@@ -11,6 +11,7 @@
     'href' => null,
     'icon' => null,
     'iconAlias' => null,
+    'iconColor' => null,
     'iconSize' => IconSize::Medium,
     'image' => null,
     'keyBindings' => null,
@@ -43,7 +44,7 @@
             alias: 'dropdown.list.item',
         ) => $color !== 'gray',
     ]);
-
+    
     $iconClasses = \Illuminate\Support\Arr::toCssClasses([
         'fi-dropdown-list-item-icon',
         match ($iconSize) {
@@ -52,7 +53,7 @@
             IconSize::Large, 'lg' => 'h-6 w-6',
             default => $iconSize,
         },
-        match ($color) {
+        match ($iconColor ?? $color) {
             'gray' => 'text-gray-400 dark:text-gray-500',
             default => 'text-custom-500 dark:text-custom-400',
         },
@@ -60,10 +61,10 @@
 
     $iconStyles = \Illuminate\Support\Arr::toCssStyles([
         \Filament\Support\get_color_css_variables(
-            $color,
+            $iconColor ?? $color,
             shades: [400, 500],
             alias: 'dropdown.list.item.icon',
-        ) => $color !== 'gray',
+        ) => ($iconColor ?? $color) !== 'gray',
     ]);
 
     $imageClasses = 'fi-dropdown-list-item-image h-5 w-5 rounded-full bg-cover bg-center';


### PR DESCRIPTION
## Description
This pull request adds a feature for independent icon coloring in the Filament Dropdown list item component, enhancing UI customization for a more aesthetically pleasing look in some cases. It decouples icon and label text colors, allowing for selective icon highlighting without affecting text color and hover state.

Left has `iconColor` set, while right has `color` set.
![305409083-f7103533-290b-4eb9-af75-4830f9868cca](https://github.com/filamentphp/filament/assets/22501510/696130d9-5699-4d2a-9c2c-81444fbda998)

## Code style

Simply add the new `iconColor` attribute to the `<x-filament::dropdown-list-item>` component.

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
