### PR TITLE
Ensure Only Initial CSV File in Export Retains BOM

### DIFF
--- a/packages/actions/src/Exports/Downloaders/CsvDownloader.php
+++ b/packages/actions/src/Exports/Downloaders/CsvDownloader.php
@@ -31,7 +31,14 @@ class CsvDownloader implements Downloader
                     continue;
                 }
 
-                echo $disk->get($file);
+                $fileContents = $disk->get($file);
+
+                // Remove the BOM for subsequent CSV files
+                if (substr($fileContents, 0, 3) === "\xEF\xBB\xBF") {
+                    $fileContents = substr($fileContents, 3);
+                }
+
+                echo $fileContents;
 
                 flush();
             }


### PR DESCRIPTION
## Description

This PR addresses an issue introduced by https://github.com/filamentphp/filament/commit/d628a5d189b741d42c7385ff3ed705f81af1d858, where Byte Order Marks (BOM) were duplicated in CSV export files when merging multiple CSV parts in `CsvDownloader`. To ensure the correct encoding of the final merged CSV while avoiding the duplication of BOM, the implementation now checks for and removes any BOM from subsequent CSV parts before merging. This ensures the final CSV export has a single BOM at the beginning, if the first CSV file (seems to be header.csv) contains one, as expected, without altering the original encoding intent.

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

This fix improves the CSV export functionality, ensuring compatibility and correct file formatting when opened in various text editors and spreadsheet software that relies on BOM for encoding detection.