### PR TITLE
Detect vite.config.ts when creating new theme

### DIFF
--- a/packages/panels/src/Commands/MakeThemeCommand.php
+++ b/packages/panels/src/Commands/MakeThemeCommand.php
@@ -93,7 +93,7 @@ class MakeThemeCommand extends Command
 
         $this->components->info("Filament theme [resources/css/filament/{$panelId}/theme.css] and [resources/css/filament/{$panelId}/tailwind.config.js] created successfully.");
 
-        if (! file_exists(base_path('vite.config.js'))) {
+        if (empty(glob(base_path('vite.config.*s')))) {
             $this->components->warn('Action is required to complete the theme setup:');
             $this->components->bulletList([
                 "It looks like you don't have Vite installed. Please use your asset bundling system of choice to compile `resources/css/filament/{$panelId}/theme.css` into `public/css/filament/{$panelId}/theme.css`.",


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Minor thing, but Vite config may also have a `.ts` extension instead `.js`, as described here: https://vitejs.dev/config/#config-intellisense. This PR changes a way the Vite config file is detected, so the message is not misleading.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
