### PR TITLE
Fix nested Eager Loading for EntanglesStateWithSingularRelationship Components Concern

### DIFF
--- a/packages/forms/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
+++ b/packages/forms/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
@@ -203,14 +203,18 @@ trait EntanglesStateWithSingularRelationship
             return $this->cachedExistingRecord;
         }
 
-        $relationshipName = $this->getRelationshipName();
-
-        if (! $relationshipName) {
+        if (! $parentRecord = $this->getRecord()) {
             return null;
         }
 
-        if ($this->getModelInstance()->relationLoaded($relationshipName)) {
-            $record = $this->getModelInstance()->getRelationValue($relationshipName);
+        $relationshipName = $this->getRelationshipName();
+
+        if (blank($relationshipName)) {
+            return null;
+        }
+
+        if ($parentRecord->relationLoaded($relationshipName)) {
+            $record = $parentRecord->getRelationValue($relationshipName);
         } else {
             $record = $this->getRelationship()?->getResults();
         }

--- a/packages/forms/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
+++ b/packages/forms/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
@@ -203,7 +203,9 @@ trait EntanglesStateWithSingularRelationship
             return $this->cachedExistingRecord;
         }
 
-        if (! $parentRecord = $this->getRecord()) {
+        $parentRecord = $this->getRecord();
+
+        if (! $parentRecord) {
             return null;
         }
 

--- a/packages/forms/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
+++ b/packages/forms/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
@@ -203,7 +203,17 @@ trait EntanglesStateWithSingularRelationship
             return $this->cachedExistingRecord;
         }
 
-        $record = $this->getRelationship()?->getResults();
+        $relationshipName = $this->getRelationshipName();
+
+        if (! $relationshipName) {
+            return null;
+        }
+
+        if ($this->getModelInstance()->relationLoaded($relationshipName)) {
+            $record = $this->getModelInstance()->getRelationValue($relationshipName);
+        } else {
+            $record = $this->getRelationship()?->getResults();
+        }
 
         if (! $record?->exists) {
             return null;


### PR DESCRIPTION
## Description

If you use many nested grids / field sets and others with relationship, all nested relations are reloaded in `getCachedExistingRecord` function even if they have been eager loaded.
And so, too many requests are executed.

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
