### PR TITLE
feat: loading section customizable height

### DIFF
--- a/packages/panels/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManager.php
@@ -520,4 +520,18 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
                 fn (Table $table, ?Closure $using) => $table->recordUrl($using),
             );
     }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function getDefaultProperties(): array
+    {
+        $properties = [];
+
+        if (static::isLazy()) {
+            $properties['lazy'] = true;
+        }
+
+        return $properties;
+    }
 }

--- a/packages/panels/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManager.php
@@ -12,6 +12,7 @@ use Filament\Infolists\Infolist;
 use Filament\Pages\Page;
 use Filament\Resources\Concerns\InteractsWithRelationshipTable;
 use Filament\Resources\Pages\ViewRecord;
+use Filament\Support\Concerns\CanBeLazy;
 use Filament\Support\Enums\IconPosition;
 use Filament\Tables;
 use Filament\Tables\Actions\BulkAction;
@@ -27,6 +28,7 @@ use function Filament\authorize;
 class RelationManager extends Component implements Actions\Contracts\HasActions, Forms\Contracts\HasForms, Infolists\Contracts\HasInfolists, Tables\Contracts\HasTable
 {
     use Actions\Concerns\InteractsWithActions;
+    use CanBeLazy;
     use Forms\Concerns\InteractsWithForms;
     use Infolists\Concerns\InteractsWithInfolists;
     use InteractsWithRelationshipTable {
@@ -85,8 +87,6 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
     protected static ?string $badgeColor = null;
 
     protected static ?string $badgeTooltip = null;
-
-    protected static bool $isLazy = true;
 
     public function mount(): void
     {
@@ -519,24 +519,5 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
                 $this->getTableRecordUrlUsing(),
                 fn (Table $table, ?Closure $using) => $table->recordUrl($using),
             );
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    public static function getDefaultProperties(): array
-    {
-        $properties = [];
-
-        if (static::isLazy()) {
-            $properties['lazy'] = true;
-        }
-
-        return $properties;
-    }
-
-    public static function isLazy(): bool
-    {
-        return static::$isLazy;
     }
 }

--- a/packages/support/resources/views/components/loading-section.blade.php
+++ b/packages/support/resources/views/components/loading-section.blade.php
@@ -29,5 +29,5 @@
     :twoXlStart="$columnStart['2xl'] ?? null"
     class="fi-loading-section"
 >
-    <x-filament::section class="animate-pulse" style="height: {{ $placeholderHeight }};" />
+    <x-filament::section class="animate-pulse" style="height: {{ $placeholderHeight }}" />
 </x-filament::grid.column>

--- a/packages/support/resources/views/components/loading-section.blade.php
+++ b/packages/support/resources/views/components/loading-section.blade.php
@@ -11,7 +11,7 @@
         ];
     }
 
-    $placeholderHeight = $getPlaceholderHeight() ?? '8rem'; // 8rem = h-32
+    $placeholderHeight = $getPlaceholderHeight() ?? '8rem';
 @endphp
 
 <x-filament::grid.column

--- a/packages/support/resources/views/components/loading-section.blade.php
+++ b/packages/support/resources/views/components/loading-section.blade.php
@@ -10,6 +10,8 @@
             'default' => $columnStart ?? null,
         ];
     }
+
+    $placeholderHeight = $getPlaceholderHeight() ?? '8rem'; // 8rem = h-32
 @endphp
 
 <x-filament::grid.column
@@ -27,5 +29,5 @@
     :twoXlStart="$columnStart['2xl'] ?? null"
     class="fi-loading-section"
 >
-    <x-filament::section class="h-32 animate-pulse" />
+    <x-filament::section class="animate-pulse" style="height: {{ $placeholderHeight }};" />
 </x-filament::grid.column>

--- a/packages/support/resources/views/components/loading-section.blade.php
+++ b/packages/support/resources/views/components/loading-section.blade.php
@@ -29,5 +29,8 @@
     :twoXlStart="$columnStart['2xl'] ?? null"
     class="fi-loading-section"
 >
-    <x-filament::section class="animate-pulse" style="height: {{ $placeholderHeight }}" />
+    <x-filament::section
+        class="animate-pulse"
+        style="height: {{ $placeholderHeight }}"
+    />
 </x-filament::grid.column>

--- a/packages/support/src/Concerns/CanBeLazy.php
+++ b/packages/support/src/Concerns/CanBeLazy.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Filament\Support\Concerns;
+
+use Illuminate\Contracts\View\View;
+
+trait CanBeLazy
+{
+    protected static bool $isLazy = true;
+
+    protected ?string $placeholderHeight = null;
+
+    public static function isLazy(): bool
+    {
+        return static::$isLazy;
+    }
+
+    public function placeholder(): View
+    {
+        return view('filament::components.loading-section', $this->getPlaceholderData());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function getDefaultProperties(): array
+    {
+        $properties = [];
+
+        if (static::isLazy()) {
+            $properties['lazy'] = true;
+        }
+
+        return $properties;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getPlaceholderData(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public function getPlaceholderHeight(): ?string
+    {
+        return $this->placeholderHeight;
+    }
+}

--- a/packages/support/src/Concerns/CanBeLazy.php
+++ b/packages/support/src/Concerns/CanBeLazy.php
@@ -23,20 +23,6 @@ trait CanBeLazy
     /**
      * @return array<string, mixed>
      */
-    public static function getDefaultProperties(): array
-    {
-        $properties = [];
-
-        if (static::isLazy()) {
-            $properties['lazy'] = true;
-        }
-
-        return $properties;
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
     public function getPlaceholderData(): array
     {
         return [

--- a/packages/widgets/src/Widget.php
+++ b/packages/widgets/src/Widget.php
@@ -91,4 +91,18 @@ abstract class Widget extends Component
             'columnStart' => $this->getColumnStart(),
         ];
     }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function getDefaultProperties(): array
+    {
+        $properties = [];
+
+        if (static::isLazy()) {
+            $properties['lazy'] = true;
+        }
+
+        return $properties;
+    }
 }

--- a/packages/widgets/src/Widget.php
+++ b/packages/widgets/src/Widget.php
@@ -2,14 +2,15 @@
 
 namespace Filament\Widgets;
 
+use Filament\Support\Concerns\CanBeLazy;
 use Illuminate\Contracts\View\View;
 use Livewire\Component;
 
 abstract class Widget extends Component
 {
-    protected static bool $isDiscovered = true;
+    use CanBeLazy;
 
-    protected static bool $isLazy = true;
+    protected static bool $isDiscovered = true;
 
     protected static ?int $sort = null;
 
@@ -67,11 +68,6 @@ abstract class Widget extends Component
         return static::$isDiscovered;
     }
 
-    public static function isLazy(): bool
-    {
-        return static::$isLazy;
-    }
-
     public function render(): View
     {
         return view(static::$view, $this->getViewData());
@@ -88,22 +84,11 @@ abstract class Widget extends Component
     /**
      * @return array<string, mixed>
      */
-    public static function getDefaultProperties(): array
+    public function getPlaceholderData(): array
     {
-        $properties = [];
-
-        if (static::isLazy()) {
-            $properties['lazy'] = true;
-        }
-
-        return $properties;
-    }
-
-    public function placeholder(): View
-    {
-        return view('filament::components.loading-section', [
+        return [
             'columnSpan' => $this->getColumnSpan(),
             'columnStart' => $this->getColumnStart(),
-        ]);
+        ];
     }
 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Sometimes the fixed `h-32` height on the loading section can cause a lot of layout shift when the components are loaded.

This PR adds `$placeholderHeight` to components that can lazy loaded.

I've wrapped the common lazy properties and methods into a new `CanBeLazy` concern and created the `$placeholderHeight` property, so users can override it in each component.

I am just not sure where to put the documentation for this since its a shared concept between multiple components.

Also, I would love a word from you to see what do you think about this, @danharrin.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
