### PR TITLE
Add note about user responsibility for deleting/managing export files

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/09-export.md
+++ b/packages/actions/docs/07-prebuilt-actions/09-export.md
@@ -72,9 +72,6 @@ public function table(Table $table): Table
 
 The ["exporter" class needs to be created](#creating-an-exporter) to tell Filament how to export each row.
 
-## Note
-Created export files are the user's responsibility to delete/manage. Filament does not automatically delete them.
-
 ## Creating an exporter
 
 To create an exporter class for a model, you may use the `make:filament-exporter` command, passing the name of a model:
@@ -388,6 +385,8 @@ public function getFileDisk(): string
     return 's3';
 }
 ```
+
+Export files that are created are the developer's responsibility to delete if they wish. Filament does not delete these files in case the exports need to be downloaded again at a later date.
 
 ### Configuring the export file names
 

--- a/packages/actions/docs/07-prebuilt-actions/09-export.md
+++ b/packages/actions/docs/07-prebuilt-actions/09-export.md
@@ -72,6 +72,9 @@ public function table(Table $table): Table
 
 The ["exporter" class needs to be created](#creating-an-exporter) to tell Filament how to export each row.
 
+## Note
+Created export files are the user's responsibility to delete/manage. Filament does not automatically delete them.
+
 ## Creating an exporter
 
 To create an exporter class for a model, you may use the `make:filament-exporter` command, passing the name of a model:


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
This pull request includes an important update to the documentation for prebuilt actions in the `packages/actions/docs/07-prebuilt-actions/09-export.md` file. The key change is the addition of a note regarding the management of created export files.

Documentation update:

* [`packages/actions/docs/07-prebuilt-actions/09-export.md`](diffhunk://#diff-ce53c9a7193a3149af7de4acab906c3f2361a024c12feb8e8cf9454a8386fae5R75-R77): Added a note clarifying that created export files are the user's responsibility to delete or manage, as Filament does not automatically handle this.

## Visual changes
![image](https://github.com/user-attachments/assets/d46ef049-8ddc-45c9-811a-6385f35b10b3)

![image](https://github.com/user-attachments/assets/838981b1-c700-4f1c-b088-80e70a025b7a)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
