### PR TITLE
Group download middlewares within a filament.actions middleware group

### DIFF
--- a/packages/actions/routes/web.php
+++ b/packages/actions/routes/web.php
@@ -6,8 +6,8 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/filament/exports/{export}/download', DownloadExport::class)
     ->name('filament.exports.download')
-    ->middleware(['web', 'auth']);
+    ->middleware('filament.actions');
 
 Route::get('/filament/imports/{import}/failed-rows/download', DownloadImportFailureCsv::class)
     ->name('filament.imports.failed-rows.download')
-    ->middleware(['web', 'auth']);
+    ->middleware('filament.actions');

--- a/packages/actions/src/ActionsServiceProvider.php
+++ b/packages/actions/src/ActionsServiceProvider.php
@@ -4,6 +4,7 @@ namespace Filament\Actions;
 
 use Filament\Actions\Testing\TestsActions;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Routing\Router;
 use Livewire\Features\SupportTesting\Testable;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -23,6 +24,11 @@ class ActionsServiceProvider extends PackageServiceProvider
             ->hasRoute('web')
             ->hasTranslations()
             ->hasViews();
+    }
+
+    public function packageRegistered(): void
+    {
+        app(Router::class)->middlewareGroup('filament.actions', ['web', 'auth']);
     }
 
     public function packageBooted(): void


### PR DESCRIPTION
## Description

See proposed preliminary work for downloading exports as an authorized non-default auth guard user here: https://github.com/filamentphp/filament/pull/11471#issuecomment-1956999171

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.

## Documentation

- [x] Documentation is up-to-date.
