### PR TITLE
Allow poll action on tables

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -284,8 +284,12 @@
         @endif
 
         <div
-            @if ((! $isReordering) && ($pollingInterval = $getPollingInterval()))
-                wire:poll.{{ $pollingInterval }}
+            @if(! $isReordering)
+                @if($pollingInterval = $getPollingInterval() && $pollingAction = $getPollingAction())
+                    wire:poll.{{ $pollingInterval }}="{{ $pollingAction }}"
+                @elseif($pollingInterval = $getPollingInterval())
+                    wire:poll.{{ $pollingInterval }}
+                @endif
             @endif
             @class([
                 'fi-ta-content relative divide-y divide-gray-200 overflow-x-auto dark:divide-white/10 dark:border-t-white/10',

--- a/packages/tables/src/Table/Concerns/CanPollRecords.php
+++ b/packages/tables/src/Table/Concerns/CanPollRecords.php
@@ -8,6 +8,8 @@ trait CanPollRecords
 {
     protected string | Closure | null $pollingInterval = null;
 
+    protected string | Closure | null $pollingAction = null;
+
     public function poll(string | Closure | null $interval = '10s'): static
     {
         $this->pollingInterval = $interval;
@@ -15,8 +17,20 @@ trait CanPollRecords
         return $this;
     }
 
+    public function pollAction(string | Closure $action): static
+    {
+        $this->pollingAction = $action;
+
+        return $this;
+    }
+
     public function getPollingInterval(): ?string
     {
         return $this->evaluate($this->pollingInterval);
+    }
+
+    public function getPollingAction(): ?string
+    {
+        return $this->evaluate($this->pollingAction);
     }
 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Since Livewire supports polling with the ability [to trigger actions](https://livewire.laravel.com/docs/wire-poll#:~:text=You%20can%20also%20specify%20an%20action%20to%20fire%20on%20the%20polling%20interval), it would be a great feature to have in Filament tables. With each table refresh, an event could be triggered, or any custom action the developer wishes to initiate. This would add more flexibility to the table’s functionality.

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
    - I couldn’t find any tests specifically for table polling, so I tested it on a separate test project, and everything seems to be working fine.
- [ ] Documentation is up-to-date.
    - Will do once this pull request gets accepted!