### PR TITLE
Fixed toArray database notification

### DIFF
--- a/packages/notifications/src/BroadcastNotification.php
+++ b/packages/notifications/src/BroadcastNotification.php
@@ -4,12 +4,11 @@ namespace Filament\Notifications;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Messages\BroadcastMessage;
 use Illuminate\Notifications\Notification as BaseNotification;
 
-class BroadcastNotification extends BaseNotification implements ShouldQueue, Arrayable
+class BroadcastNotification extends BaseNotification implements ShouldQueue
 {
     use Queueable;
 
@@ -36,13 +35,5 @@ class BroadcastNotification extends BaseNotification implements ShouldQueue, Arr
     public function toBroadcast($notifiable): BroadcastMessage
     {
         return new BroadcastMessage($this->data);
-    }
-
-     /**
-     * Array representation of this notification.
-     */
-    public function toArray(): array
-    {
-        return $this->data;
     }
 }

--- a/packages/notifications/src/BroadcastNotification.php
+++ b/packages/notifications/src/BroadcastNotification.php
@@ -4,11 +4,12 @@ namespace Filament\Notifications;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Messages\BroadcastMessage;
 use Illuminate\Notifications\Notification as BaseNotification;
 
-class BroadcastNotification extends BaseNotification implements ShouldQueue
+class BroadcastNotification extends BaseNotification implements ShouldQueue, Arrayable
 {
     use Queueable;
 
@@ -35,5 +36,13 @@ class BroadcastNotification extends BaseNotification implements ShouldQueue
     public function toBroadcast($notifiable): BroadcastMessage
     {
         return new BroadcastMessage($this->data);
+    }
+
+     /**
+     * Array representation of this notification.
+     */
+    public function toArray(): array
+    {
+        return $this->data;
     }
 }

--- a/packages/notifications/src/DatabaseNotification.php
+++ b/packages/notifications/src/DatabaseNotification.php
@@ -39,7 +39,7 @@ class DatabaseNotification extends BaseNotification implements ShouldQueue, Arra
     }
 
     /**
-     * Array representation of this notification.
+     * @return array<string, mixed>
      */
     public function toArray(): array
     {

--- a/packages/notifications/src/DatabaseNotification.php
+++ b/packages/notifications/src/DatabaseNotification.php
@@ -36,4 +36,12 @@ class DatabaseNotification extends BaseNotification implements ShouldQueue
     {
         return $this->data;
     }
+
+    /**
+     * Array representation of this notification.
+     */
+    public function toArray(): array
+    {
+        return [];
+    }
 }

--- a/packages/notifications/src/DatabaseNotification.php
+++ b/packages/notifications/src/DatabaseNotification.php
@@ -4,10 +4,11 @@ namespace Filament\Notifications;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notification as BaseNotification;
 
-class DatabaseNotification extends BaseNotification implements ShouldQueue
+class DatabaseNotification extends BaseNotification implements ShouldQueue, Arrayable
 {
     use Queueable;
 
@@ -42,6 +43,6 @@ class DatabaseNotification extends BaseNotification implements ShouldQueue
      */
     public function toArray(): array
     {
-        return [];
+        return $this->data;
     }
 }


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

When I'm trying to send database notification using this code.

```
Notification::make()
    ->danger()
    ->title("Error in the row {$failure->row()}")
    ->body($failure->errors()[0])
    ->sendToDatabase($this->user)
```

I got this error

`Call to undefined method Filament\Notifications\DatabaseNotification::toArray()`

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

<!-- Replace this comment with your description. -->

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [ ] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
