### PR TITLE
Add CSS hook classes for split

### DIFF
--- a/packages/forms/resources/views/components/split.blade.php
+++ b/packages/forms/resources/views/components/split.blade.php
@@ -13,7 +13,7 @@
         $attributes
             ->merge($getExtraAttributes(), escape: false)
             ->class([
-                'flex gap-6',
+                'fi-fo-split flex gap-6',
                 match ($getFromBreakpoint()) {
                     'sm' => 'flex-col sm:flex-row ' . match ($verticalAlignment) {
                         VerticalAlignment::Center => 'sm:items-center',

--- a/packages/infolists/resources/views/components/split.blade.php
+++ b/packages/infolists/resources/views/components/split.blade.php
@@ -13,7 +13,7 @@
         $attributes
             ->merge($getExtraAttributes(), escape: false)
             ->class([
-                'flex gap-6',
+                'fi-in-split flex gap-6',
                 match ($getFromBreakpoint()) {
                     'sm' => 'flex-col sm:flex-row ' . match ($verticalAlignment) {
                         VerticalAlignment::Center => 'sm:items-center',

--- a/packages/tables/resources/views/columns/layout/split.blade.php
+++ b/packages/tables/resources/views/columns/layout/split.blade.php
@@ -3,7 +3,7 @@
         $attributes
             ->merge($getExtraAttributes(), escape: false)
             ->class([
-                'flex',
+                'fi-ta-split flex',
                 match ($getFromBreakpoint()) {
                     'sm' => 'flex-col gap-2 sm:flex-row sm:items-center sm:gap-3',
                     'md' => 'flex-col gap-2 md:flex-row md:items-center md:gap-3',


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Adds missing CSS hook classes.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
