### PR TITLE
Fixes the 'guessBelongsToRelationshipTitleColumnName' primary key logic

### DIFF
--- a/packages/support/src/Commands/Concerns/CanReadModelSchemas.php
+++ b/packages/support/src/Commands/Concerns/CanReadModelSchemas.php
@@ -107,6 +107,12 @@ trait CanReadModelSchemas
             return 'title';
         }
 
-        return $schema->getPrimaryKey()->getColumns()[0];
+        $primaryKeyColumns = $schema->getPrimaryKey()?->getColumns();
+
+        if (empty($primaryKeyColumns)) {
+            return 'id';
+        }
+
+        return $primaryKeyColumns[0];
     }
 }


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

In a certain case where the model of a `BelongsTo` relationship has neither a primary key nor a column called 'title' or 'name' it throws the following error:

`Call to a member function getColumns() on null at vendor\filament\support\src\Commands\Concerns\CanReadModelSchemas.php:110`

### How does this PR fix this issue?

When guessing the relationship column name and neither the primary key nor the columns 'name' or 'title' are present it returns 'id' instead. It also checks if the Index object returned by `getPrimaryKey()` actually has at least one column to 

### Consideration:

Since we are taking about a `BelongsTo` relationship and assuming the developer is going with Laravel's opinion on column names there should be an 'id' column on that Model.

Of course using an id, of whatever format, as title is not ideal and the developer will have to change it, but at least the command will generate the form/table etc. successfully.

## Visual Changes

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

Nothing to show since its a CLI command.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

Ran the existing tests since only one existing function was modified.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.

No changes required, since it was a simple bug fix
