### PR TITLE
fix return type for navigation icon

### DIFF
--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -804,7 +804,7 @@ abstract class Resource
         static::$navigationParentItem = $item;
     }
 
-    public static function getNavigationIcon(): string | Htmlable | null
+    public static function getNavigationIcon(): ?string
     {
         return static::$navigationIcon;
     }
@@ -814,7 +814,7 @@ abstract class Resource
         static::$navigationIcon = $icon;
     }
 
-    public static function getActiveNavigationIcon(): string | Htmlable | null
+    public static function getActiveNavigationIcon(): ?string
     {
         return static::$activeNavigationIcon ?? static::getNavigationIcon();
     }


### PR DESCRIPTION
Given that `$navigationIcon` is a nullable string as well as `$activeNavigationIcon` (https://github.com/juliangums/filament/blob/3.x/packages/panels/src/Resources/Resource.php#L75),
`getNavigationIcon()` and `getActiveNavigationIcon()` should not be able to return an Htmlable. 
It also causes issues with static analysers if I want to use it like
```php
                MenuItem::make()
                    ->icon(SomeResource::getNavigationIcon()),
```