### PR TITLE
Update action testing documentation to include testing modals

### DIFF
--- a/packages/actions/docs/09-testing.md
+++ b/packages/actions/docs/09-testing.md
@@ -86,7 +86,7 @@ it('stops sending if invoice has no email address', function () {
 });
 ```
 
-## Testing modal content
+## Testing modals
 
 To assert against the content of a modal, you should first mount the action (rather than call it which resolves the modal). You can then use [livewire assertions](https://livewire.laravel.com/docs/testing#assertions) such as `assertSee` to assert the modal has rendered as you expect:
 

--- a/packages/actions/docs/09-testing.md
+++ b/packages/actions/docs/09-testing.md
@@ -86,6 +86,25 @@ it('stops sending if invoice has no email address', function () {
 });
 ```
 
+## Testing modal content
+
+To assert against the content of a modal, you should first mount the action (rather than call it which resolves the modal). You can then use [livewire assertions](https://livewire.laravel.com/docs/testing#assertions) such as `assertSee` to assert the modal has rendered as you expect:
+
+```php
+use function Pest\Livewire\livewire;
+
+it('confirms the target address before sending', function () {
+    $invoice = Invoice::factory()->create();
+    $recipientEmail = $invoice->company->primaryContact->email;
+
+    livewire(EditInvoice::class, [
+        'invoice' => $invoice,
+    ])
+        ->mountAction('send')
+        ->assertSee($recipientEmail);
+});
+```
+
 ## Errors
 
 `assertHasNoActionErrors()` is used to assert that no validation errors occurred when submitting the action form.
@@ -126,7 +145,7 @@ it('can send invoices to the primary contact by default', function () {
         ])
         ->callMountedAction()
         ->assertHasNoActionErrors();
-        
+
     expect($invoice->refresh())
         ->isSent()->toBeTrue()
         ->recipient_email->toBe($recipientEmail);

--- a/packages/actions/docs/09-testing.md
+++ b/packages/actions/docs/09-testing.md
@@ -86,9 +86,9 @@ it('stops sending if invoice has no email address', function () {
 });
 ```
 
-## Testing modals
+## Modal content
 
-To assert against the content of a modal, you should first mount the action (rather than call it which resolves the modal). You can then use [livewire assertions](https://livewire.laravel.com/docs/testing#assertions) such as `assertSee` to assert the modal has rendered as you expect:
+To assert the content of a modal, you should first mount the action (rather than call it which closes the modal). You can then use [Livewire assertions](https://livewire.laravel.com/docs/testing#assertions) such as `assertSee()` to assert the modal contains the content that you expect it to:
 
 ```php
 use function Pest\Livewire\livewire;


### PR DESCRIPTION
## Description

The [existing documentation](https://filamentphp.com/docs/3.x/actions/testing) on testing actions contains no information on how to test that modals are rendering as expected.

A number of my actions are just modals, so testing they are rending correctly is the entirety of the test.

This PR improves the situation by adding a section on testing modals.

A few points:
- This is just how I have managed to get it working by inferring things from other sections in the docs & a few threads online. If it is unclear or incorrect feel free to update, but it would be great to have the official best practice way to achieve this in the docs given modals are a key part of actions.
- I've tried to inject it into the docs at a place that feels logical but YMMV.
- I've tried to use an example that illustrates the key points but also lines up with others in the doc.

## Visual changes

No visual changes aside from the additional documentation to `docs/actions/testing`.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
