### PR TITLE
Support `Htmlable` navigation icons

### DIFF
--- a/packages/panels/docs/03-resources/01-getting-started.md
+++ b/packages/panels/docs/03-resources/01-getting-started.md
@@ -301,7 +301,9 @@ protected static ?string $navigationIcon = 'heroicon-o-user-group';
 Alternatively, you may set a dynamic navigation icon in the `getNavigationIcon()` method:
 
 ```php
-public static function getNavigationIcon(): ?string
+use Illuminate\Contracts\Support\Htmlable;
+
+public static function getNavigationIcon(): string | Htmlable | null
 {
     return 'heroicon-o-user-group';
 }

--- a/packages/panels/resources/views/components/page/sub-navigation/tabs.blade.php
+++ b/packages/panels/resources/views/components/page/sub-navigation/tabs.blade.php
@@ -24,18 +24,25 @@
                 <x-filament::dropdown.list>
                     @foreach ($navigationGroup->getItems() as $navigationItem)
                         @php
-                            $icon = $navigationItem->getIcon();
+                            $navigationItemIcon = $navigationItem->getIcon();
+                            $navigationItemIcon = $navigationItem->isActive() ? ($navigationItem->getActiveIcon() ?? $navigationItemIcon) : $navigationItemIcon;
                         @endphp
 
                         <x-filament::dropdown.list.item
                             :badge="$navigationItem->getBadge()"
                             :badge-color="$navigationItem->getBadgeColor()"
                             :href="$navigationItem->getUrl()"
-                            :icon="$navigationItem->isActive() ? ($navigationItem->getActiveIcon() ?? $icon) : $icon"
+                            :icon="$navigationItemIcon"
                             tag="a"
                             :target="$navigationItem->shouldOpenUrlInNewTab() ? '_blank' : null"
                         >
                             {{ $navigationItem->getLabel() }}
+
+                            @if ($navigationItemIcon instanceof \Illuminate\Contracts\Support\Htmlable)
+                                <x-slot name="icon">
+                                    {{ $navigationItemIcon }}
+                                </x-slot>
+                            @endif
                         </x-filament::dropdown.list.item>
                     @endforeach
                 </x-filament::dropdown.list>
@@ -43,7 +50,8 @@
         @else
             @foreach ($navigationGroup->getItems() as $navigationItem)
                 @php
-                    $icon = $navigationItem->getIcon();
+                    $navigationItemIcon = $navigationItem->getIcon();
+                    $navigationItemIcon = $navigationItem->isActive() ? ($navigationItem->getActiveIcon() ?? $navigationItemIcon) : $navigationItemIcon;
                 @endphp
 
                 <x-filament::tabs.item
@@ -51,11 +59,17 @@
                     :badge="$navigationItem->getBadge()"
                     :badge-color="$navigationItem->getBadgeColor()"
                     :href="$navigationItem->getUrl()"
-                    :icon="$navigationItem->isActive() ? ($navigationItem->getActiveIcon() ?? $icon) : $icon"
+                    :icon="$navigationItemIcon"
                     tag="a"
                     :target="$navigationItem->shouldOpenUrlInNewTab() ? '_blank' : null"
                 >
                     {{ $navigationItem->getLabel() }}
+
+                    @if ($navigationItemIcon instanceof \Illuminate\Contracts\Support\Htmlable)
+                        <x-slot name="icon">
+                            {{ $navigationItemIcon }}
+                        </x-slot>
+                    @endif
                 </x-filament::tabs.item>
             @endforeach
         @endif

--- a/packages/panels/resources/views/components/sidebar/group.blade.php
+++ b/packages/panels/resources/views/components/sidebar/group.blade.php
@@ -172,25 +172,42 @@
         @foreach ($items as $item)
             @php
                 $itemIcon = $item->getIcon();
+                $itemActiveIcon = $item->getActiveIcon();
+
+                if ($icon && (! $hasDropdown) && (filled($itemIcon) || filled($itemActiveIcon))) {
+                    throw new \Exception('Navigation group [' . $label . '] has an icon but one or more of its items also have icons. Either the group or its items can have icons, but not both. This is to ensure a proper user experience.');
+                }
             @endphp
 
             <x-filament-panels::sidebar.item
                 :active="$item->isActive()"
                 :active-child-items="$item->isChildItemsActive()"
-                :active-icon="$item->getActiveIcon()"
+                :active-icon="$itemActiveIcon"
                 :badge="$item->getBadge()"
                 :badge-color="$item->getBadgeColor()"
                 :badge-tooltip="$item->getBadgeTooltip()"
                 :child-items="$item->getChildItems()"
                 :first="$loop->first"
                 :grouped="filled($label)"
-                :icon="$icon ? (($hasDropdown || blank($itemIcon)) ? null : throw new \Exception('Navigation group [' . $label . '] has an icon but one or more of its items also have icons. Either the group or its items can have icons, but not both. This is to ensure a proper user experience.')) : $itemIcon"
+                :icon="$itemIcon"
                 :last="$loop->last"
                 :should-open-url-in-new-tab="$item->shouldOpenUrlInNewTab()"
                 :sidebar-collapsible="$sidebarCollapsible"
                 :url="$item->getUrl()"
             >
                 {{ $item->getLabel() }}
+
+                @if ($itemIcon instanceof \Illuminate\Contracts\Support\Htmlable)
+                    <x-slot name="icon">
+                        {{ $itemIcon }}
+                    </x-slot>
+                @endif
+
+                @if ($itemActiveIcon instanceof \Illuminate\Contracts\Support\Htmlable)
+                    <x-slot name="activeIcon">
+                        {{ $itemActiveIcon }}
+                    </x-slot>
+                @endif
             </x-filament-panels::sidebar.item>
         @endforeach
     </ul>

--- a/packages/panels/src/Navigation/NavigationItem.php
+++ b/packages/panels/src/Navigation/NavigationItem.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception;
 use Filament\Support\Components\Component;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Htmlable;
 
 class NavigationItem extends Component
 {
@@ -15,9 +16,9 @@ class NavigationItem extends Component
 
     protected bool | Closure | null $isActive = null;
 
-    protected string | Closure | null $icon = null;
+    protected string | Htmlable | Closure | null $icon = null;
 
-    protected string | Closure | null $activeIcon = null;
+    protected string | Htmlable | Closure | null $activeIcon = null;
 
     protected string | Closure $label;
 
@@ -85,7 +86,7 @@ class NavigationItem extends Component
         return $this;
     }
 
-    public function icon(string | Closure | null $icon): static
+    public function icon(string | Htmlable | Closure | null $icon): static
     {
         $this->icon = $icon;
 
@@ -113,7 +114,7 @@ class NavigationItem extends Component
         return $this;
     }
 
-    public function activeIcon(string | Closure | null $activeIcon): static
+    public function activeIcon(string | Htmlable | Closure | null $activeIcon): static
     {
         $this->activeIcon = $activeIcon;
 
@@ -184,7 +185,7 @@ class NavigationItem extends Component
         return $this->evaluate($this->parentItem);
     }
 
-    public function getIcon(): ?string
+    public function getIcon(): string | Htmlable | null
     {
         $icon = $this->evaluate($this->icon);
 
@@ -209,7 +210,7 @@ class NavigationItem extends Component
         return ! $this->evaluate($this->isVisible);
     }
 
-    public function getActiveIcon(): ?string
+    public function getActiveIcon(): string | Htmlable | null
     {
         return $this->evaluate($this->activeIcon);
     }

--- a/packages/panels/src/Pages/Dashboard.php
+++ b/packages/panels/src/Pages/Dashboard.php
@@ -26,7 +26,7 @@ class Dashboard extends Page
             __('filament-panels::pages/dashboard.title');
     }
 
-    public static function getNavigationIcon(): ?string
+    public static function getNavigationIcon(): string | Htmlable | null
     {
         return static::$navigationIcon
             ?? FilamentIcon::resolve('panels::pages.dashboard.navigation-item')

--- a/packages/panels/src/Pages/Page.php
+++ b/packages/panels/src/Pages/Page.php
@@ -8,6 +8,7 @@ use Filament\Navigation\NavigationItem;
 use Filament\Panel;
 use Filament\Widgets\Widget;
 use Filament\Widgets\WidgetConfiguration;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Route;
@@ -146,12 +147,12 @@ abstract class Page extends BasePage
         return static::$navigationParentItem;
     }
 
-    public static function getActiveNavigationIcon(): ?string
+    public static function getActiveNavigationIcon(): string | Htmlable | null
     {
         return static::$activeNavigationIcon ?? static::getNavigationIcon();
     }
 
-    public static function getNavigationIcon(): ?string
+    public static function getNavigationIcon(): string | Htmlable | null
     {
         return static::$navigationIcon;
     }

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -50,7 +50,7 @@ class EditRecord extends Page
 
     public ?string $previousUrl = null;
 
-    public static function getNavigationIcon(): ?string
+    public static function getNavigationIcon(): string | Htmlable | null
     {
         return static::$navigationIcon
             ?? FilamentIcon::resolve('panels::resources.pages.edit-record.navigation-item')

--- a/packages/panels/src/Resources/Pages/ManageRelatedRecords.php
+++ b/packages/panels/src/Resources/Pages/ManageRelatedRecords.php
@@ -13,6 +13,7 @@ use Filament\Support\Facades\FilamentIcon;
 use Filament\Tables;
 use Filament\Tables\Actions\BulkAction;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Url;
 
@@ -63,7 +64,7 @@ class ManageRelatedRecords extends Page implements Tables\Contracts\HasTable
     #[Url]
     public ?string $activeTab = null;
 
-    public static function getNavigationIcon(): ?string
+    public static function getNavigationIcon(): string | Htmlable | null
     {
         return static::$navigationIcon
             ?? FilamentIcon::resolve('panels::resources.pages.manage-related-records.navigation-item')

--- a/packages/panels/src/Resources/Pages/ViewRecord.php
+++ b/packages/panels/src/Resources/Pages/ViewRecord.php
@@ -37,7 +37,7 @@ class ViewRecord extends Page
      */
     public ?array $data = [];
 
-    public static function getNavigationIcon(): ?string
+    public static function getNavigationIcon(): string | Htmlable | null
     {
         return static::$navigationIcon
             ?? FilamentIcon::resolve('panels::resources.pages.view-record.navigation-item')

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -804,7 +804,7 @@ abstract class Resource
         static::$navigationParentItem = $item;
     }
 
-    public static function getNavigationIcon(): ?string
+    public static function getNavigationIcon(): string | Htmlable | null
     {
         return static::$navigationIcon;
     }
@@ -814,7 +814,7 @@ abstract class Resource
         static::$navigationIcon = $icon;
     }
 
-    public static function getActiveNavigationIcon(): ?string
+    public static function getActiveNavigationIcon(): string | Htmlable | null
     {
         return static::$activeNavigationIcon ?? static::getNavigationIcon();
     }

--- a/packages/support/resources/views/components/icon.blade.php
+++ b/packages/support/resources/views/components/icon.blade.php
@@ -5,13 +5,13 @@
 ])
 
 @php
-    $icon = ($alias ? \Filament\Support\Facades\FilamentIcon::resolve($alias) : null) ?: $icon;
+    $icon = ($alias ? \Filament\Support\Facades\FilamentIcon::resolve($alias) : null) ?: ($icon ?? $slot);
 @endphp
 
 @if ($icon instanceof \Illuminate\Contracts\Support\Htmlable)
-    <div {{ $attributes->class($class) }}>
-        {{ $icon ?? $slot }}
-    </div>
+    <span {{ $attributes->class($class) }}>
+        {{ $icon }}
+    </span>
 @elseif (str_contains($icon, '/'))
     <img
         {{


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

Currently navigation icons don't support `Htmlable` values. Sometimes a simple SVG icon from an icon set doesn't fit the use case, and a custom Blade view is required to gain more control over what should be rendered as icon. This PR adds support for that.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
