### PR TITLE
Docs: Added `static` to example `Importer::getColumns()` method

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -90,7 +90,7 @@ To define the columns that can be imported, you need to override the `getColumns
 ```php
 use Filament\Actions\Imports\ImportColumn;
 
-public function getColumns(): array
+public static function getColumns(): array
 {
     return [
         ImportColumn::make('name')


### PR DESCRIPTION
## Description

Added `static` to example `Importer::getColumns()` method

## Visual changes
Before:
![CleanShot 2024-05-17 at 16 25 45@2x](https://github.com/filamentphp/filament/assets/133571/9292632e-8d1b-4ead-9406-b5878538b63c)

After:
![CleanShot 2024-05-17 at 16 27 15@2x](https://github.com/filamentphp/filament/assets/133571/8435d8f0-1fd8-42ed-828c-de765f1fb576)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
