### PR TITLE
Unable to set collapsed() in Builder field due to hardcoded setting

### DIFF
--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -144,8 +144,6 @@ class Builder extends Field implements Contracts\CanConcealComponents, Contracts
 
                 $component->getChildComponentContainer($newUuid)->fill();
 
-                $component->collapsed(false, shouldMakeComponentCollapsible: false);
-
                 $component->callAfterStateUpdated();
             })
             ->livewireClickHandlerEnabled(false)


### PR DESCRIPTION
## Description
The component to add new Builder blocks to the field contains hardcoded collapsed(false) which prevents from setting this setting at Resource level.

## Visual changes
No visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
