### PR TITLE
Artisan command - Checking the Installed Filament Version

### DIFF
--- a/packages/panels/docs/01-installation.md
+++ b/packages/panels/docs/01-installation.md
@@ -164,3 +164,11 @@ composer update
 
 php artisan filament:upgrade
 ```
+
+## Checking the Installed Filament Version
+
+To check the version of Filament that is installed, use the following command:
+
+```bash
+php artisan filament:version
+```

--- a/packages/panels/src/Commands/CheckVersionCommand.php
+++ b/packages/panels/src/Commands/CheckVersionCommand.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'filament:version', aliases: [
     'filament:about',
-    'filament:v'
+    'filament:v',
 ])]
 class CheckVersionCommand extends Command
 {
@@ -20,7 +20,7 @@ class CheckVersionCommand extends Command
      */
     protected $aliases = [
         'filament:about',
-        'filament:v'
+        'filament:v',
     ];
 
     public function handle(): int

--- a/packages/panels/src/Commands/CheckVersionCommand.php
+++ b/packages/panels/src/Commands/CheckVersionCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Filament\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'filament:version', aliases: [
+    'filament:about',
+    'filament:v'
+])]
+class CheckVersionCommand extends Command
+{
+    protected $description = 'Check the Filament version';
+
+    protected $signature = 'filament:version';
+
+    /**
+     * @var array<string>
+     */
+    protected $aliases = [
+        'filament:about',
+        'filament:v'
+    ];
+
+    public function handle(): int
+    {
+        $this->call('about', ['--only' => 'Filament']);
+
+        return static::SUCCESS;
+    }
+}

--- a/packages/panels/src/FilamentServiceProvider.php
+++ b/packages/panels/src/FilamentServiceProvider.php
@@ -47,6 +47,7 @@ class FilamentServiceProvider extends PackageServiceProvider
                 Commands\MakeResourceCommand::class,
                 Commands\MakeThemeCommand::class,
                 Commands\MakeUserCommand::class,
+                Commands\CheckVersionCommand::class
             ])
             ->hasRoutes('web')
             ->hasTranslations()

--- a/packages/panels/src/FilamentServiceProvider.php
+++ b/packages/panels/src/FilamentServiceProvider.php
@@ -47,7 +47,7 @@ class FilamentServiceProvider extends PackageServiceProvider
                 Commands\MakeResourceCommand::class,
                 Commands\MakeThemeCommand::class,
                 Commands\MakeUserCommand::class,
-                Commands\CheckVersionCommand::class
+                Commands\CheckVersionCommand::class,
             ])
             ->hasRoutes('web')
             ->hasTranslations()


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
A new artisan command is now available to check the installed Filament version.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
