### PR TITLE
Add defaultAction to docs

### DIFF
--- a/packages/panels/docs/04-pages.md
+++ b/packages/panels/docs/04-pages.md
@@ -54,21 +54,33 @@ protected function getHeaderActions(): array
 }
 ```
 
-### Default action
+### Opening an action modal when a page loads
 
-You can also easily trigger an action to be launched when a page loads. Just add a method that returns your action and then set the `$defaultAction` property to the name of that action:
+You can also open an action when a page loads by setting the `$defaultAction` property to the name of the action you want to open:
 
 ```php
 use Filament\Actions\Action;
 
-public $defaultAction = 'onboardingAction';
+public $defaultAction = 'onboarding';
 
 public function onboardingAction(): Action
 {
-    return Action::make('onboardingAction')
+    return Action::make('onboarding')
         ->modalHeading('Welcome')
-        ->visible(fn () => ! auth()->user()->isOnBoarded());
+        ->visible(fn (): bool => ! auth()->user()->isOnBoarded());
 }
+```
+
+You can also pass an array of arguments to the default action using the `$defaultActionArguments` property:
+
+```php
+public $defaultActionArguments = ['step' => 2];
+```
+
+Alternatively, you can open an action modal when a page loads by specifying the `defaultAction` as a query string parameter to the page:
+
+```
+/admin/products/edit/932510?defaultAction=onboarding
 ```
 
 ### Refreshing form data

--- a/packages/panels/docs/04-pages.md
+++ b/packages/panels/docs/04-pages.md
@@ -54,6 +54,23 @@ protected function getHeaderActions(): array
 }
 ```
 
+### Default action
+
+You can also easily trigger an action to be launched when a page loads. Just add a method that returns your action and then set the `$defaultAction` property to the name of that action:
+
+```php
+use Filament\Actions\Action;
+
+public $defaultAction = 'onboardingAction';
+
+public function onboardingAction(): Action
+{
+    return Action::make('onboardingAction')
+        ->modalHeading('Welcome')
+        ->visible(fn () => ! auth()->user()->isOnBoarded());
+}
+```
+
 ### Refreshing form data
 
 If you're using actions on an [Edit](resources/editing-records) or [View](resources/viewing-records) resource page, you can refresh data within the main form using the `refreshFormData()` method:


### PR DESCRIPTION
This is an awesome built in feature that definitely needs to be documented. I stumbled upon it when I had to implement this exact feature, but it was a welcome suprise to see you've already implemented it! So many uses cases! I chose an onboarding type example, but change it to anything you like.  

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
