### PR TITLE
Fix infolist entry label

### DIFF
--- a/packages/infolists/src/Components/Entry.php
+++ b/packages/infolists/src/Components/Entry.php
@@ -41,7 +41,8 @@ class Entry extends Component implements HasHintActions
     public function getLabel(): string | Htmlable | null
     {
         $label = parent::getLabel() ?? (string) str($this->getName())
-            ->before('.')
+            ->beforeLast('.')
+            ->afterLast('.')
             ->kebab()
             ->replace(['-', '_'], ' ')
             ->ucfirst();


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Infolist entries of nested relationship attributes currently get a wrong label which is different from what a table column with the same name gets.

| | Column/entry name | Table column label | Infolist entry label
|---|---|---|---|
| **Before this fix** | generation.project.team.name | Team | Generation |
| **After this fix** | generation.project.team.name | Team | Team |

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
