### PR TITLE
Fix evaluating labels in ternary filter

### DIFF
--- a/packages/tables/src/Filters/TernaryFilter.php
+++ b/packages/tables/src/Filters/TernaryFilter.php
@@ -57,12 +57,12 @@ class TernaryFilter extends SelectFilter
 
     public function getTrueLabel(): ?string
     {
-        return $this->trueLabel;
+        return $this->evaluate($this->trueLabel);
     }
 
     public function getFalseLabel(): ?string
     {
-        return $this->falseLabel;
+        return $this->evaluate($this->falseLabel);
     }
 
     public function getFormField(): Select


### PR DESCRIPTION
## Description

When using a TernaryFilter, passing a closure to be evaluated for trueLabel and falseLabel gives error since getTrueLabel and getFalseLabel should return a string.
Evaluating trueLabel and false Label resolves the problem.

## Visual changes

None

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
