### PR TITLE
Add missing support for extra item actions in simple repeater

### DIFF
--- a/packages/forms/resources/views/components/repeater/simple.blade.php
+++ b/packages/forms/resources/views/components/repeater/simple.blade.php
@@ -1,4 +1,6 @@
 @php
+    use Filament\Forms\Components\Actions\Action;
+
     $containers = $getChildComponentContainers();
 
     $addAction = $getAction($getAddActionName());
@@ -7,6 +9,7 @@
     $moveDownAction = $getAction($getMoveDownActionName());
     $moveUpAction = $getAction($getMoveUpActionName());
     $reorderAction = $getAction($getReorderActionName());
+    $extraItemActions = $getExtraItemActions();
 
     $isAddable = $isAddable();
     $isCloneable = $isCloneable();
@@ -41,6 +44,12 @@
                     class="gap-4"
                 >
                     @foreach ($containers as $uuid => $item)
+                        @php
+                            $visibleExtraItemActions = array_filter(
+                                $extraItemActions,
+                                fn (Action $action): bool => $action(['item' => $uuid])->isVisible(),
+                            );
+                        @endphp
                         <li
                             wire:key="{{ $this->getId() }}.{{ $item->getStatePath() }}.{{ $field::class }}.item"
                             x-sortable-item="{{ $uuid }}"
@@ -50,8 +59,14 @@
                                 {{ $item }}
                             </div>
 
-                            @if ($isReorderableWithDragAndDrop || $isReorderableWithButtons || $isCloneable || $isDeletable)
+                            @if ($isReorderableWithDragAndDrop || $isReorderableWithButtons || $isCloneable || $isDeletable || filled($visibleExtraItemActions))
                                 <ul class="flex items-center gap-x-1">
+                                    @foreach ($visibleExtraItemActions as $extraItemAction)
+                                        <li x-on:click.stop>
+                                            {{ $extraItemAction(['item' => $uuid]) }}
+                                        </li>
+                                    @endforeach
+
                                     @if ($isReorderableWithDragAndDrop)
                                         <li x-sortable-handle>
                                             {{ $reorderAction }}

--- a/packages/forms/resources/views/components/repeater/simple.blade.php
+++ b/packages/forms/resources/views/components/repeater/simple.blade.php
@@ -50,6 +50,7 @@
                                 fn (Action $action): bool => $action(['item' => $uuid])->isVisible(),
                             );
                         @endphp
+
                         <li
                             wire:key="{{ $this->getId() }}.{{ $item->getStatePath() }}.{{ $field::class }}.item"
                             x-sortable-item="{{ $uuid }}"
@@ -61,12 +62,6 @@
 
                             @if ($isReorderableWithDragAndDrop || $isReorderableWithButtons || $isCloneable || $isDeletable || $visibleExtraItemActions)
                                 <ul class="flex items-center gap-x-1">
-                                    @foreach ($visibleExtraItemActions as $extraItemAction)
-                                        <li x-on:click.stop>
-                                            {{ $extraItemAction(['item' => $uuid]) }}
-                                        </li>
-                                    @endforeach
-
                                     @if ($isReorderableWithDragAndDrop)
                                         <li x-sortable-handle>
                                             {{ $reorderAction }}
@@ -86,6 +81,12 @@
                                             {{ $moveDownAction(['item' => $uuid])->disabled($loop->last) }}
                                         </li>
                                     @endif
+
+                                    @foreach ($visibleExtraItemActions as $extraItemAction)
+                                        <li>
+                                            {{ $extraItemAction(['item' => $uuid]) }}
+                                        </li>
+                                    @endforeach
 
                                     @if ($isCloneable)
                                         <li>

--- a/packages/forms/resources/views/components/repeater/simple.blade.php
+++ b/packages/forms/resources/views/components/repeater/simple.blade.php
@@ -59,7 +59,7 @@
                                 {{ $item }}
                             </div>
 
-                            @if ($isReorderableWithDragAndDrop || $isReorderableWithButtons || $isCloneable || $isDeletable || filled($visibleExtraItemActions))
+                            @if ($isReorderableWithDragAndDrop || $isReorderableWithButtons || $isCloneable || $isDeletable || $visibleExtraItemActions)
                                 <ul class="flex items-center gap-x-1">
                                     @foreach ($visibleExtraItemActions as $extraItemAction)
                                         <li x-on:click.stop>


### PR DESCRIPTION
## Description

Add missing support for extra item actions in simple repeater

## Visual changes

![CleanShot 2024-05-07 at 14 28 40@2x](https://github.com/filamentphp/filament/assets/4272598/017fc5d1-3334-47c4-8f41-44943f8b8f51)

![CleanShot 2024-05-07 at 14 29 46@2x](https://github.com/filamentphp/filament/assets/4272598/5657b6d9-cebd-4c2a-91c4-cc37eccf024e)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
