### PR TITLE
Fix collapsible Block behavior when containing Wizard

### DIFF
--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -156,8 +156,6 @@ class Builder extends Field implements Contracts\CanConcealComponents, Contracts
 
                 $component->getChildComponentContainer($newUuid ?? array_key_last($items))->fill();
 
-                $component->collapsed(false, shouldMakeComponentCollapsible: false);
-
                 $component->callAfterStateUpdated();
             })
             ->livewireClickHandlerEnabled(false)
@@ -220,8 +218,6 @@ class Builder extends Field implements Contracts\CanConcealComponents, Contracts
 
                 $component->getChildComponentContainer($newKey)->fill();
 
-                $component->collapsed(false, shouldMakeComponentCollapsible: false);
-
                 $component->callAfterStateUpdated();
             })
             ->livewireClickHandlerEnabled(false)
@@ -268,8 +264,6 @@ class Builder extends Field implements Contracts\CanConcealComponents, Contracts
                 }
 
                 $component->state($items);
-
-                $component->collapsed(false, shouldMakeComponentCollapsible: false);
 
                 $component->callAfterStateUpdated();
             })

--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -28,7 +28,7 @@
         @endphp
 
         <title>
-            {{ (filled($title) ? "{$title} - " : null) }} {{ $brandName }}
+            {{ filled($title) ? "{$title} - " : null }} {{ $brandName }}
         </title>
 
         {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::STYLES_BEFORE, scopes: $livewire->getRenderHookScopes()) }}


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fixes #12623 

I found that the issue was related with [this line](https://github.com/filamentphp/filament/blob/6de3b9b55abb4c061ead93b1dc643d8100f3e0df/packages/forms/src/Components/Builder.php#L159) in the `Builder` component. The problem occurs when you have when you have a `$builder->collapsed(true)` and a Wizard with 3 steps. In Step 2 there is also a minor visual bug where the collapsible icon rotates as if the block is collapsed, but it isn't.

I couldn't find any reason why `$component->collapsed(false, shouldMakeComponentCollapsible: false);` should be present in `Builder`. I tested deleting `$component->collapsed(false, shouldMakeComponentCollapsible: false);` from `Builder` and it is working correctly, eliminating the bug.

I also tested the other two parts where `$component->collapsed(false, shouldMakeComponentCollapsible: false);` is used in `Builder`, and found that they can be deleted too.

- [X] Changes have been tested to not break existing functionality.
