### PR TITLE
fix: add row wrong index after reorder

### DIFF
--- a/packages/forms/resources/js/components/key-value.js
+++ b/packages/forms/resources/js/components/key-value.js
@@ -59,12 +59,16 @@ export default function keyValueFormComponent({ state }) {
         reorderRows: function (event) {
             const rows = Alpine.raw(this.rows)
 
+            this.rows = []
+
             const reorderedRow = rows.splice(event.oldIndex, 1)[0]
             rows.splice(event.newIndex, 0, reorderedRow)
 
-            this.rows = rows
+            this.$nextTick(() => {
+                this.rows = rows
 
-            this.updateState()
+                this.updateState()
+            })
         },
 
         updateRows: function () {

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -98,7 +98,7 @@
                     'ring-1 ring-gray-950/10 dark:ring-white/20' => (($color === 'gray') || ($tag === 'label')) && (! $grouped),
                     'bg-custom-600 text-white hover:bg-custom-500 focus-visible:ring-custom-500/50 dark:bg-custom-500 dark:hover:bg-custom-400 dark:focus-visible:ring-custom-400/50' => ($color !== 'gray') && ($tag !== 'label'),
                     '[input:checked+&]:bg-custom-600 [input:checked+&]:text-white [input:checked+&]:ring-0 [input:checked+&]:hover:bg-custom-500 dark:[input:checked+&]:bg-custom-500 dark:[input:checked+&]:hover:bg-custom-400 [input:checked:focus-visible+&]:ring-custom-500/50 dark:[input:checked:focus-visible+&]:ring-custom-400/50 [input:focus-visible+&]:z-10 [input:focus-visible+&]:ring-2 [input:focus-visible+&]:ring-gray-950/10 dark:[input:focus-visible+&]:ring-white/20' => ($color !== 'gray') && ($tag === 'label'),
-                ]
+                    ]
         ),
     ]);
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
add new row insert at wrong position after reorder

steps: reorder 1 any item, then add row (refer video below) 

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes
**Before** 

https://github.com/filamentphp/filament/assets/67364036/fbf4b9c6-56eb-4580-8f4b-51eeb3c00a08


**After**

https://github.com/filamentphp/filament/assets/67364036/5284a8fb-02dd-47be-9fa1-30b092e9dbe4



<!-- Add screenshots/recordings of before and after. -->

## Functional changes
n/a

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
