### PR TITLE
Fix using HtmlString for HasIcon

### DIFF
--- a/packages/support/docs/03-icons.md
+++ b/packages/support/docs/03-icons.md
@@ -33,7 +33,7 @@ use Filament\Support\Facades\FilamentIcon;
 
 FilamentIcon::register([
     'panels::topbar.global-search.field' => 'fas-magnifying-glass',
-    'panels::sidebar.group.collapse-button' => view('icons.chevron-up'),
+    'panels::sidebar.group.collapse-button' => new HtmlString(view('icons.chevron-up')->render()),
 ]);
 ```
 

--- a/packages/support/src/Concerns/HasIcon.php
+++ b/packages/support/src/Concerns/HasIcon.php
@@ -5,16 +5,17 @@ namespace Filament\Support\Concerns;
 use Closure;
 use Filament\Support\Enums\IconPosition;
 use Filament\Support\Enums\IconSize;
+use Illuminate\Support\HtmlString;
 
 trait HasIcon
 {
-    protected string | Closure | null $icon = null;
+    protected string | HtmlString | Closure | null $icon = null;
 
     protected IconPosition | string | Closure | null $iconPosition = null;
 
     protected IconSize | string | Closure | null $iconSize = null;
 
-    public function icon(string | Closure | null $icon): static
+    public function icon(string | HtmlString | Closure | null $icon): static
     {
         $this->icon = $icon;
 
@@ -35,7 +36,7 @@ trait HasIcon
         return $this;
     }
 
-    public function getIcon(): ?string
+    public function getIcon(): string | HtmlString | null
     {
         return $this->evaluate($this->icon);
     }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Tried to fix this issue on Discord: 
https://discord.com/channels/883083792112300104/1254017792902959124

According to the docs you should be able to pass a view to register an icon alias. This gets casted to a string though and is then outputted as an image.

Also `view()` doesn't work. I think the issue is that `View` gets converted to string when passed as a Blade component param. Not sure how to fix this. I think the issue is how we pass `$icon` in `actions/resources/views/components/action.blade.php`.

CC: @zepfietje not sure how this was intended to work. Maybe you can have a look at this.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
