### PR TITLE
Fix: 404 for XLSX file on export

### DIFF
--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -219,14 +219,13 @@ trait CanExportRecords
                         fn (PendingBatch $batch) => $batch->name($jobBatchName),
                     )
                     ->allowFailures(),
-                ...(($hasXlsx && (! $hasCsv)) ? [$makeCreateXlsxFileJob()] : []),
+                ...($hasXlsx ? [$makeCreateXlsxFileJob()] : []),
                 app(ExportCompletion::class, [
                     'export' => $export,
                     'columnMap' => $columnMap,
                     'formats' => $formats,
                     'options' => $options,
                 ]),
-                ...(($hasXlsx && $hasCsv) ? [$makeCreateXlsxFileJob()] : []),
             ])
                 ->when(
                     filled($jobQueue),


### PR DESCRIPTION
## Description

The job that creates XLSX file after export is scheduled after the notification job. Meaning user can get notification about export completion before that XLSX file is created. This causes the button "Download .xlsx" to return 404. The issue is only noticeable for larger exports when `CreateXlsxFile` job can take at least a few seconds.

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
