### PR TITLE
Docs: Fix codeblocks

### DIFF
--- a/packages/tables/docs/08-grouping.md
+++ b/packages/tables/docs/08-grouping.md
@@ -333,7 +333,7 @@ use Filament\Tables\Table;
 public function table(Table $table): Table
 {
     return $table
-		->defaultGroup('status');
+		->defaultGroup('status')
         ->groupingSettingsHidden();
 }
 ```
@@ -348,7 +348,7 @@ use Filament\Tables\Table;
 public function table(Table $table): Table
 {
     return $table
-		->defaultGroup('status');
+		->defaultGroup('status')
         ->groupingDirectionSettingHidden();
 }
 ```


### PR DESCRIPTION
## Description

Table builder row grouping section had 2 instances in codeblocks where extra `;` was used on the line before the last.