### PR TITLE
Allow to use html in checkboxlist labels

### DIFF
--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -424,7 +424,7 @@ trait CanImportRecords
 
         $inputEncoding = $this->detectCsvEncoding($resource);
         $outputEncoding = 'UTF-8';
-        
+
         if (
             filled($inputEncoding) &&
             (Str::lower($inputEncoding) !== Str::lower($outputEncoding))

--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -251,7 +251,7 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
         return $this->getOptionLabelFromRecordUsing !== null;
     }
 
-    public function getOptionLabelFromRecord(Model $record): string
+    public function getOptionLabelFromRecord(Model $record): Htmlable
     {
         return $this->evaluate(
             $this->getOptionLabelFromRecordUsing,

--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -251,7 +251,7 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
         return $this->getOptionLabelFromRecordUsing !== null;
     }
 
-    public function getOptionLabelFromRecord(Model $record): Htmlable
+    public function getOptionLabelFromRecord(Model $record): string | Htmlable
     {
         return $this->evaluate(
             $this->getOptionLabelFromRecordUsing,

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -98,7 +98,7 @@
                     'ring-1 ring-gray-950/10 dark:ring-white/20' => (($color === 'gray') || ($tag === 'label')) && (! $grouped),
                     'bg-custom-600 text-white hover:bg-custom-500 focus-visible:ring-custom-500/50 dark:bg-custom-500 dark:hover:bg-custom-400 dark:focus-visible:ring-custom-400/50' => ($color !== 'gray') && ($tag !== 'label'),
                     '[input:checked+&]:bg-custom-600 [input:checked+&]:text-white [input:checked+&]:ring-0 [input:checked+&]:hover:bg-custom-500 dark:[input:checked+&]:bg-custom-500 dark:[input:checked+&]:hover:bg-custom-400 [input:checked:focus-visible+&]:ring-custom-500/50 dark:[input:checked:focus-visible+&]:ring-custom-400/50 [input:focus-visible+&]:z-10 [input:focus-visible+&]:ring-2 [input:focus-visible+&]:ring-gray-950/10 dark:[input:focus-visible+&]:ring-white/20' => ($color !== 'gray') && ($tag === 'label'),
-                ]
+                    ]
         ),
     ]);
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Just a minor change of a single return type from `string` to `Htmlable`, so that you can use HTML inside a checkbox label.

## Visual changes

As an example:

```
CheckboxList::make('newsletterSubscriptions')
      ->getOptionLabelFromRecordUsing(function (NewsletterSubscription $record) {
          return new HtmlString( $record->name. " (<small> ". $record->userCount . " Abonnenten</small>)");
      })
```

Before: 

![image](https://github.com/filamentphp/filament/assets/642292/86ecba4c-148b-416b-8f1a-b34571375735)


After:

![image](https://github.com/filamentphp/filament/assets/642292/8d81ff21-090f-4501-9e25-66d09720a413)

## Functional changes

- [ x] Code style has been fixed by running the `composer cs` command.
- [ x] Changes have been tested to not break existing functionality.
- [ x] Documentation is up-to-date.
