### PR TITLE
Fix modal content padding

### DIFF
--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -312,8 +312,8 @@
                             @class([
                                 'fi-modal-content flex flex-col gap-y-4 py-6',
                                 'flex-1' => ($width === MaxWidth::Screen) || $slideOver,
-                                'pe-6 ps-[5.25rem]' => $hasIcon && ($alignment === Alignment::Start),
-                                'px-6' => ! ($hasIcon && ($alignment === Alignment::Start)),
+                                'pe-6 ps-[5.25rem]' => $hasIcon && ($alignment === Alignment::Start) && (! $stickyHeader),
+                                'px-6' => ! ($hasIcon && ($alignment === Alignment::Start) && (! $stickyHeader)),
                             ])
                         >
                             {{ $slot }}


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

Slide-over modals with an icon in the header and start alignment had their content indented at the inline start. This should only be the case when using a modal without a sticky header (slide-over modals have a sticky header by default).

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

### Before

<img width="575" alt="Screenshot 2024-03-01 at 11 14 40" src="https://github.com/filamentphp/filament/assets/44533235/c02e2bac-7264-4f9e-aec9-ba1d56d8abdd">

### After

<img width="575" alt="Screenshot 2024-03-01 at 11 14 07" src="https://github.com/filamentphp/filament/assets/44533235/c0187658-9356-43ca-b1e7-96b6d47cbcdd">

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
