### PR TITLE
feat/repeater extra item classes

### DIFF
--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -418,6 +418,18 @@ Any fields that you use from `$state` should be `live()` if you wish to see the 
 
 <AutoScreenshot name="forms/fields/repeater/labelled" alt="Repeater with item labels" version="3.x" />
 
+## Adding extra classes to repeater items
+You can use the `extraItemClasses()` method to add extra classes to repeater items. This method accepts classes string or a closure that receives the current item's data in a `$data` variable.
+
+```php
+use Filament\Forms\Components\Repeater;
+
+Repeater::make('members')
+    // ...
+    ->extraItemClasses(fn (array $data): ?string => $data['is_admin'] ? '!bg-success-100' : null),
+```
+
+
 ## Simple repeaters with one field
 
 You can use the `simple()` method to create a repeater with a single field, using a minimal design

--- a/packages/forms/resources/views/components/repeater/index.blade.php
+++ b/packages/forms/resources/views/components/repeater/index.blade.php
@@ -94,7 +94,7 @@
                                 {{
                                     $attributes
                                         ->class(['fi-fo-repeater-item divide-y divide-gray-100 rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:divide-white/10 dark:bg-white/5 dark:ring-white/10'])
-                                        ->merge($getExtraItemClasses(['item' => $uuid]))
+                                        ->merge(['class' => $getExtraItemClasses(['item' => $uuid]) ?? ''])
 
                                 }}
                                 x-bind:class="{ 'fi-collapsed overflow-hidden': isCollapsed }"

--- a/packages/forms/resources/views/components/repeater/index.blade.php
+++ b/packages/forms/resources/views/components/repeater/index.blade.php
@@ -26,23 +26,23 @@
 
 <x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
     <div
-        x-data="{}"
-        {{
-            $attributes
-                ->merge($getExtraAttributes(), escape: false)
-                ->class(['fi-fo-repeater grid gap-y-4'])
-        }}
+            x-data="{}"
+            {{
+                $attributes
+                    ->merge($getExtraAttributes(), escape: false)
+                    ->class(['fi-fo-repeater grid gap-y-4'])
+            }}
     >
         @if ($isCollapsible && ($collapseAllAction->isVisible() || $expandAllAction->isVisible()))
             <div
-                @class([
-                    'flex gap-x-3',
-                    'hidden' => count($containers) < 2,
-                ])
+                    @class([
+                        'flex gap-x-3',
+                        'hidden' => count($containers) < 2,
+                    ])
             >
                 @if ($collapseAllAction->isVisible())
                     <span
-                        x-on:click="$dispatch('repeater-collapse', '{{ $statePath }}')"
+                            x-on:click="$dispatch('repeater-collapse', '{{ $statePath }}')"
                     >
                         {{ $collapseAllAction }}
                     </span>
@@ -50,7 +50,7 @@
 
                 @if ($expandAllAction->isVisible())
                     <span
-                        x-on:click="$dispatch('repeater-expand', '{{ $statePath }}')"
+                            x-on:click="$dispatch('repeater-expand', '{{ $statePath }}')"
                     >
                         {{ $expandAllAction }}
                     </span>
@@ -61,16 +61,16 @@
         @if (count($containers))
             <ul>
                 <x-filament::grid
-                    :default="$getGridColumns('default')"
-                    :sm="$getGridColumns('sm')"
-                    :md="$getGridColumns('md')"
-                    :lg="$getGridColumns('lg')"
-                    :xl="$getGridColumns('xl')"
-                    :two-xl="$getGridColumns('2xl')"
-                    :wire:end.stop="'mountFormComponentAction(\'' . $statePath . '\', \'reorder\', { items: $event.target.sortable.toArray() })'"
-                    x-sortable
-                    :data-sortable-animation-duration="$getReorderAnimationDuration()"
-                    class="items-start gap-4"
+                        :default="$getGridColumns('default')"
+                        :sm="$getGridColumns('sm')"
+                        :md="$getGridColumns('md')"
+                        :lg="$getGridColumns('lg')"
+                        :xl="$getGridColumns('xl')"
+                        :two-xl="$getGridColumns('2xl')"
+                        :wire:end.stop="'mountFormComponentAction(\'' . $statePath . '\', \'reorder\', { items: $event.target.sortable.toArray() })'"
+                        x-sortable
+                        :data-sortable-animation-duration="$getReorderAnimationDuration()"
+                        class="items-start gap-4"
                 >
                     @foreach ($containers as $uuid => $item)
                         @php
@@ -83,33 +83,38 @@
                         @endphp
 
                         <li
-                            wire:key="{{ $this->getId() }}.{{ $item->getStatePath() }}.{{ $field::class }}.item"
-                            x-data="{
+                                wire:key="{{ $this->getId() }}.{{ $item->getStatePath() }}.{{ $field::class }}.item"
+                                x-data="{
                                 isCollapsed: @js($isCollapsed($item)),
                             }"
-                            x-on:expand="isCollapsed = false"
-                            x-on:repeater-expand.window="$event.detail === '{{ $statePath }}' && (isCollapsed = false)"
-                            x-on:repeater-collapse.window="$event.detail === '{{ $statePath }}' && (isCollapsed = true)"
-                            x-sortable-item="{{ $uuid }}"
-                            class="fi-fo-repeater-item divide-y divide-gray-100 rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:divide-white/10 dark:bg-white/5 dark:ring-white/10"
-                            x-bind:class="{ 'fi-collapsed overflow-hidden': isCollapsed }"
+                                x-on:expand="isCollapsed = false"
+                                x-on:repeater-expand.window="$event.detail === '{{ $statePath }}' && (isCollapsed = false)"
+                                x-on:repeater-collapse.window="$event.detail === '{{ $statePath }}' && (isCollapsed = true)"
+                                x-sortable-item="{{ $uuid }}"
+                                {{
+                                    $attributes
+                                        ->class(['fi-fo-repeater-item divide-y divide-gray-100 rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:divide-white/10 dark:bg-white/5 dark:ring-white/10'])
+                                        ->merge($getExtraItemClasses(['item' => $uuid]))
+
+                                }}
+                                x-bind:class="{ 'fi-collapsed overflow-hidden': isCollapsed }"
                         >
                             @if ($itemHasToolbar)
                                 <div
-                                    @if ($isCollapsible)
-                                        x-on:click.stop="isCollapsed = !isCollapsed"
-                                    @endif
-                                    @class([
-                                        'fi-fo-repeater-item-header flex items-center gap-x-3 overflow-hidden px-4 py-3',
-                                        'cursor-pointer select-none' => $isCollapsible,
-                                    ])
+                                        @if ($isCollapsible)
+                                            x-on:click.stop="isCollapsed = !isCollapsed"
+                                        @endif
+                                        @class([
+                                            'fi-fo-repeater-item-header flex items-center gap-x-3 overflow-hidden px-4 py-3',
+                                            'cursor-pointer select-none' => $isCollapsible,
+                                        ])
                                 >
                                     @if ($isReorderableWithDragAndDrop || $isReorderableWithButtons)
                                         <ul class="flex items-center gap-x-3">
                                             @if ($isReorderableWithDragAndDrop)
                                                 <li
-                                                    x-sortable-handle
-                                                    x-on:click.stop
+                                                        x-sortable-handle
+                                                        x-on:click.stop
                                                 >
                                                     {{ $reorderAction }}
                                                 </li>
@@ -117,15 +122,15 @@
 
                                             @if ($isReorderableWithButtons)
                                                 <li
-                                                    x-on:click.stop
-                                                    class="flex items-center justify-center"
+                                                        x-on:click.stop
+                                                        class="flex items-center justify-center"
                                                 >
                                                     {{ $moveUpAction(['item' => $uuid])->disabled($loop->first) }}
                                                 </li>
 
                                                 <li
-                                                    x-on:click.stop
-                                                    class="flex items-center justify-center"
+                                                        x-on:click.stop
+                                                        class="flex items-center justify-center"
                                                 >
                                                     {{ $moveDownAction(['item' => $uuid])->disabled($loop->last) }}
                                                 </li>
@@ -135,10 +140,10 @@
 
                                     @if (filled($itemLabel))
                                         <h4
-                                            @class([
-                                                'text-sm font-medium text-gray-950 dark:text-white',
-                                                'truncate' => $isItemLabelTruncated(),
-                                            ])
+                                                @class([
+                                                    'text-sm font-medium text-gray-950 dark:text-white',
+                                                    'truncate' => $isItemLabelTruncated(),
+                                                ])
                                         >
                                             {{ $itemLabel }}
                                         </h4>
@@ -146,7 +151,7 @@
 
                                     @if ($isCloneable || $isDeletable || $isCollapsible || count($visibleExtraItemActions))
                                         <ul
-                                            class="ms-auto flex items-center gap-x-3"
+                                                class="ms-auto flex items-center gap-x-3"
                                         >
                                             @foreach ($visibleExtraItemActions as $extraItemAction)
                                                 <li x-on:click.stop>
@@ -168,20 +173,20 @@
 
                                             @if ($isCollapsible)
                                                 <li
-                                                    class="relative transition"
-                                                    x-on:click.stop="isCollapsed = !isCollapsed"
-                                                    x-bind:class="{ '-rotate-180': isCollapsed }"
+                                                        class="relative transition"
+                                                        x-on:click.stop="isCollapsed = !isCollapsed"
+                                                        x-bind:class="{ '-rotate-180': isCollapsed }"
                                                 >
                                                     <div
-                                                        class="transition"
-                                                        x-bind:class="{ 'opacity-0 pointer-events-none': isCollapsed }"
+                                                            class="transition"
+                                                            x-bind:class="{ 'opacity-0 pointer-events-none': isCollapsed }"
                                                     >
                                                         {{ $getAction('collapse') }}
                                                     </div>
 
                                                     <div
-                                                        class="absolute inset-0 rotate-180 transition"
-                                                        x-bind:class="{ 'opacity-0 pointer-events-none': ! isCollapsed }"
+                                                            class="absolute inset-0 rotate-180 transition"
+                                                            x-bind:class="{ 'opacity-0 pointer-events-none': ! isCollapsed }"
                                                     >
                                                         {{ $getAction('expand') }}
                                                     </div>
@@ -193,8 +198,8 @@
                             @endif
 
                             <div
-                                x-show="! isCollapsed"
-                                class="fi-fo-repeater-item-content p-4"
+                                    x-show="! isCollapsed"
+                                    class="fi-fo-repeater-item-content p-4"
                             >
                                 {{ $item }}
                             </div>
@@ -204,17 +209,17 @@
                             @if ($isAddable && $addBetweenAction->isVisible())
                                 <li class="flex w-full justify-center">
                                     <div
-                                        class="fi-fo-repeater-add-between-action-ctn rounded-lg bg-white dark:bg-gray-900"
+                                            class="fi-fo-repeater-add-between-action-ctn rounded-lg bg-white dark:bg-gray-900"
                                     >
                                         {{ $addBetweenAction(['afterItem' => $uuid]) }}
                                     </div>
                                 </li>
                             @elseif (filled($labelBetweenItems = $getLabelBetweenItems()))
                                 <li
-                                    class="relative border-t border-gray-200 dark:border-white/10"
+                                        class="relative border-t border-gray-200 dark:border-white/10"
                                 >
                                     <span
-                                        class="absolute -top-3 left-3 px-1 text-sm font-medium"
+                                            class="absolute -top-3 left-3 px-1 text-sm font-medium"
                                     >
                                         {{ $labelBetweenItems }}
                                     </span>

--- a/packages/forms/src/Components/Concerns/HasExtraItemClasses.php
+++ b/packages/forms/src/Components/Concerns/HasExtraItemClasses.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Filament\Forms\Components\Concerns;
+
+use Closure;
+
+trait HasExtraItemClasses
+{
+    /**
+     * @var ?Closure
+     */
+    protected ?Closure $extraItemClasses = null;
+
+    /**
+     * @param Closure $extraItemClasses
+     * @return $this
+     */
+    public function extraItemClasses(Closure $extraItemClasses): static
+    {
+        $this->extraItemClasses = $extraItemClasses;
+        return $this;
+    }
+
+    /**
+     * @param array $arguments
+     * @return ?array
+     */
+    public function getExtraItemClasses(array $arguments): ?array
+    {
+        return $this->evaluate($this->extraItemClasses, [
+            'arguments' => $arguments,
+        ]);
+    }
+}

--- a/packages/forms/src/Components/Concerns/HasExtraItemClasses.php
+++ b/packages/forms/src/Components/Concerns/HasExtraItemClasses.php
@@ -7,15 +7,15 @@ use Closure;
 trait HasExtraItemClasses
 {
     /**
-     * @var ?Closure
+     * @var null|Closure|string
      */
-    protected ?Closure $extraItemClasses = null;
+    protected null|Closure|string $extraItemClasses = null;
 
     /**
-     * @param Closure $extraItemClasses
+     * @param null|Closure|string $extraItemClasses
      * @return $this
      */
-    public function extraItemClasses(Closure $extraItemClasses): static
+    public function extraItemClasses(null|Closure|string $extraItemClasses): static
     {
         $this->extraItemClasses = $extraItemClasses;
         return $this;
@@ -25,10 +25,25 @@ trait HasExtraItemClasses
      * @param array $arguments
      * @return ?array
      */
-    public function getExtraItemClasses(array $arguments): ?array
+    public function getExtraItemClasses(array $arguments): ?string
     {
+        if(! $this->extraItemClasses) {
+            return null;
+        }
+
+        if (is_string($this->extraItemClasses)) {
+            return $this->extraItemClasses;
+        }
+
+        $items = $this->getState();
+        $data = [];
+
+        if (isset($items[$arguments['item']])) {
+            $data = $items[$arguments['item']];
+        }
+
         return $this->evaluate($this->extraItemClasses, [
-            'arguments' => $arguments,
+            'data' => $data,
         ]);
     }
 }

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -27,6 +27,7 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
     use Concerns\CanLimitItemsLength;
     use Concerns\HasContainerGridLayout;
     use Concerns\HasExtraItemActions;
+    use Concerns\HasExtraItemClasses;
     use HasReorderAnimationDuration;
 
     protected string | Closure | null $addActionLabel = null;


### PR DESCRIPTION
## Description

Added `extraItemClasses()` method to add extra classes to repeater items. This method accepts classes string or a closure that receives the current item's data in a `$data` variable.

## Visual changes

![Screenshot](https://github.com/onexer/screenshots/blob/main/filament_repeater_item_classes.png?raw=true)


## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
