### PR TITLE
Update 03-database-notifications.md

### DIFF
--- a/packages/notifications/docs/03-database-notifications.md
+++ b/packages/notifications/docs/03-database-notifications.md
@@ -98,7 +98,7 @@ $recipient->notify(
 );
 ```
 
-> Database notifications dispatched with `sendToDatabase` and `toDatabase` are queued. Ensure your queue is running to receive notifications dispatched in these ways.
+> Laravel sends database notifications using the queue. Ensure your queue is running in order to receive the notifications.
 
 Alternatively, use a traditional [Laravel notification class](https://laravel.com/docs/notifications#generating-notifications) by returning the notification from the `toDatabase()` method:
 

--- a/packages/notifications/docs/03-database-notifications.md
+++ b/packages/notifications/docs/03-database-notifications.md
@@ -23,7 +23,7 @@ php artisan notifications:table
 
 ## Rendering the database notifications modal
 
-> If you want to add database notifications to a panel, [follow this part of the guide](#adding-database-notifications-to-a-panel).
+> If you want to add database notifications to a panel, [follow this part of the guide](#adding-the-database-notifications-modal-to-a-panel).
 
 If you'd like to render the database notifications modal outside of the [Panel Builder](../panels), you'll need to add a new Livewire component to your Blade layout:
 
@@ -97,6 +97,8 @@ $recipient->notify(
         ->toDatabase(),
 );
 ```
+
+> Database notifications dispatched with `sendToDatabase` and `toDatabase` are queued. Ensure your queue is running to receive notifications dispatched in these ways.
 
 Alternatively, use a traditional [Laravel notification class](https://laravel.com/docs/notifications#generating-notifications) by returning the notification from the `toDatabase()` method:
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Two updates to the documentation have been made:
1. Fix for heading link
2. Inclusion of notification queuing.

### Heading Link
The heading link for adding database notifications to a Filament panel was broken. This PR updates the link to navigate correctly.

### Notification Queuing
When implementing database notifications within Filament panels, I didn't pick up that the Filament engine queues the notifications. This PR adds a small note to highlight this.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

See PR diff.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
