### PR TITLE
Don't lazy-load the GlobalSearch component

### DIFF
--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -158,7 +158,7 @@
             {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::GLOBAL_SEARCH_BEFORE) }}
 
             @if (filament()->isGlobalSearchEnabled())
-                @livewire(Filament\Livewire\GlobalSearch::class, ['lazy' => true])
+                @livewire(Filament\Livewire\GlobalSearch::class)
             @endif
 
             {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::GLOBAL_SEARCH_AFTER) }}


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

- The `Filament\Livewire\GlobalSearch` component is lazy-loaded, despite it being a very simple component with effectively no overhead on initial load.
- Because it's lazy-loaded it triggers a pointless network request after the initial page load
- It also causes the component to "jump" in after a delay (like a FOUC)

I've simply removed the `lazy` flag for better user experience. I don't see this being a breaking change.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

No visual changes, except the search component is now present on the page immediately without unnecessary network requests:

![Screenshot 2024-06-19 at 15 10 49@2x](https://github.com/filamentphp/filament/assets/627533/d5f1b99c-d597-4d0a-b179-50a71cb359f6)

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
