### PR TITLE
Update 07-advanced.md

### DIFF
--- a/packages/forms/docs/07-advanced.md
+++ b/packages/forms/docs/07-advanced.md
@@ -258,7 +258,20 @@ TextInput::make('name')
     ->required()
     ->dehydrateStateUsing(fn (string $state): string => ucwords($state))
 ```
+#### Handling Nullable Unique Fields
 
+When using unique fields that are nullable (e.g., an `email` field), the dehydration process might set the field to an empty string if left blank, which can cause validation errors. To resolve this, you can ensure the field remains `null` when empty by using the `dehydrateStateUsing()` method.
+
+For example:
+
+```php
+use Filament\Forms\Components\TextInput;
+
+TextInput::make('email')
+    ->unique()
+    ->nullable()
+    ->dehydrateStateUsing(fn ($state) => $state ? strtolower($state) : null)
+```
 #### Preventing a field from being dehydrated
 
 You may also prevent a field from being dehydrated altogether using `dehydrated(false)`. In this example, the field will not be present in the array returned from `getState()`:


### PR DESCRIPTION
handle nullable , unique field when using 'dehydrateStaaeUsing() ' if field left blank it returns empty string  when using strtolower()

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
