### PR TITLE
Make filterMediaUsing() available in SpatieMediaLibraryImageColumn and SpatieMediaLibraryImageEntry

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/README.md
+++ b/packages/spatie-laravel-media-library-plugin/README.md
@@ -222,10 +222,7 @@ SpatieMediaLibraryImageColumn::make('avatar')
 
 ### Filtering media
 
-It's possible to target a column component to only display a certain subset of media in a collection. To do that, you
-can filter the media collection using the `filterMediaUsing()` method. This method accepts a function that receives the
-`$media` collection and manipulates it. You can use
-any [collection method](https://laravel.com/docs/collections#available-methods) to filter it.
+It's possible to target the column to only display a subset of media in a collection. To do that, you can filter the media collection using the `filterMediaUsing()` method. This method accepts a function that receives the `$media` collection and manipulates it. You can use any [collection method](https://laravel.com/docs/collections#available-methods) to filter it.
 
 For example, you could scope the column to only display media that has certain custom properties:
 
@@ -237,7 +234,7 @@ SpatieMediaLibraryImageColumn::make('images')
     ->filterMediaUsing(
         fn (Collection $media): Collection => $media->where(
             'custom_properties.gallery_id',
-            12345
+            12345,
         ),
     )
 ```
@@ -289,10 +286,7 @@ SpatieMediaLibraryImageEntry::make('avatar')
 
 ### Filtering media
 
-It's possible to target an infolist component to only display a certain subset of media in a collection. To do that, you
-can filter the media collection using the `filterMediaUsing()` method. This method accepts a function that receives the
-`$media` collection and manipulates it. You can use
-any [collection method](https://laravel.com/docs/collections#available-methods) to filter it.
+It's possible to target the entry to only display a subset of media in a collection. To do that, you can filter the media collection using the `filterMediaUsing()` method. This method accepts a function that receives the `$media` collection and manipulates it. You can use any [collection method](https://laravel.com/docs/collections#available-methods) to filter it.
 
 For example, you could scope the entry to only display media that has certain custom properties:
 
@@ -304,7 +298,7 @@ SpatieMediaLibraryImageEntry::make('images')
     ->filterMediaUsing(
         fn (Collection $media): Collection => $media->where(
             'custom_properties.gallery_id',
-            12345
+            12345,
         ),
     )
 ```

--- a/packages/spatie-laravel-media-library-plugin/README.md
+++ b/packages/spatie-laravel-media-library-plugin/README.md
@@ -227,7 +227,7 @@ can filter the media collection using the `filterMediaUsing()` method. This meth
 `$media` collection and manipulates it. You can use
 any [collection method](https://laravel.com/docs/collections#available-methods) to filter it.
 
-For example, you could scope the field to only display media that has certain custom properties:
+For example, you could scope the column to only display media that has certain custom properties:
 
 ```php
 use Filament\Tables\Columns\SpatieMediaLibraryImageColumn;
@@ -294,7 +294,7 @@ can filter the media collection using the `filterMediaUsing()` method. This meth
 `$media` collection and manipulates it. You can use
 any [collection method](https://laravel.com/docs/collections#available-methods) to filter it.
 
-For example, you could scope the field to only display media that has certain custom properties:
+For example, you could scope the entry to only display media that has certain custom properties:
 
 ```php
 use Filament\Tables\Columns\SpatieMediaLibraryImageEntry;

--- a/packages/spatie-laravel-media-library-plugin/README.md
+++ b/packages/spatie-laravel-media-library-plugin/README.md
@@ -220,6 +220,28 @@ SpatieMediaLibraryImageColumn::make('avatar')
     ->conversion('thumb')
 ```
 
+### Filtering media
+
+It's possible to target a column component to only display a certain subset of media in a collection. To do that, you
+can filter the media collection using the `filterMediaUsing()` method. This method accepts a function that receives the
+`$media` collection and manipulates it. You can use
+any [collection method](https://laravel.com/docs/collections#available-methods) to filter it.
+
+For example, you could scope the field to only display media that has certain custom properties:
+
+```php
+use Filament\Tables\Columns\SpatieMediaLibraryImageColumn;
+use Illuminate\Support\Collection;
+
+SpatieMediaLibraryImageColumn::make('images')
+    ->filterMediaUsing(
+        fn (Collection $media): Collection => $media->where(
+            'custom_properties.gallery_id',
+            12345
+        ),
+    )
+```
+
 ## Infolist entry
 
 To use the media library image entry:
@@ -263,4 +285,26 @@ use Filament\Infolists\Components\SpatieMediaLibraryImageEntry;
 
 SpatieMediaLibraryImageEntry::make('avatar')
     ->conversion('thumb')
+```
+
+### Filtering media
+
+It's possible to target an infolist component to only display a certain subset of media in a collection. To do that, you
+can filter the media collection using the `filterMediaUsing()` method. This method accepts a function that receives the
+`$media` collection and manipulates it. You can use
+any [collection method](https://laravel.com/docs/collections#available-methods) to filter it.
+
+For example, you could scope the field to only display media that has certain custom properties:
+
+```php
+use Filament\Tables\Columns\SpatieMediaLibraryImageEntry;
+use Illuminate\Support\Collection;
+
+SpatieMediaLibraryImageEntry::make('images')
+    ->filterMediaUsing(
+        fn (Collection $media): Collection => $media->where(
+            'custom_properties.gallery_id',
+            12345
+        ),
+    )
 ```

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -3,7 +3,7 @@
 namespace Filament\Forms\Components;
 
 use Closure;
-use Filament\Resources\Concerns\HasMediaFilter;
+use Filament\Support\Concerns\HasMediaFilter;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use League\Flysystem\UnableToCheckFileExistence;

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -3,6 +3,7 @@
 namespace Filament\Forms\Components;
 
 use Closure;
+use Filament\Resources\Concerns\HasMediaFilter;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use League\Flysystem\UnableToCheckFileExistence;
@@ -15,6 +16,8 @@ use Throwable;
 
 class SpatieMediaLibraryFileUpload extends FileUpload
 {
+    use HasMediaFilter;
+
     protected string | Closure | null $collection = null;
 
     protected string | Closure | null $conversion = null;
@@ -44,8 +47,6 @@ class SpatieMediaLibraryFileUpload extends FileUpload
      * @var array<string, mixed> | Closure | null
      */
     protected array | Closure | null $properties = null;
-
-    protected ?Closure $filterMediaUsing = null;
 
     protected function setUp(): void
     {
@@ -236,13 +237,6 @@ class SpatieMediaLibraryFileUpload extends FileUpload
         return $this;
     }
 
-    public function filterMediaUsing(?Closure $callback): static
-    {
-        $this->filterMediaUsing = $callback;
-
-        return $this;
-    }
-
     public function responsiveImages(bool | Closure $condition = true): static
     {
         $this->hasResponsiveImages = $condition;
@@ -328,18 +322,6 @@ class SpatieMediaLibraryFileUpload extends FileUpload
     public function getProperties(): array
     {
         return $this->evaluate($this->properties) ?? [];
-    }
-
-    public function filterMedia(Collection $media): Collection
-    {
-        return $this->evaluate($this->filterMediaUsing, [
-            'media' => $media,
-        ]) ?? $media;
-    }
-
-    public function hasMediaFilter(): bool
-    {
-        return $this->filterMediaUsing instanceof Closure;
     }
 
     public function hasResponsiveImages(): bool

--- a/packages/spatie-laravel-media-library-plugin/src/Infolists/Components/SpatieMediaLibraryImageEntry.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Infolists/Components/SpatieMediaLibraryImageEntry.php
@@ -3,8 +3,8 @@
 namespace Filament\Infolists\Components;
 
 use Closure;
-use Filament\Resources\Concerns\HasMediaFilter;
 use Filament\SpatieLaravelMediaLibraryPlugin\Collections\AllMediaCollections;
+use Filament\Support\Concerns\HasMediaFilter;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;

--- a/packages/spatie-laravel-media-library-plugin/src/Infolists/Components/SpatieMediaLibraryImageEntry.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Infolists/Components/SpatieMediaLibraryImageEntry.php
@@ -3,15 +3,19 @@
 namespace Filament\Infolists\Components;
 
 use Closure;
+use Filament\Resources\Concerns\HasMediaFilter;
 use Filament\SpatieLaravelMediaLibraryPlugin\Collections\AllMediaCollections;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\MediaCollections\Models\Collections\MediaCollection;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Throwable;
 
 class SpatieMediaLibraryImageEntry extends ImageEntry
 {
+    use HasMediaFilter;
+
     protected string | AllMediaCollections | Closure | null $collection = null;
 
     protected string | Closure | null $conversion = null;
@@ -146,6 +150,10 @@ class SpatieMediaLibraryImageEntry extends ImageEntry
                     ->when(
                         ! $collection instanceof AllMediaCollections,
                         fn (MediaCollection $mediaCollection) => $mediaCollection->filter(fn (Media $media): bool => $media->getAttributeValue('collection_name') === $collection),
+                    )
+                    ->when(
+                        $this->hasMediaFilter(),
+                        fn (Collection $media) => $this->filterMedia($media)
                     )
                     ->sortBy('order_column')
                     ->pluck('uuid')

--- a/packages/spatie-laravel-media-library-plugin/src/Resources/Concerns/HasMediaFilter.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Resources/Concerns/HasMediaFilter.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Filament\Resources\Concerns;
+
+use Closure;
+use Illuminate\Support\Collection;
+
+trait HasMediaFilter
+{
+    protected ?Closure $filterMediaUsing = null;
+
+    public function filterMediaUsing(?Closure $callback): static
+    {
+        $this->filterMediaUsing = $callback;
+
+        return $this;
+    }
+
+    public function filterMedia(Collection $media): Collection
+    {
+        return $this->evaluate($this->filterMediaUsing, [
+            'media' => $media,
+        ]) ?? $media;
+    }
+
+    public function hasMediaFilter(): bool
+    {
+        return $this->filterMediaUsing instanceof Closure;
+    }
+}

--- a/packages/spatie-laravel-media-library-plugin/src/Support/Concerns/HasMediaFilter.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Support/Concerns/HasMediaFilter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Filament\Resources\Concerns;
+namespace Filament\Support\Concerns;
 
 use Closure;
 use Illuminate\Support\Collection;

--- a/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
@@ -3,8 +3,8 @@
 namespace Filament\Tables\Columns;
 
 use Closure;
-use Filament\Resources\Concerns\HasMediaFilter;
 use Filament\SpatieLaravelMediaLibraryPlugin\Collections\AllMediaCollections;
+use Filament\Support\Concerns\HasMediaFilter;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -70,13 +70,6 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
     public function conversion(string | Closure | null $conversion): static
     {
         $this->conversion = $conversion;
-
-        return $this;
-    }
-
-    public function filterMediaUsing(?Closure $callback): static
-    {
-        $this->filterMediaUsing = $callback;
 
         return $this;
     }


### PR DESCRIPTION
## Description

Adds media filters (previously available only in SpatieMediaLibraryFileUpload) to SpatieMediaLibraryImageColumn and SpatieMediaLibraryImageEntry. Moves the related methods to a concern.

## Visual changes

No changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
