### PR TITLE
Fixed wrong placement of a comma in docs

### DIFF
--- a/packages/admin/docs/08-appearance.md
+++ b/packages/admin/docs/08-appearance.md
@@ -259,7 +259,7 @@ In `config/filament.php`, set the `layout.notifications.alignment` to any value 
 'layout' => [
     'notifications' => [
         'vertical_alignment' => 'top',
-        'alignment' => 'center'
+        'alignment' => 'center',
     ],
 ],
 ```

--- a/packages/admin/docs/08-appearance.md
+++ b/packages/admin/docs/08-appearance.md
@@ -258,8 +258,8 @@ In `config/filament.php`, set the `layout.notifications.alignment` to any value 
 ```php
 'layout' => [
     'notifications' => [
-        'vertical_alignment' => 'top'
-        'alignment' => 'center',
+        'vertical_alignment' => 'top',
+        'alignment' => 'center'
     ],
 ],
 ```


### PR DESCRIPTION
## Description

It fixes the wrong placement of the comma in the example of `Notification position` in `Appearance` page.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

Before:
<img width="861" alt="image" src="https://github.com/filamentphp/filament/assets/30431426/8c8cf5c8-b46e-4231-8d47-45ba45f2f55e">

After:
<img width="1033" alt="image" src="https://github.com/filamentphp/filament/assets/30431426/fdcc7256-3e3a-4d24-90c3-1c8a494f5711">


## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
