### PR TITLE
Fix: getStartStep to accommodate for hidden components

### DIFF
--- a/packages/forms/src/Components/Wizard.php
+++ b/packages/forms/src/Components/Wizard.php
@@ -214,7 +214,9 @@ class Wizard extends Component
         if ($this->isStepPersistedInQueryString()) {
             $queryStringStep = request()->query($this->getStepQueryStringKey());
 
-            foreach ($this->getChildComponents() as $index => $step) {
+            $components = collect($this->getChildComponents())->filter(fn ($component) => ! $component->isHidden())->values();
+
+            foreach ($components as $index => $step) {
                 if ($step->getId() !== $queryStringStep) {
                     continue;
                 }

--- a/packages/forms/src/Components/Wizard.php
+++ b/packages/forms/src/Components/Wizard.php
@@ -214,9 +214,7 @@ class Wizard extends Component
         if ($this->isStepPersistedInQueryString()) {
             $queryStringStep = request()->query($this->getStepQueryStringKey());
 
-            $components = collect($this->getChildComponents())->filter(fn ($component) => ! $component->isHidden())->values();
-
-            foreach ($components as $index => $step) {
+            foreach ($this->getChildComponentContainer()->getComponents() as $index => $step) {
                 if ($step->getId() !== $queryStringStep) {
                     continue;
                 }


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

This pull request will fix the issue of `getStartStep()` in `wizard.php@line:212`  It does not accommodate for a scenario where a Step Component is hidden.

<!-- Replace this comment with your description. -->

- [✅] Visual changes (if any) are shown using screenshots/recordings of before and after.

There isn't really any visual changes, it only fixes an issue.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [✅] `composer cs` command has been run.

I was able to run `composer cs`.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [✅] Changes have been tested.

There was no tests for the Wizard component (I might be wrong here, so if you can redirect me to the right files, I will gladly write a test for this issue.)

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [✅] Documentation is up-to-date.

I'm Guessing there is no need for Documentation for this change?
