### PR TITLE
Add console command optimization in FilamentServiceProvider

### DIFF
--- a/packages/panels/src/FilamentServiceProvider.php
+++ b/packages/panels/src/FilamentServiceProvider.php
@@ -108,6 +108,11 @@ class FilamentServiceProvider extends PackageServiceProvider
                     $file->getRealPath() => base_path("stubs/filament/{$file->getFilename()}"),
                 ], 'filament-stubs');
             }
+
+            $this->optimizes(
+                optimize: 'filament:optimize',
+                clear: 'filament:optimize-clear',
+            );
         }
     }
 }

--- a/packages/panels/src/FilamentServiceProvider.php
+++ b/packages/panels/src/FilamentServiceProvider.php
@@ -109,10 +109,12 @@ class FilamentServiceProvider extends PackageServiceProvider
                 ], 'filament-stubs');
             }
 
-            $this->optimizes(
-                optimize: 'filament:optimize',
-                clear: 'filament:optimize-clear',
-            );
+            if (method_exists($this, 'optimize')) {
+                $this->optimizes(
+                    optimize: 'filament:optimize',
+                    clear: 'filament:optimize-clear',
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
Sponsored by a relatively new addition to the Laravel framework: https://laravel.com/docs/11.x/packages#optimize-commands.

This will be helpful in local dev, especially whne clearing the cache and forgetting to clear Filament's cache.