### PR TITLE
Add download explanation to export action started language.

### DIFF
--- a/packages/actions/resources/lang/en/export.php
+++ b/packages/actions/resources/lang/en/export.php
@@ -67,7 +67,7 @@ return [
 
         'started' => [
             'title' => 'Export started',
-            'body' => 'Your export has begun and 1 row will be processed in the background.|Your export has begun and :count rows will be processed in the background.',
+            'body' => 'Your export has begun and 1 row will be processed in the background. You will receive a notification with the download link when it is complete.|Your export has begun and :count rows will be processed in the background. You will receive a notification with the download link when it is complete.',
         ],
 
     ],

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -98,7 +98,7 @@
                     'ring-1 ring-gray-950/10 dark:ring-white/20' => (($color === 'gray') || ($tag === 'label')) && (! $grouped),
                     'bg-custom-600 text-white hover:bg-custom-500 focus-visible:ring-custom-500/50 dark:bg-custom-500 dark:hover:bg-custom-400 dark:focus-visible:ring-custom-400/50' => ($color !== 'gray') && ($tag !== 'label'),
                     '[input:checked+&]:bg-custom-600 [input:checked+&]:text-white [input:checked+&]:ring-0 [input:checked+&]:hover:bg-custom-500 dark:[input:checked+&]:bg-custom-500 dark:[input:checked+&]:hover:bg-custom-400 [input:checked:focus-visible+&]:ring-custom-500/50 dark:[input:checked:focus-visible+&]:ring-custom-400/50 [input:focus-visible+&]:z-10 [input:focus-visible+&]:ring-2 [input:focus-visible+&]:ring-gray-950/10 dark:[input:focus-visible+&]:ring-white/20' => ($color !== 'gray') && ($tag === 'label'),
-                ]
+                    ]
         ),
     ]);
 

--- a/packages/tables/src/Columns/Summarizers/Summarizer.php
+++ b/packages/tables/src/Columns/Summarizers/Summarizer.php
@@ -106,7 +106,7 @@ class Summarizer extends ViewComponent
         }
 
         $asName = (string) str($query->getModel()->getTable())->afterLast('.');
-        
+
         $query = DB::connection($query->getModel()->getConnectionName())
             ->table($query->toBase(), $asName);
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

We just started using the baked in Filament export on a live site, and immediately got confused users asking where their exported file is.  Added an explanation in the "Export Started" language.

## Visual changes

I tried, but the notification keeps disappearing before I can get a screenshot.  Picture in your mind a notification with the new language in it.  :)

Which does beg the question of whether this notification should be sticky, as it's longer than usual, and contains instructions on the next action the user will need to take.  So perhaps it should stay until dismissed?

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
