### PR TITLE
euc-kr is a superset of iso-8859-1

### DIFF
--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -410,6 +410,11 @@ trait CanImportRecords
                 continue;
             }
 
+            // euc-kr is a superset of iso-8859-1
+            if ($encoding === 'ISO-8859-1' && mb_detect_encoding($fileContents, 'EUC-KR')) {
+                $encoding = 'EUC-KR';
+            }
+
             return $encoding;
         }
 

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -410,8 +410,11 @@ trait CanImportRecords
                 continue;
             }
 
-            // euc-kr is a superset of iso-8859-1
-            if ($encoding === 'ISO-8859-1' && mb_detect_encoding($fileContents, 'EUC-KR')) {
+            if (
+                ($encoding === 'ISO-8859-1') &&
+                mb_detect_encoding($fileContents, 'EUC-KR')
+            ) {
+                // EUC-KR is a superset of ISO-8859-1
                 $encoding = 'EUC-KR';
             }
 


### PR DESCRIPTION
## Description

Fix encoding issues when importing CSV files in Excel 2007

When importing CSV files into Excel 2007, there were encoding issues. While converting from ISO-8859-1 to UTF-8 worked, encoding errors persisted.

After trying various approaches, it was discovered that EUC-KR is a subset of ISO-8859-1. By adding code to handle EUC-KR encoding, the issue was resolved.

This commit addresses the encoding problems by incorporating the necessary changes to handle EUC-KR encoding when importing CSV files into Excel 2007.

## Visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
