### PR TITLE
Improve type support for model related methods

### DIFF
--- a/packages/actions/src/Commands/Concerns/CanGenerateExporterColumns.php
+++ b/packages/actions/src/Commands/Concerns/CanGenerateExporterColumns.php
@@ -2,10 +2,14 @@
 
 namespace Filament\Actions\Commands\Concerns;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
 trait CanGenerateExporterColumns
 {
+    /**
+     * @param  string|class-string<Model>  $model
+     */
     protected function getExporterColumns(string $model): string
     {
         $model = $this->getModel($model);

--- a/packages/actions/src/Commands/Concerns/CanGenerateImporterColumns.php
+++ b/packages/actions/src/Commands/Concerns/CanGenerateImporterColumns.php
@@ -2,10 +2,14 @@
 
 namespace Filament\Actions\Commands\Concerns;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
 trait CanGenerateImporterColumns
 {
+    /**
+     * @param  string|class-string<Model>  $model
+     */
     protected function getImporterColumns(string $model): string
     {
         $model = $this->getModel($model);

--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -561,6 +561,9 @@ trait InteractsWithActions
         return $this->getMountedActionSchema($actionNestingIndex, $mountedAction);
     }
 
+    /**
+     * @return Model|class-string<Model>|null
+     */
     protected function getMountedActionSchemaModel(): Model | string | null
     {
         return null;

--- a/packages/actions/src/Concerns/InteractsWithRecord.php
+++ b/packages/actions/src/Concerns/InteractsWithRecord.php
@@ -14,12 +14,15 @@ use function Filament\Support\locale_has_pluralization;
 trait InteractsWithRecord
 {
     /**
-     * @var Model | string | array<string, mixed> | Closure | null
+     * @var Model | class-string<Model> | array<string, mixed> | Closure | null
      */
     protected Model | string | array | Closure | null $record = null;
 
     protected ?Closure $resolveRecordUsing = null;
 
+    /**
+     * @var class-string<Model>|Closure|null
+     */
     protected string | Closure | null $model = null;
 
     protected string | Closure | null $modelLabel = null;
@@ -47,6 +50,9 @@ trait InteractsWithRecord
         return $this;
     }
 
+    /**
+     * @param  class-string<Model>|Closure|null  $model
+     */
     public function model(string | Closure | null $model): static
     {
         $this->model = $model;
@@ -84,6 +90,8 @@ trait InteractsWithRecord
 
     /**
      * @return Model | array<string, mixed> | null
+     *
+     * @throws Exception
      */
     public function getRecord(): Model | array | null
     {
@@ -184,6 +192,11 @@ trait InteractsWithRecord
         return $this->record !== null;
     }
 
+    /**
+     * @return class-string<Model>|null
+     *
+     * @throws Exception
+     */
     public function getModel(): ?string
     {
         $model = $this->getCustomModel();
@@ -207,6 +220,9 @@ trait InteractsWithRecord
         return $record::class;
     }
 
+    /**
+     * @return class-string<Model>|null
+     */
     public function getCustomModel(): ?string
     {
         return $this->evaluate($this->model);

--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -18,6 +18,9 @@ abstract class Exporter
 
     protected ?Model $record;
 
+    /**
+     * @var class-string<Model>|null
+     */
     protected static ?string $model = null;
 
     /**

--- a/packages/actions/src/Imports/Importer.php
+++ b/packages/actions/src/Imports/Importer.php
@@ -27,6 +27,9 @@ abstract class Importer
 
     protected ?Model $record;
 
+    /**
+     * @var class-string<Model>|null
+     */
     protected static ?string $model = null;
 
     /**

--- a/packages/forms/src/Commands/Concerns/CanGenerateForms.php
+++ b/packages/forms/src/Commands/Concerns/CanGenerateForms.php
@@ -3,10 +3,14 @@
 namespace Filament\Forms\Commands\Concerns;
 
 use Filament\Forms;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
 trait CanGenerateForms
 {
+    /**
+     * @param  string|class-string<Model>  $model
+     */
     protected function getResourceFormSchema(string $model): string
     {
         $model = $this->getModel($model);

--- a/packages/forms/src/Components/MorphToSelect/Type.php
+++ b/packages/forms/src/Components/MorphToSelect/Type.php
@@ -37,10 +37,16 @@ class Type
 
     protected int $optionsLimit = 50;
 
+    /**
+     * @var class-string<Model>
+     */
     protected string $model;
 
     protected ?bool $isSearchForcedCaseInsensitive = null;
 
+    /**
+     * @param  class-string<Model>  $model
+     */
     final public function __construct(string $model)
     {
         $this->model($model);
@@ -48,6 +54,9 @@ class Type
         $this->setUp();
     }
 
+    /**
+     * @param  class-string<Model>  $model
+     */
     public static function make(string $model): static
     {
         return app(static::class, ['model' => $model]);
@@ -179,6 +188,9 @@ class Type
         });
     }
 
+    /**
+     * @param  class-string<Model>  $model
+     */
     public function model(string $model): static
     {
         $this->model = $model;
@@ -265,6 +277,9 @@ class Type
         return $this->getOptionLabelFromRecordUsing !== null;
     }
 
+    /**
+     * @return class-string<Model>
+     */
     public function getModel(): string
     {
         return $this->model;

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1156,6 +1156,9 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         $this->cachedExistingRecords = null;
     }
 
+    /**
+     * @return class-string<Model>
+     */
     public function getRelatedModel(): string
     {
         return $this->getRelationship()->getModel()::class;

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -1224,6 +1224,9 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
         return $this->getSearchResultsUsing instanceof Closure;
     }
 
+    /**
+     * @return Model|class-string<Model>|null
+     */
     public function getActionFormModel(): Model | string | null
     {
         if ($this->hasRelationship()) {

--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -150,6 +150,8 @@ trait InteractsWithForms
 
     /**
      * @deprecated Override the `form()` method to configure the default form.
+     *
+     * @return Model|class-string<Model>|null
      */
     protected function getFormModel(): Model | string | null
     {

--- a/packages/panels/src/Commands/MakeUserCommand.php
+++ b/packages/panels/src/Commands/MakeUserCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Hash;
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -56,7 +57,7 @@ class MakeUserCommand extends Command
                 required: true,
                 validate: fn (string $email): ?string => match (true) {
                     ! filter_var($email, FILTER_VALIDATE_EMAIL) => 'The email address must be valid.',
-                    static::getUserModel()::where('email', $email)->exists() => 'A user with this email address already exists',
+                    static::getUserModel()::query()->where('email', $email)->exists() => 'A user with this email address already exists',
                     default => null,
                 },
             ),
@@ -68,12 +69,15 @@ class MakeUserCommand extends Command
         ];
     }
 
-    protected function createUser(): Authenticatable
+    protected function createUser(): Model & Authenticatable
     {
-        return static::getUserModel()::create($this->getUserData());
+        /** @var Model & Authenticatable $user */
+        $user = static::getUserModel()::query()->create($this->getUserData());
+
+        return $user;
     }
 
-    protected function sendSuccessMessage(Authenticatable $user): void
+    protected function sendSuccessMessage(Model & Authenticatable $user): void
     {
         $loginUrl = Filament::getLoginUrl();
 
@@ -90,6 +94,9 @@ class MakeUserCommand extends Command
         return $this->getAuthGuard()->getProvider();
     }
 
+    /**
+     * @return class-string<Model & Authenticatable>
+     */
     protected function getUserModel(): string
     {
         /** @var EloquentUserProvider $provider */

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -272,6 +272,9 @@ class FilamentManager
         return $this->getCurrentPanel()->getMaxContentWidth();
     }
 
+    /**
+     * @param  class-string<Model>|Model  $model
+     */
     public function getModelResource(string | Model $model): ?string
     {
         return $this->getCurrentPanel()->getModelResource($model);
@@ -443,6 +446,9 @@ class FilamentManager
         return $this->getCurrentPanel()->getTenantMenuItems();
     }
 
+    /**
+     * @return class-string<Model>|null
+     */
     public function getTenantModel(): ?string
     {
         return $this->getCurrentPanel()->getTenantModel();

--- a/packages/panels/src/Pages/Auth/Register.php
+++ b/packages/panels/src/Pages/Auth/Register.php
@@ -45,6 +45,9 @@ class Register extends SimplePage
      */
     public ?array $data = [];
 
+    /**
+     * @var class-string<Model>
+     */
     protected string $userModel;
 
     public function mount(): void
@@ -219,6 +222,9 @@ class Register extends SimplePage
             ->url(filament()->getLoginUrl());
     }
 
+    /**
+     * @return class-string<Model>
+     */
     protected function getUserModel(): string
     {
         if (isset($this->userModel)) {

--- a/packages/panels/src/Pages/Tenancy/RegisterTenant.php
+++ b/packages/panels/src/Pages/Tenancy/RegisterTenant.php
@@ -142,6 +142,9 @@ abstract class RegisterTenant extends SimplePage
         ];
     }
 
+    /**
+     * @return class-string<Model>
+     */
     public function getModel(): string
     {
         return Filament::getTenantModel();

--- a/packages/panels/src/Panel/Concerns/HasComponents.php
+++ b/packages/panels/src/Panel/Concerns/HasComponents.php
@@ -145,6 +145,9 @@ trait HasComponents
         return $this;
     }
 
+    /**
+     * @param  class-string<Model>|Model  $model
+     */
     public function getModelResource(string | Model $model): ?string
     {
         if ($model instanceof Model) {

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -25,6 +25,9 @@ trait HasTenancy
 
     protected ?string $tenantDomain = null;
 
+    /**
+     * @var class-string<Model>|null
+     */
     protected ?string $tenantModel = null;
 
     protected ?string $tenantProfilePage = null;
@@ -69,6 +72,9 @@ trait HasTenancy
         return $this;
     }
 
+    /**
+     * @param  class-string<Model>|null  $model
+     */
     public function tenant(?string $model, ?string $slugAttribute = null, ?string $ownershipRelationship = null): static
     {
         $this->tenantModel = $model;
@@ -199,6 +205,9 @@ trait HasTenancy
         return $record;
     }
 
+    /**
+     * @return class-string<Model>|null
+     */
     public function getTenantModel(): ?string
     {
         return $this->tenantModel;

--- a/packages/panels/src/Resources/Pages/Concerns/InteractsWithRecord.php
+++ b/packages/panels/src/Resources/Pages/Concerns/InteractsWithRecord.php
@@ -124,6 +124,9 @@ trait InteractsWithRecord
         ];
     }
 
+    /**
+     * @return Model|class-string<Model>|null
+     */
     protected function getMountedActionSchemaModel(): Model | string | null
     {
         return $this->getRecord();

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -325,6 +325,9 @@ class CreateRecord extends Page
         return [];
     }
 
+    /**
+     * @return Model|class-string<Model>|null
+     */
     protected function getMountedActionSchemaModel(): Model | string | null
     {
         return $this->getModel();

--- a/packages/panels/src/Resources/Pages/ListRecords.php
+++ b/packages/panels/src/Resources/Pages/ListRecords.php
@@ -231,6 +231,9 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
             ->authorize(static::getResource()::canRestoreAny());
     }
 
+    /**
+     * @return Model|class-string<Model>|null
+     */
     protected function getMountedActionSchemaModel(): Model | string | null
     {
         return $this->getModel();

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -11,6 +11,7 @@ use Filament\Schema\Schema;
 use Filament\Tables\Table;
 use Filament\Widgets\Widget;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Macroable;
 
 abstract class Resource
@@ -32,6 +33,9 @@ abstract class Resource
 
     protected static bool $isDiscovered = true;
 
+    /**
+     * @var class-string<Model>|null
+     */
     protected static ?string $model = null;
 
     public static function form(Schema $form): Schema
@@ -75,6 +79,9 @@ abstract class Resource
         return $query;
     }
 
+    /**
+     * @return class-string<Model>
+     */
     public static function getModel(): string
     {
         return static::$model ?? (string) str(class_basename(static::class))

--- a/packages/panels/src/helpers.php
+++ b/packages/panels/src/helpers.php
@@ -10,6 +10,8 @@ use Illuminate\Support\Facades\Gate;
 
 if (! function_exists('Filament\authorize')) {
     /**
+     * @param  Model|class-string<Model>  $model
+     *
      * @throws AuthorizationException
      */
     function authorize(string $action, Model | string $model, bool $shouldCheckPolicyExistence = true): Response

--- a/packages/schema/src/Components/Concerns/BelongsToModel.php
+++ b/packages/schema/src/Components/Concerns/BelongsToModel.php
@@ -7,6 +7,9 @@ use Illuminate\Database\Eloquent\Model;
 
 trait BelongsToModel
 {
+    /**
+     * @var Model|class-string<Model>|Closure|null
+     */
     protected Model | string | Closure | null $model = null;
 
     protected ?Closure $loadStateFromRelationshipsUsing = null;
@@ -19,6 +22,9 @@ trait BelongsToModel
 
     protected bool | Closure $shouldSaveRelationshipsWhenHidden = false;
 
+    /**
+     * @param  Model|class-string<Model>|Closure|null  $model
+     */
     public function model(Model | string | Closure | null $model = null): static
     {
         $this->model = $model;
@@ -142,6 +148,9 @@ trait BelongsToModel
         return $this;
     }
 
+    /**
+     * @return class-string<Model>|null
+     */
     public function getModel(): ?string
     {
         $model = $this->evaluate($this->model);

--- a/packages/schema/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
+++ b/packages/schema/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
@@ -186,6 +186,9 @@ trait EntanglesStateWithSingularRelationship
         return $this->relationship;
     }
 
+    /**
+     * @return class-string<Model>|null
+     */
     public function getRelatedModel(): ?string
     {
         return $this->getRelationship()?->getModel()::class;

--- a/packages/schema/src/Components/Concerns/HasActions.php
+++ b/packages/schema/src/Components/Concerns/HasActions.php
@@ -21,6 +21,9 @@ trait HasActions
      */
     protected array $actions = [];
 
+    /**
+     * @var Model|class-string<Model>|null
+     */
     protected Model | string | null $actionFormModel = null;
 
     protected ?Action $action = null;
@@ -138,6 +141,9 @@ trait HasActions
         return $action->schemaComponent($this);
     }
 
+    /**
+     * @param  Model|class-string<Model>|null  $model
+     */
     public function actionFormModel(Model | string | null $model): static
     {
         $this->actionFormModel = $model;
@@ -145,6 +151,9 @@ trait HasActions
         return $this;
     }
 
+    /**
+     * @return Model|class-string<Model>|null
+     */
     public function getActionFormModel(): Model | string | null
     {
         return $this->actionFormModel ?? $this->getRecord() ?? $this->getModel();

--- a/packages/schema/src/Components/Contracts/CanEntangleWithSingularRelationships.php
+++ b/packages/schema/src/Components/Contracts/CanEntangleWithSingularRelationships.php
@@ -17,6 +17,9 @@ interface CanEntangleWithSingularRelationships
 
     public function getCachedExistingRecord(): ?Model;
 
+    /**
+     * @return class-string<Model>|null
+     */
     public function getRelatedModel(): ?string;
 
     public function getRelationship(): BelongsTo | HasOne | MorphOne | null;

--- a/packages/schema/src/Concerns/BelongsToModel.php
+++ b/packages/schema/src/Concerns/BelongsToModel.php
@@ -7,12 +7,12 @@ use Illuminate\Database\Eloquent\Model;
 trait BelongsToModel
 {
     /**
-     * @var Model | array<string, mixed> | string | null
+     * @var Model | array<string, mixed> | class-string<Model> | null
      */
     public Model | array | string | null $model = null;
 
     /**
-     * @param  Model | array<string, mixed> | string | null  $model
+     * @param  Model | array<string, mixed> | class-string<Model> | null  $model
      */
     public function model(Model | array | string | null $model = null): static
     {
@@ -61,6 +61,9 @@ trait BelongsToModel
         }
     }
 
+    /**
+     * @return class-string<Model>|null
+     */
     public function getModel(): ?string
     {
         $model = $this->model;

--- a/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
+++ b/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
@@ -100,7 +100,7 @@ class SpatieTagsInput extends TagsInput
         }
 
         $model = $this->getModel();
-        $tagClass = $model && method_exists($model, 'getTagClassName') ? $model::getTagClassName() : config('tags.tag_model', Tag::class);
+        $tagClass = ($model && method_exists($model, 'getTagClassName')) ? $model::getTagClassName() : config('tags.tag_model', Tag::class);
         $type = $this->getType();
         $query = $tagClass::query();
 

--- a/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
+++ b/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
@@ -100,7 +100,7 @@ class SpatieTagsInput extends TagsInput
         }
 
         $model = $this->getModel();
-        $tagClass = $model ? $model::getTagClassName() : config('tags.tag_model', Tag::class);
+        $tagClass = $model && method_exists($model, 'getTagClassName') ? $model::getTagClassName() : config('tags.tag_model', Tag::class);
         $type = $this->getType();
         $query = $tagClass::query();
 

--- a/packages/spatie-laravel-translatable-plugin/src/SpatieLaravelTranslatableContentDriver.php
+++ b/packages/spatie-laravel-translatable-plugin/src/SpatieLaravelTranslatableContentDriver.php
@@ -14,6 +14,9 @@ class SpatieLaravelTranslatableContentDriver implements TranslatableContentDrive
 {
     public function __construct(protected string $activeLocale) {}
 
+    /**
+     * @param  class-string<Model>  $model
+     */
     public function isAttributeTranslatable(string $model, string $attribute): bool
     {
         $model = app($model);
@@ -26,6 +29,7 @@ class SpatieLaravelTranslatableContentDriver implements TranslatableContentDrive
     }
 
     /**
+     * @param  class-string<Model>  $model
      * @param  array<string, mixed>  $data
      */
     public function makeRecord(string $model, array $data): Model

--- a/packages/support/src/Commands/Concerns/CanReadModelSchemas.php
+++ b/packages/support/src/Commands/Concerns/CanReadModelSchemas.php
@@ -12,6 +12,9 @@ use ReflectionException;
 
 trait CanReadModelSchemas
 {
+    /**
+     * @return class-string<Model>|null
+     */
     protected function getModel(string $model): ?string
     {
         if (! class_exists($model)) {
@@ -21,6 +24,9 @@ trait CanReadModelSchemas
         return $model;
     }
 
+    /**
+     * @param  class-string<Model>  $model
+     */
     protected function getModelSchema(string $model): Builder
     {
         return app($model)
@@ -28,11 +34,17 @@ trait CanReadModelSchemas
             ->getSchemaBuilder();
     }
 
+    /**
+     * @param  class-string<Model>  $model
+     */
     protected function getModelTable(string $model): string
     {
         return app($model)->getTable();
     }
 
+    /**
+     * @param  class-string<Model>  $model
+     */
     protected function guessBelongsToRelationshipName(string $column, string $model): ?string
     {
         /** @var Model $modelInstance */
@@ -82,6 +94,9 @@ trait CanReadModelSchemas
         return $tableName;
     }
 
+    /**
+     * @param  class-string<Model>  $model
+     */
     protected function guessBelongsToRelationshipTitleColumnName(string $column, string $model): string
     {
         $schema = $this->getModelSchema($model);
@@ -145,6 +160,7 @@ trait CanReadModelSchemas
 
     /**
      * @param  array<string, mixed>  $column
+     * @param  class-string<Model>  $model
      */
     protected function parseDefaultExpression(array $column, string $model): mixed
     {

--- a/packages/support/src/Contracts/TranslatableContentDriver.php
+++ b/packages/support/src/Contracts/TranslatableContentDriver.php
@@ -9,6 +9,9 @@ interface TranslatableContentDriver
 {
     public function __construct(string $activeLocale);
 
+    /**
+     * @param  class-string<Model>  $model
+     */
     public function isAttributeTranslatable(string $model, string $attribute): bool;
 
     /**
@@ -17,6 +20,7 @@ interface TranslatableContentDriver
     public function getRecordAttributesToArray(Model $record): array;
 
     /**
+     * @param  class-string<Model>  $model
      * @param  array<string, mixed>  $data
      */
     public function makeRecord(string $model, array $data): Model;

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -6,6 +6,7 @@ use Filament\Support\Facades\FilamentColor;
 use Filament\Support\Facades\FilamentView;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Connection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Http\Request;
 use Illuminate\Support\HtmlString;
@@ -40,6 +41,9 @@ if (! function_exists('Filament\Support\format_number')) {
 }
 
 if (! function_exists('Filament\Support\get_model_label')) {
+    /**
+     * @param  class-string<Model>  $model
+     */
     function get_model_label(string $model): string
     {
         return (string) str(class_basename($model))

--- a/packages/tables/src/Commands/Concerns/CanGenerateTables.php
+++ b/packages/tables/src/Commands/Concerns/CanGenerateTables.php
@@ -3,10 +3,14 @@
 namespace Filament\Tables\Commands\Concerns;
 
 use Filament\Tables;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
 trait CanGenerateTables
 {
+    /**
+     * @param  string|class-string<Model>  $model
+     */
     protected function getResourceTableColumns(string $model): string
     {
         $model = $this->getModel($model);

--- a/packages/tables/src/Table/Concerns/HasRecords.php
+++ b/packages/tables/src/Table/Concerns/HasRecords.php
@@ -107,15 +107,14 @@ trait HasRecords
         return $this->getLivewire()->getTableRecordKey($record);
     }
 
+    /**
+     * @return class-string<Model>|null
+     */
     public function getModel(): ?string
     {
         $query = $this->getQuery();
 
-        if (! $query) {
-            return null;
-        }
-
-        return $query->getModel()::class;
+        return $query?->getModel()::class;
     }
 
     public function allowsDuplicates(): bool


### PR DESCRIPTION
## Description

Enhanced type support by adding docblock annotations with `class-string<Model>` and, in some cases, adding the native type `Model & Authenticatable` to ensure the object extends the `Model` class and implements the `Authenticatable` interface.

Addressed an edge case for `SpatieTagInput` by checking if the `getTagClassName` method exists before calling it. This was necessary because there isn't a docblock annotation to describe an instance of a class using a specific trait.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
