### PR TITLE
Add option to add caption in tables

### DIFF
--- a/packages/notifications/src/DatabaseNotification.php
+++ b/packages/notifications/src/DatabaseNotification.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notification as BaseNotification;
 
-class DatabaseNotification extends BaseNotification implements ShouldQueue, Arrayable
+class DatabaseNotification extends BaseNotification implements Arrayable, ShouldQueue
 {
     use Queueable;
 

--- a/packages/notifications/src/DatabaseNotification.php
+++ b/packages/notifications/src/DatabaseNotification.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notification as BaseNotification;
 
-class DatabaseNotification extends BaseNotification implements Arrayable, ShouldQueue
+class DatabaseNotification extends BaseNotification implements ShouldQueue, Arrayable
 {
     use Queueable;
 

--- a/packages/tables/docs/10-advanced.md
+++ b/packages/tables/docs/10-advanced.md
@@ -402,6 +402,35 @@ public function table(Table $table): Table
 
 These classes are not automatically compiled by Tailwind CSS. If you want to apply Tailwind CSS classes that are not already used in Blade files, you should update your `content` configuration in `tailwind.config.js` to also scan for classes inside your directory: `'./app/Filament/**/*.php'`
 
+## Adding the table caption
+
+You can add a caption to a table using the `$table->caption()` method:
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->caption('This is a table caption');
+}
+```
+
+You can pass `string` or `Closure` to the `$table->caption()` method:
+
+You can also pass `translateCaption()` with the `$table->caption()` method to translate the caption:
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->caption('tables.caption')
+        ->translateCaption();
+}
+```
+
 ## Resetting the table
 
 If you make changes to the table definition during a Livewire request, for example, when consuming a public property in the `table()` method, you may need to reset the table to ensure that the changes are applied. To do this, you can call the `resetTable()` method on the Livewire component:

--- a/packages/tables/resources/views/components/caption.blade.php
+++ b/packages/tables/resources/views/components/caption.blade.php
@@ -1,0 +1,5 @@
+<div
+    {{ $attributes->class(['px-4 py-2 text-sm text-gray-500 dark:text-gray-400']) }}
+>
+    {{ $slot }}
+</div>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -14,6 +14,7 @@
     $actionsPosition = $getActionsPosition();
     $actionsColumnLabel = $getActionsColumnLabel();
     $activeFiltersCount = $getActiveFiltersCount();
+    $caption = $getCaption();
     $columns = $getVisibleColumns();
     $collapsibleColumnsLayout = $getCollapsibleColumnsLayout();
     $columnsLayout = $getColumnsLayout();
@@ -1221,6 +1222,12 @@
                 </tr>
             @endif
         </div>
+
+        @if($caption)
+            <div class="px-4 py-2 text-sm text-gray-500 dark:text-gray-400">
+                {{ $caption }}
+            </div>
+        @endif
 
         @if ((($records instanceof \Illuminate\Contracts\Pagination\Paginator) || ($records instanceof \Illuminate\Contracts\Pagination\CursorPaginator)) &&
              ((! ($records instanceof \Illuminate\Contracts\Pagination\LengthAwarePaginator)) || $records->total()))

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -1223,7 +1223,7 @@
             @endif
         </div>
 
-        @if($caption)
+        @if ($caption)
             <x-filament-tables::caption>
                 {{ $caption }}
             </x-filament-tables::caption>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -1224,9 +1224,9 @@
         </div>
 
         @if($caption)
-            <div class="px-4 py-2 text-sm text-gray-500 dark:text-gray-400">
+            <x-filament-tables::caption>
                 {{ $caption }}
-            </div>
+            </x-filament-tables::caption>
         @endif
 
         @if ((($records instanceof \Illuminate\Contracts\Pagination\Paginator) || ($records instanceof \Illuminate\Contracts\Pagination\CursorPaginator)) &&

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -20,6 +20,7 @@ class Table extends ViewComponent
     use Table\Concerns\CanToggleColumns;
     use Table\Concerns\HasActions;
     use Table\Concerns\HasBulkActions;
+    use Table\Concerns\HasCaption;
     use Table\Concerns\HasColumns;
     use Table\Concerns\HasContent;
     use Table\Concerns\HasEmptyState;

--- a/packages/tables/src/Table/Concerns/HasCaption.php
+++ b/packages/tables/src/Table/Concerns/HasCaption.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Filament\Tables\Table\Concerns;
+
+use Closure;
+use Illuminate\Contracts\Support\Htmlable;
+
+trait HasCaption
+{
+    protected string | Htmlable | Closure | null $caption = null;
+
+    protected bool $shouldTranslateCaption = false;
+
+    public function caption(string | Htmlable | Closure | null $caption): static
+    {
+        $this->caption = $caption;
+
+        return $this;
+    }
+
+    public function translateCaption(bool $shouldTranslateCaption = true): static
+    {
+        $this->shouldTranslateCaption = $shouldTranslateCaption;
+
+        return $this;
+    }
+
+    public function getCaption(): string | Htmlable
+    {
+        $caption = $this->evaluate($this->caption);
+
+        return $this->shouldTranslateCaption ? __($caption) : $caption;
+    }
+}

--- a/packages/tables/src/Table/Concerns/HasCaption.php
+++ b/packages/tables/src/Table/Concerns/HasCaption.php
@@ -25,7 +25,7 @@ trait HasCaption
         return $this;
     }
 
-    public function getCaption(): string | null
+    public function getCaption(): ?string
     {
         if ($this->caption === null) {
             return null;

--- a/packages/tables/src/Table/Concerns/HasCaption.php
+++ b/packages/tables/src/Table/Concerns/HasCaption.php
@@ -11,7 +11,7 @@ trait HasCaption
 
     protected bool $shouldTranslateCaption = false;
 
-    public function caption(string | Htmlable | Closure | null $caption): static
+    public function caption(string | Closure | null $caption): static
     {
         $this->caption = $caption;
 
@@ -25,7 +25,7 @@ trait HasCaption
         return $this;
     }
 
-    public function getCaption(): string | Htmlable | null
+    public function getCaption(): string | null
     {
         if ($this->caption === null) {
             return null;

--- a/packages/tables/src/Table/Concerns/HasCaption.php
+++ b/packages/tables/src/Table/Concerns/HasCaption.php
@@ -3,11 +3,10 @@
 namespace Filament\Tables\Table\Concerns;
 
 use Closure;
-use Illuminate\Contracts\Support\Htmlable;
 
 trait HasCaption
 {
-    protected string | Htmlable | Closure | null $caption = null;
+    protected string | Closure | null $caption = null;
 
     protected bool $shouldTranslateCaption = false;
 

--- a/packages/tables/src/Table/Concerns/HasCaption.php
+++ b/packages/tables/src/Table/Concerns/HasCaption.php
@@ -25,8 +25,12 @@ trait HasCaption
         return $this;
     }
 
-    public function getCaption(): string | Htmlable
+    public function getCaption(): string | Htmlable | null
     {
+        if ($this->caption === null) {
+            return null;
+        }
+
         $caption = $this->evaluate($this->caption);
 
         return $this->shouldTranslateCaption ? __($caption) : $caption;


### PR DESCRIPTION
<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

With this PR, users can add table captions using `caption()` method.

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

### Before
<img width="1256" alt="image" src="https://github.com/filamentphp/filament/assets/30431426/dc0a58fd-c175-4071-90f7-5c61a60248e1">

### Code changes
<img width="588" alt="image" src="https://github.com/filamentphp/filament/assets/30431426/afd7c972-d4d5-4a7a-b0c1-da9549f50aad">

### After 
<img width="1250" alt="image" src="https://github.com/filamentphp/filament/assets/30431426/6b700abd-db11-400e-b882-4269815f8e6c">

### When pagination is disabled
<img width="1246" alt="image" src="https://github.com/filamentphp/filament/assets/30431426/c8eb72df-4754-41c8-a13a-2d78f44da642">

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [x] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
