### PR TITLE
Feature: Prune sensitive data from failed_import_rows data

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -159,20 +159,6 @@ ImportColumn::make('sku')
 
 Any rows that do not pass validation will not be imported. Instead, they will be compiled into a new CSV of "failed rows", which the user can download after the import has finished. The user will be shown a list of validation errors for each row that failed.
 
-### Marking columns as sensitive
-You may want to exclude certain columns from the failed import data to avoid storing sensitive or encrypted information in plain text. To achieve this, you can use the `sensitive()` method on the `ImportColumn` class:
-
-```php
-use Filament\Actions\Imports\ImportColumn;
-
-ImportColumn::make('ssn')
-    ->label('Social Security Number')
-    ->sensitive()
-    ->rules(['required', 'digits:9'])
-```
-
-When a column is marked as sensitive, its data will be excluded from the JSON data stored for any failed import rows. This helps to ensure that sensitive information is not stored in a vulnerable manner.
-
 ### Casting state
 
 Before [validation](#validating-csv-data), data from the CSV can be cast. This is useful for converting strings into the correct data type, otherwise validation may fail. For example, if you have a `price` column in your CSV, you may want to cast it to a float:
@@ -348,6 +334,19 @@ ImportColumn::make('customer_ratings')
     ->integer()
     ->rules(['array'])
     ->nestedRecursiveRules(['integer', 'min:1', 'max:5'])
+```
+
+### Marking column data as sensitive
+
+When import rows fail validation, they are logged to the database, ready for export when the import completes. You may want to exclude certain columns from this logging to avoid storing sensitive data in plain text. To achieve this, you can use the `sensitive()` method on the `ImportColumn` to prevent its data from being logged:
+
+```php
+use Filament\Actions\Imports\ImportColumn;
+
+ImportColumn::make('ssn')
+    ->label('Social security number')
+    ->sensitive()
+    ->rules(['required', 'digits:9'])
 ```
 
 ### Customizing how a column is filled into a record

--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -159,6 +159,20 @@ ImportColumn::make('sku')
 
 Any rows that do not pass validation will not be imported. Instead, they will be compiled into a new CSV of "failed rows", which the user can download after the import has finished. The user will be shown a list of validation errors for each row that failed.
 
+### Marking columns as sensitive
+You may want to exclude certain columns from the failed import data to avoid storing sensitive or encrypted information in plain text. To achieve this, you can use the `sensitive()` method on the `ImportColumn` class:
+
+```php
+use Filament\Actions\Imports\ImportColumn;
+
+ImportColumn::make('ssn')
+    ->label('Social Security Number')
+    ->sensitive()
+    ->rules(['required', 'digits:9'])
+```
+
+When a column is marked as sensitive, its data will be excluded from the JSON data stored for any failed import rows. This helps to ensure that sensitive information is not stored in a vulnerable manner.
+
 ### Casting state
 
 Before [validation](#validating-csv-data), data from the CSV can be cast. This is useful for converting strings into the correct data type, otherwise validation may fail. For example, if you have a `price` column in your CSV, you may want to cast it to a float:

--- a/packages/actions/src/Imports/ImportColumn.php
+++ b/packages/actions/src/Imports/ImportColumn.php
@@ -78,6 +78,8 @@ class ImportColumn extends Component
 
     protected string | Htmlable | Closure | null $helperText = null;
 
+    protected bool | Closure $isSensitive = false;
+
     final public function __construct(string $name)
     {
         $this->name($name);
@@ -605,5 +607,17 @@ class ImportColumn extends Component
             Model::class, $record ? $record::class : null => [$record],
             default => parent::resolveDefaultClosureDependencyForEvaluationByType($parameterType),
         };
+    }
+
+    public function sensitive(bool | Closure $condition = true): static
+    {
+        $this->isSensitive = $condition;
+
+        return $this;
+    }
+
+    public function isSensitive(): bool
+    {
+        return (bool) $this->evaluate($this->isSensitive);
     }
 }

--- a/packages/actions/src/Imports/Jobs/ImportCsv.php
+++ b/packages/actions/src/Imports/Jobs/ImportCsv.php
@@ -144,11 +144,15 @@ class ImportCsv implements ShouldQueue
         $failedRow = app(FailedImportRow::class);
         $failedRow->import()->associate($this->import);
         $failedRow->data = $this->filterSensitiveData($data, $this->columnMap);
-
         $failedRow->validation_error = $validationError;
         $failedRow->save();
     }
 
+    /**
+     * @param  array<string, mixed>  $data
+     * @param  array<string, string>  $columnMap
+     * @return array<string, mixed>
+     */
     protected function filterSensitiveData(array $data, array $columnMap): array
     {
         $sensitiveColumns = [];
@@ -162,7 +166,7 @@ class ImportCsv implements ShouldQueue
             }
         }
 
-        return array_filter($data, function ($key) use ($sensitiveColumns) {
+        return array_filter($data, function (string $key) use ($sensitiveColumns): bool {
             return ! in_array($key, $sensitiveColumns, true);
         }, ARRAY_FILTER_USE_KEY);
     }


### PR DESCRIPTION
## Description

This pull request adds a `sensitive()` method to the `ImportColumn` class, allowing developers to mark specific columns as sensitive. When a column is marked as sensitive, its data will be excluded from the JSON data stored for failed import rows. This is particularly important for handling encrypted or sensitive data that should not be stored in plain text within the application.

The `filterSensitiveData()` method has been introduced in the `ImportCsv` job to handle the filtering of sensitive data before it is logged. The method checks each column for the `isSensitive()` flag and ensures that any data from these columns is removed before saving the failed row data.

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to ensure they do not break existing functionality.
- [x] Documentation has been updated to include the new `sensitive()` method for `ImportColumn`.
