### PR TITLE
Fix: Table grouping key

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -975,7 +975,7 @@
                                 $recordGroupTitle = $group?->getTitle($record);
                             @endphp
 
-                            @if ($recordGroupTitle !== $previousRecordGroupTitle)
+                            @if ($recordGroupTitle !== $previousRecordGroupTitle || $recordGroupKey !== $previousRecordGroupKey)
                                 @if ($hasSummary && (! $isReordering) && filled($previousRecordGroupTitle))
                                     <x-filament-tables::summary.row
                                         :actions="count($actions)"


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
I have a table that I want to display in groups, where it should be group by `id` and display by the `name` column
the issue happens when the `name` is the same but different record.id
from the doc it seems I should be able to use [getTitleFromRecordUsing](https://filamentphp.com/docs/3.x/tables/grouping#setting-a-group-key) to achieve this but it makes no difference

```php
->defaultGroup('event.id')
  ->groups([
      Group::make('event.id')
          ->getTitleFromRecordUsing(fn ($record) => $record->event->name)
          // ->getKeyFromRecordUsing(fn ($record): string => $record->event->id) # if using `event.name` as the group
          ->titlePrefixedWithLabel(false),
  ])
```

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->
**before**
`event.id`
<img width="363" alt="image" src="https://github.com/user-attachments/assets/9038b362-1a84-453f-a4ac-6956a317fff3">

 apply `->getTitleFromRecordUsing(fn ($record) => $record->event->name)`
<img width="449" alt="image" src="https://github.com/user-attachments/assets/40506972-66cf-49f8-ae29-99bac8b3cf5c">

**after**
<img width="407" alt="image" src="https://github.com/user-attachments/assets/b3adc3b6-b2f7-49cf-a979-c9e4b23b2b0d">


## Functional changes
not tested with grid table, so not applying to it
- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
