### PR TITLE
Fix: Add the bind value that is initialized in reorder()

### DIFF
--- a/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
+++ b/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
@@ -73,6 +73,7 @@ class PrepareCsvExport implements ShouldQueue
                 ->reject(fn (array $order): bool => in_array($order['column'] ?? null, [$keyName, $qualifiedKeyName]))
                 ->unique('column');
 
+            /** @var array<array-key> $beforeReorderBindings */
             $beforeReorderBindings = $query->getRawBindings();
 
             $query->reorder($qualifiedKeyName);

--- a/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
+++ b/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
@@ -73,7 +73,7 @@ class PrepareCsvExport implements ShouldQueue
                 ->reject(fn (array $order): bool => in_array($order['column'] ?? null, [$keyName, $qualifiedKeyName]))
                 ->unique('column');
 
-            /** @var array<array-key> $beforeReorderBindings */
+            /** @var array $beforeReorderBindings */
             $beforeReorderBindings = $query->getRawBindings();
 
             $query->reorder($qualifiedKeyName);
@@ -82,7 +82,6 @@ class PrepareCsvExport implements ShouldQueue
             }
 
             $afterReorderBindings = $query->getRawBindings();
-
             foreach ($beforeReorderBindings as $key => $value) {
                 if ($diffBinding = array_diff($value, $afterReorderBindings[$key])) {
                     $query->addBinding($diffBinding, $key);

--- a/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
+++ b/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
@@ -163,14 +163,14 @@ class PrepareCsvExport implements ShouldQueue
             ->reject(fn (array $order): bool => in_array($order['column'] ?? null, [$keyName, $qualifiedKeyName]))
             ->unique('column');
 
-        $beforeReorderBindings = $query->getrawbindings();
+        $beforeReorderBindings = $query->getRawBindings();
 
         $query->reorder($qualifiedKeyName);
         foreach ($originalOrders as $order) {
             $query->orderBy($order['column'], $order['direction']);
         }
 
-        $afterReorderBindings = $query->getrawbindings();
+        $afterReorderBindings = $query->getRawBindings();
 
         foreach ($beforeReorderBindings as $key => $value) {
             if ($diffBinding = array_diff($value, $afterReorderBindings[$key])) {

--- a/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
+++ b/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
@@ -73,18 +73,20 @@ class PrepareCsvExport implements ShouldQueue
                 ->reject(fn (array $order): bool => in_array($order['column'] ?? null, [$keyName, $qualifiedKeyName]))
                 ->unique('column');
 
-            /** @var array $beforeReorderBindings */
-            $beforeReorderBindings = $query->getRawBindings();
+            /** @var array<string, mixed> $originalBindings */
+            $originalBindings = $query->getRawBindings();
 
             $query->reorder($qualifiedKeyName);
+            
             foreach ($originalOrders as $order) {
                 $query->orderBy($order['column'], $order['direction']);
             }
 
-            $afterReorderBindings = $query->getRawBindings();
-            foreach ($beforeReorderBindings as $key => $value) {
-                if ($diffBinding = array_diff($value, $afterReorderBindings[$key])) {
-                    $query->addBinding($diffBinding, $key);
+            $newBindings = $query->getRawBindings();
+            
+            foreach ($originalBindings as $key => $value) {
+                if ($binding = array_diff($value, $newBindings[$key])) {
+                    $query->addBinding($binding, $key);
                 }
             }
         }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
In the case of PostgreSQL, we are performing reorder during individual processing at the time of export. However, when the query contains bindings, the bindings are initialized, leading to an SQL error.

In this fix, we search for the initialized bind attributes before and after the reorder, and re-bind the initialized values to prevent SQL errors.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
