### PR TITLE
Check for Duplicate / Empty columns before attempting to submit import

### DIFF
--- a/packages/actions/resources/lang/en/import.php
+++ b/packages/actions/resources/lang/en/import.php
@@ -21,10 +21,10 @@ return [
             ],
 
             'rules' => [
-                'empty_columns' => 'Spreadsheet contains duplicate empty column headers.',
-                'duplicate_columns' => 'Spreadsheet contains duplicate column headers - :columns.',
+                'duplicate_columns' => '{0} Spreadsheet contains empty columns.
+                    |{1} Spreadsheet contains duplicate column header - :columns.
+                    |[2,*] Spreadsheet contains :count duplicate column headers - :columns.',
             ],
-
         ],
 
         'actions' => [

--- a/packages/actions/resources/lang/en/import.php
+++ b/packages/actions/resources/lang/en/import.php
@@ -11,19 +11,20 @@ return [
         'form' => [
 
             'file' => [
+
                 'label' => 'File',
+
                 'placeholder' => 'Upload a CSV file',
+
+                'rules' => [
+                    'duplicate_columns' => '{0} The file must not contain more than one empty column header.|{1,*} The file must not contain duplicate column headers: :columns.',
+                ],
+
             ],
 
             'columns' => [
                 'label' => 'Columns',
                 'placeholder' => 'Select a column',
-            ],
-
-            'rules' => [
-                'duplicate_columns' => '{0} Spreadsheet contains empty columns.
-                    |{1} Spreadsheet contains duplicate column header - :columns.
-                    |[2,*] Spreadsheet contains :count duplicate column headers - :columns.',
             ],
         ],
 

--- a/packages/actions/resources/lang/en/import.php
+++ b/packages/actions/resources/lang/en/import.php
@@ -72,6 +72,8 @@ return [
         'file_name' => 'import-:import_id-:csv_name-failed-rows',
         'error_header' => 'error',
         'system_error' => 'System error, please contact support.',
+        'empty_columns' => 'Spreadsheet contains duplicate empty column headers.',
+        'duplicate_columns' => 'Spreadsheet contains duplicate column headers - :columns.',
     ],
 
 ];

--- a/packages/actions/resources/lang/en/import.php
+++ b/packages/actions/resources/lang/en/import.php
@@ -20,6 +20,11 @@ return [
                 'placeholder' => 'Select a column',
             ],
 
+            'rules' => [
+                'empty_columns' => 'Spreadsheet contains duplicate empty column headers.',
+                'duplicate_columns' => 'Spreadsheet contains duplicate column headers - :columns.',
+            ],
+
         ],
 
         'actions' => [
@@ -72,8 +77,6 @@ return [
         'file_name' => 'import-:import_id-:csv_name-failed-rows',
         'error_header' => 'error',
         'system_error' => 'System error, please contact support.',
-        'empty_columns' => 'Spreadsheet contains duplicate empty column headers.',
-        'duplicate_columns' => 'Spreadsheet contains duplicate column headers - :columns.',
     ],
 
 ];

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -84,7 +84,7 @@ trait CanImportRecords
                 ->rule('extensions:csv,txt')
                 ->rules([
                     'extensions:csv,txt',
-                    File::types(['csv','txt'])->rules([
+                    File::types(['csv', 'txt'])->rules([
                         function (string $attribute, mixed $value, Closure $fail) use ($action) {
                             $csvStream = $this->getUploadedFileStream($value);
                             $csvReader = CsvReader::createFromStream($csvStream);

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -102,13 +102,9 @@ trait CanImportRecords
                             }
 
                             $columns = Arr::where($duplicates, fn (string $value): bool => $value !== '');
-                            if (empty($columns)) {
-                                $fail(__('filament-actions::import.modal.form.rules.empty_columns'));
-                            } else {
-                                $fail(__('filament-actions::import.modal.form.rules.duplicate_columns', [
-                                    'columns' => implode(', ', $columns),
-                                ]));
-                            }
+                            $fail(trans_choice('filament-actions::import.modal.form.rules.duplicate_columns', count($columns), [
+                                'columns' => implode(', ', $columns),
+                            ]));
                         },
                     ]),
                 ])

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -33,6 +33,7 @@ use League\Csv\CharsetConverter;
 use League\Csv\Info;
 use League\Csv\Reader as CsvReader;
 use League\Csv\Statement;
+use League\Csv\SyntaxError;
 use League\Csv\Writer;
 use Livewire\Component;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -81,7 +81,6 @@ trait CanImportRecords
                 ->label(__('filament-actions::import.modal.form.file.label'))
                 ->placeholder(__('filament-actions::import.modal.form.file.placeholder'))
                 ->acceptedFileTypes(['text/csv', 'text/x-csv', 'application/csv', 'application/x-csv', 'text/comma-separated-values', 'text/x-comma-separated-values', 'text/plain', 'application/vnd.ms-excel'])
-                ->rule('extensions:csv,txt')
                 ->rules([
                     'extensions:csv,txt',
                     File::types(['csv', 'txt'])->rules([

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -87,7 +87,6 @@ trait CanImportRecords
                         function (string $attribute, mixed $value, Closure $fail) use ($action) {
                             $csvStream = $this->getUploadedFileStream($value);
                             $csvReader = CsvReader::createFromStream($csvStream);
-
                             $csvReader->setHeaderOffset($action->getHeaderOffset() ?? 0);
                             $csvColumns = $csvReader->getHeader();
 
@@ -98,16 +97,17 @@ trait CanImportRecords
                                 }
                             }
 
-                            if (! empty($duplicates)) {
-                                $columns = Arr::where($duplicates, fn (string $value): bool => $value !== '');
+                            if (empty($duplicates)) {
+                                return;
+                            }
 
-                                if (empty($columns)) {
-                                    $fail(__('filament-actions::import.failure_csv.empty_columns'));
-                                } else {
-                                    $fail(__('filament-actions::import.failure_csv.duplicate_columns', [
-                                        'columns' => implode(', ', $columns),
-                                    ]));
-                                }
+                            $columns = Arr::where($duplicates, fn (string $value): bool => $value !== '');
+                            if (empty($columns)) {
+                                $fail(__('filament-actions::import.modal.form.rules.empty_columns'));
+                            } else {
+                                $fail(__('filament-actions::import.modal.form.rules.duplicate_columns', [
+                                    'columns' => implode(', ', $columns),
+                                ]));
                             }
                         },
                     ]),

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -189,13 +189,13 @@ trait CanImportRecords
                 $csvReader->setHeaderOffset($action->getHeaderOffset() ?? 0);
                 $csvResults = Statement::create()->process($csvReader);
             } catch (SyntaxError $e) {
-                $columns = Arr::where($e->duplicateColumnNames(), fn(string $value): bool => $value !== '');
+                $columns = Arr::where($e->duplicateColumnNames(), fn (string $value): bool => $value !== '');
 
-                if(empty($columns)) {
+                if (empty($columns)) {
                     $message = __('filament-actions::import.failure_csv.empty_columns');
                 } else {
                     $message = __('filament-actions::import.failure_csv.duplicate_columns', [
-                        'columns' => join(', ', $columns),
+                        'columns' => implode(', ', $columns),
                     ]);
                 }
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When importing data through the pre-built import action, duplicate column headers will cause a 500 error to be thrown. This is due to the League/Csv package throwing an Uncaught SyntaxError when these are detected.

This fix catches the syntax error and does some logic to determine whether:

- The duplicate headers are all empty
- There are duplicate header names

A different message is displayed for each, for better user experience. The reason for uniquely detecting empty headers is that seemingly, some spreadsheet software may include completely empty columns even after saving. I'm not fully certain why these would be preserved as this doesn't seem to occur in the latest version of Excel, but it's an issue that some users have had so far when attempting to import data.

## Visual changes

### Error when submitting spreadsheet with duplicate columns:
![image](https://github.com/filamentphp/filament/assets/39706150/109aad0e-a972-4692-8b8b-2c55b76bf13a)

### New message when submitting with duplicate column headers
![image](https://github.com/filamentphp/filament/assets/39706150/8971950d-c155-4092-a707-dd3c2ea7549e)

### New Message when submitting with duplicate empty column headers
![image](https://github.com/filamentphp/filament/assets/39706150/101fc4aa-ef6c-4b61-a5bf-e1e75786231a)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
