### PR TITLE
Make it possible to submit form from outside itself

### DIFF
--- a/packages/panels/resources/views/resources/pages/create-record.blade.php
+++ b/packages/panels/resources/views/resources/pages/create-record.blade.php
@@ -4,8 +4,12 @@
         'fi-resource-' . str_replace('/', '-', $this->getResource()::getSlug()),
     ])
 >
+    @php
+        $identifier = $this->getId() . '.forms.' . $this->getFormStatePath();
+    @endphp
     <x-filament-panels::form
-        :wire:key="$this->getId() . '.forms.' . $this->getFormStatePath()"
+        :id="$identifier"
+        :wire:key="$identifier"
         wire:submit="create"
     >
         {{ $this->form }}

--- a/packages/panels/resources/views/resources/pages/edit-record.blade.php
+++ b/packages/panels/resources/views/resources/pages/edit-record.blade.php
@@ -6,8 +6,12 @@
     ])
 >
     @capture($form)
+        @php
+            $identifier = $this->getId() . '.forms.' . $this->getFormStatePath();
+        @endphp
         <x-filament-panels::form
-            :wire:key="$this->getId() . '.forms.' . $this->getFormStatePath()"
+            :id="$identifier"
+            :wire:key="$identifier"
             wire:submit="save"
         >
             {{ $this->form }}

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -217,6 +217,7 @@
                 'wire:loading.attr' => $tag === 'button' ? 'disabled' : null,
                 'wire:target' => ($hasLoadingIndicator && $loadingIndicatorTarget) ? $loadingIndicatorTarget : null,
                 'x-bind:disabled' => $hasFormProcessingLoadingIndicator ? 'isProcessing' : null,
+                'form' => $hasFormProcessingLoadingIndicator ? $form : null,
             ], escape: false)
             ->class([$buttonClasses])
             ->style([$buttonStyles])

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -217,7 +217,7 @@
                 'wire:loading.attr' => $tag === 'button' ? 'disabled' : null,
                 'wire:target' => ($hasLoadingIndicator && $loadingIndicatorTarget) ? $loadingIndicatorTarget : null,
                 'x-bind:disabled' => $hasFormProcessingLoadingIndicator ? 'isProcessing' : null,
-                'form' => $hasFormProcessingLoadingIndicator ? $form : null,
+                'form' => ($tag === 'button' && $hasFormProcessingLoadingIndicator) ? $form : null,
             ], escape: false)
             ->class([$buttonClasses])
             ->style([$buttonStyles])

--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -111,7 +111,8 @@
 
     $wireTarget = $loadingIndicator ? $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(fn ($value): bool => filled($value))->first() : null;
 
-    $hasLoadingIndicator = filled($wireTarget) || ($type === 'submit' && filled($form));
+    $hasFormProcessingLoadingIndicator = $type === 'submit' && filled($form);
+    $hasLoadingIndicator = filled($wireTarget) || $hasFormProcessingLoadingIndicator;
 
     if ($hasLoadingIndicator) {
         $loadingIndicatorTarget = html_entity_decode($wireTarget ?: $form, ENT_QUOTES);
@@ -139,6 +140,7 @@
                 ->merge([
                     'disabled' => $disabled,
                     'type' => $type,
+                    'form' => $hasFormProcessingLoadingIndicator ? $form : null,
                 ], escape: false)
                 ->merge([
                     'title' => $label,


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Usecase: move the "save" button to the header actions of EditRecord or CreateRecord.  
Using the [form HTML feature](https://stackoverflow.com/a/12567605)

- [packages/support/resources/views/components/button/index.blade.php#L199](https://github.com/filamentphp/filament/blob/75f4cbd2353066a737026e21d6931d5217376a98/packages/support/resources/views/components/button/index.blade.php#L199) form selection will probably not work anymore

## Visual changes

None

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
  - `npm run prettier` suggests quite some changes to untouched files, I did not commit those
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
