### PR TITLE
Disable `<x-filament::button>` `wire:navigate`

### DIFF
--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -17,6 +17,7 @@
     'keyBindings' => null,
     'loadingIndicator' => true,
     'size' => ActionSize::Medium,
+    'spaMode' => null,
     'tag' => 'span',
     'target' => null,
     'tooltip' => null,
@@ -73,7 +74,7 @@
 
 <{{ $tag }}
     @if ($tag === 'a')
-        {{ \Filament\Support\generate_href_html($href, $target === '_blank') }}
+        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode) }}
     @endif
     @if ($keyBindings || $hasTooltip)
         x-data="{}"

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -5,6 +5,7 @@
 @endphp
 
 @props([
+    'allowBrowserNavigation' => true,
     'badge' => null,
     'badgeColor' => 'primary',
     'color' => 'primary',
@@ -173,7 +174,7 @@
 
 <{{ $tag }}
     @if ($tag === 'a')
-        {{ \Filament\Support\generate_href_html($href, $target === '_blank') }}
+        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $allowBrowserNavigation) }}
     @endif
     @if (($keyBindings || $hasTooltip) && (! $hasFormProcessingLoadingIndicator))
         x-data="{}"

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -5,7 +5,6 @@
 @endphp
 
 @props([
-    'allowBrowserNavigation' => true,
     'badge' => null,
     'badgeColor' => 'primary',
     'color' => 'primary',
@@ -23,6 +22,7 @@
     'loadingIndicator' => true,
     'outlined' => false,
     'size' => ActionSize::Medium,
+    'spaMode' => null,
     'tag' => 'button',
     'target' => null,
     'tooltip' => null,
@@ -174,7 +174,7 @@
 
 <{{ $tag }}
     @if ($tag === 'a')
-        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $allowBrowserNavigation) }}
+        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode) }}
     @endif
     @if (($keyBindings || $hasTooltip) && (! $hasFormProcessingLoadingIndicator))
         x-data="{}"

--- a/packages/support/resources/views/components/dropdown/list/item.blade.php
+++ b/packages/support/resources/views/components/dropdown/list/item.blade.php
@@ -16,6 +16,7 @@
     'image' => null,
     'keyBindings' => null,
     'loadingIndicator' => true,
+    'spaMode' => null,
     'tag' => 'button',
     'target' => null,
     'tooltip' => null,
@@ -176,7 +177,7 @@
     </button>
 @elseif ($tag === 'a')
     <a
-        {{ \Filament\Support\generate_href_html($href, $target === '_blank') }}
+        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode) }}
         @if ($keyBindings || $hasTooltip)
             x-data="{}"
         @endif

--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -17,6 +17,7 @@
     'label' => null,
     'loadingIndicator' => true,
     'size' => ActionSize::Medium,
+    'spaMode' => null,
     'tag' => 'button',
     'target' => null,
     'tooltip' => null,
@@ -188,7 +189,7 @@
     </button>
 @elseif ($tag === 'a')
     <a
-        {{ \Filament\Support\generate_href_html($href, $target === '_blank') }}
+        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode) }}
         @if ($keyBindings || $hasTooltip)
             x-data="{}"
         @endif

--- a/packages/support/resources/views/components/link.blade.php
+++ b/packages/support/resources/views/components/link.blade.php
@@ -19,6 +19,7 @@
     'labelSrOnly' => false,
     'loadingIndicator' => true,
     'size' => ActionSize::Medium,
+    'spaMode' => null,
     'tag' => 'a',
     'target' => null,
     'tooltip' => null,
@@ -127,7 +128,7 @@
 
 @if ($tag === 'a')
     <a
-        {{ \Filament\Support\generate_href_html($href, $target === '_blank') }}
+        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode) }}
         @if ($keyBindings || $hasTooltip)
             x-data="{}"
         @endif

--- a/packages/support/resources/views/components/tabs/item.blade.php
+++ b/packages/support/resources/views/components/tabs/item.blade.php
@@ -12,6 +12,7 @@
     'icon' => null,
     'iconColor' => 'gray',
     'iconPosition' => IconPosition::Before,
+    'spaMode' => null,
     'tag' => 'button',
     'target' => null,
     'type' => 'button',
@@ -44,7 +45,7 @@
     @if ($tag === 'button')
         type="{{ $type }}"
     @elseif ($tag === 'a')
-        {{ \Filament\Support\generate_href_html($href, $target === '_blank') }}
+        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode) }}
     @endif
     @if ($hasAlpineActiveClasses)
         x-bind:class="{

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -137,7 +137,7 @@ if (! function_exists('Filament\Support\is_app_url')) {
 }
 
 if (! function_exists('Filament\Support\generate_href_html')) {
-    function generate_href_html(?string $url, bool $shouldOpenInNewTab = false): Htmlable
+    function generate_href_html(?string $url, bool $shouldOpenInNewTab = false, bool $allowBrowserNavigation = true): Htmlable
     {
         if (blank($url)) {
             return new HtmlString('');
@@ -147,7 +147,7 @@ if (! function_exists('Filament\Support\generate_href_html')) {
 
         if ($shouldOpenInNewTab) {
             $html .= ' target="_blank"';
-        } elseif (FilamentView::hasSpaMode() && is_app_url($url)) {
+        } elseif ($allowBrowserNavigation && FilamentView::hasSpaMode() && is_app_url($url)) {
             $html .= ' wire:navigate';
         }
 

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -137,7 +137,7 @@ if (! function_exists('Filament\Support\is_app_url')) {
 }
 
 if (! function_exists('Filament\Support\generate_href_html')) {
-    function generate_href_html(?string $url, bool $shouldOpenInNewTab = false, bool $allowBrowserNavigation = true): Htmlable
+    function generate_href_html(?string $url, bool $shouldOpenInNewTab = false, ?bool $shouldOpenInSpaMode = null): Htmlable
     {
         if (blank($url)) {
             return new HtmlString('');
@@ -147,7 +147,7 @@ if (! function_exists('Filament\Support\generate_href_html')) {
 
         if ($shouldOpenInNewTab) {
             $html .= ' target="_blank"';
-        } elseif ($allowBrowserNavigation && FilamentView::hasSpaMode() && is_app_url($url)) {
+        } elseif ($shouldOpenInSpaMode ?? (FilamentView::hasSpaMode() && is_app_url($url))) {
             $html .= ' wire:navigate';
         }
 


### PR DESCRIPTION
## Description
This PR adds the ability to add `:allow-browser-navigation="false"` to the `<x-filament::button>` component. Adding this attribute disables the addition of `wire:navigate` even when in [SPA mode](https://filamentphp.com/docs/3.x/panels/configuration#spa-mode).

**Use case**
For our package https://github.com/DutchCodingCompany/filament-socialite we'd like to disable browser-navigation for a specific button that sends the user to an external oauth provider, since browser-navigation is not allowed due to CORS restrictions. However, enabling SPA mode enables browser-navigation for all in-app routes (our route has a redirect so it is still counted as an in-app route, causing `wire:navigate` to be added).
