### PR TITLE
Add Filament:generateResourceUrl() method

### DIFF
--- a/packages/panels/src/Facades/Filament.php
+++ b/packages/panels/src/Facades/Filament.php
@@ -71,7 +71,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string | null getRequestPasswordResetUrl(array $parameters = [])
  * @method static string getResetPasswordUrl(string $token, CanResetPassword | Model | Authenticatable $user, array $parameters = [])
  * @method static array getResources()
- * @method static array getResourceUrl(string | Model $model, string $name = 'index', array $parameters = [], bool $isAbsolute = false, ?string $panel = null, ?Model $tenant = null)
+ * @method static array getResourceUrl(string | Model $model, string $name = 'index', array $parameters = [], bool $isAbsolute = false, ?Model $tenant = null)
  * @method static string getSidebarWidth()
  * @method static Model | null getTenant()
  * @method static string | null getTenantAvatarUrl(Model $tenant)

--- a/packages/panels/src/Facades/Filament.php
+++ b/packages/panels/src/Facades/Filament.php
@@ -71,6 +71,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string | null getRequestPasswordResetUrl(array $parameters = [])
  * @method static string getResetPasswordUrl(string $token, CanResetPassword | Model | Authenticatable $user, array $parameters = [])
  * @method static array getResources()
+ * @method static array getResourceUrl(string | Model $model, string $name = 'index', array $parameters = [], bool $isAbsolute = false, ?string $panel = null, ?Model $tenant = null)
  * @method static string getSidebarWidth()
  * @method static Model | null getTenant()
  * @method static string | null getTenantAvatarUrl(Model $tenant)

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -350,21 +350,9 @@ class FilamentManager
      */
     public function getResourceUrl(string | Model $model, string $name = 'index', array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null): string
     {
-        $modelClass = is_string($model) ? $model : $model::class;
-
         $panel = filled($panel) ? $this->getPanel($panel) : $this->getCurrentPanel();
-        $resource = $panel->getModelResource($modelClass);
 
-        if (blank($resource)) {
-            throw new Exception("No Filament resource found for model {$modelClass}");
-        }
-
-        // If the model is an instance of Model and the name is "edit" or "view" pass the record as a parameter.
-        if ($model instanceof Model && in_array($name, ['edit', 'view']) && blank($parameters)) {
-            $parameters = ['record' => $model];
-        }
-
-        return $resource::getUrl($name, $parameters, $isAbsolute, $panel->getId(), $tenant);
+        return $panel->getResourceUrl($model, $name, $parameters, $isAbsolute, $tenant);
     }
 
     public function getSidebarWidth(): string

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -348,11 +348,9 @@ class FilamentManager
      *
      * @throws Throwable
      */
-    public function getResourceUrl(string | Model $model, string $name = 'index', array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null): string
+    public function getResourceUrl(string | Model $model, string $name = 'index', array $parameters = [], bool $isAbsolute = true, ?Model $tenant = null): string
     {
-        $panel = filled($panel) ? $this->getPanel($panel) : $this->getCurrentPanel();
-
-        return $panel->getResourceUrl($model, $name, $parameters, $isAbsolute, $tenant);
+        return $this->getCurrentPanel()->getResourceUrl($model, $name, $parameters, $isAbsolute, $tenant);
     }
 
     public function getSidebarWidth(): string

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -9,6 +9,7 @@ use Filament\Enums\ThemeMode;
 use Filament\Events\ServingFilament;
 use Filament\Events\TenantSet;
 use Filament\Exceptions\NoDefaultPanelSetException;
+use Filament\Facades\Filament;
 use Filament\GlobalSearch\Contracts\GlobalSearchProvider;
 use Filament\Models\Contracts\HasAvatar;
 use Filament\Models\Contracts\HasDefaultTenant;
@@ -31,6 +32,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
+use Throwable;
 
 class FilamentManager
 {
@@ -340,6 +342,40 @@ class FilamentManager
     public function getResources(): array
     {
         return $this->getCurrentPanel()->getResources();
+    }
+
+    /**
+     * @param  array<mixed>  $parameters
+     *
+     * @throws Throwable
+     */
+    public function getResourceUrl(string | Model $model, string $name = 'index', array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null): string
+    {
+        $modelClass = is_string($model) ? $model : $model::class;
+
+        $resources = filled($tenant) ? $this->getPanel($panel)->getResources() : Filament::getResources();
+
+        $matchingResources = collect($resources)
+            ->filter(fn ($resource) => $resource::getModel() === $modelClass);
+
+        if ($matchingResources->isEmpty()) {
+            throw new Exception("No Filament resource found for model {$modelClass}");
+        }
+
+        if ($matchingResources->count() > 1) {
+            $resourceList = $matchingResources->implode(', ');
+
+            throw new Exception("Multiple Filament resources found for model {$modelClass}: {$resourceList}");
+        }
+
+        // If the model is an instance of Model and the name is 'edit' and no parameters are passed, we assume the user wants to edit the given record
+        if ($model instanceof Model && in_array($name, ['edit', 'view']) && blank($parameters)) {
+            $parameters = ['record' => $model];
+        }
+
+        $resourceClass = $matchingResources->first();
+
+        return $resourceClass::getUrl($name, $parameters, $isAbsolute, $panel, $tenant);
     }
 
     public function getSidebarWidth(): string

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -345,8 +345,6 @@ class FilamentManager
 
     /**
      * @param  array<mixed>  $parameters
-     *
-     * @throws Throwable
      */
     public function getResourceUrl(string | Model $model, string $name = 'index', array $parameters = [], bool $isAbsolute = true, ?Model $tenant = null): string
     {

--- a/packages/panels/src/Panel.php
+++ b/packages/panels/src/Panel.php
@@ -42,6 +42,7 @@ class Panel extends Component
     use Panel\Concerns\HasTopbar;
     use Panel\Concerns\HasTopNavigation;
     use Panel\Concerns\HasUnsavedChangesAlerts;
+    use Panel\Concerns\HasUrls;
     use Panel\Concerns\HasUserMenu;
 
     protected bool $isDefault = false;

--- a/packages/panels/src/Panel.php
+++ b/packages/panels/src/Panel.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Route;
 
 class Panel extends Component
 {
+    use Panel\Concerns\CanGenerateResourceUrls;
     use Panel\Concerns\HasAssets;
     use Panel\Concerns\HasAuth;
     use Panel\Concerns\HasAvatars;
@@ -42,7 +43,6 @@ class Panel extends Component
     use Panel\Concerns\HasTopbar;
     use Panel\Concerns\HasTopNavigation;
     use Panel\Concerns\HasUnsavedChangesAlerts;
-    use Panel\Concerns\HasUrls;
     use Panel\Concerns\HasUserMenu;
 
     protected bool $isDefault = false;

--- a/packages/panels/src/Panel/Concerns/CanGenerateResourceUrls.php
+++ b/packages/panels/src/Panel/Concerns/CanGenerateResourceUrls.php
@@ -6,26 +6,22 @@ use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Throwable;
 
-trait HasUrls
+trait CanGenerateResourceUrls
 {
     /**
      * @param  array<mixed>  $parameters
-     *
-     * @throws Throwable
      */
     public function getResourceUrl(string | Model $model, string $name = 'index', array $parameters = [], bool $isAbsolute = true, ?Model $tenant = null): string
     {
         $modelClass = is_string($model) ? $model : $model::class;
 
-        $resource = $this->getModelResource($modelClass);
+        $resource = $this->getModelResource($modelClass) ?? throw new Exception("No Filament resource found for model [{$modelClass}].");
 
-        if (blank($resource)) {
-            throw new Exception("No Filament resource found for model {$modelClass}");
-        }
-
-        // If the model is an instance of Model and the name is "edit" or "view" pass the record as a parameter.
-        if ($model instanceof Model && in_array($name, ['edit', 'view']) && blank($parameters)) {
-            $parameters = ['record' => $model];
+        if (
+            ($model instanceof Model) &&
+            in_array($name, ['edit', 'view'])
+        ) {
+            $parameters['record'] ??= $model;
         }
 
         return $resource::getUrl($name, $parameters, $isAbsolute, $this->getId(), $tenant);

--- a/packages/panels/src/Panel/Concerns/HasUrls.php
+++ b/packages/panels/src/Panel/Concerns/HasUrls.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Filament\Panel\Concerns;
+
+use Exception;
+use Illuminate\Database\Eloquent\Model;
+use Throwable;
+
+trait HasUrls
+{
+    /**
+     * @param  array<mixed>  $parameters
+     *
+     * @throws Throwable
+     */
+    public function getResourceUrl(string | Model $model, string $name = 'index', array $parameters = [], bool $isAbsolute = true, ?Model $tenant = null): string
+    {
+        $modelClass = is_string($model) ? $model : $model::class;
+
+        $resource = $this->getModelResource($modelClass);
+
+        if (blank($resource)) {
+            throw new Exception("No Filament resource found for model {$modelClass}");
+        }
+
+        // If the model is an instance of Model and the name is "edit" or "view" pass the record as a parameter.
+        if ($model instanceof Model && in_array($name, ['edit', 'view']) && blank($parameters)) {
+            $parameters = ['record' => $model];
+        }
+
+        return $resource::getUrl($name, $parameters, $isAbsolute, $this->getId(), $tenant);
+    }
+}

--- a/tests/src/Panels/Resources/ResourceTest.php
+++ b/tests/src/Panels/Resources/ResourceTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Filament\Facades\Filament;
 use Filament\Tests\Models\Post;
 use Filament\Tests\Panels\Fixtures\Resources\PostCategoryResource;
 use Filament\Tests\Panels\Fixtures\Resources\PostResource;
@@ -102,4 +103,19 @@ it('can retrieve a page\'s URL', function () {
     expect(PostResource::getUrl('view', ['record' => $post]))
         ->toContain($resourceSlug)
         ->toContain(strval($post->getRouteKey()));
+});
+
+it('can retrieve page urls by models', function () {
+    $post = Post::factory()->create();
+
+    expect(Filament::getResourceUrl($post, 'edit'))
+        ->toEndWith('/posts/' . $post->getKey() . '/edit');
+    expect(Filament::getResourceUrl($post, 'view'))
+        ->toEndWith('/posts/' . $post->getKey());
+    expect(Filament::getResourceUrl(Post::class, 'view', ['record' => $post]))
+        ->toEndWith('/posts/' . $post->getKey());
+    expect(Filament::getResourceUrl(Post::class))
+        ->toEndWith('/posts');
+    expect(Filament::getResourceUrl($post))
+        ->toEndWith('/posts');
 });

--- a/tests/src/Panels/Resources/ResourceTest.php
+++ b/tests/src/Panels/Resources/ResourceTest.php
@@ -105,17 +105,17 @@ it('can retrieve a page\'s URL', function () {
         ->toContain(strval($post->getRouteKey()));
 });
 
-it('can retrieve page urls by models', function () {
+it('can retrieve a page\'s URL from its model', function () {
     $post = Post::factory()->create();
 
     expect(Filament::getResourceUrl($post, 'edit'))
-        ->toEndWith('/posts/' . $post->getKey() . '/edit');
+        ->toEndWith("/posts/{$post->getKey(}/edit");
     expect(Filament::getResourceUrl($post, 'view'))
-        ->toEndWith('/posts/' . $post->getKey());
+        ->toEndWith("/posts/{$post->getKey()}");
     expect(Filament::getResourceUrl(Post::class, 'view', ['record' => $post]))
-        ->toEndWith('/posts/' . $post->getKey());
+        ->toEndWith("/posts/{$post->getKey()}");
     expect(Filament::getResourceUrl(Post::class))
-        ->toEndWith('/posts');
+        ->toEndWith("/posts");
     expect(Filament::getResourceUrl($post))
-        ->toEndWith('/posts');
+        ->toEndWith("/posts");
 });

--- a/tests/src/Panels/Resources/ResourceTest.php
+++ b/tests/src/Panels/Resources/ResourceTest.php
@@ -109,7 +109,7 @@ it('can retrieve a page\'s URL from its model', function () {
     $post = Post::factory()->create();
 
     expect(Filament::getResourceUrl($post, 'edit'))
-        ->toEndWith("/posts/{$post->getKey(}/edit");
+        ->toEndWith("/posts/{$post->getKey()}/edit");
     expect(Filament::getResourceUrl($post, 'view'))
         ->toEndWith("/posts/{$post->getKey()}");
     expect(Filament::getResourceUrl(Post::class, 'view', ['record' => $post]))


### PR DESCRIPTION
Hey Filament team! 👋

First, I want to say how much I love working with Filament. You've created an amazing tool, and I'm excited to contribute to the project for the first time.

I've been working on a little DX improvement that could make life easier for Filament developers. It's all about generating URLs for Resources more smoothly.

I constantly typed out `SomeResource::getUrl()` with similar parameters repeatedly. It got me thinking - what if we could simplify this?

So, I came up with a new method: `Filament::getResourceUrl()`. The cool thing is that you can pass in a model instance or class, and it figures out the rest. Here's a quick before and after:

Before:
```PHP
$post = Post::first();
PostResource::getUrl('view', ['record' => $post]);
PostResource::getUrl('edit', ['record' => $post]);
PostResource::getUrl('index');
```
After:
```PHP
$post = Post::first();
Filament::getResourceUrl($post, 'view');
Filament::getResourceUrl($post, 'edit');
Filament::getResourceUrl(Post::class, 'index');
```
I think this could be a nice win for a couple of reasons:

1. It's way easier to remember and type, especially when you're in the flow of working with your models.
2. You don't have to juggle those `['record' => $post]` parameters for editing and viewing routes anymore.

This change is not a breaking change. It's just a new option that works well with all the existing stuff.

I've added some tests to ensure everything works as expected, and I'd be happy to update the docs if you think this is worth including.

What do you think? I'm open to feedback or suggestions if you see ways to improve this.

Thanks for checking this out!
## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
