### PR TITLE
Fix download exports and failed row imports as non-default auth guard

### DIFF
--- a/packages/actions/routes/web.php
+++ b/packages/actions/routes/web.php
@@ -2,12 +2,20 @@
 
 use Filament\Actions\Exports\Http\Controllers\DownloadExport;
 use Filament\Actions\Imports\Http\Controllers\DownloadImportFailureCsv;
+use Filament\Facades\Filament;
+use Filament\Panel;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Route;
+
+$guards = Collection::make(Filament::getPanels())
+    ->map(static fn (Panel $panel): string => $panel->getAuthGuard())
+    ->unique()
+    ->implode(',');
 
 Route::get('/filament/exports/{export}/download', DownloadExport::class)
     ->name('filament.exports.download')
-    ->middleware(['web', 'auth']);
+    ->middleware(['web', "auth:$guards"]);
 
 Route::get('/filament/imports/{import}/failed-rows/download', DownloadImportFailureCsv::class)
     ->name('filament.imports.failed-rows.download')
-    ->middleware(['web', 'auth']);
+    ->middleware(['web', "auth:$guards"]);


### PR DESCRIPTION
Currently, I have multiple panels (3 in total) that use different auth guards because they are all associated with different models. They all make use of Filament's export and import functionality. Presently, only the default auth guard allows downloads of exports and handling of failed row imports.

This pull request's code gathers all Filament panels, retrieves their associated auth guards, and passes them as arguments to the auth middleware. This change will enable users authenticated with non-default auth guards to download exports and handle failed row imports.

<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
