### PR TITLE
Fix Groupable contract implementation order

### DIFF
--- a/packages/actions/src/Action.php
+++ b/packages/actions/src/Action.php
@@ -5,7 +5,7 @@ namespace Filament\Actions;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Js;
 
-class Action extends MountableAction implements Contracts\Groupable, Contracts\HasRecord
+class Action extends MountableAction implements Contracts\HasRecord
 {
     use Concerns\CanSubmitForm;
     use Concerns\HasMountableArguments;

--- a/packages/actions/src/StaticAction.php
+++ b/packages/actions/src/StaticAction.php
@@ -11,7 +11,7 @@ use Filament\Support\Concerns\HasIcon;
 use Illuminate\Support\Js;
 use Illuminate\Support\Traits\Conditionable;
 
-class StaticAction extends ViewComponent
+class StaticAction extends ViewComponent implements Contracts\Groupable
 {
     use Concerns\BelongsToGroup;
     use Concerns\CanBeDisabled;

--- a/packages/notifications/src/Actions/Action.php
+++ b/packages/notifications/src/Actions/Action.php
@@ -3,13 +3,12 @@
 namespace Filament\Notifications\Actions;
 
 use Closure;
-use Filament\Actions\Contracts\Groupable;
 use Filament\Actions\StaticAction;
 use Filament\Support\Enums\ActionSize;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Str;
 
-class Action extends StaticAction implements Arrayable, Groupable
+class Action extends StaticAction implements Arrayable
 {
     protected string $viewIdentifier = 'action';
 

--- a/packages/tables/src/Actions/BulkAction.php
+++ b/packages/tables/src/Actions/BulkAction.php
@@ -3,13 +3,12 @@
 namespace Filament\Tables\Actions;
 
 use Closure;
-use Filament\Actions\Contracts\Groupable;
 use Filament\Actions\MountableAction;
 use Filament\Tables\Actions\Contracts\HasTable;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection;
 
-class BulkAction extends MountableAction implements Groupable, HasTable
+class BulkAction extends MountableAction implements HasTable
 {
     use Concerns\BelongsToTable;
     use Concerns\CanDeselectRecordsAfterCompletion;


### PR DESCRIPTION
## Description
The `grouped()` method is implemented on the `StaticAction` class and not the `Action` class:
https://github.com/juliangums/filament/blob/patch-2/packages/actions/src/StaticAction.php#L88
It will not produce any errors currently because `Action` extends `StaticAction`, but it isn't as clean and leads to issues in static analysers like Psalm when extending Action with a custom action.

## Functional changes
- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
