### PR TITLE
Docs Update - Modify the modal blade component page

### DIFF
--- a/packages/support/docs/09-blade-components/02-modal.md
+++ b/packages/support/docs/09-blade-components/02-modal.md
@@ -207,10 +207,13 @@ By default, when you press escape on a modal, it will close itself. If you wish 
 
 ## Hiding the modal close button
 
-By default, modals have a close button in the top right corner. You can remove the close button from the modal by using the `close-button` attribute:
+By default, modals with a heading have a close button in the top right corner. You can remove the close button from the modal by using the `close-button` attribute:
 
 ```blade
 <x-filament::modal :close-button="false">
+    <x-slot name="heading">
+        Modal heading
+    </x-slot>
     {{-- Modal content --}}
 </x-filament::modal>
 ```

--- a/packages/support/docs/09-blade-components/02-modal.md
+++ b/packages/support/docs/09-blade-components/02-modal.md
@@ -207,13 +207,14 @@ By default, when you press escape on a modal, it will close itself. If you wish 
 
 ## Hiding the modal close button
 
-By default, modals with a heading have a close button in the top right corner. You can remove the close button from the modal by using the `close-button` attribute:
+By default, modals with a header have a close button in the top right corner. You can remove the close button from the modal by using the `close-button` attribute:
 
 ```blade
 <x-filament::modal :close-button="false">
     <x-slot name="heading">
         Modal heading
     </x-slot>
+
     {{-- Modal content --}}
 </x-filament::modal>
 ```


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
When using the modal blade component, a close button only displays in the top right corner when using a heading. This commit makes a slight adjustment to the documentation to make this clearer.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes
Before:
<img width="660" alt="Screenshot 2024-08-07 at 15 15 35" src="https://github.com/user-attachments/assets/1daf4e18-70d0-482a-889e-b29db1f06610">
After:
<img width="654" alt="Screenshot 2024-08-07 at 15 19 29" src="https://github.com/user-attachments/assets/9912905b-7def-45ab-b73b-40faafbcfb13">


<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
