### PR TITLE
Specify Tailwind variants position

### DIFF
--- a/docs-assets/app/resources/css/app.css
+++ b/docs-assets/app/resources/css/app.css
@@ -1,3 +1,4 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@tailwind variants;

--- a/packages/actions/docs/01-installation.md
+++ b/packages/actions/docs/01-installation.md
@@ -73,6 +73,7 @@ Add Tailwind's CSS layers to your `resources/css/app.css`:
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@tailwind variants;
 ```
 
 Create a `postcss.config.js` file in the root of your project and register Tailwind CSS, PostCSS Nesting and Autoprefixer as plugins:

--- a/packages/forms/docs/01-installation.md
+++ b/packages/forms/docs/01-installation.md
@@ -73,6 +73,7 @@ Add Tailwind's CSS layers to your `resources/css/app.css`:
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@tailwind variants;
 ```
 
 Create a `postcss.config.js` file in the root of your project and register Tailwind CSS, PostCSS Nesting and Autoprefixer as plugins:

--- a/packages/infolists/docs/01-installation.md
+++ b/packages/infolists/docs/01-installation.md
@@ -73,6 +73,7 @@ Add Tailwind's CSS layers to your `resources/css/app.css`:
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@tailwind variants;
 ```
 
 Create a `postcss.config.js` file in the root of your project and register Tailwind CSS, PostCSS Nesting and Autoprefixer as plugins:

--- a/packages/notifications/docs/01-installation.md
+++ b/packages/notifications/docs/01-installation.md
@@ -71,6 +71,7 @@ Add Tailwind's CSS layers to your `resources/css/app.css`:
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@tailwind variants;
 ```
 
 Create a `postcss.config.js` file in the root of your project and register Tailwind CSS, PostCSS Nesting and Autoprefixer as plugins:

--- a/packages/panels/resources/css/index.css
+++ b/packages/panels/resources/css/index.css
@@ -1,6 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@tailwind variants;
 
 @layer base {
     :root.dark {

--- a/packages/support/stubs/scaffolding/resources/css/app.css
+++ b/packages/support/stubs/scaffolding/resources/css/app.css
@@ -1,3 +1,4 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@tailwind variants;

--- a/packages/tables/docs/01-installation.md
+++ b/packages/tables/docs/01-installation.md
@@ -73,6 +73,7 @@ Add Tailwind's CSS layers to your `resources/css/app.css`:
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@tailwind variants;
 ```
 
 Create a `postcss.config.js` file in the root of your project and register Tailwind CSS, PostCSS Nesting and Autoprefixer as plugins:

--- a/packages/widgets/docs/01-installation.md
+++ b/packages/widgets/docs/01-installation.md
@@ -73,6 +73,7 @@ Add Tailwind's CSS layers to your `resources/css/app.css`:
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@tailwind variants;
 ```
 
 Create a `postcss.config.js` file in the root of your project and register Tailwind CSS, PostCSS Nesting and Autoprefixer as plugins:


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This pull request adds the optional Tailwind CSS variants import.

Previously, any custom CSS to override Filament's styles would be overridden by Tailwind CSS variants used in the Filament views. Adding the `@tailwind variants` "import" explicitly marks the position in the CSS file where the compiled variants should be placed.

You'd expect to be able to override Filament's body background color using:

```css
.fi-body {
    @apply bg-white dark:bg-gray-900;
}
```

This works fine for light mode, but in dark mode the new color isn't applied.
The cause of this is `dark:bg-gray-950` in Filament's views being generated as a "variant" because of `dark:` (just as variants for breakpoints like `lg:hidden`).

Currently, you'd have to use `!important` all over the place, which is bad practice and a nightmare to use and maintain. This is no longer needed after this PR. Hopefully this will make it much easier for people to restyle Filament to their liking. 😊

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
