### PR TITLE
Display current state for placeholder field

### DIFF
--- a/packages/forms/src/Components/Placeholder.php
+++ b/packages/forms/src/Components/Placeholder.php
@@ -50,6 +50,6 @@ class Placeholder extends Component implements Contracts\HasHintActions
 
     public function getContent(): mixed
     {
-        return $this->evaluate($this->content);
+        return $this->evaluate($this->content) ?? $this->getState();
     }
 }


### PR DESCRIPTION
By default, when no `->content()` is specified, the content is empty. This PR automatically adds the current state to the content when none is specified.

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
