### PR TITLE
Fix issue #12045 : Unsaved changes alert is triggered when none ascii characters are used.

### DIFF
--- a/packages/panels/src/Pages/Concerns/HasUnsavedDataChangesAlert.php
+++ b/packages/panels/src/Pages/Concerns/HasUnsavedDataChangesAlert.php
@@ -23,7 +23,7 @@ trait HasUnsavedDataChangesAlert
             return;
         }
 
-        $this->savedDataHash = md5((string) str(json_encode($this->data))->replace('\\', ''));
+        $this->savedDataHash = md5((string) str(json_encode($this->data, JSON_UNESCAPED_UNICODE))->replace('\\', ''));
     }
 
     protected function hasUnsavedDataChangesAlert(): bool


### PR DESCRIPTION
## Description
Fix issue :
https://github.com/filamentphp/filament/issues/12045


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
