### PR TITLE
Correct color count in docs (04-colors.md)

### DIFF
--- a/packages/support/docs/04-colors.md
+++ b/packages/support/docs/04-colors.md
@@ -10,7 +10,7 @@ Filament uses CSS variables to define its color palette. These CSS variables are
 
 From a service provider's `boot()` method, or middleware, you can call the `FilamentColor::register()` method, which you can use to customize which colors Filament uses for UI elements.
 
-There are 7 default colors that are used throughout Filament that you are able to customize:
+There are 6 default colors that are used throughout Filament that you are able to customize:
 
 ```php
 use Filament\Support\Colors\Color;


### PR DESCRIPTION
Reduced default color count from 7 to 6 to match number of colors listed in subsequent code snippet. 

This incorrect count presumably emanated from the prior removal of the 'secondary' color from the default set of colors used throughout Filament.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Out-dated and incorrect documentation in the following section of documentation: 

Core Concepts > Colors > Customizing the default colors

## Visual changes

**Before...**

![image](https://github.com/filamentphp/filament/assets/155970197/5e7cf0f2-9c9e-4ff6-ac44-fe1d0f57dbbe)

**After...**

![image](https://github.com/filamentphp/filament/assets/155970197/dc26a054-eb19-4fc2-bc9d-0589c677a37f)

## Functional changes

- [ ] Documentation is up-to-date.
