### PR TITLE
Fix active indicators when using group options

### DIFF
--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -98,7 +98,7 @@
                     'ring-1 ring-gray-950/10 dark:ring-white/20' => (($color === 'gray') || ($tag === 'label')) && (! $grouped),
                     'bg-custom-600 text-white hover:bg-custom-500 focus-visible:ring-custom-500/50 dark:bg-custom-500 dark:hover:bg-custom-400 dark:focus-visible:ring-custom-400/50' => ($color !== 'gray') && ($tag !== 'label'),
                     '[input:checked+&]:bg-custom-600 [input:checked+&]:text-white [input:checked+&]:ring-0 [input:checked+&]:hover:bg-custom-500 dark:[input:checked+&]:bg-custom-500 dark:[input:checked+&]:hover:bg-custom-400 [input:checked:focus-visible+&]:ring-custom-500/50 dark:[input:checked:focus-visible+&]:ring-custom-400/50 [input:focus-visible+&]:z-10 [input:focus-visible+&]:ring-2 [input:focus-visible+&]:ring-gray-950/10 dark:[input:focus-visible+&]:ring-white/20' => ($color !== 'gray') && ($tag === 'label'),
-                ]
+                    ]
         ),
     ]);
 

--- a/packages/tables/src/Columns/Summarizers/Summarizer.php
+++ b/packages/tables/src/Columns/Summarizers/Summarizer.php
@@ -106,7 +106,7 @@ class Summarizer extends ViewComponent
         }
 
         $asName = (string) str($query->getModel()->getTable())->afterLast('.');
-        
+
         $query = DB::connection($query->getModel()->getConnectionName())
             ->table($query->toBase(), $asName);
 

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -65,7 +65,7 @@ class SelectFilter extends BaseFilter
                         ->all();
                 } else {
                     $labels = collect($filter->getOptions())
-                        ->mapWithKeys(fn($label, $value) => is_array($label) ? $label : [$value => $label])
+                        ->mapWithKeys(fn ($label, $value) => is_array($label) ? $label : [$value => $label])
                         ->only($state['values'])
                         ->all();
                 }
@@ -100,7 +100,7 @@ class SelectFilter extends BaseFilter
                     ?->getAttributeValue($filter->getRelationshipTitleAttribute());
             } else {
                 $label = collect($filter->getOptions())
-                    ->mapWithKeys(fn($label, $value) => is_array($label) ? $label : [$value => $label])
+                    ->mapWithKeys(fn ($label, $value) => is_array($label) ? $label : [$value => $label])
                     ->get($state['value']);
             }
 

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -65,7 +65,7 @@ class SelectFilter extends BaseFilter
                         ->all();
                 } else {
                     $labels = collect($filter->getOptions())
-                        ->mapWithKeys(fn ($label, $value) => is_array($label) ? $label : [$value => $label])
+                        ->mapWithKeys(fn (string | array $label, string $value): array => is_array($label) ? $label : [$value => $label])
                         ->only($state['values'])
                         ->all();
                 }
@@ -100,7 +100,7 @@ class SelectFilter extends BaseFilter
                     ?->getAttributeValue($filter->getRelationshipTitleAttribute());
             } else {
                 $label = collect($filter->getOptions())
-                    ->mapWithKeys(fn ($label, $value) => is_array($label) ? $label : [$value => $label])
+                    ->mapWithKeys(fn (string | array $label, string $value): array => is_array($label) ? $label : [$value => $label])
                     ->get($state['value']);
             }
 

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -65,7 +65,7 @@ class SelectFilter extends BaseFilter
                         ->all();
                 } else {
                     $labels = collect($filter->getOptions())
-                        ->flatten()
+                        ->mapWithKeys(fn ($label, $value) => is_array($label) ? $label : [$value => $label])
                         ->only($state['values'])
                         ->all();
                 }
@@ -100,7 +100,7 @@ class SelectFilter extends BaseFilter
                     ?->getAttributeValue($filter->getRelationshipTitleAttribute());
             } else {
                 $label = collect($filter->getOptions())
-                    ->flatten()
+                    ->mapWithKeys(fn ($label, $value) => is_array($label) ? $label : [$value => $label])
                     ->get($state['value']);
             }
 

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -65,7 +65,7 @@ class SelectFilter extends BaseFilter
                         ->all();
                 } else {
                     $labels = collect($filter->getOptions())
-                        ->mapWithKeys(fn ($label, $value) => is_array($label) ? $label : [$value => $label])
+                        ->flatten()
                         ->only($state['values'])
                         ->all();
                 }
@@ -100,7 +100,7 @@ class SelectFilter extends BaseFilter
                     ?->getAttributeValue($filter->getRelationshipTitleAttribute());
             } else {
                 $label = collect($filter->getOptions())
-                    ->mapWithKeys(fn ($label, $value) => is_array($label) ? $label : [$value => $label])
+                    ->flatten()
                     ->get($state['value']);
             }
 

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -64,7 +64,10 @@ class SelectFilter extends BaseFilter
                         ->pluck($relationshipQuery->qualifyColumn($filter->getRelationshipTitleAttribute()))
                         ->all();
                 } else {
-                    $labels = Arr::only($filter->getOptions(), $state['values']);
+                    $labels = collect($filter->getOptions())
+                        ->mapWithKeys(fn($label, $value) => is_array($label) ? $label : [$value => $label])
+                        ->only($state['values'])
+                        ->all();
                 }
 
                 if (! count($labels)) {
@@ -96,7 +99,9 @@ class SelectFilter extends BaseFilter
                     ->first()
                     ?->getAttributeValue($filter->getRelationshipTitleAttribute());
             } else {
-                $label = $filter->getOptions()[$state['value']] ?? null;
+                $label = collect($filter->getOptions())
+                    ->mapWithKeys(fn($label, $value) => is_array($label) ? $label : [$value => $label])
+                    ->get($state['value']);
             }
 
             if (blank($label)) {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When select filter options is grouped, the indicator will not show anything by default. This PR fixes that behaviour
<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

Before:
![image](https://github.com/filamentphp/filament/assets/32760797/62984def-7f7a-44f3-b4a5-95901251bce8)

After:
![image](https://github.com/filamentphp/filament/assets/32760797/c5e1f5df-fed3-44f6-adba-ff994be69749)

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
