### PR TITLE
Qualify sort column

### DIFF
--- a/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
@@ -146,7 +146,7 @@ trait InteractsWithTableQuery
             [];
 
         if (! count($relationships)) {
-            return $sortColumn;
+            return $query->getModel()->qualifyColumn($sortColumn);
         }
 
         $currentRelationshipName = array_shift($relationships);

--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -110,7 +110,7 @@ trait CanSortRecords
         }
 
         if ($sortColumnName) {
-            return $query->orderBy($sortColumnName, $sortDirection);
+            return $query->orderBy($query->getModel()->qualifyColumn($sortColumnName), $sortDirection);
         }
 
         if ($sortQueryUsing = $this->getTable()->getDefaultSortQuery()) {

--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -326,7 +326,9 @@ class Group extends Component
             [];
 
         if (! count($relationships)) {
-            return $lastRelationship ? $lastRelationship->getQuery()->getModel()->qualifyColumn($sortColumn) : $sortColumn;
+            return $lastRelationship
+                ? $lastRelationship->getQuery()->getModel()->qualifyColumn($sortColumn)
+                : $query->getModel()->qualifyColumn($sortColumn);
         }
 
         $currentRelationshipName = array_shift($relationships);


### PR DESCRIPTION
## Description

When changing the default sort, eg. `->defaultSort('id', 'desc')` the column has to be prefixed with the table name in certain scenarios to prevent:
`SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'id' in order clause is ambiguous`

This can be automatically done by filament in these cases.

I am not sure if only `Filament\Tables\Concerns\CanSortRecords` should be changed, or also the `getSortColumnForQuery()` method in the `Group` class and `InteractsWithTableQuery` trait.

## Code style

- [X] `composer cs` command has been run.

## Testing

- [X] Changes to `Filament\Tables\Concerns\CanSortRecords` have been tested
- [ ] Changes to `getSortColumnForQuery()` method in the `Group` class and `InteractsWithTableQuery` trait have not been extensively tested, but works on system

## Documentation

-