### PR TITLE
Text column and entry tooltip per item

### DIFF
--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -125,6 +125,8 @@
                         $lineClamp = $getLineClamp($state);
                         $size = $getSize($state);
                         $weight = $getWeight($state);
+                        $itemTooltip = $getItemTooltip($state);
+                        $hasItemTooltip = filled($itemTooltip);
 
                         $iconClasses = \Illuminate\Support\Arr::toCssClasses([
                             'fi-ta-text-item-icon h-5 w-5',
@@ -182,11 +184,18 @@
                                 :color="$color"
                                 :icon="$icon"
                                 :icon-position="$iconPosition"
+                                :tooltip="$itemTooltip"
                             >
                                 {{ $formattedState }}
                             </x-filament::badge>
                         @else
                             <div
+                                @if ($hasItemTooltip)
+                                    x-tooltip="{
+                                        content: @js($itemTooltip),
+                                        theme: $store.theme,
+                                    }"
+                                @endif
                                 @class([
                                     'fi-ta-text-item inline-flex items-center gap-1.5',
                                     'group/item' => $url,

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -39,6 +39,8 @@ class TextColumn extends Column
 
     protected bool | Closure $isLimitedListExpandable = false;
 
+    protected string | Closure | null $itemTooltip = null;
+
     public function badge(bool | Closure $condition = true): static
     {
         $this->isBadge = $condition;
@@ -140,5 +142,19 @@ class TextColumn extends Column
     public function isLimitedListExpandable(): bool
     {
         return (bool) $this->evaluate($this->isLimitedListExpandable);
+    }
+
+    public function itemTooltip(string | Closure | null $tooltip): static
+    {
+        $this->itemTooltip = $tooltip;
+
+        return $this;
+    }
+
+    public function getItemTooltip(mixed $state): ?string
+    {
+        return $this->evaluate($this->itemTooltip, [
+            'state' => $state,
+        ]);
     }
 }


### PR DESCRIPTION
## Description

This PR is a followup of #13420 as per agreement with @danharrin
It introduces the ability to add tooltips to text columns that contain repeatable text: badges, list items, or concatenated list items.

Method  name is up for change if it's not good enough!

## Visual changes
Before:
![Screenshot 2024-07-11 alle 10 41 17](https://github.com/filamentphp/filament/assets/1104083/73e61f60-8745-4e16-ad2c-d00616f31a26)
![Screenshot 2024-07-11 alle 10 41 29](https://github.com/filamentphp/filament/assets/1104083/aa7dee50-444c-425b-9bf7-1e0703a9030a)
![Screenshot 2024-07-11 alle 10 41 41](https://github.com/filamentphp/filament/assets/1104083/9e3f957e-7e7a-46fb-a9e5-a5f82d95d634)

After:
![Screenshot 2024-07-11 alle 10 41 23](https://github.com/filamentphp/filament/assets/1104083/b66c710e-13a7-4286-b521-09382ab0bafc)
![Screenshot 2024-07-11 alle 10 41 33](https://github.com/filamentphp/filament/assets/1104083/8a01b43b-3dbe-4f70-ad7c-158e05ab9d5d)
![Screenshot 2024-07-11 alle 10 41 45](https://github.com/filamentphp/filament/assets/1104083/be1b789a-d525-4201-8060-c84cf4264596)

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
