### PR TITLE
add optional label to Form Fields and Table Column to their __construct.

### DIFF
--- a/packages/forms/src/Components/Field.php
+++ b/packages/forms/src/Components/Field.php
@@ -15,15 +15,20 @@ class Field extends Component implements Contracts\HasHintActions, Contracts\Has
 
     protected string $viewIdentifier = 'field';
 
-    final public function __construct(string $name)
+    final public function __construct(string $name, ?string $label = null)
     {
         $this->name($name);
+
+        if(!is_null($label)) {
+            $this->label($label);
+        }
+
         $this->statePath($name);
     }
 
-    public static function make(string $name): static
+    public static function make(string $name, ?string $label = null): static
     {
-        $static = app(static::class, ['name' => $name]);
+        $static = app(static::class, ['name' => $name, 'label' => $label]);
         $static->configure();
 
         return $static;

--- a/packages/forms/src/Components/Field.php
+++ b/packages/forms/src/Components/Field.php
@@ -19,7 +19,7 @@ class Field extends Component implements Contracts\HasHintActions, Contracts\Has
     {
         $this->name($name);
 
-        if(!is_null($label)) {
+        if (! is_null($label)) {
             $this->label($label);
         }
 

--- a/packages/tables/src/Columns/Column.php
+++ b/packages/tables/src/Columns/Column.php
@@ -53,14 +53,18 @@ class Column extends ViewComponent
 
     protected string $viewIdentifier = 'column';
 
-    final public function __construct(string $name)
+    final public function __construct(string $name, ?string $label = null)
     {
         $this->name($name);
+
+        if(!is_null($label)) {
+            $this->label($label);
+        }
     }
 
-    public static function make(string $name): static
+    public static function make(string $name, ?string $label = null): static
     {
-        $static = app(static::class, ['name' => $name]);
+        $static = app(static::class, ['name' => $name, 'label' => $label]);
         $static->configure();
 
         return $static;

--- a/packages/tables/src/Columns/Column.php
+++ b/packages/tables/src/Columns/Column.php
@@ -57,7 +57,7 @@ class Column extends ViewComponent
     {
         $this->name($name);
 
-        if(!is_null($label)) {
+        if (! is_null($label)) {
             $this->label($label);
         }
     }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Most of the time any field or column created needed to give it label instead of doing it in to lines make it one line.

## Visual changes

`Filament\Forms\Components\Field` and `Filament\Tables\Columns\Column` Before:
```
    final public function __construct(string $name)
    {
        $this->name($name);
        $this->statePath($name);
    }
```

`Filament\Forms\Components\Field` and `Filament\Tables\Columns\Column` After:
```
    final public function __construct(string $name, ?string $label = null)
    {
        $this->name($name);

        if (! is_null($label)) {
            $this->label($label);
        }
    }
```

also the change made to `make` function:
```
    public static function make(string $name, ?string $label = null): static
    {
        $static = app(static::class, ['name' => $name, 'label' => $label]);
        $static->configure();

        return $static;
    }
```


## Functional changes

- [ ✅ ] Code style has been fixed by running the `composer cs` command.
- [ ✅ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
