### PR TITLE
Add badgeSize Prop to Icon Button Component

### DIFF
--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -6,6 +6,7 @@
 @props([
     'badge' => null,
     'badgeColor' => 'primary',
+    'badgeSize' => 'xs',
     'color' => 'primary',
     'disabled' => false,
     'form' => null,
@@ -185,7 +186,7 @@
 
         @if (filled($badge))
             <div class="{{ $badgeContainerClasses }}">
-                <x-filament::badge :color="$badgeColor" size="xs">
+                <x-filament::badge :color="$badgeColor" :size="$badgeSize">
                     {{ $badge }}
                 </x-filament::badge>
             </div>


### PR DESCRIPTION
This pull request introduces a new prop `badgeSize` to the Icon Button component, allowing for finer control over the size of badges displayed on the buttons. The badgeSize prop supports different size specifications, with 'xs' being set as the default value.

Let me know if you have any questions about this PR. Appreciate it.