### PR TITLE
Update docs with missing HTML input type "integer" for TextInput

### DIFF
--- a/packages/forms/docs/03-fields/02-text-input.md
+++ b/packages/forms/docs/03-fields/02-text-input.md
@@ -25,6 +25,7 @@ use Filament\Forms\Components\TextInput;
 TextInput::make('text')
     ->email() // or
     ->numeric() // or
+    ->integer() // or
     ->password() // or
     ->tel() // or
     ->url()


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

TextInput can be of type "integer". There is a preset in the code. But it's missing in the docs.

<!-- Replace this comment with your description. -->

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [ ] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
