### PR TITLE
Protect properties and introduce getter

### DIFF
--- a/packages/panels/resources/views/components/resources/relation-managers.blade.php
+++ b/packages/panels/resources/views/components/resources/relation-managers.blade.php
@@ -100,7 +100,7 @@
 
                 @livewire(
                     $normalizedManagerClass,
-                    [...$managerLivewireProperties, ...(($manager instanceof \Filament\Resources\RelationManagers\RelationManagerConfiguration) ? [...$manager->relationManager::getDefaultProperties(), ...$manager->properties] : $manager::getDefaultProperties())],
+                    [...$managerLivewireProperties, ...(($manager instanceof \Filament\Resources\RelationManagers\RelationManagerConfiguration) ? [...$manager->relationManager::getDefaultProperties(), ...$manager->getProperties()] : $manager::getDefaultProperties())],
                     key($normalizedManagerClass),
                 )
             @endif

--- a/packages/panels/resources/views/components/resources/relation-managers.blade.php
+++ b/packages/panels/resources/views/components/resources/relation-managers.blade.php
@@ -88,7 +88,7 @@
 
                     @livewire(
                         $normalizedGroupedManagerClass,
-                        [...$managerLivewireProperties, ...(($groupedManager instanceof \Filament\Resources\RelationManagers\RelationManagerConfiguration) ? [...$groupedManager->relationManager::getDefaultProperties(), ...$groupedManager->properties] : $groupedManager::getDefaultProperties())],
+                        [...$managerLivewireProperties, ...(($groupedManager instanceof \Filament\Resources\RelationManagers\RelationManagerConfiguration) ? [...$groupedManager->relationManager::getDefaultProperties(), ...$groupedManager->getProperties()] : $groupedManager::getDefaultProperties())],
                         key("{$normalizedGroupedManagerClass}-{$groupedManagerKey}"),
                     )
                 @endforeach

--- a/packages/panels/src/Resources/RelationManagers/RelationManagerConfiguration.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManagerConfiguration.php
@@ -10,7 +10,15 @@ class RelationManagerConfiguration
      */
     public function __construct(
         readonly public string $relationManager,
-        readonly public array $properties = [],
+        protected array $properties = [],
     ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getProperties(): array
+    {
+        return $this->properties;
     }
 }

--- a/packages/widgets/resources/views/components/widgets.blade.php
+++ b/packages/widgets/resources/views/components/widgets.blade.php
@@ -32,7 +32,7 @@
 
         @livewire(
             $widgetClass,
-            [...(($widget instanceof \Filament\Widgets\WidgetConfiguration) ? [...$widget->widget::getDefaultProperties(), ...$widget->properties] : $widget::getDefaultProperties()), ...$data],
+            [...(($widget instanceof \Filament\Widgets\WidgetConfiguration) ? [...$widget->widget::getDefaultProperties(), ...$widget->getProperties()] : $widget::getDefaultProperties()), ...$data],
             key("{$widgetClass}-{$widgetKey}"),
         )
     @endforeach

--- a/packages/widgets/src/WidgetConfiguration.php
+++ b/packages/widgets/src/WidgetConfiguration.php
@@ -14,6 +14,9 @@ class WidgetConfiguration
     ) {
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getProperties(): array
     {
         return $this->properties;

--- a/packages/widgets/src/WidgetConfiguration.php
+++ b/packages/widgets/src/WidgetConfiguration.php
@@ -10,7 +10,12 @@ class WidgetConfiguration
      */
     public function __construct(
         readonly public string $widget,
-        readonly public array $properties = [],
+        protected array $properties = [],
     ) {
+    }
+
+    public function getProperties(): array
+    {
+        return $this->properties;
     }
 }


### PR DESCRIPTION
## Description

This pull requests modifies the **WidgetConfiguration** DTO to allow widget builders to fluently configure their widgets by creating their own **WidgetConfiguration** class.

The feature has also been extended to the **RelationManagerConfiguration** class. The same changes below can be made to both classes.

Firstly, create your custom configuration by extending the **WidgetConfigurationClass** and adding some fluent properties:
```php
class MyWidgetConfiguration extends WidgetConfiguration
{
    public function foo($condition = false)
    {
        $this->properties['foo'] = $condition;
    }

    public function bar($name = 'baz')
    {
        $this->properties['bar'] = $name;
    }
}
```

This allows you to update your widget's `make` function to return a new copy of your configuration with some default values:

```php
class MyWidget extends Widget
{
    public static function make(array $properties = []): MyWidgetConfiguration
    {
         return new MyWidgetConfiguration(static::class, [
             ...['foo' => true, 'bar' => 'baz'],
             ...$properties
         );
    }
}
```

Finally, give your consumer the ability to fluently configure your widget in their **Panel** provider.

```php
class AdminPanelProvider extends PanelProvider
{
    public function panel(Panel $panel): Panel
    {
        return $panel
            ->widgets([
               MyWidget::make()->foo(false)->bar('boz')
            ]);
    }
}
```
```

## Code style

- [*] `composer cs` command has been run.

## Testing

Changes have been tested against the existing default Admin Panel widgets, and a custom widget with the new features. No issues have been encountered.

- [*] Changes have been tested.

## Documentation

Documentation has not been changed. This requires some discussion as to where to add the changes, and what the Filament Team want to necessarily allow the consumers to do.

- [ ] Documentation is up-to-date.
