### PR TITLE
Update CanFormatState.php

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -136,6 +136,7 @@ trait CanFormatState
                 return $state;
             }
 
+            $decimalPlaces = $column->evaluate($decimalPlaces);
             $decimalSeparator = $column->evaluate($decimalSeparator);
             $thousandsSeparator = $column->evaluate($thousandsSeparator);
 

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -146,7 +146,7 @@ trait CanFormatState
             ) {
                 return number_format(
                     $state,
-                    $column->evaluate($decimalPlaces),
+                    $decimalPlaces,
                     $decimalSeparator === ArgumentValue::Default ? '.' : $decimalSeparator,
                     $thousandsSeparator === ArgumentValue::Default ? ',' : $thousandsSeparator,
                 );


### PR DESCRIPTION
In this method, we can resolve the issue by using `decimalPlaces` as a closure.

Before that, to address the error "Illuminate\Support\Number::format(): Argument #2 ($precision) must be of type ?int, Closure given,"

I added an evaluation for the decimal place.

<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [ ] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
