### PR TITLE
fix creating resources in vendor when plugin uses cluster

### DIFF
--- a/packages/panels/src/Commands/MakeClusterCommand.php
+++ b/packages/panels/src/Commands/MakeClusterCommand.php
@@ -65,6 +65,13 @@ class MakeClusterCommand extends Command
         $clusterDirectories = $panel->getClusterDirectories();
         $clusterNamespaces = $panel->getClusterNamespaces();
 
+        foreach ($clusterDirectories as $clusterIndex => $clusterDirectory) {
+            if (str($clusterDirectory)->startsWith(base_path('vendor'))) {
+                unset($clusterDirectories[$clusterIndex]);
+                unset($clusterNamespaces[$clusterIndex]);
+            }
+        }
+
         $namespace = (count($clusterNamespaces) > 1) ?
             select(
                 label: 'Which namespace would you like to create this in?',

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -205,24 +205,25 @@ class MakePageCommand extends Command
                 $pageDirectories[array_search($namespace, $pageNamespaces)] :
                 (Arr::first($pageDirectories) ?? app_path('Filament/Pages/'));
         } else {
-            $resourceDirectories = [
-                app_path('Filament/Resources/'),
-                ...$panel->getResourceDirectories(),
-            ];
-            $resourceNamespaces = [
-                'App\\Filament\\Resources',
-                ...$panel->getResourceNamespaces(),
-            ];
+            $resourceDirectories = $panel->getResourceDirectories();
+            $resourceNamespaces = $panel->getResourceNamespaces();
+
+            foreach ($resourceDirectories as $resourceIndex => $resourceDirectory) {
+                if (mb_strpos($resourceDirectory, base_path('vendor')) === 0) {
+                    unset($resourceDirectories[$resourceIndex]);
+                    unset($resourceNamespaces[$resourceIndex]);
+                }
+            }
 
             $resourceNamespace = (count($resourceNamespaces) > 1) ?
                 select(
                     label: 'Which namespace would you like to create this in?',
                     options: $resourceNamespaces
                 ) :
-                Arr::first($resourceNamespaces);
+                (Arr::first($resourceNamespaces) ?? 'App\\Filament\\Resources');
             $resourcePath = (count($resourceDirectories) > 1) ?
                 $resourceDirectories[array_search($resourceNamespace, $resourceNamespaces)] :
-                Arr::first($resourceDirectories);
+                (Arr::first($resourceDirectories) ?? app_path('Filament/Resources/'));
         }
 
         $view = str($page)

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -209,7 +209,7 @@ class MakePageCommand extends Command
             $resourceNamespaces = $panel->getResourceNamespaces();
 
             foreach ($resourceDirectories as $resourceIndex => $resourceDirectory) {
-                if (mb_strpos($resourceDirectory, base_path('vendor')) === 0) {
+                if (str($resourceDirectory)->startsWith(base_path('vendor'))) {
                     unset($resourceDirectories[$resourceIndex]);
                     unset($resourceNamespaces[$resourceIndex]);
                 }

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -70,10 +70,20 @@ class MakePageCommand extends Command
             )] : Arr::first($panels);
         }
 
+        $resourceDirectories = $panel->getResourceDirectories();
+        $resourceNamespaces = $panel->getResourceNamespaces();
+
+        foreach ($resourceDirectories as $resourceIndex => $resourceDirectory) {
+            if (str($resourceDirectory)->startsWith(base_path('vendor'))) {
+                unset($resourceDirectories[$resourceIndex]);
+                unset($resourceNamespaces[$resourceIndex]);
+            }
+        }
+
         $resourceInput = $this->option('resource') ?? suggest(
             label: 'Which resource would you like to create this in?',
             options: collect($panel->getResources())
-                ->filter(fn (string $namespace): bool => str($namespace)->contains('\\Resources\\'))
+                ->filter(fn (string $namespace): bool => str($namespace)->contains('\\Resources\\') && str($namespace)->startsWith($resourceNamespaces))
                 ->map(
                     fn (string $namespace): string => (string) str($namespace)
                         ->afterLast('\\Resources\\')
@@ -194,6 +204,13 @@ class MakePageCommand extends Command
         if (empty($resource)) {
             $pageDirectories = $panel->getPageDirectories();
             $pageNamespaces = $panel->getPageNamespaces();
+
+            foreach ($pageDirectories as $pageIndex => $pageDirectory) {
+                if (str($pageDirectory)->startsWith(base_path('vendor'))) {
+                    unset($pageDirectories[$pageIndex]);
+                    unset($pageNamespaces[$pageIndex]);
+                }
+            }
 
             $namespace = (count($pageNamespaces) > 1) ?
                 select(

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -205,18 +205,24 @@ class MakePageCommand extends Command
                 $pageDirectories[array_search($namespace, $pageNamespaces)] :
                 (Arr::first($pageDirectories) ?? app_path('Filament/Pages/'));
         } else {
-            $resourceDirectories = $panel->getResourceDirectories();
-            $resourceNamespaces = $panel->getResourceNamespaces();
+            $resourceDirectories = [
+                app_path('Filament/Resources/'),
+                ...$panel->getResourceDirectories(),
+            ];
+            $resourceNamespaces = [
+                'App\\Filament\\Resources',
+                ...$panel->getResourceNamespaces(),
+            ];
 
             $resourceNamespace = (count($resourceNamespaces) > 1) ?
                 select(
                     label: 'Which namespace would you like to create this in?',
                     options: $resourceNamespaces
                 ) :
-                (Arr::first($resourceNamespaces) ?? 'App\\Filament\\Resources');
+                Arr::first($resourceNamespaces);
             $resourcePath = (count($resourceDirectories) > 1) ?
                 $resourceDirectories[array_search($resourceNamespace, $resourceNamespaces)] :
-                (Arr::first($resourceDirectories) ?? app_path('Filament/Resources/'));
+                Arr::first($resourceDirectories);
         }
 
         $view = str($page)

--- a/packages/panels/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/panels/src/Commands/MakeRelationManagerCommand.php
@@ -79,18 +79,24 @@ class MakeRelationManagerCommand extends Command
             )] : Arr::first($panels);
         }
 
-        $resourceDirectories = $panel->getResourceDirectories();
-        $resourceNamespaces = $panel->getResourceNamespaces();
+        $resourceDirectories = [
+            app_path('Filament/Resources/'),
+            ...$panel->getResourceDirectories(),
+        ];
+        $resourceNamespaces = [
+            'App\\Filament\\Resources',
+            ...$panel->getResourceNamespaces(),
+        ];
 
         $resourceNamespace = (count($resourceNamespaces) > 1) ?
             select(
                 label: 'Which namespace would you like to create this in?',
                 options: $resourceNamespaces
             ) :
-            (Arr::first($resourceNamespaces) ?? 'App\\Filament\\Resources');
+            Arr::first($resourceNamespaces);
         $resourcePath = (count($resourceDirectories) > 1) ?
             $resourceDirectories[array_search($resourceNamespace, $resourceNamespaces)] :
-            (Arr::first($resourceDirectories) ?? app_path('Filament/Resources/'));
+            Arr::first($resourceDirectories);
 
         $path = (string) str($managerClass)
             ->prepend("{$resourcePath}/{$resource}/RelationManagers/")

--- a/packages/panels/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/panels/src/Commands/MakeRelationManagerCommand.php
@@ -79,24 +79,25 @@ class MakeRelationManagerCommand extends Command
             )] : Arr::first($panels);
         }
 
-        $resourceDirectories = [
-            app_path('Filament/Resources/'),
-            ...$panel->getResourceDirectories(),
-        ];
-        $resourceNamespaces = [
-            'App\\Filament\\Resources',
-            ...$panel->getResourceNamespaces(),
-        ];
+        $resourceDirectories = $panel->getResourceDirectories();
+        $resourceNamespaces = $panel->getResourceNamespaces();
+
+        foreach ($resourceDirectories as $resourceIndex => $resourceDirectory) {
+            if (mb_strpos($resourceDirectory, base_path('vendor')) === 0) {
+                unset($resourceDirectories[$resourceIndex]);
+                unset($resourceNamespaces[$resourceIndex]);
+            }
+        }
 
         $resourceNamespace = (count($resourceNamespaces) > 1) ?
             select(
                 label: 'Which namespace would you like to create this in?',
                 options: $resourceNamespaces
             ) :
-            Arr::first($resourceNamespaces);
+            (Arr::first($resourceNamespaces) ?? 'App\\Filament\\Resources');
         $resourcePath = (count($resourceDirectories) > 1) ?
             $resourceDirectories[array_search($resourceNamespace, $resourceNamespaces)] :
-            Arr::first($resourceDirectories);
+            (Arr::first($resourceDirectories) ?? app_path('Filament/Resources/'));
 
         $path = (string) str($managerClass)
             ->prepend("{$resourcePath}/{$resource}/RelationManagers/")

--- a/packages/panels/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/panels/src/Commands/MakeRelationManagerCommand.php
@@ -83,7 +83,7 @@ class MakeRelationManagerCommand extends Command
         $resourceNamespaces = $panel->getResourceNamespaces();
 
         foreach ($resourceDirectories as $resourceIndex => $resourceDirectory) {
-            if (mb_strpos($resourceDirectory, base_path('vendor')) === 0) {
+            if (str($resourceDirectory)->startsWith(base_path('vendor'))) {
                 unset($resourceDirectories[$resourceIndex]);
                 unset($resourceNamespaces[$resourceIndex]);
             }

--- a/packages/panels/src/Commands/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/MakeResourceCommand.php
@@ -106,7 +106,7 @@ class MakeResourceCommand extends Command
         $resourceNamespaces = $panel->getResourceNamespaces();
 
         foreach ($resourceDirectories as $resourceIndex => $resourceDirectory) {
-            if (mb_strpos($resourceDirectory, base_path('vendor')) === 0) {
+            if (str($resourceDirectory)->startsWith(base_path('vendor'))) {
                 unset($resourceDirectories[$resourceIndex]);
                 unset($resourceNamespaces[$resourceIndex]);
             }

--- a/packages/panels/src/Commands/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/MakeResourceCommand.php
@@ -102,18 +102,24 @@ class MakeResourceCommand extends Command
             )] : Arr::first($panels);
         }
 
-        $resourceDirectories = $panel->getResourceDirectories();
-        $resourceNamespaces = $panel->getResourceNamespaces();
+        $resourceDirectories = [
+            app_path('Filament/Resources/'),
+            ...$panel->getResourceDirectories(),
+        ];
+        $resourceNamespaces = [
+            'App\\Filament\\Resources',
+            ...$panel->getResourceNamespaces(),
+        ];
 
         $namespace = (count($resourceNamespaces) > 1) ?
             select(
                 label: 'Which namespace would you like to create this in?',
                 options: $resourceNamespaces
             ) :
-            (Arr::first($resourceNamespaces) ?? 'App\\Filament\\Resources');
+            Arr::first($resourceNamespaces);
         $path = (count($resourceDirectories) > 1) ?
             $resourceDirectories[array_search($namespace, $resourceNamespaces)] :
-            (Arr::first($resourceDirectories) ?? app_path('Filament/Resources/'));
+            Arr::first($resourceDirectories);
 
         $resource = "{$model}Resource";
         $resourceClass = "{$modelClass}Resource";

--- a/packages/panels/src/Commands/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/MakeResourceCommand.php
@@ -102,24 +102,25 @@ class MakeResourceCommand extends Command
             )] : Arr::first($panels);
         }
 
-        $resourceDirectories = [
-            app_path('Filament/Resources/'),
-            ...$panel->getResourceDirectories(),
-        ];
-        $resourceNamespaces = [
-            'App\\Filament\\Resources',
-            ...$panel->getResourceNamespaces(),
-        ];
+        $resourceDirectories = $panel->getResourceDirectories();
+        $resourceNamespaces = $panel->getResourceNamespaces();
+
+        foreach ($resourceDirectories as $resourceIndex => $resourceDirectory) {
+            if (mb_strpos($resourceDirectory, base_path('vendor')) === 0) {
+                unset($resourceDirectories[$resourceIndex]);
+                unset($resourceNamespaces[$resourceIndex]);
+            }
+        }
 
         $namespace = (count($resourceNamespaces) > 1) ?
             select(
                 label: 'Which namespace would you like to create this in?',
                 options: $resourceNamespaces
             ) :
-            Arr::first($resourceNamespaces);
+            (Arr::first($resourceNamespaces) ?? 'App\\Filament\\Resources');
         $path = (count($resourceDirectories) > 1) ?
             $resourceDirectories[array_search($namespace, $resourceNamespaces)] :
-            Arr::first($resourceDirectories);
+            (Arr::first($resourceDirectories) ?? app_path('Filament/Resources/'));
 
         $resource = "{$model}Resource";
         $resourceClass = "{$modelClass}Resource";

--- a/packages/spatie-laravel-settings-plugin/src/Commands/MakeSettingsPageCommand.php
+++ b/packages/spatie-laravel-settings-plugin/src/Commands/MakeSettingsPageCommand.php
@@ -70,6 +70,13 @@ class MakeSettingsPageCommand extends Command
         $pageDirectories = $panel->getPageDirectories();
         $pageNamespaces = $panel->getPageNamespaces();
 
+        foreach ($pageDirectories as $pageIndex => $pageDirectory) {
+            if (str($pageDirectory)->startsWith(base_path('vendor'))) {
+                unset($pageDirectories[$pageIndex]);
+                unset($pageNamespaces[$pageIndex]);
+            }
+        }
+
         $namespace = (count($pageNamespaces) > 1) ?
             select(
                 label: 'Which namespace would you like to create this in?',

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -114,6 +114,13 @@ class MakeWidgetCommand extends Command
             $widgetDirectories = $panel->getWidgetDirectories();
             $widgetNamespaces = $panel->getWidgetNamespaces();
 
+            foreach ($widgetDirectories as $widgetIndex => $widgetDirectory) {
+                if (str($widgetDirectory)->startsWith(base_path('vendor'))) {
+                    unset($widgetDirectories[$widgetIndex]);
+                    unset($widgetNamespaces[$widgetIndex]);
+                }
+            }
+
             $namespace = (count($widgetNamespaces) > 1) ?
                 select(
                     label: 'Which namespace would you like to create this in?',

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -124,24 +124,25 @@ class MakeWidgetCommand extends Command
                 $widgetDirectories[array_search($namespace, $widgetNamespaces)] :
                 (Arr::first($widgetDirectories) ?? app_path('Filament/Widgets/'));
         } else {
-            $resourceDirectories = [
-                app_path('Filament/Resources/'),
-                ...$panel->getResourceDirectories(),
-            ];
-            $resourceNamespaces = [
-                'App\\Filament\\Resources',
-                ...$panel->getResourceNamespaces(),
-            ];
+            $resourceDirectories = $panel->getResourceDirectories();
+            $resourceNamespaces = $panel->getResourceNamespaces();
+
+            foreach ($resourceDirectories as $resourceIndex => $resourceDirectory) {
+                if (mb_strpos($resourceDirectory, base_path('vendor')) === 0) {
+                    unset($resourceDirectories[$resourceIndex]);
+                    unset($resourceNamespaces[$resourceIndex]);
+                }
+            }
 
             $resourceNamespace = (count($resourceNamespaces) > 1) ?
                 select(
                     label: 'Which namespace would you like to create this in?',
                     options: $resourceNamespaces,
                 ) :
-                Arr::first($resourceNamespaces);
+                (Arr::first($resourceNamespaces) ?? 'App\\Filament\\Resources');
             $resourcePath = (count($resourceDirectories) > 1) ?
                 $resourceDirectories[array_search($resourceNamespace, $resourceNamespaces)] :
-                Arr::first($resourceDirectories);
+                (Arr::first($resourceDirectories) ?? app_path('Filament/Resources/'));
         }
 
         $view = str($widget)->prepend(

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -124,18 +124,24 @@ class MakeWidgetCommand extends Command
                 $widgetDirectories[array_search($namespace, $widgetNamespaces)] :
                 (Arr::first($widgetDirectories) ?? app_path('Filament/Widgets/'));
         } else {
-            $resourceDirectories = $panel->getResourceDirectories();
-            $resourceNamespaces = $panel->getResourceNamespaces();
+            $resourceDirectories = [
+                app_path('Filament/Resources/'),
+                ...$panel->getResourceDirectories(),
+            ];
+            $resourceNamespaces = [
+                'App\\Filament\\Resources',
+                ...$panel->getResourceNamespaces(),
+            ];
 
             $resourceNamespace = (count($resourceNamespaces) > 1) ?
                 select(
                     label: 'Which namespace would you like to create this in?',
                     options: $resourceNamespaces,
                 ) :
-                (Arr::first($resourceNamespaces) ?? 'App\\Filament\\Resources');
+                Arr::first($resourceNamespaces);
             $resourcePath = (count($resourceDirectories) > 1) ?
                 $resourceDirectories[array_search($resourceNamespace, $resourceNamespaces)] :
-                (Arr::first($resourceDirectories) ?? app_path('Filament/Resources/'));
+                Arr::first($resourceDirectories);
         }
 
         $view = str($widget)->prepend(

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -128,7 +128,7 @@ class MakeWidgetCommand extends Command
             $resourceNamespaces = $panel->getResourceNamespaces();
 
             foreach ($resourceDirectories as $resourceIndex => $resourceDirectory) {
-                if (mb_strpos($resourceDirectory, base_path('vendor')) === 0) {
+                if (str($resourceDirectory)->startsWith(base_path('vendor'))) {
                     unset($resourceDirectories[$resourceIndex]);
                     unset($resourceNamespaces[$resourceIndex]);
                 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

when a plugin register cluster discovery in plugin's panel, it register vendor's namespace and path and when runs make:* commands it detected as the only registered namespace and path, it creates resources/page/RM in the vendor directory

example: https://github.com/lunarphp/lunar/blob/2b31dcabc4cc7f169051be63648836b75bf91d18/packages/admin/src/LunarPanelManager.php#L231

added filter to remove directories in vendor `mb_strpos($resourceDirectory, base_path('vendor')) === 0`

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
