### PR TITLE
fix: Duplicate request to count records

### DIFF
--- a/packages/tables/src/Concerns/CanPaginateRecords.php
+++ b/packages/tables/src/Concerns/CanPaginateRecords.php
@@ -32,7 +32,7 @@ trait CanPaginateRecords
 
         /** @var LengthAwarePaginator $records */
         $records = $query->paginate(
-            perPage: $perPage === 'all' ? $total : $perPage,
+            perPage: ($perPage === 'all') ? $total : $perPage,
             columns: ['*'],
             pageName: $this->getTablePaginationPageName(),
             total: $total,

--- a/packages/tables/src/Concerns/CanPaginateRecords.php
+++ b/packages/tables/src/Concerns/CanPaginateRecords.php
@@ -28,12 +28,14 @@ trait CanPaginateRecords
     protected function paginateTableQuery(Builder $query): Paginator | CursorPaginator
     {
         $perPage = $this->getTableRecordsPerPage();
+        $total = $query->toBase()->getCountForPagination();
 
         /** @var LengthAwarePaginator $records */
         $records = $query->paginate(
-            $perPage === 'all' ? $query->toBase()->getCountForPagination() : $perPage,
-            ['*'],
-            $this->getTablePaginationPageName(),
+            perPage: $perPage === 'all' ? $total : $perPage,
+            columns: ['*'],
+            pageName: $this->getTablePaginationPageName(),
+            total: $total,
         );
 
         return $records->onEachSide(0);


### PR DESCRIPTION
## Description

If you select to display all records, then the request to count the number of records is executed 2 times

## Visual changes

### Before

![fix-before](https://github.com/filamentphp/filament/assets/590390/f98ed8fb-4652-4143-87bd-bed83b55e62c)

### After

![fix-after](https://github.com/filamentphp/filament/assets/590390/6dbf1f90-80ac-44de-83f1-33ffd14e42b7)

## Functional changes

- [x] Changes have been tested to not break existing functionality.
