### PR TITLE
Correct view path in notifications documentation

### DIFF
--- a/packages/notifications/docs/05-customizing-notifications.md
+++ b/packages/notifications/docs/05-customizing-notifications.md
@@ -31,11 +31,11 @@ If your desired customization can't be achieved using the CSS classes above, you
 use Filament\Notifications\Notification;
 
 Notification::configureUsing(function (Notification $notification): void {
-    $notification->view('notifications.notification');
+    $notification->view('filament.notifications.notification');
 });
 ```
 
-Next, create the view, in this example `resources/views/notifications/notification.blade.php`. The view should use the package's base notification component for the notification functionality and pass the available `$notification` variable through the `notification` attribute. This is the bare minimum required to create your own notification view:
+Next, create the view, in this example `resources/views/filament/notifications/notification.blade.php`. The view should use the package's base notification component for the notification functionality and pass the available `$notification` variable through the `notification` attribute. This is the bare minimum required to create your own notification view:
 
 ```blade
 <x-filament-notifications::notification :notification="$notification">

--- a/packages/notifications/docs/05-customizing-notifications.md
+++ b/packages/notifications/docs/05-customizing-notifications.md
@@ -31,7 +31,7 @@ If your desired customization can't be achieved using the CSS classes above, you
 use Filament\Notifications\Notification;
 
 Notification::configureUsing(function (Notification $notification): void {
-    $notification->view('filament-notifications.notification');
+    $notification->view('notifications.notification');
 });
 ```
 


### PR DESCRIPTION
corrected the view path 

Previous : filament-notifications.notification

correct one : notifications.notifications

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

##  path mentioned in view() was wrong. It was giving error. So I changed the path , and use correct path which was mention in example section
issue was in view path
``` 
Notification::configureUsing(function (Notification $notification): void {
    $notification->view('filament-notifications.notification');
});
```

## Visual changes
Before :
![image](https://github.com/user-attachments/assets/71aeaab8-bef3-4c47-a4fe-d7caab040298)

After : 
![image](https://github.com/user-attachments/assets/a1ee11dd-8603-4957-8742-84c3dade3940)


## Functional changes

No functionality change. just Typo fixed
