### PR TITLE
Add option to allow paste in fileuploads

### DIFF
--- a/packages/forms/docs/03-fields/09-file-upload.md
+++ b/packages/forms/docs/03-fields/09-file-upload.md
@@ -314,6 +314,19 @@ FileUpload::make('attachments')
     ->appendFiles()
 ```
 
+## Upload file through paste
+
+You can allow users to upload a file though paste using the `allowPaste()` method. 
+
+```php
+use Filament\Forms\Components\FileUpload;
+
+FileUpload::make('attachments')
+    ->allowPaste()
+```
+
+Bare in mind that this feature is [not supported in all browsers](https://caniuse.com/?search=paste).
+
 ## Opening files in a new tab
 
 You can add a button to open each file in a new tab with the `openable()` method:

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -51,6 +51,7 @@ export default function fileUploadFormComponent({
     isOpenable,
     isPreviewable,
     isReorderable,
+    doesAllowPaste,
     itemPanelAspectRatio,
     loadingIndicatorPosition,
     locale,
@@ -99,7 +100,7 @@ export default function fileUploadFormComponent({
             this.pond = FilePond.create(this.$refs.input, {
                 acceptedFileTypes,
                 allowImageExifOrientation: shouldOrientImageFromExif,
-                allowPaste: false,
+                allowPaste: doesAllowPaste || false,
                 allowRemove: isDeletable,
                 allowReorder: isReorderable,
                 allowImagePreview: isPreviewable,

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -62,6 +62,7 @@
                     isOpenable: @js($isOpenable()),
                     isPreviewable: @js($isPreviewable()),
                     isReorderable: @js($isReorderable()),
+                    doesAllowPaste: @js($doesAllowPaste()),
                     itemPanelAspectRatio: @js($getItemPanelAspectRatio()),
                     loadingIndicatorPosition: @js($getLoadingIndicatorPosition()),
                     locale: @js(app()->getLocale()),

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -36,6 +36,8 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
 
     protected bool | Closure $isReorderable = false;
 
+    protected bool | Closure $doesAllowPaste = false;
+
     protected string | Closure | null $directory = null;
 
     protected string | Closure | null $diskName = null;
@@ -282,6 +284,13 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
         return $this;
     }
 
+    public function allowPaste(bool | Closure $condition = true): static
+    {
+        $this->doesAllowPaste = $condition;
+
+        return $this;
+    }
+
     public function previewable(bool | Closure $condition = true): static
     {
         $this->isPreviewable = $condition;
@@ -489,6 +498,11 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
     public function isReorderable(): bool
     {
         return (bool) $this->evaluate($this->isReorderable);
+    }
+
+    public function doesAllowPaste(): bool
+    {
+        return (bool) $this->evaluate($this->doesAllowPaste);
     }
 
     /**


### PR DESCRIPTION
## Description

Currently the `allowPaste` [Filepond](https://pqina.nl/filepond/docs/api/instance/properties/) options is always disabled. These changes allow to configure this property and ensure keeping the current behavior for existing usages.


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
