### PR TITLE
Fix: Missing Tenant Registration, Profile and User Profile page component registration

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasComponents.php
+++ b/packages/panels/src/Panel/Concerns/HasComponents.php
@@ -495,6 +495,18 @@ trait HasComponents
                 $this->queueLivewireComponentForRegistration($loginRouteAction);
             }
 
+            if ($this->hasTenantRegistration() && is_subclass_of($tenantRegistrationComponent = $this->getTenantRegistrationPage(), Component::class)) {
+                $this->queueLivewireComponentForRegistration($tenantRegistrationComponent);
+            }
+
+            if ($this->hasTenantProfile() && is_subclass_of($tenantProfileComponent = $this->getTenantProfilePage(), Component::class)) {
+                $this->queueLivewireComponentForRegistration($tenantProfileComponent);
+            }
+
+            if ($this->hasProfile() && is_subclass_of($profilePageComponent = $this->getProfilePage(), Component::class)) {
+                $this->queueLivewireComponentForRegistration($profilePageComponent);
+            }
+
             if ($this->hasPasswordReset()) {
                 if (is_subclass_of($requestPasswordResetRouteAction = $this->getRequestPasswordResetRouteAction(), Component::class)) {
                     $this->queueLivewireComponentForRegistration($requestPasswordResetRouteAction);

--- a/packages/panels/src/Panel/Concerns/HasComponents.php
+++ b/packages/panels/src/Panel/Concerns/HasComponents.php
@@ -495,18 +495,6 @@ trait HasComponents
                 $this->queueLivewireComponentForRegistration($loginRouteAction);
             }
 
-            if ($this->hasTenantRegistration() && is_subclass_of($tenantRegistrationComponent = $this->getTenantRegistrationPage(), Component::class)) {
-                $this->queueLivewireComponentForRegistration($tenantRegistrationComponent);
-            }
-
-            if ($this->hasTenantProfile() && is_subclass_of($tenantProfileComponent = $this->getTenantProfilePage(), Component::class)) {
-                $this->queueLivewireComponentForRegistration($tenantProfileComponent);
-            }
-
-            if ($this->hasProfile() && is_subclass_of($profilePageComponent = $this->getProfilePage(), Component::class)) {
-                $this->queueLivewireComponentForRegistration($profilePageComponent);
-            }
-
             if ($this->hasPasswordReset()) {
                 if (is_subclass_of($requestPasswordResetRouteAction = $this->getRequestPasswordResetRouteAction(), Component::class)) {
                     $this->queueLivewireComponentForRegistration($requestPasswordResetRouteAction);
@@ -517,8 +505,20 @@ trait HasComponents
                 }
             }
 
+            if ($this->hasProfile() && is_subclass_of($profilePageComponent = $this->getProfilePage(), Component::class)) {
+                $this->queueLivewireComponentForRegistration($profilePageComponent);
+            }
+
             if ($this->hasRegistration() && is_subclass_of($registrationRouteAction = $this->getRegistrationRouteAction(), Component::class)) {
                 $this->queueLivewireComponentForRegistration($registrationRouteAction);
+            }
+
+            if ($this->hasTenantRegistration() && is_subclass_of($tenantRegistrationComponent = $this->getTenantRegistrationPage(), Component::class)) {
+                $this->queueLivewireComponentForRegistration($tenantRegistrationComponent);
+            }
+
+            if ($this->hasTenantProfile() && is_subclass_of($tenantProfileComponent = $this->getTenantProfilePage(), Component::class)) {
+                $this->queueLivewireComponentForRegistration($tenantProfileComponent);
             }
 
             foreach ($this->getResources() as $resource) {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Currently it not possible to use these features as they simply don't get registered with Livewire. This probably wont bug you if you have no form on those sites but as soon as something needs to be submitted through livewire it will throw an exception since it has no knowledge of these components.

This PR is in response to issue #12837

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

Visually no changes for screenshots about the problem check the issue #12837

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
