### PR TITLE
Fix $persist breaking Alpine when Tabs are used in modals

### DIFF
--- a/packages/forms/resources/views/components/tabs.blade.php
+++ b/packages/forms/resources/views/components/tabs.blade.php
@@ -48,7 +48,7 @@
                     const tabs = getTabs()
 
                     if (! tabs.includes(tab)) {
-                        tab = tabs[@js($getActiveTab()) - 1]
+                        tab = tabs[@js($getActiveTab()) - 1] || tab
                     }
                 })
             })

--- a/packages/forms/resources/views/components/tabs.blade.php
+++ b/packages/forms/resources/views/components/tabs.blade.php
@@ -48,7 +48,7 @@
                     const tabs = getTabs()
 
                     if (! tabs.includes(tab)) {
-                        tab = tabs[@js($getActiveTab()) - 1] || tab
+                        tab = tabs[@js($getActiveTab()) - 1] ?? tab
                     }
                 })
             })


### PR DESCRIPTION
## Description

We can persist the currently active `Tab` to localStorage:

```php
Tabs::make('Example Tabs')
                ->persistTab(true)
                ->id('example-tabs')
                ->tabs([...])
```

I can see the value being updated and written in devtools when the tab is changed. However, when tabs are used in a modal which is being dismissed, the value of `tab` is incorrectly set to `undefined` during a Livewire commit hook.

When opening the modal again, the UI breaks and nothing is rendered. This error appears in the console:

![Screenshot 2024-04-04 at 17 08 10@2x](https://github.com/filamentphp/filament/assets/627533/7d34b2ef-9445-4ba7-a9ee-651e8d9fa497)

The fix seems to be to fall back to the current tab, instead of trying to persist a potentially undefined array offset.

## Visual changes

N/A

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
