### PR TITLE
Add fallback default locale for format curreny

### DIFF
--- a/packages/infolists/src/Components/Concerns/CanFormatState.php
+++ b/packages/infolists/src/Components/Concerns/CanFormatState.php
@@ -118,7 +118,7 @@ trait CanFormatState
                 $state /= $divideBy;
             }
 
-            return Number::currency($state, $currency, $component->evaluate($locale));
+            return Number::currency($state, $currency, $component->evaluate($locale ?? config('app.locale')));
         });
 
         return $this;

--- a/packages/infolists/src/Components/Concerns/CanFormatState.php
+++ b/packages/infolists/src/Components/Concerns/CanFormatState.php
@@ -118,7 +118,7 @@ trait CanFormatState
                 $state /= $divideBy;
             }
 
-            return Number::currency($state, $currency, $component->evaluate($locale ?? config('app.locale')));
+            return Number::currency($state, $currency, $component->evaluate($locale) ?? config('app.locale'));
         });
 
         return $this;
@@ -153,7 +153,7 @@ trait CanFormatState
                 );
             }
 
-            return Number::format($state, $decimalPlaces, $component->evaluate($maxDecimalPlaces), $component->evaluate($locale));
+            return Number::format($state, $decimalPlaces, $component->evaluate($maxDecimalPlaces), $component->evaluate($locale) ?? config('app.locale'));
         });
 
         return $this;

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -118,7 +118,7 @@ trait CanFormatState
                 $state /= $divideBy;
             }
 
-            return Number::currency($state, $currency, $column->evaluate($locale ?? config('app.locale')));
+            return Number::currency($state, $currency, $column->evaluate($locale) ?? config('app.locale'));
         });
 
         return $this;
@@ -153,7 +153,7 @@ trait CanFormatState
                 );
             }
 
-            return Number::format($state, $decimalPlaces, $column->evaluate($maxDecimalPlaces), locale: $column->evaluate($locale));
+            return Number::format($state, $decimalPlaces, $column->evaluate($maxDecimalPlaces), locale: $column->evaluate($locale) ?? config('app.locale'));
         });
 
         return $this;

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -118,7 +118,7 @@ trait CanFormatState
                 $state /= $divideBy;
             }
 
-            return Number::currency($state, $currency, $column->evaluate($locale));
+            return Number::currency($state, $currency, $column->evaluate($locale ?? config('app.locale')));
         });
 
         return $this;

--- a/packages/tables/src/Columns/Summarizers/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Summarizers/Concerns/CanFormatState.php
@@ -52,7 +52,7 @@ trait CanFormatState
                 $state /= $divideBy;
             }
 
-            return Number::currency($state, $currency, $summarizer->evaluate($locale ?? config('app.locales')));
+            return Number::currency($state, $currency, $summarizer->evaluate($locale ?? config('app.locale')));
         });
 
         return $this;

--- a/packages/tables/src/Columns/Summarizers/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Summarizers/Concerns/CanFormatState.php
@@ -52,7 +52,7 @@ trait CanFormatState
                 $state /= $divideBy;
             }
 
-            return Number::currency($state, $currency, $summarizer->evaluate($locale));
+            return Number::currency($state, $currency, $summarizer->evaluate($locale ?? config('app.locales')));
         });
 
         return $this;

--- a/packages/tables/src/Columns/Summarizers/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Summarizers/Concerns/CanFormatState.php
@@ -52,7 +52,7 @@ trait CanFormatState
                 $state /= $divideBy;
             }
 
-            return Number::currency($state, $currency, $summarizer->evaluate($locale ?? config('app.locale')));
+            return Number::currency($state, $currency, $summarizer->evaluate($locale) ?? config('app.locale'));
         });
 
         return $this;
@@ -85,7 +85,7 @@ trait CanFormatState
                 );
             }
 
-            return Number::format($state, $decimalPlaces, $summarizer->evaluate($maxDecimalPlaces), locale: $summarizer->evaluate($locale));
+            return Number::format($state, $decimalPlaces, $summarizer->evaluate($maxDecimalPlaces), locale: $summarizer->evaluate($locale) ?? config('app.locale'));
         });
 
         return $this;


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Add fallback default locale for format curreny.

This update simplifies the code for passing the locale parameter when chaining to the `money()` method. If no locale is provided, the application’s default locale will be used automatically.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
