### PR TITLE
Improve translation

### DIFF
--- a/packages/panels/resources/lang/it/resources/pages/view-record.php
+++ b/packages/panels/resources/lang/it/resources/pages/view-record.php
@@ -2,14 +2,14 @@
 
 return [
 
-    'title' => 'Guarda :label',
+    'title' => 'Visualizza :label',
 
-    'breadcrumb' => 'Guarda',
+    'breadcrumb' => 'Visualizza',
 
     'content' => [
 
         'tab' => [
-            'label' => 'Guarda',
+            'label' => 'Visualizza',
         ],
 
     ],


### PR DESCRIPTION
## Description

In Italian “Visualizza” is used instead of “Guarda” because “Visualizza” specifically refers to the action of displaying or rendering something on a screen, aligning with the technical context of viewing data or content. “Guarda” sounds silly/confusing because is more informal and commonly associated with physically looking at something in a general sense

## Visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
