### PR TITLE
Add authorization to register method

### DIFF
--- a/packages/panels/src/Pages/Tenancy/RegisterTenant.php
+++ b/packages/panels/src/Pages/Tenancy/RegisterTenant.php
@@ -72,7 +72,7 @@ abstract class RegisterTenant extends SimplePage
     public function register(): void
     {
         abort_unless(static::canView(), 404);
-        
+
         try {
             $this->beginDatabaseTransaction();
 

--- a/packages/panels/src/Pages/Tenancy/RegisterTenant.php
+++ b/packages/panels/src/Pages/Tenancy/RegisterTenant.php
@@ -71,6 +71,8 @@ abstract class RegisterTenant extends SimplePage
 
     public function register(): void
     {
+        abort_unless(static::canView(), 404);
+        
         try {
             $this->beginDatabaseTransaction();
 


### PR DESCRIPTION
## Description

Issue scenario:
if the user keep the page open (skipping the mount method that check for authorization), and keep submitting the form, it will work because there is no authorization check on the register method.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
