### PR TITLE
Fix Dragged Record ID Access in Table Reorder Event Handler

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -391,7 +391,7 @@
                         :lg="$contentGrid['lg'] ?? null"
                         :xl="$contentGrid['xl'] ?? null"
                         :two-xl="$contentGrid['2xl'] ?? null"
-                        x-on:end.stop="$wire.reorderTable($event.target.sortable.toArray(), $event.target.sortable.item.getAttribute('x-sortable-item')))"
+                        x-on:end.stop="$wire.reorderTable($event.target.sortable.toArray(), $event.item.getAttribute('x-sortable-item'))"
                         x-sortable
                         :data-sortable-animation-duration="$getReorderAnimationDuration()"
                         @class([


### PR DESCRIPTION
## Description

This pull request serves as a follow-up to https://github.com/filamentphp/filament/pull/12096. It corrects a minor issue in the `index.blade.php` event handler, ensuring that the ID of the dragged record is accurately passed to the `reorderTable` method.

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
