### PR TITLE
Allow table groups to accept a closure

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -36,7 +36,7 @@
         $getBulkActions(),
         fn (\Filament\Tables\Actions\BulkAction | \Filament\Tables\Actions\ActionGroup $action): bool => $action->isVisible(),
     );
-    $groups = $getGroups();
+    $groups = $getCachedGroups();
     $description = $getDescription();
     $isGroupsOnly = $isGroupsOnly() && $group;
     $isReorderable = $isReorderable();

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -36,7 +36,7 @@
         $getBulkActions(),
         fn (\Filament\Tables\Actions\BulkAction | \Filament\Tables\Actions\ActionGroup $action): bool => $action->isVisible(),
     );
-    $groups = $getCachedGroups();
+    $groups = $getGroups();
     $description = $getDescription();
     $isGroupsOnly = $isGroupsOnly() && $group;
     $isReorderable = $isReorderable();

--- a/packages/tables/src/Table/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Table/Concerns/CanGroupRecords.php
@@ -15,6 +15,11 @@ trait CanGroupRecords
     /**
      * @var array<string, Group>
      */
+    protected array $cachedGroups;
+
+    /**
+     * @var array<string | Group> | Closure
+     */
     protected array | Closure $groups = [];
 
     protected bool | Closure $isGroupsOnly = false;
@@ -73,7 +78,7 @@ trait CanGroupRecords
     }
 
     /**
-     * @param  array<Group | string>  $groups
+     * @param  array<string | Group> | Closure  $groups
      */
     public function groups(array | Closure $groups): static
     {
@@ -160,10 +165,18 @@ trait CanGroupRecords
     /**
      * @return array<string, Group>
      */
+    public function getCachedGroups(): array
+    {
+        return $this->cachedGroups ??= $this->getGroups();
+    }
+
+    /**
+     * @return array<string, Group>
+     */
     public function getGroups(): array
     {
         $groups = [];
-        
+
         foreach ($this->evaluate($this->groups) as $group) {
             if (! $group instanceof Group) {
                 $group = Group::make($group);
@@ -171,13 +184,13 @@ trait CanGroupRecords
 
             $groups[$group->getId()] = $group;
         }
-        
+
         return $groups;
     }
 
     public function getGroup(string $id): ?Group
     {
-        return $this->getGroups()[$id] ?? null;
+        return $this->getCachedGroups()[$id] ?? null;
     }
 
     public function getGrouping(): ?Group

--- a/packages/tables/src/Table/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Table/Concerns/CanGroupRecords.php
@@ -13,9 +13,9 @@ trait CanGroupRecords
     protected string | Group | null $defaultGroup = null;
 
     /**
-     * @var array<string, Group>
+     * @var array<string, Group> | null
      */
-    protected array $cachedGroups;
+    protected ?array $cachedGroups = null;
 
     /**
      * @var array<string | Group> | Closure
@@ -165,16 +165,12 @@ trait CanGroupRecords
     /**
      * @return array<string, Group>
      */
-    public function getCachedGroups(): array
-    {
-        return $this->cachedGroups ??= $this->getGroups();
-    }
-
-    /**
-     * @return array<string, Group>
-     */
     public function getGroups(): array
     {
+        if ($this->cachedGroups) {
+            return $this->cachedGroups;
+        }
+
         $groups = [];
 
         foreach ($this->evaluate($this->groups) as $group) {
@@ -185,12 +181,12 @@ trait CanGroupRecords
             $groups[$group->getId()] = $group;
         }
 
-        return $groups;
+        return $this->cachedGroups = $groups;
     }
 
     public function getGroup(string $id): ?Group
     {
-        return $this->getCachedGroups()[$id] ?? null;
+        return $this->getGroups()[$id] ?? null;
     }
 
     public function getGrouping(): ?Group

--- a/packages/tables/src/Table/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Table/Concerns/CanGroupRecords.php
@@ -15,7 +15,7 @@ trait CanGroupRecords
     /**
      * @var array<string, Group>
      */
-    protected array $groups = [];
+    protected array | Closure $groups = [];
 
     protected bool | Closure $isGroupsOnly = false;
 
@@ -75,15 +75,9 @@ trait CanGroupRecords
     /**
      * @param  array<Group | string>  $groups
      */
-    public function groups(array $groups): static
+    public function groups(array | Closure $groups): static
     {
-        foreach ($groups as $group) {
-            if (! $group instanceof Group) {
-                $group = Group::make($group);
-            }
-
-            $this->groups[$group->getId()] = $group;
-        }
+        $this->groups = $groups;
 
         return $this;
     }
@@ -168,7 +162,19 @@ trait CanGroupRecords
      */
     public function getGroups(): array
     {
-        return $this->groups;
+        $evaluatedGroups = $this->evaluate($this->groups);
+
+        $groups = [];
+        
+        foreach ($evaluatedGroups as $group) {
+            if (! $group instanceof Group) {
+                $group = Group::make($group);
+            }
+
+            $groups[$group->getId()] = $group;
+        }
+        
+        return $groups;
     }
 
     public function getGroup(string $id): ?Group

--- a/packages/tables/src/Table/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Table/Concerns/CanGroupRecords.php
@@ -162,11 +162,9 @@ trait CanGroupRecords
      */
     public function getGroups(): array
     {
-        $evaluatedGroups = $this->evaluate($this->groups);
-
         $groups = [];
         
-        foreach ($evaluatedGroups as $group) {
+        foreach ($this->evaluate($this->groups) as $group) {
             if (! $group instanceof Group) {
                 $group = Group::make($group);
             }

--- a/packages/tables/src/Table/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Table/Concerns/CanGroupRecords.php
@@ -18,7 +18,7 @@ trait CanGroupRecords
     protected ?array $cachedGroups;
 
     /**
-     * @var array<Group | string> | Closure
+     * @var array<string | Group> | Closure
      */
     protected array | Closure $groups = [];
 
@@ -78,7 +78,7 @@ trait CanGroupRecords
     }
 
     /**
-     * @param  array<Group | string> | Closure  $groups
+     * @param  array<string | Group> | Closure  $groups
      */
     public function groups(array | Closure $groups): static
     {


### PR DESCRIPTION
## Description

Allow table groups to accept a closure:

```php
return $table
    ->groups(function (Component $livewire) {
        return match ($livewire->activeTab) {
            'pending' => ['order_date'],
            'shipped' => ['shipping_date'],
            'delivered' => [
                  Group::make('delivered_date')->label('Delivered'),
             ],
        };
    })
```

## Visual changes


## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
