### PR TITLE
Add possibility of closure to sidebarCollapsible methods

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasSidebar.php
+++ b/packages/panels/src/Panel/Concerns/HasSidebar.php
@@ -2,26 +2,28 @@
 
 namespace Filament\Panel\Concerns;
 
+use Closure;
+
 trait HasSidebar
 {
     protected string $sidebarWidth = '20rem';
 
     protected string $collapsedSidebarWidth = '4.5rem';
 
-    protected bool $isSidebarCollapsibleOnDesktop = false;
+    protected Closure | bool $isSidebarCollapsibleOnDesktop = false;
 
-    protected bool $isSidebarFullyCollapsibleOnDesktop = false;
+    protected Closure | bool $isSidebarFullyCollapsibleOnDesktop = false;
 
     protected bool $hasCollapsibleNavigationGroups = true;
 
-    public function sidebarCollapsibleOnDesktop(bool $condition = true): static
+    public function sidebarCollapsibleOnDesktop(Closure | bool $condition = true): static
     {
         $this->isSidebarCollapsibleOnDesktop = $condition;
 
         return $this;
     }
 
-    public function sidebarFullyCollapsibleOnDesktop(bool $condition = true): static
+    public function sidebarFullyCollapsibleOnDesktop(Closure | bool $condition = true): static
     {
         $this->isSidebarFullyCollapsibleOnDesktop = $condition;
 
@@ -61,12 +63,12 @@ trait HasSidebar
 
     public function isSidebarCollapsibleOnDesktop(): bool
     {
-        return $this->isSidebarCollapsibleOnDesktop;
+        return $this->evaluate($this->isSidebarCollapsibleOnDesktop);
     }
 
     public function isSidebarFullyCollapsibleOnDesktop(): bool
     {
-        return $this->isSidebarFullyCollapsibleOnDesktop;
+        return $this->evaluate($this->isSidebarFullyCollapsibleOnDesktop);
     }
 
     public function hasCollapsibleNavigationGroups(): bool

--- a/packages/panels/src/Panel/Concerns/HasSidebar.php
+++ b/packages/panels/src/Panel/Concerns/HasSidebar.php
@@ -10,27 +10,27 @@ trait HasSidebar
 
     protected string $collapsedSidebarWidth = '4.5rem';
 
-    protected Closure | bool $isSidebarCollapsibleOnDesktop = false;
+    protected bool | Closure $isSidebarCollapsibleOnDesktop = false;
 
-    protected Closure | bool $isSidebarFullyCollapsibleOnDesktop = false;
+    protected bool | Closure $isSidebarFullyCollapsibleOnDesktop = false;
 
-    protected bool $hasCollapsibleNavigationGroups = true;
+    protected bool | Closure $hasCollapsibleNavigationGroups = true;
 
-    public function sidebarCollapsibleOnDesktop(Closure | bool $condition = true): static
+    public function sidebarCollapsibleOnDesktop(bool | Closure $condition = true): static
     {
         $this->isSidebarCollapsibleOnDesktop = $condition;
 
         return $this;
     }
 
-    public function sidebarFullyCollapsibleOnDesktop(Closure | bool $condition = true): static
+    public function sidebarFullyCollapsibleOnDesktop(bool | Closure $condition = true): static
     {
         $this->isSidebarFullyCollapsibleOnDesktop = $condition;
 
         return $this;
     }
 
-    public function collapsibleNavigationGroups(bool $condition = true): static
+    public function collapsibleNavigationGroups(bool | Closure $condition = true): static
     {
         $this->hasCollapsibleNavigationGroups = $condition;
 
@@ -63,16 +63,16 @@ trait HasSidebar
 
     public function isSidebarCollapsibleOnDesktop(): bool
     {
-        return $this->evaluate($this->isSidebarCollapsibleOnDesktop);
+        return (bool) $this->evaluate($this->isSidebarCollapsibleOnDesktop);
     }
 
     public function isSidebarFullyCollapsibleOnDesktop(): bool
     {
-        return $this->evaluate($this->isSidebarFullyCollapsibleOnDesktop);
+        return (bool) $this->evaluate($this->isSidebarFullyCollapsibleOnDesktop);
     }
 
     public function hasCollapsibleNavigationGroups(): bool
     {
-        return $this->hasCollapsibleNavigationGroups;
+        return (bool) $this->evaluate($this->hasCollapsibleNavigationGroups);
     }
 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

This PR adds possibility to use closures when defining if the sidebar should be collapsible or fully collapsible on desktop. This allows to hook into user settings or something similar to decide whether the sidebar should be collapsed.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

No visual changes on this PR.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
