### PR TITLE
Add ide.json for Blade icon autocompletions with Laravel Idea

### DIFF
--- a/ide.json
+++ b/ide.json
@@ -1,8 +1,8 @@
 {
-    "$schema":     "https://laravel-ide.com/schema/laravel-ide-v2.json",
+    "$schema": "https://laravel-ide.com/schema/laravel-ide-v2.json",
     "completions": [
         {
-            "complete":  "bladeIcon",
+            "complete": "bladeIcon",
             "condition": [
                 {
                     "methodNames": [
@@ -22,9 +22,7 @@
                         "groupedIcon",
                         "emptyStateIcon"
                     ],
-                    "parameters":  [
-                        1
-                    ]
+                    "parameters": [1]
                 }
             ]
         }

--- a/ide.json
+++ b/ide.json
@@ -1,0 +1,32 @@
+{
+    "$schema":     "https://laravel-ide.com/schema/laravel-ide-v2.json",
+    "completions": [
+        {
+            "complete":  "bladeIcon",
+            "condition": [
+                {
+                    "methodNames": [
+                        "icon",
+                        "trueIcon",
+                        "falseIcon",
+                        "offIcon",
+                        "onIcon",
+                        "prefixIcon",
+                        "suffixIcon",
+                        "activeIcon",
+                        "completedIcon",
+                        "badgeIcon",
+                        "hintIcon",
+                        "modalIcon",
+                        "descriptionIcon",
+                        "groupedIcon",
+                        "emptyStateIcon"
+                    ],
+                    "parameters":  [
+                        1
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ide.json
+++ b/ide.json
@@ -6,21 +6,21 @@
             "condition": [
                 {
                     "methodNames": [
-                        "icon",
-                        "trueIcon",
+                        "activeIcon",
+                        "badgeIcon",
+                        "completedIcon",
+                        "descriptionIcon",
+                        "emptyStateIcon",
                         "falseIcon",
+                        "groupedIcon",
+                        "hintIcon",
+                        "icon",
+                        "modalIcon",
                         "offIcon",
                         "onIcon",
                         "prefixIcon",
                         "suffixIcon",
-                        "activeIcon",
-                        "completedIcon",
-                        "badgeIcon",
-                        "hintIcon",
-                        "modalIcon",
-                        "descriptionIcon",
-                        "groupedIcon",
-                        "emptyStateIcon"
+                        "trueIcon"
                     ],
                     "parameters": [1]
                 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The Laravel Idea plugin for PhpStorm allows autocompletions to be added at runtime via an [`ide.json` file](https://laravel-idea.com/docs/ide_json/completion).

After seeing [this issue](https://github.com/laravel-idea/plugin/issues/1025) I've added an initial `ide.json` file to Filament, with support for Blade Icon autocompletions in every icon method I could find.

There's lots more opportunities for Filament-specific completions (see the full schema for context), but this is a starting point to build off in future. 

## Visual changes

![Screenshot 2024-07-18 at 16 04 30@2x](https://github.com/user-attachments/assets/bb69d3cf-ce15-44c3-94b3-6a969fbf6170)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
