### PR TITLE
Add zh_CN Action Translation

### DIFF
--- a/packages/actions/resources/lang/zh_CN/export.php
+++ b/packages/actions/resources/lang/zh_CN/export.php
@@ -1,0 +1,77 @@
+<?php
+
+return [
+
+    'label' => '导出:label',
+
+    'modal' => [
+
+        'heading' => '导出:label',
+
+        'form' => [
+
+            'columns' => [
+
+                'label' => '字段',
+
+                'form' => [
+
+                    'is_enabled' => [
+                        'label' => '开启:column',
+                    ],
+
+                    'label' => [
+                        'label' => ':column标签',
+                    ],
+
+                ],
+
+            ],
+
+        ],
+
+        'actions' => [
+
+            'export' => [
+                'label' => '导出',
+            ],
+
+        ],
+
+    ],
+
+    'notifications' => [
+
+        'completed' => [
+
+            'title' => '导出完毕',
+
+            'actions' => [
+
+                'download_csv' => [
+                    'label' => '下载.csv',
+                ],
+
+                'download_xlsx' => [
+                    'label' => '下载.xlsx',
+                ],
+
+            ],
+
+        ],
+
+        'max_rows' => [
+            'title' => '导出的文件过大',
+            'body' => '不能一次导出超过的行记录。|不能一次导出超过:count 行记录。',
+        ],
+
+        'started' => [
+            'title' => '开始导出',
+            'body' => '你的导出已经开始，将在后台处理:count 行。',
+        ],
+
+    ],
+
+    'file_name' => 'export-:export_id-:model',
+
+];


### PR DESCRIPTION
## Description

Add missing action translation for zh_CN

## Visual changes

<img width="424" alt="image" src="https://github.com/filamentphp/filament/assets/8327004/01b01c16-c80d-4364-a6c5-74e5ba0978c9">


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
