### PR TITLE
Fixed bug issue on TextArea with autosize after validation failed

### DIFF
--- a/packages/forms/resources/js/components/textarea.js
+++ b/packages/forms/resources/js/components/textarea.js
@@ -12,12 +12,20 @@ export default function textareaFormComponent({ initialHeight }) {
         },
 
         input: {
-            ['@intersect.once']() { this.render() },
-            ['@input']() { this.render() },
-            ['@resize.window']() { this.render() },
-            ['@form-validation-error.window']() {
-                this.$nextTick(() => { this.render() })
+            ['@intersect.once']() {
+                this.render()
             },
-        }
+            ['@input']() {
+                this.render()
+            },
+            ['@resize.window']() {
+                this.render()
+            },
+            ['@form-validation-error.window']() {
+                this.$nextTick(() => {
+                    this.render()
+                })
+            },
+        },
     }
 }

--- a/packages/forms/resources/js/components/textarea.js
+++ b/packages/forms/resources/js/components/textarea.js
@@ -10,5 +10,14 @@ export default function textareaFormComponent({ initialHeight }) {
                 this.$el.style.height = this.$el.scrollHeight + 'px'
             }
         },
+
+        input: {
+            ['@intersect.once']() { this.render() },
+            ['@input']() { this.render() },
+            ['@resize.window']() { this.render() },
+            ['@form-validation-error.window']() {
+                this.$nextTick(() => { this.render() })
+            },
+        }
     }
 }

--- a/packages/forms/resources/js/components/textarea.js
+++ b/packages/forms/resources/js/components/textarea.js
@@ -10,22 +10,5 @@ export default function textareaFormComponent({ initialHeight }) {
                 this.$el.style.height = this.$el.scrollHeight + 'px'
             }
         },
-
-        input: {
-            ['@intersect.once']() {
-                this.render()
-            },
-            ['@input']() {
-                this.render()
-            },
-            ['@resize.window']() {
-                this.render()
-            },
-            ['@form-validation-error.window']() {
-                this.$nextTick(() => {
-                    this.render()
-                })
-            },
-        },
     }
 }

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -42,7 +42,11 @@
                 @endif
                 ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('textarea', 'filament/forms') }}"
                 x-data="textareaFormComponent({ initialHeight: @js($initialHeight) })"
-                x-bind="input"
+                x-ignore
+                x-intersect.once="render()"
+                x-on:input="render()"
+                x-on:resize.window="render()"
+                x-on:form-validation-error.window = '$nextTick(() => render())'
                 wire:ignore.style.height
                 {{ $getExtraAlpineAttributeBag() }}
             @endif

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -42,10 +42,8 @@
                 @endif
                 ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('textarea', 'filament/forms') }}"
                 x-data="textareaFormComponent({ initialHeight: @js($initialHeight) })"
-                x-ignore
-                x-intersect.once="render()"
-                x-on:input="render()"
-                x-on:resize.window="render()"
+                x-bind="input"
+                wire:ignore.style.height
                 {{ $getExtraAlpineAttributeBag() }}
             @endif
             {{

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -46,7 +46,7 @@
                 x-intersect.once="render()"
                 x-on:input="render()"
                 x-on:resize.window="render()"
-                x-on:form-validation-error.window = '$nextTick(() => render())'
+                x-on:form-validation-error.window="$nextTick(() => render())"
                 wire:ignore.style.height
                 {{ $getExtraAlpineAttributeBag() }}
             @endif

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -44,9 +44,9 @@
                 x-data="textareaFormComponent({ initialHeight: @js($initialHeight) })"
                 x-ignore
                 x-intersect.once="render()"
+                x-on:form-validation-error.window="$nextTick(() => render())"
                 x-on:input="render()"
                 x-on:resize.window="render()"
-                x-on:form-validation-error.window="$nextTick(() => render())"
                 wire:ignore.style.height
                 {{ $getExtraAlpineAttributeBag() }}
             @endif


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Reference issue #11428 

Fixes bug issue on TextArea form component with autosize() return the height to initial height after validation failed

## Visual changes


https://github.com/filamentphp/filament/assets/13638285/e22ea86a-2e85-4faf-bb01-f2456f4ae672



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
