### PR TITLE
Fix KeyValue reorderable

### DIFF
--- a/packages/forms/resources/js/components/key-value.js
+++ b/packages/forms/resources/js/components/key-value.js
@@ -59,12 +59,16 @@ export default function keyValueFormComponent({ state }) {
         reorderRows: function (event) {
             const rows = Alpine.raw(this.rows)
 
+            this.rows = []
+
             const reorderedRow = rows.splice(event.oldIndex, 1)[0]
             rows.splice(event.newIndex, 0, reorderedRow)
 
-            this.rows = rows
+            this.$nextTick(() => {
+                this.rows = rows
 
-            this.updateState()
+                this.updateState()
+            })
         },
 
         updateRows: function () {

--- a/packages/forms/resources/js/components/key-value.js
+++ b/packages/forms/resources/js/components/key-value.js
@@ -78,7 +78,6 @@ export default function keyValueFormComponent({ state }) {
                 return
             }
 
-
             this.rows = Alpine.raw(this.state)
         },
 

--- a/packages/forms/resources/js/components/key-value.js
+++ b/packages/forms/resources/js/components/key-value.js
@@ -96,7 +96,7 @@ export default function keyValueFormComponent({ state }) {
 
                 state.push({
                     key: row.key,
-                    value: row.value
+                    value: row.value,
                 })
             })
 

--- a/packages/forms/resources/js/components/key-value.js
+++ b/packages/forms/resources/js/components/key-value.js
@@ -87,14 +87,17 @@ export default function keyValueFormComponent({ state }) {
         },
 
         updateState: function () {
-            let state = {}
+            let state = []
 
             this.rows.forEach((row) => {
                 if (row.key === '' || row.key === null) {
                     return
                 }
 
-                state[row.key] = row.value
+                state.push({
+                    key: row.key,
+                    value: row.value
+                })
             })
 
             // This is a hack to prevent the component from updating rows again

--- a/packages/forms/resources/js/components/key-value.js
+++ b/packages/forms/resources/js/components/key-value.js
@@ -74,16 +74,8 @@ export default function keyValueFormComponent({ state }) {
                 return
             }
 
-            let rows = []
 
-            for (let [key, value] of Object.entries(this.state ?? {})) {
-                rows.push({
-                    key,
-                    value,
-                })
-            }
-
-            this.rows = rows
+            this.rows = Alpine.raw(this.state)
         },
 
         updateState: function () {

--- a/packages/forms/src/Components/KeyValue.php
+++ b/packages/forms/src/Components/KeyValue.php
@@ -55,6 +55,19 @@ class KeyValue extends Field
 
         $this->default([]);
 
+        $this->afterStateHydrated(static function (KeyValue $component, $state): void {
+            if (blank($state)) {
+                $component->state([]);
+
+                return;
+            }
+
+            $component->state(collect($state)
+                ->map(fn ($value, $key) => ['key' => $key, 'value' => $value])
+                ->values()
+                ->toArray());
+        });
+
         $this->dehydrateStateUsing(static function (?array $state) {
             return collect($state ?? [])
                 ->mapWithKeys(static fn ($state) => [$state['key'] => $state['value']])

--- a/packages/forms/src/Components/KeyValue.php
+++ b/packages/forms/src/Components/KeyValue.php
@@ -57,6 +57,7 @@ class KeyValue extends Field
 
         $this->dehydrateStateUsing(static function (?array $state) {
             return collect($state ?? [])
+                ->mapWithKeys(static fn ($state) => [$state['key'] => $state['value']])
                 ->filter(static fn (?string $value, ?string $key): bool => filled($key))
                 ->map(static fn (?string $value): ?string => filled($value) ? $value : null)
                 ->all();


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
1. fixes #11128 
2. add new row insert at wrong position after reorder
    steps: reorder 1 any item, then add row (refer video below) 

this can arguably breaking change for those override `afterStateHydrated ` and `dehydrateStateUsing` but at current state the reorderable is not properly working

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes
n/a

Issue 2
**Before** 

https://github.com/filamentphp/filament/assets/67364036/c42679d3-026f-453e-80bf-39cf5845cd02

**After**

https://github.com/filamentphp/filament/assets/67364036/1c315020-313f-4932-a371-f6fbfb2c3038



<!-- Add screenshots/recordings of before and after. -->

## Functional changes
n/a

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
