### PR TITLE
Use assertEqualsCanonicalized() for summary testing

### DIFF
--- a/packages/tables/docs/12-testing.md
+++ b/packages/tables/docs/12-testing.md
@@ -638,7 +638,7 @@ it('can average values in a column', function () {
 
 The first argument is the column name, the second is the summarizer ID, and the third is the expected value.
 
-Note that the expected and actual values are normalized, such that 123.12 is considered the same as "123.12", and ['Fred', 'Jim'] is the same as ['Jim', 'Fred'].
+Note that the expected and actual values are normalized, such that `123.12` is considered the same as `"123.12"`, and `['Fred', 'Jim']` is the same as `['Jim', 'Fred']`.
 
 You may set a summarizer ID by passing it to the `make()` method:
 

--- a/packages/tables/docs/12-testing.md
+++ b/packages/tables/docs/12-testing.md
@@ -638,6 +638,8 @@ it('can average values in a column', function () {
 
 The first argument is the column name, the second is the summarizer ID, and the third is the expected value.
 
+Note that the expected and actual values are normalized, such that 123.12 is considered the same as "123.12", and ['Fred', 'Jim'] is the same as ['Jim', 'Fred'].
+
 You may set a summarizer ID by passing it to the `make()` method:
 
 ```php

--- a/packages/tables/src/Testing/TestsSummaries.php
+++ b/packages/tables/src/Testing/TestsSummaries.php
@@ -39,7 +39,7 @@ class TestsSummaries
 
             $livewireClass = $this->instance()::class;
 
-            Assert::assertSame(
+            Assert::assertEqualsCanonicalizing(
                 $state,
                 $actualState,
                 message: "Failed asserting that summarizer [$summarizerId], for column [{$columnName}], on the [{$livewireClass}] component, is set.",
@@ -73,7 +73,7 @@ class TestsSummaries
 
             $livewireClass = $this->instance()::class;
 
-            Assert::assertNotSame(
+            Assert::assertNotEqualsCanonicalizing(
                 $state,
                 $actualState,
                 message: "Failed asserting that summarizer [$summarizerId], for column [{$columnName}], on the [{$livewireClass}] component, is not set.",


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The assertTableColumnSummarySet() method currently fails for Values summaries if the expected state array is not sorted the same as the actual value.  As the ordering/sorting of the Values summary is not specified, this makes testing difficult.  Using assertEqualsCanonicalized() instead of assertSame() fixes this.

Note that other potential differences between using an "Equals" test vs a "Same" test are not applicable, as we internally normalize strings vs numeric before calling the assertion anyway.

Also added a line to the doc noting that expected and actual values are normalized.

## Visual changes

No visual changes

## Functional changes

- [ x ] Code style has been fixed by running the `composer cs` command.
- [ x ] Changes have been tested to not break existing functionality.
- [ x ] Documentation is up-to-date.
