### PR TITLE
fix: missed header column with grouped only list

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -833,6 +833,10 @@
                             @endif
                         @endif
 
+                        @if ($isGroupsOnly)
+                            <x-filament-tables::header-cell>{{ $group->getLabel() }}</x-filament-tables::header-cell>
+                        @endif
+
                         @foreach ($columns as $column)
                             @php
                                 $columnWidth = $column->getWidth();

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -834,7 +834,9 @@
                         @endif
 
                         @if ($isGroupsOnly)
-                            <x-filament-tables::header-cell>{{ $group->getLabel() }}</x-filament-tables::header-cell>
+                            <x-filament-tables::header-cell>
+                                {{ $group->getLabel() }}
+                            </x-filament-tables::header-cell>
                         @endif
 
                         @foreach ($columns as $column)


### PR DESCRIPTION
## Description

I faced a problem when displaying columns in the table when using grouping. If only grouped records are displayed in the table (->groupsOnly()) then one column is lost in the header of the table (in the record it`s a grouping column), and all column names move 1 cell to the left.

## Visual changes
before:
![image](https://github.com/user-attachments/assets/168fcb46-b6b9-4f22-b9d6-d10e7e422824)

after:
![image](https://github.com/user-attachments/assets/ad4cf181-fc07-4a5c-81e2-fcf61a2975ca)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.

I tested this all on my project on our cases, whether it can break the functionality - I think you guys know better :)