### PR TITLE
Change danger icon

### DIFF
--- a/packages/notifications/src/Concerns/HasIcon.php
+++ b/packages/notifications/src/Concerns/HasIcon.php
@@ -14,7 +14,7 @@ trait HasIcon
     public function getIcon(): ?string
     {
         return $this->baseGetIcon() ?? match ($this->getStatus()) {
-            'danger' => FilamentIcon::resolve('notifications::notification.danger') ?? 'heroicon-o-x-circle',
+            'danger' => FilamentIcon::resolve('notifications::notification.danger') ?? 'heroicon-o-exclamation-triangle',
             'info' => FilamentIcon::resolve('notifications::notification.info') ?? 'heroicon-o-information-circle',
             'success' => FilamentIcon::resolve('notifications::notification.success') ?? 'heroicon-o-check-circle',
             'warning' => FilamentIcon::resolve('notifications::notification.warning') ?? 'heroicon-o-exclamation-circle',


### PR DESCRIPTION
I hope I am not offending anyone but I think the default notification, danger, icon is a bit strange. 
It looks like a button to close the notification...

This suggested icon follows the design of the warning icon.

Current warning, and suggested danger icon
<img width="314" alt="image" src="https://github.com/filamentphp/filament/assets/21239634/caa39cff-a7c5-428e-98b5-16795ea30eef">

Current danger icon
<img width="162" alt="image" src="https://github.com/filamentphp/filament/assets/21239634/46b9c33e-26c5-4e66-9400-ccfdb4ac1d3e">

