### PR TITLE
fix: allow view() to be used as icon

### DIFF
--- a/packages/support/src/Concerns/HasIcon.php
+++ b/packages/support/src/Concerns/HasIcon.php
@@ -40,9 +40,9 @@ trait HasIcon
 
     public function getIcon(): string | Htmlable | null
     {
-        $icon = $this->icon instanceof Renderable
-            ? new HtmlString($this->icon->render())
-            : $this->icon;
+        $icon = $this->icon instanceof Renderable ?
+            new HtmlString($this->icon->render()) :
+            $this->icon;
 
         return $this->evaluate($icon);
     }

--- a/packages/support/src/Concerns/HasIcon.php
+++ b/packages/support/src/Concerns/HasIcon.php
@@ -5,16 +5,19 @@ namespace Filament\Support\Concerns;
 use Closure;
 use Filament\Support\Enums\IconPosition;
 use Filament\Support\Enums\IconSize;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\HtmlString;
 
 trait HasIcon
 {
-    protected string | Closure | null $icon = null;
+    protected string | Htmlable | Closure | null $icon = null;
 
     protected IconPosition | string | Closure | null $iconPosition = null;
 
     protected IconSize | string | Closure | null $iconSize = null;
 
-    public function icon(string | Closure | null $icon): static
+    public function icon(string | Htmlable | Closure | null $icon): static
     {
         $this->icon = $icon;
 
@@ -35,9 +38,13 @@ trait HasIcon
         return $this;
     }
 
-    public function getIcon(): ?string
+    public function getIcon(): string | Htmlable | null
     {
-        return $this->evaluate($this->icon);
+        $icon = $this->icon instanceof Renderable
+            ? new HtmlString($this->icon->render())
+            : $this->icon;
+
+        return $this->evaluate($icon);
     }
 
     public function getIconPosition(): IconPosition | string

--- a/packages/support/src/Concerns/HasIcon.php
+++ b/packages/support/src/Concerns/HasIcon.php
@@ -40,11 +40,14 @@ trait HasIcon
 
     public function getIcon(): string | Htmlable | null
     {
-        $icon = $this->icon instanceof Renderable ?
-            new HtmlString($this->icon->render()) :
-            $this->icon;
+        $icon = $this->evaluate($icon);
 
-        return $this->evaluate($icon);
+        // https://github.com/filamentphp/filament/pull/13512
+        if ($this->icon instanceof Renderable) {
+            return new HtmlString($this->icon->render());
+        }
+
+        return $this->icon;
     }
 
     public function getIconPosition(): IconPosition | string


### PR DESCRIPTION
## Description

This is an updated PR of #13358.

In the [docs](https://filamentphp.com/docs/3.x/support/icons#replacing-the-default-icons) it mentions you can use a view as an icon within `FilamentIcon::register`. This didn't work.

A view gets rendered to a string because it implements the magic method `__toString()` and `HasIcon` did not accept `Htmlable`, but does accept strings. PHP converts it to a string to match the string type on properties and methods.

The reason it doesn't work when you also accept `Htmlable` is because views also implement `Renderable`. All data passed to views an its derivatives (e.g. Blade components) will get processed by [gatherData](https://github.com/laravel/framework/blob/11.x/src/Illuminate/View/View.php#L221) whichs renders Renderables to HTML.

This is why we're wrapping the rendered view into an `HtmlString` as that's not `Renderable`.

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
