### PR TITLE
Fix RichEditor field state being changed inside of block builder when block is removed

### DIFF
--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -53,7 +53,7 @@
                         },
                     )
                 "
-                x-on:trix-change="$nextTick(() => state = $event.target.value)"
+                x-on:trix-change="$nextTick(() => (state = $event.target.value))"
                 @if ($isLiveDebounced())
                     x-on:trix-change.debounce.{{ $getLiveDebounce() }}="$nextTick(() => $wire.call('$refresh'))"
                 @endif

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -53,9 +53,23 @@
                         },
                     )
                 "
-                x-on:trix-change="$nextTick(() => (state = $event.target.value))"
+                x-on:trix-change="
+                    $nextTick(() => {
+                        if ($refs.trix == undefined) {
+                            return
+                        }
+                        state = $event.target.value
+                    })
+                "
                 @if ($isLiveDebounced())
-                    x-on:trix-change.debounce.{{ $getLiveDebounce() }}="$nextTick(() => $wire.call('$refresh'))"
+                    x-on:trix-change.debounce.{{ $getLiveDebounce() }}="
+                        $nextTick(() => {
+                            if ($refs.trix == undefined) {
+                                return
+                            }
+                            $wire.call('$refresh')
+                        })
+                    "
                 @endif
                 @if (! $hasToolbarButton('attachFiles'))
                     x-on:trix-file-accept="$event.preventDefault()"

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -53,9 +53,9 @@
                         },
                     )
                 "
-                x-on:trix-change="state = $event.target.value"
+                x-on:trix-change="$nextTick(() => state = $event.target.value)"
                 @if ($isLiveDebounced())
-                    x-on:trix-change.debounce.{{ $getLiveDebounce() }}="$wire.call('$refresh')"
+                    x-on:trix-change.debounce.{{ $getLiveDebounce() }}="$nextTick(() => $wire.call('$refresh'))"
                 @endif
                 @if (! $hasToolbarButton('attachFiles'))
                     x-on:trix-file-accept="$event.preventDefault()"

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -55,18 +55,16 @@
                 "
                 x-on:trix-change="
                     $nextTick(() => {
-                        if ($refs.trix == undefined) {
-                            return
-                        }
+                        if (! $refs.trix) return
+                
                         state = $event.target.value
                     })
                 "
                 @if ($isLiveDebounced())
                     x-on:trix-change.debounce.{{ $getLiveDebounce() }}="
                         $nextTick(() => {
-                            if ($refs.trix == undefined) {
-                                return
-                            }
+                            if (! $refs.trix) return
+                
                             $wire.call('$refresh')
                         })
                     "

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -55,7 +55,9 @@
                 "
                 x-on:trix-change="
                     $nextTick(() => {
-                        if (! $refs.trix) return
+                        if (! $refs.trix) {
+                            return
+                        }
                 
                         state = $event.target.value
                     })
@@ -63,7 +65,9 @@
                 @if ($isLiveDebounced())
                     x-on:trix-change.debounce.{{ $getLiveDebounce() }}="
                         $nextTick(() => {
-                            if (! $refs.trix) return
+                            if (! $refs.trix) {
+                                return
+                            }
                 
                             $wire.call('$refresh')
                         })


### PR DESCRIPTION
## Description

fixes https://github.com/filamentphp/filament/issues/11819

The underlying issue is that the `trix-change` event gets fired as the editor is removed from the dom. This PR defers the entangled alpine/livewire updates using `$nextTick` and checks that the trix editor still exists in the DOM before making any updates

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

- [x] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.

## Documentation

- [x] Documentation is up-to-date.
