### PR TITLE
Prevent resetting action record

### DIFF
--- a/packages/actions/src/Concerns/CanOpenModal.php
+++ b/packages/actions/src/Concerns/CanOpenModal.php
@@ -434,7 +434,8 @@ trait CanOpenModal
 
         if (
             ($this instanceof HasRecord) &&
-            ($action instanceof HasRecord)
+            ($action instanceof HasRecord) &&
+            invade($action)->record === null
         ) {
             $action->record($this->getRecord());
         }

--- a/packages/actions/src/Concerns/CanOpenModal.php
+++ b/packages/actions/src/Concerns/CanOpenModal.php
@@ -435,7 +435,7 @@ trait CanOpenModal
         if (
             ($this instanceof HasRecord) &&
             ($action instanceof HasRecord) &&
-            invade($action)->record === null
+            ! $action->hasRecord()
         ) {
             $action->record($this->getRecord());
         }

--- a/packages/actions/src/Concerns/CanOpenModal.php
+++ b/packages/actions/src/Concerns/CanOpenModal.php
@@ -435,7 +435,7 @@ trait CanOpenModal
         if (
             ($this instanceof HasRecord) &&
             ($action instanceof HasRecord) &&
-            ! $action->hasRecord()
+            (! $action->hasRecord())
         ) {
             $action->record($this->getRecord());
         }

--- a/packages/actions/src/Concerns/InteractsWithRecord.php
+++ b/packages/actions/src/Concerns/InteractsWithRecord.php
@@ -131,6 +131,11 @@ trait InteractsWithRecord
         return $this->recordTitleAttribute !== null;
     }
 
+    public function hasRecord(): bool
+    {
+        return $this->record !== null;
+    }
+
     public function getModel(): ?string
     {
         $model = $this->getCustomModel();

--- a/packages/actions/src/Contracts/HasRecord.php
+++ b/packages/actions/src/Contracts/HasRecord.php
@@ -12,4 +12,6 @@ interface HasRecord
     public function getRecord(): ?Model;
 
     public function getRecordTitle(): ?string;
+
+    public function hasRecord(): bool;
 }

--- a/packages/tables/src/Columns/Concerns/HasRecord.php
+++ b/packages/tables/src/Columns/Concerns/HasRecord.php
@@ -19,4 +19,9 @@ trait HasRecord
     {
         return $this->record ?? $this->getLayout()?->getRecord();
     }
+
+    public function hasRecord(): bool
+    {
+        return $this->record !== null;
+    }
 }

--- a/packages/tables/src/Columns/Concerns/HasRecord.php
+++ b/packages/tables/src/Columns/Concerns/HasRecord.php
@@ -19,9 +19,4 @@ trait HasRecord
     {
         return $this->record ?? $this->getLayout()?->getRecord();
     }
-
-    public function hasRecord(): bool
-    {
-        return $this->record !== null;
-    }
 }


### PR DESCRIPTION
## Description

creds: @joshhanley

### Mountable actions:
This PR ensures that, if an action's record is dynamically assigned, it does not revert to its initial value.

## Example
You define a header action to issue refunds on an `InvoiceResource` page.
```php
class ManageInvoice extends ViewRecord

protected function getHeaderActions(): array
{
    return [
        RefundInvoiceAction::make(),
    ];
}
```

You declare additional modal actions where you will need to dynamically assign the record.
```php
Action::make('refundInvoice')
    ->registerModalActions([
        RefundStripePaymentAction::make()->record(see below),
    ])
```

This `$action->record` and its "sub-actions", are by default the `Invoice` model

On the `ManageInvoice` page you loop through the `$invoice->payments` and you pass the `Payment` to the refund action.

```blade
@foreach ($this->record->payments as $payment)
     {{ $action->getModalAction('refundStripePayment')(['payment_id' => $payment->id]) }}
@endforeach
```

You dynamically set the action's record using the passed payment id
```php
RefundStripePaymentAction::make()->record(fn ($arguments) => Payment::findOrFail($arguments['payment_id'])),
```

### Problem
The **prepareModalAction()** reverts the actions record back to the `$invoice`.
```php
public function prepareModalAction(StaticAction $action): StaticAction
{
    //...
    if (
        ($this instanceof HasRecord) &&
        ($action instanceof HasRecord)
    ) {
        $action->record($this->getRecord()); //<-------------------- back to the $invoice again
    }
    //...
}
```

### Fix
This modification ensures that, if an action's record is dynamically assigned, it does not revert to its initial value.
```php
public function prepareModalAction(StaticAction $action): StaticAction
{
    //...
    if (
        ($this instanceof HasRecord) &&
        ($action instanceof HasRecord) &&
        invade($action)->record === null //<------------------------prevent reset
    ) {
        $action->record($this->getRecord());
    }
    //...
}
```

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
