### PR TITLE
Fix: Select HasManyThrough relationship

### DIFF
--- a/packages/forms/resources/lang/lt/components.php
+++ b/packages/forms/resources/lang/lt/components.php
@@ -189,7 +189,7 @@ return [
 
                 'messages' => [
                     'confirmation' => 'Redaguoti SVG failų nerekomenduojama, kadangi tai gali įtakoti kokybės praradimą keičiant mastelį.\n Ar tikrai norite tęsti?',
-                    'disabled' => 'SVG failų redagavimas išjungtas, kadangi tai gali įtakoti kokybės praradimą keičiant mastelį.'
+                    'disabled' => 'SVG failų redagavimas išjungtas, kadangi tai gali įtakoti kokybės praradimą keičiant mastelį.',
                 ],
 
             ],

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -811,7 +811,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
             if (
                 ($relationship instanceof BelongsToMany) ||
                 ($relationship instanceof HasManyThrough)
-            ){
+            ) {
                 /** @var Collection $relatedModels */
                 $relatedModels = $relationship->getResults();
 

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -808,7 +808,10 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
 
             $relationship = $component->getRelationship();
 
-            if ($relationship instanceof BelongsToMany) {
+            if (
+                ($relationship instanceof BelongsToMany) ||
+                ($relationship instanceof HasManyThrough)
+            ){
                 /** @var Collection $relatedModels */
                 $relatedModels = $relationship->getResults();
 
@@ -818,7 +821,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
                     //
                     // https://github.com/filamentphp/filament/issues/1111
                     $relatedModels
-                        ->pluck($relationship->getRelatedKeyName())
+                        ->pluck($relationship->getRelated()->getKeyName())
                         ->map(static fn ($key): string => strval($key))
                         ->toArray(),
                 );
@@ -826,10 +829,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
                 return;
             }
 
-            if (
-                ($relationship instanceof HasManyThrough) ||
-                ($relationship instanceof BelongsToThrough)
-            ) {
+            if ($relationship instanceof BelongsToThrough) {
                 $relatedModel = $relationship->getResults();
 
                 $component->state(

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -821,7 +821,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
                     //
                     // https://github.com/filamentphp/filament/issues/1111
                     $relatedModels
-                        ->pluck($relationship->getRelated()->getKeyName())
+                        ->pluck(($relationship instanceof BelongsToMany) ? $relationship->getRelatedKeyName() : $relationship->getRelated()->getKeyName())
                         ->map(static fn ($key): string => strval($key))
                         ->toArray(),
                 );

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -98,7 +98,7 @@
                     'ring-1 ring-gray-950/10 dark:ring-white/20' => (($color === 'gray') || ($tag === 'label')) && (! $grouped),
                     'bg-custom-600 text-white hover:bg-custom-500 focus-visible:ring-custom-500/50 dark:bg-custom-500 dark:hover:bg-custom-400 dark:focus-visible:ring-custom-400/50' => ($color !== 'gray') && ($tag !== 'label'),
                     '[input:checked+&]:bg-custom-600 [input:checked+&]:text-white [input:checked+&]:ring-0 [input:checked+&]:hover:bg-custom-500 dark:[input:checked+&]:bg-custom-500 dark:[input:checked+&]:hover:bg-custom-400 [input:checked:focus-visible+&]:ring-custom-500/50 dark:[input:checked:focus-visible+&]:ring-custom-400/50 [input:focus-visible+&]:z-10 [input:focus-visible+&]:ring-2 [input:focus-visible+&]:ring-gray-950/10 dark:[input:focus-visible+&]:ring-white/20' => ($color !== 'gray') && ($tag === 'label'),
-                ]
+                    ]
         ),
     ]);
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When using a Select with a `HasManyThrough` relationship, the component fails to load its state from relationship because `getResults()` returns a collection not a single record. 

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
