### PR TITLE
Add Reset Password notification locale

### DIFF
--- a/packages/panels/src/Http/Responses/Auth/PasswordResetResponse.php
+++ b/packages/panels/src/Http/Responses/Auth/PasswordResetResponse.php
@@ -12,7 +12,8 @@ class PasswordResetResponse implements Responsable
     public function toResponse($request): RedirectResponse | Redirector
     {
         return redirect()->to(
-            Filament::hasLogin() ? Filament::getLoginUrl() : Filament::getUrl(),
+            (Filament::hasLogin() ? Filament::getLoginUrl() : Filament::getUrl()) .
+                ($request->query('locale') ? '?locale=' . $request->query('locale', app()->getLocale()) : null)
         );
     }
 }

--- a/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
+++ b/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
@@ -78,8 +78,11 @@ class RequestPasswordReset extends SimplePage
                     throw new Exception("Model [{$userClass}] does not have a [notify()] method.");
                 }
 
+                $locale = app()->getLocale();
+
                 $notification = new ResetPasswordNotification($token);
-                $notification->url = Filament::getResetPasswordUrl($token, $user);
+                $notification->url = Filament::getResetPasswordUrl($token, $user, ['locale' => $locale]);
+                $notification->locale = $locale;
 
                 $user->notify($notification);
             },


### PR DESCRIPTION
## Description

Send reset password notification by user selected locale (app->getLocale()) 

## Visual changes

none

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
