### PR TITLE
Closure support to forms method on CanBeValidated trait

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -676,15 +676,15 @@ trait CanBeValidated
             if (is_numeric($rule)) {
                 $rules[] = $this->evaluate($condition);
             } elseif ($this->evaluate($condition)) {
-                $evaluted = $this->evaluate($rule);
+                $evaluated = $this->evaluate($rule);
 
-                if (is_array($evaluted)) {
+                if (is_array($evaluated)) {
                     $rules = [
                         ...$rules,
-                        ...$evaluted
+                        ...$evaluated
                     ];
                 } else {
-                    $rules[] = $evaluted;
+                    $rules[] = $evaluated;
                 }
             }
         }

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -675,18 +675,26 @@ trait CanBeValidated
         foreach ($this->rules as [$rule, $condition]) {
             if (is_numeric($rule)) {
                 $rules[] = $this->evaluate($condition);
-            } elseif ($this->evaluate($condition)) {
-                $evaluated = $this->evaluate($rule);
 
-                if (is_array($evaluated)) {
-                    $rules = [
-                        ...$rules,
-                        ...$evaluated
-                    ];
-                } else {
-                    $rules[] = $evaluated;
-                }
+                continue;
             }
+            
+            if (! $this->evaluate($condition)) {
+                continue;
+            }
+
+            $rule = $this->evaluate($rule);
+
+            if (is_array($rule)) {
+                $rules = [
+                    ...$rules,
+                    ...$rule
+                ];
+
+                continue;
+            }
+
+            $rules[] = $rule;
         }
 
         return $rules;

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -426,10 +426,19 @@ trait CanBeValidated
     }
 
     /**
-     * @param  string | array<mixed>  $rules
+     * @param  string | array<mixed> | Closure  $rules
      */
-    public function rules(string | array $rules, bool | Closure $condition = true): static
+    public function rules(string | array | Closure $rules, bool | Closure $condition = true): static
     {
+        if ($rules instanceof Closure) {
+            $this->rules = [
+                ...$this->rules,
+                [$rules, $condition]
+            ];
+
+            return $this;
+        }
+
         if (is_string($rules)) {
             $rules = explode('|', $rules);
         }
@@ -667,7 +676,16 @@ trait CanBeValidated
             if (is_numeric($rule)) {
                 $rules[] = $this->evaluate($condition);
             } elseif ($this->evaluate($condition)) {
-                $rules[] = $this->evaluate($rule);
+                $evaluted = $this->evaluate($rule);
+
+                if (is_array($evaluted)) {
+                    $rules = [
+                        ...$rules,
+                        ...$evaluted
+                    ];
+                } else {
+                    $rules[] = $evaluted;
+                }
             }
         }
 


### PR DESCRIPTION
## Description

This PR implements support for closure evaluation in the ->forms($closure) method on classes that use the CanBeValidated trait. While closure evaluation already exists for individual rules, there is currently no implementation that returns an array of rules. For our use case, this implementation allows us to dynamically modify the rules for a specific field. Centralizing the rules on an Enum.

## Visual changes
Before
![Screenshot 2024-04-28 alle 18 30 38](https://github.com/filamentphp/filament/assets/30530408/8c1d53fb-4c68-421d-b1fa-0107485fb2c1)

After
![Screenshot 2024-04-28 alle 18 34 16](https://github.com/filamentphp/filament/assets/30530408/8a5670a8-f112-49aa-b10e-9240de0d46b3)

Enum
![Screenshot 2024-04-28 alle 18 31 26](https://github.com/filamentphp/filament/assets/30530408/19e657e8-6cc2-4920-9b24-6f423b3dc1d2)

## Functional changes
- [x] Changed Trait `vendor/filament/forms/src/Components/Concerns/CanBeValidated.php`
- [x] Test passed
