### PR TITLE
fix(constraints): human-readable summary display

### DIFF
--- a/packages/tables/src/Filters/QueryBuilder/Constraints/SelectConstraint/Operators/IsOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/SelectConstraint/Operators/IsOperator.php
@@ -29,8 +29,19 @@ class IsOperator extends Operator
     public function getSummary(): string
     {
         $constraint = $this->getConstraint();
+        $settings = $this->getSettings();
 
-        $values = Arr::wrap($this->getSettings()[$constraint->isMultiple() ? 'values' : 'value']);
+        if ($constraint->isMultiple()) {
+            $callback = $constraint->getOptionLabelsUsingCallback();
+            $valuesKey = 'values';
+        } else {
+            $callback = $constraint->getOptionLabelUsingCallback();
+            $valuesKey = 'value';
+        }
+
+        $values = $callback
+            ? Arr::wrap($this->evaluate($callback, [$valuesKey => $settings[$valuesKey]]))
+            : Arr::only($constraint->getOptions(), $settings[$valuesKey]);
 
         $values = Arr::join($values, glue: __('filament-tables::filters/query-builder.operators.select.is.summary.values_glue.0'), finalGlue: __('filament-tables::filters/query-builder.operators.select.is.summary.values_glue.final'));
 

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/SelectConstraint/Operators/IsOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/SelectConstraint/Operators/IsOperator.php
@@ -40,7 +40,7 @@ class IsOperator extends Operator
         }
 
         $labels = $getLabels ?
-            Arr::wrap($this->evaluate($getValues, [$valuesKey => $settings[$valuesKey]])) :
+            Arr::wrap($this->evaluate($getLabels, [$valuesKey => $settings[$valuesKey]])) :
             Arr::only($constraint->getOptions(), $settings[$valuesKey]);
 
         $joinedValues = Arr::join(

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/SelectConstraint/Operators/IsOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/SelectConstraint/Operators/IsOperator.php
@@ -32,18 +32,22 @@ class IsOperator extends Operator
         $settings = $this->getSettings();
 
         if ($constraint->isMultiple()) {
-            $callback = $constraint->getOptionLabelsUsingCallback();
+            $getLabels = $constraint->getOptionLabelsUsingCallback();
             $valuesKey = 'values';
         } else {
-            $callback = $constraint->getOptionLabelUsingCallback();
+            $getLabels = $constraint->getOptionLabelUsingCallback();
             $valuesKey = 'value';
         }
 
-        $values = $callback
-            ? Arr::wrap($this->evaluate($callback, [$valuesKey => $settings[$valuesKey]]))
-            : Arr::only($constraint->getOptions(), $settings[$valuesKey]);
+        $labels = $getLabels ?
+            Arr::wrap($this->evaluate($getValues, [$valuesKey => $settings[$valuesKey]])) :
+            Arr::only($constraint->getOptions(), $settings[$valuesKey]);
 
-        $values = Arr::join($values, glue: __('filament-tables::filters/query-builder.operators.select.is.summary.values_glue.0'), finalGlue: __('filament-tables::filters/query-builder.operators.select.is.summary.values_glue.final'));
+        $joinedValues = Arr::join(
+            $labels,
+            glue: __('filament-tables::filters/query-builder.operators.select.is.summary.values_glue.0'),
+            finalGlue: __('filament-tables::filters/query-builder.operators.select.is.summary.values_glue.final'),
+        );
 
         return __(
             $this->isInverse() ?
@@ -51,7 +55,7 @@ class IsOperator extends Operator
                 'filament-tables::filters/query-builder.operators.select.is.summary.direct',
             [
                 'attribute' => $constraint->getAttributeLabel(),
-                'values' => $values,
+                'values' => $joinedValues,
             ],
         );
     }


### PR DESCRIPTION
## Description

Implement a human-readable summary based on the configured `getOptionLabelsUsingCallback()` or `getOptionLabelUsingCallback()` methods. If both callbacks are `null`, the summary will fall back to using the selected options retrieved through `getOptions()`.

## Visual changes

### Before

![before](https://github.com/user-attachments/assets/45027a7d-3c60-4e6d-b1e7-0118fd44e934)

### After

![after](https://github.com/user-attachments/assets/10a6a870-454e-4e08-84e3-f6a479e9f878)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
