### PR TITLE
update infolist documentations

### DIFF
--- a/packages/infolists/docs/03-entries/01-getting-started.md
+++ b/packages/infolists/docs/03-entries/01-getting-started.md
@@ -10,8 +10,21 @@ Entry classes can be found in the `Filament\Infolists\Components` namespace. You
 ```php
 use Filament\Infolists\Infolist;
 
-// use `public static function` in resources
 public function infolist(Infolist $infolist): Infolist
+{
+    return $infolist
+        ->schema([
+            // ...
+        ]);
+}
+```
+
+If you're inside a [panel builder resource](../../panels/resources), the `infolist()` method should be static:
+
+```php
+use Filament\Infolists\Infolist;
+
+public static function infolist(Infolist $infolist): Infolist
 {
     return $infolist
         ->schema([

--- a/packages/infolists/docs/03-entries/01-getting-started.md
+++ b/packages/infolists/docs/03-entries/01-getting-started.md
@@ -10,6 +10,7 @@ Entry classes can be found in the `Filament\Infolists\Components` namespace. You
 ```php
 use Filament\Infolists\Infolist;
 
+// use `public static function` in resources
 public function infolist(Infolist $infolist): Infolist
 {
     return $infolist


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The `static` keyword is needed in resources, but this guide also applies to infolists outside of resources where a static function isn't nessecary (https://github.com/filamentphp/filament/pull/11578#issuecomment-1964731064). It's better to put an extra comment to indicate `static` is necessary in resources IMHO

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
