### PR TITLE
Fix placeholder line height

### DIFF
--- a/packages/infolists/resources/views/components/entries/placeholder.blade.php
+++ b/packages/infolists/resources/views/components/entries/placeholder.blade.php
@@ -1,3 +1,5 @@
-<div class="fi-in-placeholder text-sm text-gray-400 dark:text-gray-500">
+<div
+    class="fi-in-placeholder text-sm leading-6 text-gray-400 dark:text-gray-500"
+>
     {{ $slot }}
 </div>

--- a/packages/tables/resources/views/components/columns/placeholder.blade.php
+++ b/packages/tables/resources/views/components/columns/placeholder.blade.php
@@ -1,3 +1,5 @@
-<div class="fi-ta-placeholder text-sm text-gray-400 dark:text-gray-500">
+<div
+    class="fi-ta-placeholder text-sm leading-6 text-gray-400 dark:text-gray-500"
+>
     {{ $slot }}
 </div>


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Placeholder line height didn't match that of the actual content.
This PR adds the `leading-6` Tailwind CSS class to the placeholder so it matches the height of entries/rows with actual content.


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
