### PR TITLE
fix: Parent modal not reopening after child modal is closed

### DIFF
--- a/packages/forms/src/Concerns/HasFormComponentActions.php
+++ b/packages/forms/src/Concerns/HasFormComponentActions.php
@@ -302,9 +302,7 @@ trait HasFormComponentActions
         }
 
         if (! count($this->mountedFormComponentActions)) {
-            if ($shouldCloseModal) {
-                $this->closeFormComponentActionModal();
-            }
+            $this->closeFormComponentActionModal($shouldCloseModal);
 
             return;
         }
@@ -314,9 +312,11 @@ trait HasFormComponentActions
         $this->openFormComponentActionModal();
     }
 
-    protected function closeFormComponentActionModal(): void
+    protected function closeFormComponentActionModal(bool $shouldCloseModal = true): void
     {
-        $this->dispatch('close-modal', id: "{$this->getId()}-form-component-action");
+        if ($shouldCloseModal) {
+            $this->dispatch('close-modal', id: "{$this->getId()}-form-component-action");
+        }
 
         $this->dispatch('closed-form-component-action-modal', id: $this->getId());
     }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
This PR fixes a bug I introduced in https://github.com/filamentphp/filament/pull/14200 which prevents parent modals from reopening when a child modal gets closed.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
