### PR TITLE
Add action, tag and method options to MenuItem

### DIFF
--- a/packages/panels/docs/06-navigation.md
+++ b/packages/panels/docs/06-navigation.md
@@ -486,6 +486,18 @@ MenuItem::make()
     ->hidden(fn (): bool => ! auth()->user()->can('viewAny', Payment::class))
 ```
 
+### Sending a `POST` HTTP request from a user menu item
+
+You can send a `POST` HTTP request from a user menu item by passing a URL to the `postAction()` method:
+
+```php
+use Filament\Navigation\MenuItem;
+
+MenuItem::make()
+    ->label('Lock session')
+    ->postAction(fn (): string => route('lock-session'))
+```
+
 ## Disabling breadcrumbs
 
 The default layout will show breadcrumbs to indicate the location of the current page within the hierarchy of the app.

--- a/packages/panels/docs/11-tenancy.md
+++ b/packages/panels/docs/11-tenancy.md
@@ -435,6 +435,18 @@ MenuItem::make()
     ->hidden(fn (): bool => ! auth()->user()->can('manage-team'))
 ```
 
+### Sending a `POST` HTTP request from a tenant menu item
+
+You can send a `POST` HTTP request from a tenant menu item by passing a URL to the `postAction()` method:
+
+```php
+use Filament\Navigation\MenuItem;
+
+MenuItem::make()
+    ->label('Lock session')
+    ->postAction(fn (): string => route('lock-session'))
+```
+
 ### Hiding the tenant menu
 
 You can hide the tenant menu by using the `tenantMenu(false)`

--- a/packages/panels/resources/views/components/tenant-menu.blade.php
+++ b/packages/panels/resources/views/components/tenant-menu.blade.php
@@ -116,12 +116,18 @@
     @if (count($items))
         <x-filament::dropdown.list>
             @foreach ($items as $item)
+                @php
+                    $itemPostAction = $item->getPostAction();
+                @endphp
+
                 <x-filament::dropdown.list.item
+                    :action="$itemPostAction"
                     :color="$item->getColor()"
                     :href="$item->getUrl()"
-                    :target="$item->shouldOpenUrlInNewTab() ? '_blank' : null"
                     :icon="$item->getIcon()"
-                    tag="a"
+                    :method="filled($itemPostAction) ? 'post' : null"
+                    :tag="filled($itemPostAction) ? 'form' : 'a'"
+                    :target="$item->shouldOpenUrlInNewTab() ? '_blank' : null"
                 >
                     {{ $item->getLabel() }}
                 </x-filament::dropdown.list.item>

--- a/packages/panels/resources/views/components/user-menu.blade.php
+++ b/packages/panels/resources/views/components/user-menu.blade.php
@@ -68,16 +68,16 @@
     <x-filament::dropdown.list>
         @foreach ($items as $key => $item)
             @php
-                $itemAction = $item->getAction();
+                $itemPostAction = $item->getPostAction();
             @endphp
-        
+
             <x-filament::dropdown.list.item
-                :action="$itemAction"
+                :action="$itemPostAction"
                 :color="$item->getColor()"
                 :href="$item->getUrl()"
                 :icon="$item->getIcon()"
-                :method="filled($itemAction) ? 'post' : null"
-                :tag="filled($itemAction) ? 'form' : 'a'"
+                :method="filled($itemPostAction) ? 'post' : null"
+                :tag="filled($itemPostAction) ? 'form' : 'a'"
                 :target="$item->shouldOpenUrlInNewTab() ? '_blank' : null"
             >
                 {{ $item->getLabel() }}

--- a/packages/panels/resources/views/components/user-menu.blade.php
+++ b/packages/panels/resources/views/components/user-menu.blade.php
@@ -73,7 +73,6 @@
                 :href="$item->getUrl()"
                 :target="$item->shouldOpenUrlInNewTab() ? '_blank' : null"
                 :icon="$item->getIcon()"
-                tag="a"
                 :tag="$item->getTag() ?? 'a'"
                 :method="$item->getMethod() ?? null"
             >

--- a/packages/panels/resources/views/components/user-menu.blade.php
+++ b/packages/panels/resources/views/components/user-menu.blade.php
@@ -68,13 +68,13 @@
     <x-filament::dropdown.list>
         @foreach ($items as $key => $item)
             <x-filament::dropdown.list.item
+                :action="$item->getAction()"
                 :color="$item->getColor()"
-                :action="$item->getAction() ?? '#'"
                 :href="$item->getUrl()"
-                :target="$item->shouldOpenUrlInNewTab() ? '_blank' : null"
                 :icon="$item->getIcon()"
-                :tag="$item->getTag() ?? 'a'"
-                :method="$item->getMethod() ?? null"
+                :method="$item->getMethod()"
+                :tag="$item->getTag()"
+                :target="$item->shouldOpenUrlInNewTab() ? '_blank' : null"
             >
                 {{ $item->getLabel() }}
             </x-filament::dropdown.list.item>

--- a/packages/panels/resources/views/components/user-menu.blade.php
+++ b/packages/panels/resources/views/components/user-menu.blade.php
@@ -67,13 +67,17 @@
 
     <x-filament::dropdown.list>
         @foreach ($items as $key => $item)
+            @php
+                $itemAction = $item->getAction();
+            @endphp
+        
             <x-filament::dropdown.list.item
-                :action="$item->getAction()"
+                :action="$itemAction"
                 :color="$item->getColor()"
                 :href="$item->getUrl()"
                 :icon="$item->getIcon()"
-                :method="$item->getMethod()"
-                :tag="$item->getTag()"
+                :method="filled($itemAction) ? 'post' : null"
+                :tag="filled($itemAction) ? 'form' : 'a'"
                 :target="$item->shouldOpenUrlInNewTab() ? '_blank' : null"
             >
                 {{ $item->getLabel() }}

--- a/packages/panels/resources/views/components/user-menu.blade.php
+++ b/packages/panels/resources/views/components/user-menu.blade.php
@@ -69,10 +69,13 @@
         @foreach ($items as $key => $item)
             <x-filament::dropdown.list.item
                 :color="$item->getColor()"
+                :action="$item->getAction() ?? '#'"
                 :href="$item->getUrl()"
                 :target="$item->shouldOpenUrlInNewTab() ? '_blank' : null"
                 :icon="$item->getIcon()"
                 tag="a"
+                :tag="$item->getTag() ?? 'a'"
+                :method="$item->getMethod() ?? null"
             >
                 {{ $item->getLabel() }}
             </x-filament::dropdown.list.item>

--- a/packages/panels/src/Navigation/MenuItem.php
+++ b/packages/panels/src/Navigation/MenuItem.php
@@ -21,11 +21,7 @@ class MenuItem extends Component
 
     protected string | Closure | Native | null $url = null;
 
-    protected string | Closure | null $action = null;
-
-    protected string | Closure | null $tag = null;
-
-    protected string | Closure | null $method = null;
+    protected string | Closure | null $postAction = null;
 
     protected bool | Closure $shouldOpenUrlInNewTab = false;
 
@@ -84,23 +80,9 @@ class MenuItem extends Component
         return $this;
     }
 
-    public function action(string | Closure | null $action): static
+    public function postAction(?string $action): static
     {
-        $this->action = $action;
-
-        return $this;
-    }
-
-    public function tag(string | Closure | null $tag): static
-    {
-        $this->tag = $tag;
-
-        return $this;
-    }
-
-    public function method(string | Closure | null $method): static
-    {
-        $this->method = $method;
+        $this->postAction = $action;
 
         return $this;
     }
@@ -170,17 +152,17 @@ class MenuItem extends Component
 
     public function getAction(): ?string
     {
-        return $this->evaluate($this->action);
+        return $this->evaluate($this->postAction);
     }
 
     public function getTag(): string
     {
-        return $this->evaluate($this->tag) ?? 'a';
+        return filled($this->getAction()) ? 'form' : 'a';
     }
 
     public function getMethod(): ?string
     {
-        return $this->evaluate($this->method);
+        return filled($this->getAction()) ? 'post' : null;
     }
 
     public function shouldOpenUrlInNewTab(): bool

--- a/packages/panels/src/Navigation/MenuItem.php
+++ b/packages/panels/src/Navigation/MenuItem.php
@@ -21,7 +21,7 @@ class MenuItem extends Component
 
     protected string | Closure | Native | null $url = null;
 
-    protected string | Closure | null $postAction = null;
+    protected string | Closure | null $action = null;
 
     protected bool | Closure $shouldOpenUrlInNewTab = false;
 
@@ -82,7 +82,7 @@ class MenuItem extends Component
 
     public function postAction(?string $action): static
     {
-        $this->postAction = $action;
+        $this->action = $action;
 
         return $this;
     }
@@ -152,7 +152,7 @@ class MenuItem extends Component
 
     public function getAction(): ?string
     {
-        return $this->evaluate($this->postAction);
+        return $this->evaluate($this->action);
     }
 
     public function getTag(): string

--- a/packages/panels/src/Navigation/MenuItem.php
+++ b/packages/panels/src/Navigation/MenuItem.php
@@ -21,6 +21,12 @@ class MenuItem extends Component
 
     protected string | Closure | Native | null $url = null;
 
+    protected string | Closure | Native | null $action = null;
+
+    protected string | Closure | null $tag = "a";
+
+    protected string | Closure | null $method = null;
+
     protected bool | Closure $shouldOpenUrlInNewTab = false;
 
     protected bool | Closure $isHidden = false;
@@ -74,6 +80,27 @@ class MenuItem extends Component
     {
         $this->openUrlInNewTab($shouldOpenInNewTab);
         $this->url = $url;
+
+        return $this;
+    }
+
+    public function action(string | Closure | null $action): static
+    {
+        $this->action = $action;
+
+        return $this;
+    }
+
+    public function tag(string | Closure | null $tag): static
+    {
+        $this->tag = $tag;
+
+        return $this;
+    }
+
+    public function method(string | Closure | null $method): static
+    {
+        $this->method = $method;
 
         return $this;
     }
@@ -139,6 +166,21 @@ class MenuItem extends Component
     public function getUrl(): ?string
     {
         return $this->evaluate($this->url);
+    }
+
+    public function getAction(): ?string
+    {
+        return $this->evaluate($this->action);
+    }
+
+    public function getTag(): string
+    {
+        return $this->evaluate($this->tag);
+    }
+
+    public function getMethod(): ?string
+    {
+        return $this->evaluate($this->method);
     }
 
     public function shouldOpenUrlInNewTab(): bool

--- a/packages/panels/src/Navigation/MenuItem.php
+++ b/packages/panels/src/Navigation/MenuItem.php
@@ -8,6 +8,8 @@ use Laravel\SerializableClosure\Serializers\Native;
 
 class MenuItem extends Component
 {
+    protected string | Closure | null $postAction = null;
+
     /**
      * @var string | array{50: string, 100: string, 200: string, 300: string, 400: string, 500: string, 600: string, 700: string, 800: string, 900: string, 950: string} | Closure | null
      */
@@ -20,8 +22,6 @@ class MenuItem extends Component
     protected int | Closure | null $sort = null;
 
     protected string | Closure | Native | null $url = null;
-
-    protected string | Closure | null $action = null;
 
     protected bool | Closure $shouldOpenUrlInNewTab = false;
 
@@ -82,7 +82,7 @@ class MenuItem extends Component
 
     public function postAction(string | Closure | null $action): static
     {
-        $this->action = $action;
+        $this->postAction = $action;
 
         return $this;
     }
@@ -150,9 +150,9 @@ class MenuItem extends Component
         return $this->evaluate($this->url);
     }
 
-    public function getAction(): ?string
+    public function getPostAction(): ?string
     {
-        return $this->evaluate($this->action);
+        return $this->evaluate($this->postAction);
     }
 
     public function shouldOpenUrlInNewTab(): bool

--- a/packages/panels/src/Navigation/MenuItem.php
+++ b/packages/panels/src/Navigation/MenuItem.php
@@ -23,7 +23,7 @@ class MenuItem extends Component
 
     protected string | Closure | null $action = null;
 
-    protected string | Closure | null $tag = 'a';
+    protected string | Closure | null $tag = null;
 
     protected string | Closure | null $method = null;
 
@@ -175,7 +175,7 @@ class MenuItem extends Component
 
     public function getTag(): string
     {
-        return $this->evaluate($this->tag);
+        return $this->evaluate($this->tag) ?? 'a';
     }
 
     public function getMethod(): ?string

--- a/packages/panels/src/Navigation/MenuItem.php
+++ b/packages/panels/src/Navigation/MenuItem.php
@@ -80,7 +80,7 @@ class MenuItem extends Component
         return $this;
     }
 
-    public function postAction(?string $action): static
+    public function postAction(string | Closure | null $action): static
     {
         $this->action = $action;
 

--- a/packages/panels/src/Navigation/MenuItem.php
+++ b/packages/panels/src/Navigation/MenuItem.php
@@ -21,9 +21,9 @@ class MenuItem extends Component
 
     protected string | Closure | Native | null $url = null;
 
-    protected string | Closure | Native | null $action = null;
+    protected string | Closure | null $action = null;
 
-    protected string | Closure | null $tag = "a";
+    protected string | Closure | null $tag = 'a';
 
     protected string | Closure | null $method = null;
 

--- a/packages/panels/src/Navigation/MenuItem.php
+++ b/packages/panels/src/Navigation/MenuItem.php
@@ -155,16 +155,6 @@ class MenuItem extends Component
         return $this->evaluate($this->action);
     }
 
-    public function getTag(): string
-    {
-        return filled($this->getAction()) ? 'form' : 'a';
-    }
-
-    public function getMethod(): ?string
-    {
-        return filled($this->getAction()) ? 'post' : null;
-    }
-
     public function shouldOpenUrlInNewTab(): bool
     {
         return (bool) $this->evaluate($this->shouldOpenUrlInNewTab);


### PR DESCRIPTION
## Description

This pull request adds `action`, `tag` and `method` options to the `MenuItem` class. This enables to user to also add `POST` forms to user menu items - similar to the logout item in the user menu.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

- [ ] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.

## Documentation

- [x] Documentation is up-to-date.
