### PR TITLE
Fix no sorting in ColumnGroup

### DIFF
--- a/packages/tables/src/Columns/ColumnGroup.php
+++ b/packages/tables/src/Columns/ColumnGroup.php
@@ -78,7 +78,7 @@ class ColumnGroup extends Component
     }
 
     /**
-     * @return array<Column>
+     * @return array<string, Column>
      */
     public function getColumns(): array
     {
@@ -90,7 +90,7 @@ class ColumnGroup extends Component
     }
 
     /**
-     * @return array<Column>
+     * @return array<string, Column>
      */
     public function getVisibleColumns(): array
     {

--- a/packages/tables/src/Columns/ColumnGroup.php
+++ b/packages/tables/src/Columns/ColumnGroup.php
@@ -82,9 +82,11 @@ class ColumnGroup extends Component
      */
     public function getColumns(): array
     {
-        return array_map(function (Column $column): Column {
-            return $column->group($this);
-        }, $this->evaluate($this->columns) ?? []);
+        return array_reduce($this->evaluate($this->columns) ?? [], function (array $result, Column $column): array {
+            $result[$column->getName()] = $column->group($this);
+
+            return $result;
+        }, []);
     }
 
     /**


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

- It wasn't possible to sort the columns, if the columns were in a ColumnGroup. The getColumns() method should return an associative array, instead of a numeric array.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
