### PR TITLE
Support icon in table header

### DIFF
--- a/docs-assets/screenshots/schema.js
+++ b/docs-assets/screenshots/schema.js
@@ -2945,4 +2945,13 @@ export default {
             deviceScaleFactor: 3,
         },
     },
+    'tables/header-icon': {
+        url: 'tables?table=headerIcon',
+        selector: 'body',
+        viewport: {
+            width: 1080,
+            height: 640,
+            deviceScaleFactor: 3,
+        },
+    },
 }

--- a/packages/panels/resources/lang/el/pages/auth/login.php
+++ b/packages/panels/resources/lang/el/pages/auth/login.php
@@ -19,7 +19,6 @@ return [
 
     ],
 
-
     'form' => [
 
         'email' => [

--- a/packages/tables/docs/10-advanced.md
+++ b/packages/tables/docs/10-advanced.md
@@ -256,7 +256,36 @@ public function table(Table $table): Table
         ]);
 ```
 
-You can pass `$table->icon()` and `$table->iconColor('primary')` method to add the icon in the header:
+## Icon in table header
+
+You can add an icon to a table header using the `$table->icon()` method:
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->icon('heroicon-o-table-cells')
+        ->columns([
+            // ...
+        ]);
+```
+
+You can also change the icon color, using the `$table->iconColor('primary')` method:
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->icon('heroicon-o-table-cells')
+        ->iconColor('primary')
+        ->columns([
+            // ...
+        ]);
+```
 
 ## Polling table content
 

--- a/packages/tables/docs/10-advanced.md
+++ b/packages/tables/docs/10-advanced.md
@@ -256,6 +256,8 @@ public function table(Table $table): Table
         ]);
 ```
 
+You can pass `$table->icon()` and `$table->iconColor('primary')` method to add the icon in the header:
+
 ## Polling table content
 
 You may poll table content so that it refreshes at a set interval, using the `$table->poll()` method:

--- a/packages/tables/resources/views/components/header.blade.php
+++ b/packages/tables/resources/views/components/header.blade.php
@@ -7,11 +7,11 @@
 @props([
     'actions' => [],
     'actionsPosition',
+    'description' => null,
+    'heading' => null,
     'icon' => null,
     'iconColor' => 'gray',
     'iconSize' => IconSize::Large,
-    'heading' => null,
-    'description' => null,
 ])
 
 <div
@@ -21,26 +21,34 @@
     ]) }}>
 
     @if ($icon)
-        <x-filament::icon :icon="$icon" @class([
-            'fi-ta-header-icon self-start',
-            match ($iconColor) {
-                'gray' => 'text-gray-400 dark:text-gray-500',
-                default => 'fi-color-custom text-custom-500 dark:text-custom-400',
-            },
-            is_string($iconColor) ? "fi-color-{$iconColor}" : null,
-            match ($iconSize) {
-                IconSize::Small, 'sm' => 'h-4 w-4 mt-1',
-                IconSize::Medium, 'md' => 'h-5 w-5 mt-0.5',
-                IconSize::Large, 'lg' => 'h-6 w-6',
-                default => $iconSize,
-            },
-        ]) @style([
-            \Filament\Support\get_color_css_variables($iconColor, shades: [400, 500], alias: 'table.header.icon') => $iconColor !== 'gray',
-        ]) />
+        <x-filament::icon 
+            :icon="$icon" 
+            @class([
+                'fi-ta-header-icon self-start',
+                match ($iconColor) {
+                    'gray' => 'text-gray-400 dark:text-gray-500',
+                    default => 'fi-color-custom text-custom-500 dark:text-custom-400',
+                },
+                is_string($iconColor) ? "fi-color-{$iconColor}" : null,
+                match ($iconSize) {
+                    IconSize::Small, 'sm' => 'h-4 w-4 mt-1',
+                    IconSize::Medium, 'md' => 'h-5 w-5 mt-0.5',
+                    IconSize::Large, 'lg' => 'h-6 w-6',
+                    default => $iconSize,
+                },
+            ])
+            @style([
+                \Filament\Support\get_color_css_variables(
+                    $iconColor,
+                    shades: [400, 500],
+                    alias: 'table.header.icon',
+                ) => $iconColor !== 'gray',
+            ]) 
+        />
     @endif
 
     @if ($heading || $description)
-        <div class="grid flex-1 gap-y-1">
+        <div class="grid gap-y-1">
             @if ($heading)
                 <h3 class="text-base font-semibold leading-6 fi-ta-header-heading text-gray-950 dark:text-white">
                     {{ $heading }}

--- a/packages/tables/resources/views/components/header.blade.php
+++ b/packages/tables/resources/views/components/header.blade.php
@@ -15,14 +15,16 @@
 ])
 
 <div
-    {{ $attributes->class([
-        'fi-ta-header flex flex-col gap-3 p-4 sm:px-6',
-        'sm:flex-row sm:items-center' => $actionsPosition === HeaderActionsPosition::Adaptive,
-    ]) }}>
-
+    {{
+        $attributes->class([
+            'fi-ta-header flex flex-col gap-3 p-4 sm:px-6',
+            'sm:flex-row sm:items-center' => $actionsPosition === HeaderActionsPosition::Adaptive,
+        ])
+    }}
+>
     @if ($icon)
-        <x-filament::icon 
-            :icon="$icon" 
+        <x-filament::icon
+            :icon="$icon"
             @class([
                 'fi-ta-header-icon self-start',
                 match ($iconColor) {
@@ -43,20 +45,24 @@
                     shades: [400, 500],
                     alias: 'table.header.icon',
                 ) => $iconColor !== 'gray',
-            ]) 
+            ])
         />
     @endif
 
     @if ($heading || $description)
         <div class="grid gap-y-1">
             @if ($heading)
-                <h3 class="text-base font-semibold leading-6 fi-ta-header-heading text-gray-950 dark:text-white">
+                <h3
+                    class="fi-ta-header-heading text-base font-semibold leading-6 text-gray-950 dark:text-white"
+                >
                     {{ $heading }}
                 </h3>
             @endif
 
             @if ($description)
-                <p class="text-sm text-gray-600 fi-ta-header-description dark:text-gray-400">
+                <p
+                    class="fi-ta-header-description text-sm text-gray-600 dark:text-gray-400"
+                >
                     {{ $description }}
                 </p>
             @endif
@@ -64,11 +70,15 @@
     @endif
 
     @if ($actions)
-        <x-filament-tables::actions :actions="$actions" :alignment="Alignment::Start" wrap @class([
-            'ms-auto' =>
-                $actionsPosition === HeaderActionsPosition::Adaptive &&
-                !($heading || $description),
-            'sm:ms-auto' => $actionsPosition === HeaderActionsPosition::Adaptive,
-        ]) />
+        <x-filament-tables::actions
+            :actions="$actions"
+            :alignment="Alignment::Start"
+            wrap
+            @class([
+                'ms-auto' => $actionsPosition === HeaderActionsPosition::Adaptive &&
+                    ! ($heading || $description),
+                'sm:ms-auto' => $actionsPosition === HeaderActionsPosition::Adaptive,
+            ])
+        />
     @endif
 </div>

--- a/packages/tables/resources/views/components/header.blade.php
+++ b/packages/tables/resources/views/components/header.blade.php
@@ -1,37 +1,54 @@
 @php
     use Filament\Support\Enums\Alignment;
+    use Filament\Support\Enums\IconSize;
     use Filament\Tables\Actions\HeaderActionsPosition;
 @endphp
 
 @props([
     'actions' => [],
     'actionsPosition',
-    'description' => null,
+    'icon' => null,
+    'iconColor' => 'gray',
+    'iconSize' => IconSize::Large,
     'heading' => null,
+    'description' => null,
 ])
 
 <div
-    {{
-        $attributes->class([
-            'fi-ta-header flex flex-col gap-3 p-4 sm:px-6',
-            'sm:flex-row sm:items-center' => $actionsPosition === HeaderActionsPosition::Adaptive,
-        ])
-    }}
->
+    {{ $attributes->class([
+        'fi-ta-header flex flex-col gap-3 p-4 sm:px-6',
+        'sm:flex-row sm:items-center' => $actionsPosition === HeaderActionsPosition::Adaptive,
+    ]) }}>
+
+    @if ($icon)
+        <x-filament::icon :icon="$icon" @class([
+            'fi-ta-header-icon self-start',
+            match ($iconColor) {
+                'gray' => 'text-gray-400 dark:text-gray-500',
+                default => 'fi-color-custom text-custom-500 dark:text-custom-400',
+            },
+            is_string($iconColor) ? "fi-color-{$iconColor}" : null,
+            match ($iconSize) {
+                IconSize::Small, 'sm' => 'h-4 w-4 mt-1',
+                IconSize::Medium, 'md' => 'h-5 w-5 mt-0.5',
+                IconSize::Large, 'lg' => 'h-6 w-6',
+                default => $iconSize,
+            },
+        ]) @style([
+            \Filament\Support\get_color_css_variables($iconColor, shades: [400, 500], alias: 'table.header.icon') => $iconColor !== 'gray',
+        ]) />
+    @endif
+
     @if ($heading || $description)
-        <div class="grid gap-y-1">
+        <div class="grid flex-1 gap-y-1">
             @if ($heading)
-                <h3
-                    class="fi-ta-header-heading text-base font-semibold leading-6 text-gray-950 dark:text-white"
-                >
+                <h3 class="text-base font-semibold leading-6 fi-ta-header-heading text-gray-950 dark:text-white">
                     {{ $heading }}
                 </h3>
             @endif
 
             @if ($description)
-                <p
-                    class="fi-ta-header-description text-sm text-gray-600 dark:text-gray-400"
-                >
+                <p class="text-sm text-gray-600 fi-ta-header-description dark:text-gray-400">
                     {{ $description }}
                 </p>
             @endif
@@ -39,14 +56,11 @@
     @endif
 
     @if ($actions)
-        <x-filament-tables::actions
-            :actions="$actions"
-            :alignment="Alignment::Start"
-            wrap
-            @class([
-                'ms-auto' => $actionsPosition === HeaderActionsPosition::Adaptive && ! ($heading || $description),
-                'sm:ms-auto' => $actionsPosition === HeaderActionsPosition::Adaptive,
-            ])
-        />
+        <x-filament-tables::actions :actions="$actions" :alignment="Alignment::Start" wrap @class([
+            'ms-auto' =>
+                $actionsPosition === HeaderActionsPosition::Adaptive &&
+                !($heading || $description),
+            'sm:ms-auto' => $actionsPosition === HeaderActionsPosition::Adaptive,
+        ]) />
     @endif
 </div>

--- a/packages/tables/src/Table/Concerns/HasHeader.php
+++ b/packages/tables/src/Table/Concerns/HasHeader.php
@@ -5,9 +5,14 @@ namespace Filament\Tables\Table\Concerns;
 use Closure;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View;
+use Filament\Support\Concerns\HasIcon;
+use Filament\Support\Concerns\HasIconColor;
 
 trait HasHeader
 {
+    use HasIcon;
+    use HasIconColor;
+    
     protected string | Htmlable | Closure | null $heading = null;
 
     protected View | Htmlable | Closure | null $header = null;

--- a/packages/tables/src/Table/Concerns/HasHeader.php
+++ b/packages/tables/src/Table/Concerns/HasHeader.php
@@ -3,16 +3,16 @@
 namespace Filament\Tables\Table\Concerns;
 
 use Closure;
-use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Contracts\View\View;
 use Filament\Support\Concerns\HasIcon;
 use Filament\Support\Concerns\HasIconColor;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\View\View;
 
 trait HasHeader
 {
     use HasIcon;
     use HasIconColor;
-    
+
     protected string | Htmlable | Closure | null $heading = null;
 
     protected View | Htmlable | Closure | null $header = null;


### PR DESCRIPTION
Related to #12208

## Description

same as Section table header should support `->icon()`.

## Visual changes

<img width="1409" alt="Screenshot 2024-04-05 at 20 31 47" src="https://github.com/filamentphp/filament/assets/121255432/2a7881bf-87b2-4c2b-a7f4-2b2fead84cda">

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
