### PR TITLE
Add getDefaultName() method to Field & Entry

### DIFF
--- a/packages/forms/src/Components/Field.php
+++ b/packages/forms/src/Components/Field.php
@@ -2,6 +2,8 @@
 
 namespace Filament\Forms\Components;
 
+use Exception;
+
 class Field extends Component implements Contracts\HasHintActions, Contracts\HasValidationRules
 {
     use Concerns\CanBeAutofocused;
@@ -19,12 +21,25 @@ class Field extends Component implements Contracts\HasHintActions, Contracts\Has
         $this->statePath($name);
     }
 
-    public static function make(string $name): static
+    public static function make(?string $name = null): static
     {
+        $fieldClass = static::class;
+
+        $name ??= static::getDefaultName();
+
+        if (blank($name)) {
+            throw new Exception("Column of class [$fieldClass] must have a unique name, passed to the [make()] method.");
+        }
+
         $static = app(static::class, ['name' => $name]);
         $static->configure();
 
         return $static;
+    }
+
+    public static function getDefaultName(): ?string
+    {
+        return null;
     }
 
     public function getId(): string

--- a/packages/infolists/src/Components/Entry.php
+++ b/packages/infolists/src/Components/Entry.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Infolists\Components;
 
+use Exception;
 use Filament\Infolists\Components\Contracts\HasHintActions;
 use Filament\Support\Concerns\HasAlignment;
 use Filament\Support\Concerns\HasPlaceholder;
@@ -25,12 +26,25 @@ class Entry extends Component implements HasHintActions
         $this->statePath($name);
     }
 
-    public static function make(string $name): static
+    public static function make(?string $name = null): static
     {
+        $entryClass = static::class;
+
+        $name ??= static::getDefaultName();
+
+        if (blank($name)) {
+            throw new Exception("Column of class [$entryClass] must have a unique name, passed to the [make()] method.");
+        }
+
         $static = app(static::class, ['name' => $name]);
         $static->configure();
 
         return $static;
+    }
+
+    public static function getDefaultName(): ?string
+    {
+        return null;
     }
 
     public function getId(): string

--- a/tests/src/Forms/FieldTest.php
+++ b/tests/src/Forms/FieldTest.php
@@ -38,3 +38,11 @@ it('can be instantiated with a default name', function () {
     expect($field->getName())
         ->toBe('ID');
 });
+
+test('default name can be overridden', function () {
+
+    $field = IdField::make('Identifier');
+
+    expect($field->getName())
+        ->toBe('Identifier');
+});

--- a/tests/src/Forms/FieldTest.php
+++ b/tests/src/Forms/FieldTest.php
@@ -33,8 +33,8 @@ it('sets its fallback label from its name', function () {
 
 it('can be instantiated with a default name', function () {
 
-    $entry = IdField::make();
+    $field = IdField::make();
 
-    expect($entry->getName())
+    expect($field->getName())
         ->toBe('ID');
 });

--- a/tests/src/Forms/FieldTest.php
+++ b/tests/src/Forms/FieldTest.php
@@ -2,6 +2,7 @@
 
 use Filament\Forms\ComponentContainer;
 use Filament\Forms\Components\Field;
+use Filament\Tests\Forms\Fixtures\IdField;
 use Filament\Tests\Forms\Fixtures\Livewire;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Str;
@@ -28,4 +29,12 @@ it('sets its fallback label from its name', function () {
                 ->replace(['-', '_'], ' ')
                 ->ucfirst(),
         );
+});
+
+it('can be instantiated with a default name', function () {
+
+    $entry = IdField::make();
+
+    expect($entry->getName())
+        ->toBe('ID');
 });

--- a/tests/src/Forms/Fixtures/IdField.php
+++ b/tests/src/Forms/Fixtures/IdField.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Filament\Tests\Forms\Fixtures;
+
+use Filament\Forms\Components\TextInput;
+
+class IdField extends TextInput
+{
+    public static function getDefaultName(): ?string
+    {
+        return 'ID';
+    }
+}

--- a/tests/src/Forms/Fixtures/IdField.php
+++ b/tests/src/Forms/Fixtures/IdField.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 namespace Filament\Tests\Forms\Fixtures;
 

--- a/tests/src/Infolists/EntryTest.php
+++ b/tests/src/Infolists/EntryTest.php
@@ -12,3 +12,11 @@ it('can be instantiated with a default name', function () {
     expect($entry->getName())
         ->toBe('ID');
 });
+
+test('default name can be overridden', function () {
+
+    $entry = IdEntry::make('Identifier');
+
+    expect($entry->getName())
+        ->toBe('Identifier');
+});

--- a/tests/src/Infolists/EntryTest.php
+++ b/tests/src/Infolists/EntryTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use Filament\Tests\Infolists\Fixtures\IdEntry;
+use Filament\Tests\Tables\TestCase;
+
+uses(TestCase::class);
+
+it('can be instantiated with a default name', function () {
+
+    $entry = IdEntry::make();
+
+    expect($entry->getName())
+        ->toBe('ID');
+});

--- a/tests/src/Infolists/Fixtures/IdEntry.php
+++ b/tests/src/Infolists/Fixtures/IdEntry.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 namespace Filament\Tests\Infolists\Fixtures;
 

--- a/tests/src/Infolists/Fixtures/IdEntry.php
+++ b/tests/src/Infolists/Fixtures/IdEntry.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Filament\Tests\Infolists\Fixtures;
+
+use Filament\Infolists\Components\TextEntry;
+
+class IdEntry extends TextEntry
+{
+    public static function getDefaultName(): ?string
+    {
+        return 'ID';
+    }
+}


### PR DESCRIPTION
## Description

Follow-up on #11664 for form `Field` and infolist `Entry`.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.

## Documentation

- [x] Documentation is up-to-date.
