### PR TITLE
UploadedFile should be converted to TemporaryUploadedFile

### DIFF
--- a/packages/forms/src/Testing/TestsForms.php
+++ b/packages/forms/src/Testing/TestsForms.php
@@ -7,6 +7,7 @@ use Filament\Forms\ComponentContainer;
 use Filament\Forms\Components\Field;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Contracts\HasForms;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Testing\Assert;
 use Livewire\Features\SupportTesting\Testable;
@@ -40,6 +41,15 @@ class TestsForms
 
                 if (filled($formStatePath)) {
                     $state = Arr::undot([$formStatePath => $state]);
+                }
+
+                foreach (Arr::dot($state) as $key => $value) {
+                    if ($value instanceof UploadedFile ||
+                        (is_array($value) && isset($value[0]) && $value[0] instanceof UploadedFile)
+                    ) {
+                        $this->set($key, $value);
+                        Arr::set($state, $key, $this->get($key));
+                    }
                 }
 
                 $this->call('fillFormDataForTesting', $state);

--- a/tests/src/Forms/Components/FileUploadTest.php
+++ b/tests/src/Forms/Components/FileUploadTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Form;
+use Filament\Tests\Forms\Fixtures\Livewire;
+use Filament\Tests\TestCase;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\UploadedFile;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+
+use function Filament\Tests\livewire;
+
+uses(TestCase::class);
+
+it('UploadedFile should be converted to TemporaryUploadedFile', function () {
+    livewire(TestComponentWithFileUpload::class)
+        ->fillForm([
+            'single-file' => UploadedFile::fake()->image('single-file.jpg'),
+            'multiple-files' => [
+                UploadedFile::fake()->image('multiple-file1.jpg'),
+                UploadedFile::fake()->image('multiple-file2.jpg'),
+            ],
+        ])
+        ->assertFormSet(function (array $data) {
+            expect($data['single-file'][0])->toBeInstanceOf(TemporaryUploadedFile::class)
+                ->and($data['multiple-files'][0])->toBeInstanceOf(TemporaryUploadedFile::class)
+                ->and($data['multiple-files'][1])->toBeInstanceOf(TemporaryUploadedFile::class);
+        });
+});
+
+class TestComponentWithFileUpload extends Livewire
+{
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                FileUpload::make('single-file'),
+                FileUpload::make('multiple-files')->multiple(),
+            ])
+            ->statePath('data');
+    }
+
+    public function render(): View
+    {
+        return view('forms.fixtures.form');
+    }
+}


### PR DESCRIPTION
## Description

UploadedFile::fake() should covert to TemporaryUploadedFile

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
