### PR TITLE
make select component accept null value

### DIFF
--- a/packages/forms/src/Components/Concerns/CanDisableOptions.php
+++ b/packages/forms/src/Components/Concerns/CanDisableOptions.php
@@ -36,14 +36,14 @@ trait CanDisableOptions
     /**
      * @param  array-key  $value
      */
-    public function isOptionDisabled($value, string $label): bool
+    public function isOptionDisabled($value, ?string $label): bool
     {
         if ($this->isOptionDisabled === null) {
             return false;
         }
 
         return (bool) $this->evaluate($this->isOptionDisabled, [
-            'label' => $label,
+            'label' => $label ?? '', // Provide a default empty string if $label is null,
             'value' => $value,
         ]);
     }

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -579,7 +579,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
     {
         return $this->evaluate($this->getOptionLabelUsing, [
             'value' => fn (): mixed => $this->getState(),
-        ]);
+        ]) ?? null; // Handle null value if label is null;
     }
 
     /**
@@ -593,6 +593,11 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
 
         if ($labels instanceof Arrayable) {
             $labels = $labels->toArray();
+        }
+
+        // Handle null or empty values
+        if (empty($labels)) {
+            return [];
         }
 
         return $labels;
@@ -1090,7 +1095,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
                 Model::class => $record,
                 $record::class => $record,
             ],
-        );
+        ) ?? ''; // Provide a default empty string if label is null
     }
 
     public function getRelationshipTitleAttribute(): ?string


### PR DESCRIPTION
Package
Form builder

Package Version
v3.2


When I used the Select component on a form and tried to fetch values ​​from a relationship, I ran into some challenges. Specifically, when there is any empty record in the relationship table, it throws an error. However, if all records contain values, this works fine.

The first selection works fine because all columns of records in the form have a value
The second select return error because there are a nullable column in model

This is what the error looks like

![Screenshot 2024-07-09 at 9 07 24 PM](https://github.com/filamentphp/filament/assets/70585602/ae881be8-0b2b-4497-ac1c-4d70bbb30561)


This form in filament resource

<img width="798" alt="Screenshot 2024-07-09 at 9 12 34 PM" src="https://github.com/filamentphp/filament/assets/70585602/dd5d1199-b888-4c11-b705-76d9fe38de28">

and this relation 

<img width="760" alt="Screenshot 2024-07-09 at 9 13 06 PM" src="https://github.com/filamentphp/filament/assets/70585602/1e2a8160-1c87-4935-b63e-177c402f6463">


In This PR The Select has been made to accept a value of null.