### PR TITLE
convert boolean to string

### DIFF
--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -424,7 +424,7 @@ trait CanImportRecords
 
         $inputEncoding = $this->detectCsvEncoding($resource);
         $outputEncoding = 'UTF-8';
-        
+
         if (
             filled($inputEncoding) &&
             (Str::lower($inputEncoding) !== Str::lower($outputEncoding))

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -836,6 +836,8 @@ trait CanBeValidated
 
             if (is_array($stateValues)) {
                 $stateValues = implode(',', $stateValues);
+            } elseif (is_bool($stateValues)) {
+                $stateValues = $stateValues ? 'true' : 'false';
             }
 
             return "{$rule}:{$statePath},{$stateValues}";

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -98,7 +98,7 @@
                     'ring-1 ring-gray-950/10 dark:ring-white/20' => (($color === 'gray') || ($tag === 'label')) && (! $grouped),
                     'bg-custom-600 text-white hover:bg-custom-500 focus-visible:ring-custom-500/50 dark:bg-custom-500 dark:hover:bg-custom-400 dark:focus-visible:ring-custom-400/50' => ($color !== 'gray') && ($tag !== 'label'),
                     '[input:checked+&]:bg-custom-600 [input:checked+&]:text-white [input:checked+&]:ring-0 [input:checked+&]:hover:bg-custom-500 dark:[input:checked+&]:bg-custom-500 dark:[input:checked+&]:hover:bg-custom-400 [input:checked:focus-visible+&]:ring-custom-500/50 dark:[input:checked:focus-visible+&]:ring-custom-400/50 [input:focus-visible+&]:z-10 [input:focus-visible+&]:ring-2 [input:focus-visible+&]:ring-gray-950/10 dark:[input:focus-visible+&]:ring-white/20' => ($color !== 'gray') && ($tag === 'label'),
-                ]
+                    ]
         ),
     ]);
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

currently when the fields are configured as follow, the rule generated will be `required_if:data.is_active,1`
```php
Toggle::make('is_active')
        ->required()
        ->hint('Phone number is required too')
        ->label('Enable / Disable'),
  TextInput::make('phone_number')
        ->numeric()
        ->requiredIf('is_active', true)
```

this change will convert the value to `'true'` and `false'`

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
