### PR TITLE
update filament.php, added forceTLS option to allow choosing between …

### DIFF
--- a/packages/support/config/filament.php
+++ b/packages/support/config/filament.php
@@ -26,7 +26,7 @@ return [
         //     'authEndpoint' => '/api/v1/broadcasting/auth',
         //     'disableStats' => true,
         //     'encrypted' => true,
-        //     'forceTLS' => false,
+        //     'forceTLS' => true,
         // ],
 
     ],

--- a/packages/support/config/filament.php
+++ b/packages/support/config/filament.php
@@ -26,6 +26,7 @@ return [
         //     'authEndpoint' => '/api/v1/broadcasting/auth',
         //     'disableStats' => true,
         //     'encrypted' => true,
+        //     'forceTLS' => false,
         // ],
 
     ],


### PR DESCRIPTION
…wss and ws protocols.

## Description

In this PR, we're enhancing the Echo broadcasting functionality by introducing the "forceTLS" option. This addition enables users to choose between the "wss" and "ws" protocols according to their requirements. By implementing this option, we offer greater flexibility and control over the broadcasting process, allowing users to select the appropriate protocol for their specific use cases. This enhancement ensures that Echo broadcasting aligns more closely with diverse project needs and preferences, contributing to a more adaptable and efficient development experience.

## Visual changes
## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
