### PR TITLE
[Documentation] Fix DatabaseNotifications pollingInterval

### DIFF
--- a/packages/notifications/docs/03-database-notifications.md
+++ b/packages/notifications/docs/03-database-notifications.md
@@ -104,8 +104,7 @@ By default, Livewire polls for new notifications every 30 seconds:
 ```php
 use Filament\Notifications\Livewire\DatabaseNotifications;
 
-DatabaseNotifications::databaseNotifications();
-DatabaseNotifications::databaseNotificationsPollingInterval('30s');
+DatabaseNotifications::pollingInterval('30s');
 ```
 
 You may completely disable polling if you wish:
@@ -113,8 +112,7 @@ You may completely disable polling if you wish:
 ```php
 use Filament\Notifications\Livewire\DatabaseNotifications;
 
-DatabaseNotifications::databaseNotifications();
-DatabaseNotifications::databaseNotificationsPollingInterval(null);
+DatabaseNotifications::pollingInterval(null);
 ```
 
 ### Using Echo to receive new database notifications with websockets


### PR DESCRIPTION
## Description

The documentation at https://filamentphp.com/docs/3.x/notifications/database-notifications#polling-for-new-database-notifications is incorrect.
`DatabaseNotifications::databaseNotifications();` and 
`DatabaseNotifications::databaseNotificationsPollingInterval()` don't exist.
`DatabaseNotifications::pollingInterval()` does exist, I'm quite sure that is the intended call here in the documentation

## Visual changes

![image](https://github.com/filamentphp/filament/assets/9074391/f31f57e7-d063-4fe5-b89e-1d4ee2bdc5b3)

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
