### PR TITLE
Update 13-builder.md rename view path

### DIFF
--- a/packages/forms/docs/03-fields/13-builder.md
+++ b/packages/forms/docs/03-fields/13-builder.md
@@ -495,11 +495,11 @@ Builder::make('content')
                 TextInput::make('text')
                     ->placeholder('Default heading'),
             ])
-            ->preview('filament.content.blocks-previews.heading'),
+            ->preview('filament.content.block-previews.heading'),
     ])
 ```
 
-In `/resources/views/filament/content/blocks-previews/heading.blade.php`, you can access the block data like so:
+In `/resources/views/filament/content/block-previews/heading.blade.php`, you can access the block data like so:
 
 ```blade
 <h1>

--- a/packages/forms/docs/03-fields/13-builder.md
+++ b/packages/forms/docs/03-fields/13-builder.md
@@ -499,7 +499,7 @@ Builder::make('content')
     ])
 ```
 
-In `/resources/views/filament/content/block-previews/heading.blade.php`, you can access the block data like so:
+In `/resources/views/filament/content/blocks-previews/heading.blade.php`, you can access the block data like so:
 
 ```blade
 <h1>


### PR DESCRIPTION
The path used in preview method is not same as the resource path.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

There is incorrect path in documentation.

## Visual changes

<img width="1440" alt="Screenshot 2024-07-24 at 11 06 15 AM" src="https://github.com/user-attachments/assets/e0e79551-5050-43ae-934b-d4b19f18772e">

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
