### PR TITLE
Remove duplicate title attribute from rich editor toolbar button

### DIFF
--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -102,8 +102,8 @@
                                     <x-filament-forms::rich-editor.toolbar.button
                                         data-trix-attribute="bold"
                                         data-trix-key="b"
-                                        title="{{ __('filament-forms::components.rich_editor.toolbar_buttons.bold') }}"
                                         tabindex="-1"
+                                        title="{{ __('filament-forms::components.rich_editor.toolbar_buttons.bold') }}"
                                     >
                                         <svg
                                             class="-mx-4 h-4 dark:fill-current"

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -104,7 +104,6 @@
                                         data-trix-key="b"
                                         title="{{ __('filament-forms::components.rich_editor.toolbar_buttons.bold') }}"
                                         tabindex="-1"
-                                        title="{{ __('filament-forms::components.rich_editor.toolbar_buttons.bold') }}"
                                     >
                                         <svg
                                             class="-mx-4 h-4 dark:fill-current"

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -102,8 +102,8 @@
                                     <x-filament-forms::rich-editor.toolbar.button
                                         data-trix-attribute="bold"
                                         data-trix-key="b"
-                                        tabindex="-1"
                                         title="{{ __('filament-forms::components.rich_editor.toolbar_buttons.bold') }}"
+                                        tabindex="-1"
                                     >
                                         <svg
                                             class="-mx-4 h-4 dark:fill-current"


### PR DESCRIPTION
remove duplicates title  from the rich-editor source code file

## Description

Removed a duplicate `title` attribute from the `rich-editor` toolbar button in the Filament Forms source code. The duplicate `title` attribute was redundant and could potentially cause confusion or unexpected behavior.


## Visual changes

<!-- Add screenshots/recordings of before and after. -->
before :
![image](https://github.com/filamentphp/filament/assets/130717329/732ab3f7-7c5e-4f41-819f-549a25209ba5)
after  : 
![image](https://github.com/filamentphp/filament/assets/130717329/99079787-b128-430d-9197-137c81e12a88)



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command. (no php code changed)
- [x] Changes have been tested to not break existing functionality. (just a blade file)
- [x] Documentation is up-to-date.(no docs must be change)
