### PR TITLE
Proposal: add `brandLogoInTopBar()` method to `Panel` component

### DIFF
--- a/packages/panels/resources/views/components/sidebar/index.blade.php
+++ b/packages/panels/resources/views/components/sidebar/index.blade.php
@@ -53,12 +53,14 @@
                     x-transition:enter-end="opacity-100"
                 @endif
             >
-                @if ($homeUrl = filament()->getHomeUrl())
-                    <a {{ \Filament\Support\generate_href_html($homeUrl) }}>
+                @if (! filament()->hasBrandLogoInTopBar())
+                    @if ($homeUrl = filament()->getHomeUrl())
+                        <a {{ \Filament\Support\generate_href_html($homeUrl) }}>
+                            <x-filament-panels::logo />
+                        </a>
+                    @else
                         <x-filament-panels::logo />
-                    </a>
-                @else
-                    <x-filament-panels::logo />
+                    @endif
                 @endif
             </div>
 

--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -46,7 +46,7 @@
             />
         @endif
 
-        @if (filament()->hasTopNavigation() || (! filament()->hasNavigation()))
+        @if (filament()->hasBrandLogoInTopBar() || (filament()->hasTopNavigation() || (! filament()->hasNavigation())))
             <div class="me-6 hidden lg:flex">
                 @if ($homeUrl = filament()->getHomeUrl())
                     <a {{ \Filament\Support\generate_href_html($homeUrl) }}>
@@ -56,7 +56,9 @@
                     <x-filament-panels::logo />
                 @endif
             </div>
-
+        @endif
+    
+        @if (filament()->hasTopNavigation() || (! filament()->hasNavigation()))
             @if (filament()->hasTenancy() && filament()->hasTenantMenu())
                 <x-filament-panels::tenant-menu class="hidden lg:block" />
             @endif

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -530,6 +530,11 @@ class FilamentManager
         return $this->getCurrentPanel()->getWidgets();
     }
 
+    public function hasBrandLogoInTopBar(): bool
+    {
+        return $this->getCurrentPanel()->hasBrandLogoInTopBar();
+    }
+
     public function hasBreadcrumbs(): bool
     {
         return $this->getCurrentPanel()->hasBreadcrumbs();

--- a/packages/panels/src/Panel/Concerns/HasBrandLogo.php
+++ b/packages/panels/src/Panel/Concerns/HasBrandLogo.php
@@ -14,6 +14,8 @@ trait HasBrandLogo
 
     protected string | HtmlString | Closure | null $darkModeBrandLogo = null;
 
+    protected bool $hasBrandLogoInTopBar = false;
+
     public function brandLogo(string | Htmlable | Closure | null $logo): static
     {
         $this->brandLogo = $logo;
@@ -24,6 +26,13 @@ trait HasBrandLogo
     public function brandLogoHeight(string | Closure | null $height): static
     {
         $this->brandLogoHeight = $height;
+
+        return $this;
+    }
+
+    public function brandLogoInTopBar(bool $condition = true): static
+    {
+        $this->hasBrandLogoInTopBar = $condition;
 
         return $this;
     }
@@ -48,5 +57,10 @@ trait HasBrandLogo
     public function getDarkModeBrandLogo(): string | Htmlable | null
     {
         return $this->evaluate($this->darkModeBrandLogo);
+    }
+
+    public function hasBrandLogoInTopBar(): bool
+    {
+        return $this->hasBrandLogoInTopBar;
     }
 }


### PR DESCRIPTION
## Description

Adding a `brandLogoInTopBar()` method to the `Panel` component is proposed, which has the effect of hiding the brand logo in the sidebar and instead showing it in the topbar (after the "Expand sidebar" & "Collapse sidebar" buttons). 

This has the benefit of **always displaying the brand logo in the topbar**, even when the sidebar is collapsed.

The proposed approach is preferable to using the...
- `PanelsRenderHook::TOPBAR_START` render hook, as the brand logo then appears to the left of the "Expand sidebar" button when the sidebar is collapsed, which looks strange.
- `PanelsRenderHook::GLOBAL_SEARCH_BEFORE` render hook, as the brand logo then appears right-aligned on the topbar, to the left of the global search container / user menu, which also looks strange.

## Visual changes

### _Before (without calling proposed method)_
```php
$panel
    ->brandLogo(fn () => view('logos.logo'))
    ->sidebarFullyCollapsibleOnDesktop()
```
_...with sidebar expanded..._

![image](https://github.com/user-attachments/assets/2ed81de8-5d25-447d-ad75-035bcbda3ad4)

_...with sidebar collapsed..._

![image](https://github.com/user-attachments/assets/b39cfdca-67d9-4c58-a4ca-8c642195fa17)



### _After (calling proposed method)_
```php
$panel
    ->brandLogo(fn () => view('logos.logo'))
    ->brandLogoInTopBar()
    ->sidebarFullyCollapsibleOnDesktop()
```
_...with sidebar expanded..._

![image](https://github.com/user-attachments/assets/c2a658c6-90e0-423b-b463-e9fda8256882)

_...with sidebar collapsed..._

![image](https://github.com/user-attachments/assets/2cfa0110-d805-48f2-8aed-274180868faa)

## Functional changes

When proposed `brandLogoInTopBar()` method is employed, the brand logo is always displayed, regardless of whether the sidebar is collapsed or not.

- [x] Code style has been _checked_ by running the _`./vendor/bin/pint --test` command on each of the individual files changed. The two modified Blade templates passed. For the other two files, Pint suggested a trivial "fix" of removing spaces between alternative function argument types and function return types, which seems less readable so suggested action not taken._
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date. _Will submit documentation changes if the proposal is approved._
