### PR TITLE
Update 01-getting-started.md in Infolists

### DIFF
--- a/packages/infolists/docs/03-entries/01-getting-started.md
+++ b/packages/infolists/docs/03-entries/01-getting-started.md
@@ -10,7 +10,7 @@ Entry classes can be found in the `Filament\Infolists\Components` namespace. You
 ```php
 use Filament\Infolists\Infolist;
 
-public function infolist(Infolist $infolist): Infolist
+public static function infolist(Infolist $infolist): Infolist
 {
     return $infolist
         ->schema([


### PR DESCRIPTION
Add missing `static` keyword

## Description

The docs were missing the static keyword which would result in `Cannot make static method ... non static`


## Code style

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [ ] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
