### PR TITLE
Disable cells while table loading

### DIFF
--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -325,10 +325,13 @@ export default function fileUploadFormComponent({
                     // FilePond has a weird English translation for the error message when a file of an unexpected
                     // type is uploaded, for example: `File of invalid type: Expects  or image/*`. This is a
                     // hacky workaround to fix the message to be `File of invalid type: Expects image/*`.
-                    this.error = `${error.main}: ${error.sub}`.replace('Expects  or', 'Expects')
+                    this.error = `${error.main}: ${error.sub}`.replace(
+                        'Expects  or',
+                        'Expects',
+                    )
                 })
 
-                this.pond.on('removefile', () => this.error = null)
+                this.pond.on('removefile', () => (this.error = null))
             }
         },
 

--- a/packages/tables/resources/views/columns/checkbox-column.blade.php
+++ b/packages/tables/resources/views/columns/checkbox-column.blade.php
@@ -82,5 +82,6 @@
             \Filament\Support\prepare_inherited_attributes($attributes)
                 ->merge($getExtraInputAttributes(), escape: false)
         "
+        wire:loading.attr="disabled"
     />
 </div>

--- a/packages/tables/resources/views/columns/select-column.blade.php
+++ b/packages/tables/resources/views/columns/select-column.blade.php
@@ -96,6 +96,7 @@
                 isLoading = false
             "
             :attributes="\Filament\Support\prepare_inherited_attributes($getExtraInputAttributeBag())"
+            wire:loading.attr="disabled"
         >
             @if ($canSelectPlaceholder)
                 <option value="">{{ $getPlaceholder() }}</option>

--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -136,6 +136,7 @@
                         ])
                 )
             "
+            wire:loading.attr="disabled"
         />
         {{-- format-ignore-end --}}
     </x-filament::input.wrapper>


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This was discussed in #7294. This PR aims to fix this issue with the exception of ToggleColumn, I tried but I couldnt get it to disable to during table loading. Maybe Zep knows more :eyes: 

Thanks to @atmonshi for helping me!

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
