### PR TITLE
Fix alpine class binding for inactive tab items

### DIFF
--- a/packages/support/resources/views/components/tabs/item.blade.php
+++ b/packages/support/resources/views/components/tabs/item.blade.php
@@ -51,7 +51,7 @@
     @endif
     @if ($hasAlpineActiveClasses)
         x-bind:class="{
-            @js($inactiveItemClasses): ! {{ $alpineActive }},
+            @js($inactiveItemClasses): ! ({{ $alpineActive }}),
             @js($activeItemClasses): {{ $alpineActive }},
         }"
     @endif
@@ -83,7 +83,7 @@
     <span
         @if ($hasAlpineActiveClasses)
             x-bind:class="{
-                @js($inactiveLabelClasses): ! {{ $alpineActive }},
+                @js($inactiveLabelClasses): ! ({{ $alpineActive }}),
                 @js($activeLabelClasses): {{ $alpineActive }},
             }"
         @endif

--- a/packages/support/resources/views/components/tabs/item.blade.php
+++ b/packages/support/resources/views/components/tabs/item.blade.php
@@ -51,7 +51,7 @@
     @endif
     @if ($hasAlpineActiveClasses)
         x-bind:class="{
-            @js($inactiveItemClasses): ! ({{ $alpineActive }}),
+            @js($inactiveItemClasses): {{-- format-ignore-start --}} ! ({{ $alpineActive }}) {{-- format-ignore-end --}},
             @js($activeItemClasses): {{ $alpineActive }},
         }"
     @endif
@@ -83,7 +83,7 @@
     <span
         @if ($hasAlpineActiveClasses)
             x-bind:class="{
-                @js($inactiveLabelClasses): ! ({{ $alpineActive }}),
+                @js($inactiveLabelClasses): ! ({{-- format-ignore-start --}} ({{ $alpineActive }}) {{-- format-ignore-end --}}),
                 @js($activeLabelClasses): {{ $alpineActive }},
             }"
         @endif

--- a/packages/support/resources/views/components/tabs/item.blade.php
+++ b/packages/support/resources/views/components/tabs/item.blade.php
@@ -83,7 +83,7 @@
     <span
         @if ($hasAlpineActiveClasses)
             x-bind:class="{
-                @js($inactiveLabelClasses): ! ({{-- format-ignore-start --}} ({{ $alpineActive }}) {{-- format-ignore-end --}}),
+                @js($inactiveLabelClasses): ({{-- format-ignore-start --}} ! ({{ $alpineActive }}) {{-- format-ignore-end --}}),
                 @js($activeLabelClasses): {{ $alpineActive }},
             }"
         @endif

--- a/packages/support/resources/views/components/tabs/item.blade.php
+++ b/packages/support/resources/views/components/tabs/item.blade.php
@@ -83,7 +83,7 @@
     <span
         @if ($hasAlpineActiveClasses)
             x-bind:class="{
-                @js($inactiveLabelClasses): ({{-- format-ignore-start --}} ! ({{ $alpineActive }}) {{-- format-ignore-end --}}),
+                @js($inactiveLabelClasses): {{-- format-ignore-start --}} ! ({{ $alpineActive }}) {{-- format-ignore-end --}},
                 @js($activeLabelClasses): {{ $alpineActive }},
             }"
         @endif


### PR DESCRIPTION
## Description

There is a bug, which prevents inactive tab items from getting the correct CSS classes.

## Visual changes

This is primarily visible in dark mode. In light mode only the hover state is missing.

Before:
![CleanShot 2024-08-13 at 07 57 17@2x](https://github.com/user-attachments/assets/aa4a2b53-c121-4356-9460-b12af692ce9a)

After:
![CleanShot 2024-08-13 at 07 56 53@2x](https://github.com/user-attachments/assets/f81b1445-5c04-4963-bcf2-f8b9a82b720e)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
