### PR TITLE
add missing and improve existing bs translations

### DIFF
--- a/packages/actions/resources/lang/bs/associate.php
+++ b/packages/actions/resources/lang/bs/associate.php
@@ -4,11 +4,11 @@ return [
 
     'single' => [
 
-        'label' => 'Spajanje',
+        'label' => 'Povežite',
 
         'modal' => [
 
-            'heading' => 'Spojite :label',
+            'heading' => 'Povežite :label',
 
             'fields' => [
 
@@ -21,11 +21,11 @@ return [
             'actions' => [
 
                 'associate' => [
-                    'label' => 'Spoji',
+                    'label' => 'Povežite',
                 ],
 
                 'associate_another' => [
-                    'label' => 'Spojite i spojite još jedan',
+                    'label' => 'Povežite i povežite još jedan',
                 ],
 
             ],
@@ -35,7 +35,7 @@ return [
         'notifications' => [
 
             'associated' => [
-                'title' => 'Spojeno',
+                'title' => 'Povezano',
             ],
 
         ],

--- a/packages/actions/resources/lang/bs/attach.php
+++ b/packages/actions/resources/lang/bs/attach.php
@@ -4,7 +4,7 @@ return [
 
     'single' => [
 
-        'label' => 'Priložiti',
+        'label' => 'Priložite',
 
         'modal' => [
 

--- a/packages/actions/resources/lang/bs/create.php
+++ b/packages/actions/resources/lang/bs/create.php
@@ -4,20 +4,20 @@ return [
 
     'single' => [
 
-        'label' => 'Napraviti',
+        'label' => 'Kreirajte',
 
         'modal' => [
 
-            'heading' => 'Napravite :label',
+            'heading' => 'Kreirajte :label',
 
             'actions' => [
 
                 'create' => [
-                    'label' => 'Napraviti',
+                    'label' => 'Kreirati',
                 ],
 
                 'create_another' => [
-                    'label' => 'Napravite i napravite još jedan',
+                    'label' => 'Kreirajte i kreirajte još jedan',
                 ],
 
             ],

--- a/packages/actions/resources/lang/bs/delete.php
+++ b/packages/actions/resources/lang/bs/delete.php
@@ -13,7 +13,7 @@ return [
             'actions' => [
 
                 'delete' => [
-                    'label' => 'Izbrišiti',
+                    'label' => 'Izbrisati',
                 ],
 
             ],
@@ -32,16 +32,16 @@ return [
 
     'multiple' => [
 
-        'label' => 'Izbrišite izabrani',
+        'label' => 'Izbrišite izabrano',
 
         'modal' => [
 
-            'heading' => 'Izbriši izabrani :label ',
+            'heading' => 'Izbrišite izabrani :label ',
 
             'actions' => [
 
                 'delete' => [
-                    'label' => 'Izbriši izabrani',
+                    'label' => 'Izbrišite izabrani',
                 ],
 
             ],

--- a/packages/actions/resources/lang/bs/export.php
+++ b/packages/actions/resources/lang/bs/export.php
@@ -1,0 +1,77 @@
+<?php
+
+return [
+
+    'label' => 'Eksportujte :label',
+
+    'modal' => [
+
+        'heading' => 'Exportujte :label',
+
+        'form' => [
+
+            'columns' => [
+
+                'label' => 'Kolone',
+
+                'form' => [
+
+                    'is_enabled' => [
+                        'label' => ':column kolona aktivna',
+                    ],
+
+                    'label' => [
+                        'label' => ':column oznaka',
+                    ],
+
+                ],
+
+            ],
+
+        ],
+
+        'actions' => [
+
+            'export' => [
+                'label' => 'Eksportujte',
+            ],
+
+        ],
+
+    ],
+
+    'notifications' => [
+
+        'completed' => [
+
+            'title' => 'Eksport završen',
+
+            'actions' => [
+
+                'download_csv' => [
+                    'label' => 'Preuzmite .csv',
+                ],
+
+                'download_xlsx' => [
+                    'label' => 'Preuzmite .xlsx',
+                ],
+
+            ],
+
+        ],
+
+        'max_rows' => [
+            'title' => 'Eksport je prevelik.',
+            'body' => 'Ne možete eksportovati više od 1 reda odjednom.|Ne možete eksportovati više od :count redova odjednom',
+        ],
+
+        'started' => [
+            'title' => 'Eksport započet',
+            'body' => 'Vaš eksport je započeo i 1 red će se obrađivati u pozadini. Dobit ćete obavijest s linkom za preuzimanje kada bude dovršeno. | Vaš eksport je započeo i :count redova će se obrađivati u pozadini. Dobit ćete obavijest s linkom za preuzimanje kada bude dovršeno.',
+        ],
+
+    ],
+
+    'file_name' => 'eksport-:export_id-:model',
+
+];

--- a/packages/actions/resources/lang/bs/force-delete.php
+++ b/packages/actions/resources/lang/bs/force-delete.php
@@ -4,16 +4,16 @@ return [
 
     'single' => [
 
-        'label' => 'Konačno izbrisat',
+        'label' => 'Izbrišite zauvijek',
 
         'modal' => [
 
-            'heading' => 'Konačno izbrisati :label',
+            'heading' => 'Izbrišite :label zauvijek',
 
             'actions' => [
 
                 'delete' => [
-                    'label' => 'Izbrasiti',
+                    'label' => 'Izbrišite',
                 ],
 
             ],
@@ -32,11 +32,11 @@ return [
 
     'multiple' => [
 
-        'label' => 'Izabrani konačno izbrisati',
+        'label' => 'Izabrano izbrišite zauvijek',
 
         'modal' => [
 
-            'heading' => 'Konačno izbrisati izabrani :label ',
+            'heading' => 'Zauvijek izbrišite :label ',
 
             'actions' => [
 

--- a/packages/actions/resources/lang/bs/import.php
+++ b/packages/actions/resources/lang/bs/import.php
@@ -1,0 +1,85 @@
+<?php
+
+return [
+
+    'label' => 'Importujte :label',
+
+    'modal' => [
+
+        'heading' => 'Importujte :label',
+
+        'form' => [
+
+            'file' => [
+
+                'label' => 'Fajl',
+
+                'placeholder' => 'Priložite CSV fajl',
+
+                'rules' => [
+                    'duplicate_columns' => '{0} Fajl ne smije sadržavati više od jednog praznog zaglavlja kolone.|{1,*} Fajl ne smije sadržavati duplicirana zaglavlja kolona: :columns.',
+                ],
+
+            ],
+
+            'columns' => [
+                'label' => 'Kolone',
+                'placeholder' => 'Odaberite kolonu',
+            ],
+
+        ],
+
+        'actions' => [
+
+            'download_example' => [
+                'label' => 'Preuzmite primjer CSV fajla',
+            ],
+
+            'import' => [
+                'label' => 'Importujte',
+            ],
+
+        ],
+
+    ],
+
+    'notifications' => [
+
+        'completed' => [
+
+            'title' => 'Import završen',
+
+            'actions' => [
+
+                'download_failed_rows_csv' => [
+                    'label' => 'Preuzmite informacije o neuspješnom redu|Preuzmite informacije o neuspješnim redovima',
+                ],
+
+            ],
+
+        ],
+
+        'max_rows' => [
+            'title' => 'Učitani CSV fajl je prevelik',
+            'body' => 'Ne možete importovati više od 1 reda odjednom.|Ne možete uvesti više od :count redova odjednom.',
+        ],
+
+        'started' => [
+            'title' => 'Import započet',
+            'body' => 'Vaš uvoz je započeo i 1 red će se obrađivati u pozadini.|Vaš uvoz je započeo i :count redova će se obrađivati u pozadini.',
+        ],
+
+    ],
+
+    'example_csv' => [
+        'file_name' => ':importer-primjer',
+    ],
+
+    'failure_csv' => [
+        'file_name' => 'import-:import_id-:csv_name-neuspješni-redovi',
+        'error_header' => 'greška',
+        'system_error' => 'Sistemska greška, molimo kontaktirajte podršku.',
+        'column_mapping_required_for_new_record' => ':attribute kolona nije povezana s kolonom u fajlu, a potrebna je za kreiranje novih zapisa.',
+    ],
+
+];

--- a/packages/actions/resources/lang/bs/modal.php
+++ b/packages/actions/resources/lang/bs/modal.php
@@ -7,15 +7,15 @@ return [
     'actions' => [
 
         'cancel' => [
-            'label' => 'Prekiniti',
+            'label' => 'Prekid',
         ],
 
         'confirm' => [
-            'label' => 'Konfirmisati',
+            'label' => 'Potvrdi',
         ],
 
         'submit' => [
-            'label' => 'Poslati',
+            'label' => 'Pošalji',
         ],
 
     ],

--- a/packages/actions/resources/lang/bs/replicate.php
+++ b/packages/actions/resources/lang/bs/replicate.php
@@ -4,7 +4,7 @@ return [
 
     'single' => [
 
-        'label' => 'Duplicirati',
+        'label' => 'Duplicirajte',
 
         'modal' => [
 

--- a/packages/actions/resources/lang/bs/restore.php
+++ b/packages/actions/resources/lang/bs/restore.php
@@ -4,16 +4,16 @@ return [
 
     'single' => [
 
-        'label' => 'Restaurirati',
+        'label' => 'Povrati',
 
         'modal' => [
 
-            'heading' => 'Restaurirati :label',
+            'heading' => 'Povrati :label',
 
             'actions' => [
 
                 'restore' => [
-                    'label' => 'Restaurirati',
+                    'label' => 'Povrati',
                 ],
 
             ],
@@ -23,7 +23,7 @@ return [
         'notifications' => [
 
             'restored' => [
-                'title' => 'Zapis restauriran',
+                'title' => 'Zapis vraćen',
             ],
 
         ],
@@ -32,16 +32,16 @@ return [
 
     'multiple' => [
 
-        'label' => 'Izabrani restaurirati',
+        'label' => 'Izabrani vratiti',
 
         'modal' => [
 
-            'heading' => 'Restaurirati izabrani :label',
+            'heading' => 'Povrati :label',
 
             'actions' => [
 
                 'restore' => [
-                    'label' => 'Restaurirati',
+                    'label' => 'Povratiti',
                 ],
 
             ],
@@ -51,7 +51,7 @@ return [
         'notifications' => [
 
             'restored' => [
-                'title' => 'Zapisi restaurirani',
+                'title' => 'Zapisi vraćen',
             ],
 
         ],

--- a/packages/actions/resources/lang/bs/view.php
+++ b/packages/actions/resources/lang/bs/view.php
@@ -4,11 +4,11 @@ return [
 
     'single' => [
 
-        'label' => 'Pogled',
+        'label' => 'Pregledajte',
 
         'modal' => [
 
-            'heading' => 'Pogled :label',
+            'heading' => 'Pregled :label',
 
             'actions' => [
 

--- a/packages/infolists/resources/lang/bs/components.php
+++ b/packages/infolists/resources/lang/bs/components.php
@@ -1,0 +1,38 @@
+<?php
+
+return [
+
+    'entries' => [
+
+        'text' => [
+
+            'actions' => [
+                'collapse_list' => 'Prikaži :count manje',
+                'expand_list' => 'Prikaži :count više',
+            ],
+
+            'more_list_items' => 'i :count još',
+
+        ],
+
+        'key_value' => [
+
+            'columns' => [
+
+                'key' => [
+                    'label' => 'Ključ',
+                ],
+
+                'value' => [
+                    'label' => 'Vrijednost',
+                ],
+
+            ],
+
+            'placeholder' => 'Nema unosa',
+
+        ],
+
+    ],
+
+];


### PR DESCRIPTION
## Description

This PR aims to add missing **bs** translations for import & export and also improve the existing **bs** translations for actions package, and also add missing bs translations for infolists package.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
