### PR TITLE
Fix Arabic query builder translations

### DIFF
--- a/packages/tables/resources/lang/ar/filters/query-builder.php
+++ b/packages/tables/resources/lang/ar/filters/query-builder.php
@@ -36,8 +36,8 @@ return [
     'no_rules' => '(بدون قواعد)',
 
     'item_separators' => [
-        'and' => 'أو',
-        'or' => 'و',
+        'and' => 'و',
+        'or' => 'أو',
     ],
 
     'operators' => [


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
Fix the arabic translation of the `tables` in the `query-builder` filter where the translations of `and`, `or` where switched in the `item_separators`

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
