### PR TITLE
Ability to add script data attributes or custom attributes.

### DIFF
--- a/packages/support/src/Assets/Js.php
+++ b/packages/support/src/Assets/Js.php
@@ -142,7 +142,7 @@ class Js extends Asset
      */
     public function getExtraAttributes(): array
     {
-        return $attributes;
+        return $this->extraAttributes;
     }
 
     public function getExtraAttributesHtml(): string

--- a/packages/support/src/Assets/Js.php
+++ b/packages/support/src/Assets/Js.php
@@ -19,7 +19,7 @@ class Js extends Asset
     protected bool $isModule = false;
 
     /**
-     * @var  array<string, string>
+     * @var array<string, string>
      */
     protected array $extraAttributes = [];
 
@@ -136,9 +136,9 @@ class Js extends Asset
         ",
         );
     }
-    
+
     /**
-     * @return  array<string, string>
+     * @return array<string, string>
      */
     public function getExtraAttributes(): array
     {

--- a/packages/support/src/Assets/Js.php
+++ b/packages/support/src/Assets/Js.php
@@ -18,6 +18,9 @@ class Js extends Asset
 
     protected bool $isModule = false;
 
+    /**
+     * @var  array<string, string>
+     */
     protected array $extraAttributes = [];
 
     protected string | Htmlable | null $html = null;
@@ -89,6 +92,9 @@ class Js extends Asset
         return $this->isModule;
     }
 
+    /**
+     * @param  array<string, string>  $attributes
+     */
     public function extraAttributes(array $attributes): static
     {
         $this->extraAttributes = $attributes;
@@ -109,7 +115,7 @@ class Js extends Asset
         $async = $this->isAsync() ? 'async' : '';
         $defer = $this->isDeferred() ? 'defer' : '';
         $module = $this->isModule() ? 'type="module"' : '';
-        $extraAttributes = $this->getExtraAttributes();
+        $extraAttributesHtml = $this->getExtraAttributesHtml();
 
         $hasSpaMode = FilamentView::hasSpaMode();
 
@@ -123,19 +129,27 @@ class Js extends Asset
                 {$async}
                 {$defer}
                 {$module}
-                {$extraAttributes}
+                {$extraAttributesHtml}
                 {$navigateOnce}
                 {$navigateTrack}
             ></script>
         ",
         );
     }
+    
+    /**
+     * @return  array<string, string>
+     */
+    public function getExtraAttributes(): array
+    {
+        return $attributes;
+    }
 
-    public function getExtraAttributes(): string
+    public function getExtraAttributesHtml(): string
     {
         $attributes = '';
 
-        foreach ($this->extraAttributes as $key => $value) {
+        foreach ($this->getExtraAttributes() as $key => $value) {
             $attributes .= " {$key}=\"{$value}\"";
         }
 

--- a/packages/support/src/Assets/Js.php
+++ b/packages/support/src/Assets/Js.php
@@ -18,6 +18,8 @@ class Js extends Asset
 
     protected bool $isModule = false;
 
+    protected array $extraAttributes = [];
+
     protected string | Htmlable | null $html = null;
 
     public function async(bool $condition = true): static
@@ -87,6 +89,13 @@ class Js extends Asset
         return $this->isModule;
     }
 
+    public function extraAttributes(array $attributes): static
+    {
+        $this->extraAttributes = $attributes;
+
+        return $this;
+    }
+
     public function getHtml(): Htmlable
     {
         $html = $this->html;
@@ -100,22 +109,37 @@ class Js extends Asset
         $async = $this->isAsync() ? 'async' : '';
         $defer = $this->isDeferred() ? 'defer' : '';
         $module = $this->isModule() ? 'type="module"' : '';
+        $extraAttributes = $this->getExtraAttributes();
 
         $hasSpaMode = FilamentView::hasSpaMode();
 
         $navigateOnce = ($hasSpaMode && $this->isNavigateOnce()) ? 'data-navigate-once' : '';
         $navigateTrack = $hasSpaMode ? 'data-navigate-track' : '';
 
-        return new HtmlString("
+        return new HtmlString(
+            "
             <script
                 src=\"{$html}\"
                 {$async}
                 {$defer}
                 {$module}
+                {$extraAttributes}
                 {$navigateOnce}
                 {$navigateTrack}
             ></script>
-        ");
+        ",
+        );
+    }
+
+    public function getExtraAttributes(): string
+    {
+        $attributes = '';
+
+        foreach ($this->extraAttributes as $key => $value) {
+            $attributes .= " {$key}=\"{$value}\"";
+        }
+
+        return $attributes;
     }
 
     public function getSrc(): string


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

`Filament\Support\Assets\Js` currently supports almost all required attributes. But it does not support custom attributes. So many script integrations require some data or custom attributes. In this PR I added the ability to add custom attributes to the `Js::class` class.

## Visual changes

Before
<img width="1207" alt="image" src="https://github.com/user-attachments/assets/509ca251-7292-4057-9973-8fd83860cb80">

After
<img width="992" alt="image" src="https://github.com/user-attachments/assets/72afdb3b-776d-486e-b42d-e57b4ac732cc">


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
