### PR TITLE
Hint icon tabindex

### DIFF
--- a/packages/forms/docs/03-fields/01-getting-started.md
+++ b/packages/forms/docs/03-fields/01-getting-started.md
@@ -189,6 +189,17 @@ TextInput::make('name')
     ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Need some more information?')
 ```
 
+#### Changing tab index for a hint icon
+
+Additionally, you can change `tabindex` for a hint icon, using the `tabIndex` parameter of `hintIcon()`:
+
+```php
+use Filament\Forms\Components\TextInput;
+
+TextInput::make('name')
+    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Need some more information?', tabIndex: -1)
+```
+
 ## Adding extra HTML attributes
 
 You can pass extra HTML attributes to the field, which will be merged onto the outer DOM element. Pass an array of attributes to the `extraAttributes()` method, where the key is the attribute name and the value is the attribute value:

--- a/packages/forms/resources/views/components/field-wrapper/hint.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/hint.blade.php
@@ -3,6 +3,7 @@
     'color' => 'gray',
     'icon' => null,
     'tooltip' => null,
+    'tabindex' => null
 ])
 
 <div
@@ -39,6 +40,7 @@
             x-data="{}"
             :icon="$icon"
             :x-tooltip="filled($tooltip) ? '{ content: ' . \Illuminate\Support\Js::from($tooltip) . ', theme: $store.theme }' : null"
+            :tabindex="$tabindex"
             @class([
                 'fi-fo-field-wrp-hint-icon h-5 w-5',
                 match ($color) {

--- a/packages/forms/resources/views/components/field-wrapper/hint.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/hint.blade.php
@@ -3,7 +3,7 @@
     'color' => 'gray',
     'icon' => null,
     'tooltip' => null,
-    'tabindex' => null
+    'tabindex' => null,
 ])
 
 <div

--- a/packages/forms/resources/views/components/field-wrapper/index.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/index.blade.php
@@ -11,6 +11,7 @@
     'hintActions' => null,
     'hintColor' => null,
     'hintIcon' => null,
+    'hintIconTabIndex' => null,
     'hintIconTooltip' => null,
     'id' => null,
     'inlineLabelVerticalAlignment' => VerticalAlignment::Start,
@@ -32,6 +33,7 @@
         $hintActions ??= $field->getHintActions();
         $hintColor ??= $field->getHintColor();
         $hintIcon ??= $field->getHintIcon();
+        $hintIconTabIndex ??= $field->getHintIconTabIndex();
         $hintIconTooltip ??= $field->getHintIconTooltip();
         $id ??= $field->getId();
         $isDisabled ??= $field->isDisabled();
@@ -105,6 +107,7 @@
                         :color="$hintColor"
                         :icon="$hintIcon"
                         :tooltip="$hintIconTooltip"
+                        :tabindex="$hintIconTabIndex"
                     >
                         {{ $hint }}
                     </x-filament-forms::field-wrapper.hint>

--- a/packages/forms/src/Components/Concerns/HasHint.php
+++ b/packages/forms/src/Components/Concerns/HasHint.php
@@ -31,6 +31,8 @@ trait HasHint
 
     protected string | Closure | null $hintIconTooltip = null;
 
+    protected int | Closure | null $hintIconTabIndex = null;
+
     public function hint(string | Htmlable | Closure | null $hint): static
     {
         $this->hint = $hint;
@@ -48,10 +50,11 @@ trait HasHint
         return $this;
     }
 
-    public function hintIcon(string | Closure | null $icon, string | Closure | null $tooltip = null): static
+    public function hintIcon(string | Closure | null $icon, string | Closure | null $tooltip = null, int | Closure | null $tabIndex = null): static
     {
         $this->hintIcon = $icon;
         $this->hintIconTooltip($tooltip);
+        $this->hintIconTabIndex($tabIndex);
 
         return $this;
     }
@@ -59,6 +62,13 @@ trait HasHint
     public function hintIconTooltip(string | Closure | null $tooltip): static
     {
         $this->hintIconTooltip = $tooltip;
+
+        return $this;
+    }
+
+    public function hintIconTabIndex(int | Closure | null $tabIndex): static
+    {
+        $this->hintIconTabIndex = $tabIndex;
 
         return $this;
     }
@@ -104,6 +114,11 @@ trait HasHint
     public function getHintIconTooltip(): ?string
     {
         return $this->evaluate($this->hintIconTooltip);
+    }
+
+    public function getHintIconTabIndex(): ?int
+    {
+        return $this->evaluate($this->hintIconTabIndex);
     }
 
     /**


### PR DESCRIPTION
## Description

Parameter to change `tabindex=""` for a form field hint icon.

Usage:

```php
use Filament\Forms\Components\TextInput;

TextInput::make('name')
    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Need some more information?', tabIndex: -1)
```
or 

```php
use Filament\Forms\Components\TextInput;

TextInput::make('name')
    ->hintIcon('heroicon-m-question-mark-circle')
    ->hintIconTabIndex(-1)
```
Accepts `int`, `Closure` or `null` values, default is `null`.

It is useful when hint icon needs to have specific `tabindex`, or `tabindex="-1"` when you need the possibility to disable focusing on that hint icon when navigating through form using `Tab` key.

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
