### PR TITLE
Persist connection from model

### DIFF
--- a/packages/tables/src/Columns/Summarizers/Summarizer.php
+++ b/packages/tables/src/Columns/Summarizers/Summarizer.php
@@ -105,7 +105,8 @@ class Summarizer extends ViewComponent
                 );
         }
 
-        $query = DB::table($query->toBase(), $query->getModel()->getTable());
+        $query = DB::connection($query->getModel()->getConnectionName())
+            ->table($query->toBase(), $query->getModel()->getTable());
 
         if ($this->hasQueryModification()) {
             $query = $this->evaluate($this->modifyQueryUsing, [

--- a/packages/tables/src/Concerns/CanSummarizeRecords.php
+++ b/packages/tables/src/Concerns/CanSummarizeRecords.php
@@ -71,7 +71,8 @@ trait CanSummarizeRecords
         $queryToJoin = $query->clone();
         $joins = [];
 
-        $query = DB::table($query->toBase(), $query->getModel()->getTable());
+        $query = DB::connection($query->getModel()->getConnectionName())
+            ->table($query->toBase(), $query->getModel()->getTable());
 
         if ($modifyQueryUsing) {
             $query = $modifyQueryUsing($query) ?? $query;


### PR DESCRIPTION
When a non default connection is used on the model, summaries did not work as expected.
