### PR TITLE
Fix unintentionally scrolling sidebar

### DIFF
--- a/packages/panels/resources/views/components/sidebar/index.blade.php
+++ b/packages/panels/resources/views/components/sidebar/index.blade.php
@@ -41,7 +41,7 @@
         ])
     }}
 >
-    <div class="overflow-x-clip">
+    <div class="sticky top-0 z-20 overflow-x-clip">
         <header
             class="fi-sidebar-header flex h-16 items-center bg-white px-6 ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 lg:shadow-sm"
         >


### PR DESCRIPTION
When using certain field components that have `<template>` tags in for modals and alpine collapse functionality, the sidebar can end up scrolling incorrectly over the sticky header.

The header is `sticky` with a `z-20`, so this PR adds the same to the sidebar.

Top header wrapper:
<img width="403" alt="Screenshot 2024-04-23 at 12 25 58" src="https://github.com/filamentphp/filament/assets/20431294/9e5db8aa-5f63-4d04-bd4e-ab79d6862831">

Sidebar wrapper before:
<img width="302" alt="image" src="https://github.com/filamentphp/filament/assets/20431294/dd44a943-783b-4135-b7fd-b8fa58b101e3">

Sidebar wrapper after:
<img width="344" alt="image" src="https://github.com/filamentphp/filament/assets/20431294/af708b90-3c39-4ef9-9f79-0acae8dfcf52">

Video showing issue:

https://github.com/filamentphp/filament/assets/20431294/5da54f86-a5fc-4143-a755-f7dfee818192

I have checked scenarios for mobile menu, top navigation, collapse navigation and all appear to be correct.
