### PR TITLE
Fix form docs custom layout link

### DIFF
--- a/packages/forms/docs/04-layout/08-custom.md
+++ b/packages/forms/docs/04-layout/08-custom.md
@@ -26,7 +26,7 @@ This assumes that you have a `resources/views/filament/forms/components/wizard.b
 
 You may create your own custom component classes and views, which you can reuse across your project, and even release as a plugin to the community.
 
-> If you're just creating a simple custom component to use once, you could instead use a [view component](#view) to render any custom Blade file.
+> If you're just creating a simple custom component to use once, you could instead use a [view component](#view-components) to render any custom Blade file.
 
 To create a custom column class and view, you may use the following command:
 


### PR DESCRIPTION
## Description

This PR corrects a form documentation error where a link was pointing to the incorrect section (#view), whereas the correct section is #view-components.

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

- [ ] `composer cs` command has been run.

## Testing

- [ ] Changes have been tested.

## Documentation

- [ ] Documentation is up-to-date.
