### PR TITLE
Add Support for S3 Compatible Storage when importing data

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -707,6 +707,20 @@ ImportColumn::make('name')
     ->validationAttribute('full name')
 ```
 
+## Import File Storage
+
+By default the import action will use the path of the temporary file to store the CSV, unless your default filesystem is driven by S3 in which case it will use the S3 disk.
+
+### Support for S3 Compatible Storage
+
+If you are using an S3 compatible storage, such as DigitalOcean Spaces, you can set a custom disk to use for the import file storage by calling the `disk()` method on the action:
+
+```php
+ImportAction::make()
+    ->importer(ProductImporter::class)
+    ->disk('digitalocean')
+```
+
 ## Lifecycle hooks
 
 Hooks may be used to execute code at various points within an importer's lifecycle, like before a record is saved. To set up a hook, create a protected method on the importer class with the name of the hook:

--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -707,7 +707,7 @@ ImportColumn::make('name')
     ->validationAttribute('full name')
 ```
 
-## Import File Storage
+## Storage
 
 By default the import action will use the path of the temporary file to store the CSV, unless your default filesystem is driven by S3 in which case it will use the S3 disk.
 

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -495,9 +495,6 @@ trait CanImportRecords
         return $this->evaluate($this->options);
     }
 
-    /**
-     * @throws Exception if the disk is not an S3 disk
-     */
     private function getDisk(): string
     {
         $disk = $this->evaluate($this->disk);

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -495,7 +495,7 @@ trait CanImportRecords
         return $this->evaluate($this->options);
     }
 
-    private function getDisk(): string
+    public function getDisk(): string
     {
         $disk = $this->evaluate($this->disk);
 

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -503,7 +503,7 @@ trait CanImportRecords
         $disk = $this->evaluate($this->disk);
 
         if (config('filesystems.disks.' . $disk . '.driver') !== 's3') {
-            throw new Exception('The disk must be an S3 compatible disk.');
+            throw new Exception('The disk for the storage of import data can only be customised when using an S3 compatible disk.');
         }
         return $disk;
     }

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -499,7 +499,7 @@ trait CanImportRecords
     {
         $disk = $this->evaluate($this->disk);
 
-        if (config('filesystems.disks.' . $disk . '.driver') !== 's3') {
+        if (config("filesystems.disks.{$disk}.driver") !== 's3') {
             throw new Exception('The disk for the storage of import data can only be customised when using an S3 compatible disk.');
         }
 

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -505,6 +505,7 @@ trait CanImportRecords
         if (config('filesystems.disks.' . $disk . '.driver') !== 's3') {
             throw new Exception('The disk for the storage of import data can only be customised when using an S3 compatible disk.');
         }
+
         return $disk;
     }
 }

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -361,7 +361,7 @@ trait CanImportRecords
         $s3Adapter = Storage::disk($disk)->getAdapter();
 
         invade($s3Adapter)->client->registerStreamWrapper(); /** @phpstan-ignore-line */
-        $fileS3Path = 's3://' . config("filesystems.disks.$disk.bucket") . '/' . $filePath;
+        $fileS3Path = 's3://' . config("filesystems.disks.{$disk}.bucket") . '/' . $filePath;
 
         return fopen($fileS3Path, mode: 'r', context: stream_context_create([
             's3' => [


### PR DESCRIPTION
## Description

Following on  from PR [#12095](https://github.com/filamentphp/filament/pull/12095), I have made it easier to use S3 compatible storage that is set up with a different disk name. 

Although you could simply masquerade your chosen service as the S3 disk, this didn't feel particularly user-friendly or promote developer choice. This my first code-related open source PR so any feedback very welcome 

## Visual changes
None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
