### PR TITLE
Repeater - save relations when hidden

### DIFF
--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -902,7 +902,9 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
                 ->get()
                 ->each(static fn (Model $record) => $record->delete());
 
-            $childComponentContainers = $component->getChildComponentContainers();
+            $childComponentContainers = $component->getChildComponentContainers(
+                $component->shouldSaveRelationshipsWhenHidden()
+            );
 
             $itemOrder = 1;
             $orderColumn = $component->getOrderColumn();

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -903,7 +903,7 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
                 ->each(static fn (Model $record) => $record->delete());
 
             $childComponentContainers = $component->getChildComponentContainers(
-                $component->shouldSaveRelationshipsWhenHidden()
+                withHidden: $component->shouldSaveRelationshipsWhenHidden(),
             );
 
             $itemOrder = 1;


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When using "saveRelationshipsWhenHidden" on a repeater, and the repeater is hidden, the relations are not saved.  The function "saveRelationshipsUsing" doesn't use "shouldSaveRelationshipsWhenHidden" .. so I added it.

## Visual changes

none

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
