### PR TITLE
Added Buddhist Era plugin support to date-time-picker component.

### DIFF
--- a/packages/forms/resources/js/components/date-time-picker.js
+++ b/packages/forms/resources/js/components/date-time-picker.js
@@ -1,11 +1,13 @@
 import dayjs from 'dayjs/esm'
 import advancedFormat from 'dayjs/plugin/advancedFormat'
+import buddhistEra from 'dayjs/plugin/buddhistEra'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
 import localeData from 'dayjs/plugin/localeData'
 import timezone from 'dayjs/plugin/timezone'
 import utc from 'dayjs/plugin/utc'
 
 dayjs.extend(advancedFormat)
+dayjs.extend(buddhistEra)
 dayjs.extend(customParseFormat)
 dayjs.extend(localeData)
 dayjs.extend(timezone)


### PR DESCRIPTION
This pull request Add Buddhist Era Plugin for day.js

Normally in Thailand, as well as some other country in South East Asia, We use Buddhist year for date Ex. (year + 543, So current year is 2024 = 2567)
Before this, we don't have an easy way to display Buddhist year in Filament Form Date Picker component. With this plugin enable it will allow that.

