### PR TITLE
Handle cases where Wizard Step is not found (hidden steps)

### DIFF
--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -49,6 +49,7 @@
 
         getStepIndex: function (step) {
             let index = this.getSteps().findIndex((indexedStep) => indexedStep === step)
+            
             if (index === -1) {
                 index = this.getSteps()[0]
             }

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -51,7 +51,7 @@
             let index = this.getSteps().findIndex((indexedStep) => indexedStep === step)
             
             if (index === -1) {
-                index = this.getSteps()[0]
+                return 0
             }
             
             return index

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -48,7 +48,7 @@
         },
 
         getStepIndex: function (step) {
-            let index = this.getSteps().findIndex((indexedStep) => indexedStep === step);
+            let index = this.getSteps().findIndex((indexedStep) => indexedStep === step)
             if (index === -1) {
                 index = this.getSteps()[0]
             }

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -49,9 +49,10 @@
 
         getStepIndex: function (step) {
             let index = this.getSteps().findIndex((indexedStep) => indexedStep === step);
-            if (index == -1) {
+            if (index === -1) {
                 index = this.getSteps()[0]
             }
+            
             return index
         },
 

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -48,7 +48,11 @@
         },
 
         getStepIndex: function (step) {
-            return this.getSteps().findIndex((indexedStep) => indexedStep === step)
+            let index = this.getSteps().findIndex((indexedStep) => indexedStep === step);
+            if (index == -1) {
+                index = this.getSteps()[0]
+            }
+            return index
         },
 
         getSteps: function () {


### PR DESCRIPTION
## Description

Found related issue : https://github.com/filamentphp/filament/pull/4916#issuecomment-1315657935

I encountered the same exception in my project:
```
Undefined array key -1 at /vendor/filament/forms/src/Components/Wizard.php:78
```

It happens because the method `findIndex(...)`returns -1 if no item is found.
Thus the `getStepIndex()`returns -1 which does not exists and throws a 500 Exception.

This PR fixes this issue by returning the first Wizard step instead.

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
