### PR TITLE
Add `handleRegistration()` method to register page

### DIFF
--- a/packages/panels/src/Pages/Auth/Register.php
+++ b/packages/panels/src/Pages/Auth/Register.php
@@ -97,7 +97,7 @@ class Register extends SimplePage
     /**
      * @param  array<string, mixed>  $data
      */
-    protected function handleRegistration(array $data): Authenticatable
+    protected function handleRegistration(array $data): Model
     {
         return $this->getUserModel()::create($data);
     }

--- a/packages/panels/src/Pages/Auth/Register.php
+++ b/packages/panels/src/Pages/Auth/Register.php
@@ -80,7 +80,7 @@ class Register extends SimplePage
         $user = $this->wrapInDatabaseTransaction(function () {
             $data = $this->form->getState();
 
-            return $this->createUser($data);
+            return $this->handleRegistration($data);
         });
 
         event(new Registered($user));
@@ -95,9 +95,9 @@ class Register extends SimplePage
     }
 
     /**
-     * @param array<string, mixed> $data
+     * @param  array<string, mixed>  $data
      */
-    protected function createUser(array $data): Authenticatable
+    protected function handleRegistration(array $data): Authenticatable
     {
         return $this->getUserModel()::create($data);
     }

--- a/packages/panels/src/Pages/Auth/Register.php
+++ b/packages/panels/src/Pages/Auth/Register.php
@@ -20,6 +20,7 @@ use Filament\Pages\Concerns\InteractsWithFormActions;
 use Filament\Pages\SimplePage;
 use Illuminate\Auth\EloquentUserProvider;
 use Illuminate\Auth\SessionGuard;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
@@ -79,7 +80,7 @@ class Register extends SimplePage
         $user = $this->wrapInDatabaseTransaction(function () {
             $data = $this->form->getState();
 
-            return $this->getUserModel()::create($data);
+            return $this->createUser($data);
         });
 
         event(new Registered($user));
@@ -91,6 +92,11 @@ class Register extends SimplePage
         session()->regenerate();
 
         return app(RegistrationResponse::class);
+    }
+
+    protected function createUser(array $data): Authenticatable
+    {
+        return $this->getUserModel()::create($data);
     }
 
     protected function sendEmailVerificationNotification(Model $user): void

--- a/packages/panels/src/Pages/Auth/Register.php
+++ b/packages/panels/src/Pages/Auth/Register.php
@@ -94,6 +94,9 @@ class Register extends SimplePage
         return app(RegistrationResponse::class);
     }
 
+    /**
+     * @param array<string, mixed> $data
+     */
     protected function createUser(array $data): Authenticatable
     {
         return $this->getUserModel()::create($data);


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When customizing the user creation process, the whole register method has to be overwritten. With this, only the creation itself can be customized.

When making this edit, I was not sure what return type to choose. I ended up with choosing `Authenticatable`, the one required for `->login()`. Should the `$user` parameter of `sendEmailVerificationNotification()` not also be changed to `Authenticatable` instead of `Model`?

## Visual changes

None

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
