### PR TITLE
Add font weight to filament::link component

### DIFF
--- a/packages/support/docs/09-blade-components/02-link.md
+++ b/packages/support/docs/09-blade-components/02-link.md
@@ -64,6 +64,10 @@ By default, the font weight of links is `semibold`. You can make it `thin`, `ext
     New user
 </x-filament::link>
 
+<x-filament::link weight="normal">
+    New user
+</x-filament::link>
+
 <x-filament::link weight="medium">
     New user
 </x-filament::link>

--- a/packages/support/docs/09-blade-components/02-link.md
+++ b/packages/support/docs/09-blade-components/02-link.md
@@ -49,7 +49,7 @@ By default, the size of a link is "medium". You can make it "small", "large", "e
 
 ## Setting the font weight of a link
 
-By default, the font weight of a link is "semi-bold". You can make it "thin", "light", "medium", "semibold", "bold" or "black" by using the `weight` attribute:
+By default, the font weight of links is `semibold`. You can make it `thin`, `extralight`, `light`, `normal`, `medium`, `bold`, `extrabold` or `black` by using the `weight` attribute:
 
 ```blade
 <x-filament::link weight="thin">
@@ -81,7 +81,7 @@ By default, the font weight of a link is "semi-bold". You can make it "thin", "l
 </x-filament::link> 
 ```
 
-Or enter a custom weight
+Alternatively, you can pass in a custom CSS class to define the weight:
 
 ```blade
 <x-filament::link weight="md:font-[650]">

--- a/packages/support/docs/09-blade-components/02-link.md
+++ b/packages/support/docs/09-blade-components/02-link.md
@@ -47,6 +47,48 @@ By default, the size of a link is "medium". You can make it "small", "large", "e
 </x-filament::link>
 ```
 
+## Setting the font weight of a link
+
+By default, the font weight of a link is "semi-bold". You can make it "thin", "light", "medium", "semibold", "bold" or "black" by using the `weight` attribute:
+
+```blade
+<x-filament::link weight="thin">
+    New user
+</x-filament::link>
+
+<x-filament::link weight="extralight">
+    New user
+</x-filament::link>
+
+<x-filament::link weight="light">
+    New user
+</x-filament::link>
+
+<x-filament::link weight="medium">
+    New user
+</x-filament::link>
+
+<x-filament::link weight="semibold">
+    New user
+</x-filament::link>
+   
+<x-filament::link weight="bold">
+    New user
+</x-filament::link>
+
+<x-filament::link weight="black">
+    New user
+</x-filament::link> 
+```
+
+Or enter a custom weight
+
+```blade
+<x-filament::link weight="md:font-[650]">
+    New user
+</x-filament::link>
+```
+
 ## Changing the color of a link
 
 By default, the color of a link is "primary". You can change it to be `danger`, `gray`, `info`, `success` or `warning` by using the `color` attribute:

--- a/packages/support/resources/views/components/link.blade.php
+++ b/packages/support/resources/views/components/link.blade.php
@@ -1,5 +1,6 @@
 @php
     use Filament\Support\Enums\ActionSize;
+    use Filament\Support\Enums\FontWeight;
     use Filament\Support\Enums\IconPosition;
     use Filament\Support\Enums\IconSize;
 @endphp
@@ -26,6 +27,7 @@
     'target' => null,
     'tooltip' => null,
     'type' => 'button',
+    'weight' => 'font-semibold',
 ])
 
 @php
@@ -67,22 +69,36 @@
         is_string($color) ? "fi-color-{$color}" : null,
     ]);
 
-    $labelClasses = \Illuminate\Support\Arr::toCssClasses([
-        'font-semibold group-hover/link:underline group-focus-visible/link:underline' => ! $labelSrOnly,
-        match ($size) {
-            ActionSize::ExtraSmall => 'text-xs',
-            ActionSize::Small => 'text-sm',
-            ActionSize::Medium => 'text-sm',
-            ActionSize::Large => 'text-sm',
-            ActionSize::ExtraLarge => 'text-sm',
-            default => null,
-        } => ! $labelSrOnly,
-        match ($color) {
-            'gray' => 'text-gray-700 dark:text-gray-200',
-            default => 'text-custom-600 dark:text-custom-400',
-        } => ! $labelSrOnly,
-        'sr-only' => $labelSrOnly,
-    ]);
+    if ($labelSrOnly) {
+        $labelClasses = 'sr-only';
+    } else {
+        $labelClasses = \Illuminate\Support\Arr::toCssClasses([
+            match ($weight) {
+                FontWeight::Thin, 'thin' => 'font-thin',
+                FontWeight::ExtraLight, 'extralight' => 'font-extralight',
+                FontWeight::Light, 'light' => 'font-light',
+                FontWeight::Medium, 'medium' => 'font-medium',
+                FontWeight::SemiBold, 'semibold' => 'font-semibold',
+                FontWeight::Bold, 'bold' => 'font-bold',
+                FontWeight::ExtraBold, 'extrabold' => 'font-extrabold',
+                FontWeight::Black, 'black' => 'font-black',
+                default => $weight,
+            },
+            match ($size) {
+                ActionSize::ExtraSmall => 'text-xs',
+                ActionSize::Small => 'text-sm',
+                ActionSize::Medium => 'text-sm',
+                ActionSize::Large => 'text-sm',
+                ActionSize::ExtraLarge => 'text-sm',
+                default => null,
+            },
+            match ($color) {
+                'gray' => 'text-gray-700 dark:text-gray-200',
+                default => 'text-custom-600 dark:text-custom-400',
+            },
+            'group-hover/link:underline group-focus-visible/link:underline',
+        ]);
+    }
 
     $labelStyles = \Illuminate\Support\Arr::toCssStyles([
         \Filament\Support\get_color_css_variables(

--- a/packages/support/resources/views/components/link.blade.php
+++ b/packages/support/resources/views/components/link.blade.php
@@ -27,7 +27,7 @@
     'target' => null,
     'tooltip' => null,
     'type' => 'button',
-    'weight' => 'font-semibold',
+    'weight' => FontWeight::SemiBold,
 ])
 
 @php

--- a/packages/support/resources/views/components/link.blade.php
+++ b/packages/support/resources/views/components/link.blade.php
@@ -69,15 +69,14 @@
         is_string($color) ? "fi-color-{$color}" : null,
     ]);
 
-    if ($labelSrOnly) {
-        $labelClasses = 'sr-only';
-    } else {
+    if (! $labelSrOnly) {
         $labelClasses = \Illuminate\Support\Arr::toCssClasses([
             match ($weight) {
                 FontWeight::Thin, 'thin' => 'font-thin',
                 FontWeight::ExtraLight, 'extralight' => 'font-extralight',
                 FontWeight::Light, 'light' => 'font-light',
                 FontWeight::Medium, 'medium' => 'font-medium',
+                FontWeight::Normal, 'normal' => 'font-normal',
                 FontWeight::SemiBold, 'semibold' => 'font-semibold',
                 FontWeight::Bold, 'bold' => 'font-bold',
                 FontWeight::ExtraBold, 'extrabold' => 'font-extrabold',
@@ -98,6 +97,8 @@
             },
             'group-hover/link:underline group-focus-visible/link:underline',
         ]);
+    } else {
+        $labelClasses = 'sr-only';
     }
 
     $labelStyles = \Illuminate\Support\Arr::toCssStyles([

--- a/packages/support/src/Enums/FontWeight.php
+++ b/packages/support/src/Enums/FontWeight.php
@@ -10,6 +10,8 @@ enum FontWeight
 
     case Light;
 
+    case Normal;
+
     case Medium;
 
     case SemiBold;


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Allow link components weight to be changed. Currently it's semibold without a way of changing this. 

```blade
<x-filament::link weight="medium">
    New user
</x-filament::link>
```

Also simplified the `sr-only` for label class.

## Visual changes
<img width="88" alt="Screenshot 2024-07-22 at 17 52 04" src="https://github.com/user-attachments/assets/9485b2a0-f637-4899-ac28-447272980326">

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
