### PR TITLE
Fix #13518

### DIFF
--- a/packages/widgets/resources/js/components/stats-overview/stat/chart.js
+++ b/packages/widgets/resources/js/components/stats-overview/stat/chart.js
@@ -41,13 +41,6 @@ export default function statsOverviewStatChart({
         },
 
         initChart: function () {
-            Chart.defaults.backgroundColor = getComputedStyle(
-                this.$refs.backgroundColorElement,
-            ).color
-
-            Chart.defaults.borderColor = getComputedStyle(
-                this.$refs.borderColorElement,
-            ).color
 
             return new Chart(this.$refs.canvas, {
                 type: 'line',
@@ -59,6 +52,12 @@ export default function statsOverviewStatChart({
                             borderWidth: 2,
                             fill: 'start',
                             tension: 0.5,
+                            backgroundColor : getComputedStyle(
+                                this.$refs.backgroundColorElement,
+                            ).color,
+                            borderColor : getComputedStyle(
+                                this.$refs.borderColorElement,
+                            ).color
                         },
                     ],
                 },


### PR DESCRIPTION
Fix #13518 

use per-dataset settings instead of default colors to prevent the responsive behaviour change the chart color

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

To the chart initialization for stats widget the responsive option of chartjs override the defaults color settings randomly according to the amount of chart instances, to prevent it, this require set the colors using per-dataset settings.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

after
![Screen-Recording-2024-07-13](https://github.com/user-attachments/assets/9757e112-ae89-40c2-acdd-639ca8e212ff)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
