### PR TITLE
Ensure User is not null when getting default tenenat.

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -173,7 +173,7 @@ trait HasRoutes
 
         $hasTenancy = $this->hasTenancy();
 
-        if ((! $tenant) && $hasTenancy && $this->auth()->user()) {
+        if ((! $tenant) && $hasTenancy && $this->auth()->hasUser()) {
             $tenant = Filament::getUserDefaultTenant($this->auth()->user());
         }
 

--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -173,7 +173,7 @@ trait HasRoutes
 
         $hasTenancy = $this->hasTenancy();
 
-        if ((! $tenant) && $hasTenancy) {
+        if ((! $tenant) && $hasTenancy && $this->auth()->user()) {
             $tenant = Filament::getUserDefaultTenant($this->auth()->user());
         }
 


### PR DESCRIPTION
Some edge cases I have seen is we try and redirect after the user has logged out and as such it fails. In those instances it shouldn't try to redirect based on getUserDefaultTenant as they are logged out and instead we should check we have a user before passing one which maybe null. 

This ensure the next step is hit instead. 