### PR TITLE
Update Albanian pagination translation

### DIFF
--- a/packages/support/resources/lang/sq/components/pagination.php
+++ b/packages/support/resources/lang/sq/components/pagination.php
@@ -4,7 +4,7 @@ return [
 
     'label' => 'Pagination navigation',
 
-    'overview' => '{1} Duke shfaqur 1 rezultat|[2,*] Duke shfaqur :first në :last nga :rezultatet totale',
+    'overview' => '{1} Duke shfaqur 1 rezultat|[2,*] Duke shfaqur :first deri në :last rezultate nga :total ne total',
 
     'fields' => [
 


### PR DESCRIPTION
Replaced wrongly used :rezultatet parameter with :total and reformated the string to make more sense in the Albanian Language.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

 Parameter named :rezultatet was wrongly used instead of :total 

## Visual changes

<!-- Add screenshots/recordings of before and after. -->
Before
<img width="691" alt="before" src="https://github.com/filamentphp/filament/assets/6430816/24b4c1f0-ea3f-41af-8151-37f5a803c9a3">
After
<img width="686" alt="after" src="https://github.com/filamentphp/filament/assets/6430816/446bca19-23fc-4273-b57e-29ca1d70a9f7">



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
