### PR TITLE
fix(filters): correctly retrieve dot-notated filter state

### DIFF
--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -5,6 +5,7 @@ namespace Filament\Tables\Concerns;
 use Filament\Forms\Form;
 use Filament\Tables\Filters\BaseFilter;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
 
 /**
  * @property Form $tableFiltersForm
@@ -140,20 +141,18 @@ trait HasFilters
 
     protected function applyFiltersToTableQuery(Builder $query): Builder
     {
-        $data = $this->tableFilters;
-
         foreach ($this->getTable()->getFilters() as $filter) {
             $filter->applyToBaseQuery(
                 $query,
-                $data[$filter->getName()] ?? [],
+                $this->getTableFilterState($filter->getName()) ?? [],
             );
         }
 
-        return $query->where(function (Builder $query) use ($data) {
+        return $query->where(function (Builder $query) {
             foreach ($this->getTable()->getFilters() as $filter) {
                 $filter->apply(
                     $query,
-                    $data[$filter->getName()] ?? [],
+                    $this->getTableFilterState($filter->getName()) ?? [],
                 );
             }
         });
@@ -161,7 +160,7 @@ trait HasFilters
 
     public function getTableFilterState(string $name): ?array
     {
-        return $this->tableFilters[$this->parseTableFilterName($name)] ?? null;
+        return Arr::get($this->tableFilters, $this->parseTableFilterName($name));
     }
 
     public function parseTableFilterName(string $name): string


### PR DESCRIPTION
## Description

Addresses an issue with retrieving filter states using dot-notated names. When creating reusable custom filters, dot notation can be useful for naming filters. This fix ensures proper handling of such cases by using `Arr::get()`, which retrieves data (used for `query`'s and `indicateUsing`'s `$data` argument) from the nested `$tableFilters` array using dot notation.

## Visual changes

![image](https://github.com/user-attachments/assets/fb6ca2e6-6cb0-415c-b487-1333daca2937)

The following code outputs the dumped state:

```php
Filter::make('a.b')
    ->indicateUsing(static fn (array $data): string => implode(', ', array_keys(array_filter($data))))
    ->form([
        Checkbox::make('c'),
        Checkbox::make('d'),
    ])
    ->query(static function (Builder $query, array $data): Builder {
        dump($data);
    
        return $query;
    }),
```

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
