### PR TITLE
Move action lifecycle hooks

### DIFF
--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -91,6 +91,8 @@ trait InteractsWithActions
                         $action->callBefore();
                     }),
                 );
+            } else {
+                $action->callBefore();
             }
 
             $result = $action->call([

--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -84,12 +84,14 @@ trait InteractsWithActions
             if ($this->mountedActionHasForm(mountedAction: $action)) {
                 $action->callBeforeFormValidated();
 
-                $action->formData($form->getState());
+                $action->formData(
+                    $form->getState(afterValidate: function () use ($action) {
+                        $action->callAfterFormValidated();
 
-                $action->callAfterFormValidated();
+                        $action->callBefore();
+                    }),
+                );
             }
-
-            $action->callBefore();
 
             $result = $action->call([
                 'form' => $form,

--- a/packages/forms/src/Concerns/HasFormComponentActions.php
+++ b/packages/forms/src/Concerns/HasFormComponentActions.php
@@ -65,12 +65,14 @@ trait HasFormComponentActions
             if ($this->mountedFormComponentActionHasForm(mountedAction: $action)) {
                 $action->callBeforeFormValidated();
 
-                $action->formData($form->getState());
+                $action->formData(
+                    $form->getState(afterValidate: function () use ($action) {
+                        $action->callAfterFormValidated();
 
-                $action->callAfterFormValidated();
+                        $action->callBefore();
+                    }),
+                );
             }
-
-            $action->callBefore();
 
             $result = $action->call([
                 'form' => $form,

--- a/packages/forms/src/Concerns/HasFormComponentActions.php
+++ b/packages/forms/src/Concerns/HasFormComponentActions.php
@@ -72,6 +72,8 @@ trait HasFormComponentActions
                         $action->callBefore();
                     }),
                 );
+            } else {
+                $action->callBefore();
             }
 
             $result = $action->call([

--- a/packages/infolists/src/Concerns/InteractsWithInfolists.php
+++ b/packages/infolists/src/Concerns/InteractsWithInfolists.php
@@ -109,12 +109,14 @@ trait InteractsWithInfolists
             if ($this->mountedInfolistActionHasForm(mountedAction: $action)) {
                 $action->callBeforeFormValidated();
 
-                $action->formData($form->getState());
+                $action->formData(
+                    $form->getState(afterValidate: function () use ($action) {
+                        $action->callAfterFormValidated();
 
-                $action->callAfterFormValidated();
+                        $action->callBefore();
+                    }),
+                );
             }
-
-            $action->callBefore();
 
             $result = $action->call([
                 'form' => $form,

--- a/packages/infolists/src/Concerns/InteractsWithInfolists.php
+++ b/packages/infolists/src/Concerns/InteractsWithInfolists.php
@@ -116,6 +116,8 @@ trait InteractsWithInfolists
                         $action->callBefore();
                     }),
                 );
+            } else {
+                $action->callBefore();
             }
 
             $result = $action->call([

--- a/packages/tables/src/Concerns/HasActions.php
+++ b/packages/tables/src/Concerns/HasActions.php
@@ -99,12 +99,14 @@ trait HasActions
             if ($this->mountedTableActionHasForm(mountedAction: $action)) {
                 $action->callBeforeFormValidated();
 
-                $action->formData($form->getState());
+                $action->formData(
+                    $form->getState(afterValidate: function () use ($action) {
+                        $action->callAfterFormValidated();
 
-                $action->callAfterFormValidated();
+                        $action->callBefore();
+                    }),
+                );
             }
-
-            $action->callBefore();
 
             $result = $action->call([
                 'form' => $form,

--- a/packages/tables/src/Concerns/HasActions.php
+++ b/packages/tables/src/Concerns/HasActions.php
@@ -106,6 +106,8 @@ trait HasActions
                         $action->callBefore();
                     }),
                 );
+            } else {
+                $action->callBefore();
             }
 
             $result = $action->call([

--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -77,6 +77,8 @@ trait HasBulkActions
                         $action->callBefore();
                     }),
                 );
+            } else {
+                $action->callBefore();
             }
 
             $result = $action->call([

--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -70,12 +70,14 @@ trait HasBulkActions
             if ($this->mountedTableBulkActionHasForm(mountedBulkAction: $action)) {
                 $action->callBeforeFormValidated();
 
-                $action->formData($form->getState());
+                $action->formData(
+                    $form->getState(afterValidate: function () use ($action) {
+                        $action->callAfterFormValidated();
 
-                $action->callAfterFormValidated();
+                        $action->callBefore();
+                    }),
+                );
             }
-
-            $action->callBefore();
 
             $result = $action->call([
                 'form' => $form,


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR moves the action lifecycle hooks so the `afterFormValidated` and `before` hooks are called before any relationships are saved in `getState()`.

I **have not** tested all these action types. Please have a proper look to see if this isn't a breaking change, since you know the actions system better than I do, @danharrin.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
