### PR TITLE
Fix list bullets color

### DIFF
--- a/packages/infolists/resources/views/components/text-entry.blade.php
+++ b/packages/infolists/resources/views/components/text-entry.blade.php
@@ -167,6 +167,18 @@
                                     'max-w-max' => ! ($isBulleted || $isBadge),
                                     'w-max' => $isBadge,
                                     'cursor-pointer' => $itemIsCopyable,
+                                    match ($color) {
+                                        null => 'text-gray-950 dark:text-white',
+                                        'gray' => 'text-gray-500 dark:text-gray-400',
+                                        default => 'text-custom-600 dark:text-custom-400',
+                                    } => $isBulleted,
+                                ])
+                                @style([
+                                    \Filament\Support\get_color_css_variables(
+                                        $color,
+                                        shades: [400, 600],
+                                        alias: 'infolists::components.text-entry.item.container',
+                                    ) => $isBulleted && (! in_array($color, [null, 'gray'])),
                                 ])
                             >
                                 @if ($isBadge)

--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -164,6 +164,18 @@
                             'max-w-max' => ! ($isBulleted || $isBadge),
                             'w-max' => $isBadge,
                             'cursor-pointer' => $itemIsCopyable,
+                            match ($color) {
+                                null => 'text-gray-950 dark:text-white',
+                                'gray' => 'text-gray-500 dark:text-gray-400',
+                                default => 'text-custom-600 dark:text-custom-400',
+                            } => $isBulleted,
+                        ])
+                        @style([
+                            \Filament\Support\get_color_css_variables(
+                                $color,
+                                shades: [400, 600],
+                                alias: 'tables::columns.text-column.item.container',
+                            ) => $isBulleted && (! in_array($color, [null, 'gray'])),
                         ])
                     >
                         @if ($isBadge)


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

List item bullets in text columns and entries didn't use the item's color. This PR fixes that.

### Before

<img width="100" alt="Screenshot 2024-03-03 at 10 57 20" src="https://github.com/filamentphp/filament/assets/44533235/febb16f7-b314-464f-b447-162f5c915e42">

### After

<img width="100" alt="Screenshot 2024-03-03 at 10 57 25" src="https://github.com/filamentphp/filament/assets/44533235/4aad7fe7-e1d3-4b2f-bd01-018ebf4e155c">

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
