### PR TITLE
Able to add input attributes to disabled rich editor

### DIFF
--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -12,7 +12,12 @@
                 state: $wire.{{ $applyStateBindingModifiers("\$entangle('{$statePath}')") }},
             }"
             x-html="state"
-            class="fi-fo-rich-editor fi-disabled prose block w-full max-w-none rounded-lg bg-gray-50 px-3 py-3 text-gray-500 shadow-sm ring-1 ring-gray-950/10 dark:prose-invert dark:bg-transparent dark:text-gray-400 dark:ring-white/10 sm:text-sm"
+            {{
+               $getExtraInputAttributeBag()
+                   ->class([
+                       'fi-fo-rich-editor fi-disabled prose block w-full max-w-none rounded-lg bg-gray-50 px-3 py-3 text-gray-500 shadow-sm ring-1 ring-gray-950/10 dark:prose-invert dark:bg-transparent dark:text-gray-400 dark:ring-white/10 sm:text-sm',
+                   ])
+            }}
         ></div>
     @else
         <x-filament::input.wrapper


### PR DESCRIPTION
## Description
This will make it so that you can add attributes to your disabled rich editor input.
We actually have a scenario where we want to add some classes to a disabled rich editor input.

Im sure we are not the only one that might need this :)

Snippet:
```
          RichEditor::make('ourField')
                            ->extraInputAttributes(['class' => 'myclasses']) // this will be possible as its not possible now
                            ->label('Our field')
                            ->disabled()
```

## Visual changes

None

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
