### PR TITLE
fix: better handling of non-latin column names on import

### DIFF
--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -117,7 +117,7 @@ trait CanImportRecords
 
                     $csvColumns = $csvReader->getHeader();
 
-                    $lowercaseCsvColumnValues = array_map('strtolower', $csvColumns);
+                    $lowercaseCsvColumnValues = array_map(fn (string $column): string => Str::lower($column), $csvColumns);
                     $lowercaseCsvColumnKeys = array_combine(
                         $lowercaseCsvColumnValues,
                         $csvColumns,

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -117,7 +117,7 @@ trait CanImportRecords
 
                     $csvColumns = $csvReader->getHeader();
 
-                    $lowercaseCsvColumnValues = array_map(fn (string $column): string => Str::lower($column), $csvColumns);
+                    $lowercaseCsvColumnValues = array_map(Str::lower(...), $csvColumns);
                     $lowercaseCsvColumnKeys = array_combine(
                         $lowercaseCsvColumnValues,
                         $csvColumns,


### PR DESCRIPTION
## Description

Using `Str::lower` instead of `strtolower` here because `ImportColumn->getGuesses()` uses `Str::lower` for column guesses, and it return different result for non-latin strings.

## Visual changes

No visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
