### PR TITLE
Fix for bug #11541

### DIFF
--- a/packages/forms/resources/views/components/builder/block-picker.blade.php
+++ b/packages/forms/resources/views/components/builder/block-picker.blade.php
@@ -30,7 +30,7 @@
                 @php
                     $wireClickActionArguments = ['block' => $block->getName()];
 
-                    if ($afterItem) {
+                    if (isset($afterItem)) {
                         $wireClickActionArguments['afterItem'] = $afterItem;
                     }
 

--- a/packages/forms/resources/views/components/builder/block-picker.blade.php
+++ b/packages/forms/resources/views/components/builder/block-picker.blade.php
@@ -30,7 +30,7 @@
                 @php
                     $wireClickActionArguments = ['block' => $block->getName()];
 
-                    if (isset($afterItem)) {
+                    if (filled($afterItem)) {
                         $wireClickActionArguments['afterItem'] = $afterItem;
                     }
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fix for bug [Unable to insert a Builder block between others in a multilingual setup](https://github.com/filamentphp/filament/issues/11541#top)


## Visual changes

Nope 

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
