### PR TITLE
Fixes/docs custom layout section corrections

### DIFF
--- a/packages/forms/docs/04-layout/08-custom.md
+++ b/packages/forms/docs/04-layout/08-custom.md
@@ -28,7 +28,7 @@ You may create your own custom component classes and views, which you can reuse 
 
 > If you're just creating a simple custom component to use once, you could instead use a [view component](#view-components) to render any custom Blade file.
 
-To create a custom column class and view, you may use the following command:
+To create a custom component class and view, you may use the following command:
 
 ```bash
 php artisan make:form-layout Wizard

--- a/packages/infolists/docs/04-layout/07-custom.md
+++ b/packages/infolists/docs/04-layout/07-custom.md
@@ -28,7 +28,7 @@ You may create your own custom component classes and views, which you can reuse 
 
 > If you're just creating a simple custom component to use once, you could instead use a [view component](#view) to render any custom Blade file.
 
-To create a custom column class and view, you may use the following command:
+To create a custom component class and view, you may use the following command:
 
 ```bash
 php artisan make:infolist-layout Box


### PR DESCRIPTION
## Description

Corrected common typo in the Form Builder and Infolist Builder docs, in the "Custom layout" sections where a "custom column class" was referred to rather than a "custom component class". This was presumably a copy & paste error from the Table Builder docs for creating custom columns.

## Visual changes

`To create a custom column class and view, you may use the following command:`

...has become...

`To create a custom component class and view, you may use the following command:`

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
