### PR TITLE
Fix relative state path returned in cache

### DIFF
--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -280,7 +280,7 @@ trait HasState
         if (! $isAbsolute) {
             return $this->statePath ?? '';
         }
-        
+
         if (isset($this->cachedAbsoluteStatePath)) {
             return $this->cachedAbsoluteStatePath;
         }

--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -277,6 +277,10 @@ trait HasState
 
     public function getStatePath(bool $isAbsolute = true): string
     {
+        if (! $isAbsolute) {
+            return $this->statePath ?? '';
+        }
+        
         if (isset($this->cachedAbsoluteStatePath)) {
             return $this->cachedAbsoluteStatePath;
         }

--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -287,7 +287,7 @@ trait HasState
 
         $pathComponents = [];
 
-        if ($isAbsolute && $parentComponentStatePath = $this->getParentComponent()?->getStatePath()) {
+        if ($parentComponentStatePath = $this->getParentComponent()?->getStatePath()) {
             $pathComponents[] = $parentComponentStatePath;
         }
 

--- a/packages/tables/src/View/TablesRenderHook.php
+++ b/packages/tables/src/View/TablesRenderHook.php
@@ -13,7 +13,7 @@ class TablesRenderHook
     const HEADER_BEFORE = 'tables::header.before';
 
     const TOOLBAR_AFTER = 'tables::toolbar.after';
-    
+
     const TOOLBAR_BEFORE = 'tables::toolbar.before';
 
     const TOOLBAR_END = 'tables::toolbar.end';


### PR DESCRIPTION
## Description
When calling `getStatePath(isAbsolute: false)` it may contain the full path if it has already been cached.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.

## Reproduction
Needed to explode the state path even though isAbsolute passed as false.
>  E.g data.test.215d94ec-5235-4c6e-a89b-a5f4929bb93f
```php
Repeater::make('test')
    ->defaultItems(3)
    ->simple(
        // Checkbox that behaves like a radio input where you can only select one at a time
        Checkbox::make('selected')
            ->reactive()
            ->afterStateUpdated(function (Checkbox $component, Set $set, Get $get) {
                $statePath = $component->getContainer()->getStatePath(isAbsolute: false);

                $statePath = explode('.', $statePath);
                $statePath = end($statePath);

                foreach ((array) $get('../../test') as $index => $contact) {
                    if ($index === $statePath) {
                        continue;
                    }

                    $set("../../test.$index.selected", false);
                }
            }),
    ),
```