### PR TITLE
The import or export notification header depends on success, partial or failure completion

### DIFF
--- a/packages/actions/resources/lang/de/export.php
+++ b/packages/actions/resources/lang/de/export.php
@@ -46,6 +46,12 @@ return [
 
             'title' => 'Export abgeschlossen',
 
+            'titles' => [
+                'success' => 'Export abgeschlossen',
+                'warning' => 'Der Export ist teilweise abgeschlossen',
+                'danger' => 'Export nicht abgeschlossen',
+            ],
+
             'actions' => [
 
                 'download_csv' => [

--- a/packages/actions/resources/lang/de/import.php
+++ b/packages/actions/resources/lang/de/import.php
@@ -42,6 +42,12 @@ return [
 
             'title' => 'Import abgeschlossen',
 
+            'titles' => [
+                'success' => 'Import abgeschlossen',
+                'warning' => 'Der Import ist teilweise abgeschlossen',
+                'danger' => 'Import nicht abgeschlossen',
+            ],
+
             'actions' => [
 
                 'download_failed_rows_csv' => [

--- a/packages/actions/resources/lang/en/export.php
+++ b/packages/actions/resources/lang/en/export.php
@@ -46,6 +46,12 @@ return [
 
             'title' => 'Export completed',
 
+            'titles' => [
+                'success' => 'Export completed',
+                'warning' => 'Export is partially completed',
+                'danger' => 'Export not completed',
+            ],
+
             'actions' => [
 
                 'download_csv' => [

--- a/packages/actions/resources/lang/en/import.php
+++ b/packages/actions/resources/lang/en/import.php
@@ -49,6 +49,12 @@ return [
 
             'title' => 'Import completed',
 
+            'titles' => [
+                'success' => 'Import completed',
+                'warning' => 'Import is partially completed',
+                'danger' => 'Import not completed',
+            ],
+
             'actions' => [
 
                 'download_failed_rows_csv' => [

--- a/packages/actions/resources/lang/es/export.php
+++ b/packages/actions/resources/lang/es/export.php
@@ -46,6 +46,12 @@ return [
 
             'title' => 'Exportación completada',
 
+            'titles' => [
+                'success' => 'Exportación completada',
+                'warning' => 'La Exportación está parcialmente completada',
+                'danger' => 'Exportación no completada',
+            ],
+
             'actions' => [
 
                 'download_csv' => [

--- a/packages/actions/resources/lang/es/import.php
+++ b/packages/actions/resources/lang/es/import.php
@@ -42,6 +42,12 @@ return [
 
             'title' => 'Importación completada',
 
+            'titles' => [
+                'success' => 'Importación completada',
+                'warning' => 'La importación está parcialmente completada',
+                'danger' => 'Importación no completada',
+            ],
+
             'actions' => [
 
                 'download_failed_rows_csv' => [

--- a/packages/actions/resources/lang/it/export.php
+++ b/packages/actions/resources/lang/it/export.php
@@ -46,6 +46,12 @@ return [
 
             'title' => 'Esportazione completata',
 
+            'titles' => [
+                'success' => 'Esportazione completata',
+                'warning' => 'Lesportazione è parzialmente completata',
+                'danger' => 'Esportazione non completata',
+            ],
+
             'actions' => [
 
                 'download_csv' => [

--- a/packages/actions/resources/lang/it/import.php
+++ b/packages/actions/resources/lang/it/import.php
@@ -42,6 +42,12 @@ return [
 
             'title' => 'Importazione completata',
 
+            'titles' => [
+                'success' => 'Importazione completata',
+                'warning' => 'Limportazione è parzialmente completata',
+                'danger' => 'Importazione non completata',
+            ],
+
             'actions' => [
 
                 'download_failed_rows_csv' => [

--- a/packages/actions/resources/lang/ro/export.php
+++ b/packages/actions/resources/lang/ro/export.php
@@ -46,6 +46,12 @@ return [
 
             'title' => 'Export complet',
 
+            'titles' => [
+                'success' => 'Экспорт завершен',
+                'warning' => 'Экспорт частично завершен',
+                'danger' => 'Экспорт не завершен',
+            ],
+
             'actions' => [
 
                 'download_csv' => [

--- a/packages/actions/resources/lang/ru/import.php
+++ b/packages/actions/resources/lang/ru/import.php
@@ -42,6 +42,12 @@ return [
 
             'title' => 'Импорт завершен',
 
+            'titles' => [
+                'success' => 'Импорт завершен',
+                'warning' => 'Импорт частично завершен',
+                'danger' => 'Импорт не завершен',
+            ],
+
             'actions' => [
 
                 'download_failed_rows_csv' => [

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -273,19 +273,18 @@ trait CanImportRecords
                     $failedRowsCount = $import->getFailedRowsCount();
 
                     Notification::make()
-                        ->title(__('filament-actions::import.notifications.completed.title'))
-                        ->body($import->importer::getCompletedNotificationBody($import))
+                            ->body($import->importer::getCompletedNotificationBody($import))
                         ->when(
                             ! $failedRowsCount,
-                            fn (Notification $notification) => $notification->success(),
+                            fn (Notification $notification) => $notification->title(__('filament-actions::import.notifications.completed.titles.success'))->success(),
                         )
                         ->when(
                             $failedRowsCount && ($failedRowsCount < $import->total_rows),
-                            fn (Notification $notification) => $notification->warning(),
+                            fn (Notification $notification) => $notification->title(__('filament-actions::import.notifications.completed.titles.warning'))->warning(),
                         )
                         ->when(
                             $failedRowsCount === $import->total_rows,
-                            fn (Notification $notification) => $notification->danger(),
+                            fn (Notification $notification) => $notification->title(__('filament-actions::import.notifications.completed.titles.danger'))->danger(),
                         )
                         ->when(
                             $failedRowsCount,

--- a/packages/actions/src/Exports/Jobs/ExportCompletion.php
+++ b/packages/actions/src/Exports/Jobs/ExportCompletion.php
@@ -53,19 +53,18 @@ class ExportCompletion implements ShouldQueue
         $failedRowsCount = $this->export->getFailedRowsCount();
 
         Notification::make()
-            ->title(__('filament-actions::export.notifications.completed.title'))
             ->body($this->exporter::getCompletedNotificationBody($this->export))
             ->when(
                 ! $failedRowsCount,
-                fn (Notification $notification) => $notification->success(),
+                fn (Notification $notification) => $notification->title(__('filament-actions::export.notifications.completed.titles.success'))->success(),
             )
             ->when(
                 $failedRowsCount && ($failedRowsCount < $this->export->total_rows),
-                fn (Notification $notification) => $notification->warning(),
+                fn (Notification $notification) => $notification->title(__('filament-actions::export.notifications.completed.titles.warning'))->warning(),
             )
             ->when(
                 $failedRowsCount === $this->export->total_rows,
-                fn (Notification $notification) => $notification->danger(),
+                fn (Notification $notification) => $notification->title(__('filament-actions::export.notifications.completed.titles.danger'))->danger(),
             )
             ->when(
                 $failedRowsCount < $this->export->total_rows,


### PR DESCRIPTION
When importing or exporting data, the notification title always reads “Import/Export completed.” Receiving an “Import Completed” message when some or all rows were not imported is inconvenient. To resolve this issue, I made the import or export notification header depend on successful, partial, or failed completion.