### PR TITLE
Add missing class string type annotations

### DIFF
--- a/packages/panels/src/Resources/Pages/Page.php
+++ b/packages/panels/src/Resources/Pages/Page.php
@@ -9,7 +9,6 @@ use Filament\Pages\Page as BasePage;
 use Filament\Pages\SubNavigationPosition;
 use Filament\Panel;
 use Filament\Resources\Pages\Concerns\CanAuthorizeResourceAccess;
-use Filament\Resources\Resource;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Route as RouteFacade;
@@ -157,7 +156,7 @@ abstract class Page extends BasePage
     }
 
     /**
-     * @return class-string<Resource>
+     * @return class-string
      */
     public static function getResource(): string
     {

--- a/packages/panels/src/Resources/Pages/Page.php
+++ b/packages/panels/src/Resources/Pages/Page.php
@@ -9,6 +9,7 @@ use Filament\Pages\Page as BasePage;
 use Filament\Pages\SubNavigationPosition;
 use Filament\Panel;
 use Filament\Resources\Pages\Concerns\CanAuthorizeResourceAccess;
+use Filament\Resources\Resource;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Route as RouteFacade;
@@ -147,13 +148,16 @@ abstract class Page extends BasePage
         return parent::canAccess();
     }
 
+    /**
+     * @return class-string<Model>
+     */
     public function getModel(): string
     {
         return static::getResource()::getModel();
     }
 
     /**
-     * @return class-string
+     * @return class-string<Resource>
      */
     public static function getResource(): string
     {


### PR DESCRIPTION
This is more in line with what's been done here for example: https://github.com/filamentphp/filament/blob/3.x/packages/actions/src/Exports/Exporter.php#L66

There are a few more places where this could also be added. If needed/wanted I can add them to the PR too.