### PR TITLE
Fix footer actions on content grid not aligning to the base of the container

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -542,8 +542,9 @@
 
                                 <div
                                     @class([
-                                        'flex items-center' => ! $contentGrid,
-                                        'flex h-full items-stretch' => $contentGrid,
+                                        'flex',
+                                        'items-center' => ! $contentGrid,
+                                        'h-full items-stretch' => $contentGrid,
                                         'ps-1 sm:ps-3' => (! $contentGrid) && $hasItemBeforeRecordContent,
                                         'pe-1 sm:pe-3' => (! $contentGrid) && $hasItemAfterRecordContent,
                                         'ps-1' => $contentGrid && $hasItemBeforeRecordContent,

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -542,7 +542,8 @@
 
                                 <div
                                     @class([
-                                        'flex items-center',
+                                        'flex items-center' => ! $contentGrid,
+                                        'flex h-full items-stretch' => $contentGrid,
                                         'ps-1 sm:ps-3' => (! $contentGrid) && $hasItemBeforeRecordContent,
                                         'pe-1 sm:pe-3' => (! $contentGrid) && $hasItemAfterRecordContent,
                                         'ps-1' => $contentGrid && $hasItemBeforeRecordContent,


### PR DESCRIPTION
When a table is displayed as a grid using `contentGrid()`, if the heights of each row box differs, the footer actions will stick to the bottom of the content, rather than sitting flush with the bottom of the box.

A couple of people have encountered and reported this, and this fix has worked in those cases, but **this PR has not been thoroughly tested**, though it is a small change.

## Visual Difference

Before: 
![image](https://github.com/filamentphp/filament/assets/212036/81aa7550-a8cb-4737-9d42-040793d39e36)

After:
![image](https://github.com/filamentphp/filament/assets/212036/0a23c1ac-7428-4da0-8a91-b8dcdce089c0)


## Functional changes

- [ ] Conditionally switch to using `flex h-full items-stretch` on content grid rows in place of `flex items-center`
