### PR TITLE
Bread Crumb Component Updates and Additions

### DIFF
--- a/packages/support/docs/09-blade-components/02-breadcrumbs.md
+++ b/packages/support/docs/09-blade-components/02-breadcrumbs.md
@@ -40,5 +40,5 @@ Home > Dashboard > Users
 If you specify `rtl` as the direction, the breadcrumbs will look similar to the following:
 
 ```
-Home < Dashboard < Users
+Users < Dashboard < Home
 ```

--- a/packages/support/docs/09-blade-components/02-breadcrumbs.md
+++ b/packages/support/docs/09-blade-components/02-breadcrumbs.md
@@ -16,3 +16,29 @@ The breadcrumbs component is used to render a simple, linear navigation that inf
 ```
 
 The keys of the array are URLs that the user is able to click on to navigate, and the values are the text that will be displayed for each link.
+
+### RTL Support
+
+If you need to rotate the breadcrumb separator for RTL support, simply add the `dir` attribute with the value of `rtl`:
+
+```
+<x-filament::breadcrumbs 
+    :breadcrumbs="[
+        '/' => 'Home',
+        '/dashboard' => 'Dashboard',
+    ]"
+    dir="rtl"
+/>
+```
+
+By default the breadcrumb separator direction is set to `ltr`, and will look similar to the following:
+
+```
+Home > Dashboard > Users
+```
+
+If you specify `rtl` as the direction, the breadcrumbs will look similar to the following:
+
+```
+Home < Dashboard < Users
+```

--- a/packages/support/resources/views/components/breadcrumbs.blade.php
+++ b/packages/support/resources/views/components/breadcrumbs.blade.php
@@ -61,7 +61,7 @@
                         'ltr:hidden',
                     ])
                 />
-                <span class="font-medium text-sm text-gray-700 dark:text-gray-200 cursor-default!">{{ $current }}</span>
+                <span class="font-medium text-sm text-gray-400 dark:text-gray-500 cursor-default!">{{ $current }}</span>
             </li>
         @endif
     </ol>

--- a/packages/support/resources/views/components/breadcrumbs.blade.php
+++ b/packages/support/resources/views/components/breadcrumbs.blade.php
@@ -1,5 +1,7 @@
 @props([
     'breadcrumbs' => [],
+    'dir' => 'ltr',
+    'current' => null,
 ])
 
 @php
@@ -7,7 +9,7 @@
 @endphp
 
 <nav {{ $attributes->class(['fi-breadcrumbs']) }}>
-    <ol class="fi-breadcrumbs-list flex flex-wrap items-center gap-x-2">
+    <ol class="fi-breadcrumbs-list flex flex-wrap items-center gap-x-2" dir="{{ $dir }}">
         @foreach ($breadcrumbs as $url => $label)
             <li class="fi-breadcrumbs-item flex gap-x-2">
                 @if (! $loop->first)
@@ -39,5 +41,28 @@
                 </a>
             </li>
         @endforeach
+        @if(isset($current))
+            <li class="fi-breadcrumbs-item-current flex items-center gap-x-2 cursor-default">
+                <x-filament::icon
+                    alias="breadcrumbs.separator"
+                    icon="heroicon-m-chevron-right"
+                    @class([
+                        $iconClasses,
+                        'rtl:hidden',
+                    ])
+                />
+
+                <x-filament::icon
+                    {{-- @deprecated Use `breadcrubs.separator.rtl` instead of `breadcrumbs.separator` for RTL. --}}
+                    :alias="['breadcrumbs.separator.rtl', 'breadcrumbs.separator']"
+                    icon="heroicon-m-chevron-left"
+                    @class([
+                        $iconClasses,
+                        'ltr:hidden',
+                    ])
+                />
+                <span class="font-medium text-sm text-gray-700 dark:text-gray-200 cursor-default!">{{ $current }}</span>
+            </li>
+        @endif
     </ol>
 </nav>


### PR DESCRIPTION
This PR will add the ability to include the `Current` page text into the breadcrumbs. By default if you do not include the `current` attribute in the component, it will work as it did before.

Additionally, in the component, it would not default to a direction, so if you were to render the following code:

```
<x-breadcrumbs
    :breadcrumbs="[
        '/' => 'Home',
        '/dashboard' => 'Dashboard',
        '/dashboard/users' => 'Users'
    ]"
/>
```

You would end up with something that looks like the following:

![CleanShot 2024-03-15 at 09 53 57@2x](https://github.com/filamentphp/filament/assets/601261/eb857570-3c5a-4caa-870e-10b824a42db1)

Not the desired output.

So, in this PR `ltr` will be default and if you want to use `rtl` you would have to specify that by including the `dir` attribute in the component and setting it to `rtl`

## 📼 Quick Video.

I've also created a quick video to show you what the breadcrumbs look like in this PR. I then swap over to the original (old) breadcrumbs component that is currently in the repo. You'll see the differences and updates in this video.

https://www.loom.com/share/73273290a6ee4daa938692bd382a0b0a

## Testing

I've made sure to thoroughly test the component and make sure it is rendering correctly both in light and dark mode.

## Documentation

I've also updated the documentation to include these updates.

Please let me know if you would like me to make any further changes or need clarification on anything.

Thanks!