### PR TITLE
Fix for bug #12392

### DIFF
--- a/packages/forms/resources/js/components/markdown-editor.js
+++ b/packages/forms/resources/js/components/markdown-editor.js
@@ -83,6 +83,7 @@ CodeMirror.commands.shiftTabAndUnindentMarkdownList = function (codemirror) {
 }
 
 export default function markdownEditorFormComponent({
+    canAttachFiles,
     isLiveDebounced,
     isLiveOnBlur,
     liveDebounce,
@@ -92,7 +93,6 @@ export default function markdownEditorFormComponent({
     state,
     translations,
     toolbarButtons,
-    uploadFileAllowed,
     uploadFileAttachmentUsing,
 }) {
     return {
@@ -126,7 +126,7 @@ export default function markdownEditorFormComponent({
                     },
                 ],
                 toolbar: this.getToolbar(),
-                uploadImage: uploadFileAllowed,
+                uploadImage: canAttachFiles,
             })
 
             this.editor.codemirror.setOption(

--- a/packages/forms/resources/js/components/markdown-editor.js
+++ b/packages/forms/resources/js/components/markdown-editor.js
@@ -92,6 +92,7 @@ export default function markdownEditorFormComponent({
     state,
     translations,
     toolbarButtons,
+    uploadFileAllowed,
     uploadFileAttachmentUsing,
 }) {
     return {
@@ -125,7 +126,7 @@ export default function markdownEditorFormComponent({
                     },
                 ],
                 toolbar: this.getToolbar(),
-                uploadImage: true,
+                uploadImage: uploadFileAllowed,
             })
 
             this.editor.codemirror.setOption(

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -32,6 +32,7 @@
                             state: $wire.{{ $applyStateBindingModifiers("\$entangle('{$statePath}')", isOptimisticallyLive: false) }},
                             toolbarButtons: @js($getToolbarButtons()),
                             translations: @js(__('filament-forms::components.markdown_editor')),
+                            uploadFileAllowed: @js($hasToolbarButton('attachFiles')),
                             uploadFileAttachmentUsing: async (file, onSuccess, onError) => {
                                 $wire.upload(`componentFileAttachments.{{ $statePath }}`, file, () => {
                                     $wire

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -23,6 +23,7 @@
                 ax-load="visible"
                 ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('markdown-editor', 'filament/forms') }}"
                 x-data="markdownEditorFormComponent({
+                            canAttachFiles: @js($hasToolbarButton('attachFiles')),
                             isLiveDebounced: @js($isLiveDebounced()),
                             isLiveOnBlur: @js($isLiveOnBlur()),
                             liveDebounce: @js($getNormalizedLiveDebounce()),
@@ -32,7 +33,6 @@
                             state: $wire.{{ $applyStateBindingModifiers("\$entangle('{$statePath}')", isOptimisticallyLive: false) }},
                             toolbarButtons: @js($getToolbarButtons()),
                             translations: @js(__('filament-forms::components.markdown_editor')),
-                            uploadFileAllowed: @js($hasToolbarButton('attachFiles')),
                             uploadFileAttachmentUsing: async (file, onSuccess, onError) => {
                                 $wire.upload(`componentFileAttachments.{{ $statePath }}`, file, () => {
                                     $wire

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -98,7 +98,7 @@
                     'ring-1 ring-gray-950/10 dark:ring-white/20' => (($color === 'gray') || ($tag === 'label')) && (! $grouped),
                     'bg-custom-600 text-white hover:bg-custom-500 focus-visible:ring-custom-500/50 dark:bg-custom-500 dark:hover:bg-custom-400 dark:focus-visible:ring-custom-400/50' => ($color !== 'gray') && ($tag !== 'label'),
                     '[input:checked+&]:bg-custom-600 [input:checked+&]:text-white [input:checked+&]:ring-0 [input:checked+&]:hover:bg-custom-500 dark:[input:checked+&]:bg-custom-500 dark:[input:checked+&]:hover:bg-custom-400 [input:checked:focus-visible+&]:ring-custom-500/50 dark:[input:checked:focus-visible+&]:ring-custom-400/50 [input:focus-visible+&]:z-10 [input:focus-visible+&]:ring-2 [input:focus-visible+&]:ring-gray-950/10 dark:[input:focus-visible+&]:ring-white/20' => ($color !== 'gray') && ($tag === 'label'),
-                    ]
+                ]
         ),
     ]);
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fix for bug #12392 (Disable the ability to upload files with drag & drop when the 'attachFiles' button is not present in the editor.)

## Visual changes

Nope

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
