### PR TITLE
make Js asset when a .js file is passed to $panel->viteTheme()

### DIFF
--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -17,6 +17,7 @@ use Filament\Models\Contracts\HasTenants;
 use Filament\Navigation\MenuItem;
 use Filament\Navigation\NavigationGroup;
 use Filament\Navigation\NavigationItem;
+use Filament\Support\Assets\Js;
 use Filament\Support\Assets\Theme;
 use Filament\Support\Enums\MaxWidth;
 use Filament\Support\Facades\FilamentAsset;
@@ -425,7 +426,7 @@ class FilamentManager
         return $this->getCurrentPanel()->getTenantRegistrationUrl($parameters);
     }
 
-    public function getTheme(): Theme
+    public function getTheme(): Theme | Js
     {
         return $this->getCurrentPanel()->getTheme();
     }


### PR DESCRIPTION
## Explanation of Issue
When using a custom theme with a js file that imports the css file, running `npm run dev` will import the js file as a `link` tag instead of a `script` tag. This causes the browser to display `" rel="stylesheet" data-navigate-track />` at the top of the body.

![1](https://github.com/filamentphp/filament/assets/6693616/42b56b17-a1f4-4897-bfcb-b51cbcc491a0)

I believe importing css via js is a valid use case because the Laravel documentation states that you can import CSS via JavaScript using only the JavaScript entry point in the `vite.config.js` file. https://laravel.com/docs/10.x/vite#loading-your-scripts-and-styles

## Expected Behavior
The js file should be imported as a `script` tag.

## Actual Behavior
The js file is imported as a `link` tag.

## TL;DR Reproduction Steps
Install Filament in a fresh Laravel project, create a custom theme, add a theme.js file next to the css file, import the css file in the js file, set the js file in the vite + panel config, run `npm run dev`, login to panel to see error.

## Full Reproduction Steps (with commit links)
- [Install Fresh Laravel](https://github.com/JoshTrebilco/filament-js-theme/commit/0ad4af94200ceddbf020e10cd916bce4a345074a)
  - `laravel new "project-name"`
- Run migrations
  - `php artisan migrate:fresh`
- Require Filament
  - `composer require filament/filament:"^3.2" -W`
- [Install Filament](https://github.com/JoshTrebilco/filament-js-theme/commit/853f4a5d073798db4e2d71b0f974ebd83ed628bb)
  - `php artisan filament:install --panels`
  - accept all defaults
- Create a user
  - `php artisan make:filament-user`
- [Create a custom theme](https://github.com/JoshTrebilco/filament-js-theme/commit/bf551b597590c2b4ec53496a7f2e25b1c277272e)
  - `php artisan make:filament-theme`
- [Configure Theme](https://github.com/JoshTrebilco/filament-js-theme/commit/fc2c27adbf6daf061fb8cda2612666af414d3435)
  - add `theme.css` to `vite.config.js` and `AdminPanelProvider.php`
- [Create `theme.js` file that imports the css file
](https://github.com/JoshTrebilco/filament-js-theme/commit/8f97cbfd8ec92a538cbf9df8d82fd7855b7c8cdb)
  - `import './app.css';`
- [Replace `theme.css` with `theme.js` in `vite.config.js` and `AdminPanelProvider.php`](https://github.com/JoshTrebilco/filament-js-theme/commit/e84b73c1e4d5542f05bf0d02ecad7a6f20b9451d)
- Run `npm run dev`
- Login to panel to see error
  - `npm run dev` imports the js file as a `link` tag instead of a `script` tag. This causes the browser to display `" rel="stylesheet" data-navigate-track />` at the top of the body.

## Screenshots
![1](https://github.com/filamentphp/filament/assets/6693616/7bb5986a-2ab0-43b7-8fca-3c25bd5870ef)
![2](https://github.com/filamentphp/filament/assets/6693616/6f22f157-13df-429a-9ea6-05310aaa38e0)


## Proposed Solution
This PR fixes the issue by adding a check to see if the theme file is a js file and if it is, it will import it as a `script` tag. If it is not a js file, it will default to importing it as a `link` tag.

The PR is a fairly naive approach to solving the issue. When calling `->viteTheme()` it simply gets the file extension from the first file in the theme array using the `pathinfo()` php function, and then makes and returns an instance of `Filament\Support\Assets\Js` instead of `Filament\Support\Assets\Theme` if the file extension is `js`.

The existing functionality of importing a theme with a css entry point still works as expected.

## Proposed Solution Screenshots
![3](https://github.com/filamentphp/filament/assets/6693616/e582c55e-b27b-4042-a3e7-c2aef92f5f4b)
![4](https://github.com/filamentphp/filament/assets/6693616/0ac191b2-187a-45fe-946a-df7389d029af)
![5](https://github.com/filamentphp/filament/assets/6693616/2eb24326-7010-4603-a242-010f374598ab)

