### PR TITLE
Allow conditional control over lazy-loading database notifications

### DIFF
--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -281,11 +281,13 @@
         <span
             x-cloak
             @if (! $nextAction->isDisabled())
-                x-on:click="$wire.dispatchFormEvent(
-                    'wizard::nextStep',
-                    '{{ $statePath }}',
-                    getStepIndex(step),
-                )"
+                x-on:click="
+                    $wire.dispatchFormEvent(
+                        'wizard::nextStep',
+                        '{{ $statePath }}',
+                        getStepIndex(step),
+                    )
+                "
             @endif
             x-show="! isLastStep()"
         >

--- a/packages/panels/resources/views/components/layout/simple.blade.php
+++ b/packages/panels/resources/views/components/layout/simple.blade.php
@@ -15,7 +15,9 @@
                 class="absolute end-0 top-0 flex h-16 items-center gap-x-4 pe-4 md:pe-6 lg:pe-8"
             >
                 @if (filament()->hasDatabaseNotifications())
-                    @livewire(Filament\Livewire\DatabaseNotifications::class, ['lazy' => true])
+                    @livewire(Filament\Livewire\DatabaseNotifications::class, [
+                        'lazy' => filament()->hasLazyLoadedDatabaseNotifications()
+                    ])
                 @endif
 
                 <x-filament-panels::user-menu />

--- a/packages/panels/resources/views/components/page/sub-navigation/sidebar.blade.php
+++ b/packages/panels/resources/views/components/page/sub-navigation/sidebar.blade.php
@@ -2,7 +2,9 @@
     'navigation',
 ])
 
-<div {{ $attributes->class(['fi-page-sub-navigation-sidebar-ctn hidden w-72 flex-col md:flex']) }}>
+<div
+    {{ $attributes->class(['fi-page-sub-navigation-sidebar-ctn hidden w-72 flex-col md:flex']) }}
+>
     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_SUB_NAVIGATION_SIDEBAR_BEFORE, scopes: $this->getRenderHookScopes()) }}
 
     <ul

--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -166,7 +166,7 @@
             @if (filament()->auth()->check())
                 @if (filament()->hasDatabaseNotifications())
                     @livewire(Filament\Livewire\DatabaseNotifications::class, [
-                        'lazy' => filament()->hasLazyLoadedDatabaseNotifications()
+                        'lazy' => filament()->hasLazyLoadedDatabaseNotifications(),
                     ])
                 @endif
 

--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -165,7 +165,9 @@
 
             @if (filament()->auth()->check())
                 @if (filament()->hasDatabaseNotifications())
-                    @livewire(Filament\Livewire\DatabaseNotifications::class, ['lazy' => true])
+                    @livewire(Filament\Livewire\DatabaseNotifications::class, [
+                        'lazy' => filament()->hasLazyLoadedDatabaseNotifications()
+                    ])
                 @endif
 
                 <x-filament-panels::user-menu />

--- a/packages/panels/src/Facades/Filament.php
+++ b/packages/panels/src/Facades/Filament.php
@@ -100,6 +100,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static bool hasDarkMode()
  * @method static bool hasDarkModeForced()
  * @method static bool hasDatabaseNotifications()
+ * @method static bool hasLazyLoadedDatabaseNotifications()
  * @method static bool hasEmailVerification()
  * @method static bool hasLogin()
  * @method static bool hasNavigation()

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -566,11 +566,6 @@ class FilamentManager
         return $this->getCurrentPanel()->hasDatabaseNotifications();
     }
 
-    public function hasDatabaseNotifications(): bool
-    {
-        return $this->getCurrentPanel()->hasDatabaseNotifications();
-    }
-
     public function hasLazyLoadedDatabaseNotifications(): bool
     {
         return $this->getCurrentPanel()->hasLazyLoadedDatabaseNotifications();

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -566,6 +566,16 @@ class FilamentManager
         return $this->getCurrentPanel()->hasDatabaseNotifications();
     }
 
+    public function hasDatabaseNotifications(): bool
+    {
+        return $this->getCurrentPanel()->hasDatabaseNotifications();
+    }
+
+    public function hasLazyLoadedDatabaseNotifications(): bool
+    {
+        return $this->getCurrentPanel()->hasLazyLoadedDatabaseNotifications();
+    }
+
     public function hasEmailVerification(): bool
     {
         return $this->getCurrentPanel()->hasEmailVerification();

--- a/packages/panels/src/Panel/Concerns/HasNotifications.php
+++ b/packages/panels/src/Panel/Concerns/HasNotifications.php
@@ -12,10 +12,10 @@ trait HasNotifications
 
     protected string | Closure | null $databaseNotificationsPolling = '30s';
 
-    public function databaseNotifications(bool | Closure $condition = true, bool | Closure $lazy = true): static
+    public function databaseNotifications(bool | Closure $condition = true, bool | Closure $isLazy = true): static
     {
         $this->hasDatabaseNotifications = $condition;
-        $this->hasLazyLoadedDatabaseNotifications = $lazy;
+        $this->hasLazyLoadedDatabaseNotifications = $isLazy;
 
         return $this;
     }

--- a/packages/panels/src/Panel/Concerns/HasNotifications.php
+++ b/packages/panels/src/Panel/Concerns/HasNotifications.php
@@ -15,7 +15,14 @@ trait HasNotifications
     public function databaseNotifications(bool | Closure $condition = true, bool | Closure $isLazy = true): static
     {
         $this->hasDatabaseNotifications = $condition;
-        $this->hasLazyLoadedDatabaseNotifications = $isLazy;
+        $this->lazyLoadedDatabaseNotifications($isLazy);
+
+        return $this;
+    }
+
+    public function lazyLoadedDatabaseNotifications(bool | Closure $condition = true): static
+    {
+        $this->hasLazyLoadedDatabaseNotifications = $condition;
 
         return $this;
     }

--- a/packages/panels/src/Panel/Concerns/HasNotifications.php
+++ b/packages/panels/src/Panel/Concerns/HasNotifications.php
@@ -8,11 +8,14 @@ trait HasNotifications
 {
     protected bool | Closure $hasDatabaseNotifications = false;
 
+    protected bool | Closure $hasLazyLoadedDatabaseNotifications = true;
+
     protected string | Closure | null $databaseNotificationsPolling = '30s';
 
-    public function databaseNotifications(bool | Closure $condition = true): static
+    public function databaseNotifications(bool | Closure $condition = true, bool | Closure $lazy = true): static
     {
         $this->hasDatabaseNotifications = $condition;
+        $this->hasLazyLoadedDatabaseNotifications = $lazy;
 
         return $this;
     }
@@ -27,6 +30,11 @@ trait HasNotifications
     public function hasDatabaseNotifications(): bool
     {
         return (bool) $this->evaluate($this->hasDatabaseNotifications);
+    }
+
+    public function hasLazyLoadedDatabaseNotifications(): bool
+    {
+        return (bool) $this->evaluate($this->hasLazyLoadedDatabaseNotifications);
     }
 
     public function getDatabaseNotificationsPollingInterval(): ?string


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Something of a followup to #13321 , this backwards-compatible PR simply adds a new option to control whether database notifications are lazy-loaded when enabled.

The rationale behind this is simply that it forces an extra server roundtrip on every page load, and for many apps, that's just unnecessary overhead.

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
