### PR TITLE
Allow builder addAction to be hidden

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -237,7 +237,7 @@
             </ul>
         @endif
 
-        @if ($isAddable)
+        @if ($isAddable && $addAction->isVisible())
             <x-filament-forms::builder.block-picker
                 :action="$addAction"
                 :blocks="$blockPickerBlocks"


### PR DESCRIPTION
## Description
Currently you can only hide the addAction button in the Builder with `->addable(false)`. However this also disables the addBetweenAction button. This PR allows you to hide the addAction button by passing while maintaining the addBetweenAction button

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

- [X] `composer cs` command has been run.

## Testing
- [X] Changes have been tested.

## Documentation
- [X] Documentation is up-to-date.
