### PR TITLE
Add completed icon retrieval in wizard component

### DIFF
--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -163,6 +163,7 @@
                         @php
                             $completedIcon = $step->getCompletedIcon();
                         @endphp
+                        
                         <x-filament::icon
                             :alias="filled($completedIcon) ? null : 'forms::components.wizard.completed-step'"
                             :icon="$completedIcon ?? 'heroicon-o-check'"

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -160,6 +160,9 @@
                                 getStepIndex(step) < {{ $loop->index }},
                         }"
                     >
+                        @php
+                            $completedIcon = $step->getCompletedIcon();
+                        @endphp
                         <x-filament::icon
                             :alias="filled($completedIcon) ? null : 'forms::components.wizard.completed-step'"
                             :icon="$completedIcon ?? 'heroicon-o-check'"


### PR DESCRIPTION
Add completed icon retrieval in wizard component

## Functional changes

-  Code style has been fixed by running the `composer cs` command.
-  Changes have been tested to not break existing functionality.
-  Documentation is up-to-date.
