### PR TITLE
Htmlable Select Filter

### DIFF
--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -11,10 +11,10 @@ use Znck\Eloquent\Relations\BelongsToThrough;
 
 class SelectFilter extends BaseFilter
 {
+    use CanAllowHtml;
     use Concerns\HasOptions;
     use Concerns\HasPlaceholder;
     use Concerns\HasRelationship;
-    use CanAllowHtml;
 
     protected string | Closure | null $attribute = null;
 

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -3,6 +3,7 @@
 namespace Filament\Tables\Filters;
 
 use Closure;
+use Filament\Forms\Components\Concerns\CanAllowHtml;
 use Filament\Forms\Components\Select;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
@@ -13,6 +14,7 @@ class SelectFilter extends BaseFilter
     use Concerns\HasOptions;
     use Concerns\HasPlaceholder;
     use Concerns\HasRelationship;
+    use CanAllowHtml;
 
     protected string | Closure | null $attribute = null;
 
@@ -254,6 +256,7 @@ class SelectFilter extends BaseFilter
     public function getFormField(): Select
     {
         $field = Select::make($this->isMultiple() ? 'values' : 'value')
+            ->allowHtml($this->isHtmlAllowed())
             ->label($this->getLabel())
             ->multiple($this->isMultiple())
             ->placeholder($this->getPlaceholder())


### PR DESCRIPTION
## Description

The SelectFilter didn't support the `->allowHtml()` method, even though the `Select::` form component does. This PR fixes that issue.

## Visual changes
![old](https://github.com/user-attachments/assets/699ef14f-f82b-46f9-bdf4-157d279a6f54)
![new](https://github.com/user-attachments/assets/7b129e1e-8b5c-496e-9865-10bce70512cc)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
