### PR TITLE
Style notifications based on status

### DIFF
--- a/packages/notifications/resources/views/notification.blade.php
+++ b/packages/notifications/resources/views/notification.blade.php
@@ -5,6 +5,7 @@
     use Illuminate\Support\Arr;
 
     $color = $getColor() ?? 'gray';
+    $status = $getStatus();
     $isInline = $isInline();
     $title = $getTitle();
     $hasTitle = filled($title);
@@ -52,6 +53,7 @@
                     default => 'fi-color-custom ring-custom-600/20 dark:ring-custom-400/30',
                 },
                 is_string($color) ? 'fi-color-' . $color : null,
+                is_string($status) ? 'fi-status-' . $status : null,
             ],
         },
     ])


### PR DESCRIPTION
When manually creating Notifications, the `->color()` option adds `fi-color-foo` to the component.

When Filament generates notifications it never sets the `$color` attribute, only `$status`.
Which makes it very hard to create custom css that targets the notification, when only `fi-color-gray` is added.

This change adds the `$status` value to the blade component. Which means we get a css class that we can target.

Example coloring Filament auto generated form validation error notifications as well as custom notifications with `color('danger')`:

```css
.fi-no-notification.fi-color-danger,
.fi-no-notification.fi-status-danger {
    > div:first-child {
        @apply bg-danger-500 !important;
    }

    .fi-no-notification-title,
    .fi-no-notification-body {
        @apply text-white !important;
    }

    .fi-no-notification-icon,
    .fi-icon-btn-icon {
        @apply text-danger-300 !important;
    }
}
```

