### PR TITLE
Fix view type string vs null|string compatibility

### DIFF
--- a/packages/support/src/Components/ViewComponent.php
+++ b/packages/support/src/Components/ViewComponent.php
@@ -80,7 +80,7 @@ abstract class ViewComponent extends Component implements Htmlable
     /**
      * @return view-string
      */
-    public function getView(): string
+    public function getView(): ?string
     {
         if (isset($this->view)) {
             return $this->view;


### PR DESCRIPTION
Fix compatibility on line 99 getDefaultView()
Expected type 'string'. Found 'Filament\Support\Components\view-string|null' public function getDefaultView(): ?string

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
