### PR TITLE
Fix summaries error in MSSQL Environment 

### DIFF
--- a/packages/tables/src/Columns/Summarizers/Summarizer.php
+++ b/packages/tables/src/Columns/Summarizers/Summarizer.php
@@ -8,6 +8,7 @@ use Filament\Support\Concerns\HasExtraAttributes;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class Summarizer extends ViewComponent
 {
@@ -105,8 +106,9 @@ class Summarizer extends ViewComponent
                 );
         }
 
+        $asName = Str::afterLast($query->getModel()->getTable(), '.');
         $query = DB::connection($query->getModel()->getConnectionName())
-            ->table($query->toBase(), $query->getModel()->getTable());
+            ->table($query->toBase(), $asName);
 
         if ($this->hasQueryModification()) {
             $query = $this->evaluate($this->modifyQueryUsing, [

--- a/packages/tables/src/Columns/Summarizers/Summarizer.php
+++ b/packages/tables/src/Columns/Summarizers/Summarizer.php
@@ -8,7 +8,6 @@ use Filament\Support\Concerns\HasExtraAttributes;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 
 class Summarizer extends ViewComponent
 {
@@ -106,7 +105,8 @@ class Summarizer extends ViewComponent
                 );
         }
 
-        $asName = Str::afterLast($query->getModel()->getTable(), '.');
+        $asName = (string) str($query->getModel()->getTable())->afterLast('.');
+        
         $query = DB::connection($query->getModel()->getConnectionName())
             ->table($query->toBase(), $asName);
 


### PR DESCRIPTION
This pull request addresses an issue encountered when using the table summarization feature with complex table names in Microsoft SQL Server. The problem arises because the generated SQL subquery uses the full table name as an alias, which is invalid syntax in MSSQL when the table name includes special characters like dots.

This PR fixes the issue reported in [#12583](https://github.com/filamentphp/filament/issues/12583) on the Filament repository.