### PR TITLE
Fix recursive validation attributes

### DIFF
--- a/packages/forms/src/Components/Concerns/HasNestedRecursiveValidationRules.php
+++ b/packages/forms/src/Components/Concerns/HasNestedRecursiveValidationRules.php
@@ -45,4 +45,11 @@ trait HasNestedRecursiveValidationRules
 
         return $rules;
     }
+
+    public function dehydrateValidationAttributes(array &$attributes): void
+    {
+        parent::dehydrateValidationAttributes($attributes);
+
+        $attributes["{$this->getStatePath()}.*"] = $this->getValidationAttribute();
+    }
 }

--- a/packages/tables/resources/js/components/table.js
+++ b/packages/tables/resources/js/components/table.js
@@ -13,7 +13,8 @@ export default function table() {
         livewireId: null,
 
         init: function () {
-            this.livewireId = this.$root.closest('[wire\\:id]').attributes['wire:id'].value
+            this.livewireId =
+                this.$root.closest('[wire\\:id]').attributes['wire:id'].value
 
             this.$wire.$on('deselectAllTableRecords', () =>
                 this.deselectAllRecords(),

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -494,7 +494,9 @@
                                 x-bind:class="{
                                     'hidden':
                                         {{ $group?->isCollapsible() ? 'true' : 'false' }} &&
-                                        isGroupCollapsed({{ \Illuminate\Support\Js::from($recordGroupTitle) }}),
+                                        isGroupCollapsed(
+                                            {{ \Illuminate\Support\Js::from($recordGroupTitle) }},
+                                        ),
                                     {{ ($contentGrid ? '\'bg-gray-50 dark:bg-white/10 dark:ring-white/20\'' : '\'bg-gray-50 dark:bg-white/5 before:absolute before:start-0 before:inset-y-0 before:w-0.5 before:bg-primary-600 dark:before:bg-primary-500\'') . ': isRecordSelected(\'' . $recordKey . '\')' }},
                                     {{ $contentGrid ? '\'bg-white dark:bg-white/5 dark:ring-white/10\': ! isRecordSelected(\'' . $recordKey . '\')' : '\'\':\'\'' }},
                                 }"


### PR DESCRIPTION
## Description

Fixes: Fields with nested recursive rules got validation messages like: `The data.foo.0 field ...`

## Visual changes

```php
TagsInput::make('billing_emails')
    ->nestedRecursiveRules('email')
    ->validationAttribute('cucumber')
    ->validationMessages([
          '*.email' => 'Each :attribute has already been eaten.',
 ]),
```

<img width="978" alt="image" src="https://github.com/filamentphp/filament/assets/21239634/e37eb7ca-02ad-4704-a434-0fd99faeeeca">

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
