### PR TITLE
implement alignment in image-entry blade

### DIFF
--- a/packages/infolists/resources/views/components/image-entry.blade.php
+++ b/packages/infolists/resources/views/components/image-entry.blade.php
@@ -1,6 +1,7 @@
 @php
     use Filament\Support\Enums\Alignment;
 @endphp
+
 <x-dynamic-component :component="$getEntryWrapperView()" :entry="$entry">
     @php
         $alignment = $getAlignment();

--- a/packages/infolists/resources/views/components/image-entry.blade.php
+++ b/packages/infolists/resources/views/components/image-entry.blade.php
@@ -1,5 +1,9 @@
+@php
+    use Filament\Support\Enums\Alignment;
+@endphp
 <x-dynamic-component :component="$getEntryWrapperView()" :entry="$entry">
     @php
+        $alignment = $getAlignment();
         $state = $getState();
 
         if ($state instanceof \Illuminate\Support\Collection) {
@@ -22,6 +26,10 @@
         $limitedStateCount = count($limitedState);
 
         $defaultImageUrl = $getDefaultImageUrl();
+
+        if (! $alignment instanceof Alignment) {
+            $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
+        }
 
         if ((! $limitedStateCount) && filled($defaultImageUrl)) {
             $limitedState = [null];
@@ -59,6 +67,13 @@
                 ->merge($getExtraAttributes(), escape: false)
                 ->class([
                     'fi-in-image flex items-center gap-x-2.5',
+                    match ($alignment) {
+                        Alignment::Start, Alignment::Left => 'justify-start',
+                        Alignment::Center => 'justify-center',
+                        Alignment::End, Alignment::Right => 'justify-end',
+                        Alignment::Between, Alignment::Justify => 'justify-between',
+                        default => $alignment,
+                    },
                 ])
         }}
     >


### PR DESCRIPTION
## Description

the class `ImageEntry` already inherited the `HasAlignment` trait but the classes not applied to the views

if this more suitable or needed on v4 too, let me know, more than happy to submit another PR.

## Visual changes

Before:
![before](https://github.com/user-attachments/assets/0bd8d050-2e88-484f-a382-2664ae198cec)

After:
![after](https://github.com/user-attachments/assets/7ed6ba0f-8a89-46f5-8237-75d36c6cccf8)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
