### PR TITLE
Allow multiple `routes()` registries on `Panel`

### DIFF
--- a/packages/forms/resources/lang/lt/components.php
+++ b/packages/forms/resources/lang/lt/components.php
@@ -189,7 +189,7 @@ return [
 
                 'messages' => [
                     'confirmation' => 'Redaguoti SVG failų nerekomenduojama, kadangi tai gali įtakoti kokybės praradimą keičiant mastelį.\n Ar tikrai norite tęsti?',
-                    'disabled' => 'SVG failų redagavimas išjungtas, kadangi tai gali įtakoti kokybės praradimą keičiant mastelį.'
+                    'disabled' => 'SVG failų redagavimas išjungtas, kadangi tai gali įtakoti kokybės praradimą keičiant mastelį.',
                 ],
 
             ],

--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -25,7 +25,7 @@ Route::name('filament.')
                     ->name("{$panelId}.")
                     ->prefix($panel->getPath())
                     ->group(function () use ($panel, $hasTenancy, $tenantDomain, $tenantRoutePrefix, $tenantSlugAttribute) {
-                        if ($routes = $panel->getRoutes()) {
+                        foreach ($panel->getRoutes() as $routes) {
                             $routes($panel);
                         }
 
@@ -55,7 +55,7 @@ Route::name('filament.')
 
                         Route::middleware($panel->getAuthMiddleware())
                             ->group(function () use ($panel, $hasTenancy, $tenantDomain, $tenantRoutePrefix, $tenantSlugAttribute): void {
-                                if ($routes = $panel->getAuthenticatedRoutes()) {
+                                foreach ($panel->getAuthenticatedRoutes() as $routes) {
                                     $routes($panel);
                                 }
 
@@ -109,7 +109,7 @@ Route::name('filament.')
 
                                 $routeGroup
                                     ->group(function () use ($panel): void {
-                                        if ($routes = $panel->getAuthenticatedTenantRoutes()) {
+                                        foreach ($panel->getAuthenticatedTenantRoutes() as $routes) {
                                             $routes($panel);
                                         }
 
@@ -161,7 +161,7 @@ Route::name('filament.')
 
                             $routeGroup
                                 ->group(function () use ($panel): void {
-                                    if ($routes = $panel->getTenantRoutes()) {
+                                    foreach ($panel->getTenantRoutes() as $routes) {
                                         $routes($panel);
                                     }
                                 });

--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -11,13 +11,25 @@ use Laravel\SerializableClosure\Serializers\Native;
 
 trait HasRoutes
 {
-    protected Closure | Native | null $routes = null;
+    /**
+     * @var array<Closure | Native>
+     */
+    protected array $routes = [];
 
-    protected Closure | Native | null $authenticatedRoutes = null;
+    /**
+     * @var array<Closure | Native>
+     */
+    protected array $authenticatedRoutes = [];
 
-    protected Closure | Native | null $tenantRoutes = null;
+    /**
+     * @var array<Closure | Native>
+     */
+    protected array $tenantRoutes = [];
 
-    protected Closure | Native | null $authenticatedTenantRoutes = null;
+    /**
+     * @var array<Closure | Native>
+     */
+    protected array $authenticatedTenantRoutes = [];
 
     protected string | Closure | null $homeUrl = null;
 
@@ -61,28 +73,28 @@ trait HasRoutes
 
     public function routes(?Closure $routes): static
     {
-        $this->routes = $routes;
+        $this->routes[] = $routes;
 
         return $this;
     }
 
     public function authenticatedRoutes(?Closure $routes): static
     {
-        $this->authenticatedRoutes = $routes;
+        $this->authenticatedRoutes[] = $routes;
 
         return $this;
     }
 
     public function tenantRoutes(?Closure $routes): static
     {
-        $this->tenantRoutes = $routes;
+        $this->tenantRoutes[] = $routes;
 
         return $this;
     }
 
     public function authenticatedTenantRoutes(?Closure $routes): static
     {
-        $this->authenticatedTenantRoutes = $routes;
+        $this->authenticatedTenantRoutes[] = $routes;
 
         return $this;
     }
@@ -97,22 +109,34 @@ trait HasRoutes
         return "filament.{$this->getId()}.{$name}";
     }
 
-    public function getRoutes(): ?Closure
+    /**
+     * @return array<Closure | Native>
+     */
+    public function getRoutes(): array
     {
         return $this->routes;
     }
 
-    public function getAuthenticatedRoutes(): ?Closure
+    /**
+     * @return array<Closure | Native>
+     */
+    public function getAuthenticatedRoutes(): array
     {
         return $this->authenticatedRoutes;
     }
 
-    public function getTenantRoutes(): ?Closure
+    /**
+     * @return array<Closure | Native>
+     */
+    public function getTenantRoutes(): array
     {
         return $this->tenantRoutes;
     }
 
-    public function getAuthenticatedTenantRoutes(): ?Closure
+    /**
+     * @return array<Closure | Native>
+     */
+    public function getAuthenticatedTenantRoutes(): array
     {
         return $this->authenticatedTenantRoutes;
     }

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -98,7 +98,7 @@
                     'ring-1 ring-gray-950/10 dark:ring-white/20' => (($color === 'gray') || ($tag === 'label')) && (! $grouped),
                     'bg-custom-600 text-white hover:bg-custom-500 focus-visible:ring-custom-500/50 dark:bg-custom-500 dark:hover:bg-custom-400 dark:focus-visible:ring-custom-400/50' => ($color !== 'gray') && ($tag !== 'label'),
                     '[input:checked+&]:bg-custom-600 [input:checked+&]:text-white [input:checked+&]:ring-0 [input:checked+&]:hover:bg-custom-500 dark:[input:checked+&]:bg-custom-500 dark:[input:checked+&]:hover:bg-custom-400 [input:checked:focus-visible+&]:ring-custom-500/50 dark:[input:checked:focus-visible+&]:ring-custom-400/50 [input:focus-visible+&]:z-10 [input:focus-visible+&]:ring-2 [input:focus-visible+&]:ring-gray-950/10 dark:[input:focus-visible+&]:ring-white/20' => ($color !== 'gray') && ($tag === 'label'),
-                ]
+                    ]
         ),
     ]);
 

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -98,7 +98,7 @@
                     'ring-1 ring-gray-950/10 dark:ring-white/20' => (($color === 'gray') || ($tag === 'label')) && (! $grouped),
                     'bg-custom-600 text-white hover:bg-custom-500 focus-visible:ring-custom-500/50 dark:bg-custom-500 dark:hover:bg-custom-400 dark:focus-visible:ring-custom-400/50' => ($color !== 'gray') && ($tag !== 'label'),
                     '[input:checked+&]:bg-custom-600 [input:checked+&]:text-white [input:checked+&]:ring-0 [input:checked+&]:hover:bg-custom-500 dark:[input:checked+&]:bg-custom-500 dark:[input:checked+&]:hover:bg-custom-400 [input:checked:focus-visible+&]:ring-custom-500/50 dark:[input:checked:focus-visible+&]:ring-custom-400/50 [input:focus-visible+&]:z-10 [input:focus-visible+&]:ring-2 [input:focus-visible+&]:ring-gray-950/10 dark:[input:focus-visible+&]:ring-white/20' => ($color !== 'gray') && ($tag === 'label'),
-                    ]
+                ]
         ),
     ]);
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR aims to allow Developers and Plugin Authors to register `routes()`, `authenticatedRoutes()`, `tenantRoutes()`, `authenticatedTenantRoutes()` without interfering with one another.

The previous implementation only allow a single instance of closure. So if a developer decides to add a route, it may not be registered if they use a plugin that adds a route.

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
