### PR TITLE
Enhancement: Tooltip for disabled buttons, title attribute on icon-button without tooltip

### DIFF
--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -48,12 +48,14 @@
         },
 
         getStepIndex: function (step) {
-            let index = this.getSteps().findIndex((indexedStep) => indexedStep === step)
-            
+            let index = this.getSteps().findIndex(
+                (indexedStep) => indexedStep === step,
+            )
+
             if (index === -1) {
                 return 0
             }
-            
+
             return index
         },
 

--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -72,21 +72,26 @@
     $hasTooltip = filled($tooltip);
 @endphp
 
-<{{ $tag }}
-    @if ($tag === 'a')
-        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode) }}
-    @endif
-    @if ($keyBindings || $hasTooltip)
+@if ($hasTooltip)
+    {{-- format-ignore-start --}}<span
         x-data="{}"
-    @endif
-    @if ($keyBindings)
-        x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}
-    @endif
-    @if ($hasTooltip)
+        class="inline-flex"
         x-tooltip="{
             content: @js($tooltip),
             theme: $store.theme,
         }"
+    >{{-- format-ignore-end --}}
+@endif
+
+<{{ $tag }}
+    @if ($tag === 'a')
+        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode) }}
+    @endif
+    @if ($keyBindings)
+        x-data="{}"
+    @endif
+    @if ($keyBindings)
+        x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}
     @endif
     {{
         $attributes
@@ -233,3 +238,7 @@
         @endif
     @endif
 </{{ $tag }}>
+
+@if ($hasTooltip)
+    {{-- format-ignore-start --}}</span>{{-- format-ignore-end --}}
+@endif

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -173,21 +173,26 @@
     />
 @endif
 
-<{{ $tag }}
-    @if ($tag === 'a')
-        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode) }}
-    @endif
-    @if (($keyBindings || $hasTooltip) && (! $hasFormProcessingLoadingIndicator))
+@if ($hasTooltip)
+    {{-- format-ignore-start --}}<span
         x-data="{}"
-    @endif
-    @if ($keyBindings)
-        x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}
-    @endif
-    @if ($hasTooltip)
+        class="inline-flex"
         x-tooltip="{
             content: @js($tooltip),
             theme: $store.theme,
         }"
+    >{{-- format-ignore-end --}}
+@endif
+
+<{{ $tag }}
+    @if ($tag === 'a')
+        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode) }}
+    @endif
+    @if (($keyBindings) && (! $hasFormProcessingLoadingIndicator))
+        x-data="{}"
+    @endif
+    @if ($keyBindings)
+        x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}
     @endif
     @if ($hasFormProcessingLoadingIndicator)
         x-data="{
@@ -324,3 +329,7 @@
         </div>
     @endif
 </{{ $tag }}>
+
+@if ($hasTooltip)
+    {{-- format-ignore-start --}}</span>{{-- format-ignore-end --}}
+@endif

--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -120,19 +120,24 @@
     $hasTooltip = filled($tooltip);
 @endphp
 
+@if ($hasTooltip)
+    {{-- format-ignore-start --}}<span
+        x-data="{}"
+        class="inline-flex"
+        x-tooltip="{
+            content: @js($tooltip),
+            theme: $store.theme,
+        }"
+    >{{-- format-ignore-end --}}
+@endif
+
 @if ($tag === 'button')
     <button
-        @if ($keyBindings || $hasTooltip)
+        @if ($keyBindings)
             x-data="{}"
         @endif
         @if ($keyBindings)
             x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}
-        @endif
-        @if ($hasTooltip)
-            x-tooltip="{
-                content: @js($tooltip),
-                theme: $store.theme,
-            }"
         @endif
         {{
             $attributes
@@ -140,9 +145,9 @@
                     'disabled' => $disabled,
                     'type' => $type,
                 ], escape: false)
-                ->merge([
+                ->when(! $hasTooltip, fn ($attributes) => $attributes->merge([
                     'title' => $label,
-                ], escape: true)
+                ], escape: true))
                 ->class([$buttonClasses])
                 ->style([$buttonStyles])
         }}
@@ -190,23 +195,17 @@
 @elseif ($tag === 'a')
     <a
         {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode) }}
-        @if ($keyBindings || $hasTooltip)
+        @if ($keyBindings)
             x-data="{}"
         @endif
         @if ($keyBindings)
             x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}
         @endif
-        @if ($hasTooltip)
-            x-tooltip="{
-                content: @js($tooltip),
-                theme: $store.theme,
-            }"
-        @endif
         {{
             $attributes
-                ->merge([
+                ->when(! $hasTooltip, fn ($attributes) => $attributes->merge([
                     'title' => $label,
-                ], escape: true)
+                ], escape: true))
                 ->class([$buttonClasses])
                 ->style([$buttonStyles])
         }}
@@ -231,4 +230,8 @@
             </div>
         @endif
     </a>
+@endif
+
+@if ($hasTooltip)
+    {{-- format-ignore-start --}}</span>{{-- format-ignore-end --}}
 @endif

--- a/packages/support/resources/views/components/link.blade.php
+++ b/packages/support/resources/views/components/link.blade.php
@@ -126,20 +126,25 @@
     $hasTooltip = filled($tooltip);
 @endphp
 
+@if ($hasTooltip)
+    {{-- format-ignore-start --}}<span
+        x-data="{}"
+        class="inline-flex"
+        x-tooltip="{
+            content: @js($tooltip),
+            theme: $store.theme,
+        }"
+    >{{-- format-ignore-end --}}
+@endif
+
 @if ($tag === 'a')
     <a
         {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode) }}
-        @if ($keyBindings || $hasTooltip)
+        @if ($keyBindings)
             x-data="{}"
         @endif
         @if ($keyBindings)
             x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}
-        @endif
-        @if ($hasTooltip)
-            x-tooltip="{
-                content: @js($tooltip),
-                theme: $store.theme,
-            }"
         @endif
         {{ $attributes->class([$linkClasses]) }}
     >
@@ -176,17 +181,11 @@
     @trim
 @elseif ($tag === 'button')
     <button
-        @if ($keyBindings || $hasTooltip)
+        @if ($keyBindings)
             x-data="{}"
         @endif
         @if ($keyBindings)
             x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}
-        @endif
-        @if ($hasTooltip)
-            x-tooltip="{
-                content: @js($tooltip),
-                theme: $store.theme,
-            }"
         @endif
         {{
             $attributes
@@ -280,4 +279,8 @@
         @endif
     </button>
     @trim
+@endif
+
+@if ($hasTooltip)
+    {{-- format-ignore-start --}}</span>{{-- format-ignore-end --}}
 @endif


### PR DESCRIPTION
## Description

This PR resolves an issue where icon buttons displayed both tooltips and title attributes simultaneously. Now, the title attribute is only shown when a tooltip is not present. Additionally, it introduces the ability for disabled buttons to display tooltips, achieved by wrapping the elements in a `<span>` when a tooltip is applied. This wrapper is omitted for elements without tooltips.

To address formatting errors reported by `prettier-plugin-blade`, such as "encountered an unexpected closing tag" due to Prettier's interpretation of Blade syntax within conditionals, I've implemented `{{-- format-ignore-start --}}` and `{{-- format-ignore-end --}}` tags around the affected code blocks. This ensures compatibility without altering the intended HTML structure.

## Visual changes

### Before
<img width="1355" alt="Screenshot 2024-03-27 at 11 15 18 PM" src="https://github.com/filamentphp/filament/assets/104294090/eb5a6c9a-530b-44bf-ae70-8d0295008f39">

### After
<img width="1355" alt="Screenshot 2024-03-27 at 11 13 08 PM" src="https://github.com/filamentphp/filament/assets/104294090/66b52146-32c6-4aa5-b9ba-e6281fd1070a">
<img width="1355" alt="Screenshot 2024-03-27 at 11 14 18 PM" src="https://github.com/filamentphp/filament/assets/104294090/d9867829-9bb7-4b48-ae79-e6c89c229196">


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
