### PR TITLE
Allow defaultSort to accept Livewire

### DIFF
--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Tables\Concerns;
 
-use Closure;
 use Illuminate\Database\Eloquent\Builder;
 
 trait CanSortRecords
@@ -98,8 +97,8 @@ trait CanSortRecords
 
     protected function applyDefaultSortingToTableQuery(Builder $query): Builder
     {
-        $defaultSort = $this->getTable()->getDefaultSort();
         $sortDirection = ($this->getTable()->getDefaultSortDirection() ?? $this->tableSortDirection) === 'desc' ? 'desc' : 'asc';
+        $defaultSort = $this->getTable()->getDefaultSort($query, $sortDirection);
 
         if (
             is_string($defaultSort) &&
@@ -114,13 +113,8 @@ trait CanSortRecords
             return $query->orderBy($defaultSort, $sortDirection);
         }
 
-        if ($defaultSort instanceof Closure) {
-            app()->call($defaultSort, [
-                'direction' => $sortDirection,
-                'query' => $query,
-            ]);
-
-            return $query;
+        if ($defaultSort instanceof Builder) {
+            return $defaultSort;
         }
 
         if (filled($query->toBase()->orders)) {

--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Tables\Concerns;
 
+use Closure;
 use Illuminate\Database\Eloquent\Builder;
 
 trait CanSortRecords
@@ -97,24 +98,24 @@ trait CanSortRecords
 
     protected function applyDefaultSortingToTableQuery(Builder $query): Builder
     {
-        $sortColumnName = $this->getTable()->getDefaultSortColumn();
+        $defaultSort = $this->getTable()->getDefaultSort();
         $sortDirection = ($this->getTable()->getDefaultSortDirection() ?? $this->tableSortDirection) === 'desc' ? 'desc' : 'asc';
 
         if (
-            $sortColumnName &&
-            ($sortColumn = $this->getTable()->getSortableVisibleColumn($sortColumnName))
+            is_string($defaultSort) &&
+            ($sortColumn = $this->getTable()->getSortableVisibleColumn($defaultSort))
         ) {
             $sortColumn->applySort($query, $sortDirection);
 
             return $query;
         }
 
-        if ($sortColumnName) {
-            return $query->orderBy($sortColumnName, $sortDirection);
+        if (is_string($defaultSort)) {
+            return $query->orderBy($defaultSort, $sortDirection);
         }
 
-        if ($sortQueryUsing = $this->getTable()->getDefaultSortQuery()) {
-            app()->call($sortQueryUsing, [
+        if ($defaultSort instanceof Closure) {
+            app()->call($defaultSort, [
                 'direction' => $sortDirection,
                 'query' => $query,
             ]);

--- a/packages/tables/src/Table/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSortRecords.php
@@ -18,7 +18,6 @@ trait CanSortRecords
     public function defaultSort(string | Closure | null $column, string | Closure | null $direction = 'asc'): static
     {
         $this->defaultSort = $column;
-
         $this->defaultSortDirection = $direction;
 
         return $this;
@@ -50,10 +49,10 @@ trait CanSortRecords
         return $column;
     }
 
-    public function getDefaultSort(Builder $query, string $sortDirection): Builder | string | null
+    public function getDefaultSort(Builder $query, string $direction): string | Builder | null
     {
         return $this->evaluate($this->defaultSort, [
-            'direction' => $sortDirection,
+            'direction' => $direction,
             'query' => $query,
         ]);
     }
@@ -63,7 +62,11 @@ trait CanSortRecords
      */
     public function getDefaultSortColumn(): ?string
     {
-        return is_string($this->defaultSort) ? $this->defaultSort : null;
+        if (! is_string($this->defaultSort)) {
+            return null;
+        }
+
+        return $this->defaultSort;
     }
 
     /**
@@ -71,7 +74,11 @@ trait CanSortRecords
      */
     public function getDefaultSortQuery(): ?Closure
     {
-        return ($this->defaultSort instanceof Closure) ? $this->defaultSort : null;
+        if (! ($this->defaultSort instanceof Closure)) {
+            return null;
+        }
+
+        return $this->defaultSort;
     }
 
     public function getDefaultSortDirection(): ?string

--- a/packages/tables/src/Table/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSortRecords.php
@@ -4,11 +4,12 @@ namespace Filament\Tables\Table\Concerns;
 
 use Closure;
 use Filament\Tables\Columns\Column;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 
 trait CanSortRecords
 {
-    protected ?string $defaultSortColumn = null;
+    protected string | Closure | null $defaultSortColumn = null;
 
     protected string | Closure | null $defaultSortDirection = null;
 
@@ -18,11 +19,7 @@ trait CanSortRecords
 
     public function defaultSort(string | Closure | null $column, string | Closure | null $direction = 'asc'): static
     {
-        if ($column instanceof Closure) {
-            $this->defaultSortQuery = $column;
-        } else {
-            $this->defaultSortColumn = $column;
-        }
+        $this->defaultSortColumn = $column;
 
         $this->defaultSortDirection = $direction;
 
@@ -57,7 +54,15 @@ trait CanSortRecords
 
     public function getDefaultSortColumn(): ?string
     {
-        return $this->defaultSortColumn;
+        $column = $this->evaluate($this->defaultSortColumn);
+
+        if (is_null($column) || $column instanceof Builder) {
+            $this->defaultSortQuery = $this->defaultSortColumn;
+
+            return null;
+        }
+
+        return $column;
     }
 
     public function getDefaultSortDirection(): ?string

--- a/packages/tables/src/Table/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSortRecords.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Table\Concerns;
 
 use Closure;
 use Filament\Tables\Columns\Column;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 
 trait CanSortRecords
@@ -49,15 +50,28 @@ trait CanSortRecords
         return $column;
     }
 
-    public function getDefaultSort(): Closure | string | null
+    public function getDefaultSort(Builder $query, string $sortDirection): Builder | string | null
     {
-        $defaultSort = $this->evaluate($this->defaultSort);
+        return $this->evaluate($this->defaultSort, [
+            'direction' => $sortDirection,
+            'query' => $query,
+        ]);
+    }
 
-        if (is_string($defaultSort)) {
-            return $defaultSort;
-        }
+    /**
+     * @deprecated Use `getDefaultSort()` instead.
+     */
+    public function getDefaultSortColumn(): ?string
+    {
+        return is_string($this->defaultSort) ? $this->defaultSort : null;
+    }
 
-        return $this->defaultSort;
+    /**
+     * @deprecated Use `getDefaultSort()` instead.
+     */
+    public function getDefaultSortQuery(): ?string
+    {
+        return ($this->defaultSort instanceof Closure) ? $this->defaultSort : null;
     }
 
     public function getDefaultSortDirection(): ?string

--- a/packages/tables/src/Table/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSortRecords.php
@@ -69,7 +69,7 @@ trait CanSortRecords
     /**
      * @deprecated Use `getDefaultSort()` instead.
      */
-    public function getDefaultSortQuery(): ?string
+    public function getDefaultSortQuery(): ?Closure
     {
         return ($this->defaultSort instanceof Closure) ? $this->defaultSort : null;
     }

--- a/packages/tables/src/Table/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSortRecords.php
@@ -4,22 +4,19 @@ namespace Filament\Tables\Table\Concerns;
 
 use Closure;
 use Filament\Tables\Columns\Column;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 
 trait CanSortRecords
 {
-    protected string | Closure | null $defaultSortColumn = null;
+    protected string | Closure | null $defaultSort = null;
 
     protected string | Closure | null $defaultSortDirection = null;
-
-    protected ?Closure $defaultSortQuery = null;
 
     protected bool | Closure | null $persistsSortInSession = false;
 
     public function defaultSort(string | Closure | null $column, string | Closure | null $direction = 'asc'): static
     {
-        $this->defaultSortColumn = $column;
+        $this->defaultSort = $column;
 
         $this->defaultSortDirection = $direction;
 
@@ -52,17 +49,15 @@ trait CanSortRecords
         return $column;
     }
 
-    public function getDefaultSortColumn(): ?string
+    public function getDefaultSort(): Closure | string | null
     {
-        $column = $this->evaluate($this->defaultSortColumn);
+        $defaultSort = $this->evaluate($this->defaultSort);
 
-        if (is_null($column) || $column instanceof Builder) {
-            $this->defaultSortQuery = $this->defaultSortColumn;
-
-            return null;
+        if (is_string($defaultSort)) {
+            return $defaultSort;
         }
 
-        return $column;
+        return $this->defaultSort;
     }
 
     public function getDefaultSortDirection(): ?string
@@ -74,11 +69,6 @@ trait CanSortRecords
         }
 
         return $direction;
-    }
-
-    public function getDefaultSortQuery(): ?Closure
-    {
-        return $this->defaultSortQuery;
     }
 
     public function getSortColumn(): ?string


### PR DESCRIPTION
## Description

This PR allows `defaultSort()` to accept Livewire as a closure.

```php
return $table
     ->defaultSort(function (Component $livewire) {
          return $livewire->activeTab === 'inStock' ? 'qty' : 'created_at';
     })
```

Of course passing in Builder or a string continues to work as well.

Note: my first attempt was to keep the original condition and then evaluate the closure inside `getDefaultSortQuery()`, however `applyDefaultSortingToTableQuery()` calls `getDefaultSortColumn()` before `getDefaultSortQuery()` so we have to evaluate there. This turned out to be cleaner anyway.

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
