### PR TITLE
Use CSS content-based sizing property for textarea elements

### DIFF
--- a/packages/forms/resources/js/components/textarea.js
+++ b/packages/forms/resources/js/components/textarea.js
@@ -1,14 +1,14 @@
 export default function textareaFormComponent({ initialHeight }) {
     return {
         init: function () {
-            this.render()
+            if (this.$el.scrollHeight > 0) {
+                this.$el.style.minHeight = initialHeight + 'rem'
+                this.$el.style.minHeight = this.$el.scrollHeight + 'px'
+            }
         },
 
         render: function () {
-            if (this.$el.scrollHeight > 0) {
-                this.$el.style.height = initialHeight + 'rem'
-                this.$el.style.height = this.$el.scrollHeight + 'px'
-            }
+            //
         },
     }
 }

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -69,7 +69,7 @@
                         'resize-none' => $shouldAutosize,
                     ])
                     ->style([
-                        "height: {$initialHeight}rem" => $shouldAutosize,
+                        "field-sizing: content" => $shouldAutosize,
                     ])
             }}
         ></textarea>


### PR DESCRIPTION
## Description

Javascript is not needed anymore to calculate the textarea height sizing. Instead, we can use the new field sizing CSS property called `field-sizing`.

⚠️ Important note - this property is experimental, which means not all browsers suport it yet. I make the PR so y'all know it exists and when more browsers suport it can be merged. For now, I wouldn't merge it.

This PR is about the textarea, but this content based sizing style also works for more than a textarea.

Relevant links:
- https://caniuse.com/?search=field-sizing
- https://developer.chrome.com/docs/css-ui/css-field-sizing


## Visual changes

There is no visual changes.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
