### PR TITLE
Norwegian translation update and fix

### DIFF
--- a/packages/forms/resources/lang/no/components.php
+++ b/packages/forms/resources/lang/no/components.php
@@ -405,7 +405,7 @@ return [
 
         'max_items_message' => 'Bare :count kan velges.',
 
-        'no_search_results_message' => 'No alternativer matcher ditt søk.',
+        'no_search_results_message' => 'Ingen alternativer matcher ditt søk.',
 
         'placeholder' => 'Velg et alternativ',
 

--- a/packages/panels/resources/lang/no/layout.php
+++ b/packages/panels/resources/lang/no/layout.php
@@ -52,4 +52,12 @@ return [
 
     ],
 
+    'avatar' => [
+        'alt' => 'Avatar av :name',
+    ],
+
+    'logo' => [
+        'alt' => ':name logo',
+    ],
+
 ];

--- a/packages/panels/resources/lang/no/pages/auth/edit-profile.php
+++ b/packages/panels/resources/lang/no/pages/auth/edit-profile.php
@@ -7,7 +7,7 @@ return [
     'form' => [
 
         'email' => [
-            'label' => 'E-post adresse',
+            'label' => 'E-postadresse',
         ],
 
         'name' => [

--- a/packages/panels/resources/lang/no/pages/auth/email-verification/email-verification-prompt.php
+++ b/packages/panels/resources/lang/no/pages/auth/email-verification/email-verification-prompt.php
@@ -2,9 +2,9 @@
 
 return [
 
-    'title' => 'Bekreft din e-post adresse',
+    'title' => 'Bekreft din e-postadresse',
 
-    'heading' => 'Bekreft din e-post adresse',
+    'heading' => 'Bekreft din e-postadresse',
 
     'actions' => [
 
@@ -16,7 +16,7 @@ return [
 
     'messages' => [
         'notification_not_received' => 'Ikke mottatt e-posten vi sendte?',
-        'notification_sent' => 'Vi har sendt e-post til :email med informasjon om hvordan du bekrefter din e-post adresse.',
+        'notification_sent' => 'Vi har sendt e-post til :email med informasjon om hvordan du bekrefter din e-postadresse.',
     ],
 
     'notifications' => [

--- a/packages/panels/resources/lang/no/pages/auth/login.php
+++ b/packages/panels/resources/lang/no/pages/auth/login.php
@@ -22,7 +22,7 @@ return [
     'form' => [
 
         'email' => [
-            'label' => 'E-post adresse',
+            'label' => 'E-postedresse',
         ],
 
         'password' => [

--- a/packages/panels/resources/lang/no/pages/auth/password-reset/reset-password.php
+++ b/packages/panels/resources/lang/no/pages/auth/password-reset/reset-password.php
@@ -9,7 +9,7 @@ return [
     'form' => [
 
         'email' => [
-            'label' => 'E-post adresse',
+            'label' => 'E-postadresse',
         ],
 
         'password' => [

--- a/packages/panels/resources/lang/no/pages/auth/register.php
+++ b/packages/panels/resources/lang/no/pages/auth/register.php
@@ -18,7 +18,7 @@ return [
     'form' => [
 
         'email' => [
-            'label' => 'E-post adresse',
+            'label' => 'E-postadresse',
         ],
 
         'name' => [

--- a/packages/panels/resources/lang/no/unsaved-changes-alert.php
+++ b/packages/panels/resources/lang/no/unsaved-changes-alert.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'body' => 'Du har endringer som ikke er lagret. Er du sikker på at du vil forlate siden?',
+
+];

--- a/packages/support/resources/lang/no/components/pagination.php
+++ b/packages/support/resources/lang/no/components/pagination.php
@@ -22,8 +22,16 @@ return [
 
     'actions' => [
 
+        'first' => [
+            'label' => 'Første',
+        ],
+
         'go_to_page' => [
             'label' => 'Gå til side :page',
+        ],
+
+        'last' => [
+            'label' => 'Siste',
         ],
 
         'next' => [

--- a/packages/tables/resources/lang/no/table.php
+++ b/packages/tables/resources/lang/no/table.php
@@ -13,8 +13,8 @@ return [
         'text' => [
 
             'actions' => [
-                'collapse_list' => 'Vis :count til',
-                'expand_list' => 'Vis :count mindre',
+                'collapse_list' => 'Vis :count mindre',
+                'expand_list' => 'Vis :count til',
             ],
 
             'more_list_items' => 'og :count til',


### PR DESCRIPTION
Added missing translations.
Fixed spelling errors (email address)
Fixed missed translation of single word.
Fixed mix-up in info-list table.