### PR TITLE
Vertical wizard navigation - new `vertical()` method for Wizard class

### DIFF
--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -1,5 +1,6 @@
 @php
     $isContained = $isContained();
+    $isVertical = $isVertical();
     $statePath = $getStatePath();
 @endphp
 
@@ -106,7 +107,8 @@
             ->merge($getExtraAttributes(), escape: false)
             ->merge($getExtraAlpineAttributes(), escape: false)
             ->class([
-                'fi-fo-wizard',
+                'fi-fo-wizard ',
+                'fi-fo-wizard-vertical grid md:grid-cols-8' => $isVertical,
                 'fi-contained rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10' => $isContained,
             ])
     }}
@@ -129,14 +131,17 @@
         @endif
         role="list"
         @class([
-            'fi-fo-wizard-header grid divide-y divide-gray-200 dark:divide-white/5 md:grid-flow-col md:divide-y-0 md:overflow-x-auto',
-            'border-b border-gray-200 dark:border-white/10' => $isContained,
+            'fi-fo-wizard-header grid divide-y divide-gray-200 dark:divide-white/5',
+            'md:grid-flow-row md:divide-y md:col-span-2 content-start border-e' => $isVertical,
+            'md:grid-flow-col md:divide-y-0 md:overflow-x-auto' => !$isVertical,
+            'border-gray-200 dark:border-white/10' => $isContained,
+            'border-b' => $isContained && !$isVertical,
             'rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10' => ! $isContained,
         ])
     >
         @foreach ($getChildComponentContainer()->getComponents() as $step)
             <li
-                class="fi-fo-wizard-header-step relative flex"
+                class="fi-fo-wizard-header-step relative {{$isVertical ? 'block' : 'flex'}}"
                 x-bind:class="{
                     'fi-active': getStepIndex(step) === {{ $loop->index }},
                     'fi-completed': getStepIndex(step) > {{ $loop->index }},
@@ -148,7 +153,7 @@
                     x-on:click="step = @js($step->getId())"
                     x-bind:disabled="! isStepAccessible(@js($step->getId()))"
                     role="step"
-                    class="fi-fo-wizard-header-step-button flex h-full items-center gap-x-4 px-6 py-4 text-start"
+                    class="fi-fo-wizard-header-step-button flex {{$isVertical ? 'w-full' : 'h-full'}} items-center gap-x-4 px-6 py-4 text-start"
                 >
                     <div
                         class="fi-fo-wizard-header-step-icon-ctn flex h-10 w-10 shrink-0 items-center justify-center rounded-full"
@@ -227,7 +232,7 @@
                     </div>
                 </button>
 
-                @if (! $loop->last)
+                @if (! $loop->last && !$isVertical)
                     <div
                         aria-hidden="true"
                         class="fi-fo-wizard-header-step-separator absolute end-0 hidden h-full w-5 md:block"
@@ -257,9 +262,10 @@
 
     <div
         @class([
-            'flex items-center justify-between gap-x-3',
+            'fi-fo-wizard-actions flex items-center justify-between gap-x-3',
             'px-6 pb-6' => $isContained,
             'mt-6' => ! $isContained,
+            'md:col-span-8 border-t pt-6' => $isVertical
         ])
     >
         <span x-cloak x-on:click="previousStep" x-show="! isFirstStep()">

--- a/packages/forms/resources/views/components/wizard/step.blade.php
+++ b/packages/forms/resources/views/components/wizard/step.blade.php
@@ -1,6 +1,8 @@
 @php
     $id = $getId();
-    $isContained = $getContainer()->getParentComponent()->isContained();
+	$parentComponent = $getContainer()->getParentComponent();
+    $isContained = $parentComponent->isContained();
+    $isVertical = $parentComponent->isVertical();
 
     $activeStepClasses = \Illuminate\Support\Arr::toCssClasses([
         'fi-active',
@@ -33,7 +35,10 @@
                 'tabindex' => '0',
             ], escape: false)
             ->merge($getExtraAttributes(), escape: false)
-            ->class(['fi-fo-wizard-step outline-none'])
+            ->class([
+					'fi-fo-wizard-step outline-none',
+					'md:col-span-6' => $isVertical
+					])
     }}
 >
     {{ $getChildComponentContainer() }}

--- a/packages/forms/src/Components/Wizard.php
+++ b/packages/forms/src/Components/Wizard.php
@@ -20,6 +20,8 @@ class Wizard extends Component
 
     protected bool | Closure $isSkippable = false;
 
+    protected bool | Closure $isVertical = false;
+
     protected string | Closure | null $stepQueryStringKey = null;
 
     protected string | Htmlable | null $submitAction = null;
@@ -217,6 +219,13 @@ class Wizard extends Component
         return $this;
     }
 
+    public function vertical(bool | Closure $condition = true): static
+    {
+        $this->isVertical = $condition;
+
+        return $this;
+    }
+
     public function persistStepInQueryString(string | Closure | null $key = 'step'): static
     {
         $this->stepQueryStringKey = $key;
@@ -259,6 +268,11 @@ class Wizard extends Component
     public function isSkippable(): bool
     {
         return (bool) $this->evaluate($this->isSkippable);
+    }
+
+    public function isVertical(): bool
+    {
+        return (bool) $this->evaluate($this->isVertical);
     }
 
     public function isStepPersistedInQueryString(): bool


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

Implements vertical layout based on prototype in this discussion: https://github.com/filamentphp/filament/discussions/13894, but by natively toggling css classes in blade templates rather than adding pure css overrides.

## Visual changes

Default style:
![wizard_default](https://github.com/user-attachments/assets/41a400bf-99c0-49cf-9d1e-cead0e07b09d)

Vertical style
![wizard_vertical](https://github.com/user-attachments/assets/3337ef51-7a34-4c36-96fd-f7f4fd8b81c7)

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

Toggle vertical layout like this:

```php
Wizard::make([ ])->vertical()
```

- switching to vertical toggles bunch of css classes in wizard+ wizard/step templates
- vertical variant has extra class `fi-fo-wizard-vertical`
- added `fi-fo-wizard-actions` class to buttons container


## TODO: CSS should probably be recompiled ?

-----

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
