### PR TITLE
Improve accuracy in docs (02-text-input.md)

### DIFF
--- a/packages/forms/docs/03-fields/02-text-input.md
+++ b/packages/forms/docs/03-fields/02-text-input.md
@@ -42,7 +42,7 @@ TextInput::make('backgroundColor')
 
 ## Setting the HTML input mode
 
-You may set the [`inputmode` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attributes) of the input using the `inputMode()` method:
+You may set the [`inputmode` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#inputmode) of the input using the `inputMode()` method:
 
 ```php
 use Filament\Forms\Components\TextInput;
@@ -213,13 +213,13 @@ TextInput::make('amount')
 
 ## Making the field read-only
 
-Not to be confused with [disabling the field](getting-started#disabling-a-field), you may make the field "read-only" using the `readonly()` method:
+Not to be confused with [disabling the field](getting-started#disabling-a-field), you may make the field "read-only" using the `readOnly()` method:
 
 ```php
 use Filament\Forms\Components\TextInput;
 
 TextInput::make('name')
-    ->readonly()
+    ->readOnly()
 ```
 
 There are a few differences, compared to [`disabled()`](getting-started#disabling-a-field):


### PR DESCRIPTION
## Description
Increased accuracy in the following sections of documentation:

### 1. Form Builder > Fields > Text input > Setting the HTML input mode

Improved specificity of `inputmode` attribute link. 

### 2. Form Builder > Fields > Text input > Making the field read-only

Changed lowercase read-only method name to camel-case to be consistent with case used in later bullet points (and in the Filament code itself).

## Visual changes

### 1. Before...
 
![image](https://github.com/wickham-c/filament/assets/155970197/6f04c079-bc6b-47cf-86f3-a25b41cf2ebe)

### After...

![image](https://github.com/wickham-c/filament/assets/155970197/536a58c0-d65e-48ce-bbf8-e6e39312755f)

### 2. Before...

![image](https://github.com/wickham-c/filament/assets/155970197/246141dc-3432-442f-8503-836b4f035b9a)

### After...

![image](https://github.com/wickham-c/filament/assets/155970197/662ca550-35b9-4837-9049-656cf1da6db7)

## Functional changes

- [ ] Documentation is up-to-date.