### PR TITLE
Fix table overflow issue

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -273,7 +273,7 @@
                 wire:poll.{{ $pollingInterval }}
             @endif
             @class([
-                'fi-ta-content divide-y divide-gray-200 overflow-x-auto dark:divide-white/10 dark:border-t-white/10',
+                'fi-ta-content relative divide-y divide-gray-200 overflow-x-auto dark:divide-white/10 dark:border-t-white/10',
                 '!border-t-0' => ! $hasHeader,
             ])
         >


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

Fix the table overflow issue by adding the `relative` class to the table content wrapper.
Fixes #11146.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

|Before|After|
|-------|------|
|<img width="684" alt="Screenshot 2024-02-22 160503" src="https://github.com/filamentphp/filament/assets/6522402/22b1e753-b6c2-4ec0-90af-df2e4a39d81e">|<img width="684" alt="Screenshot 2024-02-22 160356" src="https://github.com/filamentphp/filament/assets/6522402/077da4c4-c7a9-4969-a5c0-fd9984d2ff97">|

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

Tested manually on the [issue reproduction repository](https://github.com/magarciasantos/filament-table-overflow-bug.git) and my own project where I experienced the issue. I tested resource list pages and pages with relation managers tables and both worked as expected. I also checked that row action/menu popovers still functioned correctly.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.

No documentation changes required.
