### PR TITLE
Remove useless null initialization

### DIFF
--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -455,8 +455,6 @@ class FilamentManager
 
     public function getUserAvatarUrl(Model | Authenticatable $user): string
     {
-        $avatar = null;
-
         if ($user instanceof HasAvatar) {
             $avatar = $user->getFilamentAvatarUrl();
         } else {


### PR DESCRIPTION
The `$avatar = null;` is meaningless, since:
-  the value for `$avatar` would not be undefined due to the `if ... else` condition coming after.
- the return value of `getUserAvatarUrl()` could not be nullable due to it's return type hint.
