### PR TITLE
Update item.blade.php

### DIFF
--- a/packages/support/resources/views/components/tabs/item.blade.php
+++ b/packages/support/resources/views/components/tabs/item.blade.php
@@ -49,7 +49,7 @@
     @endif
     @if ($hasAlpineActiveClasses)
         x-bind:class="{
-            @js($inactiveItemClasses): ! {{ $alpineActive }},
+            @js($inactiveItemClasses): ! ( {{ $alpineActive }} ),
             @js($activeItemClasses): {{ $alpineActive }},
         }"
     @endif
@@ -81,7 +81,7 @@
     <span
         @if ($hasAlpineActiveClasses)
             x-bind:class="{
-                @js($inactiveLabelClasses): ! {{ $alpineActive }},
+                @js($inactiveLabelClasses): ! ( {{ $alpineActive }} ),
                 @js($activeLabelClasses): {{ $alpineActive }},
             }"
         @endif


### PR DESCRIPTION
Fixes `{ 'class' : ! tab === 'tab' }`


## Description

Currently there is a bug in the Alpine comparison logic, and because of this, inactive styles are never being applied to tab items. This is because the alpine-active is a `===` comparison.

## Visual changes

Before: 
<img width="205" alt="image" src="https://github.com/filamentphp/filament/assets/9887585/11a8f9c4-956d-4dff-bce7-c97cdf54d8d8">

After:
<img width="179" alt="image" src="https://github.com/filamentphp/filament/assets/9887585/fd695a52-139c-4461-84b0-0fdcf0d6f9f2">


## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
