### PR TITLE
Add separator for Dropdown Blade components

### DIFF
--- a/packages/support/docs/09-blade-components/02-dropdown.md
+++ b/packages/support/docs/09-blade-components/02-dropdown.md
@@ -117,7 +117,7 @@ You can [change the color](badge#changing-the-color-of-the-badge) of the badge u
 </x-filament::dropdown.list.item>
 ```
 
-## Addomg a separator to a dropdown list
+## Adding a separator to a dropdown list
 
 The dropdown may be positioned relative to the trigger button by using the `placement` attribute:
 

--- a/packages/support/docs/09-blade-components/02-dropdown.md
+++ b/packages/support/docs/09-blade-components/02-dropdown.md
@@ -22,6 +22,8 @@ The dropdown component allows you to render a dropdown menu with a button that t
         <x-filament::dropdown.list.item wire:click="openEditModal">
             Edit
         </x-filament::dropdown.list.item>
+
+        </x-filament::dropdown.list.separator />
         
         <x-filament::dropdown.list.item wire:click="openDeleteModal">
             Delete
@@ -115,14 +117,14 @@ You can [change the color](badge#changing-the-color-of-the-badge) of the badge u
 </x-filament::dropdown.list.item>
 ```
 
-## Setting the placement of a dropdown
+## Addomg a separator to a dropdown list
 
 The dropdown may be positioned relative to the trigger button by using the `placement` attribute:
 
 ```blade
-<x-filament::dropdown placement="top-start">
-    {{-- Dropdown items --}}
-</x-filament::dropdown>
+<x-filament::dropdown.list>
+    </x-filament::dropdown.list.separator />
+</x-filament::dropdown.list>
 ```
 
 ## Setting the width of a dropdown

--- a/packages/support/resources/views/components/dropdown/list/separator.blade.php
+++ b/packages/support/resources/views/components/dropdown/list/separator.blade.php
@@ -1,0 +1,4 @@
+<div
+    aria-hidden="true"
+    {{ $attributes->class(['-mx-1 my-1 border-t border-gray-950/5 dark:border-white/10']) }}
+></div>


### PR DESCRIPTION
## Description

This pull request introduces a new separator component designed for use within Filament's Blade Dropdown component. This component provides a visual distinction between groups of options or individual items, enhancing the organizational structure and readability of dropdown menus.

![screenshot-001249 (2024-02-16)@2x](https://github.com/filamentphp/filament/assets/22501510/882a795f-879e-4d26-ad9a-171c46d33072)

## Code style

Simply add `<x-filament::dropdown-list.separator />` to add the separator.

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
