### PR TITLE
Rename extraFieldWrapperAttributes to extraEntryWrapperAttributes

### DIFF
--- a/packages/infolists/docs/03-entries/01-getting-started.md
+++ b/packages/infolists/docs/03-entries/01-getting-started.md
@@ -302,7 +302,7 @@ You can also pass extra HTML attributes to the entry wrapper which surrounds the
 use Filament\Infolists\Components\TextEntry;
 
 TextEntry::make('slug')
-    ->extraFieldWrapperAttributes(['class' => 'entry-locked'])
+    ->extraEntryWrapperAttributes(['class' => 'entry-locked'])
 ```
 
 ## Global settings

--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -28,7 +28,7 @@
         @endphp
 
         <title>
-            {{ (filled($title) ? "{$title} - " : null) }} {{ $brandName }}
+            {{ filled($title) ? "{$title} - " : null }} {{ $brandName }}
         </title>
 
         {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::STYLES_BEFORE, scopes: $livewire->getRenderHookScopes()) }}


### PR DESCRIPTION
## Description

The `extraFieldWrapperAttributes` was wrongly documented in the info lists docs.