### PR TITLE
Handle array states and values in assertTableColumnStateSet

### DIFF
--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -146,8 +146,18 @@ class TestsColumns
 
             $livewireClass = $this->instance()::class;
 
+            $state = $column->getState();
+
+            if (is_array($state)) {
+                $state = serialize($state);
+            }
+
+            if (is_array($value)) {
+                $value = serialize($value);
+            }
+
             Assert::assertTrue(
-                $column->getState() == $value,
+                $state == $value,
                 message: "Failed asserting that a table column with name [{$name}] has value of [{$value}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
             );
 
@@ -171,8 +181,18 @@ class TestsColumns
 
             $livewireClass = $this->instance()::class;
 
+            $state = $column->getState();
+
+            if (is_array($state)) {
+                $state = serialize($state);
+            }
+
+            if (is_array($value)) {
+                $value = serialize($value);
+            }
+
             Assert::assertFalse(
-                $column->getState() == $value,
+                $state == $value,
                 message: "Failed asserting that a table column with name [{$name}] does not have a value of [{$value}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
             );
 

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -149,11 +149,11 @@ class TestsColumns
             $state = $column->getState();
 
             if (is_array($state)) {
-                $state = serialize($state);
+                $state = json_encode($state);
             }
 
             if (is_array($value)) {
-                $value = serialize($value);
+                $value = json_encode($value);
             }
 
             Assert::assertTrue(
@@ -184,11 +184,11 @@ class TestsColumns
             $state = $column->getState();
 
             if (is_array($state)) {
-                $state = serialize($state);
+                $state = json_encode($state);
             }
 
             if (is_array($value)) {
-                $value = serialize($value);
+                $value = json_encode($value);
             }
 
             Assert::assertFalse(


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

Allows assertTableColumnStateSet() (and NotSet) to be used for testing columns with array states, such as when rendering a dotted relation with multiple values.

No backward compat issues, doesn't affect any existing usage of these methods, only has any effect if the column state or the expected value are arrays.

Prior to this PR, attempting to test an array value against an array state would error out, because the code assumed $value was stringable when composing the failure message (so "array to string conversion" error).  By serializing the state and/or value, this avoids that error, and also avoids potential array comparison issues (by comparing the serialized versions).

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

No visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
