### PR TITLE
bugfix: stream_get_contents retrieves content in bytes, which may result in unexpected content

### DIFF
--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -398,8 +398,8 @@ trait CanImportRecords
     {
         $fileHeader = fgets($resource);
 
-        // Encoding of a subset should be declared before the encoding of its superset
-        $encodingLists = [
+        // The encoding of a subset should be declared before the encoding of its superset.
+        $encodings = [
             'UTF-8',
             'SJIS-win',
             'EUC-KR',
@@ -410,7 +410,7 @@ trait CanImportRecords
             'EUC-JP',
         ];
 
-        foreach ($encodingLists as $encoding) {
+        foreach ($encodings as $encoding) {
             if (! mb_check_encoding($fileHeader, $encoding)) {
                 continue;
             }

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -396,26 +396,23 @@ trait CanImportRecords
 
     protected function detectCsvEncoding(mixed $resource): ?string
     {
-        $fileContents = stream_get_contents($resource, 1000);
+        $fileHeader = fgets($resource);
 
-        foreach ([
+        // Encoding of a subset should be declared before the encoding of its superset
+        $encodingLists = [
             'UTF-8',
+            'SJIS-win',
+            'EUC-KR',
             'ISO-8859-1',
             'GB18030',
             'Windows-1251',
             'Windows-1252',
             'EUC-JP',
-        ] as $encoding) {
-            if (! mb_check_encoding($fileContents, $encoding)) {
-                continue;
-            }
+        ];
 
-            if (
-                ($encoding === 'ISO-8859-1') &&
-                mb_detect_encoding($fileContents, 'EUC-KR')
-            ) {
-                // EUC-KR is a superset of ISO-8859-1
-                $encoding = 'EUC-KR';
+        foreach ($encodingLists as $encoding) {
+            if (! mb_check_encoding($fileHeader, $encoding)) {
+                continue;
             }
 
             return $encoding;


### PR DESCRIPTION

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
The change in #12381 caused a phenomenon where the mapping string of headers during file upload gets garbled. 
![スクリーンショット 2024-05-01 21 30 28](https://github.com/filamentphp/filament/assets/28666304/a4607e04-e221-4c12-b42e-5685ebdfd93c)


It was found that when there is a multibyte character at the 1000th byte, the garbled content obtained by stream_get_contents is retrieved.
it's advisable to avoid using `stream_get_contents($resource, 1000)`.
![スクリーンショット 2024-05-01 21 29 22](https://github.com/filamentphp/filament/assets/28666304/c1e9ddb6-d85d-45c9-9f2f-e70ccef8133e)

Proposal:
Instead of retrieving up to the 1000th byte, we will modify it to retrieve the first line (header) of the CSV and determine the character code. In this case, there is no need to worry about multibyte characters.

The list of header mappings after the fix
![スクリーンショット 2024-05-01 21 31 29](https://github.com/filamentphp/filament/assets/28666304/ec9d9356-f8fb-4a64-b5a4-2bea37c95366)




<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
