### PR TITLE
add default placeholder for select and input fields depending on the Field Label 

### DIFF
--- a/packages/forms/resources/lang/en/components.php
+++ b/packages/forms/resources/lang/en/components.php
@@ -413,6 +413,8 @@ return [
 
         'search_prompt' => 'Start typing to search...',
 
+        'select'=>'Select'
+
     ],
 
     'tags_input' => [
@@ -432,6 +434,8 @@ return [
             ],
 
         ],
+
+        'enter'=>'Enter'
 
     ],
 

--- a/packages/forms/src/Components/Concerns/HasPlaceholder.php
+++ b/packages/forms/src/Components/Concerns/HasPlaceholder.php
@@ -17,6 +17,6 @@ trait HasPlaceholder
 
     public function getPlaceholder(): ?string
     {
-        return $this->evaluate($this->placeholder);
+        return $this->placeholder?$this->evaluate($this->placeholder):__('filament-forms::components.text_input.enter') .' '.$this->getLabel();
     }
 }

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -188,7 +188,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
                 ->all();
         });
 
-        $this->placeholder(static fn (Select $component): ?string => $component->isDisabled() ? null : __('filament-forms::components.select.placeholder'));
+        $this->placeholder(static fn (Select $component): ?string => $component->isDisabled() ? null : __('filament-forms::components.select.select').' '.$component->getLabel());
 
         $this->suffixActions([
             static fn (Select $component): ?Action => $component->getCreateOptionAction(),


### PR DESCRIPTION
…label
   add  default placeholder for Select and Input fields depending on the field label
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description
All text fields will be filled with this placeholder: Enter {field label} => Field label name ---> Placeholder: Enter Name.
And all select fields will be filled with a placeholder like this: Select {field label} => Field label country---> Placeholder: Select Country.

