### PR TITLE
Fix: default theme mode not respected for pages before login

### DIFF
--- a/packages/panels/resources/js/index.js
+++ b/packages/panels/resources/js/index.js
@@ -37,7 +37,11 @@ document.addEventListener('alpine:init', () => {
         },
     })
 
-    const theme = localStorage.getItem('theme') ?? 'system'
+    const theme =
+        localStorage.getItem('theme') ??
+        getComputedStyle(document.documentElement).getPropertyValue(
+            '--default-theme-mode',
+        )
 
     window.Alpine.store(
         'theme',

--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -59,6 +59,7 @@
                 --font-family: '{!! filament()->getFontFamily() !!}';
                 --sidebar-width: {{ filament()->getSidebarWidth() }};
                 --collapsed-sidebar-width: {{ filament()->getCollapsedSidebarWidth() }};
+                --default-theme-mode: {{ filament()->getDefaultThemeMode()->value }};
             }
         </style>
 


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

when `->defaultThemeMode(\Filament\Enums\ThemeMode::Light)` is configured, it is expected throughout the panel it will be using light mode. Currently the default value is only set to after login (localStorage set in theme-switcher/index.blade)

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

Steps to test before this change:
1. configure panel->defaultThemeMode(...) to opposite of your system mode. Eg: system=dark panelDefault=light
2. logout from panel
3. clear localStorage.theme
4. refresh

After:
1. logout and clear localStorage.theme
2. configure panel->defaultThemeMode(...)
3. refresh
4. it will always use panel default theme mode

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
