### PR TITLE
TranslatableSpatieMediaLibraryFileUpload should first filter and then resize the collection

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -55,12 +55,12 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             /** @var Model&HasMedia $record */
             $media = $record->load('media')->getMedia($component->getCollection())
                 ->when(
-                    ! $component->isMultiple(),
-                    fn (Collection $media): Collection => $media->take(1),
-                )
-                ->when(
                     $component->hasMediaFilter(),
                     fn (Collection $media) => $component->filterMedia($media)
+                )
+                ->when(
+                    ! $component->isMultiple(),
+                    fn (Collection $media): Collection => $media->take(1),
                 )
                 ->mapWithKeys(function (Media $media): array {
                     $uuid = $media->getAttributeValue('uuid');


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

The load state closure of the TranslatableSpatieMediaLibraryFileUpload first clips the media collection to one item if the upload field does not allow multiple uploads. This removes media items that could be filtered out by the media filter. I just switched the order of both `->when()` clauses to first apply the media filter and then limit the collection to 1 item if needed.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

No visual changes

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
