### PR TITLE
feat: introduce `defaultToNA()`

### DIFF
--- a/packages/support/src/Concerns/HasCellState.php
+++ b/packages/support/src/Concerns/HasCellState.php
@@ -60,6 +60,13 @@ trait HasCellState
         return $this;
     }
 
+    public function defaultToNA(): static
+    {
+        $this->defaultState = 'N/A';
+
+        return $this;
+    }
+
     public function isDistinctList(): bool
     {
         return (bool) $this->evaluate($this->isDistinctList);


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
This pull request introduces a new static method to set a default cell state in the filament table builder. In some cases, certain table columns may contain null values, which can negatively impact user experience if left empty. Although you can already use `default('N/A')` to address this, I believe adding `defaultToNA()` would provide a more concise option.

```php
Tables\Columns\TextColumn::make('mobile')
    ->defaultToNA();
```

With this enhancement, the output for columns with null values will now elegantly display as "N/A".

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
