### PR TITLE
fix translation for bulk actions

### DIFF
--- a/packages/tables/resources/lang/fa/table.php
+++ b/packages/tables/resources/lang/fa/table.php
@@ -81,7 +81,7 @@ return [
         ],
 
         'open_bulk_actions' => [
-            'label' => 'بازکردن عملیات',
+            'label' => 'عملیات گروهی',
         ],
 
         'toggle_columns' => [


### PR DESCRIPTION
This fixes the translation to a more clear and natural sounding label, which is used by most Farsi apps.