### PR TITLE
Allow optionally hiding topbar on simple pages

### DIFF
--- a/packages/panels/resources/views/components/layout/simple.blade.php
+++ b/packages/panels/resources/views/components/layout/simple.blade.php
@@ -1,7 +1,5 @@
 @php
     use Filament\Support\Enums\MaxWidth;
-
-    $hideTopbar = $hideTopbar ?? false;
 @endphp
 
 <x-filament-panels::layout.base :livewire="$livewire">
@@ -12,7 +10,7 @@
     ])
 
     <div class="fi-simple-layout flex min-h-screen flex-col items-center">
-        @if (! $hideTopbar && filament()->auth()->check())
+        @if (($hasTopbar ?? true) && filament()->auth()->check())
             <div
                 class="absolute end-0 top-0 flex h-16 items-center gap-x-4 pe-4 md:pe-6 lg:pe-8"
             >

--- a/packages/panels/resources/views/components/layout/simple.blade.php
+++ b/packages/panels/resources/views/components/layout/simple.blade.php
@@ -1,5 +1,7 @@
 @php
     use Filament\Support\Enums\MaxWidth;
+
+    $hideTopbar = $hideTopbar ?? false;
 @endphp
 
 <x-filament-panels::layout.base :livewire="$livewire">

--- a/packages/panels/resources/views/components/layout/simple.blade.php
+++ b/packages/panels/resources/views/components/layout/simple.blade.php
@@ -10,7 +10,7 @@
     ])
 
     <div class="fi-simple-layout flex min-h-screen flex-col items-center">
-        @if (filament()->auth()->check())
+        @if (! $hideTopbar && filament()->auth()->check())
             <div
                 class="absolute end-0 top-0 flex h-16 items-center gap-x-4 pe-4 md:pe-6 lg:pe-8"
             >

--- a/packages/panels/src/Pages/SimplePage.php
+++ b/packages/panels/src/Pages/SimplePage.php
@@ -10,13 +10,13 @@ abstract class SimplePage extends BasePage
 
     protected ?string $maxWidth = null;
 
-    protected bool $hideTopbar = false;
+    protected bool $hasTopbar = true;
 
     protected function getLayoutData(): array
     {
         return [
             'maxWidth' => $this->getMaxWidth(),
-            'hideTopbar' => $this->hideTopbar(),
+            'hasTopbar' => $this->hasTopbar(),
         ];
     }
 
@@ -30,8 +30,8 @@ abstract class SimplePage extends BasePage
         return true;
     }
 
-    public function hideTopbar(): bool
+    public function hasTopbar(): bool
     {
-        return $this->hideTopbar;
+        return $this->hasTopbar;
     }
 }

--- a/packages/panels/src/Pages/SimplePage.php
+++ b/packages/panels/src/Pages/SimplePage.php
@@ -10,10 +10,13 @@ abstract class SimplePage extends BasePage
 
     protected ?string $maxWidth = null;
 
+    protected bool $hideTopbar = false;
+
     protected function getLayoutData(): array
     {
         return [
             'maxWidth' => $this->getMaxWidth(),
+            'hideTopbar' => $this->hideTopbar(),
         ];
     }
 
@@ -25,5 +28,10 @@ abstract class SimplePage extends BasePage
     public function hasLogo(): bool
     {
         return true;
+    }
+
+    public function hideTopbar(): bool
+    {
+        return $this->hideTopbar;
     }
 }

--- a/packages/panels/src/Pages/SimplePage.php
+++ b/packages/panels/src/Pages/SimplePage.php
@@ -15,8 +15,8 @@ abstract class SimplePage extends BasePage
     protected function getLayoutData(): array
     {
         return [
-            'maxWidth' => $this->getMaxWidth(),
             'hasTopbar' => $this->hasTopbar(),
+            'maxWidth' => $this->getMaxWidth(),
         ];
     }
 


### PR DESCRIPTION
Adds an option to hide the topbar elements (database notifications and profile menu) on simple pages.

This is necessary for 2fa code pages since they are accessed after a user has logged in, but before they are allowed to access notificaitons or edit their profile. Solves: https://github.com/jeffgreco13/filament-breezy/issues/334

There are also times you don't want these shown on standalone pages for UX/styling reasons.