### PR TITLE
Fix issue testing visible action with arguments

### DIFF
--- a/packages/actions/.stubs.php
+++ b/packages/actions/.stubs.php
@@ -19,9 +19,9 @@ namespace Livewire\Features\SupportTesting {
 
         public function assertActionDoesNotExist(string | array $name): static {}
 
-        public function assertActionVisible(string | array $name): static {}
+        public function assertActionVisible(string | array $name, array $arguments = []): static {}
 
-        public function assertActionHidden(string | array $name): static {}
+        public function assertActionHidden(string | array $name, array $arguments = []): static {}
 
         public function assertActionEnabled(string | array $name): static {}
 

--- a/packages/actions/src/Testing/TestsActions.php
+++ b/packages/actions/src/Testing/TestsActions.php
@@ -90,7 +90,7 @@ class TestsActions
     {
         return function (string | array $name, array $data = [], array $arguments = []): static {
             /** @phpstan-ignore-next-line */
-            $this->assertActionVisible($name);
+            $this->assertActionVisible($name, $arguments);
 
             /** @phpstan-ignore-next-line */
             $this->mountAction($name, $arguments);
@@ -181,7 +181,7 @@ class TestsActions
 
     public function assertActionVisible(): Closure
     {
-        return function (string | array $name): static {
+        return function (string | array $name, array $arguments): static {
             /** @var array<string> $name */
             /** @phpstan-ignore-next-line */
             $name = $this->parseNestedActionName($name);
@@ -190,6 +190,8 @@ class TestsActions
             $this->assertActionExists($name);
 
             $action = $this->instance()->getAction($name);
+
+            $action->arguments($arguments);
 
             $livewireClass = $this->instance()::class;
             $prettyName = implode(' > ', $name);

--- a/packages/actions/src/Testing/TestsActions.php
+++ b/packages/actions/src/Testing/TestsActions.php
@@ -181,7 +181,7 @@ class TestsActions
 
     public function assertActionVisible(): Closure
     {
-        return function (string | array $name, array $arguments): static {
+        return function (string | array $name, array $arguments = []): static {
             /** @var array<string> $name */
             /** @phpstan-ignore-next-line */
             $name = $this->parseNestedActionName($name);
@@ -207,7 +207,7 @@ class TestsActions
 
     public function assertActionHidden(): Closure
     {
-        return function (string | array $name): static {
+        return function (string | array $name, array $arguments = []): static {
             /** @var array<string> $name */
             /** @phpstan-ignore-next-line */
             $name = $this->parseNestedActionName($name);
@@ -216,6 +216,8 @@ class TestsActions
             $this->assertActionExists($name);
 
             $action = $this->instance()->getAction($name);
+
+            $action->arguments($arguments);
 
             $livewireClass = $this->instance()::class;
             $prettyName = implode(' > ', $name);

--- a/packages/forms/resources/js/components/textarea.js
+++ b/packages/forms/resources/js/components/textarea.js
@@ -1,4 +1,8 @@
-export default function textareaFormComponent({ initialHeight, shouldAutosize, state }) {
+export default function textareaFormComponent({
+    initialHeight,
+    shouldAutosize,
+    state,
+}) {
     return {
         state,
 
@@ -13,7 +17,6 @@ export default function textareaFormComponent({ initialHeight, shouldAutosize, s
                 this.$watch('state', () => {
                     this.resize()
                 })
-                
             } else {
                 this.setUpResizeObserver()
             }

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -33,7 +33,7 @@
                 ->class(['fi-fo-textarea overflow-hidden'])
         "
     >
-        <div wire:ignore.self style="height: '{{ $initialHeight . 'rem' }}';">
+        <div wire:ignore.self style="height: '{{ $initialHeight . 'rem' }}'">
             <textarea
                 x-ignore
                 @if (FilamentView::hasSpaMode())
@@ -43,10 +43,10 @@
                 @endif
                 ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('textarea', 'filament/forms') }}"
                 x-data="textareaFormComponent({
-                    initialHeight: @js($initialHeight),
-                    shouldAutosize: @js($shouldAutosize),
-                    state: $wire.$entangle('{{ $statePath }}'),
-                })"
+                            initialHeight: @js($initialHeight),
+                            shouldAutosize: @js($shouldAutosize),
+                            state: $wire.$entangle('{{ $statePath }}'),
+                        })"
                 @if ($shouldAutosize)
                     x-intersect.once="resize()"
                     x-on:resize.window="resize()"
@@ -70,7 +70,7 @@
                             $applyStateBindingModifiers('wire:model') => $statePath,
                         ], escape: false)
                         ->class([
-                            'block w-full h-full border-none bg-transparent px-3 py-1.5 text-base text-gray-950 placeholder:text-gray-400 focus:ring-0 disabled:text-gray-500 disabled:[-webkit-text-fill-color:theme(colors.gray.500)] disabled:placeholder:[-webkit-text-fill-color:theme(colors.gray.400)] dark:text-white dark:placeholder:text-gray-500 dark:disabled:text-gray-400 dark:disabled:[-webkit-text-fill-color:theme(colors.gray.400)] dark:disabled:placeholder:[-webkit-text-fill-color:theme(colors.gray.500)] sm:text-sm sm:leading-6',
+                            'block h-full w-full border-none bg-transparent px-3 py-1.5 text-base text-gray-950 placeholder:text-gray-400 focus:ring-0 disabled:text-gray-500 disabled:[-webkit-text-fill-color:theme(colors.gray.500)] disabled:placeholder:[-webkit-text-fill-color:theme(colors.gray.400)] dark:text-white dark:placeholder:text-gray-500 dark:disabled:text-gray-400 dark:disabled:[-webkit-text-fill-color:theme(colors.gray.400)] dark:disabled:placeholder:[-webkit-text-fill-color:theme(colors.gray.500)] sm:text-sm sm:leading-6',
                             'resize-none' => $shouldAutosize,
                         ])
                 }}


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Fix issue when testing action that has arguments to control the visibility. 

https://github.com/filamentphp/demo/compare/main...howdu:demo:test-action-with-arguments

```php
Action::make('test')
      ->label(fn (array $arguments): string => "Test {$arguments['foo']}")
      ->visible(fn (array $arguments): bool => $arguments['foo'] == 'bar');

Livewire::test(Form::class)
      ->assertStatus(200)
      ->callAction('testAction', arguments: ['foo' => 'bar']);
```

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
