### PR TITLE
Improve Repeater's `grid()` method to accept closure that can be evaluated later

### DIFF
--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -403,6 +403,8 @@ Repeater::make('qualifications')
 
 This method accepts the same options as the `columns()` method of the [grid](../layout/grid). This allows you to responsively customize the number of grid columns at various breakpoints.
 
+You can configure the grid to automatically adjust its size based on the number of items in the repeater by passing `'auto'` to the `grid()` method. Alternatively, you can provide a closure to calculate the grid size dynamically, allowing for custom logic based on the repeater's state or other conditions.
+
 ## Adding a label to repeater items based on their content
 
 You may add a label for repeater items using the `itemLabel()` method. This method accepts a closure that receives the current item's data in a `$state` variable. You must return a string to be used as the item label:

--- a/packages/forms/src/Components/Concerns/HasContainerGridLayout.php
+++ b/packages/forms/src/Components/Concerns/HasContainerGridLayout.php
@@ -7,12 +7,12 @@ use Closure;
 trait HasContainerGridLayout
 {
     /**
-     * @var array<string, int | string | null> | null
+     * @var array<string, int | string | null> | int | string | Closure | null
      */
     protected array | int | string | Closure | null $gridColumns = null;
 
     /**
-     * @param  array<string, int | string | null> | int | string | null  $columns
+     * @param  array<string, int | string | null> | int | string | Closure | null  $columns
      */
     public function grid(array | int | string | Closure | null $columns = 2): static
     {

--- a/packages/forms/src/Components/Concerns/HasContainerGridLayout.php
+++ b/packages/forms/src/Components/Concerns/HasContainerGridLayout.php
@@ -18,6 +18,7 @@ trait HasContainerGridLayout
     {
         if (is_string($columns) && $columns === 'auto') {
             $this->gridColumns = fn ($component) => count($component->getState());
+
             return $this;
         }
 

--- a/packages/forms/src/Components/Concerns/HasContainerGridLayout.php
+++ b/packages/forms/src/Components/Concerns/HasContainerGridLayout.php
@@ -2,28 +2,26 @@
 
 namespace Filament\Forms\Components\Concerns;
 
+use Closure;
+
 trait HasContainerGridLayout
 {
     /**
      * @var array<string, int | string | null> | null
      */
-    protected ?array $gridColumns = null;
+    protected array | int | string | Closure | null $gridColumns = null;
 
     /**
      * @param  array<string, int | string | null> | int | string | null  $columns
      */
-    public function grid(array | int | string | null $columns = 2): static
+    public function grid(array | int | string | Closure | null $columns = 2): static
     {
-        if (! is_array($columns)) {
-            $columns = [
-                'lg' => $columns,
-            ];
+        if (is_string($columns) && $columns === 'auto') {
+            $this->gridColumns = fn ($component) => count($component->getState());
+            return $this;
         }
 
-        $this->gridColumns = [
-            ...($this->gridColumns ?? []),
-            ...$columns,
-        ];
+        $this->gridColumns = $columns;
 
         return $this;
     }
@@ -33,7 +31,15 @@ trait HasContainerGridLayout
      */
     public function getGridColumns(?string $breakpoint = null): array | int | string | null
     {
-        $columns = $this->gridColumns ?? [
+        $gridColumns = $this->evaluate($this->gridColumns);
+
+        if (! is_array($gridColumns)) {
+            $gridColumns = [
+                'lg' => $gridColumns,
+            ];
+        }
+
+        $columns = $gridColumns ?? [
             'default' => 1,
             'sm' => null,
             'md' => null,

--- a/packages/forms/src/Components/Concerns/HasContainerGridLayout.php
+++ b/packages/forms/src/Components/Concerns/HasContainerGridLayout.php
@@ -33,7 +33,7 @@ trait HasContainerGridLayout
     {
         $gridColumns = $this->evaluate($this->gridColumns);
 
-        if (! is_array($gridColumns)) {
+        if (isset($gridColumns) && ! is_array($gridColumns)) {
             $gridColumns = [
                 'lg' => $gridColumns,
             ];


### PR DESCRIPTION
## Description

The `grid()` method of the Repeater component already accepts arrays, integers, or strings. This PR introduces support for using closures that can be evaluated later. If the value `'auto'` is provided to the `grid()` method, a closure will be registered to automatically return the number of items in the Repeater. Additionally, users can provide their own custom closure to calculate the grid size based on specific logic.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
