### PR TITLE
Allow webp upload in markdown editor

### DIFF
--- a/packages/forms/resources/js/components/markdown-editor.js
+++ b/packages/forms/resources/js/components/markdown-editor.js
@@ -112,7 +112,7 @@ export default function markdownEditorFormComponent({
                 autoRefresh: true,
                 autoSave: false,
                 element: this.$refs.editor,
-                imageAccept: 'image/png, image/jpeg, image/gif, image/avif',
+                imageAccept: 'image/png, image/jpeg, image/gif, image/avif, image/webp',
                 imageUploadFunction: uploadFileAttachmentUsing,
                 initialValue: this.state ?? '',
                 maxHeight,


### PR DESCRIPTION
Add `image/webp` as allowed upload for EasyMDE.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
