### PR TITLE
refactor(Tables): Add searchable functionality to SelectFilter

### DIFF
--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -22,7 +22,10 @@ class SelectFilter extends BaseFilter
 
     protected bool | Closure $isStatic = false;
 
-    protected bool | Closure $isSearchable = false;
+    /**
+     * @var bool|Closure|array<int, mixed>
+     */
+    protected bool | Closure | array $isSearchable = false;
 
     protected bool | Closure $canSelectPlaceholder = true;
 
@@ -257,7 +260,7 @@ class SelectFilter extends BaseFilter
             ->label($this->getLabel())
             ->multiple($this->isMultiple())
             ->placeholder($this->getPlaceholder())
-            ->searchable($this->isSearchable())
+            ->searchable($this->getIsSearchable())
             ->selectablePlaceholder($this->canSelectPlaceholder())
             ->preload($this->isPreloaded())
             ->native($this->isNative())
@@ -303,9 +306,12 @@ class SelectFilter extends BaseFilter
         return (bool) $this->evaluate($this->isMultiple);
     }
 
-    public function isSearchable(): bool
+    /**
+     * @return bool|Closure|array<int, mixed>
+     */
+    public function getIsSearchable(): bool | Closure | array
     {
-        return (bool) $this->evaluate($this->isSearchable);
+        return $this->evaluate($this->isSearchable);
     }
 
     public function canSelectPlaceholder(): bool

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -23,9 +23,9 @@ class SelectFilter extends BaseFilter
     protected bool | Closure $isStatic = false;
 
     /**
-     * @var bool|Closure|array<int, mixed>
+     * @var bool | array<string> | Closure
      */
-    protected bool | Closure | array $isSearchable = false;
+    protected bool | array | Closure $searchable = false;
 
     protected bool | Closure $canSelectPlaceholder = true;
 
@@ -215,9 +215,12 @@ class SelectFilter extends BaseFilter
         return $this;
     }
 
-    public function searchable(bool | Closure $condition = true): static
+    /**
+     * @param bool | array<string> | Closure $condition
+     */
+    public function searchable(bool | array | Closure $condition = true): static
     {
-        $this->isSearchable = $condition;
+        $this->searchable = $condition;
 
         return $this;
     }
@@ -260,7 +263,7 @@ class SelectFilter extends BaseFilter
             ->label($this->getLabel())
             ->multiple($this->isMultiple())
             ->placeholder($this->getPlaceholder())
-            ->searchable($this->getIsSearchable())
+            ->searchable($this->getSearchable())
             ->selectablePlaceholder($this->canSelectPlaceholder())
             ->preload($this->isPreloaded())
             ->native($this->isNative())
@@ -307,11 +310,11 @@ class SelectFilter extends BaseFilter
     }
 
     /**
-     * @return bool|Closure|array<int, mixed>
+     * @return bool | array<string> | Closure
      */
-    public function getIsSearchable(): bool | Closure | array
+    public function getSearchable(): bool | array | Closure
     {
-        return $this->evaluate($this->isSearchable);
+        return $this->evaluate($this->searchable);
     }
 
     public function canSelectPlaceholder(): bool

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -95,7 +95,7 @@ class PostsTable extends Component implements HasForms, Tables\Contracts\HasTabl
                     ->query(fn (EloquentBuilder $query) => $query->where('is_published', true)),
                 Tables\Filters\SelectFilter::make('author')
                     ->relationship('author', 'name')
-                    ->searchable(fn () => ['name', 'email', 'job']),
+                    ->searchable(['name', 'email', 'job']),
                 Tables\Filters\SelectFilter::make('select_filter_attribute')
                     ->options([
                         true => 'Published',

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -94,7 +94,8 @@ class PostsTable extends Component implements HasForms, Tables\Contracts\HasTabl
                 Tables\Filters\Filter::make('is_published')
                     ->query(fn (EloquentBuilder $query) => $query->where('is_published', true)),
                 Tables\Filters\SelectFilter::make('author')
-                    ->relationship('author', 'name'),
+                    ->relationship('author', 'name')
+                    ->searchable(fn () => ['name', 'email', 'job']),
                 Tables\Filters\SelectFilter::make('select_filter_attribute')
                     ->options([
                         true => 'Published',


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

Enhanced the SelectFilter to accept an array of searchable attributes. This update allows for more flexible and comprehensive search capabilities within the filter. Updated the PostsTable to utilize the new searchable functionality.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

```php
Tables\Filters\SelectFilter::make('author')
  ->relationship('author', 'name')
  ->searchable(fn () => ['name', 'email', 'job']), // columns in database
```


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
