### PR TITLE
Add option to remove topbar from the profile page

### DIFF
--- a/packages/panels/src/Pages/Auth/EditProfile.php
+++ b/packages/panels/src/Pages/Auth/EditProfile.php
@@ -35,6 +35,7 @@ use function Filament\Support\is_app_url;
 class EditProfile extends Page
 {
     use Concerns\CanUseDatabaseTransactions;
+    use Concerns\HasTopbar;
     use Concerns\InteractsWithFormActions;
 
     /**
@@ -43,8 +44,6 @@ class EditProfile extends Page
     public ?array $data = [];
 
     protected ?string $maxWidth = null;
-
-    protected bool $hasTopbar = true;
 
     protected static bool $isDiscovered = false;
 
@@ -368,10 +367,5 @@ class EditProfile extends Page
     public function getMaxWidth(): MaxWidth | string | null
     {
         return $this->maxWidth;
-    }
-
-    public function hasTopbar(): bool
-    {
-        return $this->hasTopbar;
     }
 }

--- a/packages/panels/src/Pages/Auth/EditProfile.php
+++ b/packages/panels/src/Pages/Auth/EditProfile.php
@@ -44,6 +44,8 @@ class EditProfile extends Page
 
     protected ?string $maxWidth = null;
 
+    protected bool $hasTopbar = true;
+
     protected static bool $isDiscovered = false;
 
     public function getLayout(): string
@@ -358,6 +360,7 @@ class EditProfile extends Page
     protected function getLayoutData(): array
     {
         return [
+            'hasTopbar' => $this->hasTopbar(),
             'maxWidth' => $this->getMaxWidth(),
         ];
     }
@@ -365,5 +368,10 @@ class EditProfile extends Page
     public function getMaxWidth(): MaxWidth | string | null
     {
         return $this->maxWidth;
+    }
+
+    public function hasTopbar(): bool
+    {
+        return $this->hasTopbar;
     }
 }

--- a/packages/panels/src/Pages/Auth/EditProfile.php
+++ b/packages/panels/src/Pages/Auth/EditProfile.php
@@ -15,7 +15,6 @@ use Filament\Pages\Concerns;
 use Filament\Pages\Page;
 use Filament\Panel;
 use Filament\Support\Enums\Alignment;
-use Filament\Support\Enums\MaxWidth;
 use Filament\Support\Exceptions\Halt;
 use Filament\Support\Facades\FilamentView;
 use Illuminate\Contracts\Auth\Authenticatable;
@@ -35,6 +34,7 @@ use function Filament\Support\is_app_url;
 class EditProfile extends Page
 {
     use Concerns\CanUseDatabaseTransactions;
+    use Concerns\HasMaxWidth;
     use Concerns\HasTopbar;
     use Concerns\InteractsWithFormActions;
 
@@ -42,8 +42,6 @@ class EditProfile extends Page
      * @var array<string, mixed> | null
      */
     public ?array $data = [];
-
-    protected ?string $maxWidth = null;
 
     protected static bool $isDiscovered = false;
 
@@ -362,10 +360,5 @@ class EditProfile extends Page
             'hasTopbar' => $this->hasTopbar(),
             'maxWidth' => $this->getMaxWidth(),
         ];
-    }
-
-    public function getMaxWidth(): MaxWidth | string | null
-    {
-        return $this->maxWidth;
     }
 }

--- a/packages/panels/src/Pages/Concerns/HasMaxWidth.php
+++ b/packages/panels/src/Pages/Concerns/HasMaxWidth.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Filament\Pages\Concerns;
+
+use Filament\Support\Enums\MaxWidth;
+
+trait HasMaxWidth
+{
+    protected ?string $maxWidth = null;
+
+    public function getMaxWidth(): MaxWidth | string | null
+    {
+        return $this->maxWidth;
+    }
+}

--- a/packages/panels/src/Pages/Concerns/HasTopbar.php
+++ b/packages/panels/src/Pages/Concerns/HasTopbar.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Filament\Pages\Concerns;
+
+trait HasTopbar
+{
+    protected bool $hasTopbar = true;
+
+    public function hasTopbar(): bool
+    {
+        return $this->hasTopbar;
+    }
+}

--- a/packages/panels/src/Pages/SimplePage.php
+++ b/packages/panels/src/Pages/SimplePage.php
@@ -6,11 +6,11 @@ use Filament\Support\Enums\MaxWidth;
 
 abstract class SimplePage extends BasePage
 {
+    use Concerns\HasTopbar;
+
     protected static string $layout = 'filament-panels::components.layout.simple';
 
     protected ?string $maxWidth = null;
-
-    protected bool $hasTopbar = true;
 
     protected function getLayoutData(): array
     {
@@ -28,10 +28,5 @@ abstract class SimplePage extends BasePage
     public function hasLogo(): bool
     {
         return true;
-    }
-
-    public function hasTopbar(): bool
-    {
-        return $this->hasTopbar;
     }
 }

--- a/packages/panels/src/Pages/SimplePage.php
+++ b/packages/panels/src/Pages/SimplePage.php
@@ -2,15 +2,12 @@
 
 namespace Filament\Pages;
 
-use Filament\Support\Enums\MaxWidth;
-
 abstract class SimplePage extends BasePage
 {
+    use Concerns\HasMaxWidth;
     use Concerns\HasTopbar;
 
     protected static string $layout = 'filament-panels::components.layout.simple';
-
-    protected ?string $maxWidth = null;
 
     protected function getLayoutData(): array
     {
@@ -18,11 +15,6 @@ abstract class SimplePage extends BasePage
             'hasTopbar' => $this->hasTopbar(),
             'maxWidth' => $this->getMaxWidth(),
         ];
-    }
-
-    public function getMaxWidth(): MaxWidth | string | null
-    {
-        return $this->maxWidth;
     }
 
     public function hasLogo(): bool


### PR DESCRIPTION
### Description

Every auth page has an option to remove the topbar except for the profile page. This PR adds the same configuration option as the other pages.