### PR TITLE
docs: Fix backticks to single quotes in docs

### DIFF
--- a/packages/tables/docs/12-testing.md
+++ b/packages/tables/docs/12-testing.md
@@ -171,7 +171,7 @@ use function Pest\Livewire\livewire;
 
 it('has an author column', function () {
     livewire(PostResource\Pages\ListPosts::class)
-        ->assertTableColumnExists(`author`);
+        ->assertTableColumnExists('author');
 });
 ```
 
@@ -200,8 +200,8 @@ use function Pest\Livewire\livewire;
 
 it('shows the correct columns', function () {
     livewire(PostResource\Pages\ListPosts::class)
-        ->assertTableColumnVisible(`created_at`)
-        ->assertTableColumnHidden(`author`);
+        ->assertTableColumnVisible('created_at')
+        ->assertTableColumnHidden('author');
 });
 ```
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Documentation uses backticks instead of single quotes

## Visual changes

-

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
