### PR TITLE
Fix: Generating a slug from a title

### DIFF
--- a/packages/forms/docs/07-advanced.md
+++ b/packages/forms/docs/07-advanced.md
@@ -338,7 +338,7 @@ use Filament\Forms\Set;
 use Illuminate\Support\Str;
 
 TextInput::make('title')
-    ->live()
+    ->live(onBlur: true)
     ->afterStateUpdated(fn (Set $set, ?string $state) => $set('slug', Str::slug($state)))
     
 TextInput::make('slug')
@@ -355,7 +355,7 @@ use Filament\Forms\Set;
 use Illuminate\Support\Str;
 
 TextInput::make('title')
-    ->live()
+    ->live(onBlur: true)
     ->afterStateUpdated(function (Get $get, Set $set, ?string $old, ?string $state) {
         if (($get('slug') ?? '') !== Str::slug($old)) {
             return;

--- a/packages/forms/docs/07-advanced.md
+++ b/packages/forms/docs/07-advanced.md
@@ -344,7 +344,7 @@ TextInput::make('title')
 TextInput::make('slug')
 ```
 
-In this example, the `title` field is [`live()`](#the-basics-of-reactivity). This allows the form to rerender when the value of the `title` field changes. The `afterStateUpdated()` method is used to run a function after the state of the `title` field is updated. The function injects the [`$set()` utility](#injecting-a-function-to-set-the-state-of-another-field) and the new state of the `title` field. The `Str::slug()` utility method is part of Laravel and is used to generate a slug from a string. The `slug` field is then updated using the `$set()` function.
+In this example, the `title` field is [`live(onBlur: true)`](#reactive-fields-on-blur). This allows the form to rerender when the value of the `title` field changes and the user clicks away. The `afterStateUpdated()` method is used to run a function after the state of the `title` field is updated. The function injects the [`$set()` utility](#injecting-a-function-to-set-the-state-of-another-field) and the new state of the `title` field. The `Str::slug()` utility method is part of Laravel and is used to generate a slug from a string. The `slug` field is then updated using the `$set()` function.
 
 One thing to note is that the user may customize the slug manually, and we don't want to overwrite their changes if the title changes. To prevent this, we can use the old version of the title to work out if the user has modified it themselves. To access the old version of the title, you can inject `$old`, and to get the current value of the slug before it gets changed, we can use the [`$get()` utility](#injecting-the-state-of-another-field):
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
Improve documentation for `Generating a slug from a title` exemple.
Automatic slug generation should use `->live(onBlur: true)` instead of `->live()`.
Otherwise, the text is jumbled.
Fix #12326

## Visual changes

<!-- Add screenshots/recordings of before and after. -->
In this screen capture, I wrote `The quick brown fox jump over the lazy dog`.

![2024-08-06 13 13 30](https://github.com/user-attachments/assets/0df8e0d7-ca6d-4bf2-b50c-ab7ac572b64f)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
