### PR TITLE
Replace `js` directive with `json` directive in order to fix sidebars

### DIFF
--- a/packages/panels/resources/views/components/sidebar/index.blade.php
+++ b/packages/panels/resources/views/components/sidebar/index.blade.php
@@ -137,13 +137,12 @@
             if (collapsedGroups === null || collapsedGroups === 'null') {
                 localStorage.setItem(
                     'collapsedGroups',
-                    JSON.stringify(@js(
-                        collect($navigation)
+                        '@json(collect($navigation)
                             ->filter(fn (\Filament\Navigation\NavigationGroup $group): bool => $group->isCollapsed())
                             ->map(fn (\Filament\Navigation\NavigationGroup $group): string => $group->getLabel())
                             ->values()
                             ->all()
-                    )),
+                        )',
                 )
             }
 


### PR DESCRIPTION
## Description

In filament 3.2.119 a fix was released which attempted to fix the side collapsing issue that has been introduced due to `JS::make(collect())` returning `'null'` instead of `'JSON.parse('[]')'`. That attempt didn't work for me so i have updated it to instead use the `@json` directive as that seems to do the trick instead.

This works because the generated output will be
```php
<?php echo json_encode(collect($navigation)
                            ->filter(fn (\Filament\Navigation\NavigationGroup $group): bool => $group->isCollapsed())
                            ->map(fn (\Filament\Navigation\NavigationGroup $group): string => $group->getLabel())
                            ->values()
                            ->all()
                        , 15, 512) ?>
```
instead of
```php
<?php echo \Illuminate\Support\Js::from(collect($navigation)
                            ->filter(fn (\Filament\Navigation\NavigationGroup $group): bool => $group->isCollapsed())
                            ->map(fn (\Filament\Navigation\NavigationGroup $group): string => $group->getLabel())
                            ->values()
                            ->all()
                        )->toHtml() ?>
```

The `Js::from([])->toHtml()` produces `'null'` as output when it should be `JSON.parse('[]')` which is the issue.

## Visual changes

Collapsing sidebars are possible once more!

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
