### PR TITLE
Add `Support & Help` page to documenation

### DIFF
--- a/packages/support/docs/10-support.md
+++ b/packages/support/docs/10-support.md
@@ -1,0 +1,43 @@
+---
+title: Support & Help
+---
+
+> We offer a variety of support options, mostly free of charge. If you need help, the community is here for you.
+
+## Discord
+
+We are fortunate to have a growing community of Filament users that help each other out on our [Discord server](https://filamentphp.com/discord). Join now, its free!
+We also have many dedicated channels in different languages. Currently, we have channels for the following languages:
+
+- [#ar](https://discord.com/channels/883083792112300104/961199444789973024) - Arabic 🇸🇦
+- [#de](https://discord.com/channels/883083792112300104/998221767850070057) - German 🇩🇪
+- [#es](https://discord.com/channels/883083792112300104/1049794522181275749) - Spanish 🇪🇸
+- [#fa](https://discord.com/channels/883083792112300104/1042736860826443807) - Farsi 🇮🇷
+- [#fr](https://discord.com/channels/883083792112300104/978572814317682688) - French 🇫🇷
+- [#id](https://discord.com/channels/883083792112300104/1051444835254538271) - Indonesian 🇮🇩
+- [#it](https://discord.com/channels/883083792112300104/979015654675996672) - Italian 🇮🇹
+- [#nl](https://discord.com/channels/883083792112300104/998685582031061102) - Dutch 🇳🇱
+- [#pt-br](https://discord.com/channels/883083792112300104/966832715536162846) - Portuguese (Brazil) 🇧🇷
+- [#tr](https://discord.com/channels/883083792112300104/988729996803702794) - Turkish 🇹🇷
+- [#ko](https://discord.com/channels/883083792112300104/1221712398017232926) - Korean 🇰🇷
+
+If you are missing a channel for your language, please let us know and we will create one for you.
+
+## GitHub (mostly free)
+
+You can also reach out to us on our GitHub community section. We are always happy to help you with any questions you may have.
+
+Of course, you are free to open an [issue](https://github.com/filamentphp/filament/discussions/new/choose) if you find a bug or have a [feature request](https://filamentphp.com/docs/3.x/support/contributing#development-of-new-features). If you don't want to wait, until a community member has addressed your issue, you can directly **fast track your issue** by [sponsoring]() Filament or directly use the [funding]() options provided on the issue page itself.
+
+## Professional Support & Consulting (paid)
+
+If you're looking for dedicated help with your Filament project, we're here for you. Whether you're a solo developer or running a large company, we provide support and development services that fit your needs.
+More information can be found on our [consulting page](https://filamentphp.com/consulting).
+
+## Laracasts 
+
+[Laracasts](https://laracasts.com/) has a dedicated [Filament help section](https://laracasts.com/discuss/channels/filament) where you can ask questions and get help from their community.
+
+## Google
+
+Since we make use of [AnswerOverflow](https://www.answeroverflow.com/c/883083792112300104), you are mainly one google search away from finding an answer to your question or at least a hint on how to solve your problem.

--- a/packages/support/docs/10-support.md
+++ b/packages/support/docs/10-support.md
@@ -27,7 +27,7 @@ If you are missing a channel for your language, please let us know and we will c
 
 You can also reach out to us on our [GitHub community forum](https://github.com/filamentphp/filament/discussions). Where our community members and maintainers are happy to help you out.
 
-Of course, you are free to open an [issue](https://github.com/filamentphp/filament/discussions/new/choose) if you find a bug or have a [feature request](https://filamentphp.com/docs/3.x/support/contributing#development-of-new-features). If you don't want to wait, until a community member has addressed your issue, you can directly **fast track your issue** by [sponsoring]() Filament or directly use the [funding]() options provided on the issue page itself.
+Of course, you are free to open an [issue](https://github.com/filamentphp/filament/discussions/new/choose) if you find a bug or have a [feature request](https://filamentphp.com/docs/3.x/support/contributing#development-of-new-features). If you don't want to wait, until a community member has addressed your issue, you can directly **fast track your issue** by [sponsoring](https://github.com/filamentphp/filament?sponsor=1) Filament or directly use the [funding](https://github.com/filamentphp/filament/issues?q=is%3Aopen+is%3Aissue+label%3Afund) options provided on the issue page itself.
 
 ## Professional Support & Consulting (paid)
 

--- a/packages/support/docs/10-support.md
+++ b/packages/support/docs/10-support.md
@@ -23,30 +23,31 @@ We also have many dedicated channels in different languages. Currently, we have 
 
 If you are missing a channel for your language, please let us know and we will create one for you.
 
-## GitHub (mostly free)
+## GitHub
 
 You can also reach out to us on our [GitHub community forum](https://github.com/filamentphp/filament/discussions). Where our community members and maintainers are happy to help you out.
 
-Of course, you are free to open an [issue](https://github.com/filamentphp/filament/discussions/new/choose) if you find a bug or have a [feature request](https://filamentphp.com/docs/3.x/support/contributing#development-of-new-features). If you don't want to wait, until a community member has addressed your issue, you can directly **fast track your issue** by [sponsoring](https://github.com/filamentphp/filament?sponsor=1) Filament or directly use the [funding](https://github.com/filamentphp/filament/issues?q=is%3Aopen+is%3Aissue+label%3Afund) options provided on the issue page itself.
+If you find a bug, you can open an [issue](https://github.com/filamentphp/filament/issues/new/choose), and even donate to the bug fix by using the link automatically added to the bottom of every new issue description.
 
-## Professional Support & Consulting (paid)
+If you have a feature request, you can create a discussion on GitHub [following these instructions](contributing#development-of-new-features). If you are not planning to contribute the feature yourself but the core team adds it to the roadmap, an issue will be created which you are able to fast-track its development by donating money to it using the link added to the bottom of the issue description.
 
-If you're looking for dedicated help with your Filament project, we're here for you. Whether you're a solo developer or running a large company, we provide support and development services that fit your needs.
-More information can be found on our [consulting page](https://filamentphp.com/consulting).
+## One-on-one private support & consulting (paid)
 
-## Laracasts 
+If you're looking for dedicated help with your Filament project, we're here for you. Whether you're a solo developer or running a large company, we provide support and development services that fit your needs. More information can be found on our [consulting page](https://filamentphp.com/consulting).
 
-[Laracasts](https://laracasts.com/) has a dedicated [Filament help section](https://laracasts.com/discuss/channels/filament) where you can ask questions and get help from their community.
-Additionally on laracasts you can find two excellent courses about Filament:
+## Laracasts
 
-- [Build Advanced Components for Filament](https://laracasts.com/series/build-advanced-components-for-filament) by the founder of Filament.
+[Laracasts](https://laracasts.com) has a dedicated [Filament help section](https://laracasts.com/discuss/channels/filament) where you can ask questions and get help from their community.
+Additionally on Laracasts you can find two excellent courses about Filament:
+
 - [Rapid Laravel Apps With Filament](https://laracasts.com/series/rapid-laravel-development-with-filament)
+- [Build Advanced Components for Filament](https://laracasts.com/series/build-advanced-components-for-filament) by one of the creators of Filament.
 
-> *An active subscription may be required to access these courses.
+> An active subscription may be required to access these parts of these courses.
 
 ## Google
 
-Since we make use of [AnswerOverflow](https://www.answeroverflow.com/c/883083792112300104), you are mainly one google search away from finding an answer to your question or at least a hint on how to solve your problem.
+Since we make use of [AnswerOverflow](https://www.answeroverflow.com/c/883083792112300104) on our [Discord](#discord) server, you are often one Google search away from finding an answer to your question or at least a hint on how to solve your problem. You may also find results from [GitHub](#github), the [Laracasts forum](#laracasts), or even Stack Overflow.
 
 ## Helping others
 

--- a/packages/support/docs/10-support.md
+++ b/packages/support/docs/10-support.md
@@ -25,7 +25,7 @@ If you are missing a channel for your language, please let us know and we will c
 
 ## GitHub (mostly free)
 
-You can also reach out to us on our GitHub community section. We are always happy to help you with any questions you may have.
+You can also reach out to us on our [GitHub community forum](https://github.com/filamentphp/filament/discussions). Where our community members and maintainers are happy to help you out.
 
 Of course, you are free to open an [issue](https://github.com/filamentphp/filament/discussions/new/choose) if you find a bug or have a [feature request](https://filamentphp.com/docs/3.x/support/contributing#development-of-new-features). If you don't want to wait, until a community member has addressed your issue, you can directly **fast track your issue** by [sponsoring]() Filament or directly use the [funding]() options provided on the issue page itself.
 
@@ -37,6 +37,12 @@ More information can be found on our [consulting page](https://filamentphp.com/c
 ## Laracasts 
 
 [Laracasts](https://laracasts.com/) has a dedicated [Filament help section](https://laracasts.com/discuss/channels/filament) where you can ask questions and get help from their community.
+Additionally on laracasts you can find two excellent courses about Filament:
+
+- [Build Advanced Components for Filament](https://laracasts.com/series/build-advanced-components-for-filament) by the founder of Filament.
+- [Rapid Laravel Apps With Filament](https://laracasts.com/series/rapid-laravel-development-with-filament)
+
+> *An active subscription may be required to access these courses.
 
 ## Google
 

--- a/packages/support/docs/10-support.md
+++ b/packages/support/docs/10-support.md
@@ -47,3 +47,7 @@ Additionally on laracasts you can find two excellent courses about Filament:
 ## Google
 
 Since we make use of [AnswerOverflow](https://www.answeroverflow.com/c/883083792112300104), you are mainly one google search away from finding an answer to your question or at least a hint on how to solve your problem.
+
+## Helping others
+
+We would like to encourage you to join any of the above platforms and help yourself and our community out. Additionally, we would like to encourage you to [contribute](https://filamentphp.com/docs/3.x/support/contributing) to Filament itself. We are always looking for new contributors to help us improve Filament.


### PR DESCRIPTION
This PR adds a new page within the support package docs with a comprehensive list of ways to get support (free and paid)

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

@danharrin i thought about also adding a "sponsor" page, but i guess its too early for that?
