### PR TITLE
Check for mariadb in CanReadModelSchemas

### DIFF
--- a/packages/support/src/Commands/Concerns/CanReadModelSchemas.php
+++ b/packages/support/src/Commands/Concerns/CanReadModelSchemas.php
@@ -156,7 +156,7 @@ trait CanReadModelSchemas
 
         $driver = app($model)->getConnection()->getDriverName();
 
-        if ($driver === 'mysql' || $driver === 'mariadb') {
+        if (in_array($driver, ['mysql', 'mariadb'])) {
             if ($default === 'NULL'
             || preg_match("/^\(.*\)$/", $default) === 1
             || str_ends_with($default, '()')

--- a/packages/support/src/Commands/Concerns/CanReadModelSchemas.php
+++ b/packages/support/src/Commands/Concerns/CanReadModelSchemas.php
@@ -156,7 +156,7 @@ trait CanReadModelSchemas
 
         $driver = app($model)->getConnection()->getDriverName();
 
-        if ($driver === 'mysql') {
+        if ($driver === 'mysql' || $driver === 'mariadb') {
             if ($default === 'NULL'
             || preg_match("/^\(.*\)$/", $default) === 1
             || str_ends_with($default, '()')


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

Laravel 11 added a dedicated MariaDB driver, this pull request adds a check for 'mariadb' in CanReadModelSchemas. 

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
