### PR TITLE
The toggleAllCheckboxes function should not check a disable checkbox

### DIFF
--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -33,8 +33,10 @@
                 this.visibleCheckboxListOptions.forEach((checkboxLabel) => {
                     checkbox = checkboxLabel.querySelector('input[type=checkbox]')
 
-                    checkbox.checked = state
-                    checkbox.dispatchEvent(new Event('change'))
+                    if (!checkbox.disabled) {
+                        checkbox.checked = state
+                        checkbox.dispatchEvent(new Event('change'))
+                    }
                 })
 
                 this.areAllCheckboxesChecked = state

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -33,10 +33,12 @@
                 this.visibleCheckboxListOptions.forEach((checkboxLabel) => {
                     checkbox = checkboxLabel.querySelector('input[type=checkbox]')
 
-                    if (!checkbox.disabled) {
-                        checkbox.checked = state
-                        checkbox.dispatchEvent(new Event('change'))
+                    if (checkbox.disabled) {
+                        return
                     }
+
+                    checkbox.checked = state
+                    checkbox.dispatchEvent(new Event('change'))
                 })
 
                 this.areAllCheckboxesChecked = state


### PR DESCRIPTION
Close #14137

## Description

There is a function in the js part of the checkbox named `toggleAllCheckboxes`, that will effect on all checkboxes without considering the disabled attribute. in this merge request I made a condition to prevent changing disable checkboxxes.

## Functional changes

- [ ] The toggleAllCheckboxes in JS part of checkbox will effect only on non disable checkboxes
