### PR TITLE
ToggleFilter to use in tables

### DIFF
--- a/packages/forms/resources/views/components/toggle-buttons/grouped.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/grouped.blade.php
@@ -53,6 +53,7 @@
                 grouped
                 :icon="$getIcon($value)"
                 tag="label"
+                :attributes="$getExtraAttributeBag()"
             >
                 {{ $label }}
             </x-filament::button>

--- a/packages/forms/resources/views/components/toggle-buttons/index.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/index.blade.php
@@ -71,6 +71,7 @@
                     :for="$inputId"
                     :icon="$getIcon($value)"
                     tag="label"
+                    :attributes="$getExtraAttributeBag()"
                 >
                     {{ $label }}
                 </x-filament::button>

--- a/packages/forms/src/Components/ToggleButtons.php
+++ b/packages/forms/src/Components/ToggleButtons.php
@@ -47,9 +47,11 @@ class ToggleButtons extends Field implements Contracts\CanDisableOptions
         });
     }
 
-    public function grouped(): static
+    public function grouped(bool | Closure $condition = true): static
     {
+        if($condition)
         return $this->view(static::GROUPED_VIEW);
+        return $this;
     }
 
     public function boolean(?string $trueLabel = null, ?string $falseLabel = null): static

--- a/packages/forms/src/Components/ToggleButtons.php
+++ b/packages/forms/src/Components/ToggleButtons.php
@@ -12,6 +12,7 @@ class ToggleButtons extends Field implements Contracts\CanDisableOptions
     use Concerns\CanFixIndistinctState;
     use Concerns\HasColors;
     use Concerns\HasExtraInputAttributes;
+    use \Filament\Support\Concerns\HasExtraAttributes;
     use Concerns\HasGridDirection;
     use Concerns\HasIcons;
     use Concerns\HasOptions;

--- a/packages/tables/src/Filters/ToggleFilter.php
+++ b/packages/tables/src/Filters/ToggleFilter.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace Filament\Tables\Filters;
+
+use Closure;
+use Filament\Forms\Components\ToggleButtons;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
+
+class ToggleFilter extends BaseFilter
+{
+    use Concerns\HasOptions;
+    use Concerns\HasRelationship;
+
+    protected string | Closure | null $attribute = null;
+
+    protected bool | Closure $isMultiple = false;
+
+    protected bool | Closure $isGrouped = false;
+
+    protected bool | Closure $isNative = true;
+
+    protected bool | Closure $isStatic = false;
+
+    protected bool | Closure $isSearchable = false;
+
+    protected array | Closure $extraAttributes = [];
+
+    protected int | Closure $optionsLimit = 50;
+
+    protected bool | Closure | null $isSearchForcedCaseInsensitive = null;
+
+    protected ?Closure $getOptionLabelFromRecordUsing = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->indicateUsing(function (ToggleFilter $filter, array $state): array {
+            if ($filter->isMultiple()) {
+                if (blank($state['values'] ?? null)) {
+                    return [];
+                }
+
+                if ($filter->queriesRelationships()) {
+                    $relationshipQuery = $filter->getRelationshipQuery();
+
+                    $labels = $relationshipQuery
+                        ->when(
+                            $filter->getRelationship() instanceof \Znck\Eloquent\Relations\BelongsToThrough,
+                            fn (Builder $query) => $query->distinct(),
+                        )
+                        ->when(
+                            $this->getRelationshipKey(),
+                            fn (Builder $query, string $relationshipKey) => $query->whereIn($relationshipKey, $state['values']),
+                            fn (Builder $query) => $query->whereKey($state['values'])
+                        )
+                        ->pluck($relationshipQuery->qualifyColumn($filter->getRelationshipTitleAttribute()))
+                        ->all();
+                } else {
+                    $labels = Arr::only($filter->getOptions(), $state['values']);
+                }
+
+                if (! count($labels)) {
+                    return [];
+                }
+
+                $labels = collect($labels)->join(', ', ' & ');
+
+                $indicator = $filter->getIndicator();
+
+                if (! $indicator instanceof Indicator) {
+                    $indicator = Indicator::make("{$indicator}: {$labels}");
+                }
+
+                return [$indicator];
+            }
+
+            if (blank($state['value'] ?? null)) {
+                return [];
+            }
+
+            if ($filter->queriesRelationships()) {
+                $label = $filter->getRelationshipQuery()
+                    ->when(
+                        $this->getRelationshipKey(),
+                        fn (Builder $query, string $relationshipKey) => $query->where($relationshipKey, $state['value']),
+                        fn (Builder $query) => $query->whereKey($state['value'])
+                    )
+                    ->first()
+                    ?->getAttributeValue($filter->getRelationshipTitleAttribute());
+            } else {
+                $label = $filter->getOptions()[$state['value']] ?? null;
+            }
+
+            if (blank($label)) {
+                return [];
+            }
+
+            $indicator = $filter->getIndicator();
+
+            if (! $indicator instanceof Indicator) {
+                $indicator = Indicator::make("{$indicator}: {$label}");
+            }
+
+            return [$indicator];
+        });
+
+        $this->resetState(['value' => null]);
+    }
+
+    public function getActiveCount(): int
+    {
+        $state = $this->getState();
+
+        return filled($this->isMultiple() ? ($state['values'] ?? []) : ($state['value'] ?? null)) ? 1 : 0;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function apply(Builder $query, array $data = []): Builder
+    {
+        if ($this->evaluate($this->isStatic)) {
+            return $query;
+        }
+
+        if ($this->hasQueryModificationCallback()) {
+            return parent::apply($query, $data);
+        }
+
+        $isMultiple = $this->isMultiple();
+
+        $values = $isMultiple ?
+            $data['values'] ?? null :
+            $data['value'] ?? null;
+
+        if (blank(Arr::first(
+            Arr::wrap($values),
+            fn ($value) => filled($value),
+        ))) {
+            return $query;
+        }
+
+        if (! $this->queriesRelationships()) {
+            return $query->{$isMultiple ? 'whereIn' : 'where'}(
+                $this->getAttribute(),
+                $values,
+            );
+        }
+
+        return $query->whereHas(
+            $this->getRelationshipName(),
+            function (Builder $query) use ($isMultiple, $values) {
+                if ($this->modifyRelationshipQueryUsing) {
+                    $query = $this->evaluate($this->modifyRelationshipQueryUsing, [
+                        'query' => $query,
+                    ]) ?? $query;
+                }
+
+                if ($relationshipKey = $this->getRelationshipKey($query)) {
+                    return $query->{$isMultiple ? 'whereIn' : 'where'}(
+                        $relationshipKey,
+                        $values,
+                    );
+                }
+
+                return $query->whereKey($values);
+            },
+        );
+    }
+
+    public function attribute(string | Closure | null $name): static
+    {
+        $this->attribute = $name;
+
+        return $this;
+    }
+
+    /**
+     * @deprecated Use `attribute()` instead.
+     */
+    public function column(string | Closure | null $name): static
+    {
+        $this->attribute($name);
+
+        return $this;
+    }
+
+    public function static(bool | Closure $condition = true): static
+    {
+        $this->isStatic = $condition;
+
+        return $this;
+    }
+
+    public function multiple(bool | Closure $condition = true): static
+    {
+        $this->isMultiple = $condition;
+
+        return $this;
+    }
+
+    public function grouped(bool | Closure $condition = true): static
+    {
+        $this->isGrouped = $condition;
+
+        return $this;
+    }
+
+    public function extraAttributes(array | Closure $condition = []): static
+    {
+        $this->extraAttributes = $condition;
+
+        return $this;
+    }
+
+    public function getAttribute(): string
+    {
+        return $this->evaluate($this->attribute) ?? $this->getName();
+    }
+
+    /**
+     * @deprecated Use `getAttribute()` instead.
+     */
+    public function getColumn(): string
+    {
+        return $this->getAttribute();
+    }
+
+    public function forceSearchCaseInsensitive(bool | Closure | null $condition = true): static
+    {
+        $this->isSearchForcedCaseInsensitive = $condition;
+
+        return $this;
+    }
+
+    public function isSearchForcedCaseInsensitive(): ?bool
+    {
+        return $this->evaluate($this->isSearchForcedCaseInsensitive);
+    }
+
+    public function getFormField(): ToggleButtons
+    {
+        $field = ToggleButtons::make($this->isMultiple() ? 'values' : 'value')
+            ->label($this->getLabel())
+            ->grouped($this->isGrouped())
+            ->extraAttributes($this->extraAttributes,true)
+            ->multiple($this->isMultiple());
+
+        if ($this->queriesRelationships()) {
+            $field
+                ->relationship(
+                    $this->getRelationshipName(),
+                    $this->getRelationshipTitleAttribute(),
+                    $this->modifyRelationshipQueryUsing,
+                )
+                ->forceSearchCaseInsensitive($this->isSearchForcedCaseInsensitive());
+        } else {
+            $field->options($this->getOptions());
+        }
+
+        if ($this->getOptionLabelUsing) {
+            $field->getOptionLabelUsing($this->getOptionLabelUsing);
+        }
+
+        if ($this->getOptionLabelsUsing) {
+            $field->getOptionLabelsUsing($this->getOptionLabelsUsing);
+        }
+
+        if ($this->getOptionLabelFromRecordUsing) {
+            $field->getOptionLabelFromRecordUsing($this->getOptionLabelFromRecordUsing);
+        }
+
+        if ($this->getSearchResultsUsing) {
+            $field->getSearchResultsUsing($this->getSearchResultsUsing);
+        }
+
+        if (filled($defaultState = $this->getDefaultState())) {
+            $field->default($defaultState);
+        }
+
+        return $field;
+    }
+
+    public function isMultiple(): bool
+    {
+        return (bool) $this->evaluate($this->isMultiple);
+    }
+
+    public function isGrouped(): bool
+    {
+        return (bool) $this->evaluate($this->isGrouped);
+    }
+
+    
+    public function getExtraAttributes(): array
+    {
+        return (array) $this->evaluate($this->extraAttributes);
+    }
+
+    public function getOptionLabelFromRecordUsing(?Closure $callback): static
+    {
+        $this->getOptionLabelFromRecordUsing = $callback;
+
+        return $this;
+    }
+}

--- a/packages/tables/src/Filters/ToggleFilter.php
+++ b/packages/tables/src/Filters/ToggleFilter.php
@@ -244,9 +244,11 @@ class ToggleFilter extends BaseFilter
     {
         $field = ToggleButtons::make($this->isMultiple() ? 'values' : 'value')
             ->label($this->getLabel())
-            ->grouped($this->isGrouped())
             ->extraAttributes($this->extraAttributes,true)
             ->multiple($this->isMultiple());
+
+        if($this->isGrouped)
+            $field->grouped();
 
         if ($this->queriesRelationships()) {
             $field


### PR DESCRIPTION
## Description

Since using filament I feeled the need to have a fast usable filter on top of the tables, so instead of having selects or search for specific queries i implemented this filter.

Here an example usage

```
ToggleFilter::make('stato_assistenza_id')
->options(StatoAssistenza::pluck('stato'))
->multiple()
->grouped()
->default([0, 1, 2, 3, 4, 8, 9])
->extraAttributes(['class' => 'h-16'])
```

or not grouped in normal filter
```
ToggleFilter::make('stato_assistenza_id')
->options(StatoAssistenza::pluck('stato'))
->multiple()
->default([0, 1, 2, 3, 4, 8, 9])
```


## Visual changes

![image](https://github.com/user-attachments/assets/381e8348-a8cb-42ae-baf6-a199730c9e1b)

![image](https://github.com/user-attachments/assets/5676fe0a-2dcb-4acb-b265-91e6ba4b0383)


## Functional changes

I had to adapt toggle buttons class to allow extra attributes and have better control over it, since in my case some labels were two lines and the height was not adapting

