### PR TITLE
feat: add support to override media model on spatie media file upload

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -163,15 +163,9 @@ class SpatieMediaLibraryFileUpload extends FileUpload
         $this->reorderUploadedFilesUsing(static function (SpatieMediaLibraryFileUpload $component, array $state, ?Model $record): array {
             $uuids = array_filter(array_values($state));
 
-            $mediaClass = $component->getMediaClass();
-
-            if (is_null($mediaClass) && method_exists($record, 'getMediaModel')) {
-                $mediaClass = $record->getMediaModel();
-            }
-
-            if (is_null($mediaClass)) {
-                $mediaClass = config('media-library.media_model', Media::class);
-            }
+            $mediaClass = $component->getMediaClass()
+                ?? (method_exists($record, 'getMediaModel') ? $record->getMediaModel() : null)
+                ?? config('media-library.media_model', Media::class);
 
             $mappedIds = $mediaClass::query()->whereIn('uuid', $uuids)->pluck('id', 'uuid')->toArray();
 

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -25,8 +25,6 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
     protected string | Closure | null $mediaName = null;
 
-    protected string | Closure | null $mediaClass = null;
-
     /**
      * @var array<string, mixed> | Closure | null
      */
@@ -163,9 +161,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
         $this->reorderUploadedFilesUsing(static function (SpatieMediaLibraryFileUpload $component, array $state, ?Model $record): array {
             $uuids = array_filter(array_values($state));
 
-            $mediaClass = $component->getMediaClass()
-                ?? (method_exists($record, 'getMediaModel') ? $record->getMediaModel() : null)
-                ?? config('media-library.media_model', Media::class);
+            $mediaClass = method_exists($record, 'getMediaModel') ? $record->getMediaModel() : config('media-library.media_model', Media::class);
 
             $mappedIds = $mediaClass::query()->whereIn('uuid', $uuids)->pluck('id', 'uuid')->toArray();
 
@@ -362,17 +358,5 @@ class SpatieMediaLibraryFileUpload extends FileUpload
         return $this->evaluate($this->mediaName, [
             'file' => $file,
         ]);
-    }
-
-    public function mediaClass(string | Closure | null $mediaClass): static
-    {
-        $this->mediaClass = $mediaClass;
-
-        return $this;
-    }
-
-    public function getMediaClass(): ?string
-    {
-        return $this->evaluate($this->mediaClass);
     }
 }

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -160,7 +160,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             return $media->getAttributeValue('uuid');
         });
 
-        $this->reorderUploadedFilesUsing(static function (SpatieMediaLibraryFileUpload $component, array $state): array {
+        $this->reorderUploadedFilesUsing(static function (SpatieMediaLibraryFileUpload $component, array $state, ?Model $record): array {
             $uuids = array_filter(array_values($state));
 
             $mediaClass = $component->getMediaClass();

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -158,10 +158,11 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             return $media->getAttributeValue('uuid');
         });
 
-        $this->reorderUploadedFilesUsing(static function (SpatieMediaLibraryFileUpload $component, array $state, ?Model $record): array {
+        $this->reorderUploadedFilesUsing(static function (SpatieMediaLibraryFileUpload $component, ?Model $record, array $state): array {
             $uuids = array_filter(array_values($state));
 
-            $mediaClass = method_exists($record, 'getMediaModel') ? $record->getMediaModel() : config('media-library.media_model', Media::class);
+            $mediaClass = ($record && method_exists($record, 'getMediaModel')) ? $record->getMediaModel() : null;
+            $mediaClass ??= config('media-library.media_model', Media::class);
 
             $mappedIds = $mediaClass::query()->whereIn('uuid', $uuids)->pluck('id', 'uuid')->toArray();
 

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -25,6 +25,8 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
     protected string | Closure | null $mediaName = null;
 
+    protected string | Closure | null $mediaClass = null;
+
     /**
      * @var array<string, mixed> | Closure | null
      */
@@ -161,7 +163,15 @@ class SpatieMediaLibraryFileUpload extends FileUpload
         $this->reorderUploadedFilesUsing(static function (SpatieMediaLibraryFileUpload $component, array $state): array {
             $uuids = array_filter(array_values($state));
 
-            $mediaClass = config('media-library.media_model', Media::class);
+            $mediaClass = $component->getMediaClass();
+
+            if (is_null($mediaClass) && method_exists($record, 'getMediaModel')) {
+                $mediaClass = $record->getMediaModel();
+            }
+
+            if (is_null($mediaClass)) {
+                $mediaClass = config('media-library.media_model', Media::class);
+            }
 
             $mappedIds = $mediaClass::query()->whereIn('uuid', $uuids)->pluck('id', 'uuid')->toArray();
 
@@ -358,5 +368,17 @@ class SpatieMediaLibraryFileUpload extends FileUpload
         return $this->evaluate($this->mediaName, [
             'file' => $file,
         ]);
+    }
+
+    public function mediaClass(string | Closure | null $mediaClass): static
+    {
+        $this->mediaClass = $mediaClass;
+
+        return $this;
+    }
+
+    public function getMediaClass(): ?string
+    {
+        return $this->evaluate($this->mediaClass);
     }
 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Adding support to override the media model on SpatieMediaLibraryFileUpload in line with the ability to do so in the Spatie Media Libday since version [11.4.0](https://github.com/spatie/laravel-medialibrary/releases/tag/11.4.0)

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
