### PR TITLE
Feature/add icons to builder header

### DIFF
--- a/packages/forms/docs/03-fields/13-builder.md
+++ b/packages/forms/docs/03-fields/13-builder.md
@@ -141,9 +141,9 @@ Builder\Block::make('paragraph')
 
 <AutoScreenshot name="forms/fields/builder/icons" alt="Builder with block icons in the dropdown" version="3.x" />
 
-### Enable block icons in header
+### Adding icons to the header of blocks
 
-By default, items in the builder don't have an icon next to the label. You may enable this using the `blockIcons(true)` method:
+By default, blocks in the builder don't have an icon next to the header label, just in the dropdown to add new blocks. You may enable this using the `blockIcons()` method:
 
 ```php
 use Filament\Forms\Components\Builder;
@@ -152,10 +152,8 @@ Builder::make('content')
     ->blocks([
         // ...
     ])
-    ->blockIcons(true)
+    ->blockIcons()
 ```
-
-This will automatically pull in the icon set for the `Builder\Block`.
 
 ## Adding items
 

--- a/packages/forms/docs/03-fields/13-builder.md
+++ b/packages/forms/docs/03-fields/13-builder.md
@@ -141,6 +141,22 @@ Builder\Block::make('paragraph')
 
 <AutoScreenshot name="forms/fields/builder/icons" alt="Builder with block icons in the dropdown" version="3.x" />
 
+### Enable block icons in header
+
+By default, items in the builder don't have an icon next to the label. You may enable this using the `blockIcons(true)` method:
+
+```php
+use Filament\Forms\Components\Builder;
+
+Builder::make('content')
+    ->blocks([
+        // ...
+    ])
+    ->blockIcons(true)
+```
+
+This will automatically pull in the icon set for the `Builder\Block`.
+
 ## Adding items
 
 An action button is displayed below the builder to allow the user to add a new item.

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -76,8 +76,8 @@
             >
                 @php
                     $hasBlockLabels = $hasBlockLabels();
-                    $hasBlockNumbers = $hasBlockNumbers();
                     $hasBlockIcons = $hasBlockIcons();
+                    $hasBlockNumbers = $hasBlockNumbers();
                 @endphp
 
                 @foreach ($containers as $uuid => $item)
@@ -111,7 +111,7 @@
                         class="fi-fo-builder-item rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-white/5 dark:ring-white/10"
                         x-bind:class="{ 'fi-collapsed overflow-hidden': isCollapsed }"
                     >
-                        @if ($reorderActionIsVisible || $moveUpActionIsVisible || $moveDownActionIsVisible || $hasBlockLabels || $editActionIsVisible || $cloneActionIsVisible || $deleteActionIsVisible || $isCollapsible || $visibleExtraItemActions)
+                        @if ($reorderActionIsVisible || $moveUpActionIsVisible || $moveDownActionIsVisible || $hasBlockIcons || $hasBlockLabels || $editActionIsVisible || $cloneActionIsVisible || $deleteActionIsVisible || $isCollapsible || $visibleExtraItemActions)
                             <div
                                 @if ($isCollapsible)
                                     x-on:click.stop="isCollapsed = !isCollapsed"
@@ -148,11 +148,11 @@
                                     $blockIcon = $item->getParentComponent()->getIcon($item->getRawState(), $uuid);
                                 @endphp
 
-                                @if ($hasBlockIcons && $blockIcon)
+                                @if ($hasBlockIcons && filled($blockIcon))
                                     <x-filament::icon
-                                        icon="{{ $blockIcon }}"
+                                        :icon="$blockIcon"
                                         class="fi-fo-builder-item-header-icon h-5 w-5 text-gray-400 dark:text-gray-500"
-                                    ></x-filament::icon>
+                                    />
                                 @endif
 
                                 @if ($hasBlockLabels)

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -145,7 +145,7 @@
                                 @endif
 
                                 @php
-                                  $blockIcon = $item->getParentComponent()->getIcon($item->getRawState(), $uuid);    
+                                    $blockIcon = $item->getParentComponent()->getIcon($item->getRawState(), $uuid);
                                 @endphp
 
                                 @if ($hasBlockIcons && $blockIcon)

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -36,19 +36,10 @@
 <x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
     <div
         x-data="{}"
-        {{
-            $attributes
-                ->merge($getExtraAttributes(), escape: false)
-                ->class(['fi-fo-builder grid gap-y-4'])
-        }}
+        {{ $attributes->merge($getExtraAttributes(), escape: false)->class(['fi-fo-builder grid gap-y-4']) }}
     >
         @if ($collapseAllActionIsVisible || $expandAllActionIsVisible)
-            <div
-                @class([
-                    'flex gap-x-3',
-                    'hidden' => count($containers) < 2,
-                ])
-            >
+            <div @class(['flex gap-x-3', 'hidden' => count($containers) < 2])>
                 @if ($collapseAllActionIsVisible)
                     <span
                         x-on:click="$dispatch('builder-collapse', '{{ $statePath }}')"
@@ -77,6 +68,7 @@
                 @php
                     $hasBlockLabels = $hasBlockLabels();
                     $hasBlockNumbers = $hasBlockNumbers();
+                    $hasBlockIcons = $hasBlockIcons();
                 @endphp
 
                 @foreach ($containers as $uuid => $item)
@@ -110,11 +102,17 @@
                         class="fi-fo-builder-item rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-white/5 dark:ring-white/10"
                         x-bind:class="{ 'fi-collapsed overflow-hidden': isCollapsed }"
                     >
-                        @if ($reorderActionIsVisible || $moveUpActionIsVisible || $moveDownActionIsVisible || $hasBlockLabels || $editActionIsVisible || $cloneActionIsVisible || $deleteActionIsVisible || $isCollapsible || $visibleExtraItemActions)
+                        @if ($reorderActionIsVisible ||
+                             $moveUpActionIsVisible ||
+                             $moveDownActionIsVisible ||
+                             $hasBlockLabels ||
+                             $editActionIsVisible ||
+                             $cloneActionIsVisible ||
+                             $deleteActionIsVisible ||
+                             $isCollapsible ||
+                             $visibleExtraItemActions)
                             <div
-                                @if ($isCollapsible)
-                                    x-on:click.stop="isCollapsed = !isCollapsed"
-                                @endif
+                                @if ($isCollapsible) x-on:click.stop="isCollapsed = !isCollapsed" @endif
                                 @class([
                                     'fi-fo-builder-item-header flex items-center gap-x-3 overflow-hidden px-4 py-3',
                                     'cursor-pointer select-none' => $isCollapsible,
@@ -143,6 +141,13 @@
                                     </ul>
                                 @endif
 
+                                @if ($hasBlockIcons)
+                                    <x-filament::icon
+                                        icon="{{ $item->getParentComponent()->getIcon($item->getRawState(), $uuid) }}"
+                                        class="fi-fo-builder-item-header-icon h-5 w-5 text-gray-400 dark:text-gray-500"
+                                    ></x-filament::icon>
+                                @endif
+
                                 @if ($hasBlockLabels)
                                     <h4
                                         @class([
@@ -158,7 +163,11 @@
                                     </h4>
                                 @endif
 
-                                @if ($editActionIsVisible || $cloneActionIsVisible || $deleteActionIsVisible || $isCollapsible || $visibleExtraItemActions)
+                                @if ($editActionIsVisible ||
+                                     $cloneActionIsVisible ||
+                                     $deleteActionIsVisible ||
+                                     $isCollapsible ||
+                                     $visibleExtraItemActions)
                                     <ul
                                         class="ms-auto flex items-center gap-x-3"
                                     >
@@ -229,7 +238,7 @@
                                     {{ $item->getParentComponent()->renderPreview($item->getRawState()) }}
                                 </div>
 
-                                @if ($editActionIsVisible && (! $hasInteractiveBlockPreviews))
+                                @if ($editActionIsVisible && ! $hasInteractiveBlockPreviews)
                                     <div
                                         class="absolute inset-0 z-[1] cursor-pointer"
                                         role="button"

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -36,10 +36,19 @@
 <x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
     <div
         x-data="{}"
-        {{ $attributes->merge($getExtraAttributes(), escape: false)->class(['fi-fo-builder grid gap-y-4']) }}
+        {{
+            $attributes
+                ->merge($getExtraAttributes(), escape: false)
+                ->class(['fi-fo-builder grid gap-y-4'])
+        }}
     >
         @if ($collapseAllActionIsVisible || $expandAllActionIsVisible)
-            <div @class(['flex gap-x-3', 'hidden' => count($containers) < 2])>
+            <div
+                @class([
+                    'flex gap-x-3',
+                    'hidden' => count($containers) < 2,
+                ])
+            >
                 @if ($collapseAllActionIsVisible)
                     <span
                         x-on:click="$dispatch('builder-collapse', '{{ $statePath }}')"
@@ -102,17 +111,11 @@
                         class="fi-fo-builder-item rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-white/5 dark:ring-white/10"
                         x-bind:class="{ 'fi-collapsed overflow-hidden': isCollapsed }"
                     >
-                        @if ($reorderActionIsVisible ||
-                             $moveUpActionIsVisible ||
-                             $moveDownActionIsVisible ||
-                             $hasBlockLabels ||
-                             $editActionIsVisible ||
-                             $cloneActionIsVisible ||
-                             $deleteActionIsVisible ||
-                             $isCollapsible ||
-                             $visibleExtraItemActions)
+                        @if ($reorderActionIsVisible || $moveUpActionIsVisible || $moveDownActionIsVisible || $hasBlockLabels || $editActionIsVisible || $cloneActionIsVisible || $deleteActionIsVisible || $isCollapsible || $visibleExtraItemActions)
                             <div
-                                @if ($isCollapsible) x-on:click.stop="isCollapsed = !isCollapsed" @endif
+                                @if ($isCollapsible)
+                                    x-on:click.stop="isCollapsed = !isCollapsed"
+                                @endif
                                 @class([
                                     'fi-fo-builder-item-header flex items-center gap-x-3 overflow-hidden px-4 py-3',
                                     'cursor-pointer select-none' => $isCollapsible,
@@ -163,11 +166,7 @@
                                     </h4>
                                 @endif
 
-                                @if ($editActionIsVisible ||
-                                     $cloneActionIsVisible ||
-                                     $deleteActionIsVisible ||
-                                     $isCollapsible ||
-                                     $visibleExtraItemActions)
+                                @if ($editActionIsVisible || $cloneActionIsVisible || $deleteActionIsVisible || $isCollapsible || $visibleExtraItemActions)
                                     <ul
                                         class="ms-auto flex items-center gap-x-3"
                                     >
@@ -238,7 +237,7 @@
                                     {{ $item->getParentComponent()->renderPreview($item->getRawState()) }}
                                 </div>
 
-                                @if ($editActionIsVisible && ! $hasInteractiveBlockPreviews)
+                                @if ($editActionIsVisible && (! $hasInteractiveBlockPreviews))
                                     <div
                                         class="absolute inset-0 z-[1] cursor-pointer"
                                         role="button"

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -144,9 +144,13 @@
                                     </ul>
                                 @endif
 
-                                @if ($hasBlockIcons)
+                                @php
+                                  $blockIcon = $item->getParentComponent()->getIcon($item->getRawState(), $uuid);    
+                                @endphp
+
+                                @if ($hasBlockIcons && $blockIcon)
                                     <x-filament::icon
-                                        icon="{{ $item->getParentComponent()->getIcon($item->getRawState(), $uuid) }}"
+                                        icon="{{ $blockIcon }}"
                                         class="fi-fo-builder-item-header-icon h-5 w-5 text-gray-400 dark:text-gray-500"
                                     ></x-filament::icon>
                                 @endif

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -48,6 +48,8 @@ class Builder extends Field implements Contracts\CanConcealComponents, Contracts
 
     protected bool | Closure $hasBlockNumbers = true;
 
+    protected bool | Closure $hasBlockIcons = false;
+
     protected bool | Closure $hasBlockPreviews = false;
 
     protected bool | Closure $hasInteractiveBlockPreviews = false;
@@ -824,6 +826,13 @@ class Builder extends Field implements Contracts\CanConcealComponents, Contracts
         return $this;
     }
 
+    public function blockIcons(bool | Closure $condition = true): static
+    {
+        $this->hasBlockIcons = $condition;
+
+        return $this;
+    }
+
     public function blockPreviews(bool | Closure $condition = true, bool | Closure $areInteractive = false): static
     {
         $this->hasBlockPreviews = $condition;
@@ -936,6 +945,11 @@ class Builder extends Field implements Contracts\CanConcealComponents, Contracts
     public function hasBlockNumbers(): bool
     {
         return (bool) $this->evaluate($this->hasBlockNumbers);
+    }
+
+    public function hasBlockIcons(): bool
+    {
+        return (bool) $this->evaluate($this->hasBlockIcons);
     }
 
     public function hasBlockPreviews(): bool


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR adds a `blockIcons()` method to the Builder class.

This is very helpful for quickly visually scanning builder blocks to see what kind of block type they are.

It is disabled by default, but when enabled, will pull in the icon set in the individual blocks.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

### Before
<img width="759" alt="image" src="https://github.com/filamentphp/filament/assets/527849/6bf1b6d5-6192-497d-a5a8-4e2434594471">

### After
<img width="754" alt="image" src="https://github.com/filamentphp/filament/assets/527849/60d08316-49bc-4d29-84c7-897f5e8a581c">

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
