### PR TITLE
Add mask money for text input

### DIFF
--- a/packages/forms/docs/03-fields/02-text-input.md
+++ b/packages/forms/docs/03-fields/02-text-input.md
@@ -211,6 +211,15 @@ TextInput::make('amount')
     ->numeric()
 ```
 
+or
+
+```php
+use Filament\Forms\Components\TextInput;
+
+TextInput::make('amount')
+    ->maskMoney()
+```
+
 ## Making the field read-only
 
 Not to be confused with [disabling the field](getting-started#disabling-a-field), you may make the field "read-only" using the `readOnly()` method:

--- a/packages/forms/docs/03-fields/02-text-input.md
+++ b/packages/forms/docs/03-fields/02-text-input.md
@@ -217,7 +217,7 @@ or
 use Filament\Forms\Components\TextInput;
 
 TextInput::make('amount')
-    ->maskMoney()
+    ->money()
 ```
 
 ## Making the field read-only

--- a/packages/forms/src/Components/TextInput.php
+++ b/packages/forms/src/Components/TextInput.php
@@ -88,6 +88,19 @@ class TextInput extends Field implements CanHaveNumericState, Contracts\CanBeLen
         return $this;
     }
 
+    public function maskMoney(int | Closure | null $decimalPlaces = 2, string | Closure | null $decimalSeparator = '.', string | Closure | null $thousandsSeparator = ','): static
+    {
+        $decimalPlaces = $this->evaluate($decimalPlaces);
+        $decimalSeparator = $this->evaluate($decimalSeparator);
+        $thousandsSeparator = $this->evaluate($thousandsSeparator);
+
+        $this->numeric()
+            ->mask(RawJs::make(sprintf('$money($input, \'%s\', \'%s\', %s)', $decimalSeparator, $thousandsSeparator, $decimalPlaces)))
+            ->stripCharacters($thousandsSeparator);
+
+        return $this;
+    }
+
     /**
      * @param  scalar | Closure | null  $value
      */

--- a/packages/forms/src/Components/TextInput.php
+++ b/packages/forms/src/Components/TextInput.php
@@ -88,7 +88,7 @@ class TextInput extends Field implements CanHaveNumericState, Contracts\CanBeLen
         return $this;
     }
 
-    public function maskMoney(int | Closure | null $decimalPlaces = 2, string | Closure | null $decimalSeparator = '.', string | Closure | null $thousandsSeparator = ','): static
+    public function money(int | Closure | null $decimalPlaces = 2, string | Closure | null $decimalSeparator = '.', string | Closure | null $thousandsSeparator = ','): static
     {
         $decimalPlaces = $this->evaluate($decimalPlaces);
         $decimalSeparator = $this->evaluate($decimalSeparator);


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

I really don't like whenever I need to create mask input money for my input, I have to ask myself "what was that again?" and search something like this in documentation:
<img width="1047" alt="image" src="https://github.com/filamentphp/filament/assets/25253808/def32c8d-07a4-46fb-a093-546d76cbf897">

EVERYTIME!

## Visual changes

<img width="471" alt="image" src="https://github.com/filamentphp/filament/assets/25253808/999ed8b3-38b4-4866-a756-d16a35a1aefb">

<img width="608" alt="image" src="https://github.com/filamentphp/filament/assets/25253808/d9f1f390-0a0f-49e5-b139-33a3b7d88f97">


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
