### PR TITLE
Check model view policy on related records pages

### DIFF
--- a/packages/panels/src/Resources/Pages/ManageRelatedRecords.php
+++ b/packages/panels/src/Resources/Pages/ManageRelatedRecords.php
@@ -105,7 +105,7 @@ class ManageRelatedRecords extends Page implements Tables\Contracts\HasTable
         $model = $record->{static::getRelationshipName()}()->getQuery()->getModel()::class;
 
         try {
-            return authorize('viewAny', $model, static::shouldCheckPolicyExistence())->allowed();
+            return authorize('view', $record, static::shouldCheckPolicyExistence())->allowed() && authorize('viewAny', $model, static::shouldCheckPolicyExistence())->allowed();
         } catch (AuthorizationException $exception) {
             return $exception->toResponse()->allowed();
         }


### PR DESCRIPTION
## Description

If you are using a ManageRelatedRecords page it checks the `viewAny` policy for the relation, but it doesn't check the `view` policy for the record itself. This makes it possible to 'game' the URLs by changing the IDs in the address bar, potentially being able to see something you don't have permission to see.

This PR ensures the `view` policy on the record is checked alongside the existing `viewAny` check on the relation.

## Visual changes

There are no visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
