### PR TITLE
Allow table row record url to open in new tab

### DIFF
--- a/packages/tables/docs/10-advanced.md
+++ b/packages/tables/docs/10-advanced.md
@@ -128,6 +128,18 @@ public function table(Table $table): Table
 
 In this example, clicking on each post will take you to the `posts.edit` route.
 
+You may also open the URL in a new tab:
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->openRecordUrlInNewTab();
+}
+```
+
 If you'd like to [override the URL](columns/getting-started#opening-urls) for a specific column, or instead [run an action](columns/getting-started#running-actions) when a column is clicked, see the [columns documentation](columns/getting-started#opening-urls).
 
 ## Reordering records

--- a/packages/tables/resources/views/components/columns/column.blade.php
+++ b/packages/tables/resources/views/components/columns/column.blade.php
@@ -5,6 +5,7 @@
     'recordAction' => null,
     'recordKey' => null,
     'recordUrl' => null,
+    'shouldOpenRecordUrlInNewTab' => false,
 ])
 
 @php
@@ -49,7 +50,7 @@
 >
     @if (($url || ($recordUrl && $action === null)) && (! $isClickDisabled))
         <a
-            {{ \Filament\Support\generate_href_html($url ?: $recordUrl, $shouldOpenUrlInNewTab) }}
+            {{ \Filament\Support\generate_href_html($url ?: $recordUrl, $url ? $shouldOpenUrlInNewTab : $shouldOpenRecordUrlInNewTab) }}
             class="{{ $columnClasses }}"
         >
             {{ $slot }}

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -417,6 +417,7 @@
                                 $recordAction = $getRecordAction($record);
                                 $recordKey = $getRecordKey($record);
                                 $recordUrl = $getRecordUrl($record);
+                                $openRecordUrlInNewTab = $shouldOpenRecordUrlInNewTab($record);
                                 $recordGroupKey = $group?->getStringKey($record);
                                 $recordGroupTitle = $group?->getTitle($record);
 
@@ -568,7 +569,7 @@
                                         <div class="flex-1">
                                             @if ($recordUrl)
                                                 <a
-                                                    {{ \Filament\Support\generate_href_html($recordUrl) }}
+                                                    {{ \Filament\Support\generate_href_html($recordUrl, $openRecordUrlInNewTab) }}
                                                     class="{{ $recordContentClasses }}"
                                                 >
                                                     <x-filament-tables::columns.layout
@@ -954,6 +955,7 @@
                                 $recordAction = $getRecordAction($record);
                                 $recordKey = $getRecordKey($record);
                                 $recordUrl = $getRecordUrl($record);
+                                $openRecordUrlInNewTab = $shouldOpenRecordUrlInNewTab($record);
                                 $recordGroupKey = $group?->getStringKey($record);
                                 $recordGroupTitle = $group?->getTitle($record);
                             @endphp
@@ -1121,6 +1123,7 @@
                                                 :record-action="$recordAction"
                                                 :record-key="$recordKey"
                                                 :record-url="$recordUrl"
+                                                :should-open-record-url-in-new-tab="$openRecordUrlInNewTab"
                                             />
                                         </x-filament-tables::cell>
                                     @endforeach

--- a/packages/tables/src/Table/Concerns/HasRecordUrl.php
+++ b/packages/tables/src/Table/Concerns/HasRecordUrl.php
@@ -7,10 +7,20 @@ use Illuminate\Database\Eloquent\Model;
 
 trait HasRecordUrl
 {
+    protected bool | Closure $shouldOpenRecordUrlInNewTab = false;
+
     protected string | Closure | null $recordUrl = null;
 
-    public function recordUrl(string | Closure | null $url): static
+    public function openRecordUrlInNewTab(bool | Closure $condition = true): static
     {
+        $this->shouldOpenRecordUrlInNewTab = $condition;
+
+        return $this;
+    }
+
+    public function recordUrl(string | Closure | null $url, bool | Closure $shouldOpenInNewTab = false): static
+    {
+        $this->openRecordUrlInNewTab($shouldOpenInNewTab);
         $this->recordUrl = $url;
 
         return $this;
@@ -20,6 +30,20 @@ trait HasRecordUrl
     {
         return $this->evaluate(
             $this->recordUrl,
+            namedInjections: [
+                'record' => $record,
+            ],
+            typedInjections: [
+                Model::class => $record,
+                $record::class => $record,
+            ],
+        );
+    }
+
+    public function shouldOpenRecordUrlInNewTab(Model $record): bool
+    {
+        return (bool) $this->evaluate(
+            $this->shouldOpenRecordUrlInNewTab,
             namedInjections: [
                 'record' => $record,
             ],


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This adds the ability to configure the table row `recordUrl` to be opened in a new tab. 

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
