### PR TITLE
fix: removed form-validation-error attribute on TextArea component

### DIFF
--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -44,7 +44,6 @@
                 x-data="textareaFormComponent({ initialHeight: @js($initialHeight) })"
                 x-ignore
                 x-intersect.once="render()"
-                x-on:form-validation-error.window="$nextTick(() => render())"
                 x-on:input="render()"
                 x-on:resize.window="render()"
                 wire:ignore.style.height

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -43,6 +43,7 @@
                 ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('textarea', 'filament/forms') }}"
                 x-data="textareaFormComponent({ initialHeight: @js($initialHeight) })"
                 x-ignore
+                x-intersect.once="render()"
                 x-on:input="render()"
                 x-on:resize.window="render()"
                 wire:ignore.style.height

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -43,7 +43,6 @@
                 ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('textarea', 'filament/forms') }}"
                 x-data="textareaFormComponent({ initialHeight: @js($initialHeight) })"
                 x-ignore
-                x-intersect.once="render()"
                 x-on:input="render()"
                 x-on:resize.window="render()"
                 wire:ignore.style.height


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Ref: #12348 
Removed `x-on:form-validation-error.window` as it is not needed for autosize bug issue