### PR TITLE
Apply unsaved data changes alert on spatie settings page

### DIFF
--- a/packages/spatie-laravel-settings-plugin/resources/views/pages/settings-page.blade.php
+++ b/packages/spatie-laravel-settings-plugin/resources/views/pages/settings-page.blade.php
@@ -7,4 +7,6 @@
             :full-width="$this->hasFullWidthFormActions()"
         />
     </x-filament-panels::form>
+
+    <x-filament-panels::page.unsaved-data-changes-alert />
 </x-filament-panels::page>

--- a/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
+++ b/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
@@ -8,6 +8,7 @@ use Filament\Forms\ComponentContainer;
 use Filament\Forms\Form;
 use Filament\Notifications\Notification;
 use Filament\Pages\Concerns\CanUseDatabaseTransactions;
+use Filament\Pages\Concerns\HasUnsavedDataChangesAlert;
 use Filament\Support\Exceptions\Halt;
 use Filament\Support\Facades\FilamentView;
 use Throwable;
@@ -21,6 +22,7 @@ class SettingsPage extends Page
 {
     use CanUseDatabaseTransactions;
     use Concerns\InteractsWithFormActions;
+    use HasUnsavedDataChangesAlert;
 
     protected static string $settings;
 
@@ -92,6 +94,8 @@ class SettingsPage extends Page
 
             throw $exception;
         }
+
+        $this->rememberData();
 
         $this->getSavedNotification()?->send();
 


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

This PR will allow the page setting to use the [Unsaved changes alerts](https://filamentphp.com/docs/3.x/panels/configuration#unsaved-changes-alerts), Which are also available on CreateRecord and EditRecord Resource Pages.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

<img width="1665" alt="image" src="https://github.com/filamentphp/filament/assets/24932380/bd838c7a-57bc-4b37-bcd6-de4d4f64f20a">

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
