### PR TITLE
Add infolists text entry date tooltip methods

### DIFF
--- a/packages/infolists/src/Components/Concerns/CanFormatState.php
+++ b/packages/infolists/src/Components/Concerns/CanFormatState.php
@@ -99,6 +99,56 @@ trait CanFormatState
         return $this;
     }
 
+    public function dateTooltip(?string $format = null, ?string $timezone = null): static
+    {
+        $format ??= Infolist::$defaultDateDisplayFormat;
+
+        $this->tooltip(static function (TextEntry $component, mixed $state) use ($format, $timezone): ?string {
+            if (blank($state)) {
+                return null;
+            }
+
+            return Carbon::parse($state)
+                ->setTimezone($timezone ?? $component->getTimezone())
+                ->translatedFormat($format);
+        });
+
+        return $this;
+    }
+
+    public function dateTimeTooltip(?string $format = null, ?string $timezone = null): static
+    {
+        $format ??= Infolist::$defaultDateTimeDisplayFormat;
+
+        $this->dateTooltip($format, $timezone);
+
+        return $this;
+    }
+
+    public function timeTooltip(?string $format = null, ?string $timezone = null): static
+    {
+        $format ??= Infolist::$defaultTimeDisplayFormat;
+
+        $this->dateTooltip($format, $timezone);
+
+        return $this;
+    }
+
+    public function sinceTooltip(?string $timezone = null): static
+    {
+        $this->tooltip(static function (TextEntry $component, mixed $state) use ($timezone): ?string {
+            if (blank($state)) {
+                return null;
+            }
+
+            return Carbon::parse($state)
+                ->setTimezone($timezone ?? $component->getTimezone())
+                ->diffForHumans();
+        });
+
+        return $this;
+    }
+
     public function money(string | Closure | null $currency = null, int $divideBy = 0, string | Closure | null $locale = null): static
     {
         $this->isMoney = true;

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -86,7 +86,7 @@ trait CanFormatState
     {
         $this->isDateTime = true;
 
-        $this->formatStateUsing(static function (TextColumn $column, $state) use ($timezone): ?string {
+        $this->formatStateUsing(static function (TextColumn $column, mixed $state) use ($timezone): ?string {
             if (blank($state)) {
                 return null;
             }
@@ -103,7 +103,7 @@ trait CanFormatState
     {
         $format ??= Table::$defaultDateDisplayFormat;
 
-        $this->tooltip(static function (TextColumn $column, $state) use ($format, $timezone): ?string {
+        $this->tooltip(static function (TextColumn $column, mixed $state) use ($format, $timezone): ?string {
             if (blank($state)) {
                 return null;
             }
@@ -136,7 +136,7 @@ trait CanFormatState
 
     public function sinceTooltip(?string $timezone = null): static
     {
-        $this->tooltip(static function (TextColumn $column, $state) use ($timezone): ?string {
+        $this->tooltip(static function (TextColumn $column, mixed $state) use ($timezone): ?string {
             if (blank($state)) {
                 return null;
             }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

https://github.com/filamentphp/filament/pull/13196 only introduced this new API for tables. This PR adds the same methods for the infolist text entry.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

Original PR didn't document the feature yet.