### PR TITLE
Add ability to disable autofocus on modals

### DIFF
--- a/packages/actions/docs/04-modals.md
+++ b/packages/actions/docs/04-modals.md
@@ -552,9 +552,9 @@ use Filament\Support\View\Components\Modal;
 Modal::closeButton(false);
 ```
 
-## Disable autofocus on modal open
+## Preventing the modal from autofocusing
 
-By default, modals will autofocus on the first focusable element when opened. If you wish to disable this behavior for the modal you can use the `modalAutofocus(false)` method:
+By default, modals will autofocus on the first focusable element when opened. If you wish to disable this behavior, you can use the `modalAutofocus(false)` method:
 
 ```php
 Action::make('updateAuthor')

--- a/packages/actions/docs/04-modals.md
+++ b/packages/actions/docs/04-modals.md
@@ -552,6 +552,29 @@ use Filament\Support\View\Components\Modal;
 Modal::closeButton(false);
 ```
 
+## Disable autofocus on modal open
+
+By default, modals will autofocus on the first focusable element when opened. If you wish to disable this behavior for the modal you can use the `modalAutofocus(false)` method:
+
+```php
+Action::make('updateAuthor')
+    ->form([
+        // ...
+    ])
+    ->action(function (array $data): void {
+        // ...
+    })
+    ->modalAutofocus(false)
+```
+
+If you'd like to disable autofocus for all modals in the application, you can do so by calling `Modal::autofocus(false)` inside a service provider or middleware:
+
+```php
+use Filament\Support\View\Components\Modal;
+
+Modal::autofocus(false);
+```
+
 ## Optimizing modal configuration methods
 
 When you use database queries or other heavy operations inside modal configuration methods like `modalHeading()`, they can be executed more than once. This is because Filament uses these methods to decide whether to render the modal or not, and also to render the modal's content.

--- a/packages/actions/resources/views/components/modals.blade.php
+++ b/packages/actions/resources/views/components/modals.blade.php
@@ -6,6 +6,7 @@
 
         <x-filament::modal
             :alignment="$action?->getModalAlignment()"
+            :autofocus="$action?->autofocusOnOpen()"
             :close-button="$action?->hasModalCloseButton()"
             :close-by-clicking-away="$action?->isModalClosedByClickingAway()"
             :close-by-escaping="$action?->isModalClosedByEscaping()"
@@ -67,6 +68,7 @@
 
         <x-filament::modal
             :alignment="$action?->getModalAlignment()"
+            :autofocus="$action?->autofocusOnOpen()"
             :close-button="$action?->hasModalCloseButton()"
             :close-by-clicking-away="$action?->isModalClosedByClickingAway()"
             :close-by-escaping="$action?->isModalClosedByEscaping()"
@@ -122,6 +124,7 @@
 
         <x-filament::modal
             :alignment="$action?->getModalAlignment()"
+            :autofocus="$action?->autofocusOnOpen()"
             :close-button="$action?->hasModalCloseButton()"
             :close-by-clicking-away="$action?->isModalClosedByClickingAway()"
             :close-by-escaping="$action?->isModalClosedByEscaping()"
@@ -183,6 +186,7 @@
 
         <x-filament::modal
             :alignment="$action?->getModalAlignment()"
+            :autofocus="$action?->autofocusOnOpen()"
             :close-button="$action?->hasModalCloseButton()"
             :close-by-clicking-away="$action?->isModalClosedByClickingAway()"
             :close-by-escaping="$action?->isModalClosedByEscaping()"
@@ -244,6 +248,7 @@
     <form wire:submit.prevent="callMountedFormComponentAction">
         <x-filament::modal
             :alignment="$action?->getModalAlignment()"
+            :autofocus="$action?->autofocusOnOpen()"
             :close-button="$action?->hasModalCloseButton()"
             :close-by-clicking-away="$action?->isModalClosedByClickingAway()"
             :close-by-escaping="$action?->isModalClosedByEscaping()"

--- a/packages/actions/resources/views/components/modals.blade.php
+++ b/packages/actions/resources/views/components/modals.blade.php
@@ -6,7 +6,7 @@
 
         <x-filament::modal
             :alignment="$action?->getModalAlignment()"
-            :autofocus="$action?->autofocusOnOpen()"
+            :autofocus="$action?->isModalAutofocused()"
             :close-button="$action?->hasModalCloseButton()"
             :close-by-clicking-away="$action?->isModalClosedByClickingAway()"
             :close-by-escaping="$action?->isModalClosedByEscaping()"
@@ -68,7 +68,7 @@
 
         <x-filament::modal
             :alignment="$action?->getModalAlignment()"
-            :autofocus="$action?->autofocusOnOpen()"
+            :autofocus="$action?->isModalAutofocused()"
             :close-button="$action?->hasModalCloseButton()"
             :close-by-clicking-away="$action?->isModalClosedByClickingAway()"
             :close-by-escaping="$action?->isModalClosedByEscaping()"
@@ -124,7 +124,7 @@
 
         <x-filament::modal
             :alignment="$action?->getModalAlignment()"
-            :autofocus="$action?->autofocusOnOpen()"
+            :autofocus="$action?->isModalAutofocused()"
             :close-button="$action?->hasModalCloseButton()"
             :close-by-clicking-away="$action?->isModalClosedByClickingAway()"
             :close-by-escaping="$action?->isModalClosedByEscaping()"
@@ -186,7 +186,7 @@
 
         <x-filament::modal
             :alignment="$action?->getModalAlignment()"
-            :autofocus="$action?->autofocusOnOpen()"
+            :autofocus="$action?->isModalAutofocused()"
             :close-button="$action?->hasModalCloseButton()"
             :close-by-clicking-away="$action?->isModalClosedByClickingAway()"
             :close-by-escaping="$action?->isModalClosedByEscaping()"
@@ -248,7 +248,7 @@
     <form wire:submit.prevent="callMountedFormComponentAction">
         <x-filament::modal
             :alignment="$action?->getModalAlignment()"
-            :autofocus="$action?->autofocusOnOpen()"
+            :autofocus="$action?->isModalAutofocused()"
             :close-button="$action?->hasModalCloseButton()"
             :close-by-clicking-away="$action?->isModalClosedByClickingAway()"
             :close-by-escaping="$action?->isModalClosedByEscaping()"

--- a/packages/actions/src/Concerns/CanOpenModal.php
+++ b/packages/actions/src/Concerns/CanOpenModal.php
@@ -82,6 +82,8 @@ trait CanOpenModal
 
     protected bool | Closure | null $isModalClosedByEscaping = null;
 
+    protected bool | Closure | null $autofocusOnOpen = null;
+
     protected string | Closure | null $modalIcon = null;
 
     /**
@@ -125,6 +127,13 @@ trait CanOpenModal
     public function modalCloseButton(bool | Closure | null $condition = true): static
     {
         $this->hasModalCloseButton = $condition;
+
+        return $this;
+    }
+
+    public function modalAutofocus(bool | Closure | null $condition = true): static
+    {
+        $this->autofocusOnOpen = $condition;
 
         return $this;
     }
@@ -612,6 +621,11 @@ trait CanOpenModal
     public function isModalClosedByEscaping(): bool
     {
         return (bool) ($this->evaluate($this->isModalClosedByEscaping) ?? Modal::$isClosedByEscaping);
+    }
+
+    public function autofocusOnOpen(): bool
+    {
+        return $this->evaluate($this->autofocusOnOpen) ?? Modal::$autofocusOnOpen;
     }
 
     /**

--- a/packages/actions/src/Concerns/CanOpenModal.php
+++ b/packages/actions/src/Concerns/CanOpenModal.php
@@ -82,7 +82,7 @@ trait CanOpenModal
 
     protected bool | Closure | null $isModalClosedByEscaping = null;
 
-    protected bool | Closure | null $autofocusOnOpen = null;
+    protected bool | Closure | null $isModalAutofocused = null;
 
     protected string | Closure | null $modalIcon = null;
 
@@ -133,7 +133,7 @@ trait CanOpenModal
 
     public function modalAutofocus(bool | Closure | null $condition = true): static
     {
-        $this->autofocusOnOpen = $condition;
+        $this->isModalAutofocused = $condition;
 
         return $this;
     }
@@ -623,9 +623,9 @@ trait CanOpenModal
         return (bool) ($this->evaluate($this->isModalClosedByEscaping) ?? Modal::$isClosedByEscaping);
     }
 
-    public function autofocusOnOpen(): bool
+    public function isModalAutofocused(): bool
     {
-        return $this->evaluate($this->autofocusOnOpen) ?? Modal::$autofocusOnOpen;
+        return $this->evaluate($this->isModalAutofocused) ?? Modal::$isAutofocused;
     }
 
     /**

--- a/packages/support/docs/09-blade-components/02-modal.md
+++ b/packages/support/docs/09-blade-components/02-modal.md
@@ -195,6 +195,16 @@ By default, when you click away from a modal, it will close itself. If you wish 
 </x-filament::modal>
 ```
 
+## Closing the modal by escaping
+
+By default, when you press escape on a modal, it will close itself. If you wish to disable this behavior for a specific action, you can use the `close-by-escaping` attribute:
+
+```blade
+<x-filament::modal :close-by-escaping="false">
+    {{-- Modal content --}}
+</x-filament::modal>
+```
+
 ## Hiding the modal close button
 
 By default, modals have a close button in the top right corner. You can remove the close button from the modal by using the `close-button` attribute:
@@ -205,9 +215,9 @@ By default, modals have a close button in the top right corner. You can remove t
 </x-filament::modal>
 ```
 
-## Disable autofocus on modal open
+## Preventing the modal from autofocusing
 
-By default, modals will autofocus on the first focusable element when opened. If you wish to disable this behavior for the modal you can use the `autofocus` attribute:
+By default, modals will autofocus on the first focusable element when opened. If you wish to disable this behavior, you can use the `autofocus` attribute:
 
 ```blade
 <x-filament::modal :autofocus="false">

--- a/packages/support/docs/09-blade-components/02-modal.md
+++ b/packages/support/docs/09-blade-components/02-modal.md
@@ -204,3 +204,13 @@ By default, modals have a close button in the top right corner. You can remove t
     {{-- Modal content --}}
 </x-filament::modal>
 ```
+
+## Disable autofocus on modal open
+
+By default, modals will autofocus on the first focusable element when opened. If you wish to disable this behavior for the modal you can use the `autofocus` attribute:
+
+```blade
+<x-filament::modal :autofocus="false">
+    {{-- Modal content --}}
+</x-filament::modal>
+```

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -6,6 +6,7 @@
 @props([
     'alignment' => Alignment::Start,
     'ariaLabelledby' => null,
+    'autofocus' => \Filament\Support\View\Components\Modal::$autofocusOnOpen,
     'closeButton' => \Filament\Support\View\Components\Modal::$hasCloseButton,
     'closeByClickingAway' => \Filament\Support\View\Components\Modal::$isClosedByClickingAway,
     'closeByEscaping' => \Filament\Support\View\Components\Modal::$isClosedByEscaping,
@@ -95,7 +96,11 @@
         x-on:{{ $closeEventName }}.window="if ($event.detail.id === '{{ $id }}') close()"
         x-on:{{ $openEventName }}.window="if ($event.detail.id === '{{ $id }}') open()"
     @endif
-    x-trap.noscroll="isOpen"
+    @if ($autofocus)
+        x-trap.noscroll="isOpen"
+    @else
+        x-trap.noscroll.noautofocus="isOpen"
+    @endif
     x-bind:class="{
         'fi-modal-open': isOpen,
     }"

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -6,7 +6,7 @@
 @props([
     'alignment' => Alignment::Start,
     'ariaLabelledby' => null,
-    'autofocus' => \Filament\Support\View\Components\Modal::$autofocusOnOpen,
+    'autofocus' => \Filament\Support\View\Components\Modal::$isAutofocused,
     'closeButton' => \Filament\Support\View\Components\Modal::$hasCloseButton,
     'closeByClickingAway' => \Filament\Support\View\Components\Modal::$isClosedByClickingAway,
     'closeByEscaping' => \Filament\Support\View\Components\Modal::$isClosedByEscaping,
@@ -96,11 +96,7 @@
         x-on:{{ $closeEventName }}.window="if ($event.detail.id === '{{ $id }}') close()"
         x-on:{{ $openEventName }}.window="if ($event.detail.id === '{{ $id }}') open()"
     @endif
-    @if ($autofocus)
-        x-trap.noscroll="isOpen"
-    @else
-        x-trap.noscroll.noautofocus="isOpen"
-    @endif
+    x-trap.noscroll{{ $autofocus ? '' : '.noautofocus' }}="isOpen"
     x-bind:class="{
         'fi-modal-open': isOpen,
     }"

--- a/packages/support/src/View/Components/Modal.php
+++ b/packages/support/src/View/Components/Modal.php
@@ -10,6 +10,8 @@ class Modal
 
     public static bool $isClosedByEscaping = true;
 
+    public static bool $autofocusOnOpen = true;
+
     public static function closeButton(bool $condition = true): void
     {
         static::$hasCloseButton = $condition;
@@ -23,5 +25,10 @@ class Modal
     public static function closedByEscaping(bool $condition = true): void
     {
         static::$isClosedByEscaping = $condition;
+    }
+
+    public static function autofocuces(bool $condition = true): void
+    {
+        static::$autofocusOnOpen = $condition;
     }
 }

--- a/packages/support/src/View/Components/Modal.php
+++ b/packages/support/src/View/Components/Modal.php
@@ -10,7 +10,12 @@ class Modal
 
     public static bool $isClosedByEscaping = true;
 
-    public static bool $autofocusOnOpen = true;
+    public static bool $isAutofocused = true;
+
+    public static function autofocus(bool $condition = true): void
+    {
+        static::$isAutofocused = $condition;
+    }
 
     public static function closeButton(bool $condition = true): void
     {
@@ -25,10 +30,5 @@ class Modal
     public static function closedByEscaping(bool $condition = true): void
     {
         static::$isClosedByEscaping = $condition;
-    }
-
-    public static function autofocuces(bool $condition = true): void
-    {
-        static::$autofocusOnOpen = $condition;
     }
 }

--- a/packages/tables/resources/views/components/filters/dialog.blade.php
+++ b/packages/tables/resources/views/components/filters/dialog.blade.php
@@ -15,6 +15,7 @@
 @if (($layout === FiltersLayout::Modal) || $triggerAction->isModalSlideOver())
     <x-filament::modal
         :alignment="$triggerAction->getModalAlignment()"
+        :autofocus="$triggerAction->autofocusOnOpen()"
         :close-button="$triggerAction->hasModalCloseButton()"
         :close-by-clicking-away="$triggerAction->isModalClosedByClickingAway()"
         :description="$triggerAction->getModalDescription()"

--- a/packages/tables/resources/views/components/filters/dialog.blade.php
+++ b/packages/tables/resources/views/components/filters/dialog.blade.php
@@ -15,9 +15,10 @@
 @if (($layout === FiltersLayout::Modal) || $triggerAction->isModalSlideOver())
     <x-filament::modal
         :alignment="$triggerAction->getModalAlignment()"
-        :autofocus="$triggerAction->autofocusOnOpen()"
+        :autofocus="$triggerAction->isAutofocused()"
         :close-button="$triggerAction->hasModalCloseButton()"
         :close-by-clicking-away="$triggerAction->isModalClosedByClickingAway()"
+        :close-by-escaping="$triggerAction?->isModalClosedByEscaping()"
         :description="$triggerAction->getModalDescription()"
         :footer-actions="$triggerAction->getVisibleModalFooterActions()"
         :footer-actions-alignment="$triggerAction->getModalFooterActionsAlignment()"


### PR DESCRIPTION
## Description

This PR adds the ability to disable the automatic autofocus when a modal gets opened. See https://github.com/filamentphp/filament/discussions/12977

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
