### PR TITLE
Add unsaved changes for SPA mode

### DIFF
--- a/packages/panels/docs/09-configuration.md
+++ b/packages/panels/docs/09-configuration.md
@@ -200,8 +200,6 @@ public function panel(Panel $panel): Panel
 }
 ```
 
-> Please note: this feature is not compatible with [SPA mode](#spa-mode).
-
 ## Enabling database transactions
 
 By default, Filament does not wrap operations in database transactions, and allows the user to enable this themselves when they have tested to ensure that their operations are safe to be wrapped in a transaction. However, you can enable database transactions at once for all operations by using the `databaseTransactions()` method:

--- a/packages/panels/resources/lang/en/unsaved-changes.php
+++ b/packages/panels/resources/lang/en/unsaved-changes.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'wire_navigate_alert' => 'You have unsaved changes. Are you sure you want to leave this page?',
+
+];

--- a/packages/panels/resources/views/components/page/unsaved-data-changes-alert.blade.php
+++ b/packages/panels/resources/views/components/page/unsaved-data-changes-alert.blade.php
@@ -19,7 +19,7 @@
 
                 document.addEventListener('livewire:navigate', (event) => {
                     if (typeof @this !== 'undefined') {
-                        if (! window.shouldPreventNavigation()) {
+                        if (! shouldPreventNavigation()) {
                             return
                         }
 
@@ -30,7 +30,7 @@
                 })
 
                 window.addEventListener('beforeunload', (event) => {
-                    if (! window.shouldPreventNavigation()) {
+                    if (! shouldPreventNavigation()) {
                         return;
                     }
 

--- a/packages/panels/src/Panel/Concerns/HasUnsavedChangesAlerts.php
+++ b/packages/panels/src/Panel/Concerns/HasUnsavedChangesAlerts.php
@@ -18,12 +18,6 @@ trait HasUnsavedChangesAlerts
 
     public function hasUnsavedChangesAlerts(): bool
     {
-        $hasAlerts = (bool) $this->evaluate($this->hasUnsavedChangesAlerts);
-
-        if ($hasAlerts && $this->hasSpaMode()) {
-            throw new Exception('Unsaved changes alerts are not supported in SPA mode.');
-        }
-
-        return $hasAlerts;
+        return (bool) $this->evaluate($this->hasUnsavedChangesAlerts);
     }
 }


### PR DESCRIPTION
This uses Livewire's [new cancellable navigate feature](https://github.com/livewire/livewire/pull/8093). 

Edit: This is working properly with `wire:navigate` links now. Checking if the component exists using `if (typeof @this !== 'undefined')` solved the component not found errors.

I'm still seeing component not found errors with `beforeUnload` though (but it is working...). Couldn't figure that out - someone else will need to take a look.