### PR TITLE
Fix getting infolist action in test methods

### DIFF
--- a/packages/infolists/src/Testing/TestsActions.php
+++ b/packages/infolists/src/Testing/TestsActions.php
@@ -172,7 +172,7 @@ class TestsActions
             $this->assertInfolistActionExists($component, $name, $infolistName);
 
             /** @phpstan-ignore-next-line */
-            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name);
+            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name, $infolistName);
 
             $livewireClass = $this->instance()::class;
             $prettyName = implode(' > ', Arr::wrap($name));
@@ -193,7 +193,7 @@ class TestsActions
             $this->assertInfolistActionExists($component, $name, $infolistName);
 
             /** @phpstan-ignore-next-line */
-            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name);
+            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name, $infolistName);
 
             $livewireClass = $this->instance()::class;
             $prettyName = implode(' > ', Arr::wrap($name));
@@ -214,7 +214,7 @@ class TestsActions
             $this->assertInfolistActionExists($component, $name, $infolistName);
 
             /** @phpstan-ignore-next-line */
-            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name);
+            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name, $infolistName);
 
             $livewireClass = $this->instance()::class;
             $prettyName = implode(' > ', Arr::wrap($name));
@@ -235,7 +235,7 @@ class TestsActions
             $this->assertInfolistActionExists($component, $name, $infolistName);
 
             /** @phpstan-ignore-next-line */
-            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name);
+            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name, $infolistName);
 
             $livewireClass = $this->instance()::class;
             $prettyName = implode(' > ', Arr::wrap($name));
@@ -256,7 +256,7 @@ class TestsActions
             $this->assertInfolistActionExists($component, $name, $infolistName);
 
             /** @phpstan-ignore-next-line */
-            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name);
+            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name, $infolistName);
 
             $livewireClass = $this->instance()::class;
             $prettyName = implode(' > ', Arr::wrap($name));
@@ -277,7 +277,7 @@ class TestsActions
             $this->assertInfolistActionExists($component, $name, $infolistName);
 
             /** @phpstan-ignore-next-line */
-            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name);
+            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name, $infolistName);
 
             $livewireClass = $this->instance()::class;
             $prettyName = implode(' > ', Arr::wrap($name));
@@ -298,7 +298,7 @@ class TestsActions
             $this->assertInfolistActionExists($component, $name, $infolistName);
 
             /** @phpstan-ignore-next-line */
-            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name);
+            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name, $infolistName);
 
             $livewireClass = $this->instance()::class;
             $prettyName = implode(' > ', Arr::wrap($name));
@@ -319,7 +319,7 @@ class TestsActions
             $this->assertInfolistActionExists($component, $name, $infolistName);
 
             /** @phpstan-ignore-next-line */
-            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name);
+            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name, $infolistName);
 
             $livewireClass = $this->instance()::class;
             $prettyName = implode(' > ', Arr::wrap($name));
@@ -340,7 +340,7 @@ class TestsActions
             $this->assertInfolistActionExists($component, $name, $infolistName);
 
             /** @phpstan-ignore-next-line */
-            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name);
+            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name, $infolistName);
 
             $livewireClass = $this->instance()::class;
             $prettyName = implode(' > ', Arr::wrap($name));
@@ -363,7 +363,7 @@ class TestsActions
             $this->assertInfolistActionExists($component, $name, $infolistName);
 
             /** @phpstan-ignore-next-line */
-            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name);
+            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name, $infolistName);
 
             $livewireClass = $this->instance()::class;
             $prettyName = implode(' > ', Arr::wrap($name));
@@ -386,7 +386,7 @@ class TestsActions
             $this->assertInfolistActionExists($component, $name, $infolistName);
 
             /** @phpstan-ignore-next-line */
-            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name);
+            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name, $infolistName);
 
             $livewireClass = $this->instance()::class;
             $prettyName = implode(' > ', Arr::wrap($name));
@@ -407,7 +407,7 @@ class TestsActions
             $this->assertInfolistActionExists($component, $name, $infolistName);
 
             /** @phpstan-ignore-next-line */
-            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name);
+            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name, $infolistName);
 
             $livewireClass = $this->instance()::class;
             $prettyName = implode(' > ', Arr::wrap($name));
@@ -428,7 +428,7 @@ class TestsActions
             $this->assertInfolistActionExists($component, $name, $infolistName);
 
             /** @phpstan-ignore-next-line */
-            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name);
+            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name, $infolistName);
 
             $livewireClass = $this->instance()::class;
             $prettyName = implode(' > ', Arr::wrap($name));
@@ -449,7 +449,7 @@ class TestsActions
             $this->assertInfolistActionExists($component, $name, $infolistName);
 
             /** @phpstan-ignore-next-line */
-            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name);
+            [$component, $action] = $this->getNestedInfolistActionComponentAndName($component, $name, $infolistName);
 
             $livewireClass = $this->instance()::class;
             $prettyName = implode(' > ', Arr::wrap($name));


### PR DESCRIPTION
## Description

Infolist name wasn't passed to `getNestedInfolistActionComponentAndName()` method, which resulted in test assertions failing when the infolist name was different than `"infolist"`.

I have tested this change only for `assertInfolistActionExists()` but assume the other methods need the same treatment.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
