### PR TITLE
Truncate section description when it's too long

### DIFF
--- a/packages/support/resources/views/components/section/description.blade.php
+++ b/packages/support/resources/views/components/section/description.blade.php
@@ -1,5 +1,5 @@
 <p
-    {{ $attributes->class(['fi-section-header-description text-sm text-gray-500 dark:text-gray-400']) }}
+    {{ $attributes->class(['fi-section-header-description text-sm text-gray-500 dark:text-gray-400 truncate']) }}
 >
     {{ $slot }}
 </p>


### PR DESCRIPTION
## Description

I've had a few cases where the description text of a section has overflowed and caused UI issues.

In my past experience, I've never had an issue truncating text by default and I can't imagine a case where truncating the description text here isn't preferred as the default.

| Before | After |
|---|---|
| ![before](https://github.com/filamentphp/filament/assets/6931029/93178e5d-5660-4544-8aa1-8bba2602151b) | ![after](https://github.com/filamentphp/filament/assets/6931029/17a02171-6c2e-43aa-8e75-29b77ab294a0) |

## Testing

- [x] Tested with/without `->headerActions([])`.
- [x] Tested with/without `->compact()`.
- [x] Tested with/without `->collapsed()`.

## Documentation

- [x] No changes needed.
