### PR TITLE
Fix footer actions being rendered outside viewport in image editor on mobile devices

### DIFF
--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -150,7 +150,7 @@
                 x-trap.noscroll="isEditorOpen"
                 x-on:keydown.escape.window="closeEditor"
                 @class([
-                    'fixed inset-0 isolate z-50 h-screen w-screen p-2 sm:p-10 md:p-20',
+                    'fixed inset-0 isolate z-50 h-[100dvh] w-screen p-2 sm:p-10 md:p-20',
                     'fi-fo-file-upload-circle-cropper' => $hasCircleCropper,
                 ])
             >


### PR DESCRIPTION
## Description

Currently the footer actions (Cancel, Save, Reset) are rendered outside of the viewport when the FileUpload image editor is used on most mobile devices (inc. latest iOS and Android Chrome).

This is fixed by using `100dvh` instead of `100vh`/`h-screen`. Tailwind's `h-[100dvh]` is used instead of `h-dvh` to support backwards compatibility for people using custom themes on an older version of Tailwind, as mentioned in [this comment](https://github.com/filamentphp/filament/blob/3cb37824eddbb3f4fd4e454c4938ca2225adec13/packages/support/resources/views/components/modal/index.blade.php#L178).

## Visual changes
![image](https://github.com/filamentphp/filament/assets/212036/3aaa07f6-ab8a-4e5e-b783-0fc9cb8de7ff)



## Functional changes

- [ ] Changes `h-screen` to `h-[100dvh]` on the image editor modal.
