### PR TITLE
Fix oldFormState containing new values

### DIFF
--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -288,9 +288,8 @@ trait InteractsWithForms
     {
         $statePath = (string) str($statePath)->before('.');
 
-        if (! Arr::has($this->oldFormState, $statePath)) {
-            $this->oldFormState[$statePath] = data_get($this, $statePath);
-        }
+        // https://github.com/filamentphp/filament/pull/13973
+        $this->oldFormState[$statePath] ??= data_get($this, $statePath);
     }
 
     public function getOldFormState(string $statePath): mixed

--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -288,7 +288,9 @@ trait InteractsWithForms
     {
         $statePath = (string) str($statePath)->before('.');
 
-        $this->oldFormState[$statePath] = data_get($this, $statePath);
+        if (! Arr::has($this->oldFormState, 'data')) {
+            $this->oldFormState[$statePath] = data_get($this, $statePath);
+        }
     }
 
     public function getOldFormState(string $statePath): mixed

--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -288,7 +288,7 @@ trait InteractsWithForms
     {
         $statePath = (string) str($statePath)->before('.');
 
-        if (! Arr::has($this->oldFormState, 'data')) {
+        if (! Arr::has($this->oldFormState, $statePath)) {
             $this->oldFormState[$statePath] = data_get($this, $statePath);
         }
     }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

When Livewire tries to [update multiple properties](https://github.com/livewire/livewire/blob/e7f49c360a8218047e68d2182d65bd3f99d5508e/src/Mechanisms/HandleComponents/HandleComponents.php#L294) in one request, it does trigger an *update* event for [every property](https://github.com/livewire/livewire/blob/e7f49c360a8218047e68d2182d65bd3f99d5508e/src/Mechanisms/HandleComponents/HandleComponents.php#L314). 

This will run the [`updatingInteractsWithForms`](https://github.com/filamentphp/filament/blob/8de1a8d0f861d3a824edd0ee89ef455492d18932/packages/forms/src/Concerns/InteractsWithForms.php#L291) trait hook and in turn set `oldFormState` to equal data of the component for every property.

When reacting on a properties *updated* event, this will cause the expected `$old` parameter to be wrong, as `oldFormState` has already been overwritten by updating multiple properties at once so it does include the new and not the old value.

I would propose to only set entries in the `oldFormState` in case they are not already set, as to prevent the entries being overwritten by new values.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

There are none.

## Functional changes

- [x] Only set `oldFormState` entries in case they are not set
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
