### PR TITLE
The import or export notification header depends on getCompletedNotificationTitle function

### DIFF
--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -273,7 +273,7 @@ trait CanImportRecords
                     $failedRowsCount = $import->getFailedRowsCount();
 
                     Notification::make()
-                        ->title($import->importer::getCompletedNotificationTitle($import) ?? __('filament-actions::import.notifications.completed.title'))
+                        ->title($import->importer::getCompletedNotificationTitle($import))
                         ->body($import->importer::getCompletedNotificationBody($import))
                         ->when(
                             ! $failedRowsCount,

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -273,7 +273,7 @@ trait CanImportRecords
                     $failedRowsCount = $import->getFailedRowsCount();
 
                     Notification::make()
-                        ->title(__('filament-actions::import.notifications.completed.title'))
+                        ->title($import->importer::getCompletedNotificationTitle($import) ?? __('filament-actions::import.notifications.completed.title'))
                         ->body($import->importer::getCompletedNotificationBody($import))
                         ->when(
                             ! $failedRowsCount,

--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -74,6 +74,11 @@ abstract class Exporter
 
     abstract public static function getCompletedNotificationBody(Export $export): string;
 
+    public static function getCompletedNotificationTitle(Export $export): ?string
+    {
+        return null;
+    }
+
     /**
      * @return array<int, object>
      */

--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -74,9 +74,9 @@ abstract class Exporter
 
     abstract public static function getCompletedNotificationBody(Export $export): string;
 
-    public static function getCompletedNotificationTitle(Export $export): ?string
+    public static function getCompletedNotificationTitle(Export $export): string
     {
-        return null;
+        return __('filament-actions::export.notifications.completed.title');
     }
 
     /**

--- a/packages/actions/src/Exports/Jobs/ExportCompletion.php
+++ b/packages/actions/src/Exports/Jobs/ExportCompletion.php
@@ -53,7 +53,7 @@ class ExportCompletion implements ShouldQueue
         $failedRowsCount = $this->export->getFailedRowsCount();
 
         Notification::make()
-            ->title($this->exporter::getCompletedNotificationTitle($this->export) ?? __('filament-actions::export.notifications.completed.title'))
+            ->title($this->exporter::getCompletedNotificationTitle($this->export))
             ->body($this->exporter::getCompletedNotificationBody($this->export))
             ->when(
                 ! $failedRowsCount,

--- a/packages/actions/src/Exports/Jobs/ExportCompletion.php
+++ b/packages/actions/src/Exports/Jobs/ExportCompletion.php
@@ -53,7 +53,7 @@ class ExportCompletion implements ShouldQueue
         $failedRowsCount = $this->export->getFailedRowsCount();
 
         Notification::make()
-            ->title(__('filament-actions::export.notifications.completed.title'))
+            ->title($this->exporter::getCompletedNotificationTitle($this->export) ?? __('filament-actions::export.notifications.completed.title'))
             ->body($this->exporter::getCompletedNotificationBody($this->export))
             ->when(
                 ! $failedRowsCount,

--- a/packages/actions/src/Imports/Importer.php
+++ b/packages/actions/src/Imports/Importer.php
@@ -250,9 +250,9 @@ abstract class Importer
 
     abstract public static function getCompletedNotificationBody(Import $import): string;
 
-    public static function getCompletedNotificationTitle(Import $import): ?string
+    public static function getCompletedNotificationTitle(Import $import): string
     {
-        return null;
+        return __('filament-actions::import.notifications.completed.title');
     }
 
     /**

--- a/packages/actions/src/Imports/Importer.php
+++ b/packages/actions/src/Imports/Importer.php
@@ -250,6 +250,11 @@ abstract class Importer
 
     abstract public static function getCompletedNotificationBody(Import $import): string;
 
+    public static function getCompletedNotificationTitle(Import $import): ?string
+    {
+        return null;
+    }
+
     /**
      * @return array<int, object>
      */


### PR DESCRIPTION
When importing or exporting data, the notification title always reads “Import/Export completed.” Receiving an “Import Completed” message when some or all rows were not imported is inconvenient. To resolve this issue, I made the import or export notification header depend on getCompletedNotificationTitle function to change the title if you want.