### PR TITLE
chore/changing document retrieval failiures to 404

### DIFF
--- a/packages/actions/src/Exports/Downloaders/CsvDownloader.php
+++ b/packages/actions/src/Exports/Downloaders/CsvDownloader.php
@@ -14,7 +14,7 @@ class CsvDownloader implements Downloader
         $directory = $export->getFileDirectory();
 
         if (! $disk->exists($directory)) {
-            abort(419);
+            abort(404);
         }
 
         return response()->streamDownload(function () use ($disk, $directory) {

--- a/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
+++ b/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
@@ -18,7 +18,7 @@ class XlsxDownloader implements Downloader
         $directory = $export->getFileDirectory();
 
         if (! $disk->exists($directory)) {
-            abort(419);
+            abort(404);
         }
 
         $fileName = $export->file_name . '.xlsx';


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
In this PR I have updated the two export downloader classes so that, if we cannot find the directory that contains the exports, we return a 404 error instead of a 419 one. While this might seem like a very minor difference, the fact that a 419 error was being reported falsely led me to believe that there was an issue with the CSRF tokens on our project, when in actuality the export files were not being created. If we use the correct error code then we know what the issue is right away.

## Visual changes
None

## Functional changes
Instead a 419 error being reported when we cannot find an export file to download, we will now get an error 404.

- [n] Code style has been fixed by running the `composer cs` command.
- [y] Changes have been tested to not break existing functionality.
- [n] Documentation is up-to-date. (There is no documentation for this specific case)
