### PR TITLE
Add slideOver support to RelationManager actions

### DIFF
--- a/packages/panels/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManager.php
@@ -88,6 +88,8 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
 
     protected static ?string $badgeTooltip = null;
 
+    protected bool $useSlideOver = false;
+
     public function mount(): void
     {
         $this->loadDefaultActiveTab();
@@ -213,7 +215,8 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
     {
         $action
             ->authorize(static fn (RelationManager $livewire): bool => (! $livewire->isReadOnly()) && $livewire->canCreate())
-            ->form(fn (Form $form): Form => $this->form($form->columns(2)));
+            ->form(fn (Form $form): Form => $this->form($form->columns(2)))
+            ->slideOver($this->useSlideOver);
     }
 
     protected function configureDeleteAction(Tables\Actions\DeleteAction $action): void
@@ -238,7 +241,8 @@ class RelationManager extends Component implements Actions\Contracts\HasActions,
     {
         $action
             ->authorize(static fn (RelationManager $livewire, Model $record): bool => (! $livewire->isReadOnly()) && $livewire->canEdit($record))
-            ->form(fn (Form $form): Form => $this->form($form->columns(2)));
+            ->form(fn (Form $form): Form => $this->form($form->columns(2)))
+            ->slideOver($this->useSlideOver);
     }
 
     protected function configureForceDeleteAction(Tables\Actions\ForceDeleteAction $action): void


### PR DESCRIPTION
## Description

Introduced a new boolean property $useSlideOver in the RelationManager to allow opening forms in a slide-over instead of a modal. This enhancement provides a smoother and less intrusive user experience when interacting with forms, particularly useful for workflows that benefit from preserving the context of the underlying page. The configureCreateAction and configureEditAction methods have been updated to use this new property, enabling developers to easily toggle between modal and slide-over views.

## Visual changes

Since the introduction of the $useSlideOver property affects the UI, the changes primarily involve the replacement of modal dialogs with slide-over panels when the property is set to true.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
