### PR TITLE
Display url when issue page can't be opened in browser

### DIFF
--- a/packages/support/src/Commands/MakeIssueCommand.php
+++ b/packages/support/src/Commands/MakeIssueCommand.php
@@ -15,25 +15,37 @@ class MakeIssueCommand extends Command
 
     public function handle(): void
     {
-        $this->openUrlInBrowser('https://github.com/filamentphp/filament/issues/new?' . http_build_query([
-            'template' => 'bug_report.yml',
-            'package-version' => InstalledVersions::getPrettyVersion('filament/support'),
-            'laravel-version' => InstalledVersions::getPrettyVersion('laravel/framework'),
-            'livewire-version' => InstalledVersions::getPrettyVersion('livewire/livewire'),
-            'php-version' => PHP_VERSION,
-        ]));
+        $url = 'https://github.com/filamentphp/filament/issues/new?' . http_build_query([
+                'template' => 'bug_report.yml',
+                'package-version' => InstalledVersions::getPrettyVersion('filament/support'),
+                'laravel-version' => InstalledVersions::getPrettyVersion('laravel/framework'),
+                'livewire-version' => InstalledVersions::getPrettyVersion('livewire/livewire'),
+                'php-version' => PHP_VERSION,
+            ]);
+
+        $result = $this->openUrlInBrowser($url);
+
+        if ($result !== 0) {
+            $this->components->error('An error occurred while trying to open the issue page in your browser.');
+            $this->output->writeln('  <comment>Please open the following URL in your browser:</>');
+            $this->output->writeln('  <href="' . $url . '">' . $url . '</>');
+        }
     }
 
-    public function openUrlInBrowser(string $url): void
+    public function openUrlInBrowser(string $url): int
     {
+        $result = -1;
+
         if (PHP_OS_FAMILY === 'Darwin') {
-            exec('open "' . $url . '"');
+            exec('open "' . $url . '"', result_code: $result);
         }
         if (PHP_OS_FAMILY === 'Linux') {
-            exec('xdg-open "' . $url . '"');
+            exec('xdg-open "' . $url . '"', result_code: $result);
         }
         if (PHP_OS_FAMILY === 'Windows') {
-            exec('start "" "' . $url . '"');
+            exec('start "" "' . $url . '"', result_code: $result);
         }
+
+        return $result;
     }
 }

--- a/packages/support/src/Commands/MakeIssueCommand.php
+++ b/packages/support/src/Commands/MakeIssueCommand.php
@@ -16,12 +16,12 @@ class MakeIssueCommand extends Command
     public function handle(): void
     {
         $url = 'https://github.com/filamentphp/filament/issues/new?' . http_build_query([
-                'template' => 'bug_report.yml',
-                'package-version' => InstalledVersions::getPrettyVersion('filament/support'),
-                'laravel-version' => InstalledVersions::getPrettyVersion('laravel/framework'),
-                'livewire-version' => InstalledVersions::getPrettyVersion('livewire/livewire'),
-                'php-version' => PHP_VERSION,
-            ]);
+            'template' => 'bug_report.yml',
+            'package-version' => InstalledVersions::getPrettyVersion('filament/support'),
+            'laravel-version' => InstalledVersions::getPrettyVersion('laravel/framework'),
+            'livewire-version' => InstalledVersions::getPrettyVersion('livewire/livewire'),
+            'php-version' => PHP_VERSION,
+        ]);
 
         $result = $this->openUrlInBrowser($url);
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
When executing `artisan make:filament-issue` without `xdg-open` or similar tools installed, there is no way to retrieve the generated URL. Instead, you receive an output like `xdg-open: not found`, which is not helpful. This issue can occur, for example, when developing in a Docker container where `xdg-open` is not installed (e.g. with sail).

This PR implements a simple error message when something goes wrong and additionally displays the generated link, allowing users to manually copy and paste the link into their browsers.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->
Before:
<img width="329" alt="image" src="https://github.com/user-attachments/assets/8857b919-e922-46e9-bd30-706154aa9188">

After:
<img width="1361" alt="image" src="https://github.com/user-attachments/assets/d146c21c-e586-4125-ace8-7c1ca9febdd0">

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
