### PR TITLE
Ignore textarea style height by default, not just on auto size

### DIFF
--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -42,13 +42,13 @@
                 @endif
                 ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('textarea', 'filament/forms') }}"
                 x-data="textareaFormComponent({ initialHeight: @js($initialHeight) })"
-                x-ignore
                 x-intersect.once="render()"
                 x-on:input="render()"
                 x-on:resize.window="render()"
-                wire:ignore.style.height
                 {{ $getExtraAlpineAttributeBag() }}
             @endif
+            x-ignore
+            wire:ignore.style.height
             {{
                 $getExtraInputAttributeBag()
                     ->merge([


### PR DESCRIPTION
## Description

See issue #13090 
This just changes the fact that it always ignores style height instead of just on autosize enabled.

Because when resizing and then typing, it resets (by using live() or on blur)

I've tested it manually by checking with live, live(onblur), without live() and by using autosize aswell.
Should all work now, instead of without autosize it being resetting.

Unless there are scenario's where you don't want to ignore the height that is, but can't think of any reason someone would want that :)

## Visual changes

Fixes textarea resizing without using autosize, it wont reset every keystroke / on blur.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command. (no changes)
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
