### PR TITLE
Broadcasting using the Panel builder - configuration & documentation

### DIFF
--- a/packages/panels/docs/07-notifications.md
+++ b/packages/panels/docs/07-notifications.md
@@ -32,3 +32,29 @@ public function panel(Panel $panel): Panel
         ->databaseNotificationsPolling('30s');
 }
 ```
+
+## Broadcast notifications
+
+The Panel Builder comes with a level of inbuilt support for real-time broadcast notifications. However there are a number of areas you will need to install and configure to wire everything up and get it working.
+
+1. If you haven't already, read up on [broadcasting](https://laravel.com/docs/broadcasting) in the Laravel documentation.
+2. Install and configure broadcasting to use a [server-side websockets integration](https://laravel.com/docs/broadcasting#server-side-installation) like Pusher.
+3. If you haven't already, you will need to publish the Filament package configuration:
+
+```bash
+php artisan vendor:publish --tag=filament-config
+```
+
+4. Edit the configuration at `config/filament.php` and uncomment the `broadcasting` section - ensuring the settings are correctly configured according to your broadcasting installation.
+5. Ensure the [relevant `VITE_*` entries](https://laravel.com/docs/11.x/broadcasting#client-pusher-channels) exist in your `.env` file.
+6. Clear relevant caches with `php artisan route:clear` and `php artisan config:clear` to ensure your new configuration takes effect.
+7. Rebuild your javascript and publish assets:
+
+```bash
+npm run build
+php artisan filament:assets
+```
+
+Your panel should now be connecting to your communications service. For example if you log into the Pusher debug console you should see an incoming connection each time you load a page.
+
+To send a real-time notification, see the [broadcast notifications documentation](/docs/notifications/broadcast-notifications).

--- a/packages/panels/docs/07-notifications.md
+++ b/packages/panels/docs/07-notifications.md
@@ -45,7 +45,7 @@ The Panel Builder comes with a level of inbuilt support for real-time broadcast 
 php artisan vendor:publish --tag=filament-config
 ```
 
-4. Edit the configuration at `config/filament.php` and uncomment the `broadcasting` section - ensuring the settings are correctly configured according to your broadcasting installation.
+4. Edit the configuration at `config/filament.php` and uncomment the `broadcasting.echo` section - ensuring the settings are correctly configured according to your broadcasting installation.
 5. Ensure the [relevant `VITE_*` entries](https://laravel.com/docs/11.x/broadcasting#client-pusher-channels) exist in your `.env` file.
 6. Clear relevant caches with `php artisan route:clear` and `php artisan config:clear` to ensure your new configuration takes effect.
 7. Rebuild your javascript and publish assets:

--- a/packages/panels/docs/07-notifications.md
+++ b/packages/panels/docs/07-notifications.md
@@ -33,9 +33,9 @@ public function panel(Panel $panel): Panel
 }
 ```
 
-## Broadcast notifications
+## Setting up websockets in a panel
 
-The Panel Builder comes with a level of inbuilt support for real-time broadcast notifications. However there are a number of areas you will need to install and configure to wire everything up and get it working.
+The Panel Builder comes with a level of inbuilt support for real-time broadcast and database notifications. However there are a number of areas you will need to install and configure to wire everything up and get it working.
 
 1. If you haven't already, read up on [broadcasting](https://laravel.com/docs/broadcasting) in the Laravel documentation.
 2. Install and configure broadcasting to use a [server-side websockets integration](https://laravel.com/docs/broadcasting#server-side-installation) like Pusher.
@@ -46,15 +46,9 @@ php artisan vendor:publish --tag=filament-config
 ```
 
 4. Edit the configuration at `config/filament.php` and uncomment the `broadcasting.echo` section - ensuring the settings are correctly configured according to your broadcasting installation.
-5. Ensure the [relevant `VITE_*` entries](https://laravel.com/docs/11.x/broadcasting#client-pusher-channels) exist in your `.env` file.
+5. Ensure the [relevant `VITE_*` entries](https://laravel.com/docs/broadcasting#client-pusher-channels) exist in your `.env` file.
 6. Clear relevant caches with `php artisan route:clear` and `php artisan config:clear` to ensure your new configuration takes effect.
-7. Rebuild your javascript and publish assets:
 
-```bash
-npm run build
-php artisan filament:assets
-```
+Your panel should now be connecting to your broadcasting service. For example, if you log into the Pusher debug console you should see an incoming connection each time you load a page.
 
-Your panel should now be connecting to your communications service. For example if you log into the Pusher debug console you should see an incoming connection each time you load a page.
-
-To send a real-time notification, see the [broadcast notifications documentation](/docs/notifications/broadcast-notifications).
+To send a real-time notification, see the [broadcast notifications documentation](../notifications/broadcast-notifications).

--- a/packages/support/config/filament.php
+++ b/packages/support/config/filament.php
@@ -23,7 +23,7 @@ return [
         //     'wsHost' => env('VITE_PUSHER_HOST'),
         //     'wsPort' => env('VITE_PUSHER_PORT'),
         //     'wssPort' => env('VITE_PUSHER_PORT'),
-        //     'authEndpoint' => '/api/v1/broadcasting/auth',
+        //     'authEndpoint' => '/broadcasting/auth',
         //     'disableStats' => true,
         //     'encrypted' => true,
         //     'forceTLS' => true,


### PR DESCRIPTION
## Description

I've been playing around with getting broadcasting going under the Panel Builder, however have found a few gaps in the documentation which made things a bit hard to follow. The existing documentation in the Notification section is targeted at standalone installations, and there is no mention of it in the Panel Builder documentation.

I managed to piece it together with a bunch of searching around along with some trial & error, but I think this is worth documenting.

I was also initially tripped up by the default commented configuration in `config/filament.php` containing an invalid route for the auth endpoint. The [official docs](https://laravel.com/docs/11.x/broadcasting#authorizing-channels) list this as `/broadcasting/auth` - not `/api/v1/broadcasting/auth` which returns a 404 if you attempt to use it with a default broadcasting installation.

This PR addresses these 2 areas.

## Visual changes

No visual changes aside from the additional documentation to `/docs/panels/notifications`.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
