### PR TITLE
Fix accepting heading and subheading slots

### DIFF
--- a/packages/panels/resources/views/components/header/index.blade.php
+++ b/packages/panels/resources/views/components/header/index.blade.php
@@ -1,14 +1,9 @@
 @props([
     'actions' => [],
     'breadcrumbs' => [],
+    'heading',
+    'subheading' => null,
 ])
-
-@php
-    // These are passed through in the bag otherwise Laravel converts View objects to strings prematurely.
-    $heading = $attributes->get('heading');
-    $subheading = $attributes->get('subheading');
-    $attributes = $attributes->except(['heading', 'subheading']);
-@endphp
 
 <header
     {{ $attributes->class(['fi-header flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between']) }}

--- a/packages/panels/resources/views/components/page/index.blade.php
+++ b/packages/panels/resources/views/components/page/index.blade.php
@@ -29,17 +29,28 @@
         @if ($header = $this->getHeader())
             {{ $header }}
         @elseif ($heading = $this->getHeading())
+            @php
+                $subheading = $this->getSubheading();
+            @endphp
+
             <x-filament-panels::header
                 :actions="$this->getCachedHeaderActions()"
                 :breadcrumbs="filament()->hasBreadcrumbs() ? $this->getBreadcrumbs() : []"
-                {{-- These are passed through in the bag otherwise Laravel converts View objects to strings prematurely. --}}
-                :attributes="
-                    new \Illuminate\View\ComponentAttributeBag([
-                        'heading' => $heading,
-                        'subheading' => $this->getSubheading(),
-                    ])
-                "
-            />
+                :heading="$heading"
+                :subheading="$subheading"
+            >
+                @if ($heading instanceof \Illuminate\Contracts\Support\Htmlable)
+                    <x-slot name="heading">
+                        {{ $heading }}
+                    </x-slot>
+                @endif
+
+                @if ($subheading instanceof \Illuminate\Contracts\Support\Htmlable)
+                    <x-slot name="subheading">
+                        {{ $subheading }}
+                    </x-slot>
+                @endif
+            </x-filament-panels::header>
         @endif
 
         <div


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

https://github.com/filamentphp/filament/commit/b0ac16b7e9634ba1c2375ea09718ff94c9af794e fixed rendering `Htmlable` values returned from the `getHeading()` and `getSubheading()` page methods. However, as @pxlrbt reported, the implementation broke existing support for using the page header as Blade component with slots for the heading and subheading.

While working on https://github.com/filamentphp/filament/pull/11657, I realized how the issue should've been fixed properly. This PR makes sure `Htmlable` values are rendered correctly when returned from the page class methods, while retaining support for using slots.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
