### PR TITLE
Add disable grammarly

### DIFF
--- a/packages/forms/docs/03-fields/10-rich-editor.md
+++ b/packages/forms/docs/03-fields/10-rich-editor.md
@@ -67,3 +67,14 @@ RichEditor::make('content')
     ->fileAttachmentsDirectory('attachments')
     ->fileAttachmentsVisibility('private')
 ```
+
+## Disabling Grammarly checks
+
+If the user has Grammarly installed and you would like to it from analyzing the contents of the editor, you can use the `disableGrammarly()` method:
+
+```php
+use Filament\Forms\Components\RichEditor;
+
+RichEditor::make('content')
+    ->disableGrammarly()
+```

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -489,7 +489,7 @@
                 </trix-toolbar>
 
                 <trix-editor
-                    @if($isGrammarlyDisabled())
+                    @if ($isGrammarlyDisabled())
                         data-gramm="false"
                         data-gramm_editor="false"
                         data-enable-grammarly="false"

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -489,6 +489,11 @@
                 </trix-toolbar>
 
                 <trix-editor
+                    @if($isGrammarlyDisabled())
+                        data-gramm="false"
+                        data-gramm_editor="false"
+                        data-enable-grammarly="false"
+                    @endif
                     @if ($isAutofocused())
                         autofocus
                     @endif

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -489,11 +489,6 @@
                 </trix-toolbar>
 
                 <trix-editor
-                    @if ($isGrammarlyDisabled())
-                        data-gramm="false"
-                        data-gramm_editor="false"
-                        data-enable-grammarly="false"
-                    @endif
                     @if ($isAutofocused())
                         autofocus
                     @endif
@@ -506,6 +501,11 @@
                     @endif
                     x-ref="trix"
                     wire:ignore
+                    @if ($isGrammarlyDisabled())
+                        data-gramm="false"
+                        data-gramm_editor="false"
+                        data-enable-grammarly="false"
+                    @endif
                     {{
                         $getExtraInputAttributeBag()->class([
                             'prose min-h-[theme(spacing.48)] max-w-none !border-none px-3 py-1.5 text-base text-gray-950 dark:prose-invert focus-visible:outline-none dark:text-white sm:text-sm sm:leading-6',

--- a/packages/forms/src/Components/Concerns/CanDisableGrammarly.php
+++ b/packages/forms/src/Components/Concerns/CanDisableGrammarly.php
@@ -4,7 +4,7 @@ namespace Filament\Forms\Components\Concerns;
 
 use Closure;
 
-trait CanGrammarlyBeDisabled
+trait CanDisableGrammarly
 {
     protected bool | Closure $isGrammarlyDisabled = false;
 

--- a/packages/forms/src/Components/Concerns/CanGrammarlyBeDisabled.php
+++ b/packages/forms/src/Components/Concerns/CanGrammarlyBeDisabled.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Filament\Forms\Components\Concerns;
+
+use Closure;
+
+trait CanGrammarlyBeDisabled
+{
+    protected bool | Closure $isGrammarlyDisabled = false;
+
+    public function disableGrammarly(bool | Closure $condition = true): static
+    {
+        $this->isGrammarlyDisabled = $condition;
+
+        return $this;
+    }
+
+    public function isGrammarlyDisabled(): bool
+    {
+        return (bool) $this->evaluate($this->isGrammarlyDisabled);
+    }
+}

--- a/packages/forms/src/Components/Field.php
+++ b/packages/forms/src/Components/Field.php
@@ -2,9 +2,11 @@
 
 namespace Filament\Forms\Components;
 
+
 class Field extends Component implements Contracts\HasHintActions, Contracts\HasValidationRules
 {
     use Concerns\CanBeAutofocused;
+    use Concerns\CanGrammarlyBeDisabled;
     use Concerns\CanBeMarkedAsRequired;
     use Concerns\CanBeValidated;
     use Concerns\HasExtraFieldWrapperAttributes;

--- a/packages/forms/src/Components/Field.php
+++ b/packages/forms/src/Components/Field.php
@@ -2,13 +2,12 @@
 
 namespace Filament\Forms\Components;
 
-
 class Field extends Component implements Contracts\HasHintActions, Contracts\HasValidationRules
 {
     use Concerns\CanBeAutofocused;
-    use Concerns\CanGrammarlyBeDisabled;
     use Concerns\CanBeMarkedAsRequired;
     use Concerns\CanBeValidated;
+    use Concerns\CanGrammarlyBeDisabled;
     use Concerns\HasExtraFieldWrapperAttributes;
     use Concerns\HasHelperText;
     use Concerns\HasHint;

--- a/packages/forms/src/Components/Field.php
+++ b/packages/forms/src/Components/Field.php
@@ -7,7 +7,7 @@ class Field extends Component implements Contracts\HasHintActions, Contracts\Has
     use Concerns\CanBeAutofocused;
     use Concerns\CanBeMarkedAsRequired;
     use Concerns\CanBeValidated;
-    use Concerns\CanGrammarlyBeDisabled;
+    use Concerns\CanDisableGrammarly;
     use Concerns\HasExtraFieldWrapperAttributes;
     use Concerns\HasHelperText;
     use Concerns\HasHint;


### PR DESCRIPTION
## Description
There was an issue with the rich editor It would not let you upload an image if Grammarly Browser extension is Enabled 
so i add a new method to `disableGrammarly()` that add the below attributes to trix editor to disable Grammarly

```
 data-gramm="false"
 data-gramm_editor="false"
 data-enable-grammarly="false"
```

PS i tried to test this locally before create a pull requested but when i tried to installed filament using my local repo i get the error more about the issue here

https://github.com/filamentphp/filament/discussions/14415 

## Functional changes

- [ * ] Code style has been fixed by running the `composer cs` command.
- [ * ] Changes have been tested to not break existing functionality.
- [ * ] Documentation is up-to-date.
