### PR TITLE
Fix: Rich editor not displaying data when changing languages

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug report
 description: Report a problem you're experiencing
 labels: bug,unconfirmed,low priority
-projects: ["filamentphp/2"]
+projects: ['filamentphp/2']
 body:
   - type: markdown
     attributes:

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -56,6 +56,7 @@
                 x-on:trix-change="
                     let value = $event.target.value
                     $nextTick(() => {
+                    
                         if (! $refs.trix) {
                             return
                         }

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -55,8 +55,8 @@
                 "
                 x-on:trix-change="
                     let value = $event.target.value
+                
                     $nextTick(() => {
-                    
                         if (! $refs.trix) {
                             return
                         }

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -54,12 +54,13 @@
                     )
                 "
                 x-on:trix-change="
+                    let value = $event.target.value
                     $nextTick(() => {
                         if (! $refs.trix) {
                             return
                         }
 
-                        state = $event.target.value
+                        state = value
                     })
                 "
                 @if ($isLiveDebounced())


### PR DESCRIPTION
## Description

closes #11880

The value of the editor is now captured before the nextTick callback as a local variable so that state changes work properly

## Code style

- [x] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.

## Documentation

- [x] Documentation is up-to-date.
