### PR TITLE
Use more specific return type for form component methods

### DIFF
--- a/packages/panels/docs/08-users.md
+++ b/packages/panels/docs/08-users.md
@@ -240,9 +240,9 @@ In the `form()` method of the example, we call methods like `getNameFormComponen
 If you'd like to customize a field in an authentication form without needing to define a new `form()` method, you could extend the specific field method and chain your customizations:
 
 ```php
-use Filament\Forms\Components\Component;
+use Filament\Forms\Components\TextInput;
 
-protected function getPasswordFormComponent(): Component
+protected function getPasswordFormComponent(): TextInput
 {
     return parent::getPasswordFormComponent()
         ->revealable(false);

--- a/packages/panels/src/Pages/Auth/EditProfile.php
+++ b/packages/panels/src/Pages/Auth/EditProfile.php
@@ -224,7 +224,7 @@ class EditProfile extends Page
         return null;
     }
 
-    protected function getNameFormComponent(): Component
+    protected function getNameFormComponent(): TextInput
     {
         return TextInput::make('name')
             ->label(__('filament-panels::pages/auth/edit-profile.form.name.label'))
@@ -233,7 +233,7 @@ class EditProfile extends Page
             ->autofocus();
     }
 
-    protected function getEmailFormComponent(): Component
+    protected function getEmailFormComponent(): TextInput
     {
         return TextInput::make('email')
             ->label(__('filament-panels::pages/auth/edit-profile.form.email.label'))
@@ -243,7 +243,7 @@ class EditProfile extends Page
             ->unique(ignoreRecord: true);
     }
 
-    protected function getPasswordFormComponent(): Component
+    protected function getPasswordFormComponent(): TextInput
     {
         return TextInput::make('password')
             ->label(__('filament-panels::pages/auth/edit-profile.form.password.label'))
@@ -257,7 +257,7 @@ class EditProfile extends Page
             ->same('passwordConfirmation');
     }
 
-    protected function getPasswordConfirmationFormComponent(): Component
+    protected function getPasswordConfirmationFormComponent(): TextInput
     {
         return TextInput::make('passwordConfirmation')
             ->label(__('filament-panels::pages/auth/edit-profile.form.password_confirmation.label'))

--- a/packages/panels/src/Pages/Auth/EditProfile.php
+++ b/packages/panels/src/Pages/Auth/EditProfile.php
@@ -6,7 +6,6 @@ use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Facades\Filament;
-use Filament\Forms\Components\Component;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Forms\Get;

--- a/packages/panels/src/Pages/Auth/Login.php
+++ b/packages/panels/src/Pages/Auth/Login.php
@@ -8,7 +8,6 @@ use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Checkbox;
-use Filament\Forms\Components\Component;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Http\Responses\Auth\Contracts\LoginResponse;

--- a/packages/panels/src/Pages/Auth/Login.php
+++ b/packages/panels/src/Pages/Auth/Login.php
@@ -120,7 +120,7 @@ class Login extends SimplePage
         ];
     }
 
-    protected function getEmailFormComponent(): Component
+    protected function getEmailFormComponent(): TextInput
     {
         return TextInput::make('email')
             ->label(__('filament-panels::pages/auth/login.form.email.label'))
@@ -131,7 +131,7 @@ class Login extends SimplePage
             ->extraInputAttributes(['tabindex' => 1]);
     }
 
-    protected function getPasswordFormComponent(): Component
+    protected function getPasswordFormComponent(): TextInput
     {
         return TextInput::make('password')
             ->label(__('filament-panels::pages/auth/login.form.password.label'))
@@ -143,7 +143,7 @@ class Login extends SimplePage
             ->extraInputAttributes(['tabindex' => 2]);
     }
 
-    protected function getRememberFormComponent(): Component
+    protected function getRememberFormComponent(): Checkbox
     {
         return Checkbox::make('remember')
             ->label(__('filament-panels::pages/auth/login.form.remember.label'));

--- a/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
+++ b/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
@@ -123,7 +123,7 @@ class RequestPasswordReset extends SimplePage
         ];
     }
 
-    protected function getEmailFormComponent(): Component
+    protected function getEmailFormComponent(): TextInput
     {
         return TextInput::make('email')
             ->label(__('filament-panels::pages/auth/password-reset/request-password-reset.form.email.label'))

--- a/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
+++ b/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
@@ -8,7 +8,6 @@ use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Facades\Filament;
-use Filament\Forms\Components\Component;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Notifications\Auth\ResetPassword as ResetPasswordNotification;

--- a/packages/panels/src/Pages/Auth/PasswordReset/ResetPassword.php
+++ b/packages/panels/src/Pages/Auth/PasswordReset/ResetPassword.php
@@ -125,7 +125,7 @@ class ResetPassword extends SimplePage
             ]);
     }
 
-    protected function getEmailFormComponent(): Component
+    protected function getEmailFormComponent(): TextInput
     {
         return TextInput::make('email')
             ->label(__('filament-panels::pages/auth/password-reset/reset-password.form.email.label'))
@@ -133,7 +133,7 @@ class ResetPassword extends SimplePage
             ->autofocus();
     }
 
-    protected function getPasswordFormComponent(): Component
+    protected function getPasswordFormComponent(): TextInput
     {
         return TextInput::make('password')
             ->label(__('filament-panels::pages/auth/password-reset/reset-password.form.password.label'))
@@ -145,7 +145,7 @@ class ResetPassword extends SimplePage
             ->validationAttribute(__('filament-panels::pages/auth/password-reset/reset-password.form.password.validation_attribute'));
     }
 
-    protected function getPasswordConfirmationFormComponent(): Component
+    protected function getPasswordConfirmationFormComponent(): TextInput
     {
         return TextInput::make('passwordConfirmation')
             ->label(__('filament-panels::pages/auth/password-reset/reset-password.form.password_confirmation.label'))

--- a/packages/panels/src/Pages/Auth/PasswordReset/ResetPassword.php
+++ b/packages/panels/src/Pages/Auth/PasswordReset/ResetPassword.php
@@ -7,7 +7,6 @@ use DanHarrin\LivewireRateLimiting\WithRateLimiting;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Facades\Filament;
-use Filament\Forms\Components\Component;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Http\Responses\Auth\Contracts\PasswordResetResponse;

--- a/packages/panels/src/Pages/Auth/Register.php
+++ b/packages/panels/src/Pages/Auth/Register.php
@@ -9,7 +9,6 @@ use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Events\Auth\Registered;
 use Filament\Facades\Filament;
-use Filament\Forms\Components\Component;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Http\Responses\Auth\Contracts\RegistrationResponse;

--- a/packages/panels/src/Pages/Auth/Register.php
+++ b/packages/panels/src/Pages/Auth/Register.php
@@ -165,7 +165,7 @@ class Register extends SimplePage
         ];
     }
 
-    protected function getNameFormComponent(): Component
+    protected function getNameFormComponent(): TextInput
     {
         return TextInput::make('name')
             ->label(__('filament-panels::pages/auth/register.form.name.label'))
@@ -174,7 +174,7 @@ class Register extends SimplePage
             ->autofocus();
     }
 
-    protected function getEmailFormComponent(): Component
+    protected function getEmailFormComponent(): TextInput
     {
         return TextInput::make('email')
             ->label(__('filament-panels::pages/auth/register.form.email.label'))
@@ -184,7 +184,7 @@ class Register extends SimplePage
             ->unique($this->getUserModel());
     }
 
-    protected function getPasswordFormComponent(): Component
+    protected function getPasswordFormComponent(): TextInput
     {
         return TextInput::make('password')
             ->label(__('filament-panels::pages/auth/register.form.password.label'))
@@ -197,7 +197,7 @@ class Register extends SimplePage
             ->validationAttribute(__('filament-panels::pages/auth/register.form.password.validation_attribute'));
     }
 
-    protected function getPasswordConfirmationFormComponent(): Component
+    protected function getPasswordConfirmationFormComponent(): TextInput
     {
         return TextInput::make('passwordConfirmation')
             ->label(__('filament-panels::pages/auth/register.form.password_confirmation.label'))


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Currently `Component` is used as return type for methods like `getEmailFormComponent()` on the registration page. If you want to add an additional `rule()` to the component by overriding it and calling `parent::getEmailFormComponent()`, PHPStan throws errors. This is because the method uses a generic `Component` return type. This PR changes the return types of those methods to be more specific to fix this issue. Since return types can be changed anyway when the method is overridden, this doesn't cause any issues.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
