### PR TITLE
Add language assistance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
         "": {
             "name": "filament",
             "devDependencies": {
+                "@assertchris/ellison": "^1.0.2",
                 "@awcodes/alpine-floating-ui": "^3.4.0",
                 "@babel/runtime": "^7.15.3",
                 "@danharrin/alpine-mousetrap": "^0.1.0",
@@ -79,6 +80,12 @@
             "engines": {
                 "node": ">=6.0.0"
             }
+        },
+        "node_modules/@assertchris/ellison": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@assertchris/ellison/-/ellison-1.0.2.tgz",
+            "integrity": "sha512-2O38rwN5aSq/mwTAutwWRtd9siDgggOkOVzKGPOfZdxlH/nHqjCaI1LqFi8YiBKOtyGemkcKJ2sttpktZBiUpQ==",
+            "dev": true
         },
         "node_modules/@awcodes/alpine-floating-ui": {
             "version": "3.6.3",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "prettier": "npx prettier --write ."
     },
     "devDependencies": {
+        "@assertchris/ellison": "^1.0.2",
         "@awcodes/alpine-floating-ui": "^3.4.0",
         "@babel/runtime": "^7.15.3",
         "@danharrin/alpine-mousetrap": "^0.1.0",

--- a/packages/forms/docs/03-fields/11-markdown-editor.md
+++ b/packages/forms/docs/03-fields/11-markdown-editor.md
@@ -66,3 +66,15 @@ MarkdownEditor::make('content')
     ->fileAttachmentsDirectory('attachments')
     ->fileAttachmentsVisibility('private')
 ```
+
+## Enabling language assistance
+
+You may enable language assistance in using a configuration method:
+
+```php
+use Filament\Forms\Components\MarkdownEditor;
+
+MarkdownEditor::make('content')->hasLanguageAssistance();
+```
+
+This will highlight complex sentences that may be simplified and phrases that may be improved (passive voice, verbosity etc.).

--- a/packages/forms/resources/css/components/markdown-editor.css
+++ b/packages/forms/resources/css/components/markdown-editor.css
@@ -296,3 +296,27 @@
 .EasyMDEContainer .editor-statusbar {
     @apply hidden;
 }
+
+.language-moderate-sentence {
+    background-color: #fef9c3;
+}
+
+.language-complex-sentence {
+    background-color: #fee2e2;
+}
+
+.language-adverb-phrase {
+    background-color: #e0f2fe;
+}
+
+.language-passive-phrase {
+    background-color: #dcfce7;
+}
+
+.language-complex-phrase {
+    background-color: #f3e8ff;
+}
+
+.language-qualified-phrase {
+    background-color: #f1f5f9;
+}

--- a/packages/forms/resources/js/components/markdown-editor.js
+++ b/packages/forms/resources/js/components/markdown-editor.js
@@ -224,7 +224,9 @@ export default function markdownEditorFormComponent({
 
                     return (...args) => {
                         clearTimeout(timer)
-                        timer = setTimeout(() => { func.apply(this, args); }, timeout)
+                        timer = setTimeout(() => {
+                            func.apply(this, args)
+                        }, timeout)
                     }
                 }
 
@@ -232,7 +234,7 @@ export default function markdownEditorFormComponent({
                     const indices = []
                     let i = -1
 
-                    while ((i = str.indexOf(val, i+1)) !== -1){
+                    while ((i = str.indexOf(val, i + 1)) !== -1) {
                         indices.push(i)
                     }
 
@@ -270,7 +272,10 @@ export default function markdownEditorFormComponent({
 
                         const sentences = getSentenceDifficulty(line.text)
                         const lineNumber = cm.getLineNumber(line)
-                        const lineElement = this.$refs.editor.parentNode.parentNode.querySelectorAll('.CodeMirror-line')[lineNumber]
+                        const lineElement =
+                            this.$refs.editor.parentNode.parentNode.querySelectorAll(
+                                '.CodeMirror-line',
+                            )[lineNumber]
 
                         for (let sentence of sentences) {
                             if (sentence.type === 'moderate') {
@@ -283,22 +288,36 @@ export default function markdownEditorFormComponent({
 
                             const sentenceText = sentence.text.trim()
 
-                            if (lineElement.innerText.indexOf(sentenceText) < 0) {
+                            if (
+                                lineElement.innerText.indexOf(sentenceText) < 0
+                            ) {
                                 continue
                             }
 
-                            const offset = lineElement.innerText.indexOf(sentenceText, sentenceOffset)
+                            const offset = lineElement.innerText.indexOf(
+                                sentenceText,
+                                sentenceOffset,
+                            )
 
                             const params = [
                                 {
                                     line: lineNumber,
-                                    ch: lineElement.innerText.indexOf(sentenceText, sentenceOffset),
-                                }, {
+                                    ch: lineElement.innerText.indexOf(
+                                        sentenceText,
+                                        sentenceOffset,
+                                    ),
+                                },
+                                {
                                     line: lineNumber,
-                                    ch: lineElement.innerText.indexOf(sentenceText, sentenceOffset) + sentenceText.length,
-                                }, {
+                                    ch:
+                                        lineElement.innerText.indexOf(
+                                            sentenceText,
+                                            sentenceOffset,
+                                        ) + sentenceText.length,
+                                },
+                                {
                                     className: `language-${sentence.type}-sentence`,
-                                }
+                                },
                             ]
 
                             sentenceOffset = offset + sentenceText.length
@@ -310,7 +329,7 @@ export default function markdownEditorFormComponent({
                                 ...getPassivePhrases(sentenceText),
                                 ...getComplexPhrases(sentenceText),
                                 ...getQualifiedPhrases(sentenceText),
-                            ];
+                            ]
 
                             for (let problem of problems) {
                                 if (problem.type === 'adverb') {
@@ -329,19 +348,24 @@ export default function markdownEditorFormComponent({
                                     this.qualifiedPhrases++
                                 }
 
-                                const indices = getAllIndices(lineElement.innerText.toLowerCase(), problem.text.toLowerCase());
+                                const indices = getAllIndices(
+                                    lineElement.innerText.toLowerCase(),
+                                    problem.text.toLowerCase(),
+                                )
 
                                 for (let index of indices) {
                                     const params = [
                                         {
                                             line: lineNumber,
                                             ch: index,
-                                        }, {
+                                        },
+                                        {
                                             line: lineNumber,
                                             ch: index + problem.text.length,
-                                        }, {
+                                        },
+                                        {
                                             className: `language-${problem.type}-phrase`,
-                                        }
+                                        },
                                     ]
 
                                     markers.push(cm.markText(...params))

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -54,43 +54,102 @@
             >
                 <textarea x-ref="editor" class="hidden"></textarea>
                 @if ($getHasLanguageAssistance())
-                    <div class="flex flex-row flex-wrap justify-end p-2 text-xs rounded-lg gap-2">
-                        <span x-show="moderateSentences > 0 || complexSentences > 0">{{__('sentences: ')}}</span>
-                        <span x-show="moderateSentences > 0" class="flex flex-row items-center justify-center gap-2">
-                            <span class="inline-flex rounded-full overflow-hidden w-[8px] h-[8px] language-moderate-sentence">&nbsp;</span>
+                    <div
+                        class="flex flex-row flex-wrap justify-end gap-2 rounded-lg p-2 text-xs"
+                    >
+                        <span
+                            x-show="moderateSentences > 0 || complexSentences > 0"
+                        >
+                            {{ __('sentences: ') }}
+                        </span>
+                        <span
+                            x-show="moderateSentences > 0"
+                            class="flex flex-row items-center justify-center gap-2"
+                        >
+                            <span
+                                class="language-moderate-sentence inline-flex h-[8px] w-[8px] overflow-hidden rounded-full"
+                            >
+                                &nbsp;
+                            </span>
                             <span x-text="moderateSentences"></span>
                             <span>{{ __('moderate') }}</span>
                         </span>
-                        <span x-show="complexSentences > 0" class="flex flex-row items-center justify-center gap-2">
-                            <span class="inline-flex rounded-full overflow-hidden w-[8px] h-[8px] language-complex-sentence">&nbsp;</span>
+                        <span
+                            x-show="complexSentences > 0"
+                            class="flex flex-row items-center justify-center gap-2"
+                        >
+                            <span
+                                class="language-complex-sentence inline-flex h-[8px] w-[8px] overflow-hidden rounded-full"
+                            >
+                                &nbsp;
+                            </span>
                             <span x-text="complexSentences"></span>
                             <span>{{ __('complex') }}</span>
                         </span>
                     </div>
-                    <div class="flex flex-row flex-wrap justify-end p-2 text-xs rounded-lg gap-2">
-                        <span x-show="passivePhrases > 0 || adverbPhrases > 0 || complexPhrases > 0 || qualifiedPhrases > 0">{{__('phrases: ')}}</span>
-                        <span x-show="passivePhrases > 0" class="flex flex-row items-center justify-center gap-2">
-                            <span class="inline-flex rounded-full overflow-hidden w-[8px] h-[8px] language-passive-phrase">&nbsp;</span>
+                    <div
+                        class="flex flex-row flex-wrap justify-end gap-2 rounded-lg p-2 text-xs"
+                    >
+                        <span
+                            x-show="
+                                passivePhrases > 0 ||
+                                    adverbPhrases > 0 ||
+                                    complexPhrases > 0 ||
+                                    qualifiedPhrases > 0
+                            "
+                        >
+                            {{ __('phrases: ') }}
+                        </span>
+                        <span
+                            x-show="passivePhrases > 0"
+                            class="flex flex-row items-center justify-center gap-2"
+                        >
+                            <span
+                                class="language-passive-phrase inline-flex h-[8px] w-[8px] overflow-hidden rounded-full"
+                            >
+                                &nbsp;
+                            </span>
                             <span x-text="passivePhrases"></span>
                             <span>{{ __('passive') }}</span>
                         </span>
-                        <span x-show="adverbPhrases > 0" class="flex flex-row items-center justify-center gap-2">
-                            <span class="inline-flex rounded-full overflow-hidden w-[8px] h-[8px] language-adverb-phrase">&nbsp;</span>
+                        <span
+                            x-show="adverbPhrases > 0"
+                            class="flex flex-row items-center justify-center gap-2"
+                        >
+                            <span
+                                class="language-adverb-phrase inline-flex h-[8px] w-[8px] overflow-hidden rounded-full"
+                            >
+                                &nbsp;
+                            </span>
                             <span x-text="adverbPhrases"></span>
                             <span>{{ __('adverb') }}</span>
                         </span>
-                        <span x-show="complexPhrases > 0" class="flex flex-row items-center justify-center gap-2">
-                            <span class="inline-flex rounded-full overflow-hidden w-[8px] h-[8px] language-complex-phrase">&nbsp;</span>
+                        <span
+                            x-show="complexPhrases > 0"
+                            class="flex flex-row items-center justify-center gap-2"
+                        >
+                            <span
+                                class="language-complex-phrase inline-flex h-[8px] w-[8px] overflow-hidden rounded-full"
+                            >
+                                &nbsp;
+                            </span>
                             <span x-text="complexPhrases"></span>
                             <span>{{ __('verbose') }}</span>
                         </span>
-                        <span x-show="qualifiedPhrases > 0" class="flex flex-row items-center justify-center gap-2">
-                            <span class="inline-flex rounded-full overflow-hidden w-[8px] h-[8px] language-qualified-phrase">&nbsp;</span>
+                        <span
+                            x-show="qualifiedPhrases > 0"
+                            class="flex flex-row items-center justify-center gap-2"
+                        >
+                            <span
+                                class="language-qualified-phrase inline-flex h-[8px] w-[8px] overflow-hidden rounded-full"
+                            >
+                                &nbsp;
+                            </span>
                             <span x-text="qualifiedPhrases"></span>
                             <span>{{ __('qualified') }}</span>
                         </span>
                     </div>
-               @endif
+                @endif
             </div>
         </x-filament::input.wrapper>
     @endif

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -30,6 +30,7 @@
                             maxHeight: @js($getMaxHeight()),
                             minHeight: @js($getMinHeight()),
                             placeholder: @js($getPlaceholder()),
+                            hasLanguageAssistance: @js($getHasLanguageAssistance()),
                             state: $wire.{{ $applyStateBindingModifiers("\$entangle('{$statePath}')", isOptimisticallyLive: false) }},
                             toolbarButtons: @js($getToolbarButtons()),
                             translations: @js(__('filament-forms::components.markdown_editor')),
@@ -52,6 +53,44 @@
                 {{ $getExtraAlpineAttributeBag() }}
             >
                 <textarea x-ref="editor" class="hidden"></textarea>
+                @if ($getHasLanguageAssistance())
+                    <div class="flex flex-row flex-wrap justify-end p-2 text-xs rounded-lg gap-2">
+                        <span x-show="moderateSentences > 0 || complexSentences > 0">{{__('sentences: ')}}</span>
+                        <span x-show="moderateSentences > 0" class="flex flex-row items-center justify-center gap-2">
+                            <span class="inline-flex rounded-full overflow-hidden w-[8px] h-[8px] language-moderate-sentence">&nbsp;</span>
+                            <span x-text="moderateSentences"></span>
+                            <span>{{ __('moderate') }}</span>
+                        </span>
+                        <span x-show="complexSentences > 0" class="flex flex-row items-center justify-center gap-2">
+                            <span class="inline-flex rounded-full overflow-hidden w-[8px] h-[8px] language-complex-sentence">&nbsp;</span>
+                            <span x-text="complexSentences"></span>
+                            <span>{{ __('complex') }}</span>
+                        </span>
+                    </div>
+                    <div class="flex flex-row flex-wrap justify-end p-2 text-xs rounded-lg gap-2">
+                        <span x-show="passivePhrases > 0 || adverbPhrases > 0 || complexPhrases > 0 || qualifiedPhrases > 0">{{__('phrases: ')}}</span>
+                        <span x-show="passivePhrases > 0" class="flex flex-row items-center justify-center gap-2">
+                            <span class="inline-flex rounded-full overflow-hidden w-[8px] h-[8px] language-passive-phrase">&nbsp;</span>
+                            <span x-text="passivePhrases"></span>
+                            <span>{{ __('passive') }}</span>
+                        </span>
+                        <span x-show="adverbPhrases > 0" class="flex flex-row items-center justify-center gap-2">
+                            <span class="inline-flex rounded-full overflow-hidden w-[8px] h-[8px] language-adverb-phrase">&nbsp;</span>
+                            <span x-text="adverbPhrases"></span>
+                            <span>{{ __('adverb') }}</span>
+                        </span>
+                        <span x-show="complexPhrases > 0" class="flex flex-row items-center justify-center gap-2">
+                            <span class="inline-flex rounded-full overflow-hidden w-[8px] h-[8px] language-complex-phrase">&nbsp;</span>
+                            <span x-text="complexPhrases"></span>
+                            <span>{{ __('verbose') }}</span>
+                        </span>
+                        <span x-show="qualifiedPhrases > 0" class="flex flex-row items-center justify-center gap-2">
+                            <span class="inline-flex rounded-full overflow-hidden w-[8px] h-[8px] language-qualified-phrase">&nbsp;</span>
+                            <span x-text="qualifiedPhrases"></span>
+                            <span>{{ __('qualified') }}</span>
+                        </span>
+                    </div>
+               @endif
             </div>
         </x-filament::input.wrapper>
     @endif

--- a/packages/forms/src/Components/Concerns/HasLanguageAssistance.php
+++ b/packages/forms/src/Components/Concerns/HasLanguageAssistance.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Filament\Forms\Components\Concerns;
+
+use Closure;
+
+trait HasLanguageAssistance
+{
+    protected bool | Closure | null $hasLanguageAssistance = null;
+
+    public function hasLanguageAssistance(bool | Closure | null $hasLanguageAssistance = true): static
+    {
+        $this->hasLanguageAssistance = $hasLanguageAssistance;
+
+        return $this;
+    }
+
+    public function getHasLanguageAssistance(): ?string
+    {
+        return $this->evaluate($this->hasLanguageAssistance);
+    }
+}

--- a/packages/forms/src/Components/MarkdownEditor.php
+++ b/packages/forms/src/Components/MarkdownEditor.php
@@ -13,6 +13,7 @@ class MarkdownEditor extends Field implements Contracts\CanBeLengthConstrained, 
     use Concerns\HasMinHeight;
     use Concerns\HasPlaceholder;
     use Concerns\InteractsWithToolbarButtons;
+    use Concerns\HasLanguageAssistance;
     use HasExtraAlpineAttributes;
 
     /**

--- a/packages/forms/src/Components/MarkdownEditor.php
+++ b/packages/forms/src/Components/MarkdownEditor.php
@@ -9,11 +9,11 @@ class MarkdownEditor extends Field implements Contracts\CanBeLengthConstrained, 
 {
     use Concerns\CanBeLengthConstrained;
     use Concerns\HasFileAttachments;
+    use Concerns\HasLanguageAssistance;
     use Concerns\HasMaxHeight;
     use Concerns\HasMinHeight;
     use Concerns\HasPlaceholder;
     use Concerns\InteractsWithToolbarButtons;
-    use Concerns\HasLanguageAssistance;
     use HasExtraAlpineAttributes;
 
     /**

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -98,7 +98,7 @@
                     'ring-1 ring-gray-950/10 dark:ring-white/20' => (($color === 'gray') || ($tag === 'label')) && (! $grouped),
                     'bg-custom-600 text-white hover:bg-custom-500 focus-visible:ring-custom-500/50 dark:bg-custom-500 dark:hover:bg-custom-400 dark:focus-visible:ring-custom-400/50' => ($color !== 'gray') && ($tag !== 'label'),
                     '[input:checked+&]:bg-custom-600 [input:checked+&]:text-white [input:checked+&]:ring-0 [input:checked+&]:hover:bg-custom-500 dark:[input:checked+&]:bg-custom-500 dark:[input:checked+&]:hover:bg-custom-400 [input:checked:focus-visible+&]:ring-custom-500/50 dark:[input:checked:focus-visible+&]:ring-custom-400/50 [input:focus-visible+&]:z-10 [input:focus-visible+&]:ring-2 [input:focus-visible+&]:ring-gray-950/10 dark:[input:focus-visible+&]:ring-white/20' => ($color !== 'gray') && ($tag === 'label'),
-                ]
+                    ]
         ),
     ]);
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR adds language assistance helpers (like Hemingway) to the MarkdownEditor component.

## Visual changes

![demo](https://github.com/filamentphp/filament/assets/200609/b80e178b-2049-44ad-8fcb-4baabe0be4b5)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
