### PR TITLE
feat: set locale on DateTimePicker field

### DIFF
--- a/packages/forms/docs/03-fields/08-date-time-picker.md
+++ b/packages/forms/docs/03-fields/08-date-time-picker.md
@@ -85,7 +85,7 @@ DatePicker::make('date_of_birth')
 
 <AutoScreenshot name="forms/fields/date-time-picker/display-format" alt="Date time picker with custom display format" version="3.x" />
 
-You may also configure locale when you use display format on the field and you want to use different locale from your app config. For this, you can use the `locale()` method.
+You may also configure the locale that is used when rendering the display, if you want to use different locale from your app config. For this, you can use the `locale()` method:
 
 ```php
 use Filament\Forms\Components\DatePicker;

--- a/packages/forms/docs/03-fields/08-date-time-picker.md
+++ b/packages/forms/docs/03-fields/08-date-time-picker.md
@@ -85,6 +85,17 @@ DatePicker::make('date_of_birth')
 
 <AutoScreenshot name="forms/fields/date-time-picker/display-format" alt="Date time picker with custom display format" version="3.x" />
 
+You may also configure locale when you use display format on the field and you want to use different locale from your app config. For this, you can use the `locale()` method.
+
+```php
+use Filament\Forms\Components\DatePicker;
+
+DatePicker::make('date_of_birth')
+    ->native(false)
+    ->displayFormat('d F Y')
+    ->locale('fr')
+```
+
 ### Configuring the time input intervals
 
 You may customize the input interval for increasing/decreasing the hours/minutes /seconds using the `hoursStep()` , `minutesStep()` or `secondsStep()` methods:

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -77,7 +77,7 @@
                                 '{{ convert_date_format($getDisplayFormat())->to('day.js') }}',
                             firstDayOfWeek: {{ $getFirstDayOfWeek() }},
                             isAutofocused: @js($isAutofocused()),
-                            locale: @js(app()->getLocale()),
+                            locale: @js($getLocale()),
                             shouldCloseOnDateSelection: @js($shouldCloseOnDateSelection()),
                             state: $wire.{{ $applyStateBindingModifiers("\$entangle('{$statePath}')") }},
                         })"

--- a/packages/forms/src/Components/DateTimePicker.php
+++ b/packages/forms/src/Components/DateTimePicker.php
@@ -51,6 +51,8 @@ class DateTimePicker extends Field implements Contracts\HasAffixActions
 
     protected string | Closure | null $timezone = null;
 
+    protected string | Closure | null $locale = null;
+
     /**
      * @var array<DateTime | string> | Closure
      */
@@ -259,6 +261,13 @@ class DateTimePicker extends Field implements Contracts\HasAffixActions
         return $this;
     }
 
+    public function locale(string | Closure | null $locale): static
+    {
+        $this->locale = $locale;
+
+        return $this;
+    }
+
     public function weekStartsOnMonday(): static
     {
         $this->firstDayOfWeek(1);
@@ -422,6 +431,11 @@ class DateTimePicker extends Field implements Contracts\HasAffixActions
     public function getTimezone(): string
     {
         return $this->evaluate($this->timezone) ?? config('app.timezone');
+    }
+
+    public function getLocale(): string
+    {
+        return $this->evaluate($this->locale) ?? config('app.locale');
     }
 
     public function hasDate(): bool


### PR DESCRIPTION
## Description

This PR adds the ability to customize locale on date time picker, especially when we use display format 'F' and we want to use locale different from locale on app config.

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
