### PR TITLE
Document automatic event dispatching for database notifications

### DIFF
--- a/packages/notifications/docs/03-database-notifications.md
+++ b/packages/notifications/docs/03-database-notifications.md
@@ -142,7 +142,6 @@ DatabaseNotifications::pollingInterval(null);
 
 Alternatively, the package has a native integration with [Laravel Echo](https://laravel.com/docs/broadcasting#client-side-installation). Make sure Echo is installed, as well as a [server-side websockets integration](https://laravel.com/docs/broadcasting#server-side-installation) like Pusher.
 
-Once websockets are set up, after sending a database notification you may dispatch a `DatabaseNotificationsSent` event, which will immediately fetch new notifications for that user:
 Once websockets are set up, you can automatically dispatch a `DatabaseNotificationsSent` event by setting the `isEventDispatched` parameter to `true` when sending the notification. This will trigger the immediate fetching of new notifications for the user:
 
 ```php

--- a/packages/notifications/docs/03-database-notifications.md
+++ b/packages/notifications/docs/03-database-notifications.md
@@ -143,18 +143,16 @@ DatabaseNotifications::pollingInterval(null);
 Alternatively, the package has a native integration with [Laravel Echo](https://laravel.com/docs/broadcasting#client-side-installation). Make sure Echo is installed, as well as a [server-side websockets integration](https://laravel.com/docs/broadcasting#server-side-installation) like Pusher.
 
 Once websockets are set up, after sending a database notification you may dispatch a `DatabaseNotificationsSent` event, which will immediately fetch new notifications for that user:
+Once websockets are set up, you can automatically dispatch a `DatabaseNotificationsSent` event by setting the `isEventDispatched` parameter to `true` when sending the notification. This will trigger the immediate fetching of new notifications for the user:
 
 ```php
-use Filament\Notifications\Events\DatabaseNotificationsSent;
 use Filament\Notifications\Notification;
 
 $recipient = auth()->user();
 
 Notification::make()
     ->title('Saved successfully')
-    ->sendToDatabase($recipient);
-
-event(new DatabaseNotificationsSent($recipient));
+    ->sendToDatabase($recipient, isEventDispatched: true);
 ```
 
 ## Marking database notifications as read


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

- Added `isEventDispatched` flag to `sendToDatabase` method.
- Allows automatic dispatch of `DatabaseNotificationsSent` event upon sending notifications to the database.
- Simplifies the process of real-time notification updates via websockets.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
