### PR TITLE
Add option to align add action on a repeater

### DIFF
--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -65,7 +65,7 @@ Note that these default items are only created when the form is loaded without e
 
 An action button is displayed below the repeater to allow the user to add a new item.
 
-## Align the add action button
+## Setting the add action button's label
 
 You may set a label to customize the text that should be displayed in the button for adding a repeater item, using the `addActionLabel()` method:
 
@@ -79,7 +79,7 @@ Repeater::make('members')
     ->addActionLabel('Add member')
 ```
 
-## Setting the add action button's label
+## Align the add action button
 
 By default, the add action is align in the center. You may adjust this using the `addActionAlignment()` method:
 

--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -65,7 +65,7 @@ Note that these default items are only created when the form is loaded without e
 
 An action button is displayed below the repeater to allow the user to add a new item.
 
-## Setting the add action button's label
+## Align the add action button
 
 You may set a label to customize the text that should be displayed in the button for adding a repeater item, using the `addActionLabel()` method:
 

--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -79,9 +79,9 @@ Repeater::make('members')
     ->addActionLabel('Add member')
 ```
 
-## Align the add action button
+### Aligning the add action button
 
-By default, the add action is align in the center. You may adjust this using the `addActionAlignment()` method:
+By default, the add action is aligned in the center. You may adjust this using the `addActionAlignment()` method, passing an `Alignment` option of `Alignment::Start` or `Alignment::End`:
 
 ```php
 use Filament\Forms\Components\Repeater;
@@ -91,7 +91,7 @@ Repeater::make('members')
     ->schema([
         // ...
     ])
-    ->addActionAlignment(Alignment::Left)
+    ->addActionAlignment(Alignment::Start)
 ```
 
 ### Preventing the user from adding items

--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -79,6 +79,21 @@ Repeater::make('members')
     ->addActionLabel('Add member')
 ```
 
+## Setting the add action button's label
+
+By default, the add action is align in the center. You may adjust this using the `addActionAlignment()` method:
+
+```php
+use Filament\Forms\Components\Repeater;
+use Filament\Support\Enums\Alignment;
+
+Repeater::make('members')
+    ->schema([
+        // ...
+    ])
+    ->addActionAlignment(Alignment::Left)
+```
+
 ### Preventing the user from adding items
 
 You may prevent the user from adding items to the repeater using the `addable(false)` method:

--- a/packages/forms/resources/views/components/repeater/index.blade.php
+++ b/packages/forms/resources/views/components/repeater/index.blade.php
@@ -1,5 +1,6 @@
 @php
     use Filament\Forms\Components\Actions\Action;
+    use Filament\Support\Enums\Alignment;
 
     $containers = $getChildComponentContainers();
 
@@ -238,7 +239,16 @@
         @endif
 
         @if ($isAddable && $addAction->isVisible())
-            <div class="flex justify-center">
+            <div @class([
+                "flex",
+                match ($getAddActionAlignment()) {
+                    Alignment::Start, Alignment::Left => 'justify-start',
+                    Alignment::Center, null => 'justify-center',
+                    Alignment::End, Alignment::Right => 'flex-row-reverse',
+                    Alignment::Between, Alignment::Justify => 'justify-between',
+                    default => $alignment,
+                },
+            ])>
                 {{ $addAction }}
             </div>
         @endif

--- a/packages/forms/resources/views/components/repeater/index.blade.php
+++ b/packages/forms/resources/views/components/repeater/index.blade.php
@@ -244,7 +244,7 @@
                 match ($getAddActionAlignment()) {
                     Alignment::Start, Alignment::Left => 'justify-start',
                     Alignment::Center, null => 'justify-center',
-                    Alignment::End, Alignment::Right => 'flex-row-reverse',
+                    Alignment::End, Alignment::Right => 'justify-end',
                     Alignment::Between, Alignment::Justify => 'justify-between',
                     default => $alignment,
                 },

--- a/packages/forms/resources/views/components/repeater/index.blade.php
+++ b/packages/forms/resources/views/components/repeater/index.blade.php
@@ -240,12 +240,11 @@
 
         @if ($isAddable && $addAction->isVisible())
             <div @class([
-                "flex",
+                'flex',
                 match ($getAddActionAlignment()) {
                     Alignment::Start, Alignment::Left => 'justify-start',
                     Alignment::Center, null => 'justify-center',
                     Alignment::End, Alignment::Right => 'justify-end',
-                    Alignment::Between, Alignment::Justify => 'justify-between',
                     default => $alignment,
                 },
             ])>

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -208,7 +208,12 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
 
     public function getAddActionAlignment(): Alignment | string | null
     {
-        return $this->evaluate($this->addActionAlignment);
+        $alignment = $this->evaluate($this->addActionAlignment);
+
+        return is_string($alignment)
+            ? Alignment::tryFrom($alignment) ?? $alignment
+            : $alignment;
+
     }
 
     public function addAction(?Closure $callback): static

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -210,10 +210,11 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
     {
         $alignment = $this->evaluate($this->addActionAlignment);
 
-        return is_string($alignment)
-            ? Alignment::tryFrom($alignment) ?? $alignment
-            : $alignment;
+        if (is_string($alignment)) {
+            $alignment = Alignment::tryFrom($alignment) ?? $alignment;
+        }
 
+        return $alignment;
     }
 
     public function addAction(?Closure $callback): static

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -8,6 +8,7 @@ use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Support\Concerns\HasReorderAnimationDuration;
 use Filament\Support\Enums\ActionSize;
+use Filament\Support\Enums\Alignment;
 use Filament\Support\Facades\FilamentIcon;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Collection;
@@ -54,6 +55,8 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
     protected string | Closure | null $itemLabel = null;
 
     protected Field | Closure | null $simpleField = null;
+
+    protected Alignment | string | Closure | null $addActionAlignment = null;
 
     protected ?Closure $modifyRelationshipQueryUsing = null;
 
@@ -194,6 +197,18 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
         }
 
         return $action;
+    }
+
+    public function addActionAlignment(Alignment | string | Closure | null $addActionAlignment): static
+    {
+        $this->addActionAlignment = $addActionAlignment;
+
+        return $this;
+    }
+
+    public function getAddActionAlignment(): Alignment | string | null
+    {
+        return $this->evaluate($this->addActionAlignment);
     }
 
     public function addAction(?Closure $callback): static


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Adds option to align the add action to somewhere else then the center.

## Visual changes
### Before
![ff](https://github.com/user-attachments/assets/f604f2ae-d92e-4998-9f04-8dc2d310536e)

### After
![ff1](https://github.com/user-attachments/assets/d2a9d6ee-ca2b-4fbf-85f6-e3a2ec418554)
`->addActionAlignment(Alignment::Left)`

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
