### PR TITLE
Suggest resources when creating a page

### DIFF
--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -71,7 +71,7 @@ class MakePageCommand extends Command
         $resourceInput = $this->option('resource') ?? suggest(
             label: 'Which resource would you like to create this in?',
             options: collect($panel->getResources())
-                ->filter(fn (string $path): bool => str($path)->contains('\\Resources\\'))
+                ->filter(fn (string $namespace): bool => str($namespace)->contains('\\Resources\\'))
                 ->map(
                     fn (string $namespace): string => str($namespace)
                         ->afterLast('\\Resources\\')

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -76,7 +76,8 @@ class MakePageCommand extends Command
                     fn (string $namespace): string => str($namespace)
                         ->afterLast('\\Resources\\')
                         ->beforeLast('Resource')
-                )->all(),
+                )
+                ->all(),
             placeholder: '[Optional] UserResource',
         );
 

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -73,7 +73,7 @@ class MakePageCommand extends Command
             options: collect($panel->getResources())
                 ->map(
                     fn ($resource): string => str($resource)
-                        ->afterLast('\\')
+                        ->afterLast('\\Resources\\')
                         ->beforeLast('Resource')
                 )->all(),
             placeholder: '[Optional] UserResource',

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -73,7 +73,7 @@ class MakePageCommand extends Command
             options: collect($panel->getResources())
                 ->filter(fn (string $namespace): bool => str($namespace)->contains('\\Resources\\'))
                 ->map(
-                    fn (string $namespace): string => str($namespace)
+                    fn (string $namespace): string => (string) str($namespace)
                         ->afterLast('\\Resources\\')
                         ->beforeLast('Resource')
                 )

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -76,6 +76,7 @@ class MakePageCommand extends Command
                         ->afterLast('\\')
                         ->beforeLast('Resource')
                 )->all(),
+            placeholder: '[Optional] UserResource',
         );
 
         if (filled($resourceInput)) {

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -47,6 +47,26 @@ class MakePageCommand extends Command
         $resourceClass = null;
         $resourcePage = null;
 
+        $panel = $this->option('panel');
+
+        if ($panel) {
+            $panel = Filament::getPanel($panel);
+        }
+
+        if (! $panel) {
+            $panels = Filament::getPanels();
+
+            /** @var Panel $panel */
+            $panel = (count($panels) > 1) ? $panels[select(
+                label: 'Which panel would you like to create this in?',
+                options: array_map(
+                    fn (Panel $panel): string => $panel->getId(),
+                    $panels,
+                ),
+                default: Filament::getDefaultPanel()->getId()
+            )] : Arr::first($panels);
+        }
+
         $resourceInput = $this->option('resource') ?? text(
             label: 'What is the resource you would like to create this in?',
             placeholder: '[Optional] UserResource',
@@ -158,26 +178,6 @@ class MakePageCommand extends Command
 
                 $tableBulkActions = implode(PHP_EOL, $tableBulkActions);
             }
-        }
-
-        $panel = $this->option('panel');
-
-        if ($panel) {
-            $panel = Filament::getPanel($panel);
-        }
-
-        if (! $panel) {
-            $panels = Filament::getPanels();
-
-            /** @var Panel $panel */
-            $panel = (count($panels) > 1) ? $panels[select(
-                label: 'Which panel would you like to create this in?',
-                options: array_map(
-                    fn (Panel $panel): string => $panel->getId(),
-                    $panels,
-                ),
-                default: Filament::getDefaultPanel()->getId()
-            )] : Arr::first($panels);
         }
 
         if (empty($resource)) {

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -71,7 +71,7 @@ class MakePageCommand extends Command
         $resourceInput = $this->option('resource') ?? suggest(
             label: 'Which resource would you like to create this in?',
             options: collect($panel->getResources())
-                ->filter(fn ($path) => str_contains($path, '\\Resources\\'))
+                ->filter(fn (string $path): bool => str($path)->contains('\\Resources\\'))
                 ->map(
                     fn ($resource): string => str($resource)
                         ->afterLast('\\Resources\\')

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -71,13 +71,10 @@ class MakePageCommand extends Command
         $resourceInput = $this->option('resource') ?? suggest(
             label: 'Which resource would you like to create this in?',
             options: collect($panel->getResources())
-                ->mapWithKeys(
-                    function ($resource) {
-                        $className = (string) str($resource)->afterLast('\\');
-                        $title = (string) str($className)->beforeLast('Resource');
-
-                        return [$className => $title];
-                    }
+                ->map(
+                    fn ($resource): string => str($resource)
+                        ->afterLast('\\')
+                        ->beforeLast('Resource')
                 )->all(),
         );
 

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -67,9 +67,17 @@ class MakePageCommand extends Command
             )] : Arr::first($panels);
         }
 
-        $resourceInput = $this->option('resource') ?? text(
-            label: 'What is the resource you would like to create this in?',
-            placeholder: '[Optional] UserResource',
+        $resourceInput = $this->option('resource') ?? select(
+            label: 'Which resource would you like to create this in?',
+            options: collect($panel->getResources())
+                ->mapWithKeys(
+                    function ($resource) {
+                        $className = (string) str($resource)->afterLast('\\');
+                        $title = (string) str($className)->beforeLast('Resource');
+
+                        return [$className => $title];
+                    }
+                )->all(),
         );
 
         if (filled($resourceInput)) {

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -73,7 +73,7 @@ class MakePageCommand extends Command
             options: collect($panel->getResources())
                 ->filter(fn (string $path): bool => str($path)->contains('\\Resources\\'))
                 ->map(
-                    fn ($resource): string => str($resource)
+                    fn (string $namespace): string => str($namespace)
                         ->afterLast('\\Resources\\')
                         ->beforeLast('Resource')
                 )->all(),

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Str;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\select;
+use function Laravel\Prompts\suggest;
 use function Laravel\Prompts\text;
 
 class MakePageCommand extends Command
@@ -67,7 +68,7 @@ class MakePageCommand extends Command
             )] : Arr::first($panels);
         }
 
-        $resourceInput = $this->option('resource') ?? select(
+        $resourceInput = $this->option('resource') ?? suggest(
             label: 'Which resource would you like to create this in?',
             options: collect($panel->getResources())
                 ->mapWithKeys(

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -71,6 +71,7 @@ class MakePageCommand extends Command
         $resourceInput = $this->option('resource') ?? suggest(
             label: 'Which resource would you like to create this in?',
             options: collect($panel->getResources())
+                ->filter(fn ($path) => str_contains($path, '\\Resources\\'))
                 ->map(
                     fn ($resource): string => str($resource)
                         ->afterLast('\\Resources\\')


### PR DESCRIPTION
## Description

Currently when you run `php artisan make:filament-page` you are asked to type the name of your resource. This PR makes it possible to suggest the name of resources as you type, or by selecting them directly from the dropdown.

I have moved the part of the code that identifies the current panel up and before asking for the resource, without changing it, so we can use it to get the resources of the currently selected panel.

Old:

<img width="544" alt="Screenshot 2024-03-07 at 17 21 32" src="https://github.com/filamentphp/filament/assets/6499685/0d017653-8032-4a22-9a1b-64f08670a1c6">

New:

<img width="548" alt="Screenshot 2024-03-07 at 17 20 36" src="https://github.com/filamentphp/filament/assets/6499685/3b5226af-38b3-4acb-8002-f64c17910aa4">

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.
