### PR TITLE
fix: update pgsql generate_search_column_expression

### DIFF
--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -167,8 +167,15 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
     {
         $driverName = $databaseConnection->getDriverName();
 
+        if (Str::lower($column) !== $column) {
+            $column = match ($driverName) {
+                'pgsql' => (string) str($column)->wrap('"'),
+                default => $column,
+            };
+        }
+
         $column = match ($driverName) {
-            'pgsql' => "\"{$column}\"::text",
+            'pgsql' => "{$column}::text",
             default => $column,
         };
 

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -167,14 +167,14 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
     {
         $driverName = $databaseConnection->getDriverName();
 
-        $column = match ($driverName) {
-            'pgsql' => "\"{$column}\"::text",
-            default => $column,
-        };
-
         $isSearchForcedCaseInsensitive ??= match ($driverName) {
             'pgsql' => true,
             default => str($column)->contains('json_extract('),
+        };
+
+        $column = match ($driverName) {
+            'pgsql' => $isSearchForcedCaseInsensitive ? "\"{$column}\"::text" : "{$column}::text",
+            default => $column,
         };
 
         if ($isSearchForcedCaseInsensitive) {

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -168,7 +168,7 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
         $driverName = $databaseConnection->getDriverName();
 
         $column = match ($driverName) {
-            'pgsql' => "{$column}::text",
+            'pgsql' => "\"{$column}\"::text",
             default => $column,
         };
 

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/Operators/IsFilledOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/Operators/IsFilledOperator.php
@@ -5,6 +5,7 @@ namespace Filament\Tables\Filters\QueryBuilder\Constraints\Operators;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
+use Illuminate\Support\Str;
 
 class IsFilledOperator extends Operator
 {
@@ -39,7 +40,13 @@ class IsFilledOperator extends Operator
         /** @var Connection $databaseConnection */
         $databaseConnection = $query->getConnection();
 
-        if ($databaseConnection->getDriverName() === 'pgsql') {
+        $isPostgres = $databaseConnection->getDriverName() === 'pgsql';
+
+        if ((Str::lower($qualifiedColumn) !== $qualifiedColumn) && $isPostgres) {
+            $qualifiedColumn = (string) str($qualifiedColumn)->wrap('"');
+        }
+
+        if ($isPostgres) {
             $qualifiedStringColumn = new Expression("{$qualifiedColumn}::text");
         }
 

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/ContainsOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/ContainsOperator.php
@@ -59,7 +59,13 @@ class ContainsOperator extends Operator
         /** @var Connection $databaseConnection */
         $databaseConnection = $query->getConnection();
 
-        if ($databaseConnection->getDriverName() === 'pgsql') {
+        $isPostgres = $databaseConnection->getDriverName() === 'pgsql';
+
+        if ((Str::lower($qualifiedColumn) !== $qualifiedColumn) && $isPostgres) {
+            $qualifiedColumn = (string) str($qualifiedColumn)->wrap('"');
+        }
+
+        if ($isPostgres) {
             $qualifiedColumn = new Expression("lower({$qualifiedColumn}::text)");
             $text = Str::lower($text);
         }

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EndsWithOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EndsWithOperator.php
@@ -59,7 +59,13 @@ class EndsWithOperator extends Operator
         /** @var Connection $databaseConnection */
         $databaseConnection = $query->getConnection();
 
-        if ($databaseConnection->getDriverName() === 'pgsql') {
+        $isPostgres = $databaseConnection->getDriverName() === 'pgsql';
+
+        if ((Str::lower($qualifiedColumn) !== $qualifiedColumn) && $isPostgres) {
+            $qualifiedColumn = (string) str($qualifiedColumn)->wrap('"');
+        }
+
+        if ($isPostgres) {
             $qualifiedColumn = new Expression("lower({$qualifiedColumn}::text)");
             $text = Str::lower($text);
         }

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EqualsOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EqualsOperator.php
@@ -59,7 +59,13 @@ class EqualsOperator extends Operator
         /** @var Connection $databaseConnection */
         $databaseConnection = $query->getConnection();
 
-        if ($databaseConnection->getDriverName() === 'pgsql') {
+        $isPostgres = $databaseConnection->getDriverName() === 'pgsql';
+
+        if ((Str::lower($qualifiedColumn) !== $qualifiedColumn) && $isPostgres) {
+            $qualifiedColumn = (string) str($qualifiedColumn)->wrap('"');
+        }
+
+        if ($isPostgres) {
             $qualifiedColumn = new Expression("lower({$qualifiedColumn}::text)");
             $text = Str::lower($text);
         }

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/StartsWithOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/StartsWithOperator.php
@@ -59,7 +59,13 @@ class StartsWithOperator extends Operator
         /** @var Connection $databaseConnection */
         $databaseConnection = $query->getConnection();
 
-        if ($databaseConnection->getDriverName() === 'pgsql') {
+        $isPostgres = $databaseConnection->getDriverName() === 'pgsql';
+
+        if ((Str::lower($qualifiedColumn) !== $qualifiedColumn) && $isPostgres) {
+            $qualifiedColumn = (string) str($qualifiedColumn)->wrap('"');
+        }
+
+        if ($isPostgres) {
             $qualifiedColumn = new Expression("lower({$qualifiedColumn}::text)");
             $text = Str::lower($text);
         }


### PR DESCRIPTION


## Description

PostgreSQL column names are case sensitive, and need to be quoted for certain behaviours.  The searchable() functionality currently handles case-sensitivity in the column's *value*, but not case-sensitivity in the column's name.

Most of the regular type query behaviour already quote column names, but the 'generate_search_column_expression' method does not.

If you've created mixed-case names via a migration file, the field will be created with surrounding double-quote marks

```php
$table->string('MixedCase')->nullable();
```

will create a postgres field name of "MixedCase" not MixedCase.

Regular Eloquent usage typically quotes the column name

```php
$c = Company::where('MixedCase', "dave")->get()
```

works fine.

The searchable method uses generate_search_column_expression which has

```php
$column = match ($driverName) {
    'pgsql' => "{$column}::text",
    default => $column,
};
```

For pgsql connections, we'd get MixedCase::text which then gets 'lower()'ed later on.  But this query breaks because MixedCase doesn't exist as a column.  "MixedCase" does.

Changing the column naming behaviour to
```php
$column = match ($driverName) {
    'pgsql' =>  "\"{$column}\"::text",
    default => $column,
};
```
addresses that.


- [X] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

No style changes.

'composer cs' shows 'command "cs" not defined.

- [ ] `composer cs` command has been run.

## Testing

Making a mixedCase-named column is now searchable, whereas before, it triggered a breaking error.

- [X] Changes have been tested.

## Documentation

No doc changes required.

- [X] Documentation is up-to-date.
