### PR TITLE
Docs: Add missing closing parenthesis to code example

### DIFF
--- a/packages/admin/docs/02-resources/07-relation-managers.md
+++ b/packages/admin/docs/02-resources/07-relation-managers.md
@@ -478,7 +478,7 @@ use Filament\Tables\Actions\AttachAction;
 use Illuminate\Database\Eloquent\Builder;
 
 AttachAction::make()
-    ->recordSelectOptionsQuery(fn (Builder $query) => $query->whereBelongsTo(auth()->user())
+    ->recordSelectOptionsQuery(fn (Builder $query) => $query->whereBelongsTo(auth()->user()))
 ```
 
 ### Handling duplicates


### PR DESCRIPTION
## Description

This PR just adds a missing closing parenthesis to the code example at https://filamentphp.com/docs/2.x/admin/resources/relation-managers#attaching-with-pivot-attributes.

## Visual changes
<img width="799" alt="Before" src="https://github.com/user-attachments/assets/bc6303ef-ab59-445e-b1be-725de1a327eb">
<img width="802" alt="After" src="https://github.com/user-attachments/assets/77072714-1cbb-4ab2-8506-5e12886049b8">
