### PR TITLE
modifiable select alias for Average, Count and Sum Summerizers

### DIFF
--- a/packages/tables/src/Columns/Summarizers/Average.php
+++ b/packages/tables/src/Columns/Summarizers/Average.php
@@ -40,9 +40,10 @@ class Average extends Summarizer
         return $this->selectedState[$this->getSelectAlias()];
     }
 
-    public function selectAlias(string $alias): static
+    public function selectAlias(?string $alias): static
     {
-        $this->selectAlias  = $alias;
+        $this->selectAlias = $alias;
+
         return $this;
     }
 

--- a/packages/tables/src/Columns/Summarizers/Average.php
+++ b/packages/tables/src/Columns/Summarizers/Average.php
@@ -40,6 +40,12 @@ class Average extends Summarizer
         return $this->selectedState[$this->getSelectAlias()];
     }
 
+    public function selectAlias(string $alias): static
+    {
+        $this->selectAlias  = $alias;
+        return $this;
+    }
+
     public function getSelectAlias(): string
     {
         return $this->selectAlias ??= Str::random();

--- a/packages/tables/src/Columns/Summarizers/Count.php
+++ b/packages/tables/src/Columns/Summarizers/Count.php
@@ -75,6 +75,12 @@ class Count extends Summarizer
         return $this->selectedState[$this->getSelectAlias()];
     }
 
+    public function selectAlias(string $alias): static
+    {
+        $this->selectAlias  = $alias;
+        return $this;
+    }
+
     public function getSelectAlias(): string
     {
         return $this->selectAlias ??= Str::random();

--- a/packages/tables/src/Columns/Summarizers/Count.php
+++ b/packages/tables/src/Columns/Summarizers/Count.php
@@ -75,9 +75,10 @@ class Count extends Summarizer
         return $this->selectedState[$this->getSelectAlias()];
     }
 
-    public function selectAlias(string $alias): static
+    public function selectAlias(?string $alias): static
     {
-        $this->selectAlias  = $alias;
+        $this->selectAlias = $alias;
+
         return $this;
     }
 

--- a/packages/tables/src/Columns/Summarizers/Sum.php
+++ b/packages/tables/src/Columns/Summarizers/Sum.php
@@ -40,6 +40,12 @@ class Sum extends Summarizer
         return $this->selectedState[$this->getSelectAlias()];
     }
 
+    public function selectAlias(string $alias): static
+    {
+        $this->selectAlias  = $alias;
+        return $this;
+    }
+
     public function getSelectAlias(): string
     {
         return $this->selectAlias ??= Str::random();

--- a/packages/tables/src/Columns/Summarizers/Sum.php
+++ b/packages/tables/src/Columns/Summarizers/Sum.php
@@ -40,9 +40,10 @@ class Sum extends Summarizer
         return $this->selectedState[$this->getSelectAlias()];
     }
 
-    public function selectAlias(string $alias): static
+    public function selectAlias(?string $alias): static
     {
-        $this->selectAlias  = $alias;
+        $this->selectAlias = $alias;
+
         return $this;
     }
 


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

Added function to specify the select alias for the `Average`, `Count` and `Sum` Summerizers.

### Usecase
I want to use the summarized values in the Widgets which interacts with the table with `InteractsWithPageTable` trait. In the widget I am retrieving the summarized data using `$this->getTablePageInstance()->getTableSummarySelectedState($this->getPageTableQuery())`. Without knowing the select alias beforehand, it is impossible to reference them from the array keys

Current
<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [ x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [ x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ x] Documentation is up-to-date.
