### PR TITLE
Fix CheckboxList does not display descriptions when using an enum for dynamic options

### DIFF
--- a/packages/forms/src/Components/Concerns/HasDescriptions.php
+++ b/packages/forms/src/Components/Concerns/HasDescriptions.php
@@ -52,13 +52,15 @@ trait HasDescriptions
             $descriptions = $descriptions->toArray();
         }
 
+        $options = $this->evaluate($this->options);
+
         if (
             empty($descriptions) &&
-            is_string($this->options) &&
-            enum_exists($this->options) &&
-            is_a($this->options, HasDescription::class, allow_string: true)
+            is_string($options) &&
+            enum_exists($options) &&
+            is_a($options, HasDescription::class, allow_string: true)
         ) {
-            $descriptions = array_reduce($this->options::cases(), function (array $carry, HasDescription & UnitEnum $case): array {
+            $descriptions = array_reduce($options::cases(), function (array $carry, HasDescription & UnitEnum $case): array {
                 if (filled($description = $case->getDescription())) {
                     $carry[$case?->value ?? $case->name] = $description;
                 }

--- a/tests/src/Forms/Components/CheckboxListTest.php
+++ b/tests/src/Forms/Components/CheckboxListTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use Filament\Forms\Components\CheckboxList;
+use Filament\Forms\Form;
+use Filament\Support\Contracts\HasDescription;
+use Filament\Support\Contracts\HasLabel;
+use Filament\Tests\Forms\Fixtures\Livewire;
+use Filament\Tests\TestCase;
+use Illuminate\Contracts\View\View;
+
+use function Filament\Tests\livewire;
+
+uses(TestCase::class);
+
+it('can render labels when enum implements HasLabel', function () {
+    expect(Options::class)->toImplement(HasLabel::class);
+    livewire(TestComponentWithFixedOptions::class)
+        ->assertSeeText('Foo Label')
+        ->assertSeeText('Bar Label');
+});
+
+it('can render descriptions when enum implements HasDescription', function () {
+    expect(Options::class)->toImplement(HasDescription::class);
+    livewire(TestComponentWithFixedOptions::class)
+        ->assertSeeText('Foo Description')
+        ->assertSeeText('Bar Description');
+});
+
+it('can render labels and descriptions for dynamic options', function () {
+    expect(Options::class)->toImplement(HasLabel::class);
+    expect(Options::class)->toImplement(HasDescription::class);
+    livewire(TestComponentWithDynamicOptions::class)
+        ->assertSeeText('Foo Label')
+        ->assertSeeText('Bar Label')
+        ->assertSeeText('Foo Description')
+        ->assertSeeText('Bar Description');
+});
+
+enum Options: string implements HasDescription, HasLabel
+{
+    case FOO = 'foo';
+    case BAR = 'bar';
+
+    public function getDescription(): ?string
+    {
+        return match ($this) {
+            self::FOO => 'Foo Description',
+            self::BAR => 'Bar Description',
+        };
+    }
+
+    public function getLabel(): ?string
+    {
+        return match ($this) {
+            self::FOO => 'Foo Label',
+            self::BAR => 'Bar Label',
+        };
+    }
+}
+
+class TestComponentWithFixedOptions extends Livewire
+{
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                CheckboxList::make('test')->options(Options::class),
+            ]);
+    }
+
+    public function render(): View
+    {
+        return view('forms.fixtures.form');
+    }
+}
+
+class TestComponentWithDynamicOptions extends Livewire
+{
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                CheckboxList::make('test')->options(function () {
+                    return Options::class;
+                }),
+            ]);
+    }
+
+    public function render(): View
+    {
+        return view('forms.fixtures.form');
+    }
+}


### PR DESCRIPTION
Closes #14500 

As this is my first pull request I need help with checking if this PR breaks existing functionality.

## Description

When rendering a CheckboxList field with dynamic options where an enum is returned by the options closure, the descriptions are not displayed. This issue occurs even though the enum implements both HasDescription and HasLabel.

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
