### PR TITLE
Support `->badgeIcon` in Tab Item

### DIFF
--- a/packages/forms/resources/js/components/rich-editor.js
+++ b/packages/forms/resources/js/components/rich-editor.js
@@ -30,9 +30,8 @@ Trix.config.textAttributes.underline = {
 
 Trix.Block.prototype.breaksOnReturn = function () {
     const lastAttribute = this.getLastAttribute()
-    const blockConfig = Trix.config.blockAttributes[
-        lastAttribute ? lastAttribute : 'default'
-    ]
+    const blockConfig =
+        Trix.config.blockAttributes[lastAttribute ? lastAttribute : 'default']
 
     return blockConfig?.breakOnReturn ?? false
 }

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -80,7 +80,11 @@
                 @endif
                 {{ $getExtraAlpineAttributeBag() }}
             >
-                <input id="trix-value-{{ $id }}" x-ref="trixValue" type="hidden" />
+                <input
+                    id="trix-value-{{ $id }}"
+                    x-ref="trixValue"
+                    type="hidden"
+                />
 
                 <trix-toolbar
                     id="trix-toolbar-{{ $id }}"

--- a/packages/forms/resources/views/components/tabs.blade.php
+++ b/packages/forms/resources/views/components/tabs.blade.php
@@ -90,6 +90,7 @@
                 :alpine-active="'tab === \'' . $tabId . '\''"
                 :badge="$tab->getBadge()"
                 :badge-color="$tab->getBadgeColor()"
+                :badge-icon="$tab->getBadgeIcon()"
                 :icon="$tab->getIcon()"
                 :icon-position="$tab->getIconPosition()"
                 :x-on:click="'tab = \'' . $tabId . '\''"

--- a/packages/forms/resources/views/components/tabs.blade.php
+++ b/packages/forms/resources/views/components/tabs.blade.php
@@ -91,6 +91,7 @@
                 :badge="$tab->getBadge()"
                 :badge-color="$tab->getBadgeColor()"
                 :badge-icon="$tab->getBadgeIcon()"
+                :badge-icon-position="$tab->getBadgeIconPosition()"
                 :icon="$tab->getIcon()"
                 :icon-position="$tab->getIconPosition()"
                 :x-on:click="'tab = \'' . $tabId . '\''"

--- a/packages/infolists/resources/views/components/tabs.blade.php
+++ b/packages/infolists/resources/views/components/tabs.blade.php
@@ -89,6 +89,7 @@
                 :badge="$tab->getBadge()"
                 :badge-color="$tab->getBadgeColor()"
                 :badge-icon="$tab->getBadgeIcon()"
+                :badge-icon-position="$tab->getBadgeIconPosition()"
                 :icon="$tab->getIcon()"
                 :icon-position="$tab->getIconPosition()"
                 :x-on:click="'tab = \'' . $tabId . '\''"

--- a/packages/infolists/resources/views/components/tabs.blade.php
+++ b/packages/infolists/resources/views/components/tabs.blade.php
@@ -88,6 +88,7 @@
                 :alpine-active="'tab === \'' . $tabId . '\''"
                 :badge="$tab->getBadge()"
                 :badge-color="$tab->getBadgeColor()"
+                :badge-icon="$tab->getBadgeIcon()"
                 :icon="$tab->getIcon()"
                 :icon-position="$tab->getIconPosition()"
                 :x-on:click="'tab = \'' . $tabId . '\''"

--- a/packages/panels/resources/views/components/resources/tabs.blade.php
+++ b/packages/panels/resources/views/components/resources/tabs.blade.php
@@ -17,6 +17,7 @@
                 :active="$activeTab === $tabKey"
                 :badge="$tab->getBadge()"
                 :badge-color="$tab->getBadgeColor()"
+                :badge-icon="$tab->getBadgeIcon()"
                 :icon="$tab->getIcon()"
                 :icon-position="$tab->getIconPosition()"
                 :wire:click="'$set(\'activeTab\', ' . (filled($tabKey) ? ('\'' . $tabKey . '\'') : 'null') . ')'"

--- a/packages/panels/resources/views/components/resources/tabs.blade.php
+++ b/packages/panels/resources/views/components/resources/tabs.blade.php
@@ -18,6 +18,7 @@
                 :badge="$tab->getBadge()"
                 :badge-color="$tab->getBadgeColor()"
                 :badge-icon="$tab->getBadgeIcon()"
+                :badge-icon-position="$tab->getBadgeIconPosition()"
                 :icon="$tab->getIcon()"
                 :icon-position="$tab->getIconPosition()"
                 :wire:click="'$set(\'activeTab\', ' . (filled($tabKey) ? ('\'' . $tabKey . '\'') : 'null') . ')'"

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -98,7 +98,7 @@
                     'ring-1 ring-gray-950/10 dark:ring-white/20' => (($color === 'gray') || ($tag === 'label')) && (! $grouped),
                     'bg-custom-600 text-white hover:bg-custom-500 focus-visible:ring-custom-500/50 dark:bg-custom-500 dark:hover:bg-custom-400 dark:focus-visible:ring-custom-400/50' => ($color !== 'gray') && ($tag !== 'label'),
                     '[input:checked+&]:bg-custom-600 [input:checked+&]:text-white [input:checked+&]:ring-0 [input:checked+&]:hover:bg-custom-500 dark:[input:checked+&]:bg-custom-500 dark:[input:checked+&]:hover:bg-custom-400 [input:checked:focus-visible+&]:ring-custom-500/50 dark:[input:checked:focus-visible+&]:ring-custom-400/50 [input:focus-visible+&]:z-10 [input:focus-visible+&]:ring-2 [input:focus-visible+&]:ring-gray-950/10 dark:[input:focus-visible+&]:ring-white/20' => ($color !== 'gray') && ($tag === 'label'),
-                    ]
+                ]
         ),
     ]);
 

--- a/packages/support/resources/views/components/tabs/item.blade.php
+++ b/packages/support/resources/views/components/tabs/item.blade.php
@@ -8,6 +8,7 @@
     'badge' => null,
     'badgeColor' => null,
     'badgeTooltip' => null,
+    'badgeIcon' => null,
     'href' => null,
     'icon' => null,
     'iconColor' => 'gray',
@@ -109,6 +110,7 @@
     @if (filled($badge))
         <x-filament::badge
             :color="$badgeColor"
+            :icon="$badgeIcon"
             size="sm"
             :tooltip="$badgeTooltip"
             class="w-max"

--- a/packages/support/resources/views/components/tabs/item.blade.php
+++ b/packages/support/resources/views/components/tabs/item.blade.php
@@ -51,7 +51,7 @@
     @endif
     @if ($hasAlpineActiveClasses)
         x-bind:class="{
-            @js($inactiveItemClasses): ! ({{ $alpineActive }}),
+            @js($inactiveItemClasses): ! {{ $alpineActive }},
             @js($activeItemClasses): {{ $alpineActive }},
         }"
     @endif
@@ -83,7 +83,7 @@
     <span
         @if ($hasAlpineActiveClasses)
             x-bind:class="{
-                @js($inactiveLabelClasses): ! ({{ $alpineActive }}),
+                @js($inactiveLabelClasses): ! {{ $alpineActive }},
                 @js($activeLabelClasses): {{ $alpineActive }},
             }"
         @endif

--- a/packages/support/resources/views/components/tabs/item.blade.php
+++ b/packages/support/resources/views/components/tabs/item.blade.php
@@ -9,6 +9,7 @@
     'badgeColor' => null,
     'badgeTooltip' => null,
     'badgeIcon' => null,
+    'badgeIconPosition' => IconPosition::Before,
     'href' => null,
     'icon' => null,
     'iconColor' => 'gray',
@@ -111,6 +112,7 @@
         <x-filament::badge
             :color="$badgeColor"
             :icon="$badgeIcon"
+            :icon-position="$badgeIconPosition"
             size="sm"
             :tooltip="$badgeTooltip"
             class="w-max"

--- a/packages/support/src/Concerns/HasBadge.php
+++ b/packages/support/src/Concerns/HasBadge.php
@@ -13,6 +13,8 @@ trait HasBadge
      */
     protected string | array | Closure | null $badgeColor = null;
 
+    protected string | array | Closure | null $badgeIcon = null;
+
     public function badge(string | int | float | Closure | null $badge = null): static
     {
         if (func_num_args() === 0) {
@@ -43,6 +45,13 @@ trait HasBadge
         return $this;
     }
 
+    public function badgeIcon(string | null $icon): static
+    {
+        $this->badgeIcon = $icon;
+
+        return $this;
+    }
+
     /**
      * @deprecated Use `badgeColor()` instead.
      *
@@ -64,5 +73,10 @@ trait HasBadge
     public function getBadgeColor(): string | array | null
     {
         return $this->evaluate($this->badgeColor);
+    }
+
+    public function getBadgeIcon(): string | null
+    {
+        return $this->evaluate($this->badgeIcon);
     }
 }

--- a/packages/support/src/Concerns/HasBadge.php
+++ b/packages/support/src/Concerns/HasBadge.php
@@ -3,6 +3,7 @@
 namespace Filament\Support\Concerns;
 
 use Closure;
+use Filament\Support\Enums\IconPosition;
 
 trait HasBadge
 {
@@ -13,7 +14,9 @@ trait HasBadge
      */
     protected string | array | Closure | null $badgeColor = null;
 
-    protected string | array | Closure | null $badgeIcon = null;
+    protected string | Closure | null $badgeIcon = null;
+
+    protected IconPosition | string | Closure | null $badgeIconPosition = null;
 
     public function badge(string | int | float | Closure | null $badge = null): static
     {
@@ -45,9 +48,16 @@ trait HasBadge
         return $this;
     }
 
-    public function badgeIcon(string | null $icon): static
+    public function badgeIcon(string | Closure | null $icon): static
     {
         $this->badgeIcon = $icon;
+
+        return $this;
+    }
+
+    public function badgeIconPosition(IconPosition | string | Closure | null $position): static
+    {
+        $this->badgeIconPosition = $position;
 
         return $this;
     }
@@ -75,8 +85,13 @@ trait HasBadge
         return $this->evaluate($this->badgeColor);
     }
 
-    public function getBadgeIcon(): string | null
+    public function getBadgeIcon(): ?string
     {
         return $this->evaluate($this->badgeIcon);
+    }
+
+    public function getBadgeIconPosition(): IconPosition | string
+    {
+        return $this->evaluate($this->badgeIconPosition) ?? IconPosition::Before;
     }
 }


### PR DESCRIPTION
## Description

This PR will support the posibility to add an icon to badge in tab item.

## Visual changes

<img width="386" alt="Screenshot 2024-05-09 at 22 58 17" src="https://github.com/filamentphp/filament/assets/121255432/504cc38b-92de-43ad-a54c-9cfa5284f682">


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
