### PR TITLE
Docs: CreateRecord expects a `create()` instead of `save()` in testing

### DIFF
--- a/packages/forms/docs/09-testing.md
+++ b/packages/forms/docs/09-testing.md
@@ -57,7 +57,7 @@ it('can validate input', function () {
         ->fillForm([
             'title' => null,
         ])
-        ->call('save')
+        ->call('create')
         ->assertHasFormErrors(['title' => 'required']);
 });
 ```
@@ -72,7 +72,7 @@ livewire(CreatePost::class)
         'title' => fake()->sentence(),
         // ...
     ])
-    ->call('save')
+    ->call('create')
     ->assertHasNoFormErrors();
 ```
 


### PR DESCRIPTION
## Description

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

- [ ] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.

## Documentation

- [x] Documentation is up-to-date.

Updating documentation, since [`CreateRecord` page uses method `create()` and not `save()`](https://github.com/filamentphp/filament/blob/72e07ea7c65f86969aeb2c1a070cda502a095932/packages/panels/src/Resources/Pages/CreateRecord.php#L76)

Got this following error in my project:

`Tests\Feature\Filament\Resources\PostResource\Pages\CreatePostTest > it can create post  MethodNotFoundException
  Unable to call component method. Public method [save] not found on component`