### PR TITLE
fix(docs): import and use of livewire testing class

### DIFF
--- a/packages/actions/docs/09-testing.md
+++ b/packages/actions/docs/09-testing.md
@@ -13,12 +13,12 @@ Since all actions are mounted to a Livewire component, we're just using Livewire
 You can call an action by passing its name or class to `callAction()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can send invoices', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->callAction('send');
@@ -31,12 +31,12 @@ it('can send invoices', function () {
 To pass an array of data into an action, use the `data` parameter:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can send invoices', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->callAction('send', data: [
@@ -53,12 +53,12 @@ it('can send invoices', function () {
 If you ever need to only set an action's data without immediately calling it, you can use `setActionData()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can send invoices', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->mountAction('send')
@@ -73,12 +73,12 @@ it('can send invoices', function () {
 To check if an action has been halted, you can use `assertActionHalted()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('stops sending if invoice has no email address', function () {
     $invoice = Invoice::factory(['email' => null])->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->callAction('send')
@@ -93,12 +93,12 @@ it('stops sending if invoice has no email address', function () {
 To check if a validation error has occurred with the data, use `assertHasActionErrors()`, similar to `assertHasErrors()` in Livewire:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can validate invoice recipient email', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->callAction('send', data: [
@@ -111,13 +111,13 @@ it('can validate invoice recipient email', function () {
 To check if an action is pre-filled with data, you can use the `assertActionDataSet()` method:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can send invoices to the primary contact by default', function () {
     $invoice = Invoice::factory()->create();
     $recipientEmail = $invoice->company->primaryContact->email;
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->mountAction('send')
@@ -138,12 +138,12 @@ it('can send invoices to the primary contact by default', function () {
 To ensure that an action exists or doesn't, you can use the `assertActionExists()` or  `assertActionDoesNotExist()` method:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can send but not unsend invoices', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertActionExists('send')
@@ -154,12 +154,12 @@ it('can send but not unsend invoices', function () {
 To ensure an action is hidden or visible for a user, you can use the `assertActionHidden()` or `assertActionVisible()` methods:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can only print invoices', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertActionHidden('send')
@@ -170,12 +170,12 @@ it('can only print invoices', function () {
 To ensure an action is enabled or disabled for a user, you can use the `assertActionEnabled()` or `assertActionDisabled()` methods:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can only print a sent invoice', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertActionDisabled('send')
@@ -186,12 +186,12 @@ it('can only print a sent invoice', function () {
 To ensure sets of actions exist in the correct order, you can use `assertActionsExistInOrder()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can have actions in order', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertActionsExistInOrder(['send', 'export']);
@@ -201,12 +201,12 @@ it('can have actions in order', function () {
 To check if an action is hidden to a user, you can use the `assertActionHidden()` method:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can not send invoices', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertActionHidden('send');
@@ -218,12 +218,12 @@ it('can not send invoices', function () {
 To ensure an action has the correct label, you can use `assertActionHasLabel()` and `assertActionDoesNotHaveLabel()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('send action has correct label', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertActionHasLabel('send', 'Email Invoice')
@@ -234,12 +234,12 @@ it('send action has correct label', function () {
 To ensure an action's button is showing the correct icon, you can use `assertActionHasIcon()` or `assertActionDoesNotHaveIcon()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('when enabled the send button has correct icon', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertActionEnabled('send')
@@ -251,12 +251,12 @@ it('when enabled the send button has correct icon', function () {
 To ensure that an action's button is displaying the right color, you can use `assertActionHasColor()` or `assertActionDoesNotHaveColor()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('actions display proper colors', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertActionHasColor('delete', 'danger')
@@ -269,12 +269,12 @@ it('actions display proper colors', function () {
 To ensure an action has the correct URL, you can use `assertActionHasUrl()`, `assertActionDoesNotHaveUrl()`, `assertActionShouldOpenUrlInNewTab()`, and `assertActionShouldNotOpenUrlInNewTab()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('links to the correct Filament sites', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertActionHasUrl('filament', 'https://filamentphp.com/')

--- a/packages/forms/docs/09-testing.md
+++ b/packages/forms/docs/09-testing.md
@@ -13,9 +13,9 @@ Since the Form Builder works on Livewire components, you can use the [Livewire t
 To fill a form with data, pass the data to `fillForm()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
-livewire(CreatePost::class)
+Livewire::test(CreatePost::class)
     ->fillForm([
         'title' => fake()->sentence(),
         // ...
@@ -28,12 +28,12 @@ To check that a form has data, use `assertFormSet()`:
 
 ```php
 use Illuminate\Support\Str;
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can automatically generate a slug from the title', function () {
     $title = fake()->sentence();
 
-    livewire(CreatePost::class)
+    Livewire::test(CreatePost::class)
         ->fillForm([
             'title' => $title,
         ])
@@ -50,10 +50,10 @@ it('can automatically generate a slug from the title', function () {
 Use `assertHasFormErrors()` to ensure that data is properly validated in a form:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can validate input', function () {
-    livewire(CreatePost::class)
+    Livewire::test(CreatePost::class)
         ->fillForm([
             'title' => null,
         ])
@@ -65,9 +65,9 @@ it('can validate input', function () {
 And `assertHasNoFormErrors()` to ensure there are no validation errors:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
-livewire(CreatePost::class)
+Livewire::test(CreatePost::class)
     ->fillForm([
         'title' => fake()->sentence(),
         // ...
@@ -83,10 +83,10 @@ livewire(CreatePost::class)
 To check that a Livewire component has a form, use `assertFormExists()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('has a form', function () {
-    livewire(CreatePost::class)
+    Livewire::test(CreatePost::class)
         ->assertFormExists();
 });
 ```
@@ -98,10 +98,10 @@ it('has a form', function () {
 To ensure that a form has a given field, pass the field name to `assertFormFieldExists()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('has a title field', function () {
-    livewire(CreatePost::class)
+    Livewire::test(CreatePost::class)
         ->assertFormFieldExists('title');
 });
 ```
@@ -109,10 +109,10 @@ it('has a title field', function () {
 You may pass a function as an additional argument in order to assert that a field passes a given "truth test". This is useful for asserting that a field has a specific configuration:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('has a title field', function () {
-    livewire(CreatePost::class)
+    Livewire::test(CreatePost::class)
         ->assertFormFieldExists('title', function (TextInput $field): bool {
             return $field->isDisabled();
         });
@@ -126,10 +126,10 @@ it('has a title field', function () {
 To ensure that a field is visible, pass the name to `assertFormFieldIsVisible()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 test('title is visible', function () {
-    livewire(CreatePost::class)
+    Livewire::test(CreatePost::class)
         ->assertFormFieldIsVisible('title');
 });
 ```
@@ -137,10 +137,10 @@ test('title is visible', function () {
 Or to ensure that a field is hidden you can pass the name to `assertFormFieldIsHidden()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 test('title is hidden', function () {
-    livewire(CreatePost::class)
+    Livewire::test(CreatePost::class)
         ->assertFormFieldIsHidden('title');
 });
 ```
@@ -152,10 +152,10 @@ test('title is hidden', function () {
 To ensure that a field is enabled, pass the name to `assertFormFieldIsEnabled()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 test('title is enabled', function () {
-    livewire(CreatePost::class)
+    Livewire::test(CreatePost::class)
         ->assertFormFieldIsEnabled('title');
 });
 ```
@@ -163,10 +163,10 @@ test('title is enabled', function () {
 Or to ensure that a field is disabled you can pass the name to `assertFormFieldIsDisabled()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 test('title is disabled', function () {
-    livewire(CreatePost::class)
+    Livewire::test(CreatePost::class)
         ->assertFormFieldIsDisabled('title');
 });
 ```
@@ -178,12 +178,12 @@ test('title is disabled', function () {
 You can call an action by passing its form component name, and then the name of the action to `callFormComponentAction()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can send invoices', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->callFormComponentAction('customer_id', 'send');
@@ -196,12 +196,12 @@ it('can send invoices', function () {
 To pass an array of data into an action, use the `data` parameter:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can send invoices', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->callFormComponentAction('customer_id', 'send', data: [
@@ -218,12 +218,12 @@ it('can send invoices', function () {
 If you ever need to only set an action's data without immediately calling it, you can use `setFormComponentActionData()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can send invoices', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->mountFormComponentAction('customer_id', 'send')
@@ -238,12 +238,12 @@ it('can send invoices', function () {
 To check if an action has been halted, you can use `assertFormComponentActionHalted()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('stops sending if invoice has no email address', function () {
     $invoice = Invoice::factory(['email' => null])->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->callFormComponentAction('customer_id', 'send')
@@ -258,12 +258,12 @@ it('stops sending if invoice has no email address', function () {
 To check if a validation error has occurred with the data, use `assertHasFormComponentActionErrors()`, similar to `assertHasErrors()` in Livewire:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can validate invoice recipient email', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->callFormComponentAction('customer_id', 'send', data: [
@@ -276,13 +276,13 @@ it('can validate invoice recipient email', function () {
 To check if an action is pre-filled with data, you can use the `assertFormComponentActionDataSet()` method:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can send invoices to the primary contact by default', function () {
     $invoice = Invoice::factory()->create();
     $recipientEmail = $invoice->company->primaryContact->email;
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->mountFormComponentAction('customer_id', 'send')
@@ -303,12 +303,12 @@ it('can send invoices to the primary contact by default', function () {
 To ensure that an action exists or doesn't in a form, you can use the `assertFormComponentActionExists()` or  `assertFormComponentActionDoesNotExist()` method:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can send but not unsend invoices', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertFormComponentActionExists('customer_id', 'send')
@@ -319,12 +319,12 @@ it('can send but not unsend invoices', function () {
 To ensure an action is hidden or visible for a user, you can use the `assertFormComponentActionHidden()` or `assertFormComponentActionVisible()` methods:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can only print customers', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertFormComponentActionHidden('customer_id', 'send')
@@ -335,12 +335,12 @@ it('can only print customers', function () {
 To ensure an action is enabled or disabled for a user, you can use the `assertFormComponentActionEnabled()` or `assertFormComponentActionDisabled()` methods:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can only print a customer for a sent invoice', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertFormComponentActionDisabled('customer_id', 'send')
@@ -351,12 +351,12 @@ it('can only print a customer for a sent invoice', function () {
 To check if an action is hidden to a user, you can use the `assertFormComponentActionHidden()` method:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can not send invoices', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertFormComponentActionHidden('customer_id', 'send');
@@ -368,12 +368,12 @@ it('can not send invoices', function () {
 To ensure an action has the correct label, you can use `assertFormComponentActionHasLabel()` and `assertFormComponentActionDoesNotHaveLabel()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('send action has correct label', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertFormComponentActionHasLabel('customer_id', 'send', 'Email Invoice')
@@ -384,12 +384,12 @@ it('send action has correct label', function () {
 To ensure an action's button is showing the correct icon, you can use `assertFormComponentActionHasIcon()` or `assertFormComponentActionDoesNotHaveIcon()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('when enabled the send button has correct icon', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertFormComponentActionEnabled('customer_id', 'send')
@@ -401,12 +401,12 @@ it('when enabled the send button has correct icon', function () {
 To ensure that an action's button is displaying the right color, you can use `assertFormComponentActionHasColor()` or `assertFormComponentActionDoesNotHaveColor()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('actions display proper colors', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertFormComponentActionHasColor('customer_id', 'delete', 'danger')
@@ -419,12 +419,12 @@ it('actions display proper colors', function () {
 To ensure an action has the correct URL, you can use `assertFormComponentActionHasUrl()`, `assertFormComponentActionDoesNotHaveUrl()`, `assertFormComponentActionShouldOpenUrlInNewTab()`, and `assertFormComponentActionShouldNotOpenUrlInNewTab()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('links to the correct Filament sites', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertFormComponentActionHasUrl('customer_id', 'filament', 'https://filamentphp.com/')

--- a/packages/infolists/docs/08-testing.md
+++ b/packages/infolists/docs/08-testing.md
@@ -13,12 +13,12 @@ Since the Infolist Builder works on Livewire components, you can use the [Livewi
 You can call an action by passing its infolist component key, and then the name of the action to `callInfolistAction()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can send invoices', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->callInfolistAction('customer', 'send', infolistName: 'infolist');
@@ -31,12 +31,12 @@ it('can send invoices', function () {
 To pass an array of data into an action, use the `data` parameter:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can send invoices', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->callInfolistAction('customer', 'send', data: [
@@ -53,12 +53,12 @@ it('can send invoices', function () {
 If you ever need to only set an action's data without immediately calling it, you can use `setInfolistActionData()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can send invoices', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->mountInfolistAction('customer', 'send')
@@ -73,12 +73,12 @@ it('can send invoices', function () {
 To check if an action has been halted, you can use `assertInfolistActionHalted()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('stops sending if invoice has no email address', function () {
     $invoice = Invoice::factory(['email' => null])->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->callInfolistAction('customer', 'send')
@@ -93,12 +93,12 @@ it('stops sending if invoice has no email address', function () {
 To check if a validation error has occurred with the data, use `assertHasInfolistActionErrors()`, similar to `assertHasErrors()` in Livewire:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can validate invoice recipient email', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->callInfolistAction('customer', 'send', data: [
@@ -111,13 +111,13 @@ it('can validate invoice recipient email', function () {
 To check if an action is pre-filled with data, you can use the `assertInfolistActionDataSet()` method:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can send invoices to the primary contact by default', function () {
     $invoice = Invoice::factory()->create();
     $recipientEmail = $invoice->company->primaryContact->email;
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->mountInfolistAction('customer', 'send')
@@ -138,12 +138,12 @@ it('can send invoices to the primary contact by default', function () {
 To ensure that an action exists or doesn't in an infolist, you can use the `assertInfolistActionExists()` or  `assertInfolistActionDoesNotExist()` method:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can send but not unsend invoices', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertInfolistActionExists('customer', 'send')
@@ -154,12 +154,12 @@ it('can send but not unsend invoices', function () {
 To ensure an action is hidden or visible for a user, you can use the `assertInfolistActionHidden()` or `assertInfolistActionVisible()` methods:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can only print customers', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertInfolistActionHidden('customer', 'send')
@@ -170,12 +170,12 @@ it('can only print customers', function () {
 To ensure an action is enabled or disabled for a user, you can use the `assertInfolistActionEnabled()` or `assertInfolistActionDisabled()` methods:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can only print a customer for a sent invoice', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertInfolistActionDisabled('customer', 'send')
@@ -186,12 +186,12 @@ it('can only print a customer for a sent invoice', function () {
 To check if an action is hidden to a user, you can use the `assertInfolistActionHidden()` method:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can not send invoices', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertInfolistActionHidden('customer', 'send');
@@ -203,12 +203,12 @@ it('can not send invoices', function () {
 To ensure an action has the correct label, you can use `assertInfolistActionHasLabel()` and `assertInfolistActionDoesNotHaveLabel()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('send action has correct label', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertInfolistActionHasLabel('customer', 'send', 'Email Invoice')
@@ -219,12 +219,12 @@ it('send action has correct label', function () {
 To ensure an action's button is showing the correct icon, you can use `assertInfolistActionHasIcon()` or `assertInfolistActionDoesNotHaveIcon()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('when enabled the send button has correct icon', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertInfolistActionEnabled('customer', 'send')
@@ -236,12 +236,12 @@ it('when enabled the send button has correct icon', function () {
 To ensure that an action's button is displaying the right color, you can use `assertInfolistActionHasColor()` or `assertInfolistActionDoesNotHaveColor()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('actions display proper colors', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertInfolistActionHasColor('customer', 'delete', 'danger')
@@ -254,12 +254,12 @@ it('actions display proper colors', function () {
 To ensure an action has the correct URL, you can use `assertInfolistActionHasUrl()`, `assertInfolistActionDoesNotHaveUrl()`, `assertInfolistActionShouldOpenUrlInNewTab()`, and `assertInfolistActionShouldNotOpenUrlInNewTab()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('links to the correct Filament sites', function () {
     $invoice = Invoice::factory()->create();
 
-    livewire(EditInvoice::class, [
+    Livewire::test(EditInvoice::class, [
         'invoice' => $invoice,
     ])
         ->assertInfolistActionHasUrl('customer', 'filament', 'https://filamentphp.com/')

--- a/packages/notifications/docs/06-testing.md
+++ b/packages/notifications/docs/06-testing.md
@@ -11,10 +11,10 @@ All examples in this guide will be written using [Pest](https://pestphp.com). Ho
 To check if a notification was sent using the session, use the `assertNotified()` helper:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('sends a notification', function () {
-    livewire(CreatePost::class)
+    Livewire::test(CreatePost::class)
         ->assertNotified();
 });
 ```
@@ -39,10 +39,10 @@ You may optionally pass a notification title to test for:
 
 ```php
 use Filament\Notifications\Notification;
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('sends a notification', function () {
-    livewire(CreatePost::class)
+    Livewire::test(CreatePost::class)
         ->assertNotified('Unable to create post');
 });
 ```
@@ -51,10 +51,10 @@ Or test if the exact notification was sent:
 
 ```php
 use Filament\Notifications\Notification;
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('sends a notification', function () {
-    livewire(CreatePost::class)
+    Livewire::test(CreatePost::class)
         ->assertNotified(
             Notification::make()
                 ->danger()
@@ -68,10 +68,10 @@ Conversely, you can assert that a notification was not sent:
 
 ```php
 use Filament\Notifications\Notification;
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('does not send a notification', function () {
-    livewire(CreatePost::class)
+    Livewire::test(CreatePost::class)
         ->assertNotNotified()
         // or
         ->assertNotNotified('Unable to create post')

--- a/packages/panels/docs/14-testing.md
+++ b/packages/panels/docs/14-testing.md
@@ -44,12 +44,12 @@ Filament includes a selection of helpers for testing tables. A full guide to tes
 To use a table [testing helper](../tables/testing), make assertions on the resource's List page class, which holds the table:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can list posts', function () {
     $posts = Post::factory()->count(10)->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertCanSeeTableRecords($posts);
 });
 ```
@@ -71,12 +71,12 @@ it('can render page', function () {
 You may check that data is correctly saved into the database by calling `fillForm()` with your form data, and then asserting that the database contains a matching record:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can create', function () {
     $newData = Post::factory()->make();
 
-    livewire(PostResource\Pages\CreatePost::class)
+    Livewire::test(PostResource\Pages\CreatePost::class)
         ->fillForm([
             'author_id' => $newData->author->getKey(),
             'content' => $newData->content,
@@ -100,10 +100,10 @@ it('can create', function () {
 Use `assertHasFormErrors()` to ensure that data is properly validated in a form:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can validate input', function () {
-    livewire(PostResource\Pages\CreatePost::class)
+    Livewire::test(PostResource\Pages\CreatePost::class)
         ->fillForm([
             'title' => null,
         ])
@@ -131,12 +131,12 @@ it('can render page', function () {
 To check that the form is filled with the correct data from the database, you may `assertFormSet()` that the data in the form matches that of the record:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can retrieve data', function () {
     $post = Post::factory()->create();
 
-    livewire(PostResource\Pages\EditPost::class, [
+    Livewire::test(PostResource\Pages\EditPost::class, [
         'record' => $post->getRouteKey(),
     ])
         ->assertFormSet([
@@ -153,13 +153,13 @@ it('can retrieve data', function () {
 You may check that data is correctly saved into the database by calling `fillForm()` with your form data, and then asserting that the database contains a matching record:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can save', function () {
     $post = Post::factory()->create();
     $newData = Post::factory()->make();
 
-    livewire(PostResource\Pages\EditPost::class, [
+    Livewire::test(PostResource\Pages\EditPost::class, [
         'record' => $post->getRouteKey(),
     ])
         ->fillForm([
@@ -184,12 +184,12 @@ it('can save', function () {
 Use `assertHasFormErrors()` to ensure that data is properly validated in a form:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can validate input', function () {
     $post = Post::factory()->create();
 
-    livewire(PostResource\Pages\EditPost::class, [
+    Livewire::test(PostResource\Pages\EditPost::class, [
         'record' => $post->getRouteKey(),
     ])
         ->fillForm([
@@ -206,12 +206,12 @@ You can test the `DeleteAction` using `callAction()`:
 
 ```php
 use Filament\Actions\DeleteAction;
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can delete', function () {
     $post = Post::factory()->create();
 
-    livewire(PostResource\Pages\EditPost::class, [
+    Livewire::test(PostResource\Pages\EditPost::class, [
         'record' => $post->getRouteKey(),
     ])
         ->callAction(DeleteAction::class);
@@ -224,12 +224,12 @@ You can ensure that a particular user is not able to see a `DeleteAction` using 
 
 ```php
 use Filament\Actions\DeleteAction;
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can not delete', function () {
     $post = Post::factory()->create();
 
-    livewire(PostResource\Pages\EditPost::class, [
+    Livewire::test(PostResource\Pages\EditPost::class, [
         'record' => $post->getRouteKey(),
     ])
         ->assertActionHidden(DeleteAction::class);
@@ -255,12 +255,12 @@ it('can render page', function () {
 To check that the form is filled with the correct data from the database, you may `assertSet()` that the data in the form matches that of the record:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can retrieve data', function () {
     $post = Post::factory()->create();
 
-    livewire(PostResource\Pages\ViewPost::class, [
+    Livewire::test(PostResource\Pages\ViewPost::class, [
         'record' => $post->getRouteKey(),
     ])
         ->assertFormSet([
@@ -280,14 +280,14 @@ To ensure that a relation manager is able to render successfully, mount the Live
 
 ```php
 use App\Filament\Resources\CategoryResource\Pages\EditCategory;
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can render relation manager', function () {
     $category = Category::factory()
         ->has(Post::factory()->count(10))
         ->create();
 
-    livewire(CategoryResource\RelationManagers\PostsRelationManager::class, [
+    Livewire::test(CategoryResource\RelationManagers\PostsRelationManager::class, [
         'ownerRecord' => $category,
         'pageClass' => EditCategory::class,
     ])
@@ -303,14 +303,14 @@ To use a table [testing helper](../tables/testing), make assertions on the relat
 
 ```php
 use App\Filament\Resources\CategoryResource\Pages\EditCategory;
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can list posts', function () {
     $category = Category::factory()
         ->has(Post::factory()->count(10))
         ->create();
 
-    livewire(CategoryResource\RelationManagers\PostsRelationManager::class, [
+    Livewire::test(CategoryResource\RelationManagers\PostsRelationManager::class, [
         'ownerRecord' => $category,
         'pageClass' => EditCategory::class,
     ])

--- a/packages/tables/docs/12-testing.md
+++ b/packages/tables/docs/12-testing.md
@@ -13,23 +13,23 @@ Since the Table Builder works on Livewire components, you can use the [Livewire 
 To ensure a table component renders, use the `assertSuccessful()` Livewire helper:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can render page', function () {
-    livewire(ListPosts::class)->assertSuccessful();
+    Livewire::test(ListPosts::class)->assertSuccessful();
 });
 ```
 
 To test which records are shown, you can use `assertCanSeeTableRecords()`, `assertCanNotSeeTableRecords()` and `assertCountTableRecords()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('cannot display trashed posts by default', function () {
     $posts = Post::factory()->count(4)->create();
     $trashedPosts = Post::factory()->trashed()->count(6)->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertCanSeeTableRecords($posts)
         ->assertCanNotSeeTableRecords($trashedPosts)
         ->assertCountTableRecords(4);
@@ -45,12 +45,12 @@ it('cannot display trashed posts by default', function () {
 To ensure that a certain column is rendered, pass the column name to `assertCanRenderTableColumn()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can render post titles', function () {
     Post::factory()->count(10)->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertCanRenderTableColumn('title');
 });
 ```
@@ -60,12 +60,12 @@ This helper will get the HTML for this column, and check that it is present in t
 For testing that a column is not rendered, you can use `assertCanNotRenderTableColumn()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can not render post comments', function () {
     Post::factory()->count(10)->create()
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertCanNotRenderTableColumn('comments');
 });
 ```
@@ -79,12 +79,12 @@ To sort table records, you can call `sortTable()`, passing the name of the colum
 Once the table is sorted, you can ensure that the table records are rendered in order using `assertCanSeeTableRecords()` with the `inOrder` parameter:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can sort posts by title', function () {
     $posts = Post::factory()->count(10)->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->sortTable('title')
         ->assertCanSeeTableRecords($posts->sortBy('title'), inOrder: true)
         ->sortTable('title', 'desc')
@@ -99,14 +99,14 @@ To search the table, call the `searchTable()` method with your search query.
 You can then use `assertCanSeeTableRecords()` to check your filtered table records, and use `assertCanNotSeeTableRecords()` to assert that some records are no longer in the table:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can search posts by title', function () {
     $posts = Post::factory()->count(10)->create();
 
     $title = $posts->first()->title;
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->searchTable($title)
         ->assertCanSeeTableRecords($posts->where('title', $title))
         ->assertCanNotSeeTableRecords($posts->where('title', '!=', $title));
@@ -116,14 +116,14 @@ it('can search posts by title', function () {
 To search individual columns, you can pass an array of searches to `searchTableColumns()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can search posts by title column', function () {
     $posts = Post::factory()->count(10)->create();
 
     $title = $posts->first()->title;
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->searchTableColumns(['title' => $title])
         ->assertCanSeeTableRecords($posts->where('title', $title))
         ->assertCanNotSeeTableRecords($posts->where('title', '!=', $title));
@@ -135,14 +135,14 @@ it('can search posts by title column', function () {
 To assert that a certain column has a state or does not have a state for a record you can use `assertTableColumnStateSet()` and `assertTableColumnStateNotSet()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can get post author names', function () {
     $posts = Post::factory()->count(10)->create();
 
     $post = $posts->first();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertTableColumnStateSet('author.name', $post->author->name, record: $post)
         ->assertTableColumnStateNotSet('author.name', 'Anonymous', record: $post);
 });
@@ -151,12 +151,12 @@ it('can get post author names', function () {
 To assert that a certain column has a formatted state or does not have a formatted state for a record you can use `assertTableColumnFormattedStateSet()` and `assertTableColumnFormattedStateNotSet()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can get post author names', function () {
     $post = Post::factory(['name' => 'John Smith'])->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertTableColumnFormattedStateSet('author.name', 'Smith, John', record: $post)
         ->assertTableColumnFormattedStateNotSet('author.name', $post->author->name, record: $post);
 });
@@ -167,10 +167,10 @@ it('can get post author names', function () {
 To ensure that a column exists, you can use the `assertTableColumnExists()` method:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('has an author column', function () {
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertTableColumnExists(`author`);
 });
 ```
@@ -178,13 +178,13 @@ it('has an author column', function () {
 You may pass a function as an additional argument in order to assert that a column passes a given "truth test". This is useful for asserting that a column has a specific configuration. You can also pass in a record as the third parameter, which is useful if your check is dependant on which table row is being rendered:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 use Filament\Tables\Columns\TextColumn;
 
 it('has an author column', function () {
     $post = Post::factory()->create();
     
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertTableColumnExists('author', function (TextColumn $column): bool {
             return $column->getDescriptionBelow() === $post->subtitle;
         }, $post);
@@ -196,10 +196,10 @@ it('has an author column', function () {
 To ensure that a particular user cannot see a column, you can use the `assertTableColumnVisible()` and `assertTableColumnHidden()` methods:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('shows the correct columns', function () {
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertTableColumnVisible(`created_at`)
         ->assertTableColumnHidden(`author`);
 });
@@ -210,12 +210,12 @@ it('shows the correct columns', function () {
 To ensure a column has the correct description above or below you can use the `assertTableColumnHasDescription()` and `assertTableColumnDoesNotHaveDescription()` methods:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('has the correct descriptions above and below author', function () {
     $post = Post::factory()->create();
 
-    livewire(PostsTable::class)
+    Livewire::test(PostsTable::class)
         ->assertTableColumnHasDescription('author', 'Author! ↓↓↓', $post, 'above')
         ->assertTableColumnHasDescription('author', 'Author! ↑↑↑', $post)
         ->assertTableColumnDoesNotHaveDescription('author', 'Author! ↑↑↑', $post, 'above')
@@ -228,12 +228,12 @@ it('has the correct descriptions above and below author', function () {
 To ensure that a column has the correct extra attributes, you can use the `assertTableColumnHasExtraAttributes()` and `assertTableColumnDoesNotHaveExtraAttributes()` methods:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('displays author in red', function () {
     $post = Post::factory()->create();
 
-    livewire(PostsTable::class)
+    Livewire::test(PostsTable::class)
         ->assertTableColumnHasExtraAttributes('author', ['class' => 'text-danger-500'], $post)
         ->assertTableColumnDoesNotHaveExtraAttributes('author', ['class' => 'text-primary-500'], $post);
 });
@@ -244,12 +244,12 @@ it('displays author in red', function () {
 If you have a select column, you can ensure it has the correct options with `assertSelectColumnHasOptions()` and `assertSelectColumnDoesNotHaveOptions()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('has the correct statuses', function () {
     $post = Post::factory()->create();
 
-    livewire(PostsTable::class)
+    Livewire::test(PostsTable::class)
         ->assertSelectColumnHasOptions('status', ['unpublished' => 'Unpublished', 'published' => 'Published'], $post)
         ->assertSelectColumnDoesNotHaveOptions('status', ['archived' => 'Archived'], $post);
 });
@@ -260,12 +260,12 @@ it('has the correct statuses', function () {
 To filter the table records, you can use the `filterTable()` method, along with `assertCanSeeTableRecords()` and `assertCanNotSeeTableRecords()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can filter posts by `is_published`', function () {
     $posts = Post::factory()->count(10)->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertCanSeeTableRecords($posts)
         ->filterTable('is_published')
         ->assertCanSeeTableRecords($posts->where('is_published', true))
@@ -278,14 +278,14 @@ For a simple filter, this will just enable the filter.
 If you'd like to set the value of a `SelectFilter` or `TernaryFilter`, pass the value as a second argument:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can filter posts by `author_id`', function () {
     $posts = Post::factory()->count(10)->create();
 
     $authorId = $posts->first()->author_id;
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertCanSeeTableRecords($posts)
         ->filterTable('author_id', $authorId)
         ->assertCanSeeTableRecords($posts->where('author_id', $authorId))
@@ -298,12 +298,12 @@ it('can filter posts by `author_id`', function () {
 To reset all filters to their original state, call `resetTableFilters()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can reset table filters`', function () {
     $posts = Post::factory()->count(10)->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->resetTableFilters();
 });
 ```
@@ -313,14 +313,14 @@ it('can reset table filters`', function () {
 To remove a single filter you can use `removeTableFilter()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('filters list by published', function () {
     $posts = Post::factory()->count(10)->create();
 
     $unpublishedPosts = $posts->where('is_published', false)->get();
 
-    livewire(PostsTable::class)
+    Livewire::test(PostsTable::class)
         ->filterTable('is_published')
         ->assertCanNotSeeTableRecords($unpublishedPosts)
         ->removeTableFilter('is_published')
@@ -331,7 +331,7 @@ it('filters list by published', function () {
 To remove all filters you can use `removeTableFilters()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can remove all table filters', function () {
     $posts = Post::factory()->count(10)->forAuthor()->create();
@@ -340,7 +340,7 @@ it('can remove all table filters', function () {
         ->where('is_published', false)
         ->where('author_id', $posts->first()->author->getKey());
 
-    livewire(PostsTable::class)
+    Livewire::test(PostsTable::class)
         ->filterTable('is_published')
         ->filterTable('author', $author)
         ->assertCanNotSeeTableRecords($unpublishedPosts)
@@ -356,12 +356,12 @@ it('can remove all table filters', function () {
 You can call an action by passing its name or class to `callTableAction()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can delete posts', function () {
     $post = Post::factory()->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->callTableAction(DeleteAction::class, $post);
 
     $this->assertModelMissing($post);
@@ -373,12 +373,12 @@ This example assumes that you have a `DeleteAction` on your table. If you have a
 For column actions, you may do the same, using `callTableColumnAction()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can copy posts', function () {
     $post = Post::factory()->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->callTableColumnAction('copy', $post);
 
     $this->assertDatabaseCount((new Post)->getTable(), 2);
@@ -388,12 +388,12 @@ it('can copy posts', function () {
 For bulk actions, you may do the same, passing in multiple records to execute the bulk action against with `callTableBulkAction()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can bulk delete posts', function () {
     $posts = Post::factory()->count(10)->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->callTableBulkAction(DeleteBulkAction::class, $posts);
 
     foreach ($posts as $post) {
@@ -405,12 +405,12 @@ it('can bulk delete posts', function () {
 To pass an array of data into an action, use the `data` parameter:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can edit posts', function () {
     $post = Post::factory()->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->callTableAction(EditAction::class, $post, data: [
             'title' => $title = fake()->words(asText: true),
         ])
@@ -426,12 +426,12 @@ it('can edit posts', function () {
 To check if an action or bulk action has been halted, you can use `assertTableActionHalted()` / `assertTableBulkActionHalted()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('will halt delete if post is flagged', function () {
     $posts= Post::factory()->count(2)->flagged()->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->callTableAction('delete', $posts->first())
         ->callTableBulkAction('delete', $posts)
         ->assertTableActionHalted('delete')
@@ -448,12 +448,12 @@ it('will halt delete if post is flagged', function () {
 To check if a validation error has occurred with the data, use `assertHasTableActionErrors()`, similar to `assertHasErrors()` in Livewire:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can validate edited post data', function () {
     $post = Post::factory()->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->callTableAction(EditAction::class, $post, data: [
             'title' => null,
         ])
@@ -468,12 +468,12 @@ For bulk actions these methods are called `assertHasTableBulkActionErrors()` and
 To check if an action or bulk action is pre-filled with data, you can use the `assertTableActionDataSet()` or `assertTableBulkActionDataSet()` method:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can load existing post data for editing', function () {
     $post = Post::factory()->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->mountTableAction(EditAction::class, $post)
         ->assertTableActionDataSet([
             'title' => $post->title,
@@ -494,10 +494,10 @@ it('can load existing post data for editing', function () {
 To ensure that an action or bulk action exists or doesn't in a table, you can use the `assertTableActionExists()` / `assertTableActionDoesNotExist()` or  `assertTableBulkActionExists()` / `assertTableBulkActionDoesNotExist()` method:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can publish but not unpublish posts', function () {
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertTableActionExists('publish')
         ->assertTableActionDoesNotExist('unpublish')
         ->assertTableBulkActionExists('publish')
@@ -508,10 +508,10 @@ it('can publish but not unpublish posts', function () {
 To ensure different sets of actions exist in the correct order, you can use the various "InOrder" assertions
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('has all actions in expected order', function () {
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertTableActionsExistInOrder(['edit', 'delete'])
         ->assertTableBulkActionsExistInOrder(['restore', 'forceDelete'])
         ->assertTableHeaderActionsExistInOrder(['create', 'attach'])
@@ -522,12 +522,12 @@ it('has all actions in expected order', function () {
 To ensure that an action or bulk action is enabled or disabled for a user, you can use the `assertTableActionEnabled()` / `assertTableActionDisabled()` or `assertTableBulkActionEnabled()` / `assertTableBulkActionDisabled()` methods:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can not publish, but can delete posts', function () {
     $post = Post::factory()->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertTableActionDisabled('publish', $post)
         ->assertTableActionEnabled('delete', $post)
         ->assertTableBulkActionDisabled('publish')
@@ -539,12 +539,12 @@ it('can not publish, but can delete posts', function () {
 To ensure that an action or bulk action is visible or hidden for a user, you can use the `assertTableActionVisible()` / `assertTableActionHidden()` or `assertTableBulkActionVisible()` / `assertTableBulkActionHidden()` methods:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can not publish, but can delete posts', function () {
     $post = Post::factory()->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertTableActionHidden('publish', $post)
         ->assertTableActionVisible('delete', $post)
         ->assertTableBulkActionHidden('publish')
@@ -557,12 +557,12 @@ it('can not publish, but can delete posts', function () {
 To ensure an action or bulk action has the correct label, you can use `assertTableActionHasLabel()` / `assertTableBulkActionHasLabel()` and `assertTableActionDoesNotHaveLabel()` / `assertTableBulkActionDoesNotHaveLabel()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('delete actions have correct labels', function () {
     $post = Post::factory()->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertTableActionHasLabel('delete', 'Archive Post')
         ->assertTableActionDoesNotHaveLabel('delete', 'Delete');
         ->assertTableBulkActionHasLabel('delete', 'Archive Post')
@@ -573,12 +573,12 @@ it('delete actions have correct labels', function () {
 To ensure an action or bulk action's button is showing the correct icon, you can use `assertTableActionHasIcon()` / `assertTableBulkActionHasIcon()` or `assertTableActionDoesNotHaveIcon()` / `assertTableBulkActionDoesNotHaveIcon()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('delete actions have correct icons', function () {
     $post = Post::factory()->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertTableActionHasIcon('delete', 'heroicon-m-archive-box')
         ->assertTableActionDoesNotHaveIcon('delete', 'heroicon-m-trash');
         ->assertTableBulkActionHasIcon('delete', 'heroicon-m-archive-box')
@@ -589,12 +589,12 @@ it('delete actions have correct icons', function () {
 To ensure that an action or bulk action's button is displaying the right color, you can use `assertTableActionHasColor()` / `assertTableBulkActionHasColor()` or `assertTableActionDoesNotHaveColor()` / `assertTableBulkActionDoesNotHaveColor()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('delete actions have correct colors', function () {
     $post = Post::factory()->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertTableActionHasColor('delete', 'warning')
         ->assertTableActionDoesNotHaveColor('delete', 'danger');
         ->assertTableBulkActionHasColor('delete', 'warning')
@@ -607,12 +607,12 @@ it('delete actions have correct colors', function () {
 To ensure an action or bulk action has the correct URL traits, you can use `assertTableActionHasUrl()`, `assertTableActionDoesNotHaveUrl()`, `assertTableActionShouldOpenUrlInNewTab()`, and `assertTableActionShouldNotOpenUrlInNewTab()`:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('links to the correct Filament sites', function () {
     $post = Post::factory()->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertTableActionHasUrl('filament', 'https://filamentphp.com/')
         ->assertTableActionDoesNotHaveUrl('filament', 'https://github.com/filamentphp/filament')
         ->assertTableActionShouldOpenUrlInNewTab('filament')
@@ -625,12 +625,12 @@ it('links to the correct Filament sites', function () {
 To test that a summary calculation is working, you may use the `assertTableColumnSummarySet()` method:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can average values in a column', function () {
     $posts = Post::factory()->count(10)->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertCanSeeTableRecords($posts)
         ->assertTableColumnSummarySet('rating', 'average', $posts->avg('rating'));
 });
@@ -655,12 +655,12 @@ The ID should be unique between summarizers in that column.
 To calculate the average for only one pagination page, use the `isCurrentPaginationPageOnly` argument:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can average values in a column', function () {
     $posts = Post::factory()->count(20)->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertCanSeeTableRecords($posts->take(10))
         ->assertTableColumnSummarySet('rating', 'average', $posts->take(10)->avg('rating'), isCurrentPaginationPageOnly: true);
 });
@@ -671,12 +671,12 @@ it('can average values in a column', function () {
 To test a range, pass the minimum and maximum value into a tuple-style `[$minimum, $maximum]` array:
 
 ```php
-use function Pest\Livewire\livewire;
+use Livewire\Livewire;
 
 it('can average values in a column', function () {
     $posts = Post::factory()->count(10)->create();
 
-    livewire(PostResource\Pages\ListPosts::class)
+    Livewire::test(PostResource\Pages\ListPosts::class)
         ->assertCanSeeTableRecords($posts)
         ->assertTableColumnSummarySet('rating', 'range', [$posts->min('rating'), $posts->max('rating')]);
 });


### PR DESCRIPTION
Pest does not have the livewire testing function, `use function Pest\Livewire\livewire;` but we can get it from Livewire,  `use Livewire\Livewire;` .

## Description

I updated the docs testing markdown files to use the livewire class for testing, `use Livewire\Livewire;`  and changed the places where the pest livewire was being used to  instead use `Livewire::test` .

## Visual changes

Example from `packages/actions/docs/09-testing.md`:
![Screenshot 2024-03-27 15 38 59](https://github.com/filamentphp/filament/assets/52635726/24934279-f688-495d-aa21-287425be56cb)


## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
