### PR TITLE
Save pagination preference per entity rather than per entire model

### DIFF
--- a/packages/tables/src/Concerns/CanPaginateRecords.php
+++ b/packages/tables/src/Concerns/CanPaginateRecords.php
@@ -88,8 +88,9 @@ trait CanPaginateRecords
     public function getTablePerPageSessionKey(): string
     {
         $table = class_basename($this::class);
+        $id = method_exists($this, 'getOwnerRecord') ? $this->getOwnerRecord()->id : '';
 
-        return "tables.{$table}_per_page";
+        return "tables.{$table}_per_page.{$id}";
     }
 
     /**


### PR DESCRIPTION
## Description

I had multiple users confused about the pagination. Intuitively, one would assume that pagination preference is only for the table they are on. This is true for page tables, but not resource tables and relationship managers. They share the same class name, and therefore every entity shares the same preferences currently. My code change makes this more in line with the initial idea of storing different settings per table.

## Functional changes

- [x] Changes have been tested to not break existing functionality.
