### PR TITLE
Documentation "notifications/sending-notifications": title & body attribute - Added  HTML / Markdown examples

### DIFF
--- a/packages/notifications/docs/02-sending-notifications.md
+++ b/packages/notifications/docs/02-sending-notifications.md
@@ -45,6 +45,8 @@ Notification::make()
     ->send();
 ```
 
+The title text can contain HTML: `->title(str('Saved **successfully**')->markdown())`
+
 Or with JavaScript:
 
 ```js
@@ -206,6 +208,8 @@ Notification::make()
     ->body('Changes to the post have been saved.')
     ->send();
 ```
+
+The body text can contain HTML: `->body(str('Changes to the **post** have been saved.')->markdown())`
 
 Or with JavaScript:
 

--- a/packages/notifications/docs/02-sending-notifications.md
+++ b/packages/notifications/docs/02-sending-notifications.md
@@ -45,7 +45,7 @@ Notification::make()
     ->send();
 ```
 
-The title text can contain HTML: `->title(str('Saved **successfully**')->markdown())`
+The title text can contain basic, safe HTML elements. To generate safe HTML with Markdown, you can use the [`Str::markdown()` helper](https://laravel.com/docs/strings#method-str-markdown): `title(Str::markdown('Saved **successfully**'))`
 
 Or with JavaScript:
 
@@ -209,7 +209,7 @@ Notification::make()
     ->send();
 ```
 
-The body text can contain HTML: `->body(str('Changes to the **post** have been saved.')->markdown())`
+The body text can contain basic, safe HTML elements. To generate safe HTML with Markdown, you can use the [`Str::markdown()` helper](https://laravel.com/docs/strings#method-str-markdown): `body(Str::markdown('Changes to the **post** have been saved.'))`
 
 Or with JavaScript:
 


### PR DESCRIPTION
## Description

This PR updates the "notifications/sending-notifications" documentation of Filament V3.

It adds HTML / Markdown examples for the "notification title & body" attribute. In V2 Markdown was parsed automatically. In V3 this has to be done manually. The example shows how to do it.

See @pxlrbt comment / request for a PR on Discord: https://discord.com/channels/883083792112300104/1233674906995130408/1234164194987737249

---

## Original question asked on Discord:

In V3, Markdown is not parsed when I do `Notification::make()->body('Some **bold** text')->>send();`

Is there a replacement method to parse the body?

There is no mention of this change in the V3 documentation or in the "Upgrading from v2.x" guide. It would be great, if the documentation can be updated here.

V3 docs: https://filamentphp.com/docs/3.x/notifications/sending-notifications#setting-body-text

V2 docs: https://filamentphp.com/docs/2.x/notifications/sending-notifications#body 
