### PR TITLE
Update German table empty state heading translation

### DIFF
--- a/packages/tables/resources/lang/de/table.php
+++ b/packages/tables/resources/lang/de/table.php
@@ -102,7 +102,7 @@ return [
 
     'empty' => [
 
-        'heading' => 'Keine :model gefunden',
+        'heading' => 'Keine :model',
 
         'description' => 'Erstelle ein(e) :model um zu beginnen.',
 

--- a/packages/tables/resources/lang/de/table.php
+++ b/packages/tables/resources/lang/de/table.php
@@ -102,7 +102,7 @@ return [
 
     'empty' => [
 
-        'heading' => 'Keine Datensätze gefunden',
+        'heading' => 'Keine :model gefunden',
 
         'description' => 'Erstelle ein(e) :model um zu beginnen.',
 


### PR DESCRIPTION
Replacing the generic title "record" with the model specific title in German table empty state heading translation.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

Before
<img width="334" alt="Bildschirmfoto 2024-04-08 um 09 47 00" src="https://github.com/filamentphp/filament/assets/11678100/9d96beb9-9cd5-49f9-9feb-4909511ad6cf">

After
<img width="346" alt="Bildschirmfoto 2024-04-08 um 09 47 32" src="https://github.com/filamentphp/filament/assets/11678100/c5db54f5-634e-4524-a7b1-4441718c0b66">

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
