### PR TITLE
Allow multiple lines to be added to the import example file.

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -494,6 +494,15 @@ ImportColumn::make('sku')
     ->example('ABC123')
 ```
 
+Or you can add multiple example rows to the CSV using the `examples()` method:
+
+```php
+use Filament\Actions\Imports\ImportColumn;
+
+ImportColumn::make('sku')
+    ->examples(['ABC123', 'DEF456'])
+```
+
 By default, the name of the column is used in the header of the example CSV. You can customize the header per-column using `exampleHeader()`:
 
 ```php

--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -494,7 +494,7 @@ ImportColumn::make('sku')
     ->example('ABC123')
 ```
 
-Or if you want to add more than one example row, you can pass array to `examples()` method:
+Or if you want to add more than one example row, you can pass an array to the `examples()` method:
 
 ```php
 use Filament\Actions\Imports\ImportColumn;

--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -494,7 +494,7 @@ ImportColumn::make('sku')
     ->example('ABC123')
 ```
 
-Or you can add multiple example rows to the CSV using the `examples()` method:
+Or if you want to add more than one example row, you can pass array to `examples()` method:
 
 ```php
 use Filament\Actions\Imports\ImportColumn;

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -334,22 +334,13 @@ trait CanImportRecords
                         $columns,
                     ));
 
-                    /*
-                    Сount the number of lines in the file.
-                    It should be equal to the largest number of examples in the columns.
-                    */
-                    $rowsCount = 0;
-                    array_map(
-                        function (ImportColumn $column) use (&$rowsCount) {
-                            $rowsCount = count($column->getExamples()) > $rowsCount ? count($column->getExamples()) : $rowsCount;
-                        },
+                    $rowsCount = array_reduce(
                         $columns,
+                        function ($maxCount, ImportColumn $column) {
+                            return max($maxCount, count($column->getExamples()));
+                        }
                     );
 
-                    /*
-                    Get an array of “examples” in which the number of elements
-                    is equal to the number of lines in the file.
-                    */
                     $examples = [];
                     foreach ($columns as $column) {
                         $columnExamples = $column->getExamples();
@@ -359,9 +350,6 @@ trait CanImportRecords
                         }
                     }
 
-                    /*
-                    Filling out the file
-                    */
                     $csv->insertAll($examples);
 
                     return response()->streamDownload(function () use ($csv) {

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -338,7 +338,8 @@ trait CanImportRecords
                         $columns,
                         function ($maxCount, ImportColumn $column) {
                             return max($maxCount, count($column->getExamples()));
-                        }
+                        },
+                        0
                     );
 
                     $examples = [];

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -336,7 +336,7 @@ trait CanImportRecords
 
                     $rowsCount = array_reduce(
                         $columns,
-                        function ($maxCount, ImportColumn $column) {
+                        function (?int $maxCount, ImportColumn $column) {
                             return max($maxCount, count($column->getExamples()));
                         },
                         0

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -334,24 +334,26 @@ trait CanImportRecords
                         $columns,
                     ));
 
-                    $rowsCount = array_reduce(
+                    $columnExamples = array_map(
+                        fn (ImportColumn $column): array => $column->getExamples(),
                         $columns,
-                        function (?int $maxCount, ImportColumn $column) {
-                            return max($maxCount, count($column->getExamples()));
-                        },
-                        0
                     );
 
-                    $examples = [];
-                    foreach ($columns as $column) {
-                        $columnExamples = $column->getExamples();
+                    $exampleRowsCount = array_reduce(
+                        $columnExamples,
+                        fn (int $count, array $exampleData): int => max($count, count($exampleData)),
+                        initial: 0,
+                    );
 
-                        for($i = 0; $i < $rowsCount; $i++) {
-                            $examples[$i][] = $columnExamples[$i] ?? '';
+                    $exampleRows = [];
+
+                    foreach ($columnExamples as $exampleData) {
+                        for ($i = 0; $i < $exampleRowsCount; $i++) {
+                            $exampleRows[$i][] = $exampleData[$i] ?? '';
                         }
                     }
 
-                    $csv->insertAll($examples);
+                    $csv->insertAll($exampleRows);
 
                     return response()->streamDownload(function () use ($csv) {
                         echo $csv->toString();

--- a/packages/actions/src/Imports/ImportColumn.php
+++ b/packages/actions/src/Imports/ImportColumn.php
@@ -115,6 +115,8 @@ class ImportColumn extends Component
     public function example(mixed $example): static
     {
         $this->examples($example);
+
+        return $this;
     }
 
     /**

--- a/packages/actions/src/Imports/ImportColumn.php
+++ b/packages/actions/src/Imports/ImportColumn.php
@@ -119,12 +119,12 @@ class ImportColumn extends Component
         return $this;
     }
 
-    /**
-     * @param mixed $examples
-     */
     public function examples(mixed $examples): static
     {
-        if (!is_array($examples) && !$examples instanceof Closure) {
+        if (
+            (! is_array($examples)) &&
+            (! $examples instanceof Closure)
+        ) {
             $examples = Arr::wrap($examples);
         }
 

--- a/packages/actions/src/Imports/ImportColumn.php
+++ b/packages/actions/src/Imports/ImportColumn.php
@@ -51,12 +51,10 @@ class ImportColumn extends Component
 
     protected ?Importer $importer = null;
 
-    protected mixed $example = null;
-
     /**
-     * @var array<mixed>
+     * @var array<mixed> | Closure
      */
-    protected array $examples = [];
+    protected array | Closure $examples = [];
 
     protected string | Closure | null $exampleHeader = null;
 
@@ -116,16 +114,18 @@ class ImportColumn extends Component
 
     public function example(mixed $example): static
     {
-        $this->example = $example;
-
-        return $this;
+        $this->examples($example);
     }
 
     /**
-     * @param  array<mixed>  $examples
+     * @param mixed $examples
      */
-    public function examples(array $examples): static
+    public function examples(mixed $examples): static
     {
+        if (!is_array($examples) && !$examples instanceof Closure) {
+            $examples = Arr::wrap($examples);
+        }
+
         $this->examples = $examples;
 
         return $this;
@@ -447,9 +447,12 @@ class ImportColumn extends Component
         return $this->importer;
     }
 
+    /**
+     * @deprecated Use `getExamples()` instead.
+     */
     public function getExample(): mixed
     {
-        return $this->evaluate($this->example);
+        return Arr::first($this->getExamples());
     }
 
     /**
@@ -457,7 +460,7 @@ class ImportColumn extends Component
      */
     public function getExamples(): array
     {
-        return array_merge([$this->evaluate($this->example)], $this->examples);
+        return Arr::wrap($this->evaluate($this->examples));
     }
 
     /**

--- a/packages/actions/src/Imports/ImportColumn.php
+++ b/packages/actions/src/Imports/ImportColumn.php
@@ -122,7 +122,7 @@ class ImportColumn extends Component
     }
 
     /**
-     * @param  array<mixed>  $rules
+     * @param  array<mixed>  $examples
      */
     public function examples(array $examples): static
     {

--- a/packages/actions/src/Imports/ImportColumn.php
+++ b/packages/actions/src/Imports/ImportColumn.php
@@ -53,6 +53,8 @@ class ImportColumn extends Component
 
     protected mixed $example = null;
 
+    protected array $examples = [];
+
     protected string | Closure | null $exampleHeader = null;
 
     protected string | Closure | null $relationship = null;
@@ -112,6 +114,13 @@ class ImportColumn extends Component
     public function example(mixed $example): static
     {
         $this->example = $example;
+
+        return $this;
+    }
+
+    public function examples(array $examples): static
+    {
+        $this->examples = $examples;
 
         return $this;
     }
@@ -435,6 +444,11 @@ class ImportColumn extends Component
     public function getExample(): mixed
     {
         return $this->evaluate($this->example);
+    }
+
+    public function getExamples(): array
+    {
+        return array_merge([$this->evaluate($this->example)], $this->examples);
     }
 
     /**

--- a/packages/actions/src/Imports/ImportColumn.php
+++ b/packages/actions/src/Imports/ImportColumn.php
@@ -53,6 +53,9 @@ class ImportColumn extends Component
 
     protected mixed $example = null;
 
+    /**
+     * @var array<mixed>
+     */
     protected array $examples = [];
 
     protected string | Closure | null $exampleHeader = null;
@@ -118,6 +121,9 @@ class ImportColumn extends Component
         return $this;
     }
 
+    /**
+     * @param  array<mixed>  $rules
+     */
     public function examples(array $examples): static
     {
         $this->examples = $examples;
@@ -446,6 +452,9 @@ class ImportColumn extends Component
         return $this->evaluate($this->example);
     }
 
+    /**
+     * @return array<mixed>
+     */
     public function getExamples(): array
     {
         return array_merge([$this->evaluate($this->example)], $this->examples);


### PR DESCRIPTION
There was a need to add more than 1 line to the import example file, but this is not possible now. Added an "examples" function to columns that takes an array and generates a file based on it.