### PR TITLE
Refine applyGroupingToTableQuery to Control Eager Loading for isTableReordering

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -37,11 +37,11 @@
         fn (\Filament\Tables\Actions\BulkAction | \Filament\Tables\Actions\ActionGroup $action): bool => $action->isVisible(),
     );
     $groups = $getGroups();
-    $areGroupingSettingsVisible = count($groups) && (! $areGroupingSettingsHidden());
     $description = $getDescription();
     $isGroupsOnly = $isGroupsOnly() && $group;
     $isReorderable = $isReorderable();
     $isReordering = $isReordering();
+    $areGroupingSettingsVisible = (! $isReordering) && count($groups) && (! $areGroupingSettingsHidden());
     $isColumnSearchVisible = $isSearchableByColumn();
     $isGlobalSearchVisible = $isSearchable();
     $isSearchOnBlur = $isSearchOnBlur();

--- a/packages/tables/src/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Concerns/CanGroupRecords.php
@@ -45,13 +45,13 @@ trait CanGroupRecords
     {
         $group = $this->getTableGrouping();
 
-        if (!$group) {
+        if (! $group) {
             return $query;
         }
 
         $group->applyEagerLoading($query);
 
-        if (!$this->isTableReordering()) {
+        if (! $this->isTableReordering()) {
             $group->orderQuery($query, $this->getTableGroupingDirection() ?? 'asc');
         }
 

--- a/packages/tables/src/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Concerns/CanGroupRecords.php
@@ -13,6 +13,10 @@ trait CanGroupRecords
 
     public function getTableGrouping(): ?Group
     {
+        if ($this->isTableReordering()) {
+            return null;
+        }
+
         if (
             filled($this->tableGrouping) &&
             ($group = $this->getTable()->getGroup($this->tableGrouping))
@@ -51,9 +55,7 @@ trait CanGroupRecords
 
         $group->applyEagerLoading($query);
 
-        if (! $this->isTableReordering()) {
-            $group->orderQuery($query, $this->getTableGroupingDirection() ?? 'asc');
-        }
+        $group->orderQuery($query, $this->getTableGroupingDirection() ?? 'asc');
 
         return $query;
     }

--- a/packages/tables/src/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Concerns/CanGroupRecords.php
@@ -43,19 +43,17 @@ trait CanGroupRecords
 
     protected function applyGroupingToTableQuery(Builder $query): Builder
     {
-        if ($this->isTableReordering()) {
-            return $query;
-        }
-
         $group = $this->getTableGrouping();
 
-        if (! $group) {
+        if (!$group) {
             return $query;
         }
 
         $group->applyEagerLoading($query);
 
-        $group->orderQuery($query, $this->getTableGroupingDirection() ?? 'asc');
+        if (!$this->isTableReordering()) {
+            $group->orderQuery($query, $this->getTableGroupingDirection() ?? 'asc');
+        }
 
         return $query;
     }


### PR DESCRIPTION
This pull request refines the behavior of the applyGroupingToTableQuery method to provide better control over eager loading, specifically when isTableReordering is enabled.

<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [ ] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
