### PR TITLE
Fix docs assertions for `assertSelectColumnHasOptions` and `assertSelectColumnDoesNotHaveOptions`

### DIFF
--- a/packages/tables/docs/12-testing.md
+++ b/packages/tables/docs/12-testing.md
@@ -241,7 +241,7 @@ it('displays author in red', function () {
 
 ### Select Columns
 
-If you have a select column, you can ensure it has the correct options with `assertSelectColumnHasOptions()` and `assertSelectColumnDoesNotHaveOptions()`:
+If you have a select column, you can ensure it has the correct options with `assertTableSelectColumnHasOptions()` and `assertTableSelectColumnDoesNotHaveOptions()`:
 
 ```php
 use function Pest\Livewire\livewire;
@@ -250,8 +250,8 @@ it('has the correct statuses', function () {
     $post = Post::factory()->create();
 
     livewire(PostsTable::class)
-        ->assertSelectColumnHasOptions('status', ['unpublished' => 'Unpublished', 'published' => 'Published'], $post)
-        ->assertSelectColumnDoesNotHaveOptions('status', ['archived' => 'Archived'], $post);
+        ->assertTableSelectColumnHasOptions('status', ['unpublished' => 'Unpublished', 'published' => 'Published'], $post)
+        ->assertTableSelectColumnDoesNotHaveOptions('status', ['archived' => 'Archived'], $post);
 });
 ```
 


### PR DESCRIPTION
## Description

The stated assertions (no longer) exist. They are corrected now.

## Visual changes

\-

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
