### PR TITLE
removed unnecessary brackets

### DIFF
--- a/packages/forms/docs/03-fields/18-toggle-buttons.md
+++ b/packages/forms/docs/03-fields/18-toggle-buttons.md
@@ -38,7 +38,6 @@ ToggleButtons::make('status')
         'scheduled' => 'warning',
         'published' => 'success',
     ])
-])
 ```
 
 If you are using an enum for the options, you can use the [`HasColor` interface](../../support/enums#enum-colors) to define colors instead.
@@ -63,7 +62,6 @@ ToggleButtons::make('status')
         'scheduled' => 'heroicon-o-clock',
         'published' => 'heroicon-o-check-circle',
     ])
-])
 ```
 
 If you are using an enum for the options, you can use the [`HasIcon` interface](../../support/enums#enum-icons) to define icons instead.


### PR DESCRIPTION
## Description

There is no need to add ]) to https://filamentphp.com/docs/3.x/forms/fields/toggle-buttons#changing-the-color-of-option-buttons and https://filamentphp.com/docs/3.x/forms/fields/toggle-buttons#adding-icons-to-option-buttons

Because when a developer wants to copy and paste this code snippet there might be a syntax error occurring.  

example:
->schema([]) is a default syntax. If someone copies and pastes code into square brackets, there might be an issue with extra ]) brackets.

## Visual changes

![image](https://github.com/filamentphp/filament/assets/61825623/c32f7948-8ae0-4e4e-ac44-293d49d9e715)

## Functional changes

- [ ] removed 

> ])
