### PR TITLE
Global search results: Only show a label prefix if the global search details specifies one

### DIFF
--- a/packages/panels/resources/views/components/global-search/result.blade.php
+++ b/packages/panels/resources/views/components/global-search/result.blade.php
@@ -25,7 +25,7 @@
             <dl class="mt-1">
                 @foreach ($details as $label => $value)
                     <div class="text-sm text-gray-500 dark:text-gray-400">
-                        @if($isAssoc ??= \Illuminate\Support\Arr::isAssoc($details))
+                        @if ($isAssoc ??= \Illuminate\Support\Arr::isAssoc($details))
                             <dt class="inline font-medium">{{ $label }}:</dt>
                         @endif
 

--- a/packages/panels/resources/views/components/global-search/result.blade.php
+++ b/packages/panels/resources/views/components/global-search/result.blade.php
@@ -25,7 +25,9 @@
             <dl class="mt-1">
                 @foreach ($details as $label => $value)
                     <div class="text-sm text-gray-500 dark:text-gray-400">
-                        <dt class="inline font-medium">{{ $label }}:</dt>
+                        @if($isAssoc ??= \Illuminate\Support\Arr::isAssoc($details))
+                            <dt class="inline font-medium">{{ $label }}:</dt>
+                        @endif
 
                         <dd class="inline">{{ $value }}</dd>
                     </div>

--- a/packages/widgets/resources/views/stats-overview-widget/stat.blade.php
+++ b/packages/widgets/resources/views/stats-overview-widget/stat.blade.php
@@ -47,7 +47,9 @@
                 />
             @endif
 
-            <span class="fi-wi-stats-overview-stat-label text-sm font-medium text-gray-500 dark:text-gray-400">
+            <span
+                class="fi-wi-stats-overview-stat-label text-sm font-medium text-gray-500 dark:text-gray-400"
+            >
                 {{ $getLabel() }}
             </span>
         </div>


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

To include details in a global search result, we have to specify a key => value array in `getGlobalSearchResultDetails()`. The key is shown as a prefix before each line of detail when rendering the result.

In some contexts it can look a bit clunky including a prefix for every item. Maybe you just want a single line description/summary etc. — this is now possible.

**Before (key enforced):**

![Screenshot 2024-03-11 at 15 39 43@2x](https://github.com/filamentphp/filament/assets/627533/ac9f0567-653b-4091-9d99-2d77d69b7c39)

**Before (if not using an associative array):**

![Screenshot 2024-03-11 at 15 41 19@2x](https://github.com/filamentphp/filament/assets/627533/eece76d5-ca98-45e3-9903-11971e0b8e16)

**After (when not using an associative array):**

![Screenshot 2024-03-11 at 15 47 33@2x](https://github.com/filamentphp/filament/assets/627533/f1175b81-692c-4223-9ed8-efa76f36a286)


<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
