### PR TITLE
Fix for possible Path Traversal vulnerability.

### DIFF
--- a/packages/support/src/Commands/Concerns/CanManipulateFiles.php
+++ b/packages/support/src/Commands/Concerns/CanManipulateFiles.php
@@ -15,11 +15,12 @@ trait CanManipulateFiles
     protected function checkForCollision(array $paths): bool
     {
         foreach ($paths as $path) {
+            $path = basename($path);
             if (! $this->fileExists($path)) {
                 continue;
             }
 
-            if (! confirm(basename($path) . ' already exists, do you want to overwrite it?')) {
+            if (! confirm($path) . ' already exists, do you want to overwrite it?')) {
                 $this->components->error("{$path} already exists, aborting.");
 
                 return true;

--- a/packages/support/src/Commands/Concerns/CanManipulateFiles.php
+++ b/packages/support/src/Commands/Concerns/CanManipulateFiles.php
@@ -19,7 +19,7 @@ trait CanManipulateFiles
                 continue;
             }
 
-            if (! confirm(basename($path)) . ' already exists, do you want to overwrite it?')) {
+            if (! confirm(basename($path) . ' already exists, do you want to overwrite it?')) {
                 $this->components->error("{$path} already exists, aborting.");
 
                 return true;

--- a/packages/support/src/Commands/Concerns/CanManipulateFiles.php
+++ b/packages/support/src/Commands/Concerns/CanManipulateFiles.php
@@ -15,18 +15,17 @@ trait CanManipulateFiles
     protected function checkForCollision(array $paths): bool
     {
         foreach ($paths as $path) {
-            $path = basename($path);
             if (! $this->fileExists($path)) {
                 continue;
             }
 
-            if (! confirm($path) . ' already exists, do you want to overwrite it?')) {
+            if (! confirm(basename($path)) . ' already exists, do you want to overwrite it?')) {
                 $this->components->error("{$path} already exists, aborting.");
 
                 return true;
             }
 
-            unlink($path);
+            unlink(basename($path));
         }
 
         return false;


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Unsanitized input from the HTTP request body flows into unlink, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to delete arbitrary files.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [Y] Code style has been fixed by running the `composer cs` command.
- [Y] Changes have been tested to not break existing functionality.
- [Y] Documentation is up-to-date.
