### PR TITLE
setRelation on the repeater component model after saving related data

### DIFF
--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -952,7 +952,7 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
                 $existingRecords->push($record);
             }
 
-            $component->getModelInstance()->setRelation($component->getRelationshipName(), $existingRecords);
+            $component->getRecord()->setRelation($component->getRelationshipName(), $existingRecords);
         });
 
         $this->dehydrated(false);

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -894,6 +894,7 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
                 }
 
                 $recordsToDelete[] = $keyToCheckForDeletion;
+                $existingRecords->forget("record-{$keyToCheckForDeletion}");
             }
 
             $relationship
@@ -948,7 +949,10 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
 
                 $record = $relationship->save($record);
                 $item->model($record)->saveRelationships();
+                $existingRecords->push($record);
             }
+
+            $component->getModelInstance()->setRelation($component->getRelationshipName(), $existingRecords);
         });
 
         $this->dehydrated(false);


### PR DESCRIPTION
## Description

This pull request attempts to fix #13633 when the model eager loads its repeater relationships with the `$with` attribute, by setting the deleted / added existingRecords of a repeater directly on the component's model relationship.

## Visual changes

Before:


https://github.com/user-attachments/assets/27cf4fe2-fb7c-4603-b38a-67529bb483d0



After:


https://github.com/user-attachments/assets/cde82be6-4a83-4f27-a4b9-2b5c06b61b6d


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
