### PR TITLE
Fix aria-label for sortable headers, add aria-sort on active sort

### DIFF
--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -23,11 +23,11 @@
     <{{ $sortable ? 'button' : 'span' }}
         @if ($sortable)
             type="button"
-            aria-label="{{$slot}}"
+            aria-label="{{ $slot }}"
             wire:click="sortTable('{{ $name }}')"
         @endif
-        @if($activelySorted)
-            aria-sort="{{ $sortDirection === 'asc' ? 'ascending' : 'descending'}}"
+        @if ($activelySorted)
+            aria-sort="{{ __($sortDirection === 'asc' ? 'filament-tables::table.sorting.fields.direction.options.asc' : 'filament-tables::table.sorting.fields.direction.options.desc') }}"
         @endif
         @class([
             'group flex w-full items-center gap-x-1',

--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -22,8 +22,8 @@
 >
     <{{ $sortable ? 'button' : 'span' }}
         @if ($sortable)
-            type="button"
             aria-label="{{ $slot }}"
+            type="button"
             wire:click="sortTable('{{ $name }}')"
         @endif
         @if ($activelySorted)

--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -22,9 +22,12 @@
 >
     <{{ $sortable ? 'button' : 'span' }}
         @if ($sortable)
-            aria-label="{{ __('filament-tables::table.sorting.fields.column.label') }} {{ $sortDirection === 'asc' ? __('filament-tables::table.sorting.fields.direction.options.desc') : __('filament-tables::table.sorting.fields.direction.options.asc') }}"
             type="button"
+            aria-label="{{$slot}}"
             wire:click="sortTable('{{ $name }}')"
+        @endif
+        @if($activelySorted)
+            aria-sort="{{ $sortDirection === 'asc' ? 'ascending' : 'descending'}}"
         @endif
         @class([
             'group flex w-full items-center gap-x-1',

--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -18,6 +18,9 @@
 @endphp
 
 <th
+    @if ($activelySorted)
+        aria-sort="{{ $sortDirection === 'asc' ? 'ascending' : 'descending' }}"
+    @endif
     {{ $attributes->class(['fi-ta-header-cell px-3 py-3.5 sm:first-of-type:ps-6 sm:last-of-type:pe-6']) }}
 >
     <{{ $sortable ? 'button' : 'span' }}
@@ -25,9 +28,6 @@
             aria-label="{{ $slot }}"
             type="button"
             wire:click="sortTable('{{ $name }}')"
-        @endif
-        @if ($activelySorted)
-            aria-sort="{{ __($sortDirection === 'asc' ? 'filament-tables::table.sorting.fields.direction.options.asc' : 'filament-tables::table.sorting.fields.direction.options.desc') }}"
         @endif
         @class([
             'group flex w-full items-center gap-x-1',


### PR DESCRIPTION
## Description

Resolves #13986 changed the aria-label when using sortable header cells. Before this a screenreader would read out the sorting direction for every column instead of the label. Also added the aria-sort when the column is actively sorted, as per the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort) added `ascending` / `descending` as the possible values

cc @danharrin as discussed in the issue

## Visual changes

No visual changes

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
