### PR TITLE
Text Column Badge Tooltip

### DIFF
--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -178,10 +178,15 @@
                         ])
                     >
                         @if ($isBadge)
+                            @php
+                                $badgeTooltip = $getBadgeTooltip($state);
+                            @endphp
+
                             <x-filament::badge
                                 :color="$color"
                                 :icon="$icon"
                                 :icon-position="$iconPosition"
+                                :tooltip="$badgeTooltip"
                             >
                                 {{ $formattedState }}
                             </x-filament::badge>

--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -178,15 +178,11 @@
                         ])
                     >
                         @if ($isBadge)
-                            @php
-                                $badgeTooltip = $getBadgeTooltip($state);
-                            @endphp
-
                             <x-filament::badge
                                 :color="$color"
                                 :icon="$icon"
                                 :icon-position="$iconPosition"
-                                :tooltip="$badgeTooltip"
+                                :tooltip="$getBadgeTooltip($state)"
                             >
                                 {{ $formattedState }}
                             </x-filament::badge>

--- a/packages/tables/src/Columns/Concerns/HasBadge.php
+++ b/packages/tables/src/Columns/Concerns/HasBadge.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Filament\Tables\Columns\Concerns;
+
+use Closure;
+use Filament\Support\Contracts\HasColor as ColorInterface;
+use Filament\Tables\Columns\Column;
+
+trait HasBadge
+{
+    protected bool | Closure $isBadge = false;
+
+    protected string | bool | Closure | null $badgeTooltip = null;
+
+    public function badge(bool | Closure $condition = true): static
+    {
+        $this->isBadge = $condition;
+
+        return $this;
+    }
+
+    public function isBadge(): bool
+    {
+        return (bool) $this->evaluate($this->isBadge);
+    }
+
+    public function badgeTooltip(string | bool | Closure | null $tooltip): static
+    {
+        $this->badgeTooltip = $tooltip;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<mixed> | Closure  $tooltips
+     */
+    public function badgeTooltips(array | Closure $tooltips): static
+    {
+        $this->badgeTooltip(function (Column $column, $state) use ($tooltips) {
+            $tooltips = $column->evaluate($tooltips);
+
+            $tooltip = null;
+
+            foreach ($tooltips as $conditionalTooltip => $condition) {
+                if (is_numeric($conditionalTooltip)) {
+                    $tooltip = $condition;
+                } elseif ($condition instanceof Closure && $column->evaluate($condition)) {
+                    $tooltip = $conditionalTooltip;
+                } elseif ($condition === $state) {
+                    $tooltip = $conditionalTooltip;
+                }
+            }
+
+            return $tooltip;
+        });
+
+        return $this;
+    }
+
+    public function getBadgeTooltip(mixed $state): ?string
+    {
+        $tooltip = $this->evaluate($this->badgeTooltip, [
+            'state' => $state,
+        ]);
+
+        if ($tooltip === false) {
+            return null;
+        }
+
+        if (filled($tooltip)) {
+            return $tooltip;
+        }
+
+        if (! $state instanceof \Filament\Support\Contracts\HasDescription) {
+            return null;
+        }
+
+        return $state->getDescription();
+    }
+}

--- a/packages/tables/src/Columns/Concerns/HasBadge.php
+++ b/packages/tables/src/Columns/Concerns/HasBadge.php
@@ -3,7 +3,6 @@
 namespace Filament\Tables\Columns\Concerns;
 
 use Closure;
-use Filament\Support\Contracts\HasColor as ColorInterface;
 use Filament\Tables\Columns\Column;
 
 trait HasBadge

--- a/packages/tables/src/Columns/Concerns/HasBadge.php
+++ b/packages/tables/src/Columns/Concerns/HasBadge.php
@@ -9,7 +9,7 @@ trait HasBadge
 {
     protected bool | Closure $isBadge = false;
 
-    protected string | bool | Closure | null $badgeTooltip = null;
+    protected string | bool | Closure | null $badgeTooltip = false;
 
     public function badge(bool | Closure $condition = true): static
     {

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -12,6 +12,7 @@ class TextColumn extends Column
 {
     use Concerns\CanBeCopied;
     use Concerns\CanFormatState;
+    use Concerns\HasBadge;
     use Concerns\HasColor;
     use Concerns\HasDescription;
     use Concerns\HasFontFamily;
@@ -27,8 +28,6 @@ class TextColumn extends Column
 
     protected bool | Closure $canWrap = false;
 
-    protected bool | Closure $isBadge = false;
-
     protected bool | Closure $isBulleted = false;
 
     protected bool | Closure $isListWithLineBreaks = false;
@@ -38,13 +37,6 @@ class TextColumn extends Column
     protected TextColumnSize | string | Closure | null $size = null;
 
     protected bool | Closure $isLimitedListExpandable = false;
-
-    public function badge(bool | Closure $condition = true): static
-    {
-        $this->isBadge = $condition;
-
-        return $this;
-    }
 
     public function bulleted(bool | Closure $condition = true): static
     {
@@ -108,11 +100,6 @@ class TextColumn extends Column
     public function canWrap(): bool
     {
         return (bool) $this->evaluate($this->canWrap);
-    }
-
-    public function isBadge(): bool
-    {
-        return (bool) $this->evaluate($this->isBadge);
     }
 
     public function isBulleted(): bool


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR introduces the ability to add tooltips to text column badges, and supports also list of badges. 
Since this PR introduces new methods related to badges, it also creates a dedicated `HasBadge` trait, to match the rest of the codebase.

## Visual changes
Before

![Screenshot 2024-06-27 alle 17 32 17](https://github.com/filamentphp/filament/assets/1104083/29284c8c-1748-4548-8922-12e224edad07)

After
![Screenshot 2024-06-27 alle 17 28 56](https://github.com/filamentphp/filament/assets/1104083/1a713eeb-9f9b-441c-a7d0-3b4569d859c9)

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
