### PR TITLE
chart.js - Cannot read properties of undefined (reading destroy) on SPA Mode

### DIFF
--- a/packages/widgets/resources/js/components/chart.js
+++ b/packages/widgets/resources/js/components/chart.js
@@ -16,6 +16,10 @@ export default function chart({ cachedData, options, type }) {
                 Alpine.store('theme')
 
                 this.$nextTick(() => {
+                    if (!this.getChart()) {
+                        return
+                    }
+
                     this.getChart().destroy()
                     this.initChart()
                 })


### PR DESCRIPTION
SPA Mode: chart.js - Cannot read properties of undefined (reading destroy) 

I have a chart widget on my dashboard page.

Whenever I visit another page after being on the dashboard and try to change the theme, it changes the theme and immediately throws an error in the console saying "cannot read properties of undefined (reading destroy) while also making the user dropdown unclickable.

Note that this issue only happens if I am using the **SPA mode**.
I have gone through the source code and I found the issue here:

file location: vendor/filament/widgets/resources/js/components/chart.js
```             
            Alpine.effect(() => {
                Alpine.store('theme')

                this.$nextTick(() => {
                    this.getChart().destroy()
                    this.initChart()
                })
            })
```
Apparently, the issue is caused because the chart property cannot be found on the other pages, so modifying the code to check if the chart property exists seems to have fixed it.
```
Alpine.effect(() => {
                Alpine.store('theme')

                this.$nextTick(() => {
                    if (!this.getChart()) {
                        return
                    }
                    this.getChart().destroy()
                    this.initChart()
                })
            })
```