### PR TITLE
Add troubleshooting to 'Adding a form to a Livewire component'

### DIFF
--- a/packages/forms/docs/08-adding-a-form-to-a-livewire-component.md
+++ b/packages/forms/docs/08-adding-a-form-to-a-livewire-component.md
@@ -331,3 +331,9 @@ php artisan make:livewire-form Products/CreateProduct --generate
 ```
 
 > If your table contains ENUM columns, the `doctrine/dbal` package we use is unable to scan your table and will crash. Hence, Filament is unable to generate the schema for your table if it contains an ENUM column. Read more about this issue [here](https://github.com/doctrine/dbal/issues/3819#issuecomment-573419808).
+
+## Troubleshooting
+
+### Form fields not rendering properly
+
+When adding forms to a custom Livewire component, don't forget to add `@livewireStyles` and `@livewireScripts` to your layout file as discussed in [the installation instructions](installation#configuring-your-layout).


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

This PR adds a troubleshooting section to 'Adding a form to a Livewire component' with a problem I faced recently. When installing Filament in Laravel, you usually don't have to add the `@filemanetStyle` and `@filamentScripts` to your layout, unless you add forms to your front-end application. Therefore I think it would be good to point users to the instructions once again.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
