### PR TITLE
Allow local links in rich editor

### DIFF
--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -458,7 +458,8 @@
                                     name="href"
                                     placeholder="{{ __('filament-forms::components.rich_editor.dialogs.link.placeholder') }}"
                                     required
-                                    type="url"
+                                    type="text"
+                                    pattern = "(https?://|/).+"
                                     class="trix-input trix-input--dialog"
                                 />
 

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -459,7 +459,7 @@
                                     placeholder="{{ __('filament-forms::components.rich_editor.dialogs.link.placeholder') }}"
                                     required
                                     type="text"
-                                    pattern = "(https?://|/).+"
+                                    inputmode="url"
                                     class="trix-input trix-input--dialog"
                                 />
 


### PR DESCRIPTION
Using the Rich Editor link, it is only possible to insert full links: http://my.link or https://my.link this is problematic if you want to link contents inside the same site or you have to move contents between multiple domains.

## Description

Changes allow rich editor links relative to the current site, like /my/site/link and use the pattern to allow such links on a text input

## Visual changes

No visual changes

## Functional changes

- [x] Allow internal links on RichEditor
