### PR TITLE
Fix scroll to top in Wizard Form

### DIFF
--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -37,7 +37,7 @@
 
         scrollToTop: function () {
             $nextTick(() =>
-                this.$root.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                this.$root.scrollIntoView({ behavior: 'smooth', block: 'start' }),
             )
         },
 

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -36,7 +36,9 @@
         },
 
         scrollToTop: function () {
-            this.$root.scrollIntoView({ behavior: 'smooth', block: 'start' })
+            $nextTick(() =>
+                this.$root.scrollIntoView({ behavior: 'smooth', block: 'start' })
+            )
         },
 
         autofocusFields: function () {

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -36,7 +36,7 @@
         },
 
         scrollToTop: function () {
-            $nextTick(() =>
+            this.$nextTick(() =>
                 this.$root.scrollIntoView({ behavior: 'smooth', block: 'start' }),
             )
         },


### PR DESCRIPTION
## Description

Fixes #8909

As it is described in the comments of the issue, the bug was affecting only Safari web browser. Using `$nextTick` solves this issue. without affecting the original behaviour.

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
