### PR TITLE
Fix: alpine errors when textarea is in modals

### DIFF
--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -34,6 +34,7 @@
         "
     >
         <textarea
+            x-ignore
             @if (FilamentView::hasSpaMode())
                 ax-load="visible"
             @else


### PR DESCRIPTION
## Description

Resolves #13621 by adding x-ignore to the blade component to prevent alpine from initializing before the alpine component has been loaded.

## Visual changes

none.

## Functional changes

- [ X] Code style has been fixed by running the `composer cs` command.
- [ X] Changes have been tested to not break existing functionality.
- [X ] Documentation is up-to-date.
