### PR TITLE
Prevent infolist entry grid blowout

### DIFF
--- a/packages/infolists/resources/views/components/entry-wrapper/index.blade.php
+++ b/packages/infolists/resources/views/components/entry-wrapper/index.blade.php
@@ -123,6 +123,7 @@
                         Alignment::Right => 'text-right',
                         default => $alignment,
                     },
+                    'min-w-0',
                 ])
             >
                 @if ($url)

--- a/packages/infolists/resources/views/components/entry-wrapper/index.blade.php
+++ b/packages/infolists/resources/views/components/entry-wrapper/index.blade.php
@@ -101,7 +101,7 @@
 
         <div
             @class([
-                'grid gap-y-2',
+                'grid auto-cols-fr gap-y-2',
                 'sm:col-span-2' => $hasInlineLabel,
             ])
         >
@@ -123,7 +123,6 @@
                         Alignment::Right => 'text-right',
                         default => $alignment,
                     },
-                    'min-w-0',
                 ])
             >
                 @if ($url)


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

I have an a custom infolist component. The contents of this custom component are sometimes wider than the actual space allowed in the infolist grid layout. This is handled in the custom component by setting an `overflow-x-scroll`. 

However, this overflow class isn't applied om the infolist, because the infolist entry wrapper grid gives the children automatically a width of `auto`, meaning that because the infolist entry wrapper has this grid, all the children are [automatically given as much width as they can occupy](https://css-tricks.com/preventing-a-grid-blowout/), without giving the developer an option to use a scroll overflow for example.

I tested by and this doesn't change any behaviour for existing custom components that are overflow, only for components that have an `overflow-...` property set.

Thanks!

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
