### PR TITLE
docs: fix class typo

### DIFF
--- a/packages/infolists/docs/04-layout/02-grid.md
+++ b/packages/infolists/docs/04-layout/02-grid.md
@@ -80,10 +80,10 @@ If you want to start a component in a grid at a specific column, you can use the
 - `columnStart(['md' => 2, 'xl' => 4])` will make the component start at column 2 on medium devices, and at column 4 on extra large devices. The default breakpoint for smaller devices uses 1 column, unless you use a `default` array key.
 
 ```php
-use Filament\Infolists\Components\Section;
+use Filament\Infolists\Components\Grid;
 use Filament\Infolists\Components\TextEntry;
 
-Section::make()
+Grid::make()
     ->columns([
         'sm' => 3,
         'xl' => 6,


### PR DESCRIPTION
Maybe due to a copy-paste


## Description

Change class from Section to Grid in grid docs

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
