### PR TITLE
Fix createOptionUsing with multiple() and no initial options

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -290,7 +290,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
 
                 $state = $component->isMultiple()
                     ? [
-                        ...$component->getState(),
+                        ...$component->getState() ?? [],
                         $createdOptionKey,
                     ]
                     : $createdOptionKey;


### PR DESCRIPTION
## Description

When using createOptionUsing() with multiple() BUT without previously selecting options, `$component->getState()` is `null` which, when unpacking the array throws a `Only arrays and Traversables can be unpacked` error. 

This PR fixes this by assigning an empty array when the state is null. 

## Visual changes

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
