### PR TITLE
accept `float` (decimal values) directly in `multipleOf()` rule helper

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -242,7 +242,7 @@ trait CanBeValidated
         return $this;
     }
 
-    public function multipleOf(int | Closure $value): static
+    public function multipleOf(int | float | Closure $value): static
     {
         $this->rule(static function (Field $component) use ($value) {
             return 'multiple_of:' . $component->evaluate($value);


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

In Laravel, the `multipleOf()` [validation rule](https://laravel.com/docs/10.x/validation#rule-multiple-of) accepts integers or decimals. Proper handling decimal values was addressed specifically in a [Laravel framework PR](https://github.com/laravel/framework/pull/34971) after being brought up [as a separate issue](https://github.com/laravel/framework/issues/34960).

In Filament, the current signature of `multipleOf()` accepts either `int` or `Closure`:
```php
public function multipleOf(int | Closure $value): static
{
    $this->rule(static function (Field $component) use ($value) {
        return 'multiple_of:' . $component->evaluate($value);
    }, static fn (Field $component): bool => filled($component->evaluate($value)));

    return $this;
}
```
Strictly speaking, this doesn't preclude us from using decimal values here, but doing so requires a `Closure`:
```php
->multipleOf(fn() => 0.5)
```
Another workaround would be using `rules()`:
```php
->rules('multiple_of:0.5')
```
Either of these work just fine by proxying down to the Laravel rule, which validates as expected. Therefore, I am proposing that we also accept `float` into the `multipleOf()` helper method. Doing so would preclude the need to work around the issue as above, and also adhere to the way that a developer would be expect to be able to use this helper.

## Visual changes

No visual changes included in this PR.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

No tests currently cover this method, therefore none need modifying.
No documentation currently covers this method in that level of detail, nor do I feel it strictly necessary to call this out in the documentation.