### PR TITLE
Fix: Make Select loadStateFromRelationshipsUsing() consider HasOne and HasMany relationships

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -854,8 +854,9 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
                 $relatedRecords = $relationship->getResults();
 
                 $component->state(
-                    $relatedRecords
-                        ->pluck($relationship->getForeignKeyName())
+                    $relatedRecords->pluck(
+                        $relationship->getForeignKeyName()
+                    ),
                 );
 
                 return;

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -851,6 +851,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
             }
 
             if ($relationship instanceof HasMany) {
+                /** @var Collection $relatedRecords */
                 $relatedRecords = $relationship->getResults();
 
                 $component->state(

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -848,6 +848,16 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
                 return;
             }
 
+            if ($relationship instanceof HasOneOrMany) {
+                $relatedModel = $relationship->getResults();
+
+                $component->state(
+                    $relatedModel->getAttribute(
+                        $relatedModel->getKeyName(),
+                    ),
+                );
+            }
+
             /** @var BelongsTo $relationship */
             $relatedModel = $relationship->getResults();
 

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -18,7 +18,9 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
@@ -848,14 +850,27 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
                 return;
             }
 
-            if ($relationship instanceof HasOneOrMany) {
+            if ($relationship instanceof HasMany) {
+                $relatedRecords = $relationship->getResults();
+
+                $component->state(
+                    $relatedRecords
+                        ->pluck($relationship->getForeignKeyName())
+                );
+
+                return;
+            }
+
+            if ($relationship instanceof HasOne) {
                 $relatedModel = $relationship->getResults();
 
                 $component->state(
                     $relatedModel->getAttribute(
-                        $relatedModel->getKeyName(),
+                        $relationship->getForeignKeyName(),
                     ),
                 );
+
+                return;
             }
 
             /** @var BelongsTo $relationship */

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -856,7 +856,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
 
                 $component->state(
                     $relatedRecords->pluck(
-                        $relationship->getForeignKeyName()
+                        $relationship->getForeignKeyName(),
                     ),
                 );
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When using a `Filament\Forms\Components\Select` on a `HasOne` or `HasMany` relationship, a `BelongsTo` is assumed (see the line `/** @var BelongsTo $relationship */`)

When a related model is found `$relationship->getOwnerKeyName()` gets called resulting in a runtime failure due to `getOwnerKeyName` not being a valid function on `HasOne` or `HasMany`

## Visual changes

No visual differences

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
