### PR TITLE
Use identified page name in TableWidget

### DIFF
--- a/packages/tables/resources/js/components/table.js
+++ b/packages/tables/resources/js/components/table.js
@@ -179,9 +179,9 @@ export default function table() {
             if (this.checkboxClickController) {
                 this.checkboxClickController.abort()
             }
-            
+
             this.checkboxClickController = new AbortController()
-            
+
             const { signal } = this.checkboxClickController
 
             this.$root?.addEventListener(

--- a/packages/widgets/src/TableWidget.php
+++ b/packages/widgets/src/TableWidget.php
@@ -35,7 +35,7 @@ class TableWidget extends Widget implements Actions\Contracts\HasActions, Forms\
     {
         return $query->simplePaginate(
             perPage: ($this->getTableRecordsPerPage() === 'all') ? $query->count() : $this->getTableRecordsPerPage(),
-            pageName: $this->getIdentifiedTableQueryStringPropertyNameFor('page')
+            pageName: $this->getTablePaginationPageName()
         );
     }
 

--- a/packages/widgets/src/TableWidget.php
+++ b/packages/widgets/src/TableWidget.php
@@ -35,7 +35,7 @@ class TableWidget extends Widget implements Actions\Contracts\HasActions, Forms\
     {
         return $query->simplePaginate(
             perPage: ($this->getTableRecordsPerPage() === 'all') ? $query->count() : $this->getTableRecordsPerPage(),
-            pageName: $this->getTablePaginationPageName()
+            pageName: $this->getTablePaginationPageName(),
         );
     }
 

--- a/packages/widgets/src/TableWidget.php
+++ b/packages/widgets/src/TableWidget.php
@@ -33,7 +33,10 @@ class TableWidget extends Widget implements Actions\Contracts\HasActions, Forms\
 
     protected function paginateTableQuery(Builder $query): Paginator | CursorPaginator
     {
-        return $query->simplePaginate(($this->getTableRecordsPerPage() === 'all') ? $query->count() : $this->getTableRecordsPerPage());
+        return $query->simplePaginate(
+            perPage: ($this->getTableRecordsPerPage() === 'all') ? $query->count() : $this->getTableRecordsPerPage(),
+            pageName: $this->getIdentifiedTableQueryStringPropertyNameFor('page')
+        );
     }
 
     /**


### PR DESCRIPTION
## Description

Use `getTablePaginationPageName()`  to get the page name for the table widget to prevent pagination collision when using multiple table widgets on single page.

## Visual changes

Before:
![image](https://github.com/user-attachments/assets/96ba3c90-4597-4f3f-8146-f50343123fec)


After:
![image](https://github.com/user-attachments/assets/0d65b47a-186d-4916-bab5-0fc0de1531b4)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
