### PR TITLE
Allow passing a subset of data to EditPage save

### DIFF
--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -128,7 +128,7 @@ class EditRecord extends Page
         return $data;
     }
 
-    public function save(bool $shouldRedirect = true): void
+    public function save(bool $shouldRedirect = true, ?array $customData = null): void
     {
         $this->authorizeAccess();
 
@@ -137,7 +137,7 @@ class EditRecord extends Page
 
             $this->callHook('beforeValidate');
 
-            $data = $this->form->getState();
+            $data = is_array($customData) && filled($customData) ? $customData : $this->form->getState();
 
             $this->callHook('afterValidate');
 


### PR DESCRIPTION
My use case is to create a "save section" button that updates the model using a subset of data based on the fields in the section.

Allowing to pass a custom array with data, prevents me from having to replicate the entire default save method, with its permission checks, hooks and other calls to private methods.

This is a non-breaking change, but those who have overridden this method in their components will have to update the definition to match this change.

Example:

```php
<?php

namespace App\Filament\Shared\Actions;

use Filament\Forms\Components\Actions\Action;
use Filament\Forms\Components\Section;
use Livewire\Component as Livewire;

class SaveSectionButton extends Action
{
    public static function make(?string $name = null): static
    {
        return parent::make($name)
            ->label(__('Save this section'))
            ->action(function (Section $component, Livewire $livewire) {
            
                $partialData = $component->getChildComponentContainer()->getState();
                
                // I really want to avoid replicating the entire save method here
                
                // this is so much nicer :)
                
                $livewire->save(false, $partialData);
                
            })
            ->color('primary')
            ->visible(fn ($operation) => $operation === 'edit');
    }
}
```

Use

```php
Section::make(trans('fields.general'))
            ->schema([
                //
            ])->footerActions([
                SaveSectionButton::make('save-general'),
            ]) ...
  ```
  
  