### PR TITLE
fix: update resource namespace option in commands

### DIFF
--- a/packages/panels/src/Commands/Aliases/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/Aliases/MakeResourceCommand.php
@@ -10,5 +10,5 @@ class MakeResourceCommand extends Commands\MakeResourceCommand
 {
     protected $hidden = true;
 
-    protected $signature = 'filament:resource {name?} {--model-namespace=} {--soft-deletes} {--view} {--G|generate} {--S|simple} {--panel=} {--model} {--migration} {--factory} {--F|force}';
+    protected $signature = 'filament:resource {name?} {--model-namespace=} {--resource-namespace} {--soft-deletes} {--view} {--G|generate} {--S|simple} {--panel=} {--model} {--migration} {--factory} {--F|force}';
 }

--- a/packages/panels/src/Commands/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/MakeResourceCommand.php
@@ -28,7 +28,7 @@ class MakeResourceCommand extends Command
 
     protected $description = 'Create a new Filament resource class and default page classes';
 
-    protected $signature = 'make:filament-resource {name?} {--model-namespace=} {--soft-deletes} {--view} {--G|generate} {--S|simple} {--panel=} {--model} {--migration} {--factory} {--F|force}';
+    protected $signature = 'make:filament-resource {name?} {--model-namespace=} {--resource-namespace} {--soft-deletes} {--view} {--G|generate} {--S|simple} {--panel=} {--model} {--migration} {--factory} {--F|force}';
 
     public function handle(): int
     {
@@ -112,12 +112,17 @@ class MakeResourceCommand extends Command
             }
         }
 
-        $namespace = (count($resourceNamespaces) > 1) ?
-            select(
-                label: 'Which namespace would you like to create this in?',
-                options: $resourceNamespaces
-            ) :
-            (Arr::first($resourceNamespaces) ?? 'App\\Filament\\Resources');
+        if ($this->option('resource-namespace')) {
+            $namespace = (Arr::first($resourceNamespaces) ?? 'App\\Filament\\Resources');
+        } else {
+            $namespace = (count($resourceNamespaces) > 1) ?
+                select(
+                    label: 'Which namespace would you like to create this in?',
+                    options: $resourceNamespaces,
+                ) :
+                (Arr::first($resourceNamespaces) ?? 'App\\Filament\\Resources');
+        }
+
         $path = (count($resourceDirectories) > 1) ?
             $resourceDirectories[array_search($namespace, $resourceNamespaces)] :
             (Arr::first($resourceDirectories) ?? app_path('Filament/Resources/'));


### PR DESCRIPTION
## Description
Added the missing option to set the resource namespace when calling `make:filament-resource` using the `Artisan::call` method.

Maybe a bit unusual PR but I ran into this while creating some functionality and have "clusters" enabled. While this is enabled I couldn't programmatically run this command anymore because there was no way of adding that option thus getting errors.
This change resolves it for me.

## Visual changes
No visual changes unless you want a screenshot of the new command options. Just let me know😁

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
