### PR TITLE
Remove warning about Livewire v3 release

### DIFF
--- a/packages/actions/docs/01-installation.md
+++ b/packages/actions/docs/01-installation.md
@@ -12,9 +12,6 @@ Filament requires the following to run:
 - Laravel v10.0+
 - Livewire v3.0+
 
-> **Livewire v3 is recently released!**<br />
-> The Livewire team have done a great job in making it stable, but it was a complete rewrite of Livewire v2. You may encounter issues, so we recommend testing your application thoroughly before using Filament v3 in production.
-
 ## Installation
 
 Require the Actions package using Composer:

--- a/packages/actions/docs/10-upgrade-guide.md
+++ b/packages/actions/docs/10-upgrade-guide.md
@@ -11,9 +11,6 @@ title: Upgrading from v2.x
 
 Please upgrade Filament before upgrading to Livewire v3. Instructions on how to upgrade Livewire can be found [here](https://livewire.laravel.com/docs/upgrading).
 
-> **Livewire v3 is recently released!**<br />
-> The Livewire team have done a great job in making it stable, but it was a complete rewrite of Livewire v2. You may encounter issues, so we recommend testing your application thoroughly before using Filament v3 in production.
-
 ## Upgrading automatically
 
 The easiest way to upgrade your app is to run the automated upgrade script. This script will automatically upgrade your application to the latest version of Filament and make changes to your code, which handles most breaking changes.

--- a/packages/forms/docs/01-installation.md
+++ b/packages/forms/docs/01-installation.md
@@ -12,9 +12,6 @@ Filament requires the following to run:
 - Laravel v10.0+
 - Livewire v3.0+
 
-> **Livewire v3 is recently released!**<br />
-> The Livewire team have done a great job in making it stable, but it was a complete rewrite of Livewire v2. You may encounter issues, so we recommend testing your application thoroughly before using Filament v3 in production.
-
 ## Installation
 
 Require the Form Builder package using Composer:

--- a/packages/forms/docs/10-upgrade-guide.md
+++ b/packages/forms/docs/10-upgrade-guide.md
@@ -11,9 +11,6 @@ title: Upgrading from v2.x
 
 Please upgrade Filament before upgrading to Livewire v3. Instructions on how to upgrade Livewire can be found [here](https://livewire.laravel.com/docs/upgrading).
 
-> **Livewire v3 is recently released!**<br />
-> The Livewire team have done a great job in making it stable, but it was a complete rewrite of Livewire v2. You may encounter issues, so we recommend testing your application thoroughly before using Filament v3 in production.
-
 ## Upgrading automatically
 
 The easiest way to upgrade your app is to run the automated upgrade script. This script will automatically upgrade your application to the latest version of Filament, and make changes to your code which handle most breaking changes.

--- a/packages/infolists/docs/01-installation.md
+++ b/packages/infolists/docs/01-installation.md
@@ -12,9 +12,6 @@ Filament requires the following to run:
 - Laravel v10.0+
 - Livewire v3.0+
 
-> **Livewire v3 is recently released!**<br />
-> The Livewire team have done a great job in making it stable, but it was a complete rewrite of Livewire v2. You may encounter issues, so we recommend testing your application thoroughly before using Filament v3 in production.
-
 ## Installation
 
 Require the Infolist Builder package using Composer:

--- a/packages/notifications/docs/01-installation.md
+++ b/packages/notifications/docs/01-installation.md
@@ -12,9 +12,6 @@ Filament requires the following to run:
 - Laravel v10.0+
 - Livewire v3.0+
 
-> **Livewire v3 is recently released!**<br />
-> The Livewire team have done a great job in making it stable, but it was a complete rewrite of Livewire v2. You may encounter issues, so we recommend testing your application thoroughly before using Filament v3 in production.
-
 Require the Notifications package using Composer:
 
 ```bash

--- a/packages/notifications/docs/07-upgrade-guide.md
+++ b/packages/notifications/docs/07-upgrade-guide.md
@@ -11,9 +11,6 @@ title: Upgrading from v2.x
 
 Please upgrade Filament before upgrading to Livewire v3. Instructions on how to upgrade Livewire can be found [here](https://livewire.laravel.com/docs/upgrading).
 
-> **Livewire v3 is recently released!**<br />
-> The Livewire team have done a great job in making it stable, but it was a complete rewrite of Livewire v2. You may encounter issues, so we recommend testing your application thoroughly before using Filament v3 in production.
-
 ## Upgrading automatically
 
 The easiest way to upgrade your app is to run the automated upgrade script. This script will automatically upgrade your application to the latest version of Filament, and make changes to your code which handle most breaking changes.

--- a/packages/panels/docs/01-installation.md
+++ b/packages/panels/docs/01-installation.md
@@ -10,9 +10,6 @@ Filament requires the following to run:
 - Laravel v10.0+
 - Livewire v3.0+
 
-> **Livewire v3 is recently released!**<br />
-> The Livewire team have done a great job in making it stable, but it was a complete rewrite of Livewire v2. You may encounter issues, so we recommend testing your application thoroughly before using Filament v3 in production.
-
 ## Installation
 
 > If you are upgrading from Filament v2, please review the [upgrade guide](upgrade-guide).

--- a/packages/panels/docs/15-upgrade-guide.md
+++ b/packages/panels/docs/15-upgrade-guide.md
@@ -11,9 +11,6 @@ title: Upgrading from v2.x
 
 Please upgrade Filament before upgrading to Livewire v3. Instructions on how to upgrade Livewire can be found [here](https://livewire.laravel.com/docs/upgrading).
 
-> **Livewire v3 is recently released!**<br />
-> The Livewire team have done a great job in making it stable, but it was a complete rewrite of Livewire v2. You may encounter issues, so we recommend testing your application thoroughly before using Filament v3 in production.
-
 ## Upgrading automatically
 
 The easiest way to upgrade your app is to run the automated upgrade script. This script will automatically upgrade your application to the latest version of Filament and make changes to your code, which handles most breaking changes.

--- a/packages/tables/docs/01-installation.md
+++ b/packages/tables/docs/01-installation.md
@@ -12,9 +12,6 @@ Filament requires the following to run:
 - Laravel v10.0+
 - Livewire v3.0+
 
-> **Livewire v3 is recently released!**<br />
-> The Livewire team have done a great job in making it stable, but it was a complete rewrite of Livewire v2. You may encounter issues, so we recommend testing your application thoroughly before using Filament v3 in production.
-
 ## Installation
 
 Require the Table Builder package using Composer:

--- a/packages/tables/docs/13-upgrade-guide.md
+++ b/packages/tables/docs/13-upgrade-guide.md
@@ -11,9 +11,6 @@ title: Upgrading from v2.x
 
 Please upgrade Filament before upgrading to Livewire v3. Instructions on how to upgrade Livewire can be found [here](https://livewire.laravel.com/docs/upgrading).
 
-> **Livewire v3 is recently released!**<br />
-> The Livewire team have done a great job in making it stable, but it was a complete rewrite of Livewire v2. You may encounter issues, so we recommend testing your application thoroughly before using Filament v3 in production.
-
 ## Upgrading automatically
 
 The easiest way to upgrade your app is to run the automated upgrade script. This script will automatically upgrade your application to the latest version of Filament, and make changes to your code which handle most breaking changes.

--- a/packages/widgets/docs/01-installation.md
+++ b/packages/widgets/docs/01-installation.md
@@ -12,9 +12,6 @@ Filament requires the following to run:
 - Laravel v10.0+
 - Livewire v3.0+
 
-> **Livewire v3 is recently released!**<br />
-> The Livewire team have done a great job in making it stable, but it was a complete rewrite of Livewire v2. You may encounter issues, so we recommend testing your application thoroughly before using Filament v3 in production.
-
 ## Installation
 
 Require the Widgets package using Composer:


### PR DESCRIPTION
## Description

It has been 8+ months since Livewire V3 was launched and it has been stable for months. IMHO the warning messages in the docs can now safely be removed.

## Visual changes

**Before:**

![CleanShot 2024-04-02 at 16 20 16](https://github.com/filamentphp/filament/assets/171715/4b821341-246b-4242-975f-6d2695147bf9)

**After:**

![CleanShot 2024-04-02 at 16 21 30](https://github.com/filamentphp/filament/assets/171715/fb6d67a0-9797-4747-96b3-30c3a6b58e9c)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
