### PR TITLE
add missing keys in rich editor toolbar button

### DIFF
--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -151,6 +151,7 @@
                                 @if ($hasToolbarButton('underline'))
                                     <x-filament-forms::rich-editor.toolbar.button
                                         data-trix-attribute="underline"
+                                        data-trix-key="u"
                                         title="{{ __('filament-forms::components.rich_editor.toolbar_buttons.underline') }}"
                                         tabindex="-1"
                                     >
@@ -175,6 +176,7 @@
                                 @if ($hasToolbarButton('strike'))
                                     <x-filament-forms::rich-editor.toolbar.button
                                         data-trix-attribute="strike"
+                                        data-trix-key="s"
                                         title="{{ __('filament-forms::components.rich_editor.toolbar_buttons.strike') }}"
                                         tabindex="-1"
                                     >


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
add missing    `data-trix-key=""` for Two buttons in the rich editor toolbar button 


## Visual changes

<!-- Add screenshots/recordings of before and after. -->
before : 
![image](https://github.com/filamentphp/filament/assets/130717329/7377fe83-15c9-434d-8718-bd928f7dcb2d)
after 
![image](https://github.com/filamentphp/filament/assets/130717329/6dfd20c5-0127-43e1-9b7c-d51973892ee3)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date. 
