### PR TITLE
Update CanImportRecords.php

### DIFF
--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -79,7 +79,7 @@ trait CanImportRecords
                 ->label(__('filament-actions::import.modal.form.file.label'))
                 ->placeholder(__('filament-actions::import.modal.form.file.placeholder'))
                 ->acceptedFileTypes(['text/csv', 'text/x-csv', 'application/csv', 'application/x-csv', 'text/comma-separated-values', 'text/x-comma-separated-values', 'text/plain', 'application/vnd.ms-excel'])
-                ->rule('extensions:csv')
+                ->rule('extensions:csv,txt')
                 ->afterStateUpdated(function (FileUpload $component, Component $livewire, Forms\Set $set, ?TemporaryUploadedFile $state) use ($action) {
                     if (! $state instanceof TemporaryUploadedFile) {
                         return;


### PR DESCRIPTION
## Description
Solves the validation error "The file field must have one of the following extensions: csv" because the file extension of the uploaded CSV gets changed to .txt in the TemporaryUploadedFile as discussed in #12038.

## Visual changes
Before:
![grafik](https://github.com/filamentphp/filament/assets/7964115/f43a27a6-fe03-4905-9aaf-68fc6e6b53dd)

After:
![grafik](https://github.com/filamentphp/filament/assets/7964115/4b6f18e0-a401-4059-a3aa-6eb179ab9bd0)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
