### PR TITLE
Inline global search field suffix

### DIFF
--- a/packages/panels/resources/views/components/global-search/field.blade.php
+++ b/packages/panels/resources/views/components/global-search/field.blade.php
@@ -13,10 +13,11 @@
     </label>
 
     <x-filament::input.wrapper
-        inline-prefix
         prefix-icon="heroicon-m-magnifying-glass"
         prefix-icon-alias="panels::global-search.field"
+        inline-prefix
         :suffix="$suffix"
+        inline-suffix
         wire:target="search"
     >
         <x-filament::input


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The global search field suffix is currently not inline, which means it takes up more space than needed. Also, the prefix icon is in fact inline. Most places I checked have the suffix inline, so I'd suggest streamlining this in Filament too.

Maybe we could introduce an alternative API later to offer more customization options, like this:
```php
->globalSearchField(fn (TextInput $component): TextInput $component->inlineSuffix(false))
```

## Visual changes

### Before

<img width="322" alt="Screenshot 2024-05-06 at 17 23 52" src="https://github.com/filamentphp/filament/assets/44533235/2fe97853-31d4-45a0-87d9-8913611f9a76">

### After

<img width="322" alt="Screenshot 2024-05-06 at 17 23 35" src="https://github.com/filamentphp/filament/assets/44533235/4e85a611-da69-4aa1-aab1-b6118971f508">

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
