### PR TITLE
Prevent text breaking out the grid

### DIFF
--- a/packages/forms/resources/views/components/field-wrapper/helper-text.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/helper-text.blade.php
@@ -1,5 +1,5 @@
 <div
-    {{ $attributes->class(['fi-fo-field-wrp-helper-text text-sm text-gray-500']) }}
+    {{ $attributes->class(['fi-fo-field-wrp-helper-text break-words text-sm text-gray-500']) }}
 >
     {{ $slot }}
 </div>

--- a/packages/infolists/resources/views/components/entry-wrapper/helper-text.blade.php
+++ b/packages/infolists/resources/views/components/entry-wrapper/helper-text.blade.php
@@ -1,5 +1,5 @@
 <div
-    {{ $attributes->class(['fi-in-entry-wrp-helper-text text-sm text-gray-500']) }}
+    {{ $attributes->class(['fi-in-entry-wrp-helper-text break-words text-sm text-gray-500']) }}
 >
     {{ $slot }}
 </div>


### PR DESCRIPTION
## Issue:

<img width="495" alt="image" src="https://github.com/user-attachments/assets/054354e4-c8ef-4419-9455-59486cc5b7cc">

## Fix:
<img width="593" alt="image" src="https://github.com/user-attachments/assets/ffb0ba89-5b4f-4906-8180-5979c77c91e2">

## Honest notes
In the screenshot the url breaks right at the end of the word "pretty". In reality, the place where it breaks is beyond our control.

## Implementation docs:
https://tailwindcss.com/docs/word-break#break-words

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date. (Not relevant)
