### PR TITLE
Fix the missing Chinese translation of radio's Boolean method

### DIFF
--- a/packages/forms/resources/lang/zh_CN/components.php
+++ b/packages/forms/resources/lang/zh_CN/components.php
@@ -241,6 +241,15 @@ return [
 
     ],
 
+    'radio' => [
+
+        'boolean' => [
+            'true' => '是',
+            'false' => '否',
+        ],
+
+    ],
+
     'repeater' => [
 
         'actions' => [


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Under zh_CN, the Radio component in Form, after adding the boolean() method, does not display the correct translation, the error is shown as: filament-forms::components.radio.boolean.true
filament-forms::components.radio.boolean.false
So I added the translation
<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes
![image](https://github.com/user-attachments/assets/432b1fa0-5c24-42b3-9912-82aab9d956c9)
![image](https://github.com/user-attachments/assets/e62d356b-4fc0-42b6-86a4-d722e9026088)
![image](https://github.com/user-attachments/assets/56207827-4ad2-4b82-8a73-1e1da99624ae)

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
