### PR TITLE
Replace 'overflow-y-hidden' to 'hidden' for tab content

### DIFF
--- a/packages/forms/resources/views/components/tabs/tab.blade.php
+++ b/packages/forms/resources/views/components/tabs/tab.blade.php
@@ -8,7 +8,7 @@
         'mt-6' => ! $isContained,
     ]);
 
-    $inactiveTabClasses = 'invisible h-0 overflow-y-hidden p-0';
+    $inactiveTabClasses = 'invisible h-0 hidden p-0';
 @endphp
 
 <div

--- a/packages/forms/resources/views/components/wizard/step.blade.php
+++ b/packages/forms/resources/views/components/wizard/step.blade.php
@@ -8,7 +8,7 @@
         'mt-6' => ! $isContained,
     ]);
 
-    $inactiveStepClasses = 'invisible h-0 overflow-y-hidden p-0';
+    $inactiveStepClasses = 'invisible h-0 hidden p-0';
 @endphp
 
 <div

--- a/packages/infolists/resources/views/components/tabs/tab.blade.php
+++ b/packages/infolists/resources/views/components/tabs/tab.blade.php
@@ -8,7 +8,7 @@
         'mt-6' => ! $isContained,
     ]);
 
-    $inactiveTabClasses = 'invisible h-0 overflow-y-hidden p-0';
+    $inactiveTabClasses = 'invisible h-0 hidden p-0';
 @endphp
 
 <div

--- a/packages/support/resources/views/components/section/index.blade.php
+++ b/packages/support/resources/views/components/section/index.blade.php
@@ -172,7 +172,7 @@
             @if ($collapsed || $persistCollapsed)
                 x-cloak
             @endif
-            x-bind:class="{ 'invisible h-0 overflow-y-hidden border-none': isCollapsed }"
+            x-bind:class="{ 'invisible h-0 hidden border-none': isCollapsed }"
         @endif
         @class([
             'fi-section-content-ctn',


### PR DESCRIPTION
I will replace the 'overflow-y-hidden' with the 'hidden' class for tabs. I don't know why 'overflow' doesn't work, but with 'display:none' it works and fixes my problem.

## Description

(Closes #12151)

## Visual changes

I updated the code in the demo repository. 

Before/after with tabs on the form (see on scrollbar height and header)
![form-before](https://github.com/filamentphp/filament/assets/50796878/a6d92fa5-a04c-431f-b298-064077acf6cf)
![form-after](https://github.com/filamentphp/filament/assets/50796878/826d88f3-eaa7-4817-87c0-fb16b1993ee4)


## Functional changes

- [ ] Code style has been fixed by running the composer cs command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.