### PR TITLE
Fix ImportAction failed with Default Non-S3 Filesystem and Filament S3 Filesystem

### DIFF
--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -377,17 +377,19 @@ trait CanImportRecords
      */
     public function getUploadedFileStream(TemporaryUploadedFile $file)
     {
+        /** @phpstan-ignore-next-line */
         $fileDisk = invade($file)->disk;
+        
         $filePath = $file->getRealPath();
 
-        if (config('filesystems.disks.' . $fileDisk . '.driver') !== 's3') {
+        if (config("filesystems.disks.{$fileDisk}.driver") !== 's3') {
             $resource = fopen($filePath, mode: 'r');
         } else {
             /** @var AwsS3V3Adapter $s3Adapter */
             $s3Adapter = Storage::disk($fileDisk)->getAdapter();
 
             invade($s3Adapter)->client->registerStreamWrapper(); /** @phpstan-ignore-line */
-            $fileS3Path = 's3://' . config('filesystems.disks.' . $fileDisk . '.bucket') . '/' . $filePath;
+            $fileS3Path = 's3://' . config("filesystems.disks.{$fileDisk}.bucket") . '/' . $filePath;
 
             $resource = fopen($fileS3Path, mode: 'r', context: stream_context_create([
                 's3' => [

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -377,16 +377,17 @@ trait CanImportRecords
      */
     public function getUploadedFileStream(TemporaryUploadedFile $file)
     {
+        $fileDisk = invade($file)->disk;
         $filePath = $file->getRealPath();
 
-        if (config('filesystems.disks.' . config('filament.default_filesystem_disk') . '.driver') !== 's3') {
+        if (config('filesystems.disks.' . $fileDisk . '.driver') !== 's3') {
             $resource = fopen($filePath, mode: 'r');
         } else {
             /** @var AwsS3V3Adapter $s3Adapter */
-            $s3Adapter = Storage::disk('s3')->getAdapter();
+            $s3Adapter = Storage::disk($fileDisk)->getAdapter();
 
             invade($s3Adapter)->client->registerStreamWrapper(); /** @phpstan-ignore-line */
-            $fileS3Path = 's3://' . config('filesystems.disks.s3.bucket') . '/' . $filePath;
+            $fileS3Path = 's3://' . config('filesystems.disks.' . $fileDisk . '.bucket') . '/' . $filePath;
 
             $resource = fopen($fileS3Path, mode: 'r', context: stream_context_create([
                 's3' => [


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fixes #13502 
Alternate for #13503

Before this PR, uploaded file disk is detected using filament filesystem config. But Livewire's `TemporaryUploadedFile` uses a different filesystem disk based on Livewire's `temporary_file_upload.disk` config value.

In this PR, uploaded file disk is directly fetched from the `TemporaryUploadedFile` object using the `invade()` helper function 

## Visual changes

NA

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
