### PR TITLE
Fix: Prevent Livewire Modal Error on HTTP 419

### DIFF
--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -128,6 +128,17 @@
 
         {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::SCRIPTS_AFTER, scopes: $livewire->getRenderHookScopes()) }}
 
+        <script>
+                Livewire.hook('request', ({ uri, options, payload, respond, succeed, fail }) => {
+                    fail(({ status, content, preventDefault }) => {
+                        if (status === 419) {
+                            preventDefault()
+                        }
+                    })
+                })
+            }
+        </script>
+
         {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::BODY_END, scopes: $livewire->getRenderHookScopes()) }}
     </body>
 </html>


### PR DESCRIPTION
This fix resolves the Livewire modal error caused by HTTP 419 for users with disabled cookies, allowing Filament admin panels to function without interruptions or unnecessary popups.