### PR TITLE
Fixes bug when attaching a belongsToMany relation that has an orderByPivot

### DIFF
--- a/packages/support/src/Services/RelationshipJoiner.php
+++ b/packages/support/src/Services/RelationshipJoiner.php
@@ -97,9 +97,10 @@ class RelationshipJoiner
                     continue;
                 }
 
-                if (Str::startsWith($order['column'], "{$relationshipQuery->getModel()->getTable()}.")) {
+                if (str($order['column'])->startsWith("{$relationshipQuery->getModel()->getTable()}.")) {
                     continue;
                 }
+                
                 $relationshipQuery->addSelect($order['column']);
             }
         }

--- a/packages/support/src/Services/RelationshipJoiner.php
+++ b/packages/support/src/Services/RelationshipJoiner.php
@@ -91,6 +91,12 @@ class RelationshipJoiner
             $relationshipQuery
                 ->distinct()
                 ->select($relationshipQuery->getModel()->getTable() . '.*');
+
+            foreach ($relationshipQuery->getQuery()->orders as $order) {
+                if (array_key_exists('column', $order)) {
+                    $relationshipQuery->addSelect($order['column']);
+                }
+            }
         }
 
         return $relationshipQuery;

--- a/packages/support/src/Services/RelationshipJoiner.php
+++ b/packages/support/src/Services/RelationshipJoiner.php
@@ -93,9 +93,14 @@ class RelationshipJoiner
                 ->select($relationshipQuery->getModel()->getTable() . '.*');
 
             foreach ($relationshipQuery->getQuery()->orders as $order) {
-                if (array_key_exists('column', $order)) {
-                    $relationshipQuery->addSelect($order['column']);
+                if (! array_key_exists('column', $order)) {
+                    continue;
                 }
+
+                if (Str::startsWith($order['column'], "{$relationshipQuery->getModel()->getTable()}.")) {
+                    continue;
+                }
+                $relationshipQuery->addSelect($order['column']);
             }
         }
 


### PR DESCRIPTION
## Description

When trying to attach a BelongsToMany relation through the RelationManager where the belongsToMany relation has an **orderByPivot** method it will give an error in the SQL query.

This used to work but seems to give an error since filament v3. 
I think its because of the distinct query that has been added in RelationshipJoiner.php class.
As the orderBy query with a distinct needs that orderBy field to be added to the select.

I added a simple foreach that adds the existing orderBy columns to the select. 
This seems to fix the error and has no extra side effects afaik.

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

For extra info also see this discussion I found discussing this exact problem:
https://github.com/filamentphp/filament/discussions/8022
