### PR TITLE
✨ Allow additional arguments on `authorize()`

### DIFF
--- a/packages/panels/src/Resources/Concerns/InteractsWithRelationshipTable.php
+++ b/packages/panels/src/Resources/Concerns/InteractsWithRelationshipTable.php
@@ -22,6 +22,9 @@ trait InteractsWithRelationshipTable
 
     protected static bool $shouldSkipAuthorization = false;
 
+    /** @var array<mixed> */
+    protected static array $authorizationArguments = [];
+
     public static function checkPolicyExistence(bool $condition = true): void
     {
         static::$shouldCheckPolicyExistence = $condition;
@@ -40,6 +43,14 @@ trait InteractsWithRelationshipTable
     public static function shouldSkipAuthorization(): bool
     {
         return static::$shouldSkipAuthorization;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public static function getAuthorizationArguments(string $action, ?Model $record = null): array
+    {
+        return static::$authorizationArguments;
     }
 
     public function getRelationship(): Relation | Builder

--- a/packages/panels/src/Resources/Pages/ManageRelatedRecords.php
+++ b/packages/panels/src/Resources/Pages/ManageRelatedRecords.php
@@ -105,7 +105,7 @@ class ManageRelatedRecords extends Page implements Tables\Contracts\HasTable
         $model = $record->{static::getRelationshipName()}()->getQuery()->getModel()::class;
 
         try {
-            return authorize('viewAny', $model, static::shouldCheckPolicyExistence())->allowed();
+            return authorize('viewAny', $model, static::shouldCheckPolicyExistence(), static::getAuthorizationArguments('viewAny'))->allowed();
         } catch (AuthorizationException $exception) {
             return $exception->toResponse()->allowed();
         }
@@ -273,7 +273,7 @@ class ManageRelatedRecords extends Page implements Tables\Contracts\HasTable
         $model = $this->getTable()->getModel();
 
         try {
-            return authorize($action, $record ?? $model, static::shouldCheckPolicyExistence())->allowed();
+            return authorize($action, $record ?? $model, static::shouldCheckPolicyExistence(), static::getAuthorizationArguments($action, $record))->allowed();
         } catch (AuthorizationException $exception) {
             return $exception->toResponse()->allowed();
         }

--- a/packages/panels/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManager.php
@@ -318,7 +318,7 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
         $model = $this->getTable()->getModel();
 
         try {
-            return authorize($action, $record ?? $model, static::shouldCheckPolicyExistence())->allowed();
+            return authorize($action, $record ?? $model, static::shouldCheckPolicyExistence(), static::getAuthorizationArguments($action, $record))->allowed();
         } catch (AuthorizationException $exception) {
             return $exception->toResponse()->allowed();
         }
@@ -495,7 +495,7 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
         $model = $ownerRecord->{static::getRelationshipName()}()->getQuery()->getModel()::class;
 
         try {
-            return authorize('viewAny', $model, static::shouldCheckPolicyExistence())->allowed();
+            return authorize('viewAny', $model, static::shouldCheckPolicyExistence(), static::getAuthorizationArguments('viewAny'))->allowed();
         } catch (AuthorizationException $exception) {
             return $exception->toResponse()->allowed();
         }

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -117,6 +117,11 @@ abstract class Resource
 
     protected static bool $shouldSkipAuthorization = false;
 
+    /**
+     * @var array<mixed>
+     */
+    protected static array $authorizationArguments = [];
+
     protected static ?bool $isGlobalSearchForcedCaseInsensitive = null;
 
     protected static SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Start;
@@ -201,7 +206,7 @@ abstract class Resource
         $model = static::getModel();
 
         try {
-            return authorize($action, $record ?? $model, static::shouldCheckPolicyExistence())->allowed();
+            return authorize($action, $record ?? $model, static::shouldCheckPolicyExistence(), static::getAuthorizationArguments($action, $record))->allowed();
         } catch (AuthorizationException $exception) {
             return $exception->toResponse()->allowed();
         }
@@ -219,7 +224,7 @@ abstract class Resource
         $model = static::getModel();
 
         try {
-            return authorize($action, $record ?? $model, static::shouldCheckPolicyExistence());
+            return authorize($action, $record ?? $model, static::shouldCheckPolicyExistence(), static::getAuthorizationArguments($action, $record));
         } catch (AuthorizationException $exception) {
             return $exception->toResponse();
         }
@@ -243,6 +248,14 @@ abstract class Resource
     public static function shouldSkipAuthorization(): bool
     {
         return static::$shouldSkipAuthorization;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public static function getAuthorizationArguments(string $action, ?Model $record = null): array
+    {
+        return static::$authorizationArguments;
     }
 
     public static function canViewAny(): bool

--- a/packages/panels/src/helpers.php
+++ b/packages/panels/src/helpers.php
@@ -10,14 +10,16 @@ use Illuminate\Support\Facades\Gate;
 
 if (! function_exists('Filament\authorize')) {
     /**
+     * @param array<mixed> $arguments
+     *
      * @throws AuthorizationException
      */
-    function authorize(string $action, Model | string $model, bool $shouldCheckPolicyExistence = true): Response
+    function authorize(string $action, Model | string $model, bool $shouldCheckPolicyExistence = true, array $arguments = []): Response
     {
         $user = Filament::auth()->user();
 
         if (! $shouldCheckPolicyExistence) {
-            return Gate::forUser($user)->authorize($action, $model);
+            return Gate::forUser($user)->authorize($action, [$model, ...$arguments]);
         }
 
         $policy = Gate::getPolicyFor($model);
@@ -30,7 +32,7 @@ if (! function_exists('Filament\authorize')) {
             $response = invade(Gate::forUser($user))->callBeforeCallbacks( /** @phpstan-ignore-line */
                 $user,
                 $action,
-                [$model],
+                [$model, ...$arguments]
             );
 
             if ($response === false) {
@@ -44,6 +46,6 @@ if (! function_exists('Filament\authorize')) {
             return $response->authorize();
         }
 
-        return Gate::forUser($user)->authorize($action, $model);
+        return Gate::forUser($user)->authorize($action, [$model, ...$arguments]);
     }
 }

--- a/packages/panels/src/helpers.php
+++ b/packages/panels/src/helpers.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Gate;
 
 if (! function_exists('Filament\authorize')) {
     /**
-     * @param array<mixed> $arguments
+     * @param  array<mixed>  $arguments
      *
      * @throws AuthorizationException
      */


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

This PR aims to allow additional `$arguments` on `authorize()`.

Given the ff policy:

```php
class PostPolicy
{
    public function view(User $user, Post $post, PostTypeEnum $type): bool
    {
        // ...
    }
}
```

In our case, we have different `Resource`s for each type of `Post` (don't ask me why, I suggested to just use filters but the client insisted on separating each type), and certain users may only have access on certain types of `Post`s 

At the moment, Filament's `authorize` method is unable to pass a `$type` argument to the policy method unlike in Laravel's `authorize` method.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

n/a

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
