### PR TITLE
Conditionally apply margin to notification contents

### DIFF
--- a/packages/notifications/resources/views/notification.blade.php
+++ b/packages/notifications/resources/views/notification.blade.php
@@ -80,13 +80,13 @@
             @endif
 
             @if (filled($date = $getDate()))
-                <x-filament-notifications::date class="mt-1">
+                <x-filament-notifications::date @class(['mt-1' => filled($title)])>
                     {{ $date }}
                 </x-filament-notifications::date>
             @endif
 
             @if (filled($body = $getBody()))
-                <x-filament-notifications::body class="mt-1">
+                <x-filament-notifications::body @class(['mt-1' => filled($title) || filled($date)])>
                     {{ str($body)->sanitizeHtml()->toHtmlString() }}
                 </x-filament-notifications::body>
             @endif
@@ -94,7 +94,7 @@
             @if ($actions = $getActions())
                 <x-filament-notifications::actions
                     :actions="$actions"
-                    class="mt-3"
+                    @class(['mt-3' => filled($title) || filled($date) || filled($body)])
                 />
             @endif
         </div>

--- a/packages/notifications/resources/views/notification.blade.php
+++ b/packages/notifications/resources/views/notification.blade.php
@@ -4,6 +4,12 @@
 
     $color = $getColor() ?? 'gray';
     $isInline = $isInline();
+    $title = $getTitle();
+    $hasTitle = filled($title);
+    $date = $getDate();
+    $hasDate = filled($date);
+    $body = $getBody();
+    $hasBody = filled($body);
 @endphp
 
 <x-filament-notifications::notification
@@ -73,23 +79,21 @@
         @endif
 
         <div class="mt-0.5 grid flex-1">
-            @if (filled($title = $getTitle()))
+            @if ($hasTitle)
                 <x-filament-notifications::title>
                     {{ str($title)->sanitizeHtml()->toHtmlString() }}
                 </x-filament-notifications::title>
             @endif
 
-            @if (filled($date = $getDate()))
-                <x-filament-notifications::date
-                    @class(['mt-1' => filled($title)])
-                >
+            @if ($hasDate)
+                <x-filament-notifications::date @class(['mt-1' => $hasTitle])>
                     {{ $date }}
                 </x-filament-notifications::date>
             @endif
 
-            @if (filled($body = $getBody()))
+            @if ($hasBody)
                 <x-filament-notifications::body
-                    @class(['mt-1' => filled($title) || filled($date)])
+                    @class(['mt-1' => $hasTitle || $hasDate])
                 >
                     {{ str($body)->sanitizeHtml()->toHtmlString() }}
                 </x-filament-notifications::body>
@@ -98,7 +102,7 @@
             @if ($actions = $getActions())
                 <x-filament-notifications::actions
                     :actions="$actions"
-                    @class(['mt-3' => filled($title) || filled($date) || filled($body)])
+                    @class(['mt-3' => $hasTitle || $hasDate || $hasBody])
                 />
             @endif
         </div>

--- a/packages/notifications/resources/views/notification.blade.php
+++ b/packages/notifications/resources/views/notification.blade.php
@@ -80,13 +80,17 @@
             @endif
 
             @if (filled($date = $getDate()))
-                <x-filament-notifications::date @class(['mt-1' => filled($title)])>
+                <x-filament-notifications::date
+                    @class(['mt-1' => filled($title)])
+                >
                     {{ $date }}
                 </x-filament-notifications::date>
             @endif
 
             @if (filled($body = $getBody()))
-                <x-filament-notifications::body @class(['mt-1' => filled($title) || filled($date)])>
+                <x-filament-notifications::body
+                    @class(['mt-1' => filled($title) || filled($date)])
+                >
                     {{ str($body)->sanitizeHtml()->toHtmlString() }}
                 </x-filament-notifications::body>
             @endif


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When not using for example a title in a notification, the body still has the margin-top applied.

## Visual changes

### Before
<img width="408" alt="before" src="https://github.com/filamentphp/filament/assets/100052/a67f5399-2b92-4195-afff-1ad6697c6f23">


### After
<img width="410" alt="after" src="https://github.com/filamentphp/filament/assets/100052/13097401-6ac9-437e-af4e-bcc1d30fa07f">

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
  - when running this, very many changes were suggested, I only applied the ones on the notification blade file
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
