### PR TITLE
fix: choicesjs toggle disable/enable

### DIFF
--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -98,10 +98,14 @@
             <div
                 x-data="{
                     disabled: @js($isDisabled),
-                    init(){
+                    init() {
                         const container = $el.querySelector('div[data-select-container]')
-                        container.dispatchEvent(new CustomEvent('toggle-state', { detail : { disabled: this.disabled } }))
-                    }
+                        container.dispatchEvent(
+                            new CustomEvent('toggle-state', {
+                                detail: { disabled: this.disabled },
+                            }),
+                        )
+                    },
                 }"
             >
                 <div

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -108,8 +108,7 @@
                         )
                     },
                 }"
-            >
-            </div>
+            ></div>
             <div
                 x-ignore
                 @if (FilamentView::hasSpaMode())

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -98,12 +98,12 @@
             <div
                 class="hidden"
                 x-data="{
-                    disabled: @js($isDisabled),
-                    init() {
+                    isDisabled: @js($isDisabled),
+                    init: function () {
                         const container = $el.nextElementSibling
                         container.dispatchEvent(
-                            new CustomEvent('toggle-state', {
-                                detail: { disabled: this.disabled },
+                            new CustomEvent('set-select-property', {
+                                detail: { isDisabled: this.isDisabled },
                             }),
                         )
                     },
@@ -155,7 +155,7 @@
                         })"
                 wire:ignore
                 x-on:keydown.esc="select.dropdown.isActive && $event.stopPropagation()"
-                x-on:toggle-state="$event.detail.disabled ? select.disable() : select.enable()"
+                x-on:set-select-property="$event.detail.isDisabled ? select.disable() : select.enable()"
                 {{
                     $attributes
                         ->merge($getExtraAlpineAttributes(), escape: false)

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -96,10 +96,11 @@
             </x-filament::input.select>
         @else
             <div
+                class="hidden"
                 x-data="{
                     disabled: @js($isDisabled),
                     init() {
-                        const container = $el.querySelector('div[data-select-container]')
+                        const container = $el.nextElementSibling
                         container.dispatchEvent(
                             new CustomEvent('toggle-state', {
                                 detail: { disabled: this.disabled },
@@ -108,77 +109,76 @@
                     },
                 }"
             >
-                <div
-                    data-select-container
-                    x-ignore
-                    @if (FilamentView::hasSpaMode())
-                        ax-load="visible"
-                    @else
-                        ax-load
-                    @endif
-                    ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('select', 'filament/forms') }}"
-                    x-data="selectFormComponent({
-                                canSelectPlaceholder: @js($canSelectPlaceholder),
-                                isHtmlAllowed: @js($isHtmlAllowed()),
-                                getOptionLabelUsing: async () => {
-                                    return await $wire.getFormSelectOptionLabel(@js($statePath))
-                                },
-                                getOptionLabelsUsing: async () => {
-                                    return await $wire.getFormSelectOptionLabels(@js($statePath))
-                                },
-                                getOptionsUsing: async () => {
-                                    return await $wire.getFormSelectOptions(@js($statePath))
-                                },
-                                getSearchResultsUsing: async (search) => {
-                                    return await $wire.getFormSelectSearchResults(@js($statePath), search)
-                                },
-                                isAutofocused: @js($isAutofocused()),
-                                isMultiple: @js($isMultiple()),
-                                isSearchable: @js($isSearchable()),
-                                livewireId: @js($this->getId()),
-                                hasDynamicOptions: @js($hasDynamicOptions()),
-                                hasDynamicSearchResults: @js($hasDynamicSearchResults()),
-                                loadingMessage: @js($getLoadingMessage()),
-                                maxItems: @js($getMaxItems()),
-                                maxItemsMessage: @js($getMaxItemsMessage()),
-                                noSearchResultsMessage: @js($getNoSearchResultsMessage()),
-                                options: @js($getOptionsForJs()),
-                                optionsLimit: @js($getOptionsLimit()),
-                                placeholder: @js($getPlaceholder()),
-                                position: @js($getPosition()),
-                                searchDebounce: @js($getSearchDebounce()),
-                                searchingMessage: @js($getSearchingMessage()),
-                                searchPrompt: @js($getSearchPrompt()),
-                                searchableOptionFields: @js($getSearchableOptionFields()),
-                                state: $wire.{{ $applyStateBindingModifiers("\$entangle('{$statePath}')") }},
-                                statePath: @js($statePath),
-                            })"
-                    wire:ignore
-                    x-on:keydown.esc="select.dropdown.isActive && $event.stopPropagation()"
-                    x-on:toggle-state="$event.detail.disabled ? select.disable() : select.enable()"
+            </div>
+            <div
+                x-ignore
+                @if (FilamentView::hasSpaMode())
+                    ax-load="visible"
+                @else
+                    ax-load
+                @endif
+                ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('select', 'filament/forms') }}"
+                x-data="selectFormComponent({
+                            canSelectPlaceholder: @js($canSelectPlaceholder),
+                            isHtmlAllowed: @js($isHtmlAllowed()),
+                            getOptionLabelUsing: async () => {
+                                return await $wire.getFormSelectOptionLabel(@js($statePath))
+                            },
+                            getOptionLabelsUsing: async () => {
+                                return await $wire.getFormSelectOptionLabels(@js($statePath))
+                            },
+                            getOptionsUsing: async () => {
+                                return await $wire.getFormSelectOptions(@js($statePath))
+                            },
+                            getSearchResultsUsing: async (search) => {
+                                return await $wire.getFormSelectSearchResults(@js($statePath), search)
+                            },
+                            isAutofocused: @js($isAutofocused()),
+                            isMultiple: @js($isMultiple()),
+                            isSearchable: @js($isSearchable()),
+                            livewireId: @js($this->getId()),
+                            hasDynamicOptions: @js($hasDynamicOptions()),
+                            hasDynamicSearchResults: @js($hasDynamicSearchResults()),
+                            loadingMessage: @js($getLoadingMessage()),
+                            maxItems: @js($getMaxItems()),
+                            maxItemsMessage: @js($getMaxItemsMessage()),
+                            noSearchResultsMessage: @js($getNoSearchResultsMessage()),
+                            options: @js($getOptionsForJs()),
+                            optionsLimit: @js($getOptionsLimit()),
+                            placeholder: @js($getPlaceholder()),
+                            position: @js($getPosition()),
+                            searchDebounce: @js($getSearchDebounce()),
+                            searchingMessage: @js($getSearchingMessage()),
+                            searchPrompt: @js($getSearchPrompt()),
+                            searchableOptionFields: @js($getSearchableOptionFields()),
+                            state: $wire.{{ $applyStateBindingModifiers("\$entangle('{$statePath}')") }},
+                            statePath: @js($statePath),
+                        })"
+                wire:ignore
+                x-on:keydown.esc="select.dropdown.isActive && $event.stopPropagation()"
+                x-on:toggle-state="$event.detail.disabled ? select.disable() : select.enable()"
+                {{
+                    $attributes
+                        ->merge($getExtraAlpineAttributes(), escape: false)
+                        ->class([
+                            '[&_.choices\_\_inner]:ps-0' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
+                        ])
+                }}
+            >
+                <select
+                    x-ref="input"
                     {{
-                        $attributes
-                            ->merge($getExtraAlpineAttributes(), escape: false)
+                        $getExtraInputAttributeBag()
+                            ->merge([
+                                'disabled' => $isDisabled,
+                                'id' => $getId(),
+                                'multiple' => $isMultiple(),
+                            ], escape: false)
                             ->class([
-                                '[&_.choices\_\_inner]:ps-0' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
+                                'h-9 w-full rounded-lg border-none bg-transparent !bg-none',
                             ])
                     }}
-                >
-                    <select
-                        x-ref="input"
-                        {{
-                            $getExtraInputAttributeBag()
-                                ->merge([
-                                    'disabled' => $isDisabled,
-                                    'id' => $getId(),
-                                    'multiple' => $isMultiple(),
-                                ], escape: false)
-                                ->class([
-                                    'h-9 w-full rounded-lg border-none bg-transparent !bg-none',
-                                ])
-                        }}
-                    ></select>
-                </div>
+                ></select>
             </div>
         @endif
     </x-filament::input.wrapper>

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -96,73 +96,85 @@
             </x-filament::input.select>
         @else
             <div
-                x-ignore
-                @if (FilamentView::hasSpaMode())
-                    ax-load="visible"
-                @else
-                    ax-load
-                @endif
-                ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('select', 'filament/forms') }}"
-                x-data="selectFormComponent({
-                            canSelectPlaceholder: @js($canSelectPlaceholder),
-                            isHtmlAllowed: @js($isHtmlAllowed()),
-                            getOptionLabelUsing: async () => {
-                                return await $wire.getFormSelectOptionLabel(@js($statePath))
-                            },
-                            getOptionLabelsUsing: async () => {
-                                return await $wire.getFormSelectOptionLabels(@js($statePath))
-                            },
-                            getOptionsUsing: async () => {
-                                return await $wire.getFormSelectOptions(@js($statePath))
-                            },
-                            getSearchResultsUsing: async (search) => {
-                                return await $wire.getFormSelectSearchResults(@js($statePath), search)
-                            },
-                            isAutofocused: @js($isAutofocused()),
-                            isMultiple: @js($isMultiple()),
-                            isSearchable: @js($isSearchable()),
-                            livewireId: @js($this->getId()),
-                            hasDynamicOptions: @js($hasDynamicOptions()),
-                            hasDynamicSearchResults: @js($hasDynamicSearchResults()),
-                            loadingMessage: @js($getLoadingMessage()),
-                            maxItems: @js($getMaxItems()),
-                            maxItemsMessage: @js($getMaxItemsMessage()),
-                            noSearchResultsMessage: @js($getNoSearchResultsMessage()),
-                            options: @js($getOptionsForJs()),
-                            optionsLimit: @js($getOptionsLimit()),
-                            placeholder: @js($getPlaceholder()),
-                            position: @js($getPosition()),
-                            searchDebounce: @js($getSearchDebounce()),
-                            searchingMessage: @js($getSearchingMessage()),
-                            searchPrompt: @js($getSearchPrompt()),
-                            searchableOptionFields: @js($getSearchableOptionFields()),
-                            state: $wire.{{ $applyStateBindingModifiers("\$entangle('{$statePath}')") }},
-                            statePath: @js($statePath),
-                        })"
-                wire:ignore
-                x-on:keydown.esc="select.dropdown.isActive && $event.stopPropagation()"
-                {{
-                    $attributes
-                        ->merge($getExtraAlpineAttributes(), escape: false)
-                        ->class([
-                            '[&_.choices\_\_inner]:ps-0' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
-                        ])
-                }}
+                x-data="{
+                    disabled: @js($isDisabled),
+                    init(){
+                        const container = $el.querySelector('div[data-select-container]')
+                        container.dispatchEvent(new CustomEvent('toggle-state', { detail : { disabled: this.disabled } }))
+                    }
+                }"
             >
-                <select
-                    x-ref="input"
+                <div
+                    data-select-container
+                    x-ignore
+                    @if (FilamentView::hasSpaMode())
+                        ax-load="visible"
+                    @else
+                        ax-load
+                    @endif
+                    ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('select', 'filament/forms') }}"
+                    x-data="selectFormComponent({
+                                canSelectPlaceholder: @js($canSelectPlaceholder),
+                                isHtmlAllowed: @js($isHtmlAllowed()),
+                                getOptionLabelUsing: async () => {
+                                    return await $wire.getFormSelectOptionLabel(@js($statePath))
+                                },
+                                getOptionLabelsUsing: async () => {
+                                    return await $wire.getFormSelectOptionLabels(@js($statePath))
+                                },
+                                getOptionsUsing: async () => {
+                                    return await $wire.getFormSelectOptions(@js($statePath))
+                                },
+                                getSearchResultsUsing: async (search) => {
+                                    return await $wire.getFormSelectSearchResults(@js($statePath), search)
+                                },
+                                isAutofocused: @js($isAutofocused()),
+                                isMultiple: @js($isMultiple()),
+                                isSearchable: @js($isSearchable()),
+                                livewireId: @js($this->getId()),
+                                hasDynamicOptions: @js($hasDynamicOptions()),
+                                hasDynamicSearchResults: @js($hasDynamicSearchResults()),
+                                loadingMessage: @js($getLoadingMessage()),
+                                maxItems: @js($getMaxItems()),
+                                maxItemsMessage: @js($getMaxItemsMessage()),
+                                noSearchResultsMessage: @js($getNoSearchResultsMessage()),
+                                options: @js($getOptionsForJs()),
+                                optionsLimit: @js($getOptionsLimit()),
+                                placeholder: @js($getPlaceholder()),
+                                position: @js($getPosition()),
+                                searchDebounce: @js($getSearchDebounce()),
+                                searchingMessage: @js($getSearchingMessage()),
+                                searchPrompt: @js($getSearchPrompt()),
+                                searchableOptionFields: @js($getSearchableOptionFields()),
+                                state: $wire.{{ $applyStateBindingModifiers("\$entangle('{$statePath}')") }},
+                                statePath: @js($statePath),
+                            })"
+                    wire:ignore
+                    x-on:keydown.esc="select.dropdown.isActive && $event.stopPropagation()"
+                    x-on:toggle-state="$event.detail.disabled ? select.disable() : select.enable()"
                     {{
-                        $getExtraInputAttributeBag()
-                            ->merge([
-                                'disabled' => $isDisabled,
-                                'id' => $getId(),
-                                'multiple' => $isMultiple(),
-                            ], escape: false)
+                        $attributes
+                            ->merge($getExtraAlpineAttributes(), escape: false)
                             ->class([
-                                'h-9 w-full rounded-lg border-none bg-transparent !bg-none',
+                                '[&_.choices\_\_inner]:ps-0' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
                             ])
                     }}
-                ></select>
+                >
+                    <select
+                        x-ref="input"
+                        {{
+                            $getExtraInputAttributeBag()
+                                ->merge([
+                                    'disabled' => $isDisabled,
+                                    'id' => $getId(),
+                                    'multiple' => $isMultiple(),
+                                ], escape: false)
+                                ->class([
+                                    'h-9 w-full rounded-lg border-none bg-transparent !bg-none',
+                                ])
+                        }}
+                    ></select>
+                </div>
             </div>
         @endif
     </x-filament::input.wrapper>


### PR DESCRIPTION
## Description

this fixes an issue where a Select is disabled based on another field
```php
Forms\Components\Toggle::make('toggle')
    ->live(),
Forms\Components\Select::make('quantities')
    ->disabled(fn ($get) => ! $get('toggle'))
    ->native(false)
    ->options(function ($get) {
        if (! $get('toggle')) {
            return [1 => 1];
        }

        return range(1, 10);
    }),
```

the issue is when a disabled select is changed to enabled later, it doesn't remove the `disabled` attribute from the select element.


this PR fixes it by wrapping it in a div container to get the `disabled` property
```php
x-data="{
    disabled: @js($isDisabled),
    init(){
        const container = $el.nextElementSibling
        container.dispatchEvent(new CustomEvent('toggle-state', { detail : { disabled: this.disabled } }))
    }
}"
```

```php
  x-on:toggle-state="$event.detail.disabled ? select.disable() : select.enable()"
```
this listener uses the ChoicesJs instance to toggle enable/disable, so that when click on the dropdown it triggers Choices event
https://github.com/filamentphp/filament/blob/e90998fe6aa4681569f09b6ebb01e5346d3a1644/packages/forms/resources/js/components/select.js#L91-L104

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
