### PR TITLE
Improve type support for model-related methods

### DIFF
--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -291,6 +291,9 @@ trait InteractsWithActions
         );
     }
 
+    /**
+     * @return Model|class-string<Model>|null
+     */
     protected function getMountedActionFormModel(): Model | string | null
     {
         return null;

--- a/packages/actions/src/Concerns/InteractsWithRecord.php
+++ b/packages/actions/src/Concerns/InteractsWithRecord.php
@@ -14,6 +14,9 @@ trait InteractsWithRecord
 {
     protected Model | Closure | null $record = null;
 
+    /**
+     * @var class-string<Model>|Closure|null
+     */
     protected string | Closure | null $model = null;
 
     protected string | Closure | null $modelLabel = null;
@@ -31,6 +34,9 @@ trait InteractsWithRecord
         return $this;
     }
 
+    /**
+     * @param  class-string<Model>|Closure|null  $model
+     */
     public function model(string | Closure | null $model): static
     {
         $this->model = $model;
@@ -136,6 +142,9 @@ trait InteractsWithRecord
         return $this->record !== null;
     }
 
+    /**
+     * @return class-string<Model>|null
+     */
     public function getModel(): ?string
     {
         $model = $this->getCustomModel();
@@ -153,6 +162,9 @@ trait InteractsWithRecord
         return $record::class;
     }
 
+    /**
+     * @return class-string<Model>|null
+     */
     public function getCustomModel(): ?string
     {
         return $this->evaluate($this->model);

--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -18,6 +18,9 @@ abstract class Exporter
 
     protected ?Model $record;
 
+    /**
+     * @var class-string<Model>|null
+     */
     protected static ?string $model = null;
 
     /**

--- a/packages/actions/src/Imports/Importer.php
+++ b/packages/actions/src/Imports/Importer.php
@@ -27,6 +27,9 @@ abstract class Importer
 
     protected ?Model $record;
 
+    /**
+     * @var class-string<Model>|null
+     */
     protected static ?string $model = null;
 
     /**

--- a/packages/forms/src/Components/Concerns/BelongsToModel.php
+++ b/packages/forms/src/Components/Concerns/BelongsToModel.php
@@ -7,6 +7,9 @@ use Illuminate\Database\Eloquent\Model;
 
 trait BelongsToModel
 {
+    /**
+     * @var Model|class-string<Model>|Closure|null
+     */
     protected Model | string | Closure | null $model = null;
 
     protected ?Closure $loadStateFromRelationshipsUsing = null;
@@ -19,6 +22,9 @@ trait BelongsToModel
 
     protected bool | Closure $shouldSaveRelationshipsWhenHidden = false;
 
+    /**
+     * @param  Model|class-string<Model>|Closure|null  $model
+     */
     public function model(Model | string | Closure | null $model = null): static
     {
         $this->model = $model;
@@ -142,6 +148,9 @@ trait BelongsToModel
         return $this;
     }
 
+    /**
+     * @return class-string<Model>|null
+     */
     public function getModel(): ?string
     {
         $model = $this->evaluate($this->model);

--- a/packages/forms/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
+++ b/packages/forms/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
@@ -185,6 +185,9 @@ trait EntanglesStateWithSingularRelationship
         return $this->relationship;
     }
 
+    /**
+     * @return class-string<Model>|null
+     */
     public function getRelatedModel(): ?string
     {
         return $this->getRelationship()?->getModel()::class;

--- a/packages/forms/src/Components/Concerns/HasActions.php
+++ b/packages/forms/src/Components/Concerns/HasActions.php
@@ -24,6 +24,9 @@ trait HasActions
      */
     protected array $actions = [];
 
+    /**
+     * @var Model|class-string<Model>|null
+     */
     protected Model | string | null $actionFormModel = null;
 
     /**
@@ -109,6 +112,9 @@ trait HasActions
         return $action->component($this);
     }
 
+    /**
+     * @param  Model|class-string<Model>|null  $model
+     */
     public function actionFormModel(Model | string | null $model): static
     {
         $this->actionFormModel = $model;
@@ -116,6 +122,9 @@ trait HasActions
         return $this;
     }
 
+    /**
+     * @return Model|class-string<Model>|null
+     */
     public function getActionFormModel(): Model | string | null
     {
         return $this->actionFormModel ?? $this->getRecord() ?? $this->getModel();

--- a/packages/forms/src/Components/Contracts/CanEntangleWithSingularRelationships.php
+++ b/packages/forms/src/Components/Contracts/CanEntangleWithSingularRelationships.php
@@ -17,6 +17,9 @@ interface CanEntangleWithSingularRelationships
 
     public function getCachedExistingRecord(): ?Model;
 
+    /**
+     * @return class-string<Model>|null
+     */
     public function getRelatedModel(): ?string;
 
     public function getRelationship(): BelongsTo | HasOne | MorphOne | null;

--- a/packages/forms/src/Components/MorphToSelect/Type.php
+++ b/packages/forms/src/Components/MorphToSelect/Type.php
@@ -37,10 +37,16 @@ class Type
 
     protected int $optionsLimit = 50;
 
+    /**
+     * @var class-string<Model>
+     */
     protected string $model;
 
     protected ?bool $isSearchForcedCaseInsensitive = null;
 
+    /**
+     * @param  class-string<Model>  $model
+     */
     final public function __construct(string $model)
     {
         $this->model($model);
@@ -179,6 +185,9 @@ class Type
         });
     }
 
+    /**
+     * @param  class-string<Model>  $model
+     */
     public function model(string $model): static
     {
         $this->model = $model;
@@ -265,6 +274,9 @@ class Type
         return $this->getOptionLabelFromRecordUsing !== null;
     }
 
+    /**
+     * @return class-string<Model>
+     */
     public function getModel(): string
     {
         return $this->model;

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1139,6 +1139,9 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
         $this->cachedExistingRecords = null;
     }
 
+    /**
+     * @return class-string<Model>
+     */
     public function getRelatedModel(): string
     {
         return $this->getRelationship()->getModel()::class;

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -1211,6 +1211,9 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
         return $this->getSearchResultsUsing instanceof Closure;
     }
 
+    /**
+     * @return Model|class-string<Model>|null
+     */
     public function getActionFormModel(): Model | string | null
     {
         if ($this->hasRelationship()) {

--- a/packages/forms/src/Concerns/BelongsToModel.php
+++ b/packages/forms/src/Concerns/BelongsToModel.php
@@ -6,8 +6,14 @@ use Illuminate\Database\Eloquent\Model;
 
 trait BelongsToModel
 {
+    /**
+     * @var Model|class-string<Model>|null
+     */
     public Model | string | null $model = null;
 
+    /**
+     * @param  Model|class-string<Model>|null  $model
+     */
     public function model(Model | string | null $model = null): static
     {
         $this->model = $model;
@@ -45,6 +51,9 @@ trait BelongsToModel
         }
     }
 
+    /**
+     * @return class-string<Model>|null
+     */
     public function getModel(): ?string
     {
         $model = $this->model;

--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -425,6 +425,8 @@ trait InteractsWithForms
 
     /**
      * @deprecated Override the `form()` method to configure the default form.
+     *
+     * @return Model|class-string<Model>|null
      */
     protected function getFormModel(): Model | string | null
     {

--- a/packages/panels/src/Commands/MakeUserCommand.php
+++ b/packages/panels/src/Commands/MakeUserCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Hash;
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -45,7 +46,7 @@ class MakeUserCommand extends Command
                 required: true,
                 validate: fn (string $email): ?string => match (true) {
                     ! filter_var($email, FILTER_VALIDATE_EMAIL) => 'The email address must be valid.',
-                    static::getUserModel()::where('email', $email)->exists() => 'A user with this email address already exists',
+                    static::getUserModel()::query()->where('email', $email)->exists() => 'A user with this email address already exists',
                     default => null,
                 },
             ),
@@ -57,12 +58,15 @@ class MakeUserCommand extends Command
         ];
     }
 
-    protected function createUser(): Authenticatable
+    protected function createUser(): Model & Authenticatable
     {
-        return static::getUserModel()::create($this->getUserData());
+        /** @var Model&Authenticatable $user */
+        $user = static::getUserModel()::query()->create($this->getUserData());
+
+        return $user;
     }
 
-    protected function sendSuccessMessage(Authenticatable $user): void
+    protected function sendSuccessMessage(Model & Authenticatable $user): void
     {
         $loginUrl = Filament::getLoginUrl();
 
@@ -79,6 +83,9 @@ class MakeUserCommand extends Command
         return $this->getAuthGuard()->getProvider();
     }
 
+    /**
+     * @return class-string<Model&Authenticatable>
+     */
     protected function getUserModel(): string
     {
         /** @var EloquentUserProvider $provider */

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -396,6 +396,9 @@ class FilamentManager
         return $this->getCurrentPanel()->getTenantMenuItems();
     }
 
+    /**
+     * @return class-string<Model>|null
+     */
     public function getTenantModel(): ?string
     {
         return $this->getCurrentPanel()->getTenantModel();

--- a/packages/panels/src/Pages/Auth/Register.php
+++ b/packages/panels/src/Pages/Auth/Register.php
@@ -45,6 +45,9 @@ class Register extends SimplePage
      */
     public ?array $data = [];
 
+    /**
+     * @var class-string<Model>
+     */
     protected string $userModel;
 
     public function mount(): void
@@ -219,6 +222,9 @@ class Register extends SimplePage
             ->url(filament()->getLoginUrl());
     }
 
+    /**
+     * @return class-string<Model>
+     */
     protected function getUserModel(): string
     {
         if (isset($this->userModel)) {

--- a/packages/panels/src/Pages/Tenancy/RegisterTenant.php
+++ b/packages/panels/src/Pages/Tenancy/RegisterTenant.php
@@ -142,6 +142,9 @@ abstract class RegisterTenant extends SimplePage
         ];
     }
 
+    /**
+     * @return class-string<Model>
+     */
     public function getModel(): string
     {
         return Filament::getTenantModel();

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -21,6 +21,9 @@ trait HasTenancy
 
     protected ?string $tenantDomain = null;
 
+    /**
+     * @var class-string<Model>|null
+     */
     protected ?string $tenantModel = null;
 
     protected ?string $tenantProfilePage = null;
@@ -65,6 +68,9 @@ trait HasTenancy
         return $this;
     }
 
+    /**
+     * @param  class-string<Model>|null  $model
+     */
     public function tenant(?string $model, ?string $slugAttribute = null, ?string $ownershipRelationship = null): static
     {
         $this->tenantModel = $model;
@@ -195,6 +201,9 @@ trait HasTenancy
         return $record;
     }
 
+    /**
+     * @return class-string<Model>|null
+     */
     public function getTenantModel(): ?string
     {
         return $this->tenantModel;

--- a/packages/panels/src/Resources/Pages/Concerns/InteractsWithRecord.php
+++ b/packages/panels/src/Resources/Pages/Concerns/InteractsWithRecord.php
@@ -117,6 +117,9 @@ trait InteractsWithRecord
         ];
     }
 
+    /**
+     * @return Model|class-string<Model>|null
+     */
     protected function getMountedActionFormModel(): Model | string | null
     {
         return $this->getRecord();

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -298,6 +298,9 @@ class CreateRecord extends Page
         return [];
     }
 
+    /**
+     * @return Model|class-string<Model>|null
+     */
     protected function getMountedActionFormModel(): Model | string | null
     {
         return $this->getModel();

--- a/packages/panels/src/Resources/Pages/ListRecords.php
+++ b/packages/panels/src/Resources/Pages/ListRecords.php
@@ -216,6 +216,9 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
             ->authorize(static::getResource()::canRestoreAny());
     }
 
+    /**
+     * @return Model|class-string<Model>|null
+     */
     protected function getMountedActionFormModel(): Model | string | null
     {
         return $this->getModel();

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -64,6 +64,9 @@ abstract class Resource
 
     protected static ?string $modelLabel = null;
 
+    /**
+     * @var class-string<Model>|null
+     */
     protected static ?string $model = null;
 
     protected static ?string $navigationBadgeTooltip = null;
@@ -495,6 +498,9 @@ abstract class Resource
         return Str::ucwords(static::getModelLabel());
     }
 
+    /**
+     * @return class-string<Model>
+     */
     public static function getModel(): string
     {
         return static::$model ?? (string) str(class_basename(static::class))

--- a/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
+++ b/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
@@ -100,7 +100,7 @@ class SpatieTagsInput extends TagsInput
         }
 
         $model = $this->getModel();
-        $tagClass = $model ? $model::getTagClassName() : config('tags.tag_model', Tag::class);
+        $tagClass = $model && method_exists($model, 'getTagClassName') ? $model::getTagClassName() : config('tags.tag_model', Tag::class);
         $type = $this->getType();
         $query = $tagClass::query();
 

--- a/packages/support/src/Commands/Concerns/CanReadModelSchemas.php
+++ b/packages/support/src/Commands/Concerns/CanReadModelSchemas.php
@@ -12,6 +12,9 @@ use ReflectionException;
 
 trait CanReadModelSchemas
 {
+    /**
+     * @return class-string<Model>|null
+     */
     protected function getModel(string $model): ?string
     {
         if (! class_exists($model)) {

--- a/packages/tables/src/Actions/Action.php
+++ b/packages/tables/src/Actions/Action.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Tables\Actions;
 
+use Exception;
 use Filament\Actions\Concerns\HasMountableArguments;
 use Filament\Actions\Concerns\InteractsWithRecord;
 use Filament\Actions\Contracts\Groupable;
@@ -136,6 +137,11 @@ class Action extends MountableAction implements Groupable, HasRecord, HasTable
         return $this->getCustomPluralModelLabel() ?? $this->getTable()->getPluralModelLabel();
     }
 
+    /**
+     * @return class-string<Model>
+     *
+     * @throws Exception
+     */
     public function getModel(): string
     {
         return $this->getCustomModel() ?? $this->getTable()->getModel();

--- a/packages/tables/src/Actions/Concerns/InteractsWithRecords.php
+++ b/packages/tables/src/Actions/Concerns/InteractsWithRecords.php
@@ -3,7 +3,9 @@
 namespace Filament\Tables\Actions\Concerns;
 
 use Closure;
+use Exception;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 
 trait InteractsWithRecords
@@ -35,6 +37,11 @@ trait InteractsWithRecords
         return $this;
     }
 
+    /**
+     * @return class-string<Model>
+     *
+     * @throws Exception
+     */
     public function getModel(): string
     {
         return $this->getTable()->getModel();

--- a/packages/tables/src/Table/Concerns/HasRecords.php
+++ b/packages/tables/src/Table/Concerns/HasRecords.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Table\Concerns;
 
 use BackedEnum;
 use Closure;
+use Exception;
 use Filament\Support\Contracts\HasLabel;
 use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Contracts\Pagination\Paginator;
@@ -71,6 +72,11 @@ trait HasRecords
         return $this->getLivewire()->getTableRecordKey($record);
     }
 
+    /**
+     * @return class-string<Model>
+     *
+     * @throws Exception
+     */
     public function getModel(): string
     {
         return $this->getQuery()->getModel()::class;


### PR DESCRIPTION
## Description

Enhanced type support by adding docblock annotations with `class-string<Model>` and, in some cases, adding the native type `Model & Authenticatable` to ensure the object extends the `Model` class and implements the `Authenticatable` interface.

Addressed an edge case for `SpatieTagInput` by checking if the `getTagClassName` method exists before calling it. This was necessary because there isn't a docblock annotation to describe an instance of a class using a specific trait.

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
