### PR TITLE
docs: Add info on programmatically triggering actions

### DIFF
--- a/packages/actions/docs/06-adding-an-action-to-a-livewire-component.md
+++ b/packages/actions/docs/06-adding-an-action-to-a-livewire-component.md
@@ -239,53 +239,31 @@ If the first action is canceled, the second one is not opened. If the second act
 
 ## Programmatically triggering actions
 
-Sometimes you may need to trigger an action via other means besides a button, link, or key binding, especially when integrating with other JS packages. This can be accomplished with the `mountAction` method. Here is an example of a simple test action.
+Sometimes you may need to trigger an action without the user clicking on the built-in trigger button, especially from JavaScript. Here is an example action which could be registered on a Livewire component:
 
-```PHP
-<?php
-
-namespace App\Filament\Pages;
-
+```php
 use Filament\Actions\Action;
-use Filament\Actions\Concerns\InteractsWithActions;
-use Filament\Actions\Contracts\HasActions;
-use Filament\Pages\Page;
 
-class TestPage extends Page implements HasActions
+public function testAction(): Action
 {
-    use InteractsWithActions;
-
-    protected static ?string $navigationLabel = 'Test Page';
-
-    protected static string $view = 'filament.pages.test-page';
-
-    public function testAction(): Action
-    {
-        return Action::make('test')
-            ->action(function (array $arguments) {
-                dd('test action called with id: '.$arguments['id']);
-            });
-    }
+    return Action::make('test')
+        ->requiresConfirmation()
+        ->action(function (array $arguments) {
+            dd('Test action called', $arguments);
+        });
 }
-
 ```
 
-And this is how you can trigger that action from within a script block or from a custom HTML element.
+You can trigger that action from a click in your HTML using the `wire:click` attribute, calling the `mountAction()` method and optionally passing in any arguments that you want to be available:
 
-```HTML
-<div>
-    <button wire:click="mountAction('test', {id: '123'})">Button 1</button>
-    <button id="custom-button-from-library">Button 2</button>
-</div>
-
-@script
-    <script>
-     document.getElementById("custom-button-from-library").addEventListener("click",function(){
-        $wire.mountAction("test", {id: '345'})
-     })   
-    </script>
-@endscript
-
+```blade
+<button wire:click="mountAction('test', { id: 12345 })">
+    Button
+</button>
 ```
 
+To trigger that action from JavaScript, you can use the [`$wire` utility](https://livewire.laravel.com/docs/alpine#controlling-livewire-from-alpine-using-wire), passing in the same arguments:
 
+```js
+$wire.mountAction('test', { id: 12345 })
+```

--- a/packages/actions/docs/06-adding-an-action-to-a-livewire-component.md
+++ b/packages/actions/docs/06-adding-an-action-to-a-livewire-component.md
@@ -236,3 +236,56 @@ public function publishAction(): Action
 Now, when the first action is submitted, the second action will open in its place. The [arguments](#passing-action-arguments) that were originally passed to the first action get passed to the second action, so you can use them to persist data between requests.
 
 If the first action is canceled, the second one is not opened. If the second action is canceled, the first one has already run and cannot be cancelled.
+
+## Programmatically triggering actions
+
+Sometimes you may need to trigger an action via other means besides a button, link, or key binding, especially when integrating with other JS packages. This can be accomplished with the `mountAction` method. Here is an example of a simple delete
+
+```PHP
+<?php
+
+namespace App\Filament\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Pages\Page;
+
+class TestPage extends Page implements HasActions
+{
+    use InteractsWithActions;
+
+    protected static ?string $navigationLabel = 'Test Page';
+
+    protected static string $view = 'filament.pages.test-page';
+
+    public function testAction(): Action
+    {
+        return Action::make('test')
+            ->action(function (array $arguments) {
+                dd('test action called with id: '.$arguments['id']);
+            });
+    }
+}
+
+```
+
+And this is how you can trigger that action from within a script block or from a custom HTML element.
+
+```HTML
+<div>
+    <button wire:click="mountAction('test', {id: '123'})">Button 1</button>
+    <button id="custom-button-from-library">Button 2</button>
+</div>
+
+@script
+    <script>
+     document.getElementById("custom-button-from-library").addEventListener("click",function(){
+        $wire.mountAction("test", {id: '345'})
+     })   
+    </script>
+@endscript
+
+```
+
+

--- a/packages/actions/docs/06-adding-an-action-to-a-livewire-component.md
+++ b/packages/actions/docs/06-adding-an-action-to-a-livewire-component.md
@@ -239,7 +239,7 @@ If the first action is canceled, the second one is not opened. If the second act
 
 ## Programmatically triggering actions
 
-Sometimes you may need to trigger an action via other means besides a button, link, or key binding, especially when integrating with other JS packages. This can be accomplished with the `mountAction` method. Here is an example of a simple delete
+Sometimes you may need to trigger an action via other means besides a button, link, or key binding, especially when integrating with other JS packages. This can be accomplished with the `mountAction` method. Here is an example of a simple test action.
 
 ```PHP
 <?php


### PR DESCRIPTION
docs: Add info on programmatically triggering actions

## Description

Adds info on how to programmatically trigger an action from a custom page. 

## Visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
