### PR TITLE
CanLimitItemsLength trait for CheckboxList field

### DIFF
--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -19,6 +19,7 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
     use Concerns\CanDisableOptions;
     use Concerns\CanDisableOptionsWhenSelectedInSiblingRepeaterItems;
     use Concerns\CanFixIndistinctState;
+    use Concerns\CanLimitItemsLength;
     use Concerns\HasDescriptions;
     use Concerns\HasExtraInputAttributes;
     use Concerns\HasGridDirection;


### PR DESCRIPTION
## Description
This PR adds the `CanLimitItemsLength` trait to the `CheckboxList` field. This allows validation rules like `minItems` and `maxItems` to be used.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
