### PR TITLE
Add `assertActionHasGroupedIcon` test helper, document Action's `groupedIcon` behavior

### DIFF
--- a/packages/actions/.stubs.php
+++ b/packages/actions/.stubs.php
@@ -29,6 +29,8 @@ namespace Livewire\Features\SupportTesting {
 
         public function assertActionHasIcon(string | array $name, string $icon): static {}
 
+        public function assertActionHasGroupedIcon(string | array $name, string $icon): static {}
+
         public function assertActionDoesNotHaveIcon(string | array $name, string $icon): static {}
 
         public function assertActionHasLabel(string | array $name, string $label): static {}

--- a/packages/actions/docs/03-trigger-button.md
+++ b/packages/actions/docs/03-trigger-button.md
@@ -128,6 +128,32 @@ Action::make('edit')
 
 <AutoScreenshot name="actions/trigger-button/icon-after" alt="Trigger with icon after the label" version="3.x" />
 
+## Using a different icon inside an action group
+
+Actions may have a different icon when they are placed inside an [action group](https://filamentphp.com/docs/3.x/actions/grouping-actions). This may be useful if you need to adapt or remove the icon inside an action group. If you do not set a grouped icon, the action will fall back to its regular icon. **Note:** [Prebuilt actions](https://filamentphp.com/docs/3.x/actions/prebuilt-actions/create) (and subclasses you create) have a [default `groupedIcon`](https://github.com/filamentphp/filament/blob/459c21543377267b8fbbd24bd02e4d8cf6313d42/packages/actions/src/CreateAction.php#L46), so you need to override both `icon()` and `groupedIcon()` if you want consistent icons.
+
+You can set the grouped icon using the `groupedIcon()` method:
+
+```php
+ActionGroup::make([
+    Action::make('suspend')
+        ->icon('heroicon-o-moon'), // outlined moon icon inside action group as well as on single action
+
+    Action::make('suspend')
+        ->icon('heroicon-o-moon')  // outlined moon in single action trigger button …
+        ->groupedIcon('heroicon-s-mooon'), // solid moon inside an action group
+
+    // outlined folder on trigger button, but default `heroicon-m-plus` icon inside an action group!
+    CreateAction::make()
+        ->icon('heroicon-o-folder-plus'),
+
+    // outlined folder in both cases
+    CreateAction::make()
+        ->icon('heroicon-o-folder-plus')
+        ->groupedIcon('heroicon-o-folder-plus'),
+])
+```
+
 ## Authorization
 
 You may conditionally show or hide actions for certain users. To do this, you can use either the `visible()` or `hidden()` methods:

--- a/packages/actions/docs/09-testing.md
+++ b/packages/actions/docs/09-testing.md
@@ -250,7 +250,7 @@ it('send action has correct label', function () {
 });
 ```
 
-To ensure an action's button is showing the correct icon, you can use `assertActionHasIcon()` or `assertActionDoesNotHaveIcon()`:
+To ensure an action's button is showing the correct icon, you can use `assertActionHasIcon()`, `assertActionHasGroupedIcon()` or `assertActionDoesNotHaveIcon()`:
 
 ```php
 use function Pest\Livewire\livewire;
@@ -263,6 +263,7 @@ it('when enabled the send button has correct icon', function () {
     ])
         ->assertActionEnabled('send')
         ->assertActionHasIcon('send', 'envelope-open')
+        ->assertActionHasGroupedIcon('send', 'envelope-open-outlined')
         ->assertActionDoesNotHaveIcon('send', 'envelope');
 });
 ```

--- a/packages/actions/src/Testing/TestsActions.php
+++ b/packages/actions/src/Testing/TestsActions.php
@@ -307,6 +307,30 @@ class TestsActions
         };
     }
 
+    public function assertActionHasGroupedIcon(): Closure
+    {
+        return function (string | array $name, string $icon, $record = null): static {
+            /** @var array<string> $name */
+            /** @phpstan-ignore-next-line */
+            $name = $this->parseNestedActionName($name);
+
+            /** @phpstan-ignore-next-line */
+            $this->assertActionExists($name);
+
+            $action = $this->instance()->getAction($name);
+
+            $livewireClass = $this->instance()::class;
+            $prettyName = implode(' > ', $name);
+
+            Assert::assertTrue(
+                $action->getGroupedIcon() === $icon,
+                message: "Failed asserting that an action with name [{$prettyName}] has grouped icon [{$icon}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
     public function assertActionDoesNotHaveIcon(): Closure
     {
         return function (string | array $name, string $icon, $record = null): static {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

I noticed that there's no equivalent `assertActionHasGroupedIcon` to the `assertActionHasIcon` [test helper](https://filamentphp.com/docs/3.x/actions/testing#button-appearance) when we want to assert that an action inside an action group has a specific icon which may differ from its regular icon. In fact, the docs do not mention `groupedIcon` at all, so I added documentation for this as well.

While custom actions [fall back](https://github.com/filamentphp/filament/blob/459c21543377267b8fbbd24bd02e4d8cf6313d42/packages/actions/src/Concerns/HasGroupedIcon.php#L20) to their `icon()`-defined icon if set, prebuilt actions [have a default](https://github.com/filamentphp/filament/blob/459c21543377267b8fbbd24bd02e4d8cf6313d42/packages/actions/src/CreateAction.php#L46). This means that prebuilt actions or their subclasses will show a different icon inside action groups even if the user has defined a different icon with `icon()`. I guess the behavior is intentional to allow setting a [default grouped icon](https://filamentphp.com/docs/3.x/support/icons#replacing-the-default-icons), so I opted to explain this behavior in the new docs rather than proposing to remove it.

## Visual changes

This PR has no visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
