### PR TITLE
Add option to pass a closure as the sortable condition

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanBeSortable.php
+++ b/packages/tables/src/Columns/Concerns/CanBeSortable.php
@@ -6,7 +6,7 @@ use Closure;
 
 trait CanBeSortable
 {
-    protected bool $isSortable = false;
+    protected bool | Closure $isSortable = false;
 
     /**
      * @var array<string> | null
@@ -16,9 +16,9 @@ trait CanBeSortable
     protected ?Closure $sortQuery = null;
 
     /**
-     * @param  bool | array<string>  $condition
+     * @param  bool | array<string> | Closure  $condition
      */
-    public function sortable(bool | array $condition = true, ?Closure $query = null): static
+    public function sortable(bool | array | Closure $condition = true, ?Closure $query = null): static
     {
         if (is_array($condition)) {
             $this->isSortable = true;
@@ -43,7 +43,7 @@ trait CanBeSortable
 
     public function isSortable(): bool
     {
-        return $this->isSortable;
+        return (bool) $this->evaluate($this->isSortable);
     }
 
     /**


### PR DESCRIPTION
## Description

This PR adds the ability to pass a closure as the sortable condition:

```php
TextColumn::make('date')
    ->sortable(fn() => $this->hasTableSearch()),
```

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] ~~Documentation is up-to-date.~~ (Sortable condition is not yet in the docs at all)
