### PR TITLE
Fix replicate action not filling form data

### DIFF
--- a/packages/actions/src/Concerns/CanReplicateRecords.php
+++ b/packages/actions/src/Concerns/CanReplicateRecords.php
@@ -48,8 +48,10 @@ trait CanReplicateRecords
         });
 
         $this->action(function () {
-            $result = $this->process(function (Model $record) {
+            $result = $this->process(function (array $data, Model $record) {
                 $this->replica = $record->replicate($this->getExcludedAttributes());
+
+                $this->replica->fill($data);
 
                 $this->callBeforeReplicaSaved();
 

--- a/packages/widgets/resources/js/components/stats-overview/stat/chart.js
+++ b/packages/widgets/resources/js/components/stats-overview/stat/chart.js
@@ -41,7 +41,6 @@ export default function statsOverviewStatChart({
         },
 
         initChart: function () {
-
             return new Chart(this.$refs.canvas, {
                 type: 'line',
                 data: {
@@ -52,12 +51,12 @@ export default function statsOverviewStatChart({
                             borderWidth: 2,
                             fill: 'start',
                             tension: 0.5,
-                            backgroundColor : getComputedStyle(
+                            backgroundColor: getComputedStyle(
                                 this.$refs.backgroundColorElement,
                             ).color,
-                            borderColor : getComputedStyle(
+                            borderColor: getComputedStyle(
                                 this.$refs.borderColorElement,
-                            ).color
+                            ).color,
                         },
                     ],
                 },

--- a/tests/src/Tables/Actions/ActionTest.php
+++ b/tests/src/Tables/Actions/ActionTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 
 use function Filament\Tests\livewire;
 use function Pest\Laravel\assertSoftDeleted;
+use function Pest\Laravel\assertDatabaseHas;
 
 uses(TestCase::class);
 
@@ -138,4 +139,18 @@ it('can state whether a table action exists with a given configuration', functio
     livewire(PostsTable::class)
         ->assertTableActionExists('attachMultiple', fn (AttachAction $action) => $action->isMultiple())
         ->assertTableActionDoesNotExist(AttachAction::class, fn (AttachAction $action) => $action->isMultiple());
+});
+
+it('can replicate a record', function () {
+    $post = Post::factory()->create();
+
+    livewire(PostsTable::class)
+        ->assertTableActionExists('replicate')
+        ->callTableAction('replicate', $post)
+        ->callMountedTableAction()
+        ->assertHasNoTableActionErrors();
+
+    assertDatabaseHas('posts', [
+        'title' => $post->title . ' (Copy)',
+    ]);
 });

--- a/tests/src/Tables/Actions/ActionTest.php
+++ b/tests/src/Tables/Actions/ActionTest.php
@@ -8,8 +8,8 @@ use Filament\Tests\Tables\TestCase;
 use Illuminate\Support\Str;
 
 use function Filament\Tests\livewire;
-use function Pest\Laravel\assertSoftDeleted;
 use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\assertSoftDeleted;
 
 uses(TestCase::class);
 

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -159,6 +159,17 @@ class PostsTable extends Component implements HasForms, Tables\Contracts\HasTabl
                 Tables\Actions\DeleteAction::make(),
                 Tables\Actions\ForceDeleteAction::make(),
                 Tables\Actions\RestoreAction::make(),
+                Tables\Actions\ReplicateAction::make()
+                    ->mutateRecordDataUsing(function (array $data): array {
+                        $data['title'] = $data['title'] . ' (Copy)';
+
+                        return $data;
+                    })
+                    ->form([
+                        TextInput::make('title')
+                            ->required()
+                            ->unique(),
+                    ]),
                 Tables\Actions\ActionGroup::make([
                     Tables\Actions\DeleteAction::make('groupedDelete'),
                     Tables\Actions\ForceDeleteAction::make('groupedForceDelete'),

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -167,7 +167,7 @@ class PostsTable extends Component implements HasForms, Tables\Contracts\HasTabl
                     })
                     ->form([
                         TextInput::make('title')
-                            ->required()
+                            ->required(),
                     ]),
                 Tables\Actions\ActionGroup::make([
                     Tables\Actions\DeleteAction::make('groupedDelete'),

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -168,7 +168,6 @@ class PostsTable extends Component implements HasForms, Tables\Contracts\HasTabl
                     ->form([
                         TextInput::make('title')
                             ->required()
-                            ->unique(),
                     ]),
                 Tables\Actions\ActionGroup::make([
                     Tables\Actions\DeleteAction::make('groupedDelete'),


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
The form data was not being saved when replicating a record.
```php
Tables\Actions\ReplicateAction::make()
    ->form([
        TextInput::make('name')
    ])
```

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
