### PR TITLE
Disable reorderable when tagsinput is disabled

### DIFF
--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -6,7 +6,7 @@
     $id = $getId();
     $isDisabled = $isDisabled();
     $isPrefixInline = $isPrefixInline();
-    $isReorderable = $isDisabled ? false : $isReorderable();
+    $isReorderable = (! $isDisabled) && $isReorderable();
     $isSuffixInline = $isSuffixInline();
     $prefixActions = $getPrefixActions();
     $prefixIcon = $getPrefixIcon();

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -6,7 +6,7 @@
     $id = $getId();
     $isDisabled = $isDisabled();
     $isPrefixInline = $isPrefixInline();
-    $isReorderable = $isReorderable();
+    $isReorderable = $isDisabled ? false : $isReorderable();
     $isSuffixInline = $isSuffixInline();
     $prefixActions = $getPrefixActions();
     $prefixIcon = $getPrefixIcon();


### PR DESCRIPTION
## Description

I encountered an issue where, even when the `TagsInput` component is disabled, users were still able to reorder tags. However, since the input is disabled, these changes would not be saved.

To address this, here is a simple fix:
- The reorderable functionality has been disabled when the `TagsInput `is in a disabled state.
- This update aligns with the behavior of the delete cross and of course the ability to add new tags when the input is disabled.

## Visual changes
Disabled before:

https://github.com/user-attachments/assets/6093144d-bc75-4d74-ad5c-403cc7110a64

Enabled before:

https://github.com/user-attachments/assets/e4b20507-a6b0-4630-bf01-983e76809441


Disabled after:

https://github.com/user-attachments/assets/b15c7e83-08e6-4e98-a98f-2c2a778ffad7

Enabled after:

https://github.com/user-attachments/assets/7a152d50-0113-4904-9342-0ae45dfca286

As you can see, it doesn't affect the enabled state. The only change is that the user is not allowed to reorder anymore when the field is disabled.

## Functional changes
- [x] Changes have been tested to not break existing functionality.
