### PR TITLE
Support multiple boot using callbacks

### DIFF
--- a/packages/panels/src/Panel.php
+++ b/packages/panels/src/Panel.php
@@ -49,7 +49,7 @@ class Panel extends Component
     /**
      * @var array<array-key, Closure>
      */
-    protected array $bootUsingCallbacks = [];
+    protected array $bootCallbacks = [];
 
     public static function make(): static
     {
@@ -101,14 +101,14 @@ class Panel extends Component
             $plugin->boot($this);
         }
 
-        foreach ($this->bootUsingCallbacks as $callback) {
+        foreach ($this->bootCallbacks as $callback) {
             $callback($this);
         }
     }
 
     public function bootUsing(?Closure $callback): static
     {
-        $this->bootUsingCallbacks[] = $callback;
+        $this->bootCallbacks[] = $callback;
 
         return $this;
     }

--- a/packages/panels/src/Panel.php
+++ b/packages/panels/src/Panel.php
@@ -46,7 +46,10 @@ class Panel extends Component
 
     protected bool $isDefault = false;
 
-    protected ?Closure $bootUsing = null;
+    /**
+     * @var array<array-key, Closure>
+     */
+    protected array $bootUsingCallbacks = [];
 
     public static function make(): static
     {
@@ -98,14 +101,14 @@ class Panel extends Component
             $plugin->boot($this);
         }
 
-        if ($callback = $this->bootUsing) {
+        foreach ($this->bootUsingCallbacks as $callback) {
             $callback($this);
         }
     }
 
     public function bootUsing(?Closure $callback): static
     {
-        $this->bootUsing = $callback;
+        $this->bootUsingCallbacks[] = $callback;
 
         return $this;
     }


### PR DESCRIPTION
## Description

I generally use the `bootUsing()` function quite often to provide a callback. One technique is use is to have an abstract base PanelProvider class and the actual panel provider extend this abstract class. That way, panel configuration can be applied to multiple panels at once. Currently, if I provide a `bootUsing()` in both the abstract base class and the actual panel provider that extends this, the `bootUsing()` callback provided first will be overwritten by later calls. I remember seing a PR about this earlier, but I couldn't find it, so it could've imagined it. Another risk relating to this is when registering plugins, they also get access to the `$panel` object and could (at any time) provide a custom `bootUsing()`, which could then overwrite the developer's `bootUsing()` from the panel provider class. I therefore thing it would be useful to store the callbacks as an array and call them one by one, in order to prevent such over-writing issues (and also make it safe for plugins to use `bootUsing()`).

Thanks!

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
