### PR TITLE
Allow Htmlable on Table actions column label

### DIFF
--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -2,8 +2,10 @@
 
 namespace Filament\Tables;
 
+use Closure;
 use Filament\Support\Components\ViewComponent;
 use Filament\Tables\Contracts\HasTable;
+use Illuminate\Contracts\Support\Htmlable;
 
 class Table extends ViewComponent
 {
@@ -65,6 +67,8 @@ class Table extends ViewComponent
     public static string $defaultDateTimeDisplayFormat = 'M j, Y H:i:s';
 
     public static string $defaultTimeDisplayFormat = 'H:i:s';
+
+    public static string | Closure | Htmlable | null $defaultActionsColumnLabel = null;
 
     final public function __construct(HasTable $livewire)
     {

--- a/packages/tables/src/Table/Concerns/HasActions.php
+++ b/packages/tables/src/Table/Concerns/HasActions.php
@@ -245,6 +245,6 @@ trait HasActions
 
     public function getActionsColumnLabel(): string | Htmlable | null
     {
-        return $this->evaluate($this->actionsColumnLabel ?? Table::$defaultActionsColumnLabel);
+        return $this->evaluate($this->actionsColumnLabel) ?? $this->evaluate(Table::$defaultActionsColumnLabel);
     }
 }

--- a/packages/tables/src/Table/Concerns/HasActions.php
+++ b/packages/tables/src/Table/Concerns/HasActions.php
@@ -10,6 +10,7 @@ use Filament\Tables\Actions\ActionGroup;
 use Filament\Tables\Enums\ActionsPosition;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Contracts\Support\Htmlable;
 use InvalidArgumentException;
 
 trait HasActions
@@ -24,7 +25,7 @@ trait HasActions
      */
     protected array $flatActions = [];
 
-    protected string | Closure | null $actionsColumnLabel = null;
+    protected string | Htmlable | Closure | null $actionsColumnLabel = null;
 
     protected string | Closure | null $actionsAlignment = null;
 
@@ -77,7 +78,7 @@ trait HasActions
         return $this;
     }
 
-    public function actionsColumnLabel(string | Closure | null $label): static
+    public function actionsColumnLabel(string | Htmlable | Closure | null $label): static
     {
         $this->actionsColumnLabel = $label;
 
@@ -241,7 +242,7 @@ trait HasActions
         return $this->evaluate($this->actionsAlignment);
     }
 
-    public function getActionsColumnLabel(): ?string
+    public function getActionsColumnLabel(): string | Htmlable | null
     {
         return $this->evaluate($this->actionsColumnLabel);
     }

--- a/packages/tables/src/Table/Concerns/HasActions.php
+++ b/packages/tables/src/Table/Concerns/HasActions.php
@@ -5,6 +5,7 @@ namespace Filament\Tables\Table\Concerns;
 use Closure;
 use Filament\Actions\Contracts\HasRecord;
 use Filament\Support\Enums\ActionSize;
+use Filament\Tables\Table;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\ActionGroup;
 use Filament\Tables\Enums\ActionsPosition;
@@ -244,6 +245,6 @@ trait HasActions
 
     public function getActionsColumnLabel(): string | Htmlable | null
     {
-        return $this->evaluate($this->actionsColumnLabel);
+        return $this->evaluate($this->actionsColumnLabel ?? Table::$defaultActionsColumnLabel);
     }
 }


### PR DESCRIPTION
## Description

Allows to render HTML content in a table action column label as would in other table column labels.

## Visual changes

```
$table->actionsColumnLabel(new HtmlString(Blade::render('<x-heroicon-s-bolt class="w-5 h-5"/>')));
```
Or by default with [Allow Table static default Actions Column Label](https://github.com/filamentphp/filament/pull/12414/commits/01e435a2462b8bf5c265ac0a907cf8f01adb4339)
```
Table::$defaultActionsColumnLabel = new HtmlString(Blade::render('<x-heroicon-s-bolt class="w-5 h-5"/>'));
```

![Htmable Actons Icon](https://github.com/filamentphp/filament/assets/75676493/7f67671f-50a3-4184-859a-113b69b63d3b)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
