### PR TITLE
Only render table empty state actions when any are visible

### DIFF
--- a/packages/panels/resources/lang/id/layout.php
+++ b/packages/panels/resources/lang/id/layout.php
@@ -59,5 +59,5 @@ return [
     'logo' => [
         'alt' => 'Logo :name',
     ],
-    
+
 ];

--- a/packages/tables/resources/views/components/actions.blade.php
+++ b/packages/tables/resources/views/components/actions.blade.php
@@ -26,24 +26,26 @@
     }
 @endphp
 
-<div
-    {{
-        $attributes->class([
-            'fi-ta-actions flex shrink-0 items-center gap-3',
-            'flex-wrap' => $wrap,
-            'sm:flex-nowrap' => $wrap === '-sm',
-            match ($alignment) {
-                Alignment::Center => 'justify-center',
-                Alignment::Start, Alignment::Left => 'justify-start',
-                Alignment::End, Alignment::Right => 'justify-end',
-                Alignment::Between, Alignment::Justify => 'justify-between',
-                'start md:end' => 'justify-start md:justify-end',
-                default => $alignment,
-            },
-        ])
-    }}
->
-    @foreach ($actions as $action)
-        {{ $action }}
-    @endforeach
-</div>
+@if ($actions)
+    <div
+        {{
+            $attributes->class([
+                'fi-ta-actions flex shrink-0 items-center gap-3',
+                'flex-wrap' => $wrap,
+                'sm:flex-nowrap' => $wrap === '-sm',
+                match ($alignment) {
+                    Alignment::Center => 'justify-center',
+                    Alignment::Start, Alignment::Left => 'justify-start',
+                    Alignment::End, Alignment::Right => 'justify-end',
+                    Alignment::Between, Alignment::Justify => 'justify-between',
+                    'start md:end' => 'justify-start md:justify-end',
+                    default => $alignment,
+                },
+            ])
+        }}
+    >
+        @foreach ($actions as $action)
+            {{ $action }}
+        @endforeach
+    </div>
+@endif

--- a/packages/tables/resources/views/components/empty-state/index.blade.php
+++ b/packages/tables/resources/views/components/empty-state/index.blade.php
@@ -34,7 +34,7 @@
             </x-filament-tables::empty-state.description>
         @endif
 
-        @if (array_filter($actions, fn ($action): bool => $action->isVisible()))
+        @if ($actions)
             <x-filament-tables::actions
                 :actions="$actions"
                 :alignment="Alignment::Center"

--- a/packages/tables/resources/views/components/empty-state/index.blade.php
+++ b/packages/tables/resources/views/components/empty-state/index.blade.php
@@ -34,7 +34,7 @@
             </x-filament-tables::empty-state.description>
         @endif
 
-        @if ($actions)
+        @if (array_filter($actions, fn ($action): bool => $action->isVisible()))
             <x-filament-tables::actions
                 :actions="$actions"
                 :alignment="Alignment::Center"


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Currently table empty state actions output an empty div when no actions are actually visible. This PR makes sure to first check if any actions are visible.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
