### PR TITLE
Add `preventBackNavigation()` method to restrict backward navigation in wizards

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/01-create.md
+++ b/packages/actions/docs/07-prebuilt-actions/01-create.md
@@ -237,6 +237,16 @@ CreateAction::make()
     ->skippableSteps()
 ```
 
+To prevent backward navigation and only allow users to move forward through the steps, use the `preventBackNavigationSteps()` method:
+
+```php
+CreateAction::make()
+    ->steps([
+        // ...
+    ])
+    ->preventBackNavigationSteps()
+```
+
 ## Disabling create another
 
 If you'd like to remove the "create another" button from the modal, you can use the `createAnother(false)` method:

--- a/packages/actions/src/Concerns/HasForm.php
+++ b/packages/actions/src/Concerns/HasForm.php
@@ -71,6 +71,7 @@ trait HasForm
                 ->cancelAction($this->getModalCancelAction())
                 ->submitAction($this->getModalSubmitAction())
                 ->skippable($this->isWizardSkippable())
+                ->preventBackNavigation($this->isWizardBackNavigationPrevented())
                 ->disabled($this->isFormDisabled());
 
             if ($this->modifyWizardUsing) {

--- a/packages/actions/src/Concerns/HasWizard.php
+++ b/packages/actions/src/Concerns/HasWizard.php
@@ -11,6 +11,8 @@ trait HasWizard
 
     protected bool | Closure $isWizardSkippable = false;
 
+    protected bool | Closure $isWizardBackNavigationPrevented = false;
+
     protected int | Closure $wizardStartStep = 1;
 
     protected ?Closure $modifyWizardUsing = null;
@@ -40,6 +42,13 @@ trait HasWizard
         return $this;
     }
 
+    public function preventBackNavigationSteps(bool | Closure $condition = true): static
+    {
+        $this->isWizardBackNavigationPrevented = $condition;
+
+        return $this;
+    }
+
     public function isWizard(): bool
     {
         return $this->isWizard;
@@ -48,6 +57,11 @@ trait HasWizard
     public function isWizardSkippable(): bool
     {
         return (bool) $this->evaluate($this->isWizardSkippable);
+    }
+
+    public function isWizardBackNavigationPrevented(): bool
+    {
+        return (bool) $this->evaluate($this->isWizardBackNavigationPrevented);
     }
 
     public function modifyWizardUsing(?Closure $callback): static

--- a/packages/forms/docs/04-layout/05-wizard.md
+++ b/packages/forms/docs/04-layout/05-wizard.md
@@ -140,6 +140,18 @@ Wizard::make([
 ])->skippable()
 ```
 
+## Preventing backward navigation
+
+If you'd like to restrict navigation so users can only move forward, use the `preventBackNavigation()` method. This hides the "back" button, allowing users to proceed only to the next step:
+
+```php
+use Filament\Forms\Components\Wizard;
+
+Wizard::make([
+    // ...
+])->preventBackNavigation()
+```
+
 ## Persisting the current step in the URL's query string
 
 By default, the current step is not persisted in the URL's query string. You can change this behavior using the `persistStepInQueryString()` method:

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -23,6 +23,10 @@
         },
 
         previousStep: function () {
+            if (this.isBackNavigationPrevented()) {
+                return
+            }
+
             let previousStepIndex = this.getStepIndex(this.step) - 1
 
             if (previousStepIndex < 0) {
@@ -73,10 +77,18 @@
             return this.getStepIndex(this.step) + 1 >= this.getSteps().length
         },
 
+        isBackNavigationPrevented: function () {
+            return @js($isBackNavigationPrevented());
+        },
+
+        isSkippable: function () {
+            return @js($isSkippable());
+        },
+
         isStepAccessible: function (stepId) {
-            return (
-                @js($isSkippable()) || this.getStepIndex(this.step) > this.getStepIndex(stepId)
-            )
+            return this.isSkippable()
+                ? !this.isBackNavigationPrevented() || this.getStepIndex(this.step) <= this.getStepIndex(stepId)
+                : !this.isBackNavigationPrevented() && this.getStepIndex(this.step) > this.getStepIndex(stepId);
         },
 
         updateQueryString: function () {
@@ -262,11 +274,11 @@
             'mt-6' => ! $isContained,
         ])
     >
-        <span x-cloak x-on:click="previousStep" x-show="! isFirstStep()">
+        <span x-cloak x-on:click="previousStep()" x-show="! isFirstStep() && !isBackNavigationPrevented()">
             {{ $getAction('previous') }}
         </span>
 
-        <span x-show="isFirstStep()">
+        <span x-show="isFirstStep() || isBackNavigationPrevented()">
             {{ $getCancelAction() }}
         </span>
 

--- a/packages/forms/src/Components/Wizard.php
+++ b/packages/forms/src/Components/Wizard.php
@@ -20,6 +20,8 @@ class Wizard extends Component
 
     protected bool | Closure $isSkippable = false;
 
+    protected bool | Closure $isBackNavigationPrevented = false;
+
     protected string | Closure | null $stepQueryStringKey = null;
 
     protected string | Htmlable | null $submitAction = null;
@@ -217,6 +219,13 @@ class Wizard extends Component
         return $this;
     }
 
+    public function preventBackNavigation(bool | Closure $condition = true): static
+    {
+        $this->isBackNavigationPrevented = $condition;
+
+        return $this;
+    }
+
     public function persistStepInQueryString(string | Closure | null $key = 'step'): static
     {
         $this->stepQueryStringKey = $key;
@@ -259,6 +268,11 @@ class Wizard extends Component
     public function isSkippable(): bool
     {
         return (bool) $this->evaluate($this->isSkippable);
+    }
+
+    public function isBackNavigationPrevented(): bool
+    {
+        return (bool) $this->evaluate($this->isBackNavigationPrevented);
     }
 
     public function isStepPersistedInQueryString(): bool


### PR DESCRIPTION
## Description

This update introduces the `preventBackNavigation()` method, allowing users to disable backward navigation in wizards. By applying this method, users can only move forward through the steps, ensuring a more controlled progression. This enhancement is particularly useful in contexts such as onboarding processes, booking flows, or any scenario where revisiting previous steps could lead to inconsistencies or confusion.

I did various tests and made sure that the change does not conflict with `skippable()`. 

## Visual changes

<img width="882" alt="Screenshot 2024-09-08 alle 22 45 21" src="https://github.com/user-attachments/assets/22f16af1-7155-48f3-a072-e6251c04cdd5">

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
