### PR TITLE
Add feature to show date with iso format in Table & Infolist

### DIFF
--- a/packages/infolists/docs/03-entries/02-text.md
+++ b/packages/infolists/docs/03-entries/02-text.md
@@ -47,6 +47,15 @@ TextEntry::make('created_at')
     ->dateTime()
 ```
 
+You may use also the `dateIso()` and `dateTimeIso()` methods to format the entry's state using [PHP date formatting macro-formats](https://carbon.nesbot.com/docs/#available-macro-formats):
+
+```php
+use Filament\Infolists\Components\TextEntry;
+
+TextEntry::make('created_at')
+    ->dateTimeIso()
+```
+
 You may use the `since()` method to format the entry's state using [Carbon's `diffForHumans()`](https://carbon.nesbot.com/docs/#api-humandiff):
 
 ```php
@@ -56,7 +65,7 @@ TextEntry::make('created_at')
     ->since()
 ```
 
-Additionally, you can use the `dateTooltip()`, `dateTimeTooltip()` or `timeTooltip()` method to display a formatted date in a tooltip, often to provide extra information:
+Additionally, you can use the `dateTooltip()`, `dateTimeTooltip()`, `timeTooltip()`, `dateIsoTooltip()`, `dateIsoTimeTooltip()` or `timeIsoTooltip()`, method to display a formatted date in a tooltip, often to provide extra information:
 
 ```php
 use Filament\Infolists\Components\TextEntry;

--- a/packages/infolists/src/Components/Concerns/CanFormatState.php
+++ b/packages/infolists/src/Components/Concerns/CanFormatState.php
@@ -82,6 +82,35 @@ trait CanFormatState
         return $this;
     }
 
+    public function dateIso(?string $format = null): static
+    {
+        $this->isDate = true;
+
+        $format ??= Infolist::$defaultDateIsoDisplayFormat;
+
+        $this->formatStateUsing(static function (TextEntry $component, $state) use ($format): ?string {
+            if (blank($state)) {
+                return null;
+            }
+
+            return Carbon::parse($state)
+                ->isoFormat($format);
+        });
+
+        return $this;
+    }
+
+    public function dateTimeIso(?string $format = null): static
+    {
+        $this->isDateTime = true;
+
+        $format ??= Infolist::$defaultDateTimeIsoDisplayFormat;
+
+        $this->dateIso($format);
+
+        return $this;
+    }
+
     public function since(?string $timezone = null): static
     {
         $this->isDateTime = true;
@@ -130,6 +159,40 @@ trait CanFormatState
         $format ??= Infolist::$defaultTimeDisplayFormat;
 
         $this->dateTooltip($format, $timezone);
+
+        return $this;
+    }
+
+    public function dateIsoTooltip(?string $format = null): static
+    {
+        $format ??= Infolist::$defaultDateIsoDisplayFormat;
+
+        $this->tooltip(static function (TextEntry $component, mixed $state) use ($format): ?string {
+            if (blank($state)) {
+                return null;
+            }
+
+            return Carbon::parse($state)
+                ->isoFormat($format);
+        });
+
+        return $this;
+    }
+
+    public function dateTimeIsoTooltip(?string $format = null): static
+    {
+        $format ??= Infolist::$defaultDateTimeIsoDisplayFormat;
+
+        $this->dateIsoTooltip($format);
+
+        return $this;
+    }
+
+    public function timeIsoTooltip(?string $format = null): static
+    {
+        $format ??= Infolist::$defaultTimeIsoDisplayFormat;
+
+        $this->dateIsoTooltip($format);
 
         return $this;
     }

--- a/packages/infolists/src/Infolist.php
+++ b/packages/infolists/src/Infolist.php
@@ -10,9 +10,15 @@ class Infolist extends ComponentContainer
 
     public static string $defaultDateDisplayFormat = 'M j, Y';
 
+    public static string $defaultDateIsoDisplayFormat = 'L';
+
     public static string $defaultDateTimeDisplayFormat = 'M j, Y H:i:s';
 
+    public static string $defaultDateTimeIsoDisplayFormat = 'LLL';
+
     public static string $defaultTimeDisplayFormat = 'H:i:s';
+
+    public static string $defaultTimeIsoDisplayFormat = 'LT';
 
     public static ?string $defaultNumberLocale = null;
 

--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -73,6 +73,15 @@ TextColumn::make('created_at')
     ->dateTime()
 ```
 
+You may use also the `dateIso()` and `dateTimeIso()` methods to format the column's state using [PHP date formatting macro-formats](https://carbon.nesbot.com/docs/#available-macro-formats):
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('created_at')
+    ->dateTimeIso()
+```
+
 You may use the `since()` method to format the column's state using [Carbon's `diffForHumans()`](https://carbon.nesbot.com/docs/#api-humandiff):
 
 ```php
@@ -82,7 +91,7 @@ TextColumn::make('created_at')
     ->since()
 ```
 
-Additionally, you can use the `dateTooltip()`, `dateTimeTooltip()` or `timeTooltip()` method to display a formatted date in a tooltip, often to provide extra information:
+Additionally, you can use the `dateTooltip()`, `dateTimeTooltip()`, `timeTooltip()`, `dateIsoTooltip()`, `dateTimeIsoTooltip()` or `timeIsoTooltip()` method to display a formatted date in a tooltip, often to provide extra information:
 
 ```php
 use Filament\Tables\Columns\TextColumn;

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -82,6 +82,35 @@ trait CanFormatState
         return $this;
     }
 
+    public function dateIso(?string $format = null): static
+    {
+        $this->isDate = true;
+
+        $format ??= Table::$defaultDateIsoDisplayFormat;
+
+        $this->formatStateUsing(static function (TextColumn $column, $state) use ($format): ?string {
+            if (blank($state)) {
+                return null;
+            }
+
+            return Carbon::parse($state)
+                ->isoFormat($format);
+        });
+
+        return $this;
+    }
+
+    public function dateTimeIso(?string $format = null): static
+    {
+        $this->isDateTime = true;
+
+        $format ??= Table::$defaultDateTimeIsoDisplayFormat;
+
+        $this->dateIso($format);
+
+        return $this;
+    }
+
     public function since(?string $timezone = null): static
     {
         $this->isDateTime = true;
@@ -130,6 +159,40 @@ trait CanFormatState
         $format ??= Table::$defaultTimeDisplayFormat;
 
         $this->dateTooltip($format, $timezone);
+
+        return $this;
+    }
+
+    public function dateIsoTooltip(?string $format = null): static
+    {
+        $format ??= Table::$defaultDateIsoDisplayFormat;
+
+        $this->tooltip(static function (TextColumn $column, mixed $state) use ($format): ?string {
+            if (blank($state)) {
+                return null;
+            }
+
+            return Carbon::parse($state)
+                ->isoFormat($format);
+        });
+
+        return $this;
+    }
+
+    public function dateTimeIsoTooltip(?string $format = null): static
+    {
+        $format ??= Table::$defaultDateTimeIsoDisplayFormat;
+
+        $this->dateIsoTooltip($format);
+
+        return $this;
+    }
+
+    public function timeIsoTooltip(?string $format = null): static
+    {
+        $format ??= Table::$defaultTimeIsoDisplayFormat;
+
+        $this->dateIsoTooltip($format);
 
         return $this;
     }

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -62,11 +62,17 @@ class Table extends ViewComponent
 
     public static string $defaultDateDisplayFormat = 'M j, Y';
 
+    public static string $defaultDateIsoDisplayFormat = 'L';
+
     public static string $defaultDateTimeDisplayFormat = 'M j, Y H:i:s';
+
+    public static string $defaultDateTimeIsoDisplayFormat = 'LLL';
 
     public static ?string $defaultNumberLocale = null;
 
     public static string $defaultTimeDisplayFormat = 'H:i:s';
+
+    public static string $defaultTimeIsoDisplayFormat = 'LT';
 
     final public function __construct(HasTable $livewire)
     {


### PR DESCRIPTION
## Description

Here I added new methods to the TextColumn and TextEntry, which functions to format date directly in real format of app locale. Specially useful for plugins developers.

PS : I know we can have same result with `formatStateUsing` but I think these methods added are like helpers.


## Visual changes
**TextColumn**
<img width="1694" alt="Capture d’écran 2024-09-15 à 14 19 28" src="https://github.com/user-attachments/assets/6c71f286-0ec6-4003-ac6a-ec7ddf364bf8">

**TextEntry**
<img width="1694" alt="Capture d’écran 2024-09-15 à 14 22 35" src="https://github.com/user-attachments/assets/340c4dcf-9ee3-40de-a9bf-6f8e25acf289">

## Functional changes

- [] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
