### PR TITLE
Change type hint for chart data

### DIFF
--- a/packages/widgets/src/StatsOverviewWidget/Stat.php
+++ b/packages/widgets/src/StatsOverviewWidget/Stat.php
@@ -13,7 +13,7 @@ use Illuminate\View\ComponentAttributeBag;
 class Stat extends Component implements Htmlable
 {
     /**
-     * @var array<string, mixed> | null
+     * @var array<float> | null
      */
     protected ?array $chart = null;
 
@@ -153,7 +153,7 @@ class Stat extends Component implements Htmlable
     }
 
     /**
-     * @param  array<int> | null  $chart
+     * @param  array<float> | null
      */
     public function chart(?array $chart): static
     {
@@ -187,7 +187,7 @@ class Stat extends Component implements Htmlable
     }
 
     /**
-     * @return array<string, mixed> | null
+     * @return array<float> | null
      */
     public function getChart(): ?array
     {


### PR DESCRIPTION
## Description

Fixed the type hinting for chart data on stats widgets to allow floats. 

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
