### PR TITLE
docs: add table column date tooltip

### DIFF
--- a/packages/infolists/docs/03-entries/02-text.md
+++ b/packages/infolists/docs/03-entries/02-text.md
@@ -56,6 +56,16 @@ TextEntry::make('created_at')
     ->since()
 ```
 
+Additionally, you can use the `dateTooltip()`, `dateTimeTooltip()` or `timeTooltip()` method to display a formatted date in a tooltip, often to provide extra information:
+
+```php
+use Filament\Infolists\Components\TextEntry;
+
+TextEntry::make('created_at')
+    ->since()
+    ->dateTimeTooltip()
+```
+
 ## Number formatting
 
 The `numeric()` method allows you to format an entry as a number:

--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -82,12 +82,13 @@ TextColumn::make('created_at')
     ->since()
 ```
 
-Additionally, you can use the `dateTooltip()`, `dateTimeTooltip()` OR `timeTooltip()` method to display the formatted date in a tooltip:
+Additionally, you can use the `dateTooltip()`, `dateTimeTooltip()` or `timeTooltip()` method to display a formatted date in a tooltip, often to provide extra information:
 
 ```php
 use Filament\Tables\Columns\TextColumn;
 
 TextColumn::make('created_at')
+    ->since()
     ->dateTimeTooltip()
 ```
 

--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -82,6 +82,15 @@ TextColumn::make('created_at')
     ->since()
 ```
 
+You may use the `dateTooltip()` OR `dateTimeTooltip()` method to add a tooltip to display the date in a tooltip:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('created_at')
+    ->dateTimeTooltip()
+```
+
 ## Number formatting
 
 The `numeric()` method allows you to format an entry as a number:

--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -82,7 +82,7 @@ TextColumn::make('created_at')
     ->since()
 ```
 
-You may use the `dateTooltip()` OR `dateTimeTooltip()` method to add a tooltip to display the date in a tooltip:
+Additionally, you can use the `dateTooltip()`, `dateTimeTooltip()` OR `timeTooltip()` method to display the formatted date in a tooltip:
 
 ```php
 use Filament\Tables\Columns\TextColumn;

--- a/packages/widgets/resources/js/components/stats-overview/stat/chart.js
+++ b/packages/widgets/resources/js/components/stats-overview/stat/chart.js
@@ -41,7 +41,6 @@ export default function statsOverviewStatChart({
         },
 
         initChart: function () {
-
             return new Chart(this.$refs.canvas, {
                 type: 'line',
                 data: {
@@ -52,12 +51,12 @@ export default function statsOverviewStatChart({
                             borderWidth: 2,
                             fill: 'start',
                             tension: 0.5,
-                            backgroundColor : getComputedStyle(
+                            backgroundColor: getComputedStyle(
                                 this.$refs.backgroundColorElement,
                             ).color,
-                            borderColor : getComputedStyle(
+                            borderColor: getComputedStyle(
                                 this.$refs.borderColorElement,
-                            ).color
+                            ).color,
                         },
                     ],
                 },


### PR DESCRIPTION
Found this when code diving and realised it was missing from the docs.

```php
Tables\Columns\TextColumn::make('updated_at')
    ->since()
    ->dateTimeTooltip()
```