### PR TITLE
Missing Translation - European Portuguese

### DIFF
--- a/packages/panels/resources/lang/pt_PT/unsaved-changes-alert.php
+++ b/packages/panels/resources/lang/pt_PT/unsaved-changes-alert.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'body' => 'Existem alterações não guardadas. Tem a certeza que pretende sair desta página?',
+
+];


### PR DESCRIPTION
European Portuguese missing translation

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
