### PR TITLE
fix: icon position for action group in header actions

### DIFF
--- a/packages/actions/resources/views/components/group.blade.php
+++ b/packages/actions/resources/views/components/group.blade.php
@@ -11,7 +11,6 @@
     'dynamicComponent' => null,
     'group' => null,
     'icon' => null,
-    'iconPosition' => null,
     'iconSize' => null,
     'iconButton' => false,
     'label' => null,
@@ -31,7 +30,6 @@
             ->dropdownPlacement($dropdownPlacement)
             ->dropdownWidth($dropdownWidth)
             ->icon($icon)
-            ->iconPosition($iconPosition)
             ->iconSize($iconSize)
             ->label($label)
             ->size($size)
@@ -43,7 +41,10 @@
             : $group->badge($badge);
 
         if ($button) {
-            $group->button();
+            $group
+                ->button()
+                ->iconPosition($attributes->get('iconPosition') ?? $attributes->get('icon-position'))
+                ->outlined($attributes->get('outlined') ?? false);
         }
 
         if ($iconButton) {
@@ -104,7 +105,6 @@
                 :color="$group->getColor()"
                 :component="$dynamicComponent"
                 :icon="$group->getIcon()"
-                :icon-position="$group->isIconButton() ? null : $group->getIconPosition()"
                 :icon-size="$group->getIconSize()"
                 :label-sr-only="$group->isLabelHidden()"
                 :size="$group->getSize()"

--- a/packages/actions/resources/views/components/group.blade.php
+++ b/packages/actions/resources/views/components/group.blade.php
@@ -104,6 +104,7 @@
                 :color="$group->getColor()"
                 :component="$dynamicComponent"
                 :icon="$group->getIcon()"
+                :icon-position="$group->isIconButton() ? null : $group->getIconPosition()"
                 :icon-size="$group->getIconSize()"
                 :label-sr-only="$group->isLabelHidden()"
                 :size="$group->getSize()"


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

This PR attempts to fix an issue where when using `iconPosition()` for an `ActionGroup` in the `getHeaderActions()` method of a custom page (in my case), it was not doing anything.

I am not sure if the code I proposed here would be considered the "best" or "correct" way to do it, but I thought it would be nice for this to be able to be used.

It is worth noting that when using `iconPosition()` for an `ActionGroup` with `iconButton()`, placing the `:icon-position` prop in the view without the check I did results in the error "`trim(): Argument #1 ($string) must be of type string, Filament\Support\Enums\IconPosition given`" coming from the `<x-filament::icon-button>` component view, so maybe there is a better way to handle this.

### Example
```php
protected function getHeaderActions(): array
{
    return [
        ActionGroup::make([
            Action::make('exportCSV'),
            Action::make('exportPDF'),
        ])
            ->label('Export')
            ->button()
            ->dropdownPlacement('bottom-end')
            ->icon('heroicon-c-chevron-down')
            ->iconPosition(IconPosition::After),
    ];
}
```

### Before
<img width="1369" alt="Screenshot 2024-03-04 at 10 03 28 PM" src="https://github.com/filamentphp/filament/assets/104294090/cb1467db-0b50-472f-bf43-088b877429b7">

### After
<img width="1369" alt="Screenshot 2024-03-04 at 10 03 02 PM" src="https://github.com/filamentphp/filament/assets/104294090/0d352b08-4d43-4299-b830-2cdb1e089bc9">



- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.
