### PR TITLE
Fix namespace typo \Filament\Forms\Components\Tabs\Tab::class

### DIFF
--- a/packages/forms/resources/views/components/tabs/tab.blade.php
+++ b/packages/forms/resources/views/components/tabs/tab.blade.php
@@ -24,7 +24,7 @@
                 'id' => $id,
                 'role' => 'tabpanel',
                 'tabindex' => '0',
-                'wire:key' => "{$this->getId()}.{$getStatePath()}." . \Filament\Forms\Components\Tab::class . ".tabs.{$id}",
+                'wire:key' => "{$this->getId()}.{$getStatePath()}." . \Filament\Forms\Components\Tabs\Tab::class . ".tabs.{$id}",
             ], escape: false)
             ->merge($getExtraAttributes(), escape: false)
             ->class(['fi-fo-tabs-tab outline-none'])


### PR DESCRIPTION
Just fixing the correct namespace of the class:

```diff
- \Filament\Forms\Components\Tab::class
+ \Filament\Forms\Components\Tabs\Tab::class
```
