### PR TITLE
Fix: getComponents reset array keys after array_filter (Follow-up Fix of #11869)

### DIFF
--- a/packages/forms/src/Concerns/HasComponents.php
+++ b/packages/forms/src/Concerns/HasComponents.php
@@ -109,9 +109,9 @@ trait HasComponents
             return $components;
         }
 
-        return array_filter(
+        return array_values(array_filter(
             $components,
             fn (Component $component) => $component->isVisible(),
-        );
+        ));
     }
 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This is a follow-up merge request to #11869

https://github.com/filamentphp/filament/pull/11869

This pull request will fix the issue of `array_filter` not reseting the array keys of the wizard steps... resulting in a BUG on `getStartStep()` at `wizard.php` `line: 212`

see Comment for more details

https://github.com/filamentphp/filament/pull/11869#issuecomment-2037521139

<!-- Replace this comment with your description. -->

- [✅] Visual changes (if any) are shown using screenshots/recordings of before and after.

There isn't really any visual changes, it only fixes an issue.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [✅] `composer cs` command has been run.

I was able to run `composer cs`.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [✅] Changes have been tested.

There was no tests for the Wizard component (I might be wrong here, so if you can redirect me to the right files, I will gladly write a test for this issue.)

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [✅] Documentation is up-to-date.

I'm Guessing there is no need for Documentation for this change?
