### PR TITLE
Use auth setUser() rather than login() in import/export jobs

### DIFF
--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -328,7 +328,7 @@ trait CanImportRecords
 
                     return response()->streamDownload(function () use ($csv) {
                         $csv->setOutputBOM(ByteSequence::BOM_UTF8);
-                        
+
                         echo $csv->toString();
                     }, __('filament-actions::import.example_csv.file_name', ['importer' => (string) str($this->getImporter())->classBasename()->kebab()]), [
                         'Content-Type' => 'text/csv; charset=UTF-8',

--- a/packages/actions/src/Exports/Jobs/ExportCsv.php
+++ b/packages/actions/src/Exports/Jobs/ExportCsv.php
@@ -65,7 +65,7 @@ class ExportCsv implements ShouldQueue
         /** @var Authenticatable $user */
         $user = $this->export->user;
 
-        auth()->login($user);
+        auth()->setUser($user);
 
         $exceptions = [];
 

--- a/packages/actions/src/Imports/Jobs/ImportCsv.php
+++ b/packages/actions/src/Imports/Jobs/ImportCsv.php
@@ -62,7 +62,7 @@ class ImportCsv implements ShouldQueue
         /** @var Authenticatable $user */
         $user = $this->import->user;
 
-        auth()->login($user);
+        auth()->setUser($user);
 
         $exceptions = [];
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The auth()->login() method currently used for impersonating the user during import or export of CSV doesn't exist in some gates, like Sanctum.  The setUser() method is part of the main Gate contract, so should exist for all, and is probably a better method anyway, as it has no side effect like running pre/post events or adding to the sessions table, like login() does.

Tested in an admin panel and in a Jetstream/Sanctuim front end.

## Visual changes

No visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
