### PR TITLE
Support saving without notification

### DIFF
--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -131,7 +131,7 @@ class EditRecord extends Page
         return $data;
     }
 
-    public function save(bool $shouldRedirect = true): void
+    public function save(bool $shouldSendSavedNotification = true, bool $shouldRedirect = true): void
     {
         $this->authorizeAccess();
 
@@ -167,7 +167,9 @@ class EditRecord extends Page
 
         $this->rememberData();
 
-        $this->getSavedNotification()?->send();
+        if ($shouldSendSavedNotification) {
+            $this->getSavedNotification()?->send();
+        }
 
         if ($shouldRedirect && ($redirectUrl = $this->getRedirectUrl())) {
             $this->redirect($redirectUrl, navigate: FilamentView::hasSpaMode() && is_app_url($redirectUrl));

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -131,7 +131,7 @@ class EditRecord extends Page
         return $data;
     }
 
-    public function save(bool $shouldSendSavedNotification = true, bool $shouldRedirect = true): void
+    public function save(bool $shouldRedirect = true, bool $shouldSendSavedNotification = true): void
     {
         $this->authorizeAccess();
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Currently there's no way to manually call `save()` and only send a notification in some cases. My use case is a page that's part of a flow of steps, which has a form with its own save button. However, when users forget to click the form submit button, the form should still be saved when they continue to the next page/step. In that case, the saved notification should not be sent, while it should be sent when the form gets saved directly from the form's submit button.

I don't exactly know our breaking change policy regarding method signature changes, so I've implemented this in the ideal way disregarding breaking changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
