### PR TITLE
Default ordering direction of grouped records

### DIFF
--- a/packages/tables/docs/08-grouping.md
+++ b/packages/tables/docs/08-grouping.md
@@ -352,3 +352,17 @@ public function table(Table $table): Table
         ->groupingDirectionSettingHidden();
 }
 ```
+
+### Setting the default ordering direction
+
+You can set the default ordering direction of all groups using the `defaultGroupDirection()` method:
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+		->defaultGroupDirection('desc');
+}
+```

--- a/packages/tables/resources/views/components/groups.blade.php
+++ b/packages/tables/resources/views/components/groups.blade.php
@@ -1,6 +1,7 @@
 @props([
     'directionSetting' => false,
     'dropdownOnDesktop' => false,
+    'defaultDirection',
     'groups',
     'triggerAction',
 ])
@@ -30,7 +31,7 @@
                 return
             }
 
-            direction = 'asc'
+            direction = @js($defaultDirection)
         })
     "
 >

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -207,6 +207,7 @@
                         <x-filament-tables::groups
                             :direction-setting="$isGroupingDirectionSettingHidden"
                             :dropdown-on-desktop="$areGroupingSettingsInDropdownOnDesktop()"
+                            :defaultDirection="$getDefaultDirection()"
                             :groups="$groups"
                             :trigger-action="$getGroupRecordsTriggerAction()"
                         />

--- a/packages/tables/src/Table/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Table/Concerns/CanGroupRecords.php
@@ -30,6 +30,8 @@ trait CanGroupRecords
 
     protected bool | Closure $isGroupingDirectionSettingHidden = false;
 
+    protected ?string $defaultGroupDirection = 'asc';
+
     protected ?Closure $modifyGroupRecordsTriggerActionUsing = null;
 
     public function groupRecordsTriggerAction(?Closure $callback): static
@@ -66,6 +68,13 @@ trait CanGroupRecords
     public function groupingDirectionSettingHidden(bool | Closure $condition = true): static
     {
         $this->isGroupingDirectionSettingHidden = $condition;
+
+        return $this;
+    }
+
+    public function defaultGroupDirection(string $direction): static
+    {
+        $this->defaultGroupDirection = $direction;
 
         return $this;
     }
@@ -195,5 +204,10 @@ trait CanGroupRecords
     public function isGroupsOnly(): bool
     {
         return (bool) $this->evaluate($this->isGroupsOnly);
+    }
+
+    public function getDefaultGroupDirection(): string
+    {
+        return $this->defaultGroupDirection;
     }
 }


### PR DESCRIPTION

## Description

It wasn't possible to change the default ordering direction of grouped records in a table.
This changes add the functionality to set a default ordering direction of all Groups registered on the table.

## Functional changes

Arrow-function to set a default value for the orderingdirection of records when grouped.

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
