### PR TITLE
fix textarea auto resize problem

### DIFF
--- a/packages/forms/resources/js/components/textarea.js
+++ b/packages/forms/resources/js/components/textarea.js
@@ -1,5 +1,7 @@
 export default function textareaFormComponent({ initialHeight }) {
     return {
+        height: initialHeight + 'rem',
+
         init: function () {
             this.render()
         },
@@ -7,8 +9,17 @@ export default function textareaFormComponent({ initialHeight }) {
         render: function () {
             if (this.$el.scrollHeight > 0) {
                 this.$el.style.height = initialHeight + 'rem'
-                this.$el.style.height = this.$el.scrollHeight + 'px'
+                this.height = this.$el.scrollHeight + 'px'
+                this.$el.style.height = this.height
             }
         },
+
+        styles: {
+            [':style']() {
+                return {
+                    height: this.height,
+                };
+            },
+        }
     }
 }

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -42,13 +42,12 @@
                 @endif
                 ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('textarea', 'filament/forms') }}"
                 x-data="textareaFormComponent({ initialHeight: @js($initialHeight) })"
+                x-bind="styles"
                 x-intersect.once="render()"
                 x-on:input="render()"
                 x-on:resize.window="render()"
                 {{ $getExtraAlpineAttributeBag() }}
             @endif
-            x-ignore
-            wire:ignore.style.height
             {{
                 $getExtraInputAttributeBag()
                     ->merge([
@@ -68,9 +67,6 @@
                     ->class([
                         'block w-full border-none bg-transparent px-3 py-1.5 text-base text-gray-950 placeholder:text-gray-400 focus:ring-0 disabled:text-gray-500 disabled:[-webkit-text-fill-color:theme(colors.gray.500)] disabled:placeholder:[-webkit-text-fill-color:theme(colors.gray.400)] dark:text-white dark:placeholder:text-gray-500 dark:disabled:text-gray-400 dark:disabled:[-webkit-text-fill-color:theme(colors.gray.400)] dark:disabled:placeholder:[-webkit-text-fill-color:theme(colors.gray.500)] sm:text-sm sm:leading-6',
                         'resize-none' => $shouldAutosize,
-                    ])
-                    ->style([
-                        "height: {$initialHeight}rem" => $shouldAutosize,
                     ])
             }}
         ></textarea>


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
as discussed in #13102 I stored the scroll height of textarea in an Alpine variable which fixed the issue without needing to add wire:ignore but there are 2 problems.

1. when `autosize()` and `live()` are used at the same time, there is a flicker while resizing.
2. when `autosize()` is not used but textarea is live, the problem that #13102 was fixing remains because wire:ignore is removed.

@danharrin can you take a look at these.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
