### PR TITLE
Bump Livewire to 3.4.10

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1579,7 +1579,7 @@
                 "illuminate/contracts": "^10.45|^11.0",
                 "illuminate/support": "^10.45|^11.0",
                 "illuminate/view": "^10.45|^11.0",
-                "livewire/livewire": "^3.4.9",
+                "livewire/livewire": "^3.4.10",
                 "php": "^8.1",
                 "ryangjchandler/blade-capture-directive": "^0.2|^0.3|^1.0",
                 "spatie/color": "^1.5",

--- a/packages/support/composer.json
+++ b/packages/support/composer.json
@@ -15,7 +15,7 @@
         "illuminate/contracts": "^10.45|^11.0",
         "illuminate/support": "^10.45|^11.0",
         "illuminate/view": "^10.45|^11.0",
-        "livewire/livewire": "^3.4.9",
+        "livewire/livewire": "^3.4.10",
         "ryangjchandler/blade-capture-directive": "^0.2|^0.3|^1.0",
         "spatie/color": "^1.5",
         "spatie/invade": "^1.0|^2.0",


### PR DESCRIPTION
We need to bump the minimum Livewire version to 3.4.10 for SPA mode unsaved changes to work.