### PR TITLE
Add prefix and suffix to table summaries

### DIFF
--- a/packages/tables/docs/07-summaries.md
+++ b/packages/tables/docs/07-summaries.md
@@ -315,6 +315,22 @@ TextColumn::make('sku')
     ->summarize(Range::make()->limit(5))
 ```
 
+### Adding a prefix or suffix
+
+You may add a prefix or suffix to the summary's value:
+
+```php
+use Filament\Tables\Columns\Summarizers\Sum;
+use Filament\Tables\Columns\TextColumn;
+use Illuminate\Support\HtmlString;
+
+TextColumn::make('volume')
+    ->summarize(Sum::make()
+        ->prefix('Total volume: ')
+        ->suffix(new HtmlString(' m&sup3;'))
+    )
+```
+
 ## Custom summaries
 
 You may create a custom summary by returning the value from the `using()` method:

--- a/packages/tables/src/Columns/Summarizers/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Summarizers/Concerns/CanFormatState.php
@@ -6,6 +6,8 @@ use Closure;
 use Filament\Support\Enums\ArgumentValue;
 use Filament\Tables\Columns\Summarizers\Summarizer;
 use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Number;
 use Illuminate\Support\Str;
 
@@ -14,6 +16,14 @@ trait CanFormatState
     protected ?Closure $formatStateUsing = null;
 
     protected string | Closure | null $placeholder = null;
+
+    protected string | Htmlable | Closure | null $prefix = null;
+
+    protected string | Htmlable | Closure | null $suffix = null;
+
+    protected bool | Closure $isHtml = false;
+
+    protected bool | Closure $isMarkdown = false;
 
     public function formatStateUsing(?Closure $callback): static
     {
@@ -101,16 +111,110 @@ trait CanFormatState
         return $this;
     }
 
+    public function markdown(bool | Closure $condition = true): static
+    {
+        $this->isMarkdown = $condition;
+
+        return $this;
+    }
+
+    public function prefix(string | Htmlable | Closure | null $prefix): static
+    {
+        $this->prefix = $prefix;
+
+        return $this;
+    }
+
+    public function suffix(string | Htmlable | Closure | null $suffix): static
+    {
+        $this->suffix = $suffix;
+
+        return $this;
+    }
+
+    public function html(bool | Closure $condition = true): static
+    {
+        $this->isHtml = $condition;
+
+        return $this;
+    }
+
     public function formatState(mixed $state): mixed
     {
+        $isHtml = $this->isHtml();
+
         $state = $this->evaluate($this->formatStateUsing ?? $state, [
             'state' => $state,
         ]);
+
+        if ($isHtml) {
+            $state = Str::sanitizeHtml($state);
+        }
+
+        if ($state instanceof Htmlable) {
+            $isHtml = true;
+            $state = $state->toHtml();
+        }
+
+        if ($isHtml && $this->isMarkdown()) {
+            $state = Str::markdown($state);
+        }
+
+        $prefix = $this->getPrefix();
+        $suffix = $this->getSuffix();
+
+        if (
+            (($prefix instanceof Htmlable) || ($suffix instanceof Htmlable)) &&
+            (! $isHtml)
+        ) {
+            $isHtml = true;
+            $state = e($state);
+        }
+
+        if (filled($prefix)) {
+            if ($prefix instanceof Htmlable) {
+                $prefix = $prefix->toHtml();
+            } elseif ($isHtml) {
+                $prefix = e($prefix);
+            }
+
+            $state = $prefix . $state;
+        }
+
+        if (filled($suffix)) {
+            if ($suffix instanceof Htmlable) {
+                $suffix = $suffix->toHtml();
+            } elseif ($isHtml) {
+                $suffix = e($suffix);
+            }
+
+            $state = $state . $suffix;
+        }
 
         if (blank($state)) {
             $state = $this->evaluate($this->placeholder);
         }
 
-        return $state;
+        return $isHtml ? new HtmlString($state) : $state;
+    }
+
+    public function isHtml(): bool
+    {
+        return $this->evaluate($this->isHtml) || $this->isMarkdown();
+    }
+
+    public function getPrefix(): string | Htmlable | null
+    {
+        return $this->evaluate($this->prefix);
+    }
+
+    public function getSuffix(): string | Htmlable | null
+    {
+        return $this->evaluate($this->suffix);
+    }
+
+    public function isMarkdown(): bool
+    {
+        return (bool) $this->evaluate($this->isMarkdown);
     }
 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Adds functionality to add prefix and suffix to summaries. Closes discussion #12762.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->
Before:
![image](https://github.com/user-attachments/assets/1af3e86f-1a19-4801-aaf7-12ca9270336f)

```php
TextColumn::make('volume')
    ->summarize(Sum::make()
        ->prefix('Total volume: ')
        ->suffix(new HtmlString(' m&sup3;'))
    )
```

After:
![image](https://github.com/user-attachments/assets/14daaeae-dc3e-4913-ac1f-7f31ea602879)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
