### PR TITLE
Fix long label in CheckboxList Component

### DIFF
--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -196,7 +196,7 @@
 
                         <div class="grid text-sm leading-6">
                             <span
-                                class="fi-fo-checkbox-list-option-label font-medium text-gray-950 dark:text-white"
+                                class="fi-fo-checkbox-list-option-label break-all font-medium text-gray-950 dark:text-white"
                             >
                                 {{ $label }}
                             </span>

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -196,7 +196,7 @@
 
                         <div class="grid text-sm leading-6">
                             <span
-                                class="fi-fo-checkbox-list-option-label break-all font-medium text-gray-950 dark:text-white"
+                                class="fi-fo-checkbox-list-option-label overflow-hidden break-words font-medium text-gray-950 dark:text-white"
                             >
                                 {{ $label }}
                             </span>


### PR DESCRIPTION
## Description

Adds the `break-all` class for label in CheckboxList.
When using multi columns and searchable() method, if a label is very long, search layout overflow.

## Visual changes

Before `break-all`
<img width="1473" alt="before" src="https://github.com/filamentphp/filament/assets/53862310/1229ce77-d8a7-4885-99ac-775b6e93088f">

After => `break-all`applied
<img width="1473" alt="after" src="https://github.com/filamentphp/filament/assets/53862310/81a2ada6-9b7d-4276-bc25-6ad2944e814b">


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
