### PR TITLE
Support for eloquent-power-joins v4

### DIFF
--- a/packages/support/composer.json
+++ b/packages/support/composer.json
@@ -15,7 +15,7 @@
         "illuminate/contracts": "^10.45|^11.0",
         "illuminate/support": "^10.45|^11.0",
         "illuminate/view": "^10.45|^11.0",
-        "kirschbaum-development/eloquent-power-joins": "^3.0",
+        "kirschbaum-development/eloquent-power-joins": "^3.0|^4.0",
         "livewire/livewire": "^3.4.10 <= 3.5.6",
         "ryangjchandler/blade-capture-directive": "^0.2|^0.3|^1.0",
         "spatie/color": "^1.5",

--- a/packages/support/src/Services/RelationshipJoiner.php
+++ b/packages/support/src/Services/RelationshipJoiner.php
@@ -9,12 +9,9 @@ use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Kirschbaum\PowerJoins\JoinsHelper;
-use Kirschbaum\PowerJoins\PowerJoins;
 
 class RelationshipJoiner
 {
-    use PowerJoins;
-
     public function leftJoinRelationship(Builder $query, string $relationship): Builder
     {
         if (str($relationship)->contains('.')) {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
Recently a new version of `kirschbaum-development/eloquent-power-joins` was released: https://github.com/kirschbaum-development/eloquent-power-joins/releases/tag/4.0.0

It does not seem to contain any breaking changes for Filament as only breaking change is dropping support for older Laravel versions.

Also removed `PowerJoins` trait as it was deprecated some time ago: https://github.com/kirschbaum-development/eloquent-power-joins/pull/135

## Visual changes

<!-- Add screenshots/recordings of before and after. -->
None.

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
