### PR TITLE
options limit within ManageRelatedRecords

### DIFF
--- a/packages/panels/docs/03-resources/07-relation-managers.md
+++ b/packages/panels/docs/03-resources/07-relation-managers.md
@@ -295,6 +295,17 @@ AttachAction::make()
     ->preloadRecordSelect()
 ```
 
+### Defining a limit on the select options
+
+By default, the options limit is set to 50 and will load from the Select component. If you wish to set your own limit, define the options limit to the `AttachAction`
+
+```php
+use Filament\Tables\Actions\AttachAction;
+
+AttachAction::make()
+    ->optionsLimit(5)
+```
+
 ### Attaching with pivot attributes
 
 When you attach record with the `Attach` button, you may wish to define a custom form to add pivot attributes to the relationship:

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -33,7 +33,7 @@ class AttachAction extends Action
 
     protected bool | Closure $isMultiple = false;
 
-    protected int | Closure $recordSelectOptionsLimit = 50;
+    protected int | Closure $preloadOptionsLimit = 50;
 
     /**
      * @var array<string> | Closure | null
@@ -53,7 +53,7 @@ class AttachAction extends Action
 
         $this->label(__('filament-actions::attach.single.label'));
 
-        $this->modalHeading(fn(): string => __('filament-actions::attach.single.modal.heading', ['label' => $this->getModelLabel()]));
+        $this->modalHeading(fn (): string => __('filament-actions::attach.single.modal.heading', ['label' => $this->getModelLabel()]));
 
         $this->modalSubmitActionLabel(__('filament-actions::attach.single.modal.actions.attach.label'));
 
@@ -70,11 +70,11 @@ class AttachAction extends Action
 
         $this->color('gray');
 
-        $this->form(fn(): array => [$this->getRecordSelect()]);
+        $this->form(fn (): array => [$this->getRecordSelect()]);
 
         $this->action(function (array $arguments, array $data, Form $form, Table $table): void {
             /** @var BelongsToMany $relationship */
-            $relationship = Relation::noConstraints(fn() => $table->getRelationship());
+            $relationship = Relation::noConstraints(fn () => $table->getRelationship());
 
             $relationshipQuery = app(RelationshipJoiner::class)->prepareQueryForNoConstraints($relationship);
 
@@ -140,7 +140,7 @@ class AttachAction extends Action
      */
     public function disableAttachAnother(bool | Closure $condition = true): static
     {
-        $this->attachAnother(fn(AttachAction $action): bool => ! $action->evaluate($condition));
+        $this->attachAnother(fn (AttachAction $action): bool => ! $action->evaluate($condition));
 
         return $this;
     }
@@ -152,9 +152,9 @@ class AttachAction extends Action
         return $this;
     }
 
-    public function optionsLimit(int | Closure $limit): static
+    public function optionsLimit(int | Closure $limit = 50): static
     {
-        $this->recordSelectOptionsLimit = $limit;
+        $this->preloadOptionsLimit = $limit;
 
         return $this;
     }
@@ -199,9 +199,12 @@ class AttachAction extends Action
         return $this->evaluate($this->recordSelectSearchColumns);
     }
 
-    public function getOptionsLimit(): int
+    /**
+     * @return integer
+     */
+    public function getRecordOptionsLimit(): int
     {
-        return $this->evaluate($this->recordSelectOptionsLimit);
+        return $this->evaluate($this->preloadOptionsLimit);
     }
 
     public function getRecordSelect(): Select
@@ -210,7 +213,7 @@ class AttachAction extends Action
 
         $getOptions = function (int $optionsLimit, ?string $search = null, ?array $searchColumns = []) use ($table): array {
             /** @var BelongsToMany $relationship */
-            $relationship = Relation::noConstraints(fn() => $table->getRelationship());
+            $relationship = Relation::noConstraints(fn () => $table->getRelationship());
 
             $relationshipQuery = app(RelationshipJoiner::class)->prepareQueryForNoConstraints($relationship);
 
@@ -260,9 +263,9 @@ class AttachAction extends Action
             $relationshipQuery
                 ->when(
                     ! $table->allowsDuplicates(),
-                    fn(Builder $query): Builder => $query->whereDoesntHave(
+                    fn (Builder $query): Builder => $query->whereDoesntHave(
                         $table->getInverseRelationship(),
-                        fn(Builder $query): Builder => $query->where(
+                        fn (Builder $query): Builder => $query->where(
                             // https://github.com/filamentphp/filament/issues/8067
                             $relationship->getParent()->getTable() === $relationship->getRelated()->getTable() ?
                                 "{$relationCountHash}.{$relationship->getParent()->getKeyName()}" :
@@ -290,7 +293,7 @@ class AttachAction extends Action
 
             return $relationshipQuery
                 ->get()
-                ->mapWithKeys(fn(Model $record): array => [$record->{$relatedKeyName} => $this->getRecordTitle($record)])
+                ->mapWithKeys(fn (Model $record): array => [$record->{$relatedKeyName} => $this->getRecordTitle($record)])
                 ->all();
         };
 
@@ -299,24 +302,24 @@ class AttachAction extends Action
             ->required()
             ->multiple($this->isMultiple())
             ->searchable($this->getRecordSelectSearchColumns() ?? true)
-            ->getSearchResultsUsing(static fn(Select $component, string $search): array => $getOptions(optionsLimit: $this->getOptionsLimit(), search: $search, searchColumns: $component->getSearchColumns()))
+            ->getSearchResultsUsing(static fn (Select $component, string $search): array => $getOptions(optionsLimit: $this->getRecordOptionsLimit(), search: $search, searchColumns: $component->getSearchColumns()))
             ->getOptionLabelUsing(function ($value) use ($table): string {
-                $relationship = Relation::noConstraints(fn() => $table->getRelationship());
+                $relationship = Relation::noConstraints(fn () => $table->getRelationship());
 
                 $relationshipQuery = app(RelationshipJoiner::class)->prepareQueryForNoConstraints($relationship);
 
                 return $this->getRecordTitle($relationshipQuery->find($value));
             })
             ->getOptionLabelsUsing(function (array $values) use ($table): array {
-                $relationship = Relation::noConstraints(fn() => $table->getRelationship());
+                $relationship = Relation::noConstraints(fn () => $table->getRelationship());
 
                 $relationshipQuery = app(RelationshipJoiner::class)->prepareQueryForNoConstraints($relationship);
 
                 return $relationshipQuery->find($values)
-                    ->mapWithKeys(fn(Model $record): array => [$record->getKey() => $this->getRecordTitle($record)])
+                    ->mapWithKeys(fn (Model $record): array => [$record->getKey() => $this->getRecordTitle($record)])
                     ->all();
             })
-            ->options(fn(Select $component): array => $this->isRecordSelectPreloaded() ? $getOptions(optionsLimit: $this->getOptionsLimit()) : [])
+            ->options(fn (Select $component): array => $this->isRecordSelectPreloaded() ? $getOptions(optionsLimit: $this->getRecordOptionsLimit()) : [])
             ->hiddenLabel();
 
         if ($this->modifyRecordSelectUsing) {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Found the inability to set an options limit on the attach action that was a part of a ManageRelatedRecords class, since the Select is defined in the function, unable to add options limit to the Select::make() directly

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
