### PR TITLE
fix: the breadcrumb item label of the current page should not be clickable

### DIFF
--- a/packages/support/resources/views/components/breadcrumbs.blade.php
+++ b/packages/support/resources/views/components/breadcrumbs.blade.php
@@ -38,7 +38,7 @@
                     </span>
                 @else
                     <a
-                        {{ \Filament\Support\generate_href_html(is_int($url) ? '#' : $url) }}
+                        {{ \Filament\Support\generate_href_html($url) }}
                         class="{{ $itemLabelClasses }} transition duration-75 hover:text-gray-700 dark:hover:text-gray-200"
                     >
                         {{ $label }}

--- a/packages/support/resources/views/components/breadcrumbs.blade.php
+++ b/packages/support/resources/views/components/breadcrumbs.blade.php
@@ -31,12 +31,20 @@
                     />
                 @endif
 
-                <a
-                    {{ \Filament\Support\generate_href_html(is_int($url) ? '#' : $url) }}
-                    class="fi-breadcrumbs-item-label text-sm font-medium text-gray-500 transition duration-75 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-                >
+                @if (is_int($url))
+                    <span
+                        class="fi-breadcrumbs-item-label text-sm font-medium text-gray-500 transition duration-75 dark:text-gray-400"
+                    >
+                        {{ $label }}
+                    </span>
+                @else
+                    <a
+                        {{ \Filament\Support\generate_href_html(is_int($url) ? '#' : $url) }}
+                        class="fi-breadcrumbs-item-label text-sm font-medium text-gray-500 transition duration-75 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                    >
                     {{ $label }}
-                </a>
+                    </a>
+                @endif
             </li>
         @endforeach
     </ol>

--- a/packages/support/resources/views/components/breadcrumbs.blade.php
+++ b/packages/support/resources/views/components/breadcrumbs.blade.php
@@ -4,6 +4,7 @@
 
 @php
     $iconClasses = 'fi-breadcrumbs-item-separator flex h-5 w-5 text-gray-400 dark:text-gray-500';
+    $itemLabelClasses = 'fi-breadcrumbs-item-label text-sm font-medium text-gray-500 dark:text-gray-400';
 @endphp
 
 <nav {{ $attributes->class(['fi-breadcrumbs']) }}>
@@ -32,17 +33,15 @@
                 @endif
 
                 @if (is_int($url))
-                    <span
-                        class="fi-breadcrumbs-item-label text-sm font-medium text-gray-500 transition duration-75 dark:text-gray-400"
-                    >
+                    <span class="{{ $itemLabelClasses }}">
                         {{ $label }}
                     </span>
                 @else
                     <a
                         {{ \Filament\Support\generate_href_html(is_int($url) ? '#' : $url) }}
-                        class="fi-breadcrumbs-item-label text-sm font-medium text-gray-500 transition duration-75 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                        class="{{ $itemLabelClasses }} transition duration-75 hover:text-gray-700 dark:hover:text-gray-200"
                     >
-                    {{ $label }}
+                        {{ $label }}
                     </a>
                 @endif
             </li>


### PR DESCRIPTION
## Description

When a user navigates to a resource, the breadcrumb item label after the model name is still clickable. 
For example, on a resource view page of OrderResource, the text 'View' in 'Orders > View' is still clickable and navigates to '#' href. In fact, if it navigates to '#' then it should not be clickable, because this could confuse the user.  

## Visual changes
Before:
![Screenshot from 2024-08-06 16-02-26](https://github.com/user-attachments/assets/aaf505ec-044f-4393-ad69-997691cde1f8)

After:
![Screenshot from 2024-08-06 16-02-38](https://github.com/user-attachments/assets/d4206478-d993-4985-8cb4-f08cef9ec7c6)


## Functional changes
Conditionally switch to use `span` tag if `is_int($url)` is true, otherwise use `a` tag with `$url` as the href.
