### PR TITLE
add charset converter & detect encoding on csv upload

### DIFF
--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -61,6 +61,9 @@ trait CanImportRecords
      */
     protected array | Closure $options = [];
 
+    /**
+     * @var array<string, string>
+     */
     protected array $encoding_standards = [];
 
     protected function setUp(): void

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -409,7 +409,10 @@ trait CanImportRecords
 
     protected function detectCsvEncoding(TemporaryUploadedFile $file): ?string
     {
-        $fileContents = file_get_contents($file->getRealPath());
+        $filePath = $file->getRealPath();
+        $stream = fopen($filePath, mode: 'r');
+
+        $fileContents = stream_get_contents($stream, 1000);
 
         foreach ([
             'UTF-8',

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -82,7 +82,7 @@ trait CanImportRecords
         $this->form(fn (ImportAction | ImportTableAction $action): array => array_merge([
             Select::make('encoding')
                 ->options($this->encoding_standards)
-                ->afterStateUpdated(fn(Forms\Get $get, Forms\Set $set, ?string $state) => $get('file') ? $set('file', null) : null)
+                ->afterStateUpdated(fn (Forms\Get $get, Forms\Set $set, ?string $state) => $get('file') ? $set('file', null) : null)
                 ->live(),
             FileUpload::make('file')
                 ->hidden(fn (Forms\Get $get) => ! $get('encoding'))

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -81,7 +81,7 @@ trait CanImportRecords
                 ->placeholder(__('filament-actions::import.modal.form.file.placeholder'))
                 ->acceptedFileTypes(['text/csv', 'text/x-csv', 'application/csv', 'application/x-csv', 'text/comma-separated-values', 'text/x-comma-separated-values', 'text/plain', 'application/vnd.ms-excel'])
                 ->rule('extensions:csv,txt')
-                ->afterStateUpdated(function (FileUpload $component, Component $livewire, Forms\Set $set, ?TemporaryUploadedFile $state, Forms\Get $get) use ($action) {
+                ->afterStateUpdated(function (FileUpload $component, Component $livewire, Forms\Set $set, ?TemporaryUploadedFile $state) use ($action) {
                     if (! $state instanceof TemporaryUploadedFile) {
                         return;
                     }
@@ -366,7 +366,9 @@ trait CanImportRecords
 
         $filePath = $file->getRealPath();
 
-        CharsetConverter::register();
+        if (filled($encoding)) {
+            CharsetConverter::register();
+        }
 
         if (config('filesystems.disks.' . config('filament.default_filesystem_disk') . '.driver') !== 's3') {
             $resource = fopen($filePath, mode: 'r');

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -98,7 +98,7 @@
                     'ring-1 ring-gray-950/10 dark:ring-white/20' => (($color === 'gray') || ($tag === 'label')) && (! $grouped),
                     'bg-custom-600 text-white hover:bg-custom-500 focus-visible:ring-custom-500/50 dark:bg-custom-500 dark:hover:bg-custom-400 dark:focus-visible:ring-custom-400/50' => ($color !== 'gray') && ($tag !== 'label'),
                     '[input:checked+&]:bg-custom-600 [input:checked+&]:text-white [input:checked+&]:ring-0 [input:checked+&]:hover:bg-custom-500 dark:[input:checked+&]:bg-custom-500 dark:[input:checked+&]:hover:bg-custom-400 [input:checked:focus-visible+&]:ring-custom-500/50 dark:[input:checked:focus-visible+&]:ring-custom-400/50 [input:focus-visible+&]:z-10 [input:focus-visible+&]:ring-2 [input:focus-visible+&]:ring-gray-950/10 dark:[input:focus-visible+&]:ring-white/20' => ($color !== 'gray') && ($tag === 'label'),
-                ]
+                    ]
         ),
     ]);
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fixes the issue #12063. Implements a dropdown that allows the user to select an encoding for their csv, which is then converted to UTF-8. [mb_detect_encoding()](https://www.php.net/manual/en/function.mb-detect-encoding.php) could be used to detect formatting, but is apparently (somewhat?) deprecated, as pointed out [here](https://www.php.net/manual/en/function.mb-detect-encoding.php#127650).
If implemented, this solution might require to modify documentation.
My first choice was to disable the upload field when no encoding is selected, but dynamic disabling doesn't seem to work on this filed. I've used `hidden()` instead.

## Visual changes

![image](https://github.com/filamentphp/filament/assets/100000204/db066672-7200-4b49-b107-8bc07710cefe)
*Displays an additional dropdown*

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
