### PR TITLE
Use `h-full` instead of `h-screen` for sidebar

### DIFF
--- a/packages/panels/resources/views/components/sidebar/index.blade.php
+++ b/packages/panels/resources/views/components/sidebar/index.blade.php
@@ -35,7 +35,7 @@
     @endif
     {{
         $attributes->class([
-            'fi-sidebar fixed inset-y-0 start-0 z-30 flex flex-col h-screen content-start bg-white transition-all dark:bg-gray-900 lg:z-0 lg:bg-transparent lg:shadow-none lg:ring-0 lg:transition-none dark:lg:bg-transparent',
+            'fi-sidebar fixed inset-y-0 start-0 z-30 flex flex-col h-full content-start bg-white transition-all dark:bg-gray-900 lg:z-0 lg:bg-transparent lg:shadow-none lg:ring-0 lg:transition-none dark:lg:bg-transparent',
             'lg:translate-x-0 rtl:lg:-translate-x-0' => ! (filament()->isSidebarCollapsibleOnDesktop() || filament()->isSidebarFullyCollapsibleOnDesktop() || filament()->hasTopNavigation()),
             'lg:-translate-x-full rtl:lg:translate-x-full' => filament()->hasTopNavigation(),
         ])


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fixes https://github.com/filamentphp/filament/issues/12983

## Visual changes

Before:

![SCR-20240529-blbj](https://github.com/filamentphp/filament/assets/10696975/cd340d94-1c3b-485f-8047-9531ce05e365)

After:

![SCR-20240529-bldq](https://github.com/filamentphp/filament/assets/10696975/2c371e9c-2f39-49e9-8216-f4f784bce9fe)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
