### PR TITLE
Merge extra Attributes of  ShowPasswordAction/HidePasswordAction

### DIFF
--- a/packages/forms/src/Components/TextInput/Actions/HidePasswordAction.php
+++ b/packages/forms/src/Components/TextInput/Actions/HidePasswordAction.php
@@ -25,7 +25,7 @@ class HidePasswordAction extends Action
         $this->extraAttributes([
             'x-cloak' => true,
             'x-show' => 'isPasswordRevealed',
-        ]);
+        ], true);
 
         $this->alpineClickHandler('isPasswordRevealed = false');
     }

--- a/packages/forms/src/Components/TextInput/Actions/HidePasswordAction.php
+++ b/packages/forms/src/Components/TextInput/Actions/HidePasswordAction.php
@@ -25,7 +25,7 @@ class HidePasswordAction extends Action
         $this->extraAttributes([
             'x-cloak' => true,
             'x-show' => 'isPasswordRevealed',
-        ], true);
+        ], merge: true);
 
         $this->alpineClickHandler('isPasswordRevealed = false');
     }

--- a/packages/forms/src/Components/TextInput/Actions/ShowPasswordAction.php
+++ b/packages/forms/src/Components/TextInput/Actions/ShowPasswordAction.php
@@ -24,7 +24,7 @@ class ShowPasswordAction extends Action
 
         $this->extraAttributes([
             'x-show' => '! isPasswordRevealed',
-        ]);
+        ], true);
 
         $this->alpineClickHandler('isPasswordRevealed = true');
     }

--- a/packages/forms/src/Components/TextInput/Actions/ShowPasswordAction.php
+++ b/packages/forms/src/Components/TextInput/Actions/ShowPasswordAction.php
@@ -24,7 +24,7 @@ class ShowPasswordAction extends Action
 
         $this->extraAttributes([
             'x-show' => '! isPasswordRevealed',
-        ], true);
+        ], merge: true);
 
         $this->alpineClickHandler('isPasswordRevealed = true');
     }


### PR DESCRIPTION
Merge the extra attributes so that they can be configured outside of the filament core.

Explanation:
I needed to override the extraAttributes via the global `ShowPasswordAction::configureUsing` method, but my changes got overridden by this.