### PR TITLE
Update Korean translations & .csv file encoding fixed

### DIFF
--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -27,7 +27,9 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Number;
+use League\Csv\ByteSequence;
 use League\Csv\Info;
+use League\Csv\Reader;
 use League\Csv\Reader as CsvReader;
 use League\Csv\Statement;
 use League\Csv\Writer;
@@ -326,9 +328,10 @@ trait CanImportRecords
                     }
 
                     return response()->streamDownload(function () use ($csv) {
+                        $csv->setOutputBOM(ByteSequence::BOM_UTF8);
                         echo $csv->toString();
                     }, __('filament-actions::import.example_csv.file_name', ['importer' => (string) str($this->getImporter())->classBasename()->kebab()]), [
-                        'Content-Type' => 'text/csv',
+                        'Content-Type' => 'text/csv; charset=UTF-8',
                     ]);
                 }),
         ]);

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -29,7 +29,6 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Number;
 use League\Csv\ByteSequence;
 use League\Csv\Info;
-use League\Csv\Reader;
 use League\Csv\Reader as CsvReader;
 use League\Csv\Statement;
 use League\Csv\Writer;

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -329,6 +329,7 @@ trait CanImportRecords
 
                     return response()->streamDownload(function () use ($csv) {
                         $csv->setOutputBOM(ByteSequence::BOM_UTF8);
+                        
                         echo $csv->toString();
                     }, __('filament-actions::import.example_csv.file_name', ['importer' => (string) str($this->getImporter())->classBasename()->kebab()]), [
                         'Content-Type' => 'text/csv; charset=UTF-8',

--- a/packages/actions/src/Exports/Jobs/ExportCsv.php
+++ b/packages/actions/src/Exports/Jobs/ExportCsv.php
@@ -16,6 +16,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Arr;
+use League\Csv\ByteSequence;
 use League\Csv\Writer;
 use SplTempFileObject;
 use Throwable;
@@ -73,6 +74,7 @@ class ExportCsv implements ShouldQueue
 
         $csv = Writer::createFromFileObject(new SplTempFileObject());
         $csv->setDelimiter($this->exporter::getCsvDelimiter());
+        $csv->setOutputBOM(ByteSequence::BOM_UTF8);
 
         $query = EloquentSerializeFacade::unserialize($this->query);
 

--- a/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
+++ b/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
@@ -14,6 +14,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use League\Csv\ByteSequence;
 use League\Csv\Writer;
 use SplTempFileObject;
 
@@ -53,6 +54,7 @@ class PrepareCsvExport implements ShouldQueue
         $csv = Writer::createFromFileObject(new SplTempFileObject());
         $csv->setDelimiter($this->exporter::getCsvDelimiter());
         $csv->insertOne(array_values($this->columnMap));
+        $csv->setOutputBOM(ByteSequence::BOM_UTF8);
 
         $filePath = $this->export->getFileDirectory() . DIRECTORY_SEPARATOR . 'headers.csv';
         $this->export->getFileDisk()->put($filePath, $csv->toString(), Filesystem::VISIBILITY_PRIVATE);

--- a/packages/panels/resources/lang/ko/layout.php
+++ b/packages/panels/resources/lang/ko/layout.php
@@ -52,4 +52,12 @@ return [
 
     ],
 
+    'avatar' => [
+        'alt' => ':name 아바타',
+    ],
+
+    'logo' => [
+        'alt' => ':name 로고',
+    ],
+
 ];


### PR DESCRIPTION
* Provides Korean for missing keys
* Fix encoding error when downloading sample .csv file in the import action modal