### PR TITLE
Fix array_reduce in new groups closure

### DIFF
--- a/packages/tables/src/Table/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Table/Concerns/CanGroupRecords.php
@@ -174,9 +174,9 @@ trait CanGroupRecords
                     $group = Group::make($group);
                 }
 
-                $groups[$group->getId()] = $group;
+                $carry[$group->getId()] = $group;
 
-                return $groups;
+                return $carry;
             },
             initial: [],
         );


### PR DESCRIPTION
Fixes array_reduce to use `$carry` in #13559. It's only returning one group now. 

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
