### PR TITLE
Override default number locale in Tables and Infolists

### DIFF
--- a/packages/infolists/docs/03-entries/02-text.md
+++ b/packages/infolists/docs/03-entries/02-text.md
@@ -85,12 +85,12 @@ TextEntry::make('stock')
     ->numeric(locale: 'nl')
 ```
 
-Alternatively, you can set the default locale used across your app using the `Number::useLocale()` method in the `boot()` method of a service provider:
+Alternatively, you can set the default locale used across your app using the `Infolist::$defaultNumberLocale` method in the `boot()` method of a service provider:
 
 ```php
-use Illuminate\Support\Number;
+use Filament\Infolists\Infolist;
 
-Number::useLocale('nl');
+Infolist::$defaultNumberLocale = 'nl';
 ```
 
 ## Currency formatting
@@ -122,12 +122,12 @@ TextEntry::make('price')
     ->money('EUR', locale: 'nl')
 ```
 
-Alternatively, you can set the default locale used across your app using the `Number::useLocale()` method in the `boot()` method of a service provider:
+Alternatively, you can set the default locale used across your app using the `Infolist::$defaultNumberLocale` method in the `boot()` method of a service provider:
 
 ```php
-use Illuminate\Support\Number;
+use Filament\Infolists\Infolist;
 
-Number::useLocale('nl');
+Infolist::$defaultNumberLocale = 'nl';
 ```
 
 ## Limiting text length

--- a/packages/infolists/src/Components/Concerns/CanFormatState.php
+++ b/packages/infolists/src/Components/Concerns/CanFormatState.php
@@ -169,7 +169,7 @@ trait CanFormatState
                 $state /= $divideBy;
             }
 
-            return Number::currency($state, $currency, $component->evaluate($locale) ?? config('app.locale'));
+            return Number::currency($state, $currency, $locale);
         });
 
         return $this;

--- a/packages/infolists/src/Components/Concerns/CanFormatState.php
+++ b/packages/infolists/src/Components/Concerns/CanFormatState.php
@@ -163,6 +163,7 @@ trait CanFormatState
             }
 
             $currency = $component->evaluate($currency) ?? Infolist::$defaultCurrency;
+            $locale = $component->evaluate($locale) ?? Infolist::$defaultNumberLocale ?? config('app.locale');
 
             if ($divideBy) {
                 $state /= $divideBy;
@@ -203,7 +204,9 @@ trait CanFormatState
                 );
             }
 
-            return Number::format($state, $decimalPlaces, $component->evaluate($maxDecimalPlaces), $component->evaluate($locale) ?? config('app.locale'));
+            $locale = $component->evaluate($locale) ?? Infolist::$defaultNumberLocale ?? config('app.locale');
+
+            return Number::format($state, $decimalPlaces, $component->evaluate($maxDecimalPlaces), $locale);
         });
 
         return $this;

--- a/packages/infolists/src/Infolist.php
+++ b/packages/infolists/src/Infolist.php
@@ -14,6 +14,8 @@ class Infolist extends ComponentContainer
 
     public static string $defaultTimeDisplayFormat = 'H:i:s';
 
+    public static ?string $defaultNumberLocale = null;
+
     public function name(string $name): static
     {
         $this->name = $name;

--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -111,12 +111,12 @@ TextColumn::make('stock')
     ->numeric(locale: 'nl')
 ```
 
-Alternatively, you can set the default locale used across your app using the `Number::useLocale()` method in the `boot()` method of a service provider:
+Alternatively, you can set the default locale used across your app using the `Table::$defaultNumberLocale` method in the `boot()` method of a service provider:
 
 ```php
-use Illuminate\Support\Number;
+use Filament\Tables\Table;
 
-Number::useLocale('nl');
+Table::$defaultNumberLocale = 'nl';
 ```
 
 ## Currency formatting
@@ -148,12 +148,12 @@ TextColumn::make('price')
     ->money('EUR', locale: 'nl')
 ```
 
-Alternatively, you can set the default locale used across your app using the `Number::useLocale()` method in the `boot()` method of a service provider:
+Alternatively, you can set the default locale used across your app using the `Table::$defaultNumberLocale` method in the `boot()` method of a service provider:
 
 ```php
-use Illuminate\Support\Number;
+use Filament\Tables\Table;
 
-Number::useLocale('nl');
+Table::$defaultNumberLocale = 'nl';
 ```
 
 ## Limiting text length

--- a/packages/tables/docs/07-summaries.md
+++ b/packages/tables/docs/07-summaries.md
@@ -255,12 +255,12 @@ TextColumn::make('rating')
     ))
 ```
 
-Alternatively, you can set the default locale used across your app using the `Number::useLocale()` method in the `boot()` method of a service provider:
+Alternatively, you can set the default locale used across your app using the `Table::$defaultNumberLocale` method in the `boot()` method of a service provider:
 
 ```php
-use Illuminate\Support\Number;
+use Filament\Tables\Table;
 
-Number::useLocale('nl');
+Table::$defaultNumberLocale = 'nl';
 ```
 
 ### Currency formatting
@@ -295,12 +295,12 @@ TextColumn::make('price')
     ->summarize(Sum::make()->money('EUR', locale: 'nl'))
 ```
 
-Alternatively, you can set the default locale used across your app using the `Number::useLocale()` method in the `boot()` method of a service provider:
+Alternatively, you can set the default locale used across your app using the `Table::$defaultNumberLocale` method in the `boot()` method of a service provider:
 
 ```php
-use Illuminate\Support\Number;
+use Filament\Tables\Table;
 
-Number::useLocale('nl');
+Table::$defaultNumberLocale = 'nl';
 ```
 
 ### Limiting text length

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -163,12 +163,13 @@ trait CanFormatState
             }
 
             $currency = $column->evaluate($currency) ?? Table::$defaultCurrency;
+            $locale = $column->evaluate($locale) ?? Table::$defaultNumberLocale ?? config('app.locale');
 
             if ($divideBy) {
                 $state /= $divideBy;
             }
 
-            return Number::currency($state, $currency, $column->evaluate($locale) ?? config('app.locale'));
+            return Number::currency($state, $currency, $locale);
         });
 
         return $this;
@@ -203,7 +204,9 @@ trait CanFormatState
                 );
             }
 
-            return Number::format($state, $decimalPlaces, $column->evaluate($maxDecimalPlaces), locale: $column->evaluate($locale) ?? config('app.locale'));
+            $locale = $column->evaluate($locale) ?? Table::$defaultNumberLocale ?? config('app.locale');
+
+            return Number::format($state, $decimalPlaces, $column->evaluate($maxDecimalPlaces), locale: $locale);
         });
 
         return $this;

--- a/packages/tables/src/Columns/Summarizers/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Summarizers/Concerns/CanFormatState.php
@@ -47,12 +47,13 @@ trait CanFormatState
             }
 
             $currency = $summarizer->evaluate($currency) ?? Table::$defaultCurrency;
+            $locale = $summarizer->evaluate($locale) ?? Table::$defaultNumberLocale ?? config('app.locale');
 
             if ($divideBy) {
                 $state /= $divideBy;
             }
 
-            return Number::currency($state, $currency, $summarizer->evaluate($locale) ?? config('app.locale'));
+            return Number::currency($state, $currency, $locale);
         });
 
         return $this;
@@ -85,7 +86,9 @@ trait CanFormatState
                 );
             }
 
-            return Number::format($state, $decimalPlaces, $summarizer->evaluate($maxDecimalPlaces), locale: $summarizer->evaluate($locale) ?? config('app.locale'));
+            $locale = $summarizer->evaluate($locale) ?? Table::$defaultNumberLocale ?? config('app.locale');
+
+            return Number::format($state, $decimalPlaces, $summarizer->evaluate($maxDecimalPlaces), locale: $locale);
         });
 
         return $this;

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -64,6 +64,8 @@ class Table extends ViewComponent
 
     public static string $defaultDateTimeDisplayFormat = 'M j, Y H:i:s';
 
+    public static ?string $defaultNumberLocale = null;
+
     public static string $defaultTimeDisplayFormat = 'H:i:s';
 
     final public function __construct(HasTable $livewire)


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Caused by: https://github.com/filamentphp/filament/pull/13166 (3.2.87)

In my opinion #13166 should be reverted instead of this change. If they want to set a default locale for the number helper they should have just used `Number::useLocale(config('app.locale'))`. 

If not, this workaround is the new way to set a global default number locale in filament for tables and infolists.

The filament docs suggest using `Number::useLocale($locale)` to set the default number formatting globally.

However, as reported in #13340  this does not override the `config('app.locale')` locale that filament is now passing to `Number::currency` and `Number::format` functions by default since 3.2.87.

Table docs:
<img width="653" alt="image" src="https://github.com/user-attachments/assets/6289417a-4109-4e45-af9c-1b6c14356d32">

Here in Infolists docs:
<img width="656" alt="image" src="https://github.com/user-attachments/assets/6687cef6-023d-4aa8-a4e4-b1d0966a6e17">

## Visual changes

None

## Functional changes
I have added a `Table::$defaultNumberLocale` static variable that can be used to override the table default.

I have added the same for `Infolist::$defaultNumberLocale`.

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.