### PR TITLE
Update ImportColumn.php to support negative numerics

### DIFF
--- a/packages/actions/src/Imports/ImportColumn.php
+++ b/packages/actions/src/Imports/ImportColumn.php
@@ -531,7 +531,7 @@ class ImportColumn extends Component
 
     protected function castNumericStateItem(mixed $state): int | float
     {
-        $state = floatval(preg_replace('/[^0-9.]/', '', $state));
+        $state = floatval(preg_replace('/[^0-9.-]/', '', $state));
 
         $decimalPlaces = $this->getDecimalPlaces();
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Currently, the Filament Importer strips negative values.

When using the numeric() function on an ImportColumn, it applies a preg_replace of `/[^0-9.]/`. This does not consider the "-" character, which is required for negative numbers.

Instead, these numbers are forcibly cast into positive values, damaging data accuracy.

This pull request adds the "-" into the preg_replace `/[^0-9.-]/`, meaning negative values will be correctly preserved.

## Visual changes

### Spreadsheet

![image](https://github.com/filamentphp/filament/assets/39706150/0cacfe4c-79f3-4ade-87ce-f2c0c8123da1)

### Before Fix

![image](https://github.com/filamentphp/filament/assets/39706150/907e8585-fd3c-4885-9a0b-2308c6ff83c7)

### After Fix

![image](https://github.com/filamentphp/filament/assets/39706150/0ce3c387-9958-4d1c-a0de-fbb011b69ab9)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
