### PR TITLE
Make table function static in relation manager stub to match base function definition

### DIFF
--- a/packages/panels/stubs/RelationManager.stub
+++ b/packages/panels/stubs/RelationManager.stub
@@ -24,7 +24,7 @@ class {{ managerClass }} extends RelationManager
             ]);
     }
 
-    public function table(Table $table): Table
+    public static function table(Table $table): Table
     {
         return $table
             ->recordTitleAttribute('{{ recordTitleAttribute }}')


### PR DESCRIPTION
## Description

For as long as I have been using the relation manager generator, it generated the table prototype as `public function table(Table $table): Table`, which rightfully leads to the IDE complaining that its base function in `Resource.php` is `static`, and thus, the overriding function should be, too.

![grafik](https://github.com/user-attachments/assets/fd0cbce1-46dd-4230-9850-022c75d2fe46)

This PR fixes this by making the function definition in the stub static.

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
