### PR TITLE
Prevent page from jumping to the top if the section is not collapsed

### DIFF
--- a/packages/support/resources/views/components/section/index.blade.php
+++ b/packages/support/resources/views/components/section/index.blade.php
@@ -72,6 +72,7 @@
             },
         ])
     }}
+    wire:ignore.self
 >
     @if ($hasHeader)
         <header


### PR DESCRIPTION

## Description

If a page has several sections that are collapsed by default, and the page size exceeds the window size when the sections are expanded, then under certain circumstances the page jumps back to the top of the page after a Livewire update. Apparently, when the page content is re-rendered, the original page height (when the sections are collapsed) is used and the browser jumps back to the top.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
