### PR TITLE
fix:  fixed translation for e-mail in norwegian

### DIFF
--- a/packages/panels/resources/lang/no/pages/auth/login.php
+++ b/packages/panels/resources/lang/no/pages/auth/login.php
@@ -22,7 +22,7 @@ return [
     'form' => [
 
         'email' => [
-            'label' => 'E-postedresse',
+            'label' => 'E-postadresse',
         ],
 
         'password' => [


### PR DESCRIPTION
## Description

Fixed a typo in the translation for "E-mail" in Norwegian

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
