### PR TITLE
Fix: page title formatting

### DIFF
--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -22,9 +22,13 @@
             <link rel="icon" href="{{ $favicon }}" />
         @endif
 
+        @php
+            $title = strip_tags(($livewire ?? null)?->getTitle() ?? '');
+            $brandName = strip_tags(filament()->getBrandName());
+        @endphp
+
         <title>
-            {{ filled($title = strip_tags(($livewire ?? null)?->getTitle() ?? '')) ? "{$title} - " : null }}
-            {{ strip_tags(filament()->getBrandName()) }}
+            {{ (filled($title) ? "{$title} - " : null) . $brandName }}
         </title>
 
         {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::STYLES_BEFORE, scopes: $livewire->getRenderHookScopes()) }}

--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -28,7 +28,7 @@
         @endphp
 
         <title>
-            {{ (filled($title) ? "{$title} - " : null) . $brandName }}
+            {{ (filled($title) ? "{$title} - " : null) }} {{ $brandName }}
         </title>
 
         {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::STYLES_BEFORE, scopes: $livewire->getRenderHookScopes()) }}


### PR DESCRIPTION
I've removed the new line in the title.  

## Description
The current way the title is being created adds an unnecessary new line inside the `<title>` tag. This leads to unpleasant formatting when sharing your page on WhatsApp for example.

## Visual changes

Before:
![image](https://github.com/filamentphp/filament/assets/4026917/81992686-8d4f-4b64-88b3-24f5c40da3c6)

After:
![image](https://github.com/filamentphp/filament/assets/4026917/55850e73-04a7-4e52-bdc5-b7b04d654380)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
