### PR TITLE
Allow Table static default Action Size and View

### DIFF
--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -2,6 +2,8 @@
 
 namespace Filament\Tables;
 
+use Closure;
+use Filament\Support\Enums\ActionSize;
 use Filament\Support\Components\ViewComponent;
 use Filament\Tables\Contracts\HasTable;
 
@@ -65,6 +67,10 @@ class Table extends ViewComponent
     public static string $defaultDateTimeDisplayFormat = 'M j, Y H:i:s';
 
     public static string $defaultTimeDisplayFormat = 'H:i:s';
+
+    public static string | Closure | null $defaultActionView = null;
+
+    public static string | Closure | ActionSize | null $defaultActionSize = null;
 
     final public function __construct(HasTable $livewire)
     {

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -68,9 +68,9 @@ class Table extends ViewComponent
 
     public static string $defaultTimeDisplayFormat = 'H:i:s';
 
-    public static string | Closure | null $defaultActionView = null;
+    public static string | Closure | null $defaultActionsColumnActionView = null;
 
-    public static string | Closure | ActionSize | null $defaultActionSize = null;
+    public static string | Closure | ActionSize | null $defaultActionsColumnActionSize = null;
 
     final public function __construct(HasTable $livewire)
     {

--- a/packages/tables/src/Table/Concerns/HasActions.php
+++ b/packages/tables/src/Table/Concerns/HasActions.php
@@ -64,8 +64,8 @@ trait HasActions
 
                 $this->mergeCachedFlatActions($flatActions);
             } elseif ($action instanceof Action) {
-                $action->defaultSize(Table::$defaultActionSize ?? ActionSize::Small);
-                $action->defaultView(Table::$defaultActionView ?? $action::LINK_VIEW);
+                $action->defaultSize(Table::$defaultActionsColumnActionSize ?? ActionSize::Small);
+                $action->defaultView(Table::$defaultActionsColumnActionView ?? $action::LINK_VIEW);
 
                 $this->cacheAction($action);
             } else {

--- a/packages/tables/src/Table/Concerns/HasActions.php
+++ b/packages/tables/src/Table/Concerns/HasActions.php
@@ -5,6 +5,7 @@ namespace Filament\Tables\Table\Concerns;
 use Closure;
 use Filament\Actions\Contracts\HasRecord;
 use Filament\Support\Enums\ActionSize;
+use Filament\Tables\Table;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\ActionGroup;
 use Filament\Tables\Enums\ActionsPosition;
@@ -63,8 +64,8 @@ trait HasActions
 
                 $this->mergeCachedFlatActions($flatActions);
             } elseif ($action instanceof Action) {
-                $action->defaultSize(ActionSize::Small);
-                $action->defaultView($action::LINK_VIEW);
+                $action->defaultSize(Table::$defaultActionSize ?? ActionSize::Small);
+                $action->defaultView(Table::$defaultActionView ?? $action::LINK_VIEW);
 
                 $this->cacheAction($action);
             } else {


### PR DESCRIPTION
## Description

Allow a simple default initialization method for the size and view actions of all tables.

## Visual changes

```
use Filament\Tables;
use Filament\Support\Enums;

Tables\Table::$defaultActionsColumnActionSize = Enums\ActionSize::Large;
Tables\Table::$defaultActionsColumnActionView = Tables\Actions\Action::ICON_BUTTON_VIEW;
```
![Table Actions Before](https://github.com/filamentphp/filament/assets/75676493/1ed87767-4f3d-4440-b82e-991d84bef5db)
![Table Actions After](https://github.com/filamentphp/filament/assets/75676493/8d9a5999-c2b2-4216-a79b-26f4d348e861)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
