### PR TITLE
Fix logout method when using multi panel.

### DIFF
--- a/packages/panels/src/Http/Controllers/Auth/LogoutController.php
+++ b/packages/panels/src/Http/Controllers/Auth/LogoutController.php
@@ -9,11 +9,25 @@ class LogoutController
 {
     public function __invoke(): LogoutResponse
     {
-        Filament::auth()->logout();
+        $session = session()->all(); // We will get old session values.
+        Filament::getCurrentPanel()->auth()->logout(); // We will log out only from current panel.
 
-        session()->invalidate();
-        session()->regenerateToken();
+        session()->invalidate(); // it will invalidate and destory our session data.
+        session()->regenerateToken(); // it will regenerate session token.
+        session($this->removeGuardVariables($session)); // it will remove guard values such as password_hash and login from old session data.
+        
+        return app(LogoutResponse::class); // it will send user to logout response.
+    }
 
-        return app(LogoutResponse::class);
+    public function removeGuardVariables(array $session): array
+    {
+        $guard = Filament::getCurrentPanel()->getAuthGuard(); // intended way to get guard name of the panel you've been logged in.
+        foreach ($session as $sessionKey => $sessionValue) {
+            if (str_starts_with($sessionKey, 'password_hash_' . $guard)
+                || str_starts_with($sessionKey, 'login_' . $guard)) {
+                unset($session[$sessionKey]); // if string starts with password_hash or login just remove it.
+            }
+        }
+        return $session; // return it for freshly new created session.
     }
 }

--- a/packages/panels/src/Http/Controllers/Auth/LogoutController.php
+++ b/packages/panels/src/Http/Controllers/Auth/LogoutController.php
@@ -12,10 +12,10 @@ class LogoutController
         $session = session()->all(); // We will get old session values.
         Filament::getCurrentPanel()->auth()->logout(); // We will log out only from current panel.
 
-        session()->invalidate(); // it will invalidate and destory our session data.
+        session()->invalidate(); // it will invalidate and destroy our session data.
         session()->regenerateToken(); // it will regenerate session token.
         session($this->removeGuardVariables($session)); // it will remove guard values such as password_hash and login from old session data.
-        
+
         return app(LogoutResponse::class); // it will send user to logout response.
     }
 
@@ -28,6 +28,7 @@ class LogoutController
                 unset($session[$sessionKey]); // if string starts with password_hash or login just remove it.
             }
         }
+
         return $session; // return it for freshly new created session.
     }
 }


### PR DESCRIPTION
## Description
When you try to logout from panel-A which is guarded by "web:a".
it will also logs you out from panel-n which is guarded by web:n.
with this PR you can carry your session data remove old login details in session and refresh your session token.
You can remove any comment you want. I wrote them to explain what they are doing.

## Visual changes
Nothing effected.

## Functional changes
Logout will be only done for guard the panel provided. Which makes you logout from one panel only.
- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
