### PR TITLE
Minor fixes for Turkish language.

### DIFF
--- a/packages/panels/resources/lang/tr/pages/auth/login.php
+++ b/packages/panels/resources/lang/tr/pages/auth/login.php
@@ -30,13 +30,13 @@ return [
         ],
 
         'remember' => [
-            'label' => 'Beni Hatırla',
+            'label' => 'Beni hatırla',
         ],
 
         'actions' => [
 
             'authenticate' => [
-                'label' => 'Giriş Yap',
+                'label' => 'Giriş yap',
             ],
 
         ],

--- a/packages/panels/resources/lang/tr/pages/auth/password-reset/request-password-reset.php
+++ b/packages/panels/resources/lang/tr/pages/auth/password-reset/request-password-reset.php
@@ -2,7 +2,7 @@
 
 return [
 
-    'title' => 'Şifrenizi Sıfırlayın',
+    'title' => 'Şifrenizi sıfırlayın',
 
     'heading' => 'Şifrenizi mi unuttunuz?',
 

--- a/packages/panels/resources/lang/tr/pages/auth/password-reset/reset-password.php
+++ b/packages/panels/resources/lang/tr/pages/auth/password-reset/reset-password.php
@@ -2,9 +2,9 @@
 
 return [
 
-    'title' => 'Şifrenizi Sıfırlayın',
+    'title' => 'Şifrenizi sıfırlayın',
 
-    'heading' => 'Şifrenizi Sıfırlayın',
+    'heading' => 'Şifrenizi sıfırlayın',
 
     'form' => [
 
@@ -18,13 +18,13 @@ return [
         ],
 
         'password_confirmation' => [
-            'label' => 'Şifreyi Onayla',
+            'label' => 'Şifreyi onayla',
         ],
 
         'actions' => [
 
             'reset' => [
-                'label' => 'Şifreyi Sıfırla',
+                'label' => 'Şifreyi sıfırla',
             ],
 
         ],

--- a/packages/panels/resources/lang/tr/pages/auth/register.php
+++ b/packages/panels/resources/lang/tr/pages/auth/register.php
@@ -31,13 +31,13 @@ return [
         ],
 
         'password_confirmation' => [
-            'label' => 'Şifreyi Onayla',
+            'label' => 'Şifreyi onayla',
         ],
 
         'actions' => [
 
             'register' => [
-                'label' => 'Üye Ol',
+                'label' => 'Üye ol',
             ],
 
         ],

--- a/packages/panels/resources/lang/tr/pages/tenancy/edit-tenant-profile.php
+++ b/packages/panels/resources/lang/tr/pages/tenancy/edit-tenant-profile.php
@@ -7,7 +7,7 @@ return [
         'actions' => [
 
             'save' => [
-                'label' => 'Değişiklikleri Kaydet',
+                'label' => 'Değişiklikleri kaydet',
             ],
 
         ],

--- a/packages/panels/resources/lang/tr/widgets/filament-info-widget.php
+++ b/packages/panels/resources/lang/tr/widgets/filament-info-widget.php
@@ -5,7 +5,7 @@ return [
     'actions' => [
 
         'open_documentation' => [
-            'label' => 'Dökümantasyon',
+            'label' => 'Dokümantasyon',
         ],
 
         'open_github' => [


### PR DESCRIPTION
Corrected capitalization in some places to match the referenced English language.
Fixed a spelling mistake in 1 word -> Documentation -> Dökümantasyon -> Dokümantasyon (correct spelling)
