### PR TITLE
Improve PostgreSQL Ordering Compatibility in PrepareCsvExport Job

### DIFF
--- a/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
+++ b/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
@@ -9,6 +9,7 @@ use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Connection;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;

--- a/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
+++ b/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
@@ -64,7 +64,10 @@ class PrepareCsvExport implements ShouldQueue
         $keyName = $query->getModel()->getKeyName();
         $qualifiedKeyName = $query->getModel()->getQualifiedKeyName();
 
-        if (config('database.default') === 'pgsql') {
+        /** @var Connection $databaseConnection */
+        $databaseConnection = $query->getConnection();
+
+        if ($databaseConnection->getDriverName() === 'pgsql') {
             $originalOrderings = collect($query->getQuery()->orders)
                 ->reject(function ($order) use ($keyName, $qualifiedKeyName) {
                     return in_array($order['column'], [$keyName, $qualifiedKeyName]);

--- a/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
+++ b/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
@@ -68,15 +68,14 @@ class PrepareCsvExport implements ShouldQueue
         $databaseConnection = $query->getConnection();
 
         if ($databaseConnection->getDriverName() === 'pgsql') {
-            $originalOrderings = collect($query->getQuery()->orders)
-                ->reject(function ($order) use ($keyName, $qualifiedKeyName) {
-                    return in_array($order['column'], [$keyName, $qualifiedKeyName]);
-                })
+            $originalOrders = collect($query->getQuery()->orders)
+                ->reject(fn (array $order): bool => in_array($order['column'] ?? null, [$keyName, $qualifiedKeyName]))
                 ->unique('column');
 
-            $query->reorder()->orderBy($qualifiedKeyName);
-            foreach ($originalOrderings as $ordering) {
-                $query->orderBy($ordering['column'], $ordering['direction']);
+            $query->reorder($qualifiedKeyName);
+            
+            foreach ($originalOrders as $order) {
+                $query->orderBy($order['column'], $order['direction']);
             }
         }
 


### PR DESCRIPTION
## Description

This pull request enhances the PrepareCsvExport job to handle PostgreSQL's DISTINCT ON requirements more gracefully. It ensures the primary key is always the first in the ORDER BY clause, maintaining compatibility with PostgreSQL's expectations without disrupting existing functionality for users of other database engines. The necessity for this adjustment became evident when utilizing `->defaultSort()` on tables intended for export, which introduced an additional ordering layer and highlighted the DISTINCT ON discrepancy specifically for PostgreSQL users.

## Visual changes

N/A - This change affects backend functionality only, with no direct visual impact on the user interface.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

## Additional notes

During testing, I observed that when modifying queries using modifyQueryUsing on the ExportAction, the method $query->orderBy('sort') does not clear existing orderings, leading to unexpected sorting results when using PostgreSQL, not when using MySQL. In contrast, $query->reorder()->orderBy('sort') effectively resets and applies the desired ordering. This behaviour underscores the importance of using reorder() in modifyQueryUsing when intending to override previous orderings completely. I suggest further discussion or a separate issue to explore best practices and potentially enhance documentation or functionality around this observation.
