### PR TITLE
Fixed attribute reference in ukrainian translation

### DIFF
--- a/packages/actions/resources/lang/uk/export.php
+++ b/packages/actions/resources/lang/uk/export.php
@@ -17,7 +17,7 @@ return [
                 'form' => [
 
                     'is_enabled' => [
-                        'label' => ':стовпець увімкнено',
+                        'label' => ':column увімкнено',
                     ],
 
                     'label' => [


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fixed a result of incorrect "Find/Replace translation", when the attribute reference `:column` got translated too.
