### PR TITLE
Make refreshFormData public

### DIFF
--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -114,7 +114,7 @@ class EditRecord extends Page
     /**
      * @param  array<string>  $attributes
      */
-    protected function refreshFormData(array $attributes): void
+    public function refreshFormData(array $attributes): void
     {
         $this->data = [
             ...$this->data,

--- a/packages/panels/src/Resources/Pages/ViewRecord.php
+++ b/packages/panels/src/Resources/Pages/ViewRecord.php
@@ -103,7 +103,7 @@ class ViewRecord extends Page
     /**
      * @param  array<string>  $attributes
      */
-    protected function refreshFormData(array $attributes): void
+    public function refreshFormData(array $attributes): void
     {
         $this->data = [
             ...$this->data,


### PR DESCRIPTION
## Description

I want to refresh the form data with `refreshFormData` in a hint action in a resource class. 

```
public static function form(Form $form): Form
{
    return $form
        ->schema([
            Forms\Components\TagsInput::make('assignment_terms')
                ->placeholder('')
                ->hintAction(
                    Forms\Components\Actions\Action::make('editAssignmentTerms')
                        ->form([
                            Forms\Components\TagsInput::make('assignment_terms')
                                ->default(fn($record) => $record->assignment_terms)
                        ])
                        ->action(function ($record, $data, $livewire) {
                            $record->update($data);
                            $livewire->refreshFormData(['assignment_terms']);
                        }),
                ),
        ]);
}
```

The line `$livewire->refreshFormData(['assignment_terms']);` won't work currently because the method is protected in both `ViewPage` and `EditPage`.
The workaround is to override the method in my view and edit page. With this PR accepted that would not be necessary.

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command. --> not necessary
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date. --> no changes necessary
