### PR TITLE
make IconColumn and IconEntry support collections

### DIFF
--- a/packages/infolists/resources/views/components/color-entry.blade.php
+++ b/packages/infolists/resources/views/components/color-entry.blade.php
@@ -1,4 +1,14 @@
 <x-dynamic-component :component="$getEntryWrapperView()" :entry="$entry">
+    @php
+        $arrayState = $getState();
+
+        if ($arrayState instanceof \Illuminate\Support\Collection) {
+            $arrayState = $arrayState->all();
+        }
+
+        $arrayState = \Illuminate\Support\Arr::wrap($arrayState);
+    @endphp
+
     <div
         {{
             $attributes
@@ -8,7 +18,7 @@
                 ])
         }}
     >
-        @if (count($arrayState = \Illuminate\Support\Arr::wrap($getState())))
+        @if (count($arrayState))
             @foreach ($arrayState as $state)
                 @php
                     $itemIsCopyable = $isCopyable($state);

--- a/packages/infolists/resources/views/components/icon-entry.blade.php
+++ b/packages/infolists/resources/views/components/icon-entry.blade.php
@@ -12,7 +12,7 @@
                 ])
         }}
     >
-        @if (count($arrayState = \Illuminate\Support\Arr::wrap($getState())))
+        @if (count($arrayState = \Illuminate\Support\Collection::wrap($getState())))
             @foreach ($arrayState as $state)
                 @if ($icon = $getIcon($state))
                     @php

--- a/packages/infolists/resources/views/components/icon-entry.blade.php
+++ b/packages/infolists/resources/views/components/icon-entry.blade.php
@@ -1,16 +1,16 @@
-@php
-    use Filament\Infolists\Components\IconEntry\IconEntrySize;
-
-    $arrayState = $getState();
-
-    if ($arrayState instanceof \Illuminate\Support\Collection) {
-        $arrayState = $arrayState->all();
-    }
-
-    $arrayState = \Illuminate\Support\Arr::wrap($arrayState);
-@endphp
-
 <x-dynamic-component :component="$getEntryWrapperView()" :entry="$entry">
+    @php
+        use Filament\Infolists\Components\IconEntry\IconEntrySize;
+    
+        $arrayState = $getState();
+    
+        if ($arrayState instanceof \Illuminate\Support\Collection) {
+            $arrayState = $arrayState->all();
+        }
+    
+        $arrayState = \Illuminate\Support\Arr::wrap($arrayState);
+    @endphp
+
     <div
         {{
             $attributes

--- a/packages/infolists/resources/views/components/icon-entry.blade.php
+++ b/packages/infolists/resources/views/components/icon-entry.blade.php
@@ -1,5 +1,13 @@
 @php
     use Filament\Infolists\Components\IconEntry\IconEntrySize;
+
+    $arrayState = $getState();
+
+    if ($arrayState instanceof \Illuminate\Support\Collection) {
+        $arrayState = $arrayState->all();
+    }
+
+    $arrayState = \Illuminate\Support\Arr::wrap($arrayState);
 @endphp
 
 <x-dynamic-component :component="$getEntryWrapperView()" :entry="$entry">
@@ -12,7 +20,7 @@
                 ])
         }}
     >
-        @if (count($arrayState = \Illuminate\Support\Collection::wrap($getState())))
+        @if (count($arrayState))
             @foreach ($arrayState as $state)
                 @if ($icon = $getIcon($state))
                     @php

--- a/packages/infolists/resources/views/components/image-entry.blade.php
+++ b/packages/infolists/resources/views/components/image-entry.blade.php
@@ -1,7 +1,14 @@
 <x-dynamic-component :component="$getEntryWrapperView()" :entry="$entry">
     @php
+        $state = $getState();
+
+        if ($state instanceof \Illuminate\Support\Collection) {
+            $state = $state->all();
+        }
+
+        $state = \Illuminate\Support\Arr::wrap($state);
+
         $limit = $getLimit();
-        $state = \Illuminate\Support\Arr::wrap($getState());
         $limitedState = array_slice($state, 0, $limit);
         $isCircular = $isCircular();
         $isSquare = $isSquare();

--- a/packages/tables/resources/views/columns/color-column.blade.php
+++ b/packages/tables/resources/views/columns/color-column.blade.php
@@ -1,5 +1,13 @@
 @php
     $canWrap = $canWrap();
+
+    $arrayState = $getState();
+
+    if ($arrayState instanceof \Illuminate\Support\Collection) {
+        $arrayState = $arrayState->all();
+    }
+
+    $arrayState = \Illuminate\Support\Arr::wrap($arrayState);
 @endphp
 
 <div
@@ -13,7 +21,7 @@
             ])
     }}
 >
-    @if (count($arrayState = \Illuminate\Support\Arr::wrap($getState())))
+    @if (count($arrayState))
         @foreach ($arrayState as $state)
             @php
                 $itemIsCopyable = $isCopyable($state);

--- a/packages/tables/resources/views/columns/icon-column.blade.php
+++ b/packages/tables/resources/views/columns/icon-column.blade.php
@@ -1,5 +1,13 @@
 @php
     use Filament\Tables\Columns\IconColumn\IconColumnSize;
+
+    $arrayState = $getState();
+
+    if ($arrayState instanceof \Illuminate\Support\Collection) {
+        $arrayState = $arrayState->all();
+    }
+
+    $arrayState = \Illuminate\Support\Arr::wrap($arrayState);
 @endphp
 
 <div
@@ -14,7 +22,7 @@
             ])
     }}
 >
-    @if (count($arrayState = \Illuminate\Support\Collection::wrap($getState())))
+    @if (count($arrayState))
         @foreach ($arrayState as $state)
             @if ($icon = $getIcon($state))
                 @php

--- a/packages/tables/resources/views/columns/icon-column.blade.php
+++ b/packages/tables/resources/views/columns/icon-column.blade.php
@@ -14,7 +14,7 @@
             ])
     }}
 >
-    @if (count($arrayState = \Illuminate\Support\Arr::wrap($getState())))
+    @if (count($arrayState = \Illuminate\Support\Collection::wrap($getState())))
         @foreach ($arrayState as $state)
             @if ($icon = $getIcon($state))
                 @php

--- a/packages/tables/resources/views/columns/image-column.blade.php
+++ b/packages/tables/resources/views/columns/image-column.blade.php
@@ -6,7 +6,7 @@
     }
 
     $state = \Illuminate\Support\Arr::wrap($state);
-    
+
     $limit = $getLimit();
     $limitedState = array_slice($state, 0, $limit);
     $isCircular = $isCircular();

--- a/packages/tables/resources/views/columns/image-column.blade.php
+++ b/packages/tables/resources/views/columns/image-column.blade.php
@@ -1,6 +1,13 @@
 @php
+    $state = $getState();
+
+    if ($state instanceof \Illuminate\Support\Collection) {
+        $state = $state->all();
+    }
+
+    $state = \Illuminate\Support\Arr::wrap($state);
+    
     $limit = $getLimit();
-    $state = \Illuminate\Support\Arr::wrap($getState());
     $limitedState = array_slice($state, 0, $limit);
     $isCircular = $isCircular();
     $isSquare = $isSquare();


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The `IconColumn` and the `IconEntry` doesn't support collections as state as the `Text*` equivalents does. This PR wraps the state into a Collection instead of an array.

Having a Collection is a common use case, when one has an `AsEnumCollection::class` cast on a model with an enum implementing the `HasIcon` interface . 

## Visual changes

- [x] Visual changes (if any) are shown using screenshots/recordings of before and after.

Before:

![Bildschirmfoto 2024-03-22 um 19 19 44](https://github.com/filamentphp/filament/assets/11678100/fd7a7e88-c25b-4381-8466-f9c7579ea753)
![Bildschirmfoto 2024-03-22 um 19 33 47](https://github.com/filamentphp/filament/assets/11678100/8f1860db-bf1e-4f4e-9bab-ab373b5dfdbb)

After:

![Bildschirmfoto 2024-03-22 um 19 21 44](https://github.com/filamentphp/filament/assets/11678100/b2ed1314-cbd2-40f9-80b4-d77a7a85fb1b)
![Bildschirmfoto 2024-03-22 um 19 34 11](https://github.com/filamentphp/filament/assets/11678100/8b229a1b-c6d6-498d-836c-d2efee18a178)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
