### PR TITLE
fix: Broaden dependency of `filament/support` on dbal to allow for its version 4

### DIFF
--- a/packages/support/composer.json
+++ b/packages/support/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^8.1",
         "blade-ui-kit/blade-heroicons": "^2.2.1",
-        "doctrine/dbal": "^3.2",
+        "doctrine/dbal": "^3.2|^4.0",
         "ext-intl": "*",
         "illuminate/contracts": "^10.45|^11.0",
         "illuminate/support": "^10.45|^11.0",


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

As per https://github.com/filamentphp/filament/issues/11891#issuecomment-2002562994 `doctrine/dbal` cannot be removed from `filament/support`'s dependencies. However, the currently pinned version prevents Laravel 10 projects to be migrated to Laravel 11 depending on what version of dbal other dependencies may depend on.

This PR allows for either dbal 3 or dbal 4 to be installed, and lets composer deal with conflict resolution for which would be the right one to use.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
