### PR TITLE
Revert "Fix: alpine errors when textarea is in modals"

### DIFF
--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -34,7 +34,6 @@
         "
     >
         <textarea
-            x-ignore
             @if (FilamentView::hasSpaMode())
                 ax-load="visible"
             @else


### PR DESCRIPTION
Reverts filamentphp/filament#13630

The original PR broke autosizing textareas across Livewire requests.
On every Livewire request, the textarea goes back to its initial size.

Linking to the PR that initially fixed autosizing: https://github.com/filamentphp/filament/pull/13211.
`x-ignore` seems to have been removed there.

I'd like to merge this PR that reverts the breaking fix by @awcodes.
Do you have any ideas for a definite fix we can introduce next?