### PR TITLE
Add Tenant Registration page create command

### DIFF
--- a/packages/panels/docs/11-tenancy.md
+++ b/packages/panels/docs/11-tenancy.md
@@ -114,7 +114,14 @@ A registration page will allow users to create a new tenant.
 
 When visiting your app after logging in, users will be redirected to this page if they don't already have a tenant.
 
-To set up a registration page, you'll need to create a new page class that extends `Filament\Pages\Tenancy\RegisterTenant`. This is a full-page Livewire component. You can put this anywhere you want, such as `app/Filament/Pages/Tenancy/RegisterTeam.php`:
+To create a tenant registration page, you can use:
+
+```bash
+php artisan filament:register-tenant
+```
+
+This command will create a new page class that extends `Filament\Pages\Tenancy\RegisterTenant`. This is a full-page Livewire component.
+
 
 ```php
 namespace App\Filament\Pages\Tenancy;

--- a/packages/panels/src/Commands/Aliases/MakeTenantRegisterCommand.php
+++ b/packages/panels/src/Commands/Aliases/MakeTenantRegisterCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Filament\Commands\Aliases;
+
+use Filament\Commands;
+
+class MakeTenantRegisterCommand extends Commands\MakeTenantRegisterCommand
+{
+    protected $hidden = true;
+
+    protected $signature = 'filament:register-tenant {--panel=} {--F|force}';
+}

--- a/packages/panels/src/Commands/MakeTenantRegisterCommand.php
+++ b/packages/panels/src/Commands/MakeTenantRegisterCommand.php
@@ -34,10 +34,7 @@ class MakeTenantRegisterCommand extends Command
         if (! $panel) {
             $panels = Filament::getPanels();
 
-            /**
-             * @template Panel
-             * @var Panel $panel
-             */
+            /** @var Panel $panel */
             $panel = (count($panels) > 1) ? $panels[select(
                 label: 'Which panel would you like to create this in?',
                 options: array_map(
@@ -68,21 +65,12 @@ class MakeTenantRegisterCommand extends Command
         $tenancyDirectories = $panel->getTenancyDirectories();
         $tenancyNamespaces = $panel->getTenancyNamespaces();
 
-        /**
-         * @template string
-         * @var string $namespace
-         */
         $namespace = (count($tenancyNamespaces) > 1) ?
             select(
                 label: 'Which namespace would you like to create this in?',
                 options: $tenancyNamespaces,
             ) :
             (Arr::first($tenancyNamespaces) ?: 'App\\Filament\\Pages\\Tenancy');
-
-        /**
-         * @template string
-         * @var string $path
-         */
         $path = (count($tenancyDirectories) > 1) ?
             $tenancyDirectories[array_search($namespace, $tenancyNamespaces)] :
             Arr::first($tenancyDirectories) ?? app_path('Filament/Pages/Tenancy');

--- a/packages/panels/src/Commands/MakeTenantRegisterCommand.php
+++ b/packages/panels/src/Commands/MakeTenantRegisterCommand.php
@@ -12,14 +12,14 @@ use Illuminate\Support\Str;
 
 use function Laravel\Prompts\select;
 
-class TenantRegisterCommand extends Command
+class MakeTenantRegisterCommand extends Command
 {
     use CanIndentStrings;
     use CanManipulateFiles;
 
     protected $description = 'Create a new Filament tenant registration page';
 
-    protected $signature = 'filament:register-tenant {--panel=} {--F|force}';
+    protected $signature = 'make:filament-tenant-register-page {--panel=} {--F|force}';
 
     public function handle(): int
     {

--- a/packages/panels/src/Commands/MakeTenantRegisterCommand.php
+++ b/packages/panels/src/Commands/MakeTenantRegisterCommand.php
@@ -34,7 +34,10 @@ class MakeTenantRegisterCommand extends Command
         if (! $panel) {
             $panels = Filament::getPanels();
 
-            /** @var Panel $panel */
+            /**
+             * @template Panel
+             * @var Panel $panel
+             */
             $panel = (count($panels) > 1) ? $panels[select(
                 label: 'Which panel would you like to create this in?',
                 options: array_map(
@@ -65,12 +68,21 @@ class MakeTenantRegisterCommand extends Command
         $tenancyDirectories = $panel->getTenancyDirectories();
         $tenancyNamespaces = $panel->getTenancyNamespaces();
 
+        /**
+         * @template string
+         * @var string $namespace
+         */
         $namespace = (count($tenancyNamespaces) > 1) ?
             select(
                 label: 'Which namespace would you like to create this in?',
                 options: $tenancyNamespaces,
             ) :
             (Arr::first($tenancyNamespaces) ?: 'App\\Filament\\Pages\\Tenancy');
+
+        /**
+         * @template string
+         * @var string $path
+         */
         $path = (count($tenancyDirectories) > 1) ?
             $tenancyDirectories[array_search($namespace, $tenancyNamespaces)] :
             Arr::first($tenancyDirectories) ?? app_path('Filament/Pages/Tenancy');

--- a/packages/panels/src/Commands/TenantRegisterCommand.php
+++ b/packages/panels/src/Commands/TenantRegisterCommand.php
@@ -55,6 +55,12 @@ class TenantRegisterCommand extends Command
             return 1;
         }
 
+        if ($this->option('force') && filled($panel->getTenantRegistrationPage())) {
+            $this->components->info('Tenant registration page already exists.');
+
+            return 0;
+        }
+
         $page = $panel->getTenantRegistrationPage();
 
         $tenantModel = $panel->getTenantModel();

--- a/packages/panels/src/Commands/TenantRegisterCommand.php
+++ b/packages/panels/src/Commands/TenantRegisterCommand.php
@@ -21,13 +21,13 @@ class TenantRegisterCommand extends Command
     use CanIndentStrings;
     use CanManipulateFiles;
 
-    protected $description = 'Register a new tenant';
+    protected $description = 'Create a new Filament tenant registration page';
 
     protected $signature = 'filament:register-tenant {--panel=} {--F|force}';
 
     public function handle(): int
     {
-        $this->components->info('Registering a new tenant');
+        $this->components->info('Creating a new tenant registration page');
 
         $panel = $this->option('panel');
 
@@ -52,19 +52,19 @@ class TenantRegisterCommand extends Command
         if (! $panel->hasTenancy()) {
             $this->components->error('No tenant model has been defined for this panel.');
 
-            return 1;
+            return static::FAILURE;
         }
 
         if (!$this->option('force') && filled($panel->getTenantRegistrationPage())) {
             $this->components->info('Tenant registration page already exists.');
 
-            return 0;
+            return static::INVALID;
         }
 
         $tenantModel = $panel->getTenantModel();
-        $baseClass = class_basename($tenantModel);
-        $page = "Register{$baseClass}";
-        $tenantModelLabel = Str::snake(Str::singular($baseClass));
+        $tenantBaseClass = class_basename($tenantModel);
+        $page = "Register{$tenantBaseClass}";
+        $tenantModelLabel = Str::snake(Str::singular($tenantBaseClass));
 
         $tenancyDirectories = $panel->getTenancyDirectories();
         $tenancyNamespaces = $panel->getTenancyNamespaces();
@@ -93,10 +93,13 @@ class TenantRegisterCommand extends Command
         $this->copyStubToApp('RegisterTenant', $filePath, [
             'class' => $page,
             'namespace' => $namespace,
-            'tenantModel' => $tenantModel,
+            'tenantModelFullPath' => $tenantModel,
+            'tenantModel' => $tenantBaseClass,
             'tenantModelLabel' => $tenantModelLabel,
         ]);
 
-        dd("TenantRegisterCommand.php: All done!");
+        $this->components->info("Tenant registration page created: {$filePath}");
+
+        return static::SUCCESS;
     }
 }

--- a/packages/panels/src/Commands/TenantRegisterCommand.php
+++ b/packages/panels/src/Commands/TenantRegisterCommand.php
@@ -54,5 +54,25 @@ class TenantRegisterCommand extends Command
 
             return 1;
         }
+
+        $page = $panel->getTenantRegistrationPage();
+
+        $tenantModel = $panel->getTenantModel();
+        $tenantModelLabel = Str::snake(Str::singular(class_basename($tenantModel)));
+
+        $tenancyDirectories = $panel->getTenancyDirectories();
+        $tenancyNamespaces = $panel->getTenancyNamespaces();
+
+        $namespace = (count($tenancyNamespaces) > 1) ?
+            select(
+                label: 'Which namespace would you like to create this in?',
+                options: $tenancyNamespaces,
+            ) :
+            (Arr::first($tenancyNamespaces) ?: 'App\\Filament\\Pages\\Tenancy');
+        $path = (count($tenancyDirectories) > 1) ?
+            $tenancyDirectories[array_search($namespace, $tenancyNamespaces)] :
+            Arr::first($tenancyDirectories) ?? app_path('Filament/Pages/Tenancy');
+
+        dd($namespace, $path);
     }
 }

--- a/packages/panels/src/Commands/TenantRegisterCommand.php
+++ b/packages/panels/src/Commands/TenantRegisterCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Filament\Commands;
+
+use Filament\Clusters\Cluster;
+use Filament\Facades\Filament;
+use Filament\Panel;
+use Filament\Support\Commands\Concerns\CanIndentStrings;
+use Filament\Support\Commands\Concerns\CanManipulateFiles;
+use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\suggest;
+use function Laravel\Prompts\text;
+
+class TenantRegisterCommand extends Command
+{
+    use CanIndentStrings;
+    use CanManipulateFiles;
+
+    protected $description = 'Register a new tenant';
+
+    protected $signature = 'filament:register-tenant {--panel=} {--F|force}';
+
+    public function handle(): int
+    {
+        $this->info('Registering a new tenant');
+
+        $panel = $this->option('panel');
+
+        if ($panel) {
+            $panel = Filament::getPanel($panel);
+        }
+
+        if (! $panel) {
+            $panels = Filament::getPanels();
+
+            /** @var Panel $panel */
+            $panel = (count($panels) > 1) ? $panels[select(
+                label: 'Which panel would you like to create this in?',
+                options: array_map(
+                    fn (Panel $panel): string => $panel->getId(),
+                    $panels,
+                ),
+                default: Filament::getDefaultPanel()->getId()
+            )] : Arr::first($panels);
+        }
+
+        dd($panel);
+    }
+}

--- a/packages/panels/src/Commands/TenantRegisterCommand.php
+++ b/packages/panels/src/Commands/TenantRegisterCommand.php
@@ -27,7 +27,7 @@ class TenantRegisterCommand extends Command
 
     public function handle(): int
     {
-        $this->info('Registering a new tenant');
+        $this->components->info('Registering a new tenant');
 
         $panel = $this->option('panel');
 
@@ -49,6 +49,10 @@ class TenantRegisterCommand extends Command
             )] : Arr::first($panels);
         }
 
-        dd($panel);
+        if (! $panel->hasTenancy()) {
+            $this->components->error('No tenant model has been defined for this panel.');
+
+            return 1;
+        }
     }
 }

--- a/packages/panels/src/Commands/TenantRegisterCommand.php
+++ b/packages/panels/src/Commands/TenantRegisterCommand.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Commands;
 
-use Filament\Clusters\Cluster;
 use Filament\Facades\Filament;
 use Filament\Panel;
 use Filament\Support\Commands\Concerns\CanIndentStrings;
@@ -11,10 +10,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
-use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\select;
-use function Laravel\Prompts\suggest;
-use function Laravel\Prompts\text;
 
 class TenantRegisterCommand extends Command
 {
@@ -55,7 +51,7 @@ class TenantRegisterCommand extends Command
             return static::FAILURE;
         }
 
-        if (!$this->option('force') && filled($panel->getTenantRegistrationPage())) {
+        if (! $this->option('force') && filled($panel->getTenantRegistrationPage())) {
             $this->components->info('Tenant registration page already exists.');
 
             return static::INVALID;

--- a/packages/panels/src/FilamentServiceProvider.php
+++ b/packages/panels/src/FilamentServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Filament;
 
+use Filament\Commands\TenantRegisterCommand;
 use Filament\Facades\Filament;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -114,6 +115,7 @@ class FilamentServiceProvider extends PackageServiceProvider
             Commands\MakeResourceCommand::class,
             Commands\MakeThemeCommand::class,
             Commands\MakeUserCommand::class,
+            TenantRegisterCommand::class,
         ];
 
         $aliases = [];

--- a/packages/panels/src/FilamentServiceProvider.php
+++ b/packages/panels/src/FilamentServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Filament;
 
-use Filament\Commands\TenantRegisterCommand;
+use Filament\Commands\MakeTenantRegisterCommand;
 use Filament\Facades\Filament;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -115,7 +115,7 @@ class FilamentServiceProvider extends PackageServiceProvider
             Commands\MakeResourceCommand::class,
             Commands\MakeThemeCommand::class,
             Commands\MakeUserCommand::class,
-            TenantRegisterCommand::class,
+            MakeTenantRegisterCommand::class,
         ];
 
         $aliases = [];

--- a/packages/panels/src/FilamentServiceProvider.php
+++ b/packages/panels/src/FilamentServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Filament;
 
-use Filament\Commands\MakeTenantRegisterCommand;
 use Filament\Facades\Filament;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -115,7 +114,7 @@ class FilamentServiceProvider extends PackageServiceProvider
             Commands\MakeResourceCommand::class,
             Commands\MakeThemeCommand::class,
             Commands\MakeUserCommand::class,
-            MakeTenantRegisterCommand::class,
+            Commands\MakeTenantRegisterCommand::class,
         ];
 
         $aliases = [];

--- a/packages/panels/src/Panel/Concerns/HasComponents.php
+++ b/packages/panels/src/Panel/Concerns/HasComponents.php
@@ -234,6 +234,28 @@ trait HasComponents
         ];
     }
 
+    /**
+     * @return array<string>
+     */
+    public function getTenancyDirectories(): array
+    {
+        return array_map(
+            fn (string $directory): string => "{$directory}/Tenancy",
+            $this->getPageDirectories(),
+        );
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getTenancyNamespaces(): array
+    {
+        return array_map(
+            fn (string $namespace): string => "{$namespace}\Tenancy",
+            $this->getPageNamespaces(),
+        );
+    }
+
     public function discoverClusters(string $in, string $for): static
     {
         if ($this->hasCachedComponents()) {

--- a/packages/panels/stubs/RegisterTenant.stub
+++ b/packages/panels/stubs/RegisterTenant.stub
@@ -1,0 +1,33 @@
+<?php
+
+namespace {{ namespace }};
+
+{{ clusterImport }}use Filament\Pages\Tenancy\RegisterTenant;
+use Filament\Forms\Form;
+use Filament\Pages\Tenancy\RegisterTenant;
+
+class {{ class }} extends RegisterTenant
+{
+    public static function getLabel(): string
+    {
+        return 'Register {{ label }}';
+    }
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                // Add form fields here
+            ]);
+    }
+
+    protected function handleRegistration(array $data): {{ clusterClass }}
+    {
+        // Create a new tenant
+        $tenant = {{ clusterClass }}::create($data);
+
+        // Add any additional logic here
+
+        return $tenant;
+    }
+}

--- a/packages/panels/stubs/RegisterTenant.stub
+++ b/packages/panels/stubs/RegisterTenant.stub
@@ -2,15 +2,14 @@
 
 namespace {{ namespace }};
 
-{{ clusterImport }}use Filament\Pages\Tenancy\RegisterTenant;
-use Filament\Forms\Form;
 use Filament\Pages\Tenancy\RegisterTenant;
+use Filament\Forms\Form;
 
 class {{ class }} extends RegisterTenant
 {
     public static function getLabel(): string
     {
-        return 'Register {{ label }}';
+        return 'Register {{ tenantModelLabel }}';
     }
 
     public function form(Form $form): Form
@@ -21,10 +20,10 @@ class {{ class }} extends RegisterTenant
             ]);
     }
 
-    protected function handleRegistration(array $data): {{ clusterClass }}
+    protected function handleRegistration(array $data): {{ tenantModel }}
     {
         // Create a new tenant
-        $tenant = {{ clusterClass }}::create($data);
+        $tenant = {{ tenantModel }}::create($data);
 
         // Add any additional logic here
 

--- a/packages/panels/stubs/RegisterTenant.stub
+++ b/packages/panels/stubs/RegisterTenant.stub
@@ -4,6 +4,7 @@ namespace {{ namespace }};
 
 use Filament\Pages\Tenancy\RegisterTenant;
 use Filament\Forms\Form;
+use {{ tenantModelFullPath }};
 
 class {{ class }} extends RegisterTenant
 {


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

This command:
```
php artisan filament:register-tenant
```
will create a tenant registration page according to registered model in the `PanelProvider`.

It also shows appropriate messages when:
- No model is registered as Tenant
- Tenant Registration Page already defined in Panel

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
