### PR TITLE
fix: Unmounting actions dispatches close-modal when modal is already closed

### DIFF
--- a/packages/actions/resources/views/components/modals.blade.php
+++ b/packages/actions/resources/views/components/modals.blade.php
@@ -37,7 +37,7 @@
                     return
                 }
 
-                $wire.unmountAction(false)
+                $wire.unmountAction(false, false)
             "
             x-on:opened-form-component-action-modal.window="if ($event.detail.id === '{{ $this->getId() }}') close()"
         >
@@ -99,7 +99,7 @@
                     return
                 }
 
-                $wire.unmountTableAction(false)
+                $wire.unmountTableAction(false, false)
             "
             x-on:opened-form-component-action-modal.window="if ($event.detail.id === '{{ $this->getId() }}') close()"
         >
@@ -217,7 +217,7 @@
                     return
                 }
 
-                $wire.unmountInfolistAction(false)
+                $wire.unmountInfolistAction(false, false)
             "
             x-on:opened-form-component-action-modal.window="if ($event.detail.id === '{{ $this->getId() }}') close()"
         >
@@ -271,7 +271,7 @@
                 const mountedFormComponentActionShouldOpenModal = {{ \Illuminate\Support\Js::from($action && $this->mountedFormComponentActionShouldOpenModal()) }}
 
                 if (mountedFormComponentActionShouldOpenModal) {
-                    $wire.unmountFormComponentAction(false)
+                    $wire.unmountFormComponentAction(false, false)
                 }
             "
         >

--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -398,7 +398,7 @@ trait InteractsWithActions
         $this->mountedActionsData = [];
     }
 
-    public function unmountAction(bool $shouldCancelParentActions = true): void
+    public function unmountAction(bool $shouldCancelParentActions = true, bool $shouldDispatchCloseModal = true): void
     {
         $action = $this->getMountedAction();
 
@@ -422,7 +422,9 @@ trait InteractsWithActions
         }
 
         if (! count($this->mountedActions)) {
-            $this->closeActionModal();
+            if ($shouldDispatchCloseModal) {
+                $this->closeActionModal();
+            }
 
             $action?->clearRecordAfter();
 

--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -398,7 +398,7 @@ trait InteractsWithActions
         $this->mountedActionsData = [];
     }
 
-    public function unmountAction(bool $shouldCancelParentActions = true, bool $shouldDispatchCloseModal = true): void
+    public function unmountAction(bool $shouldCancelParentActions = true, bool $shouldCloseModal = true): void
     {
         $action = $this->getMountedAction();
 
@@ -422,7 +422,7 @@ trait InteractsWithActions
         }
 
         if (! count($this->mountedActions)) {
-            if ($shouldDispatchCloseModal) {
+            if ($shouldCloseModal) {
                 $this->closeActionModal();
             }
 

--- a/packages/forms/src/Concerns/HasFormComponentActions.php
+++ b/packages/forms/src/Concerns/HasFormComponentActions.php
@@ -278,7 +278,7 @@ trait HasFormComponentActions
         }
     }
 
-    public function unmountFormComponentAction(bool $shouldCancelParentActions = true): void
+    public function unmountFormComponentAction(bool $shouldCancelParentActions = true, bool $shouldDispatchCloseModal = true): void
     {
         $action = $this->getMountedFormComponentAction();
 
@@ -302,7 +302,9 @@ trait HasFormComponentActions
         }
 
         if (! count($this->mountedFormComponentActions)) {
-            $this->closeFormComponentActionModal();
+            if ($shouldDispatchCloseModal) {
+                $this->closeFormComponentActionModal();
+            }
 
             return;
         }

--- a/packages/forms/src/Concerns/HasFormComponentActions.php
+++ b/packages/forms/src/Concerns/HasFormComponentActions.php
@@ -278,7 +278,7 @@ trait HasFormComponentActions
         }
     }
 
-    public function unmountFormComponentAction(bool $shouldCancelParentActions = true, bool $shouldDispatchCloseModal = true): void
+    public function unmountFormComponentAction(bool $shouldCancelParentActions = true, bool $shouldCloseModal = true): void
     {
         $action = $this->getMountedFormComponentAction();
 
@@ -302,7 +302,7 @@ trait HasFormComponentActions
         }
 
         if (! count($this->mountedFormComponentActions)) {
-            if ($shouldDispatchCloseModal) {
+            if ($shouldCloseModal) {
                 $this->closeFormComponentActionModal();
             }
 

--- a/packages/infolists/src/Concerns/InteractsWithInfolists.php
+++ b/packages/infolists/src/Concerns/InteractsWithInfolists.php
@@ -297,7 +297,7 @@ trait InteractsWithInfolists
         );
     }
 
-    public function unmountInfolistAction(bool $shouldCancelParentActions = true): void
+    public function unmountInfolistAction(bool $shouldCancelParentActions = true, bool $shouldDispatchCloseModal = true): void
     {
         $action = $this->getMountedInfolistAction();
 
@@ -327,7 +327,9 @@ trait InteractsWithInfolists
             $this->mountedInfolistActionsComponent = null;
             $this->mountedInfolistActionsInfolist = null;
 
-            $this->dispatch('close-modal', id: "{$this->getId()}-infolist-action");
+            if ($shouldDispatchCloseModal) {
+                $this->dispatch('close-modal', id: "{$this->getId()}-infolist-action");
+            }
 
             return;
         }

--- a/packages/infolists/src/Concerns/InteractsWithInfolists.php
+++ b/packages/infolists/src/Concerns/InteractsWithInfolists.php
@@ -297,7 +297,7 @@ trait InteractsWithInfolists
         );
     }
 
-    public function unmountInfolistAction(bool $shouldCancelParentActions = true, bool $shouldDispatchCloseModal = true): void
+    public function unmountInfolistAction(bool $shouldCancelParentActions = true, bool $shouldCloseModal = true): void
     {
         $action = $this->getMountedInfolistAction();
 
@@ -327,7 +327,7 @@ trait InteractsWithInfolists
             $this->mountedInfolistActionsComponent = null;
             $this->mountedInfolistActionsInfolist = null;
 
-            if ($shouldDispatchCloseModal) {
+            if ($shouldCloseModal) {
                 $this->dispatch('close-modal', id: "{$this->getId()}-infolist-action");
             }
 

--- a/packages/tables/src/Concerns/HasActions.php
+++ b/packages/tables/src/Concerns/HasActions.php
@@ -317,7 +317,7 @@ trait HasActions
         $this->mountedTableActionsData = [];
     }
 
-    public function unmountTableAction(bool $shouldCancelParentActions = true, bool $shouldDispatchCloseModal = true): void
+    public function unmountTableAction(bool $shouldCancelParentActions = true, bool $shouldCloseModal = true): void
     {
         $action = $this->getMountedTableAction();
 
@@ -341,7 +341,7 @@ trait HasActions
         }
 
         if (! count($this->mountedTableActions)) {
-            if ($shouldDispatchCloseModal) {
+            if ($shouldCloseModal) {
                 $this->closeTableActionModal();
             }
 

--- a/packages/tables/src/Concerns/HasActions.php
+++ b/packages/tables/src/Concerns/HasActions.php
@@ -317,7 +317,7 @@ trait HasActions
         $this->mountedTableActionsData = [];
     }
 
-    public function unmountTableAction(bool $shouldCancelParentActions = true): void
+    public function unmountTableAction(bool $shouldCancelParentActions = true, bool $shouldDispatchCloseModal = true): void
     {
         $action = $this->getMountedTableAction();
 
@@ -341,7 +341,9 @@ trait HasActions
         }
 
         if (! count($this->mountedTableActions)) {
-            $this->closeTableActionModal();
+            if ($shouldDispatchCloseModal) {
+                $this->closeTableActionModal();
+            }
 
             $action?->record(null);
             $this->mountedTableActionRecord(null);


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

This addresses the issue described in https://github.com/filamentphp/filament/issues/10581.

[The modal's close() function](https://github.com/filamentphp/filament/blob/5a8b9994e9356a0d0702b7c307d811496440ef12/packages/support/resources/views/components/modal/index.blade.php#L73)  already closes the current modal and it also dispatches the `modal-closed` event, which when [caught](https://github.com/filamentphp/filament/blob/5a8b9994e9356a0d0702b7c307d811496440ef12/packages/actions/resources/views/components/modals.blade.php#L40) will cause the action's unmount function to be called. This function, however, does not take this into account and will always dispatch the `close-modal` event again.

This PR introduces a new variable `$shouldDispatchCloseModal` for the actions' unmount function, which when set to `false` will prevent the `close-modal` event from being dispatched again. Since this variable has a default value of `true` it should not break any other uses of the functions.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->
Improved UX when rapidly closing and reopening modals on complex pages or when the user has a slower connection.

### Actions
Delete button
Before: [https://demo.filamentphp.com/shop/orders/1/edit](https://demo.filamentphp.com/shop/orders/1/edit)
After: [https://demo.filament.thenines.be/shop/orders/1/edit](https://demo.filament.thenines.be/shop/orders/1/edit)

### Table actions
Edit button
Before: [https://demo.filamentphp.com/blog/categories](https://demo.filamentphp.com/blog/categories)
After: [https://demo.filament.thenines.be/blog/categories](https://demo.filament.thenines.be/blog/categories)

### Form actions
Reset button
Before: [https://demo.filamentphp.com/shop/orders/1/edit](https://demo.filamentphp.com/shop/orders/1/edit)
After: [https://demo.filament.thenines.be/shop/orders/1/edit](https://demo.filament.thenines.be/shop/orders/1/edit)

### Infolist Actions
Author's suffix action
Before: _not present in the demo_
After: [https://demo.filament.thenines.be/blog/posts/1](https://demo.filament.thenines.be/blog/posts/1)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
