### PR TITLE
Fix options() docblock in HasOptions.php

### DIFF
--- a/packages/tables/src/Filters/Concerns/HasOptions.php
+++ b/packages/tables/src/Filters/Concerns/HasOptions.php
@@ -21,7 +21,7 @@ trait HasOptions
     protected ?Closure $getSearchResultsUsing = null;
 
     /**
-     * @param  array<string | array<string>> | Arrayable | class-string | Closure | null  $options
+     * @param  array<string|int | array<string|int>> | Arrayable | class-string | Closure | null  $options
      */
     public function options(array | Arrayable | string | Closure | null $options): static
     {


### PR DESCRIPTION
## Description

I have the following code that PHPStan level 5 falsely say is error

```php
public function filtersForm(Form $form): Form
    {
        $currentYear = (int) date('Y');
        $years = range(2020, $currentYear);
        if ($this->filters['year'] === null) {
            $this->filters['year'] = $currentYear;
        }

        return $form
            ->schema([
                Select::make('year')
                    ->required()
                    ->default($currentYear)
                    ->options(
                        //  Parameter #1 $options of method Filament\Forms\Components\Select::options() expects array<array<string>|string>|Closure|Illuminate\Contracts\Support\Arrayable|string|null, array<int, int>  given.    
                        array_combine($years, $years)
                    ),
            ]);
    }
```

```php
 Parameter #1 $options of method Filament\Forms\Components\Select::options() expects 
array<array<string>|string>|Closure|Illuminate\Contracts\Support\Arrayable|string|null, array<int, int>  
         given.    
```

So this attempt to fix it by changing the docblock to allow both string & int array