### PR TITLE
Update 11-tenancy.md

### DIFF
--- a/packages/panels/docs/11-tenancy.md
+++ b/packages/panels/docs/11-tenancy.md
@@ -24,7 +24,7 @@ class Post extends Model
     protected static function booted(): void
     {
         static::addGlobalScope('team', function (Builder $query) {
-            if (auth()->check()) {
+            if (auth()->hasUser()) {
                 $query->where('team_id', auth()->user()->team_id);
                 // or with a `team` relationship defined:
                 $query->whereBelongsTo(auth()->user()->team);


### PR DESCRIPTION
## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->
The currently suggested use of `auth()->check()` in a global scope causes an infinite loop and crashes the server when used. This is a relevant Laravel issue: https://github.com/laravel/framework/issues/18218. It seems that the auth check queries for the user at some point, which triggers the scope again, causing the loop.

I found that using `auth()->hasUser()` achieves the desired result without causing the loop condition.

Alternatively, https://github.com/filamentphp/filament/pull/9968/commits/92b09186262dd64572d6fe8f8acc132c2a43fd5a could be reverted, moving `auth()->check()` back outside of the `addGlobalScope`, which does work for the given example. The downside of suggesting that is if you use a class-based scope, like what's suggested on https://laravel.com/docs/11.x/eloquent#global-scopes, you cannot use `auth()->check()` inside of the `apply` method because it leads to the same looping condition.

Edit: I'm realizing now that this most likely only effects a global scope applied to the User model.

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
