### PR TITLE
add styling to default html select

### DIFF
--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -159,6 +159,11 @@
                                 'multiple' => $isMultiple(),
                             ], escape: false)
                     }}
+                    {{
+                        $attributes->class([
+                            "w-full rounded-lg border-none bg-white/0 h-9",
+                        ])
+                    }}
                 ></select>
             </div>
         @endif

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -158,11 +158,9 @@
                                 'id' => $getId(),
                                 'multiple' => $isMultiple(),
                             ], escape: false)
-                    }}
-                    {{
-                        $attributes->class([
-                            "w-full rounded-lg border-none bg-white/0 h-9",
-                        ])
+                            ->class([
+                                "w-full rounded-lg border-none bg-transparent h-9",
+                            ])
                     }}
                 ></select>
             </div>


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

Fix for issue #11521
The select shown before the Alpine component loads isn't styled properly.

<!-- Replace this comment with your description. -->

- [X] Visual changes (if any) are shown using screenshots/recordings of before and after.

<img width="909" alt="306832743-5224dbd9-f0d7-4b38-9443-6a0ec5cd1e88" src="https://github.com/filamentphp/filament/assets/100000204/0e12b0a5-77cb-49ed-a581-594b5bfc0937">
<i>Before</i>

![image](https://github.com/filamentphp/filament/assets/100000204/afd223c1-d4c7-4ae2-bee8-12e172ca4896)
<i>After</i>

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [X] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [X] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [X] Documentation is up-to-date.
