### PR TITLE
Removes the empty dropdown panel

### DIFF
--- a/packages/support/resources/views/components/dropdown/index.blade.php
+++ b/packages/support/resources/views/components/dropdown/index.blade.php
@@ -45,40 +45,42 @@
         {{ $trigger }}
     </div>
 
-    <div
-        x-cloak
-        x-float{{ $placement ? ".placement.{$placement}" : '' }}{{ $size ? '.size' : '' }}.flip{{ $shift ? '.shift' : '' }}{{ $teleport ? '.teleport' : '' }}{{ $offset ? '.offset' : '' }}="{ offset: {{ $offset }}, {{ $size ? ('size: ' . $sizeConfig) : '' }} }"
-        x-ref="panel"
-        x-transition:enter-start="opacity-0"
-        x-transition:leave-end="opacity-0"
-        @if ($attributes->has('wire:key'))
-            wire:ignore.self
-            wire:key="{{ $attributes->get('wire:key') }}.panel"
-        @endif
-        @class([
-            'fi-dropdown-panel absolute z-10 w-screen divide-y divide-gray-100 rounded-lg bg-white shadow-lg ring-1 ring-gray-950/5 transition dark:divide-white/5 dark:bg-gray-900 dark:ring-white/10',
-            match ($width) {
-                // These max width classes need to be `!important` otherwise they will be usurped by the Floating UI "size" middleware.
-                MaxWidth::ExtraSmall, 'xs' => '!max-w-xs',
-                MaxWidth::Small, 'sm' => '!max-w-sm',
-                MaxWidth::Medium, 'md' => '!max-w-md',
-                MaxWidth::Large, 'lg' => '!max-w-lg',
-                MaxWidth::ExtraLarge, 'xl' => '!max-w-xl',
-                MaxWidth::TwoExtraLarge, '2xl' => '!max-w-2xl',
-                MaxWidth::ThreeExtraLarge, '3xl' => '!max-w-3xl',
-                MaxWidth::FourExtraLarge, '4xl' => '!max-w-4xl',
-                MaxWidth::FiveExtraLarge, '5xl' => '!max-w-5xl',
-                MaxWidth::SixExtraLarge, '6xl' => '!max-w-6xl',
-                MaxWidth::SevenExtraLarge, '7xl' => '!max-w-7xl',
-                null => '!max-w-[14rem]',
-                default => $width,
-            },
-            'overflow-y-auto' => $maxHeight || $size,
-        ])
-        @style([
-            "max-height: {$maxHeight}" => $maxHeight,
-        ])
-    >
-        {{ $slot }}
-    </div>
+    @if (! \Filament\Support\is_slot_empty($slot))
+        <div
+            x-cloak
+            x-float{{ $placement ? ".placement.{$placement}" : '' }}{{ $size ? '.size' : '' }}.flip{{ $shift ? '.shift' : '' }}{{ $teleport ? '.teleport' : '' }}{{ $offset ? '.offset' : '' }}="{ offset: {{ $offset }}, {{ $size ? ('size: ' . $sizeConfig) : '' }} }"
+            x-ref="panel"
+            x-transition:enter-start="opacity-0"
+            x-transition:leave-end="opacity-0"
+            @if ($attributes->has('wire:key'))
+                wire:ignore.self
+                wire:key="{{ $attributes->get('wire:key') }}.panel"
+            @endif
+            @class([
+                'fi-dropdown-panel absolute z-10 w-screen divide-y divide-gray-100 rounded-lg bg-white shadow-lg ring-1 ring-gray-950/5 transition dark:divide-white/5 dark:bg-gray-900 dark:ring-white/10',
+                match ($width) {
+                    // These max width classes need to be `!important` otherwise they will be usurped by the Floating UI "size" middleware.
+                    MaxWidth::ExtraSmall, 'xs' => '!max-w-xs',
+                    MaxWidth::Small, 'sm' => '!max-w-sm',
+                    MaxWidth::Medium, 'md' => '!max-w-md',
+                    MaxWidth::Large, 'lg' => '!max-w-lg',
+                    MaxWidth::ExtraLarge, 'xl' => '!max-w-xl',
+                    MaxWidth::TwoExtraLarge, '2xl' => '!max-w-2xl',
+                    MaxWidth::ThreeExtraLarge, '3xl' => '!max-w-3xl',
+                    MaxWidth::FourExtraLarge, '4xl' => '!max-w-4xl',
+                    MaxWidth::FiveExtraLarge, '5xl' => '!max-w-5xl',
+                    MaxWidth::SixExtraLarge, '6xl' => '!max-w-6xl',
+                    MaxWidth::SevenExtraLarge, '7xl' => '!max-w-7xl',
+                    null => '!max-w-[14rem]',
+                    default => $width,
+                },
+                'overflow-y-auto' => $maxHeight || $size,
+            ])
+            @style([
+                "max-height: {$maxHeight}" => $maxHeight,
+            ])
+        >
+            {{ $slot }}
+        </div>
+    @endif
 </div>


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
This removes the empty dropdown panel if there is/are no slots (menu items) available in the dropdown.

## Visual changes
![image](https://github.com/filamentphp/filament/assets/24932380/99851887-2bd1-478c-b598-4d554b177fa0)
![image](https://github.com/filamentphp/filament/assets/24932380/054ec9d4-5372-45c1-acbf-9b2e8249df9f)

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
