### PR TITLE
Change css invisibility strategy in Wizard steps

### DIFF
--- a/packages/forms/resources/views/components/tabs/tab.blade.php
+++ b/packages/forms/resources/views/components/tabs/tab.blade.php
@@ -8,7 +8,7 @@
         'mt-6' => ! $isContained,
     ]);
 
-    $inactiveTabClasses = 'invisible h-0 overflow-y-hidden p-0';
+    $inactiveTabClasses = 'absolute h-0 overflow-hidden p-0';
 @endphp
 
 <div

--- a/packages/forms/resources/views/components/wizard/step.blade.php
+++ b/packages/forms/resources/views/components/wizard/step.blade.php
@@ -8,7 +8,7 @@
         'mt-6' => ! $isContained,
     ]);
 
-    $inactiveStepClasses = 'invisible h-0 overflow-y-hidden p-0';
+    $inactiveStepClasses = 'absolute h-0 overflow-hidden p-0';
 @endphp
 
 <div

--- a/packages/infolists/resources/views/components/tabs/tab.blade.php
+++ b/packages/infolists/resources/views/components/tabs/tab.blade.php
@@ -8,7 +8,7 @@
         'mt-6' => ! $isContained,
     ]);
 
-    $inactiveTabClasses = 'invisible h-0 overflow-y-hidden p-0';
+    $inactiveTabClasses = 'absolute h-0 overflow-hidden p-0';
 @endphp
 
 <div

--- a/packages/support/resources/views/components/section/index.blade.php
+++ b/packages/support/resources/views/components/section/index.blade.php
@@ -172,7 +172,7 @@
             @if ($collapsed || $persistCollapsed)
                 x-cloak
             @endif
-            x-bind:class="{ 'invisible h-0 overflow-y-hidden border-none': isCollapsed }"
+            x-bind:class="{ 'absolute h-0 overflow-hidden border-none': isCollapsed }"
         @endif
         @class([
             'fi-section-content-ctn',


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fixes #9426 

Digging into the issue, I found that both problems described are part of the same root cause, which is a CSS issue. The issue is related to the CSS properties `height: 0; visibility: hidden;` in hidden (or invisible) steps. The problem appears when the previous step is long enough to display the browser scrollbar, and the next step is shorter.


#### CSS examples
As it's a CSS-related issue, I made this simple HTML to make it easy to see what is happening:

[Example 0](https://html-preview.github.io/?url=https://github.com/sebapastore/css-visibility-hidden-issue/blob/main/test0.html): Here you can find a big Header and a Footer (nothing is hidden).
[Example 1](https://html-preview.github.io/?url=https://github.com/sebapastore/css-visibility-hidden-issue/blob/main/test1.html): Here the Header is hidden with `height: 0; visibility: hidden;`, and you can see there is a blank space below the Footer that shouldn't be there.
[Example 2](https://html-preview.github.io/?url=https://github.com/sebapastore/css-visibility-hidden-issue/blob/main/test2.html): Here the Header is hidden with `height: 0; overflow: hidden; position: absolute;`, and you can see it is working as expected.

#### Why not `display: none`?

I searched why `display: none` is not being used. I found that `height: 0; visibility: hidden;` was introduced in a "tab with file" related issue. Here is the [issue](https://github.com/filamentphp/filament/issues/1967), and here is the [solution](https://github.com/filamentphp/filament/pull/1997) that introduced `height: 0; visibility: hidden;` instead of `x-show`. I guess the `step` component "inherited" these properties from `tab`. I tried to reproduce the "tab with file" issue in the Wizard but couldn't, so I think that maybe in the Wizard we are able to use display: none if that was the only reason not to use it. However, in the meantime, I found this other solution.

#### Observations

Another observation is that in the HTML examples I provided, there is really no need to use `position: absolute;`, but in the Wizard, it is necessary for it to work.

The changes have been tested in Safari, Chrome and Firefox.

- [X] Changes have been tested to not break existing functionality.
