### PR TITLE
Added 'error' as alias to 'danger' to HasStatus.php

### DIFF
--- a/packages/notifications/src/Concerns/HasStatus.php
+++ b/packages/notifications/src/Concerns/HasStatus.php
@@ -25,6 +25,11 @@ trait HasStatus
         return $this->status('danger');
     }
 
+    public function error(): static
+    {
+        return $this->status('danger');
+    }
+
     public function info(): static
     {
         return $this->status('info');

--- a/tests/src/Notifications/NotificationTest.php
+++ b/tests/src/Notifications/NotificationTest.php
@@ -29,7 +29,6 @@ it('can send notifications', function () {
     $getRandomColor = function (): string {
         return Arr::random([
             'danger',
-            'error',
             'gray',
             'info',
             'primary',

--- a/tests/src/Notifications/NotificationTest.php
+++ b/tests/src/Notifications/NotificationTest.php
@@ -29,6 +29,7 @@ it('can send notifications', function () {
     $getRandomColor = function (): string {
         return Arr::random([
             'danger',
+            'error',
             'gray',
             'info',
             'primary',


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Added 'error' as an alias to 'danger' 

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
Having to debate whether it is 'danger' or 'error', this update shall help eliviate that as they should 'ideally' be the same.
On one hand, we have 'success', and it would be ideal having 'error' as its pollar opposite.

Also, after getting used to Laravel session flashing 'success' and 'error',  this would greatly reduce potential errors and the mental fatigue associated in switching between frameworks. 

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
