### PR TITLE
Extract base stylesheet

### DIFF
--- a/packages/panels/resources/css/base.css
+++ b/packages/panels/resources/css/base.css
@@ -1,0 +1,10 @@
+@layer base {
+    :root.dark {
+        color-scheme: dark;
+    }
+
+    /* When scrolling to validation error, do not hide element behind the top bar */
+    [data-field-wrapper] {
+        scroll-margin-top: 8rem;
+    }
+}

--- a/packages/panels/resources/css/index.css
+++ b/packages/panels/resources/css/index.css
@@ -1,15 +1,6 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-@tailwind variants;
+@import 'tailwindcss/base';
+@import 'tailwindcss/components';
+@import 'tailwindcss/utilities';
+@import 'tailwindcss/variants';
 
-@layer base {
-    :root.dark {
-        color-scheme: dark;
-    }
-
-    /* When scrolling to validation error, do not hide element behind the top bar */
-    [data-field-wrapper] {
-        scroll-margin-top: 8rem;
-    }
-}
+@import 'base.css';


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This pull request extracts the styles added to Tailwind's base layer by Filament.
The goal is to support importing the base stylesheet separately so developers can import Tailwind CSS into a CSS layer if desired.

This change does not affect existing projects or the compiled Filament stylesheet at all.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
