### PR TITLE
Make actions array optional

### DIFF
--- a/packages/actions/src/ActionGroup.php
+++ b/packages/actions/src/ActionGroup.php
@@ -69,7 +69,7 @@ class ActionGroup extends ViewComponent implements HasLivewire
     /**
      * @param  array<StaticAction | ActionGroup>  $actions
      */
-    public static function make(array $actions): static
+    public static function make(?array $actions = []): static
     {
         $static = app(static::class, ['actions' => $actions]);
         $static->configure();


### PR DESCRIPTION
Just a small change so that the `make()` method doesn't require an array as argument.

**Use case:**

We can create custom action classes, for example `SomeAction`, and use that like so:`SomeAction.make()`.

I would like to create a custom action **group** class so that I can reuse it in several resources. However, I cannot use it like the above example. I need to give it an empty array: `SomeActionGroup::make([])`

This doesn't look good.

Making the array optional and having an empty array by default shouldn't be an issue because the `actions()` method sets an empty array too (on the `actions` property).