### PR TITLE
Fix documentation about read-only

### DIFF
--- a/packages/forms/docs/03-fields/15-textarea.md
+++ b/packages/forms/docs/03-fields/15-textarea.md
@@ -40,13 +40,13 @@ Textarea::make('description')
 
 ## Making the field read-only
 
-Not to be confused with [disabling the field](getting-started#disabling-a-field), you may make the field "read-only" using the `readonly()` method:
+Not to be confused with [disabling the field](getting-started#disabling-a-field), you may make the field "read-only" using the `readOnly()` method:
 
 ```php
 use Filament\Forms\Components\Textarea;
 
 Textarea::make('description')
-    ->readonly()
+    ->readOnly()
 ```
 
 There are a few differences, compared to [`disabled()`](getting-started#disabling-a-field):


### PR DESCRIPTION
The method for making a textarea component read-only is called 'readOnly()' instead of 'readonly()'.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
The documentation describes that you can make a textarea component read-only by using the method readonly(). That method doesn't exist, but readOnly() does.

This fixes the documentation by referencing the readOnly() method instead of the non-existent readonly() method.
