### PR TITLE
Add option to configure the default sort option label

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -129,16 +129,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.316.1",
+            "version": "3.316.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "888cee2adf890a5b749cc22c0f05051b53619d33"
+                "reference": "4d8caae512c3be4d59ee6d583b3f82872dde5071"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/888cee2adf890a5b749cc22c0f05051b53619d33",
-                "reference": "888cee2adf890a5b749cc22c0f05051b53619d33",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/4d8caae512c3be4d59ee6d583b3f82872dde5071",
+                "reference": "4d8caae512c3be4d59ee6d583b3f82872dde5071",
                 "shasum": ""
             },
             "require": {
@@ -218,9 +218,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.316.1"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.316.2"
             },
-            "time": "2024-07-09T18:09:27+00:00"
+            "time": "2024-07-10T19:16:28+00:00"
         },
         {
             "name": "blade-ui-kit/blade-heroicons",
@@ -5139,16 +5139,16 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v2.34.8",
+            "version": "v2.34.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "e8f122bf47585c06431e0056189ec6bfd6f41f57"
+                "reference": "ef120125e036bf84c9e46a9e62219702f5b92e16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/e8f122bf47585c06431e0056189ec6bfd6f41f57",
-                "reference": "e8f122bf47585c06431e0056189ec6bfd6f41f57",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/ef120125e036bf84c9e46a9e62219702f5b92e16",
+                "reference": "ef120125e036bf84c9e46a9e62219702f5b92e16",
                 "shasum": ""
             },
             "require": {
@@ -5167,7 +5167,7 @@
             },
             "require-dev": {
                 "pestphp/pest-dev-tools": "^2.16.0",
-                "pestphp/pest-plugin-type-coverage": "^2.8.3",
+                "pestphp/pest-plugin-type-coverage": "^2.8.4",
                 "symfony/process": "^6.4.0|^7.1.1"
             },
             "bin": [
@@ -5231,7 +5231,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v2.34.8"
+                "source": "https://github.com/pestphp/pest/tree/v2.34.9"
             },
             "funding": [
                 {
@@ -5243,7 +5243,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-06-10T22:02:16+00:00"
+            "time": "2024-07-11T08:36:26+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -12818,5 +12818,5 @@
         "composer-runtime-api": "^2.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/packages/tables/docs/03-columns/01-getting-started.md
+++ b/packages/tables/docs/03-columns/01-getting-started.md
@@ -147,6 +147,23 @@ public function table(Table $table): Table
 }
 ```
 
+### Setting a default sort option label
+
+To set a default sort option label, use the `defaultSortOptionLabel()` method:
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->columns([
+            // ...
+        ])
+        ->defaultSortOptionLabel('Date');
+}
+```
+
 ## Searching
 
 Columns may be searchable by using the text input field in the top right of the table. To make a column searchable, you must use the `searchable()` method:

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -69,6 +69,7 @@
     $reorderRecordsTriggerAction = $getReorderRecordsTriggerAction($isReordering);
     $toggleColumnsTriggerAction = $getToggleColumnsTriggerAction();
     $page = $this->getTablePage();
+    $defaultSortOptionLabel = $getDefaultSortOptionLabel();
 
     if (count($actions) && (! $isReordering)) {
         $columnsCount++;
@@ -357,7 +358,7 @@
                                             <x-filament::input.select
                                                 x-model="column"
                                             >
-                                                <option value="">-</option>
+                                                <option value="">{{ $defaultSortOptionLabel }}</option>
 
                                                 @foreach ($sortableColumns as $column)
                                                     <option

--- a/packages/tables/src/Table/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSortRecords.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Table\Concerns;
 
 use Closure;
 use Filament\Tables\Columns\Column;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 
@@ -14,6 +15,8 @@ trait CanSortRecords
     protected string | Closure | null $defaultSortDirection = null;
 
     protected bool | Closure | null $persistsSortInSession = false;
+
+    protected string | Htmlable | Closure | null $defaultSortOptionLabel = null;
 
     public function defaultSort(string | Closure | null $column, string | Closure | null $direction = 'asc'): static
     {
@@ -26,6 +29,13 @@ trait CanSortRecords
     public function persistSortInSession(bool | Closure $condition = true): static
     {
         $this->persistsSortInSession = $condition;
+
+        return $this;
+    }
+
+    public function defaultSortOptionLabel(string | Htmlable | Closure | null $label): static
+    {
+        $this->defaultSortOptionLabel = $label;
 
         return $this;
     }
@@ -105,5 +115,10 @@ trait CanSortRecords
     public function persistsSortInSession(): bool
     {
         return (bool) $this->evaluate($this->persistsSortInSession);
+    }
+
+    public function getDefaultSortOptionLabel(): string | Htmlable | null
+    {
+        return $this->evaluate($this->defaultSortOptionLabel) ?? '-';
     }
 }


### PR DESCRIPTION
## Description

This PR adds the `defaultSortOptionLabel()` method to the table, to provide a label for the default sort option in the select. Currently, it is always '-':

## Visual changes

Current: 
![CleanShot 2024-07-11 at 15 30 24@2x](https://github.com/filamentphp/filament/assets/25097194/2b99ab2d-8308-459d-949c-b0966bfacc57)

After (`$table->defaultSortOptionLabel('Relevance')`:
![CleanShot 2024-07-11 at 15 14 30@2x](https://github.com/filamentphp/filament/assets/25097194/be48eea0-0b2c-4e38-94b0-d61addeacaa5)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
