### PR TITLE
fix: Removal of unnecessary save

### DIFF
--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -171,8 +171,6 @@ trait CanExportRecords
             );
 
             $export->file_disk = $action->getFileDisk() ?? $exporter->getFileDisk();
-            $export->save();
-
             $export->file_name = $action->getFileName($export) ?? $exporter->getFileName($export);
             $export->save();
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
The `save` operation on the `exports` table is being executed twice. If this is not intentional, it should be removed.
<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
