### PR TITLE
fix: Apply filters when the encoding is something other than UTF-8

### DIFF
--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -27,6 +27,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Number;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\ValidationException;
 use League\Csv\ByteSequence;
@@ -423,13 +424,17 @@ trait CanImportRecords
 
         $inputEncoding = $this->detectCsvEncoding($resource);
         $outputEncoding = 'UTF-8';
-        if (filled($inputEncoding) && $inputEncoding !== $outputEncoding) {
+        
+        if (
+            filled($inputEncoding) &&
+            (Str::lower($inputEncoding) !== Str::lower($outputEncoding))
+        ) {
             CharsetConverter::register();
 
             stream_filter_append(
                 $resource,
                 CharsetConverter::getFiltername($inputEncoding, $outputEncoding),
-                STREAM_FILTER_READ
+                STREAM_FILTER_READ,
             );
         }
 

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -421,14 +421,14 @@ trait CanImportRecords
             ]));
         }
 
-        $encoding = $this->detectCsvEncoding($resource);
-
-        if (filled($encoding)) {
+        $inputEncoding = $this->detectCsvEncoding($resource);
+        $outputEncoding = 'UTF-8';
+        if (filled($inputEncoding) && $inputEncoding !== $outputEncoding) {
             CharsetConverter::register();
 
             stream_filter_append(
                 $resource,
-                CharsetConverter::getFiltername($encoding, 'utf-8'),
+                CharsetConverter::getFiltername($inputEncoding, $outputEncoding),
                 STREAM_FILTER_READ
             );
         }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Modify to apply filters when the encoding is something other than UTF-8 during CSV import.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
