### PR TITLE
Show tooltip for disabled action button

### DIFF
--- a/packages/actions/resources/views/components/action.blade.php
+++ b/packages/actions/resources/views/components/action.blade.php
@@ -7,31 +7,35 @@
 @php
     $isDisabled = $action->isDisabled();
     $url = $action->getUrl();
+    $tooltip = $action->getTooltip();
+    $tooltipIsNotEmpty = str($tooltip)->isNotEmpty();
 @endphp
 
-<x-dynamic-component
-    :color="$action->getColor()"
-    :component="$dynamicComponent"
-    :disabled="$isDisabled"
-    :form="$action->getFormToSubmit()"
-    :form-id="$action->getFormId()"
-    :href="$isDisabled ? null : $url"
-    :icon="$icon ?? $action->getIcon()"
-    :icon-size="$action->getIconSize()"
-    :key-bindings="$action->getKeyBindings()"
-    :label-sr-only="$action->isLabelHidden()"
-    :tag="$url ? 'a' : 'button'"
-    :target="($url && $action->shouldOpenUrlInNewTab()) ? '_blank' : null"
-    :tooltip="$action->getTooltip()"
-    :type="$action->canSubmitForm() ? 'submit' : 'button'"
-    :wire:click="$action->getLivewireClickHandler()"
-    :wire:target="$action->getLivewireTarget()"
-    :x-on:click="$action->getAlpineClickHandler()"
-    :attributes="
-        \Filament\Support\prepare_inherited_attributes($attributes)
-            ->merge($action->getExtraAttributes(), escape: false)
-            ->class(['fi-ac-action'])
-    "
->
-    {{ $slot }}
-</x-dynamic-component>
+@if ($tooltipIsNotEmpty) <div x-data x-tooltip.raw="{{ $tooltip }}"> @endif
+    <x-dynamic-component
+        :color="$action->getColor()"
+        :component="$dynamicComponent"
+        :disabled="$isDisabled"
+        :form="$action->getFormToSubmit()"
+        :form-id="$action->getFormId()"
+        :href="$isDisabled ? null : $url"
+        :icon="$icon ?? $action->getIcon()"
+        :icon-size="$action->getIconSize()"
+        :key-bindings="$action->getKeyBindings()"
+        :label-sr-only="$action->isLabelHidden()"
+        :tag="$url ? 'a' : 'button'"
+        :target="($url && $action->shouldOpenUrlInNewTab()) ? '_blank' : null"
+        :tooltip="$tooltip"
+        :type="$action->canSubmitForm() ? 'submit' : 'button'"
+        :wire:click="$action->getLivewireClickHandler()"
+        :wire:target="$action->getLivewireTarget()"
+        :x-on:click="$action->getAlpineClickHandler()"
+        :attributes="
+            \Filament\Support\prepare_inherited_attributes($attributes)
+                ->merge($action->getExtraAttributes(), escape: false)
+                ->class(['fi-ac-action'])
+        "
+    >
+        {{ $slot }}
+    </x-dynamic-component>
+@if ($tooltipIsNotEmpty) </div> @endif

--- a/packages/actions/resources/views/components/action.blade.php
+++ b/packages/actions/resources/views/components/action.blade.php
@@ -25,7 +25,6 @@
         :label-sr-only="$action->isLabelHidden()"
         :tag="$url ? 'a' : 'button'"
         :target="($url && $action->shouldOpenUrlInNewTab()) ? '_blank' : null"
-        :tooltip="$tooltip"
         :type="$action->canSubmitForm() ? 'submit' : 'button'"
         :wire:click="$action->getLivewireClickHandler()"
         :wire:target="$action->getLivewireTarget()"

--- a/packages/actions/resources/views/components/action.blade.php
+++ b/packages/actions/resources/views/components/action.blade.php
@@ -9,9 +9,10 @@
     $url = $action->getUrl();
     $tooltip = $action->getTooltip();
     $tooltipIsNotEmpty = str($tooltip)->isNotEmpty();
+    $icon = $icon ?? $action->getIcon();
 @endphp
 
-@if ($tooltipIsNotEmpty) <div x-data x-tooltip.raw="{{ $tooltip }}" class="flex"> @endif
+@if ($tooltipIsNotEmpty) <div x-data x-tooltip.raw="{{ $tooltip }}" @class(['flex', 'items-center justify-center -m-2 h-9 w-9' => str($icon)->isNotEmpty() && $action->isIconButton()])> @endif
     <x-dynamic-component
         :color="$action->getColor()"
         :component="$dynamicComponent"
@@ -19,7 +20,7 @@
         :form="$action->getFormToSubmit()"
         :form-id="$action->getFormId()"
         :href="$isDisabled ? null : $url"
-        :icon="$icon ?? $action->getIcon()"
+        :icon="$icon"
         :icon-size="$action->getIconSize()"
         :key-bindings="$action->getKeyBindings()"
         :label-sr-only="$action->isLabelHidden()"
@@ -32,7 +33,7 @@
         :attributes="
             \Filament\Support\prepare_inherited_attributes($attributes)
                 ->merge($action->getExtraAttributes(), escape: false)
-                ->class(['fi-ac-action flex-1'])
+                ->class(['fi-ac-action', 'flex-1' => $tooltipIsNotEmpty])
         "
     >
         {{ $slot }}

--- a/packages/actions/resources/views/components/action.blade.php
+++ b/packages/actions/resources/views/components/action.blade.php
@@ -11,7 +11,7 @@
     $tooltipIsNotEmpty = str($tooltip)->isNotEmpty();
 @endphp
 
-@if ($tooltipIsNotEmpty) <div x-data x-tooltip.raw="{{ $tooltip }}"> @endif
+@if ($tooltipIsNotEmpty) <div x-data x-tooltip.raw="{{ $tooltip }}" class="flex"> @endif
     <x-dynamic-component
         :color="$action->getColor()"
         :component="$dynamicComponent"
@@ -32,7 +32,7 @@
         :attributes="
             \Filament\Support\prepare_inherited_attributes($attributes)
                 ->merge($action->getExtraAttributes(), escape: false)
-                ->class(['fi-ac-action'])
+                ->class(['fi-ac-action flex-1'])
         "
     >
         {{ $slot }}


### PR DESCRIPTION
## Description

We would like to show a tooltip on a disabled action button to explain why that button is disabled. https://github.com/filamentphp/filament/discussions/4271

One thing to note is that this change might be an unexpected behavior for developers who previously had tooltips configured to display only when actions were enabled. We should consider mentioning this update in the `What's Changed` section of the release notes to avoid confusion.

## Visual changes

If the action has a tooltip, despite being disabled, the tooltip will be shown.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
