### PR TITLE
Fix quirk with beforeSave hook on EditRecord page

### DIFF
--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Forms\Concerns;
 
+use Closure;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 
@@ -220,9 +221,11 @@ trait HasState
     /**
      * @return array<string, mixed>
      */
-    public function getState(bool $shouldCallHooksBefore = true): array
+    public function getState(bool $shouldCallHooksBefore = true, ?Closure $afterValidate = null): array
     {
         $state = $this->validate();
+
+        value($afterValidate);
 
         if ($shouldCallHooksBefore) {
             $this->callBeforeStateDehydrated();

--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -220,14 +220,14 @@ trait HasState
     /**
      * @return array<string, mixed>
      */
-    public function getState(bool $shouldCallHooksBefore = true, bool $shouldSaveRelationships = false): array
+    public function getState(bool $shouldCallHooksBefore = true, bool $shouldSaveRelationships = true): array
     {
         $state = $this->validate();
 
         if ($shouldCallHooksBefore) {
             $this->callBeforeStateDehydrated();
 
-            if (! $shouldSaveRelationships) {
+            if ($shouldSaveRelationships) {
                 $this->saveRelationships();
                 $this->loadStateFromRelationships(andHydrate: true);
             }

--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -220,14 +220,17 @@ trait HasState
     /**
      * @return array<string, mixed>
      */
-    public function getState(bool $shouldCallHooksBefore = true): array
+    public function getState(bool $shouldCallHooksBefore = true, bool $skipSavingRelationships = false): array
     {
         $state = $this->validate();
 
         if ($shouldCallHooksBefore) {
             $this->callBeforeStateDehydrated();
-            $this->saveRelationships();
-            $this->loadStateFromRelationships(andHydrate: true);
+
+            if (! $skipSavingRelationships) {
+                $this->saveRelationships();
+                $this->loadStateFromRelationships(andHydrate: true);
+            }
         }
 
         $this->dehydrateState($state);

--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -226,7 +226,6 @@ trait HasState
 
         if ($shouldCallHooksBefore) {
             $this->callBeforeStateDehydrated();
-
             $this->saveRelationships();
             $this->loadStateFromRelationships(andHydrate: true);
         }

--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -220,14 +220,14 @@ trait HasState
     /**
      * @return array<string, mixed>
      */
-    public function getState(bool $shouldCallHooksBefore = true, bool $skipSavingRelationships = false): array
+    public function getState(bool $shouldCallHooksBefore = true, bool $shouldSaveRelationships = false): array
     {
         $state = $this->validate();
 
         if ($shouldCallHooksBefore) {
             $this->callBeforeStateDehydrated();
 
-            if (! $skipSavingRelationships) {
+            if (! $shouldSaveRelationships) {
                 $this->saveRelationships();
                 $this->loadStateFromRelationships(andHydrate: true);
             }

--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -220,17 +220,15 @@ trait HasState
     /**
      * @return array<string, mixed>
      */
-    public function getState(bool $shouldCallHooksBefore = true, bool $shouldSaveRelationships = true): array
+    public function getState(bool $shouldCallHooksBefore = true): array
     {
         $state = $this->validate();
 
         if ($shouldCallHooksBefore) {
             $this->callBeforeStateDehydrated();
 
-            if ($shouldSaveRelationships) {
-                $this->saveRelationships();
-                $this->loadStateFromRelationships(andHydrate: true);
-            }
+            $this->saveRelationships();
+            $this->loadStateFromRelationships(andHydrate: true);
         }
 
         $this->dehydrateState($state);

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -140,13 +140,11 @@ class EditRecord extends Page
 
             $this->callHook('beforeValidate');
 
-            $this->form->validate();
+            $data = $this->form->getState(afterValidate: function () {
+                $this->callHook('afterValidate');
 
-            $this->callHook('afterValidate');
-
-            $this->callHook('beforeSave');
-
-            $data = $this->form->getState();
+                $this->callHook('beforeSave');
+            });
 
             $data = $this->mutateFormDataBeforeSave($data);
 

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -140,15 +140,15 @@ class EditRecord extends Page
 
             $this->callHook('beforeValidate');
 
-            $data = $this->form->getState(shouldSaveRelationships: false);
+            $this->form->validate();
 
             $this->callHook('afterValidate');
 
-            $data = $this->mutateFormDataBeforeSave($data);
-
             $this->callHook('beforeSave');
 
-            $this->form->saveRelationships();
+            $data = $this->form->getState();
+
+            $data = $this->mutateFormDataBeforeSave($data);
 
             $this->handleRecordUpdate($this->getRecord(), $data);
 

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -140,13 +140,15 @@ class EditRecord extends Page
 
             $this->callHook('beforeValidate');
 
-            $data = $this->form->getState();
+            $data = $this->form->getState(skipSavingRelationships: true);
 
             $this->callHook('afterValidate');
 
             $data = $this->mutateFormDataBeforeSave($data);
 
             $this->callHook('beforeSave');
+
+            $this->form->saveRelationships();
 
             $this->handleRecordUpdate($this->getRecord(), $data);
 

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -140,7 +140,7 @@ class EditRecord extends Page
 
             $this->callHook('beforeValidate');
 
-            $data = $this->form->getState(skipSavingRelationships: true);
+            $data = $this->form->getState(shouldSaveRelationships: false);
 
             $this->callHook('afterValidate');
 


### PR DESCRIPTION
## Description

This PR should fix a quirk with the `beforeSave()` hook on the EditRecord page. The issue is that currently, when saving data, the EditRecord page stores record relationships before the `beforeSave()` hook is called. I have introduced a new argument in the `getState()` method that skips saving relationships when getting the form state. After the `beforeSave()` hook is called, then the relationships are saved.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
