### PR TITLE
Add size to action group

### DIFF
--- a/packages/actions/resources/views/components/group.blade.php
+++ b/packages/actions/resources/views/components/group.blade.php
@@ -106,6 +106,7 @@
                 :icon="$group->getIcon()"
                 :icon-size="$group->getIconSize()"
                 :label-sr-only="$group->isLabelHidden()"
+                :size="$group->getSize()"
                 :tooltip="$group->getTooltip()"
                 :attributes="\Filament\Support\prepare_inherited_attributes($attributes)->merge($group->getExtraAttributes(), escape: false)"
             >


### PR DESCRIPTION
Set the size of action groups to be the same size as standard actions in a table. 
<img width="132" alt="Screenshot 2024-03-01 at 08 59 47" src="https://github.com/filamentphp/filament/assets/533658/e5fcb045-9e3a-4301-9fad-ac6cbabb90e0">

With`->iconSize('sm')`  there's a 4px difference in the button size due to the button padding.
```php
Tables\Actions\ActionGroup::make([
    Tables\Actions\Action::make('test')
])
    ->button()
    ->hiddenLabel()
    ->icon('heroicon-o-link')
    ->iconSize('sm'),
Tables\Actions\Action::make('test2')
    ->button()
    ->hiddenLabel()
    ->icon('heroicon-o-check')
```


---

After adding size both buttons are the same size. 

<img width="121" alt="Screenshot 2024-03-01 at 09 02 05" src="https://github.com/filamentphp/filament/assets/533658/2c4799e9-d7b4-41db-adef-4d3b1aa79b7b">

```php
Tables\Actions\ActionGroup::make([
    Tables\Actions\Action::make('test')
])
    ->button()
    ->hiddenLabel()
    ->icon('heroicon-o-link')
    ->size('sm'),
Tables\Actions\Action::make('test2')
    ->button()
    ->hiddenLabel()
    ->icon('heroicon-o-check')
```

