### PR TITLE
UI: Repeater and Builder header contrast on light mode

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -90,7 +90,7 @@
                         x-on:builder-collapse.window="$event.detail === '{{ $statePath }}' && (isCollapsed = true)"
                         x-on:expand="isCollapsed = false"
                         x-sortable-item="{{ $uuid }}"
-                        class="fi-fo-builder-item rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-white/5 dark:ring-white/10"
+                        class="fi-fo-builder-item rounded-xl bg-gray-50 shadow-sm ring-1 ring-gray-950/5 dark:bg-white/5 dark:ring-white/10"
                         x-bind:class="{ 'fi-collapsed overflow-hidden': isCollapsed }"
                     >
                         @if ($isReorderableWithDragAndDrop || $isReorderableWithButtons || $hasBlockLabels || $isCloneable || $isDeletable || $isCollapsible || count($visibleExtraItemActions))

--- a/packages/forms/resources/views/components/repeater/index.blade.php
+++ b/packages/forms/resources/views/components/repeater/index.blade.php
@@ -90,7 +90,7 @@
                             x-on:repeater-expand.window="$event.detail === '{{ $statePath }}' && (isCollapsed = false)"
                             x-on:repeater-collapse.window="$event.detail === '{{ $statePath }}' && (isCollapsed = true)"
                             x-sortable-item="{{ $uuid }}"
-                            class="fi-fo-repeater-item rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-white/5 dark:ring-white/10"
+                            class="fi-fo-repeater-item rounded-xl bg-gray-50 shadow-sm ring-1 ring-gray-950/5 dark:bg-white/5 dark:ring-white/10"
                             x-bind:class="{ 'fi-collapsed overflow-hidden': isCollapsed }"
                         >
                             @if ($isReorderableWithDragAndDrop || $isReorderableWithButtons || filled($itemLabel) || $isCloneable || $isDeletable || $isCollapsible || count($visibleExtraItemActions))


### PR DESCRIPTION
Repeater and Builder items have a good contrast in dark mode, however in light mode, it has the same background as the container.


### Before

<table>
  <tr>
    <th>Light</th>
    <th>Dark</th>
  </tr>
  <tr>
    <td>
<img width="701" alt="Screenshot 2024-02-16 at 21 42 35" src="https://github.com/filamentphp/filament/assets/14329460/4a8fa7e8-38ea-4dc0-82b4-30919ebeb14c">
    </td>
    <td>       
<img width="699" alt="Screenshot 2024-02-16 at 21 42 52" src="https://github.com/filamentphp/filament/assets/14329460/f5834a8f-fd74-45be-a2fd-8d4a1e71d6af">
    </td>
  </tr>
</table>

### After
<img width="701" alt="Screenshot 2024-02-16 at 21 45 51" src="https://github.com/filamentphp/filament/assets/14329460/ee032891-20a6-49fd-baf3-b2302a1900fc">