### PR TITLE
Docs Update: on Actions - Export Action

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/09-export.md
+++ b/packages/actions/docs/07-prebuilt-actions/09-export.md
@@ -14,8 +14,10 @@ php artisan make:notifications-table
 # Laravel 10
 php artisan queue:batches-table
 php artisan notifications:table
+```
 
-# Laravel 10 & higher
+```bash
+# All apps
 php artisan vendor:publish --tag=filament-actions-migrations
 php artisan migrate
 ```

--- a/packages/actions/docs/07-prebuilt-actions/09-export.md
+++ b/packages/actions/docs/07-prebuilt-actions/09-export.md
@@ -15,8 +15,8 @@ php artisan make:notifications-table
 php artisan queue:batches-table
 php artisan notifications:table
 
+# Laravel 10 & higher
 php artisan vendor:publish --tag=filament-actions-migrations
-
 php artisan migrate
 ```
 


### PR DESCRIPTION
[https://filamentphp.com/docs/3.x/actions/prebuilt-actions/export#overview](url)

In that code block, it is not 100% clear which steps are needed for L11 vs L10. This change makes it more explicit.

I thought only those first 2 steps were necessary for L11.


Just to make it clearer, for the next devs. 

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

Before: 
<img width="463" alt="image" src="https://github.com/user-attachments/assets/468db68e-81e0-45d1-aeef-cfd4d15cd87f">
After:
<img width="271" alt="image" src="https://github.com/user-attachments/assets/32b8d685-0ae0-41e3-8de6-e28f69f828f2">

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
