### PR TITLE
Add page end/start render hooks to simple page

### DIFF
--- a/packages/panels/resources/views/components/page/simple.blade.php
+++ b/packages/panels/resources/views/components/page/simple.blade.php
@@ -5,7 +5,7 @@
 
 <div {{ $attributes->class(['fi-simple-page']) }}>
     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_START, scopes: $this->getRenderHookScopes()) }}
-    
+
     <section class="grid auto-cols-fr gap-y-6">
         <x-filament-panels::header.simple
             :heading="$heading ??= $this->getHeading()"
@@ -19,6 +19,6 @@
     @if (! $this instanceof \Filament\Tables\Contracts\HasTable)
         <x-filament-actions::modals />
     @endif
-    
+
     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_END, scopes: $this->getRenderHookScopes()) }}
 </div>

--- a/packages/panels/resources/views/components/page/simple.blade.php
+++ b/packages/panels/resources/views/components/page/simple.blade.php
@@ -4,6 +4,8 @@
 ])
 
 <div {{ $attributes->class(['fi-simple-page']) }}>
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_START, scopes: $this->getRenderHookScopes()) }}
+    
     <section class="grid auto-cols-fr gap-y-6">
         <x-filament-panels::header.simple
             :heading="$heading ??= $this->getHeading()"
@@ -17,4 +19,6 @@
     @if (! $this instanceof \Filament\Tables\Contracts\HasTable)
         <x-filament-actions::modals />
     @endif
+    
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_END, scopes: $this->getRenderHookScopes()) }}
 </div>

--- a/packages/panels/resources/views/components/page/simple.blade.php
+++ b/packages/panels/resources/views/components/page/simple.blade.php
@@ -5,7 +5,7 @@
 
 <div {{ $attributes->class(['fi-simple-page']) }}>
     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::SIMPLE_PAGE_START, scopes: $this->getRenderHookScopes()) }}
-    
+
     <section class="grid auto-cols-fr gap-y-6">
         <x-filament-panels::header.simple
             :heading="$heading ??= $this->getHeading()"
@@ -19,6 +19,6 @@
     @if (! $this instanceof \Filament\Tables\Contracts\HasTable)
         <x-filament-actions::modals />
     @endif
-    
+
     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::SIMPLE_PAGE_END, scopes: $this->getRenderHookScopes()) }}
 </div>

--- a/packages/panels/resources/views/components/page/simple.blade.php
+++ b/packages/panels/resources/views/components/page/simple.blade.php
@@ -4,7 +4,7 @@
 ])
 
 <div {{ $attributes->class(['fi-simple-page']) }}>
-    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_START, scopes: $this->getRenderHookScopes()) }}
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::SIMPLE_PAGE_START, scopes: $this->getRenderHookScopes()) }}
     
     <section class="grid auto-cols-fr gap-y-6">
         <x-filament-panels::header.simple
@@ -20,5 +20,5 @@
         <x-filament-actions::modals />
     @endif
     
-    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_END, scopes: $this->getRenderHookScopes()) }}
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::SIMPLE_PAGE_END, scopes: $this->getRenderHookScopes()) }}
 </div>

--- a/packages/panels/src/View/PanelsRenderHook.php
+++ b/packages/panels/src/View/PanelsRenderHook.php
@@ -87,6 +87,10 @@ class PanelsRenderHook
     const SIDEBAR_NAV_START = 'panels::sidebar.nav.start';
 
     const SIDEBAR_FOOTER = 'panels::sidebar.footer';
+	
+	const SIMPLE_PAGE_START = 'panels::simple-page.start';
+	
+	const SIMPLE_PAGE_END = 'panels::simple-page.end';
 
     const STYLES_AFTER = 'panels::styles.after';
 

--- a/packages/panels/src/View/PanelsRenderHook.php
+++ b/packages/panels/src/View/PanelsRenderHook.php
@@ -87,10 +87,10 @@ class PanelsRenderHook
     const SIDEBAR_NAV_START = 'panels::sidebar.nav.start';
 
     const SIDEBAR_FOOTER = 'panels::sidebar.footer';
-	
-	const SIMPLE_PAGE_END = 'panels::simple-page.end';
-	
-	const SIMPLE_PAGE_START = 'panels::simple-page.start';
+
+    const SIMPLE_PAGE_END = 'panels::simple-page.end';
+
+    const SIMPLE_PAGE_START = 'panels::simple-page.start';
 
     const STYLES_AFTER = 'panels::styles.after';
 

--- a/packages/panels/src/View/PanelsRenderHook.php
+++ b/packages/panels/src/View/PanelsRenderHook.php
@@ -88,9 +88,9 @@ class PanelsRenderHook
 
     const SIDEBAR_FOOTER = 'panels::sidebar.footer';
 	
-	const SIMPLE_PAGE_START = 'panels::simple-page.start';
-	
 	const SIMPLE_PAGE_END = 'panels::simple-page.end';
+	
+	const SIMPLE_PAGE_START = 'panels::simple-page.start';
 
     const STYLES_AFTER = 'panels::styles.after';
 

--- a/packages/support/docs/06-render-hooks.md
+++ b/packages/support/docs/06-render-hooks.md
@@ -83,6 +83,8 @@ FilamentView::registerRenderHook(
 - `PanelsRenderHook::SCRIPTS_BEFORE` - Before scripts are defined
 - `PanelsRenderHook::SIDEBAR_NAV_END` - In the [sidebar](../panels/navigation), before `</nav>`
 - `PanelsRenderHook::SIDEBAR_NAV_START` - In the [sidebar](../panels/navigation), after `<nav>`
+- `PanelsRenderHook::SIMPLE_PAGE_START` - Start of the page content container, also [can be scoped](#scoping-render-hooks) to the page class
+- `PanelsRenderHook::SIMPLE_PAGE_END` - End of the simple page content container, also [can be scoped](#scoping-render-hooks) to the page class
 - `PanelsRenderHook::SIDEBAR_FOOTER` - Pinned to the bottom of the sidebar, below the content
 - `PanelsRenderHook::STYLES_AFTER` - After styles are defined
 - `PanelsRenderHook::STYLES_BEFORE` - Before styles are defined

--- a/packages/support/docs/06-render-hooks.md
+++ b/packages/support/docs/06-render-hooks.md
@@ -83,8 +83,8 @@ FilamentView::registerRenderHook(
 - `PanelsRenderHook::SCRIPTS_BEFORE` - Before scripts are defined
 - `PanelsRenderHook::SIDEBAR_NAV_END` - In the [sidebar](../panels/navigation), before `</nav>`
 - `PanelsRenderHook::SIDEBAR_NAV_START` - In the [sidebar](../panels/navigation), after `<nav>`
-- `PanelsRenderHook::SIMPLE_PAGE_START` - Start of the page content container, also [can be scoped](#scoping-render-hooks) to the page class
 - `PanelsRenderHook::SIMPLE_PAGE_END` - End of the simple page content container, also [can be scoped](#scoping-render-hooks) to the page class
+- `PanelsRenderHook::SIMPLE_PAGE_START` - Start of the page content container, also [can be scoped](#scoping-render-hooks) to the page class
 - `PanelsRenderHook::SIDEBAR_FOOTER` - Pinned to the bottom of the sidebar, below the content
 - `PanelsRenderHook::STYLES_AFTER` - After styles are defined
 - `PanelsRenderHook::STYLES_BEFORE` - Before styles are defined

--- a/packages/support/docs/06-render-hooks.md
+++ b/packages/support/docs/06-render-hooks.md
@@ -84,7 +84,7 @@ FilamentView::registerRenderHook(
 - `PanelsRenderHook::SIDEBAR_NAV_END` - In the [sidebar](../panels/navigation), before `</nav>`
 - `PanelsRenderHook::SIDEBAR_NAV_START` - In the [sidebar](../panels/navigation), after `<nav>`
 - `PanelsRenderHook::SIMPLE_PAGE_END` - End of the simple page content container, also [can be scoped](#scoping-render-hooks) to the page class
-- `PanelsRenderHook::SIMPLE_PAGE_START` - Start of the page content container, also [can be scoped](#scoping-render-hooks) to the page class
+- `PanelsRenderHook::SIMPLE_PAGE_START` - Start of the simple page content container, also [can be scoped](#scoping-render-hooks) to the page class
 - `PanelsRenderHook::SIDEBAR_FOOTER` - Pinned to the bottom of the sidebar, below the content
 - `PanelsRenderHook::STYLES_AFTER` - After styles are defined
 - `PanelsRenderHook::STYLES_BEFORE` - Before styles are defined


### PR DESCRIPTION
This PR adds the `page.start` and `page.end` render hooks to the simple page component. Alternatively, if one would like to keep these render hooks for "actual" panel pages, we could introduce a `simple-page.start` and `simple-page.end` hook or sth.

Thanks!