### PR TITLE
Fix docs on how to change pagination page when testing

### DIFF
--- a/packages/tables/docs/12-testing.md
+++ b/packages/tables/docs/12-testing.md
@@ -36,7 +36,7 @@ it('cannot display trashed posts by default', function () {
 });
 ```
 
-> If your table uses pagination, `assertCanSeeTableRecords()` will only check for records on the first page. To switch page, call `set('page', 2)`.
+> If your table uses pagination, `assertCanSeeTableRecords()` will only check for records on the first page. To switch page, call `call('gotoPage', 2)`.
 
 > If your table uses `deferLoading()`, you should call `loadTable()` before `assertCanSeeTableRecords()`.
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fixes a documentation error, for how to change pagination page when testing.  I think the set('page', 2) probably hasn't worked for a while, it needs to be call('gotoPage', 2).

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

No visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
