### PR TITLE
Add optional Custom Url Target

### DIFF
--- a/packages/actions/.stubs.php
+++ b/packages/actions/.stubs.php
@@ -43,6 +43,8 @@ namespace Livewire\Features\SupportTesting {
 
         public function assertActionShouldOpenUrlInNewTab(string | array $name): static {}
 
+        public function assertActionHasUrlTarget(string | array $name, string $target): static {}
+
         public function assertActionShouldNotOpenUrlInNewTab(string | array $name): static {}
 
         public function assertActionDoesNotHaveLabel(string | array $name, string $label): static {}

--- a/packages/actions/docs/03-trigger-button.md
+++ b/packages/actions/docs/03-trigger-button.md
@@ -128,6 +128,17 @@ Action::make('edit')
 
 <AutoScreenshot name="actions/trigger-button/icon-after" alt="Trigger with icon after the label" version="3.x" />
 
+## Setting a URL target
+
+You may optionally set a custom URL target, which can be useful if you are previewing content in a different tab & prevents opening multiple tabs.
+
+```php
+Action::make('View Post')
+    ->url(fn (): string => route('posts.view', ['post' => $this->post]))
+    ->setUrlTarget(fn () => 'post-' . $this->post->getKey())
+    ->icon('heroicon-m-newspaper')
+```
+
 ## Authorization
 
 You may conditionally show or hide actions for certain users. To do this, you can use either the `visible()` or `hidden()` methods:

--- a/packages/actions/resources/views/components/action.blade.php
+++ b/packages/actions/resources/views/components/action.blade.php
@@ -6,6 +6,7 @@
 
 @php
     $isDisabled = $action->isDisabled();
+    $target = $action->shouldOpenUrlInNewTab() ? '_blank' : $action->getUrlTarget();
     $url = $action->getUrl();
 @endphp
 
@@ -21,7 +22,7 @@
     :key-bindings="$action->getKeyBindings()"
     :label-sr-only="$action->isLabelHidden()"
     :tag="$url ? 'a' : 'button'"
-    :target="($url && $action->shouldOpenUrlInNewTab()) ? '_blank' : null"
+    :target="($url && $target) ? $target : null"
     :tooltip="$action->getTooltip()"
     :type="$action->canSubmitForm() ? 'submit' : 'button'"
     :wire:click="$action->getLivewireClickHandler()"

--- a/packages/actions/src/Concerns/CanOpenUrl.php
+++ b/packages/actions/src/Concerns/CanOpenUrl.php
@@ -10,9 +10,18 @@ trait CanOpenUrl
 
     protected string | Closure | null $url = null;
 
+    protected string | Closure | null $urlTarget = null;
+
     public function openUrlInNewTab(bool | Closure $condition = true): static
     {
         $this->shouldOpenUrlInNewTab = $condition;
+
+        return $this;
+    }
+
+    public function setUrlTarget(string | Closure | null $target): static
+    {
+        $this->urlTarget = $target;
 
         return $this;
     }
@@ -28,6 +37,11 @@ trait CanOpenUrl
     public function getUrl(): ?string
     {
         return $this->evaluate($this->url);
+    }
+
+    public function getUrlTarget(): ?string
+    {
+        return $this->evaluate($this->urlTarget);
     }
 
     public function shouldOpenUrlInNewTab(): bool

--- a/packages/actions/src/Testing/TestsActions.php
+++ b/packages/actions/src/Testing/TestsActions.php
@@ -515,6 +515,30 @@ class TestsActions
         };
     }
 
+    public function assertActionHasUrlTarget(): Closure
+    {
+        return function (string | array $name, string $url, $record = null): static {
+            /** @var array<string> $name */
+            /** @phpstan-ignore-next-line */
+            $name = $this->parseNestedActionName($name);
+
+            /** @phpstan-ignore-next-line */
+            $this->assertActionExists($name);
+
+            $action = $this->instance()->getAction($name);
+
+            $livewireClass = $this->instance()::class;
+            $prettyName = implode(' > ', $name);
+
+            Assert::assertTrue(
+                $action->getUrlTarget() === 'foo',
+                message: "Failed asserting that an action with name [{$prettyName}] has URL target [{$url}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
     public function assertActionMounted(): Closure
     {
         return function (string | array $name): static {

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -177,7 +177,7 @@
 
 <{{ $tag }}
     @if ($tag === 'a')
-        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode) }}
+        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode, $target) }}
     @endif
     @if (($keyBindings || $hasTooltip) && (! $hasFormProcessingLoadingIndicator))
         x-data="{}"

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -137,7 +137,7 @@ if (! function_exists('Filament\Support\is_app_url')) {
 }
 
 if (! function_exists('Filament\Support\generate_href_html')) {
-    function generate_href_html(?string $url, bool $shouldOpenInNewTab = false, ?bool $shouldOpenInSpaMode = null): Htmlable
+    function generate_href_html(?string $url, bool $shouldOpenInNewTab = false, ?bool $shouldOpenInSpaMode = null, ?string $target = null): Htmlable
     {
         if (blank($url)) {
             return new HtmlString('');
@@ -147,6 +147,8 @@ if (! function_exists('Filament\Support\generate_href_html')) {
 
         if ($shouldOpenInNewTab) {
             $html .= ' target="_blank"';
+        } elseif ($target) {
+            $html .= " target=\"$target\"";
         } elseif ($shouldOpenInSpaMode ?? (FilamentView::hasSpaMode($url))) {
             $html .= ' wire:navigate';
         }

--- a/tests/src/Actions/ActionTest.php
+++ b/tests/src/Actions/ActionTest.php
@@ -133,6 +133,11 @@ it('can open a URL in a new tab', function () {
         ->assertActionShouldNotOpenUrlInNewTab('urlNotInNewTab');
 });
 
+it('can have a URL target', function () {
+    livewire(Actions::class)
+        ->assertActionHasUrlTarget('urlTarget', 'foo');
+});
+
 it('can state whether a page action exists', function () {
     livewire(Actions::class)
         ->assertActionExists('exists')

--- a/tests/src/Actions/Fixtures/Pages/Actions.php
+++ b/tests/src/Actions/Fixtures/Pages/Actions.php
@@ -65,6 +65,8 @@ class Actions extends Page
                 ->url('https://filamentphp.com', true),
             Action::make('urlNotInNewTab')
                 ->url('https://filamentphp.com', false),
+            Action::make('urlTarget')
+                ->setUrlTarget('foo'),
             Action::make('shows-notification')
                 ->action(function () {
                     Notification::make()


### PR DESCRIPTION
## Description

**Use case:** Being able to set a custom target has helped us address a request raised by a client, who wanted to know if it was possible to return to the same tab every time they selected a particular action; however still have both the admin panel & tab in question open.

We noticed that WordPress uses a `target="wp-post-1234"` format to achieve this. This gives flexibility for other use cases too.

I have added a section in the Actions docs to help document this addition.

Huge thanks to @chrispage1 for the support & help on this!

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
