### PR TITLE
Allow Laravel 11 dev version

### DIFF
--- a/packages/support/src/Commands/Concerns/CanGeneratePanels.php
+++ b/packages/support/src/Commands/Concerns/CanGeneratePanels.php
@@ -50,7 +50,7 @@ trait CanGeneratePanels
             ]);
         }
 
-        $isLaravel11OrHigherWithBootstrapProvidersFile = version_compare(App::version(), '11.0', '>=') &&
+        $isLaravel11OrHigherWithBootstrapProvidersFile = version_compare(App::version(), '11.x-dev', '>=') &&
             /** @phpstan-ignore-next-line */
             file_exists($bootstrapProvidersPath = App::getBootstrapProvidersPath());
 


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

Currently when you run ` php artisan filament:install --panels` on a Laravel 11 project, you get this

```bash
 file_get_contents(/Users/mokhosh/Sites/drbanoo/config/app.php): Failed to open stream: No such file or directory

  at vendor/filament/support/src/Commands/Concerns/CanGeneratePanels.php:65
```

This is because the code checks for the version being higher than `11.0` which is actually considered higher than `11.x-dev` by php's `version_compare` function, because according to php documentation:

> The function first replaces _, - and + with a dot . in the version strings and also inserts dots . before and after any non number so that for example '4.3.2RC1' becomes '4.3.2.RC.1'. Then it compares the parts starting from left to right. If a part contains special version strings these are handled in the following order: any string not found in this list < dev < alpha = a < beta = b < RC = rc < # < pl = p. This way not only versions with different levels like '4.1' and '4.1.2' can be compared but also any PHP specific version containing development state.

This PR compares the current version against `11.x-dev` which should have been the case to begin with.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested manually, and it works on a dev Laravel 11 app.
