### PR TITLE
Add option to tie resource to relation manager

### DIFF
--- a/packages/actions/src/Concerns/CanOpenModal.php
+++ b/packages/actions/src/Concerns/CanOpenModal.php
@@ -91,6 +91,19 @@ trait CanOpenModal
      */
     protected string | array | Closure | null $modalIconColor = null;
 
+    protected bool $useModal = false;
+
+    public function preferModal($bool = false): static
+    {
+        $this->useModal = $bool;
+        return $this;
+    }
+
+    public function shouldUseModal(): bool
+    {
+        return $this->useModal;
+    }
+
     public function closeModalByClickingAway(bool | Closure | null $condition = true): static
     {
         $this->isModalClosedByClickingAway = $condition;

--- a/packages/actions/src/StaticAction.php
+++ b/packages/actions/src/StaticAction.php
@@ -60,11 +60,16 @@ class StaticAction extends ViewComponent implements Contracts\Groupable
         $this->name($name);
     }
 
-    public static function make(?string $name = null): static
+    public static function make(?string $name = null, bool $useModal = false): static
     {
         $static = app(static::class, [
             'name' => $name ?? static::getDefaultName(),
         ]);
+
+        if ($static instanceof MountableAction) {
+            $static->preferModal($useModal);
+        }
+
         $static->configure();
 
         return $static;

--- a/packages/panels/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManager.php
@@ -230,7 +230,7 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
             ->authorize(static fn (RelationManager $livewire): bool => (! $livewire->isReadOnly()) && $livewire->canCreate())
             ->form(fn (Form $form): Form => $this->form($form->columns(2)));
 
-        if (isset($resource) && $resource::hasPage('create')) {
+        if (isset($resource) && $resource::hasPage('create') && !$action->shouldUseModal()) {
             $action->url(fn (): string => $resource::getUrl('create'));
         }
     }
@@ -261,7 +261,7 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
             ->authorize(static fn (RelationManager $livewire, Model $record): bool => (! $livewire->isReadOnly()) && $livewire->canEdit($record))
             ->form(fn (Form $form): Form => $this->form($form->columns(2)));
 
-        if (isset($resource) && $resource::hasPage('edit')) {
+        if (isset($resource) && $resource::hasPage('edit') && !$action->shouldUseModal()) {
             $action->url(fn (Model $record): string => $resource::getUrl('edit', ['record' => $record]));
         }
     }
@@ -293,7 +293,7 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
             ->infolist(fn (Infolist $infolist): Infolist => $this->infolist($infolist->columns(2)))
             ->form(fn (Form $form): Form => $this->form($form->columns(2)));
 
-        if (isset($resource) && $resource::hasPage('view')) {
+        if (isset($resource) && $resource::hasPage('view') && !$action->shouldUseModal()) {
             $action->url(fn (Model $record): string => $resource::getUrl('view', ['record' => $record]));
         }
     }

--- a/packages/panels/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManager.php
@@ -40,6 +40,11 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
      */
     protected static string $view = 'filament-panels::resources.relation-manager';
 
+    /**
+     * @var ?class-string
+     */
+    protected static ?string $resource = null;
+
     #[Locked]
     public Model $ownerRecord;
 
@@ -133,6 +138,14 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
         return [];
     }
 
+    /**
+     * @return ?class-string
+     */
+    public static function getResource(): ?string
+    {
+        return static::$resource;
+    }
+
     public static function getIcon(Model $ownerRecord, string $pageClass): ?string
     {
         return static::$icon;
@@ -211,9 +224,15 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
 
     protected function configureCreateAction(Tables\Actions\CreateAction $action): void
     {
+        $resource = static::getResource();
+
         $action
             ->authorize(static fn (RelationManager $livewire): bool => (! $livewire->isReadOnly()) && $livewire->canCreate())
             ->form(fn (Form $form): Form => $this->form($form->columns(2)));
+
+        if (isset($resource) && $resource::hasPage('create')) {
+            $action->url(fn (): string => $resource::getUrl('create'));
+        }
     }
 
     protected function configureDeleteAction(Tables\Actions\DeleteAction $action): void
@@ -236,9 +255,15 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
 
     protected function configureEditAction(Tables\Actions\EditAction $action): void
     {
+        $resource = static::getResource();
+
         $action
             ->authorize(static fn (RelationManager $livewire, Model $record): bool => (! $livewire->isReadOnly()) && $livewire->canEdit($record))
             ->form(fn (Form $form): Form => $this->form($form->columns(2)));
+
+        if (isset($resource) && $resource::hasPage('edit')) {
+            $action->url(fn (Model $record): string => $resource::getUrl('edit', ['record' => $record]));
+        }
     }
 
     protected function configureForceDeleteAction(Tables\Actions\ForceDeleteAction $action): void
@@ -261,10 +286,16 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
 
     protected function configureViewAction(Tables\Actions\ViewAction $action): void
     {
+        $resource = static::getResource();
+
         $action
             ->authorize(static fn (RelationManager $livewire, Model $record): bool => $livewire->canView($record))
             ->infolist(fn (Infolist $infolist): Infolist => $this->infolist($infolist->columns(2)))
             ->form(fn (Form $form): Form => $this->form($form->columns(2)));
+
+        if (isset($resource) && $resource::hasPage('view')) {
+            $action->url(fn (Model $record): string => $resource::getUrl('view', ['record' => $record]));
+        }
     }
 
     protected function configureTableBulkAction(BulkAction $action): void


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

This PR will add the functionality as partially described in https://github.com/filamentphp/filament/discussions/213

It will add the option to link a resource to a relation manager, so view-, edit- and create actions can link to their respective resource pages.

## Functional changes

If the user wants to tie a resource to a relation manager, it can simply be done by defining the $resource variable inside the ResourceManager.

```php
<?php

namespace Filament\Resources\RelationManagers;

class RandomRelationManager extends RelationManager
{
    protected static string $relationship = 'randomRelation';

    protected static ?string $resource = RandomResource::class;
...
```
### Customization per action
If the user for some reason wants to use the modal instead of the page in only one of the actions, it can be specified in the Action::make() command. I first didn't want to add that variable there, but adding it as a function would become confusing, since it cannot be called after the make() function, because it needs to be executed before `$static->configure();` is called.


```php
->actions([
    Tables\Actions\ViewAction::make(), // uses view page if exists on resource
    Tables\Actions\EditAction::make(useModal: true), // uses modal
])
```

Updated Action::make() function:

```php
public static function make(?string $name = null, bool $useModal = false): static
    {
        $static = app(static::class, [
            'name' => $name ?? static::getDefaultName(),
        ]);

        if ($static instanceof MountableAction) {
            $static->preferModal($useModal);
        }

        $static->configure(); // $static->useModel needs to be set before called

        return $static;
    }
```

### Example repository
I've created an example repository of how the PR is supposed to work.
https://github.com/Daniel-H123/filament-example-relationmanager-with-resource

___

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
