### PR TITLE
Custom background color on modal blade component

### DIFF
--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -27,6 +27,8 @@
     'trigger' => null,
     'visible' => true,
     'width' => 'sm',
+    'backgroundColor' => 'bg-white dark:bg-gray-900',
+    'closeButtonClasses' => 'fi-modal-close-btn',
 ])
 
 @php
@@ -171,7 +173,8 @@
                         x-transition:leave-end="scale-95 opacity-0"
                     @endif
                     @class([
-                        'fi-modal-window pointer-events-auto relative row-start-2 flex w-full cursor-default flex-col bg-white shadow-xl ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10',
+                        $backgroundColor,
+                        'fi-modal-window pointer-events-auto relative row-start-2 flex w-full cursor-default flex-col shadow-xl ring-1 ring-gray-950/5 dark:ring-white/10',
                         'fi-modal-slide-over-window ms-auto overflow-y-auto' => $slideOver,
                         // Using an arbitrary value instead of the h-dvh class that was added in Tailwind CSS v3.4.0
                         // to ensure compatibility with custom themes that may use an older version of Tailwind CSS.
@@ -209,7 +212,7 @@
                         <div
                             @class([
                                 'fi-modal-header flex px-6 pt-6',
-                                'fi-sticky sticky top-0 z-10 border-b border-gray-200 bg-white pb-6 dark:border-white/10 dark:bg-gray-900' => $stickyHeader,
+                                "fi-sticky sticky top-0 z-10 border-b border-gray-200 pb-6 dark:border-white/10 $backgroundColor" => $stickyHeader,
                                 'rounded-t-xl' => $stickyHeader && ! ($slideOver || ($width === MaxWidth::Screen)),
                                 match ($alignment) {
                                     Alignment::Start, Alignment::Left => 'gap-x-5',
@@ -235,7 +238,7 @@
                                         :label="__('filament::components/modal.actions.close.label')"
                                         tabindex="-1"
                                         :x-on:click="$closeEventHandler"
-                                        class="fi-modal-close-btn"
+                                        :class="$closeButtonClasses"
                                     />
                                 </div>
                             @endif
@@ -326,7 +329,7 @@
                                 'fi-modal-footer w-full',
                                 'pe-6 ps-[5.25rem]' => $hasIcon && ($alignment === Alignment::Start) && ($footerActionsAlignment !== Alignment::Center) && (! $stickyFooter),
                                 'px-6' => ! ($hasIcon && ($alignment === Alignment::Start) && ($footerActionsAlignment !== Alignment::Center) && (! $stickyFooter)),
-                                'fi-sticky sticky bottom-0 border-t border-gray-200 bg-white py-5 dark:border-white/10 dark:bg-gray-900' => $stickyFooter,
+                                "fi-sticky sticky bottom-0 border-t border-gray-200 py-5 dark:border-white/10 $backgroundColor" => $stickyFooter,
                                 'rounded-b-xl' => $stickyFooter && ! ($slideOver || ($width === MaxWidth::Screen)),
                                 'pb-6' => ! $stickyFooter,
                                 'mt-6' => (! $stickyFooter) && \Filament\Support\is_slot_empty($slot),


### PR DESCRIPTION
Example when you want to style the background of a modal component:

```html
<x-filament::modal 
    id="custom-error" 
    background-color="!bg-danger-500"
    close-button-classes="!bg-white/5 !rounded-full !text-gray-200 hover:!text-white"
    >

        <x-slot name="heading">Missing something</x-slot>
        
        <div class="text-white">Custom error</div>

</x-filament::modal>