### PR TITLE
Fix: avoid table polling while reordering

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -284,7 +284,7 @@
         @endif
 
         <div
-            @if ($pollingInterval = $getPollingInterval())
+            @if (! $isReordering && ($pollingInterval = $getPollingInterval()))
                 wire:poll.{{ $pollingInterval }}
             @endif
             @class([
@@ -358,7 +358,9 @@
                                             <x-filament::input.select
                                                 x-model="column"
                                             >
-                                                <option value="">{{ $defaultSortOptionLabel }}</option>
+                                                <option value="">
+                                                    {{ $defaultSortOptionLabel }}
+                                                </option>
 
                                                 @foreach ($sortableColumns as $column)
                                                     <option

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -284,7 +284,7 @@
         @endif
 
         <div
-            @if (! $isReordering && ($pollingInterval = $getPollingInterval()))
+            @if ((! $isReordering) && ($pollingInterval = $getPollingInterval()))
                 wire:poll.{{ $pollingInterval }}
             @endif
             @class([


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

closes #12108 

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

NA

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
