### PR TITLE
Add `wire:navigate` to Action url method

### DIFF
--- a/packages/actions/resources/views/components/action.blade.php
+++ b/packages/actions/resources/views/components/action.blade.php
@@ -7,6 +7,11 @@
 @php
     $isDisabled = $action->isDisabled();
     $url = $action->getUrl();
+
+    if(! $isDisabled && $url) {
+        $hasSpaMode = \Filament\Facades\Filament::getCurrentPanel()->hasSpaMode();
+        $shouldNavigate = $hasSpaMode && \Filament\Support\is_app_url($url);
+    }
 @endphp
 
 <x-dynamic-component
@@ -30,6 +35,7 @@
         \Filament\Support\prepare_inherited_attributes($attributes)
             ->merge($action->getExtraAttributes(), escape: false)
             ->class(['fi-ac-action'])
+            ->merge(isset($shouldNavigate) && $shouldNavigate ? ['wire:navigate' => ''] : [], escape: false)
     "
 >
     {{ $slot }}


### PR DESCRIPTION
Adds `wire:navigate` logic to the Action `->url()` method.

`FilamentView::hasSpaMode()` wasn't working - maybe because I'm testing in a standlone SimplePage which I've manually associated with a panel using `setCurrentPanel()`? Getting it from the panel works though.