### PR TITLE
removes highlighting when day is disabled

### DIFF
--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -214,11 +214,11 @@
                                                 focusedDate.date() !== day &&
                                                 ! dayIsDisabled(day),
                                             'bg-gray-50 dark:bg-white/5':
-                                                focusedDate.date() === day && ! dayIsSelected(day),
+                                                focusedDate.date() === day && ! dayIsSelected(day) && ! dayIsDisabled(day),
                                             'text-primary-600 bg-gray-50 dark:bg-white/5 dark:text-primary-400':
                                                 dayIsSelected(day),
                                             'pointer-events-none': dayIsDisabled(day),
-                                            'opacity-50': focusedDate.date() !== day && dayIsDisabled(day),
+                                            'opacity-50': dayIsDisabled(day),
                                         }"
                                         class="rounded-full text-center text-sm leading-loose transition duration-75"
                                     ></div>


### PR DESCRIPTION
## Description

When disabling "today's date" the UI indicates that today's date is select-able and/or currently selected.  This update will resolve two UI issues.

- When opening a datepicker that has the current date disabled, that day will no longer display as visually active/selected.
- When a date in a given month is selected, switching months will ignore the disabled settings for that same numeric date.  An example:
    > If the current month is April, and April 11th is disabled, opening the datepicker will show the 11th as disabled.  Changing the month to May and selecting May 11th will show the May 11th as selected.  However, when you change the month back to April, it will show April 11th - a disabled day - as visually active.
    

This bug is particularly notable - so while the existing code _does_ have pointer-events-none, this is not perceivable when using a mobile device, so the visual changes here will more effectively communicate disabled dates across all devices. 


## Visual changes

### Today's date bug-fix

**Before:** April 19th (today's date) is shown as highlighted:

![Screenshot 2024-04-19 at 8 58 03 AM](https://github.com/filamentphp/filament/assets/4382816/49a08f45-563c-432c-b34c-2d516fcb853b)


**Before:** April 19th (today's date) is shown correctly as disabled:

![Screenshot 2024-04-19 at 8 57 52 AM](https://github.com/filamentphp/filament/assets/4382816/9227d0ca-36fa-4184-9400-f8f5e3807934)

### Cross-month selection bug-fix

**Before:** Selecting May 11th and showing April 11th as highlighted:

https://github.com/filamentphp/filament/assets/4382816/d0103cd4-773e-4950-a1fb-200a745f78d7

**After:** Selecting May 11th and showing April 11th as disabled:

https://github.com/filamentphp/filament/assets/4382816/27dcdff6-a39d-4b27-bd54-59aad0a82019



## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
