### PR TITLE
Update header-cell.blade.php

### DIFF
--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -25,7 +25,7 @@
 >
     <{{ $sortable ? 'button' : 'span' }}
         @if ($sortable)
-            aria-label="{{ $slot }}"
+            aria-label="{{ strip_tags($slot) }}"
             type="button"
             wire:click="sortTable('{{ $name }}')"
         @endif


### PR DESCRIPTION
fix for aria-label showing html when column heading is htmlable

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

fixes a bug where eroneous html gets shown on the page if the TextColumn label is a html string

## Visual changes
Before:
<img width="340" alt="Screenshot 2024-08-29 at 11 04 24" src="https://github.com/user-attachments/assets/4bee73d0-c066-4b2c-a7fb-bac940cd2496">
After:
<img width="192" alt="Screenshot 2024-08-29 at 11 04 02" src="https://github.com/user-attachments/assets/104e1d16-3958-43ed-b4c1-b06958a39b88">


## Functional changes

- [ n/a] Code style has been fixed by running the `composer cs` command.
- [Y ] Changes have been tested to not break existing functionality.
- [ n/a] Documentation is up-to-date.
