### PR TITLE
Allowing $get() to get full array of current path

### DIFF
--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -475,7 +475,7 @@ You are trying to retrieve the value of `client_id` from inside the repeater ite
 
 You can use `../` to go up a level in the data structure, so `$get('../client_id')` is `$get('repeater.client_id')` and `$get('../../client_id')` is `$get('client_id')`.
 
-The special case of `$get()` with no arguments, or `$get('')` or `$get('./')`, will always return the full data array for the current path.
+The special case of `$get()` with no arguments, or `$get('')` or `$get('./')`, will always return the full data array for the current repeater item.
 
 ## Repeater validation
 

--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -475,6 +475,8 @@ You are trying to retrieve the value of `client_id` from inside the repeater ite
 
 You can use `../` to go up a level in the data structure, so `$get('../client_id')` is `$get('repeater.client_id')` and `$get('../../client_id')` is `$get('client_id')`.
 
+The special case of `$get()` with no arguments, or `$get('')` or `$get('./')`, will always return the full data array for the current path.
+
 ## Repeater validation
 
 As well as all rules listed on the [validation](../validation) page, there are additional rules that are specific to repeaters.

--- a/packages/forms/docs/03-fields/13-builder.md
+++ b/packages/forms/docs/03-fields/13-builder.md
@@ -396,7 +396,7 @@ You are trying to retrieve the value of `client_id` from inside the builder item
 
 You can use `../` to go up a level in the data structure, so `$get('../client_id')` is `$get('builder.client_id')` and `$get('../../client_id')` is `$get('client_id')`.
 
-The special case of `$get()` with no arguments, or `$get('')` or `$get('./')`, will always return the full data array for the current path.
+The special case of `$get()` with no arguments, or `$get('')` or `$get('./')`, will always return the full data array for the current builder item.
 
 ## Customizing the builder item actions
 

--- a/packages/forms/docs/03-fields/13-builder.md
+++ b/packages/forms/docs/03-fields/13-builder.md
@@ -368,6 +368,55 @@ Builder::make('content')
     ->maxItems(5)
 ```
 
+## Using `$get()` to access parent field values
+
+All form components are able to [use `$get()` and `$set()`](../advanced) to access another field's value. However, you might experience unexpected behavior when using this inside the builder's schema.
+
+This is because `$get()` and `$set()`, by default, are scoped to the current builder item. This means that you are able to interact with another field inside that builder item easily without knowing which builder item the current form component belongs to.
+
+The consequence of this is that you may be confused when you are unable to interact with a field outside the builder. We use `../` syntax to solve this problem - `$get('../../parent_field_name')`.
+
+Consider your form has this data structure:
+
+```php
+[
+    'client_id' => 1,
+
+    'builder' => [
+        'item1' => [
+            'service_id' => 2,
+        ],
+    ],
+]
+```
+
+You are trying to retrieve the value of `client_id` from inside the builder item.
+
+`$get()` is relative to the current builder item, so `$get('client_id')` is looking for `$get('builder.item1.client_id')`.
+
+You can use `../` to go up a level in the data structure, so `$get('../client_id')` is `$get('builder.client_id')` and `$get('../../client_id')` is `$get('client_id')`.
+
+The special case of `$get()` with no arguments, or `$get('')` or `$get('./')`, will always return the full data array for the current path.
+
+## Builder validation
+
+As well as all rules listed on the [validation](../validation) page, there are additional rules that are specific to builders.
+
+### Number of items validation
+
+You can validate the minimum and maximum number of items that you can have in a builder by setting the `minItems()` and `maxItems()` methods:
+
+```php
+use Filament\Forms\Components\Builder;
+
+Builder::make('content')
+    ->blocks([
+        // ...
+    ])
+    ->minItems(1)
+    ->maxItems(5)
+```
+
 ## Customizing the builder item actions
 
 This field uses action objects for easy customization of buttons within it. You can customize these buttons by passing a function to an action registration method. The function has access to the `$action` object, which you can use to [customize it](../../actions/trigger-button). The following methods are available to customize the actions:

--- a/packages/forms/docs/03-fields/13-builder.md
+++ b/packages/forms/docs/03-fields/13-builder.md
@@ -398,25 +398,6 @@ You can use `../` to go up a level in the data structure, so `$get('../client_id
 
 The special case of `$get()` with no arguments, or `$get('')` or `$get('./')`, will always return the full data array for the current path.
 
-## Builder validation
-
-As well as all rules listed on the [validation](../validation) page, there are additional rules that are specific to builders.
-
-### Number of items validation
-
-You can validate the minimum and maximum number of items that you can have in a builder by setting the `minItems()` and `maxItems()` methods:
-
-```php
-use Filament\Forms\Components\Builder;
-
-Builder::make('content')
-    ->blocks([
-        // ...
-    ])
-    ->minItems(1)
-    ->maxItems(5)
-```
-
 ## Customizing the builder item actions
 
 This field uses action objects for easy customization of buttons within it. You can customize these buttons by passing a function to an action registration method. The function has access to the `$action` object, which you can use to [customize it](../../actions/trigger-button). The following methods are available to customize the actions:

--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -465,7 +465,7 @@ trait HasState
         return new Set($this);
     }
 
-    public function generateRelativeStatePath(string | Component $path, bool $isAbsolute = false): string
+    public function generateRelativeStatePath(string | Component $path = '', bool $isAbsolute = false): string
     {
         if ($path instanceof Component) {
             return $path->getStatePath();
@@ -489,7 +489,7 @@ trait HasState
             return $path;
         }
 
-        return "{$containerPath}.{$path}";
+        return filled(ltrim($path, './')) ? "{$containerPath}.{$path}" : $containerPath;
     }
 
     protected function flushCachedAbsoluteStatePath(): void

--- a/packages/forms/src/Get.php
+++ b/packages/forms/src/Get.php
@@ -10,7 +10,7 @@ class Get
         protected Component $component,
     ) {}
 
-    public function __invoke(string | Component $path, bool $isAbsolute = false): mixed
+    public function __invoke(string | Component $path = '', bool $isAbsolute = false): mixed
     {
         $livewire = $this->component->getLivewire();
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Allow $get() with no args, or $get('') or $get('./'), to return the entire data array for the current path.  This is particularly useful when dealing with repeaters or builders.

Note that this was discussed with Dan in another version of this PR that I closed because I somehow managed to completely screw it up with a bunch of extraneous commits.

Also note that this usage it not restricted to repeaters, it'll always return the data array for the current path regardless, I just couldn't find anywhere else to document the changes, so the documentation is in the repeater / builder sections.

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
