### PR TITLE
fix: Column still hidden when it's not toggleable anymore

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanBeToggled.php
+++ b/packages/tables/src/Columns/Concerns/CanBeToggled.php
@@ -37,6 +37,10 @@ trait CanBeToggled
 
     public function isToggledHidden(): bool
     {
+        if (! $this->isToggleable()) {
+            return false;
+        }
+
         return $this->getTable()->getLivewire()->isTableColumnToggledHidden($this->getName());
     }
 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When a column's `toggleable()` method was removed, `isToggledHidden` still checked if the column was hidden in the session. Now, the method first verifies if the column is toggleable before checking its hidden status.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
