### PR TITLE
Fix importer: do not fill unmapped columns

### DIFF
--- a/packages/actions/src/Imports/Importer.php
+++ b/packages/actions/src/Imports/Importer.php
@@ -191,6 +191,10 @@ abstract class Importer
                 continue;
             }
 
+            if (array_key_exists($columnName, $this->columnMap) && blank($this->columnMap[$columnName])) {
+                continue;
+            }
+
             $state = $this->data[$columnName];
 
             if (blank($state) && $column->isBlankStateIgnored()) {

--- a/packages/actions/src/Imports/Importer.php
+++ b/packages/actions/src/Imports/Importer.php
@@ -80,7 +80,12 @@ abstract class Importer
 
         foreach ($this->getCachedColumns() as $column) {
             $columnName = $column->getName();
-            $rowColumnName = $this->columnMap[$columnName] ?? null;
+            
+            if (blank($this->columnMap[$columnName] ?? null)) {
+                continue;
+            }
+
+            $rowColumnName = $this->columnMap[$columnName];
 
             if (! array_key_exists($rowColumnName, $this->data)) {
                 continue;
@@ -141,6 +146,10 @@ abstract class Importer
         foreach ($this->getCachedColumns() as $column) {
             $columnName = $column->getName();
 
+            if (blank($this->columnMap[$columnName] ?? null)) {
+                continue;
+            }
+
             $rules[$columnName] = $column->getDataValidationRules();
 
             if (
@@ -170,13 +179,19 @@ abstract class Importer
         $attributes = [];
 
         foreach ($this->getCachedColumns() as $column) {
+            $columnName = $column->getName();
+
+            if (blank($this->columnMap[$columnName] ?? null)) {
+                continue;
+            }
+
             $validationAttribute = $column->getValidationAttribute();
 
             if (blank($validationAttribute)) {
                 continue;
             }
 
-            $attributes[$column->getName()] = $validationAttribute;
+            $attributes[$columnName] = $validationAttribute;
         }
 
         return $attributes;
@@ -187,11 +202,11 @@ abstract class Importer
         foreach ($this->getCachedColumns() as $column) {
             $columnName = $column->getName();
 
-            if (! array_key_exists($columnName, $this->data)) {
+            if (blank($this->columnMap[$columnName] ?? null)) {
                 continue;
             }
 
-            if (blank($this->columnMap[$columnName] ?? null)) {
+            if (! array_key_exists($columnName, $this->data)) {
                 continue;
             }
 

--- a/packages/actions/src/Imports/Importer.php
+++ b/packages/actions/src/Imports/Importer.php
@@ -191,7 +191,7 @@ abstract class Importer
                 continue;
             }
 
-            if (array_key_exists($columnName, $this->columnMap) && blank($this->columnMap[$columnName])) {
+            if (blank($this->columnMap[$columnName] ?? null)) {
                 continue;
             }
 


### PR DESCRIPTION
When the column map value of a given column name is `NULL`; it means we do not want to call the `fillRecord` method.

<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
