### PR TITLE
Fix issue when Cluster large Submenu items makes content grid align items centered instead of start

### DIFF
--- a/packages/panels/resources/views/components/page/index.blade.php
+++ b/packages/panels/resources/views/components/page/index.blade.php
@@ -57,7 +57,7 @@
             @class([
                 'flex flex-col gap-8' => $subNavigation,
                 match ($subNavigationPosition) {
-                    SubNavigationPosition::Start, SubNavigationPosition::End => 'md:flex-row',
+                    SubNavigationPosition::Start, SubNavigationPosition::End => 'md:flex-row md:items-start',
                     default => null,
                 } => $subNavigation,
                 'h-full' => $fullHeight,


### PR DESCRIPTION

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fix issue when Cluster large Submenu items makes content grid align items centered instead of start. adding the "md:items-start" class fixes problem

## Visual changes

BEFORE:
![before](https://github.com/filamentphp/filament/assets/878103/d2df92c0-7c4d-45bb-9d4e-edbcbb40136e)

AFTER:
![after](https://github.com/filamentphp/filament/assets/878103/48180d6f-b67d-4f48-970b-635fb5d6ff17)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
