### PR TITLE
fix async alpine not loading reliably in spa mode

### DIFF
--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -43,7 +43,7 @@
         <div
             x-ignore
             @if (FilamentView::hasSpaMode())
-                ax-load="|| event (ax-modal-opened) visible"
+                {{-- format-ignore-start --}}ax-load="visible || event (ax-modal-opened)"{{-- format-ignore-end --}}
             @else
                 ax-load
             @endif

--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -43,7 +43,7 @@
         <div
             x-ignore
             @if (FilamentView::hasSpaMode())
-                ax-load="visible"
+                ax-load="visible || event (ax-modal-opened)"
             @else
                 ax-load
             @endif

--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -43,7 +43,7 @@
         <div
             x-ignore
             @if (FilamentView::hasSpaMode())
-                ax-load="visible || event (ax-modal-opened)"
+                ax-load="|| event (ax-modal-opened) visible"
             @else
                 ax-load
             @endif

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -67,7 +67,7 @@
             <div
                 x-ignore
                 @if (FilamentView::hasSpaMode())
-                    ax-load="|| event (ax-modal-opened) visible"
+                    {{-- format-ignore-start --}}ax-load="visible || event (ax-modal-opened)"{{-- format-ignore-end --}}
                 @else
                     ax-load
                 @endif

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -67,7 +67,7 @@
             <div
                 x-ignore
                 @if (FilamentView::hasSpaMode())
-                    ax-load="visible"
+                    ax-load="visible || event (ax-modal-opened)"
                 @else
                     ax-load
                 @endif

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -67,7 +67,7 @@
             <div
                 x-ignore
                 @if (FilamentView::hasSpaMode())
-                    ax-load="visible || event (ax-modal-opened)"
+                    ax-load="|| event (ax-modal-opened) visible"
                 @else
                     ax-load
                 @endif

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -25,7 +25,7 @@
 >
     <div
         @if (FilamentView::hasSpaMode())
-            ax-load="visible"
+            ax-load="visible || event (ax-modal-opened)"
         @else
             ax-load
         @endif

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -25,7 +25,7 @@
 >
     <div
         @if (FilamentView::hasSpaMode())
-            ax-load="visible || event (ax-modal-opened)"
+            ax-load="|| event (ax-modal-opened) visible"
         @else
             ax-load
         @endif

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -25,7 +25,7 @@
 >
     <div
         @if (FilamentView::hasSpaMode())
-            ax-load="|| event (ax-modal-opened) visible"
+            {{-- format-ignore-start --}}ax-load="visible || event (ax-modal-opened)"{{-- format-ignore-end --}}
         @else
             ax-load
         @endif

--- a/packages/forms/resources/views/components/key-value.blade.php
+++ b/packages/forms/resources/views/components/key-value.blade.php
@@ -34,7 +34,7 @@
     >
         <div
             @if (FilamentView::hasSpaMode())
-                ax-load="visible"
+                ax-load="visible || event (ax-modal-opened)"
             @else
                 ax-load
             @endif

--- a/packages/forms/resources/views/components/key-value.blade.php
+++ b/packages/forms/resources/views/components/key-value.blade.php
@@ -34,7 +34,7 @@
     >
         <div
             @if (FilamentView::hasSpaMode())
-                ax-load="visible || event (ax-modal-opened)"
+                ax-load="|| event (ax-modal-opened) visible"
             @else
                 ax-load
             @endif

--- a/packages/forms/resources/views/components/key-value.blade.php
+++ b/packages/forms/resources/views/components/key-value.blade.php
@@ -34,7 +34,7 @@
     >
         <div
             @if (FilamentView::hasSpaMode())
-                ax-load="|| event (ax-modal-opened) visible"
+                {{-- format-ignore-start --}}ax-load="visible || event (ax-modal-opened)"{{-- format-ignore-end --}}
             @else
                 ax-load
             @endif

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -20,7 +20,8 @@
             "
         >
             <div
-                ax-load="|| event (ax-modal-opened) visible"
+                {{-- prettier-ignore-start --}}ax-load="visible || event (ax-modal-opened)"
+                {{-- prettier-ignore-end --}}
                 ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('markdown-editor', 'filament/forms') }}"
                 x-data="markdownEditorFormComponent({
                             canAttachFiles: @js($hasToolbarButton('attachFiles')),

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -20,7 +20,7 @@
             "
         >
             <div
-                ax-load="visible || event (ax-modal-opened)"
+                ax-load="|| event (ax-modal-opened) visible"
                 ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('markdown-editor', 'filament/forms') }}"
                 x-data="markdownEditorFormComponent({
                             canAttachFiles: @js($hasToolbarButton('attachFiles')),

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -20,7 +20,7 @@
             "
         >
             <div
-                ax-load="visible"
+                ax-load="visible || event (ax-modal-opened)"
                 ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('markdown-editor', 'filament/forms') }}"
                 x-data="markdownEditorFormComponent({
                             canAttachFiles: @js($hasToolbarButton('attachFiles')),

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -24,7 +24,7 @@
         >
             <div
                 @if (FilamentView::hasSpaMode())
-                    ax-load="visible || event (ax-modal-opened)"
+                    ax-load="|| event (ax-modal-opened) visible"
                 @else
                     ax-load
                 @endif

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -24,7 +24,7 @@
         >
             <div
                 @if (FilamentView::hasSpaMode())
-                    ax-load="|| event (ax-modal-opened) visible"
+                    {{-- format-ignore-start --}}ax-load="visible || event (ax-modal-opened)"{{-- format-ignore-end --}}
                 @else
                     ax-load
                 @endif

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -24,7 +24,7 @@
         >
             <div
                 @if (FilamentView::hasSpaMode())
-                    ax-load="visible"
+                    ax-load="visible || event (ax-modal-opened)"
                 @else
                     ax-load
                 @endif

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -112,7 +112,7 @@
             <div
                 x-ignore
                 @if (FilamentView::hasSpaMode())
-                    ax-load="visible || event (ax-modal-opened)"
+                    ax-load="|| event (ax-modal-opened) visible"
                 @else
                     ax-load
                 @endif

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -112,7 +112,7 @@
             <div
                 x-ignore
                 @if (FilamentView::hasSpaMode())
-                    ax-load="|| event (ax-modal-opened) visible"
+                    {{-- format-ignore-start --}}ax-load="visible || event (ax-modal-opened)"{{-- format-ignore-end --}}
                 @else
                     ax-load
                 @endif

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -112,7 +112,7 @@
             <div
                 x-ignore
                 @if (FilamentView::hasSpaMode())
-                    ax-load="visible"
+                    ax-load="visible || event (ax-modal-opened)"
                 @else
                     ax-load
                 @endif

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -52,7 +52,7 @@
     >
         <div
             @if (FilamentView::hasSpaMode())
-                ax-load="|| event (ax-modal-opened) visible"
+                {{-- format-ignore-start --}}ax-load="visible || event (ax-modal-opened)"{{-- format-ignore-end --}}
             @else
                 ax-load
             @endif

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -52,7 +52,7 @@
     >
         <div
             @if (FilamentView::hasSpaMode())
-                ax-load="visible"
+                ax-load="visible || event (ax-modal-opened)"
             @else
                 ax-load
             @endif

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -52,7 +52,7 @@
     >
         <div
             @if (FilamentView::hasSpaMode())
-                ax-load="visible || event (ax-modal-opened)"
+                ax-load="|| event (ax-modal-opened) visible"
             @else
                 ax-load
             @endif

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -37,7 +37,7 @@
             <textarea
                 x-ignore
                 @if (FilamentView::hasSpaMode())
-                    ax-load="visible || event (ax-modal-opened)"
+                    ax-load="|| event (ax-modal-opened) visible"
                 @else
                     ax-load
                 @endif

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -37,7 +37,7 @@
             <textarea
                 x-ignore
                 @if (FilamentView::hasSpaMode())
-                    ax-load="|| event (ax-modal-opened) visible"
+                    {{-- format-ignore-start --}}ax-load="visible || event (ax-modal-opened)"{{-- format-ignore-end --}}
                 @else
                     ax-load
                 @endif

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -37,7 +37,7 @@
             <textarea
                 x-ignore
                 @if (FilamentView::hasSpaMode())
-                    ax-load="visible"
+                    ax-load="visible || event (ax-modal-opened)"
                 @else
                     ax-load
                 @endif

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -79,7 +79,7 @@
                 this.isOpen = true
 
                 @if (FilamentView::hasSpaMode())
-                this.$dispatch('ax-modal-opened')
+                    this.$dispatch('ax-modal-opened')
                 @endif
 
                 this.$refs.modalContainer.dispatchEvent(

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -1,6 +1,7 @@
 @php
     use Filament\Support\Enums\Alignment;
     use Filament\Support\Enums\MaxWidth;
+    use Filament\Support\Facades\FilamentView;
 @endphp
 
 @props([
@@ -76,6 +77,10 @@
         open: function () {
             this.$nextTick(() => {
                 this.isOpen = true
+
+                @if (FilamentView::hasSpaMode())
+                this.$dispatch('ax-modal-opened')
+                @endif
 
                 this.$refs.modalContainer.dispatchEvent(
                     new CustomEvent('modal-opened', { id: '{{ $id }}' }),


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
usage of $nextTick to open modal in #13740 seems affecting components loading in spa mode
this PR added a new event to trigger ax-load https://async-alpine.dev/docs/strategies/#event

the issue happens randomly and do not have consistent steps to replicate, but I observed is after browser window size change.
1. load page
2. resize window
3. open modal (close and open again if it doesn't)

with the best effort test it seems to fix the `select` component. 
applied the change to all **form** components using `ax-load="visible"`
not applied to table & widget is not usable in modal

discord ref: https://discord.com/channels/883083792112300104/970354547723730955/1272603144148488255
<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes
N/A
<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
