### PR TITLE
feat: 为`TernaryFilter`的`boolean`方法增加可选参数以支持数字过滤

### DIFF
--- a/packages/tables/src/Filters/TernaryFilter.php
+++ b/packages/tables/src/Filters/TernaryFilter.php
@@ -106,30 +106,30 @@ class TernaryFilter extends SelectFilter
         return $this;
     }
 
-    public function boolean(): static
+    public function boolean(bool $isNumeric = false) : static
     {
         $this->queries(
-            true: function (Builder $query): Builder {
+            true: function (Builder $query) use ($isNumeric) : Builder {
                 if ($this->queriesRelationships()) {
                     return $query->whereRelation(
                         $this->getRelationshipName(),
                         $this->getRelationshipTitleAttribute(),
-                        true,
+                        $isNumeric ? 1 : true,
                     );
                 }
 
-                return $query->where($this->getAttribute(), true);
+                return $query->where($this->getAttribute(), $isNumeric ? 1 : true);
             },
-            false: function (Builder $query): Builder {
+            false: function (Builder $query) use ($isNumeric) : Builder {
                 if ($this->queriesRelationships()) {
                     return $query->whereRelation(
                         $this->getRelationshipName(),
                         $this->getRelationshipTitleAttribute(),
-                        false,
+                        $isNumeric ? 0 : false,
                     );
                 }
 
-                return $query->where($this->getAttribute(), false);
+                return $query->where($this->getAttribute(), $isNumeric ? 0 : false);
             },
         );
 


### PR DESCRIPTION
 此更改扩展了`TernaryFilter`类的`boolean`方法，允许用户指定是否以数字形式（1和0）而非布尔值（true和false）进行查询过滤。通过新增参数 `$isNumeric`，可以在查询时根据其值选择使用数字或布尔值进行过滤，从而提高了查询的灵活性和兼容性。

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
