### PR TITLE
Fix beforeFill() hook in EditRecord.php

### DIFF
--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -82,22 +82,23 @@ class EditRecord extends Page
 
     protected function fillForm(): void
     {
-        $this->callHook('beforeFill');
-        
-        $data = $this->getRecord()->attributesToArray();
-
         /** @internal Read the DocBlock above the following method. */
-        $this->fillFormWithDataAndCallHooks($data);
+        $this->fillFormWithDataAndCallHooks($this->getRecord());
     }
 
     /**
      * @internal Never override or call this method. If you completely override `fillForm()`, copy the contents of this method into your override.
      *
-     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $extraData
      */
-    protected function fillFormWithDataAndCallHooks(array $data): void
+    protected function fillFormWithDataAndCallHooks(Model $record, array $extraData = []): void
     {
-        $data = $this->mutateFormDataBeforeFill($data);
+        $this->callHook('beforeFill');
+
+        $data = $this->mutateFormDataBeforeFill([
+            ...$record->attributesToArray(),
+            ...$extraData,
+        ]);
 
         $this->form->fill($data);
 

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -82,6 +82,8 @@ class EditRecord extends Page
 
     protected function fillForm(): void
     {
+        $this->callHook('beforeFill');
+        
         $data = $this->getRecord()->attributesToArray();
 
         /** @internal Read the DocBlock above the following method. */
@@ -95,8 +97,6 @@ class EditRecord extends Page
      */
     protected function fillFormWithDataAndCallHooks(array $data): void
     {
-        $this->callHook('beforeFill');
-
         $data = $this->mutateFormDataBeforeFill($data);
 
         $this->form->fill($data);

--- a/packages/panels/src/Resources/Pages/ViewRecord.php
+++ b/packages/panels/src/Resources/Pages/ViewRecord.php
@@ -13,6 +13,7 @@ use Filament\Infolists\Infolist;
 use Filament\Pages\Concerns\InteractsWithFormActions;
 use Filament\Support\Facades\FilamentIcon;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 
 /**
@@ -76,22 +77,23 @@ class ViewRecord extends Page
 
     protected function fillForm(): void
     {
-        $data = $this->getRecord()->attributesToArray();
-
         /** @internal Read the DocBlock above the following method. */
-        $this->fillFormWithDataAndCallHooks($data);
+        $this->fillFormWithDataAndCallHooks($this->getRecord());
     }
 
     /**
      * @internal Never override or call this method. If you completely override `fillForm()`, copy the contents of this method into your override.
      *
-     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $extraData
      */
-    protected function fillFormWithDataAndCallHooks(array $data): void
+    protected function fillFormWithDataAndCallHooks(Model $record, array $extraData = []): void
     {
         $this->callHook('beforeFill');
 
-        $data = $this->mutateFormDataBeforeFill($data);
+        $data = $this->mutateFormDataBeforeFill([
+            ...$record->attributesToArray(),
+            ...$extraData,
+        ]);
 
         $this->form->fill($data);
 

--- a/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/Concerns/HasTranslatableFormWithExistingRecordData.php
+++ b/packages/spatie-laravel-translatable-plugin/src/Resources/Pages/Concerns/HasTranslatableFormWithExistingRecordData.php
@@ -30,10 +30,7 @@ trait HasTranslatableFormWithExistingRecordData
             }
 
             /** @internal Read the DocBlock above the following method. */
-            $this->fillFormWithDataAndCallHooks([
-                ...$record->attributesToArray(),
-                ...$translatedData,
-            ]);
+            $this->fillFormWithDataAndCallHooks($record, $translatedData);
         }
     }
 


### PR DESCRIPTION
## Description

Before this PR, the beforeFill() hook is called in fillFormWithDataAndCallHooks(). This causes a problem if you consider this situation in your EditResource

```php
public function beforeFill(): void
    {
        // i recall this used to work in v2 but doesn't work in v3 now
       // that i can make visible here since here is admin, but other places i still want it to be in $hidden
        $this->record->makeVisible(['some_sensitive_field_in_my_model_$hidden']);
    }
```

As you may have guessed, when the Edit Resource form gets filled, that field will still not get filled because of the following:

```php
public function mount(int | string $record): void
    {
        $this->record = $this->resolveRecord($record);

        $this->authorizeAccess();

        $this->fillForm();

        $this->previousUrl = url()->previous();
    }

protected function fillForm(): void
    {
        $data = $this->getRecord()->attributesToArray();

        /** @internal Read the DocBlock above the following method. */
        $this->fillFormWithDataAndCallHooks($data);
    }

protected function fillFormWithDataAndCallHooks(array $data): void
    {
        $this->callHook('beforeFill');
        
        $data = $this->mutateFormDataBeforeFill($data);

        $this->form->fill($data);

        $this->callHook('afterFill');
    }
```

From here you can see that if `beforeFill()` is inside `fillFormWithDataAndCallHooks()`, `$this->record->makeVisible(['...']);` will not work because the $data is from the earlier `fillForm()` method that calls 

```php
$data = $this->getRecord()->attributesToArray();
```

So in order for `$this->record->makeVisible(['...']);` to work in beforeFill(), beforeFill() hook has to be before `$data = $this->getRecord()->attributesToArray();`


I understand that alternatively you can do this too (I only just realised this after writing the whole PR description)

```php
public function mutateFormDataBeforeFill(array $data): array
    {
        $data['the_hidden_field'] = $this->record->the_hidden_field;

        return $data;
    }
```

But it still make more sense to me that `beforeFill()` hook should be before `fillForm()` method. But feel free to close it if you think I should definitely just use `mutateFormDataBeforeFill()`

## Code style

- [x] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.
