### PR TITLE
Add badge and color to content tab on EditRecord and ViewRecord

### DIFF
--- a/packages/panels/docs/03-resources/07-relation-managers.md
+++ b/packages/panels/docs/03-resources/07-relation-managers.md
@@ -673,6 +673,28 @@ public function getContentTabIcon(): ?string
 }
 ```
 
+### Setting a badge for the form tab
+
+On the Edit or View page class, override the `getContentTabBadge()` method:
+
+```php
+public function getContentTabBadge(): ?string
+{
+    return '3';
+}
+```
+
+### Setting a color for the form tab badge
+
+On the Edit or View page class, override the `getContentTabBadgeColor()` method:
+
+```php
+public function getContentTabBadgeColor(): ?string
+{
+    return 'warning';
+}
+```
+
 ### Setting the position of the form tab
 
 By default, the form tab is rendered before the relation tabs. To render it after, you can override the `getContentTabPosition()` method on the Edit or View page class:

--- a/packages/panels/resources/views/components/resources/relation-managers.blade.php
+++ b/packages/panels/resources/views/components/resources/relation-managers.blade.php
@@ -3,6 +3,8 @@
     'activeManager',
     'content' => null,
     'contentTabLabel' => null,
+    'contentTabBadge' => null,
+    'contentTabBadgeColor' => null,
     'contentTabIcon' => null,
     'contentTabPosition' => null,
     'managers',
@@ -50,8 +52,8 @@
 
                 <x-filament::tabs.item
                     :active="$activeManager === $tabKey"
-                    :badge="filled($tabKey) ? ($isGroup ? $manager->getBadge() : $manager::getBadge($ownerRecord, $pageClass)) : null"
-                    :badge-color="filled($tabKey) ? ($isGroup ? $manager->getBadgeColor() : $manager::getBadgeColor($ownerRecord, $pageClass)) : null"
+                    :badge="filled($tabKey) ? ($isGroup ? $manager->getBadge() : $manager::getBadge($ownerRecord, $pageClass)) : ($contentTabBadge ?? null)"
+                    :badge-color="filled($tabKey) ? ($isGroup ? $manager->getBadgeColor() : $manager::getBadgeColor($ownerRecord, $pageClass)) : ($contentTabBadgeColor ?? null)"
                     :badge-tooltip="filled($tabKey) ? ($isGroup ? $manager->getBadgeTooltip() : $manager::getBadgeTooltip($ownerRecord, $pageClass)) : null"
                     :icon="filled($tabKey) ? ($isGroup ? $manager->getIcon() : $manager::getIcon($ownerRecord, $pageClass)) : ($contentTabIcon ?? null)"
                     :icon-position="filled($tabKey) ? ($isGroup ? $manager->getIconPosition() : $manager::getIconPosition($ownerRecord, $pageClass)) : ($contentTabIconPosition ?? null)"

--- a/packages/panels/resources/views/resources/pages/edit-record.blade.php
+++ b/packages/panels/resources/views/resources/pages/edit-record.blade.php
@@ -34,6 +34,8 @@
             :active-locale="isset($activeLocale) ? $activeLocale : null"
             :active-manager="$this->activeRelationManager ?? ($hasCombinedRelationManagerTabsWithContent ? null : array_key_first($relationManagers))"
             :content-tab-label="$this->getContentTabLabel()"
+            :content-tab-badge="$this->getContentTabBadge()"
+            :content-tab-badge-color="$this->getContentTabBadgeColor()"
             :content-tab-icon="$this->getContentTabIcon()"
             :content-tab-position="$this->getContentTabPosition()"
             :managers="$relationManagers"

--- a/packages/panels/resources/views/resources/pages/view-record.blade.php
+++ b/packages/panels/resources/views/resources/pages/view-record.blade.php
@@ -27,6 +27,8 @@
             :active-locale="isset($activeLocale) ? $activeLocale : null"
             :active-manager="$this->activeRelationManager ?? ($hasCombinedRelationManagerTabsWithContent ? null : array_key_first($relationManagers))"
             :content-tab-label="$this->getContentTabLabel()"
+            :content-tab-badge="$this->getContentTabBadge()"
+            :content-tab-badge-color="$this->getContentTabBadgeColor()"
             :content-tab-icon="$this->getContentTabIcon()"
             :content-tab-position="$this->getContentTabPosition()"
             :managers="$relationManagers"

--- a/packages/panels/src/Resources/Pages/Concerns/HasRelationManagers.php
+++ b/packages/panels/src/Resources/Pages/Concerns/HasRelationManagers.php
@@ -70,6 +70,16 @@ trait HasRelationManagers
         return null;
     }
 
+    public function getContentTabBadge(): ?string
+    {
+        return null;
+    }
+
+    public function getContentTabBadgeColor(): ?string
+    {
+        return null;
+    }
+
     public function getContentTabIcon(): ?string
     {
         return null;


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

Added options to set a badge and badge color to the content tab of EditRecord and ViewRecord pages when `hasCombinedRelationManagerTabsWithContent = true` . 

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

![edit_before](https://github.com/user-attachments/assets/16a7a8ae-d51f-4590-8904-6091e4358fbe)
![edit_after](https://github.com/user-attachments/assets/0216f5d8-e101-43d5-9644-c60bdeebe081)



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
