### PR TITLE
Have next and previous functions disabled when their actions are disabled in the Wizard component

### DIFF
--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -264,11 +264,13 @@
             'mt-6' => ! $isContained,
         ])
     >
-        <span x-cloak
-        @if (!$previousAction->isDisabled())
-            x-on:click="previousStep"
-        @endif
-        x-show="! isFirstStep()">
+        <span
+            x-cloak
+            @if (! $previousAction->isDisabled())
+                x-on:click="previousStep"
+            @endif
+            x-show="! isFirstStep()"
+        >
             {{ $previousAction }}
         </span>
 
@@ -278,14 +280,12 @@
 
         <span
             x-cloak
-            @if (!$nextAction->isDisabled())
-                x-on:click="
-                        $wire.dispatchFormEvent(
-                            'wizard::nextStep',
-                            '{{ $statePath }}',
-                            getStepIndex(step),
-                        )
-                "
+            @if (! $nextAction->isDisabled())
+                x-on:click="$wire.dispatchFormEvent(
+                    'wizard::nextStep',
+                    '{{ $statePath }}',
+                    getStepIndex(step),
+                )"
             @endif
             x-show="! isLastStep()"
         >

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -262,7 +262,10 @@
             'mt-6' => ! $isContained,
         ])
     >
-        <span x-cloak x-on:click="previousStep" x-show="! isFirstStep()">
+        <span x-cloak x-on:click="
+            if (!$el.querySelector('button').disabled){
+                previousStep();
+            }" x-show="! isFirstStep()">
             {{ $getAction('previous') }}
         </span>
 
@@ -273,11 +276,13 @@
         <span
             x-cloak
             x-on:click="
-                $wire.dispatchFormEvent(
-                    'wizard::nextStep',
-                    '{{ $statePath }}',
-                    getStepIndex(step),
-                )
+                if (!$el.querySelector('button').disabled){
+                    $wire.dispatchFormEvent(
+                        'wizard::nextStep',
+                        '{{ $statePath }}',
+                        getStepIndex(step),
+                    )
+                }
             "
             x-show="! isLastStep()"
         >

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -1,6 +1,8 @@
 @php
     $isContained = $isContained();
     $statePath = $getStatePath();
+    $previousAction = $getAction('previous');
+    $nextAction = $getAction('next');
 @endphp
 
 <div
@@ -262,11 +264,12 @@
             'mt-6' => ! $isContained,
         ])
     >
-        <span x-cloak x-on:click="
-            if (!$el.querySelector('button').disabled){
-                previousStep();
-            }" x-show="! isFirstStep()">
-            {{ $getAction('previous') }}
+        <span x-cloak
+        @if (!$previousAction->isDisabled())
+            x-on:click="previousStep"
+        @endif
+        x-show="! isFirstStep()">
+            {{ $previousAction }}
         </span>
 
         <span x-show="isFirstStep()">
@@ -275,18 +278,18 @@
 
         <span
             x-cloak
-            x-on:click="
-                if (!$el.querySelector('button').disabled){
-                    $wire.dispatchFormEvent(
-                        'wizard::nextStep',
-                        '{{ $statePath }}',
-                        getStepIndex(step),
-                    )
-                }
-            "
+            @if (!$nextAction->isDisabled())
+                x-on:click="
+                        $wire.dispatchFormEvent(
+                            'wizard::nextStep',
+                            '{{ $statePath }}',
+                            getStepIndex(step),
+                        )
+                "
+            @endif
             x-show="! isLastStep()"
         >
-            {{ $getAction('next') }}
+            {{ $nextAction }}
         </span>
 
         <span x-show="isLastStep()">


### PR DESCRIPTION
## Description

It's a small fix to have the next and previous functions disabled when their actions are disabled in the Wizard component

## Visual changes

![image](https://github.com/user-attachments/assets/02f6ff18-ec49-42a2-a279-681317073ebf)

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
