### PR TITLE
Add tooltip option to `->since()`

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -82,7 +82,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function since(?string $timezone = null): static
+    public function since(?string $timezone = null, ?string $tooltipFormat = null): static
     {
         $this->isDateTime = true;
 
@@ -95,6 +95,18 @@ trait CanFormatState
                 ->setTimezone($timezone ?? $column->getTimezone())
                 ->diffForHumans();
         });
+
+        if (filled($tooltipFormat)) {
+            $this->tooltip(static function (TextColumn $column, $state) use ($tooltipFormat, $timezone): ?string {
+                if (blank($state)) {
+                    return null;
+                }
+
+                return Carbon::parse($state)
+                    ->setTimezone($timezone ?? $column->getTimezone())
+                    ->translatedFormat($tooltipFormat);
+            });
+        }
 
         return $this;
     }

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -82,7 +82,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function since(?string $timezone = null, ?string $tooltipFormat = null): static
+    public function since(?string $timezone = null): static
     {
         $this->isDateTime = true;
 
@@ -96,17 +96,55 @@ trait CanFormatState
                 ->diffForHumans();
         });
 
-        if (filled($tooltipFormat)) {
-            $this->tooltip(static function (TextColumn $column, $state) use ($tooltipFormat, $timezone): ?string {
-                if (blank($state)) {
-                    return null;
-                }
+        return $this;
+    }
 
-                return Carbon::parse($state)
-                    ->setTimezone($timezone ?? $column->getTimezone())
-                    ->translatedFormat($tooltipFormat);
-            });
-        }
+    public function dateTooltip(?string $format = null, ?string $timezone = null): static
+    {
+        $format ??= Table::$defaultDateDisplayFormat;
+
+        $this->tooltip(static function (TextColumn $column, $state) use ($format, $timezone): ?string {
+            if (blank($state)) {
+                return null;
+            }
+
+            return Carbon::parse($state)
+                ->setTimezone($timezone ?? $column->getTimezone())
+                ->translatedFormat($format);
+        });
+
+        return $this;
+    }
+
+    public function dateTimeTooltip(?string $format = null, ?string $timezone = null): static
+    {
+        $format ??= Table::$defaultDateTimeDisplayFormat;
+
+        $this->dateTooltip($format, $timezone);
+
+        return $this;
+    }
+
+    public function timeTooltip(?string $format = null, ?string $timezone = null): static
+    {
+        $format ??= Table::$defaultTimeDisplayFormat;
+
+        $this->dateTooltip($format, $timezone);
+
+        return $this;
+    }
+
+    public function sinceTooltip(?string $timezone = null): static
+    {
+        $this->tooltip(static function (TextColumn $column, $state) use ($timezone): ?string {
+            if (blank($state)) {
+                return null;
+            }
+
+            return Carbon::parse($state)
+                ->setTimezone($timezone ?? $column->getTimezone())
+                ->diffForHumans();
+        });
 
         return $this;
     }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Often, I find myself combining `->since()` on a column with a tooltip having the exact date. With this change, it is easy to do this and specify the format.

## Visual changes

Adds a tooltip with the specified date format.

Changes
```php
                    ->since()
                    ->tooltip(static fn (TextColumn $column, ?string $state) => filled($state)
                        ? Carbon::parse($state)
                            ->setTimezone($column->getTimezone())
                            ->translatedFormat('d-m-Y H:i:s')
                        : null
                    ),
```
into
```php
                    ->since()
                    ->dateTimeTooltip()
```

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
