### PR TITLE
Update 03-creating-records.md

### DIFF
--- a/packages/panels/docs/03-resources/03-creating-records.md
+++ b/packages/panels/docs/03-resources/03-creating-records.md
@@ -162,7 +162,7 @@ use Filament\Notifications\Notification;
 
 protected function beforeCreate(): void
 {
-    if (! $this->getRecord()->team->subscribed()) {
+    if (! $this->data->team->subscribed()) {
         Notification::make()
             ->warning()
             ->title('You don\'t have an active subscription!')

--- a/packages/panels/docs/03-resources/03-creating-records.md
+++ b/packages/panels/docs/03-resources/03-creating-records.md
@@ -162,7 +162,7 @@ use Filament\Notifications\Notification;
 
 protected function beforeCreate(): void
 {
-    if (! $this->data->team->subscribed()) {
+    if (! auth()->user()->team->subscribed()) {
         Notification::make()
             ->warning()
             ->title('You don\'t have an active subscription!')


### PR DESCRIPTION
It should be $this->data not $this->getRecord(). It doesn't make sense to check a record that hasn't been created yet.

<!-- Please fill the entire template and make sure that all checkboxes are checked. -->

## Description

<!-- Explain the goal of this pull request by describing the issue it fixes or the need for the new or updated functionality. -->

Fix in the docs. Should use $this->data in the beforeCreate. It doesnt make sense to check a record that hasnt been created yet.

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [ ] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [ ] Documentation is up-to-date.
