### PR TITLE
Add `filament:about` command && add details about cached Blade icons and form components

### DIFF
--- a/packages/support/src/Commands/AboutCommand.php
+++ b/packages/support/src/Commands/AboutCommand.php
@@ -15,7 +15,7 @@ class AboutCommand extends Command
     public function handle(): void
     {
         $this->call('about', [
-            '--only' => 'filament'
+            '--only' => 'filament',
         ]);
     }
 }

--- a/packages/support/src/Commands/AboutCommand.php
+++ b/packages/support/src/Commands/AboutCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Filament\Support\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'filament:about')]
+class AboutCommand extends Command
+{
+    protected $signature = 'filament:about';
+
+    protected $description = 'Display basic information about your Filament app';
+
+    public function handle(): void
+    {
+        $this->call('about', [
+            '--only' => 'filament'
+        ]);
+    }
+}

--- a/packages/support/src/Commands/AboutCommand.php
+++ b/packages/support/src/Commands/AboutCommand.php
@@ -10,7 +10,7 @@ class AboutCommand extends Command
 {
     protected $signature = 'filament:about';
 
-    protected $description = 'Display basic information about your Filament app';
+    protected $description = 'Display basic information about Filament packages that are installed';
 
     public function handle(): void
     {

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -131,7 +131,7 @@ class SupportServiceProvider extends PackageServiceProvider
                         ? '<fg=green;options=bold>CACHED</>'
                         : '<fg=yellow;options=bold>NOT CACHED</>';
                 },
-                'Form Components' => function (): string {
+                'Panel Components' => function (): string {
                     if (! class_exists(CacheComponentsCommand::class)) {
                         return '<options=bold>NOT AVAILABLE</>';
                     }

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Filament\Support;
 
 use Composer\InstalledVersions;
+use Filament\Commands\CacheComponentsCommand;
 use Filament\Support\Assets\AssetManager;
 use Filament\Support\Assets\Css;
 use Filament\Support\Assets\Js;
@@ -23,6 +24,7 @@ use Filament\Support\View\ViewManager;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Laravel\Octane\Events\RequestReceived;
@@ -51,49 +53,6 @@ class SupportServiceProvider extends PackageServiceProvider
             ->hasConfigFile()
             ->hasTranslations()
             ->hasViews();
-    }
-
-    public function packageRegistered(): void
-    {
-        $this->app->scoped(
-            AssetManager::class,
-            fn () => new AssetManager,
-        );
-
-        $this->app->scoped(
-            ScopedComponentManager::class,
-            fn () => $this->app->make(ComponentManager::class)->clone(),
-        );
-        $this->app->booted(fn () => ComponentManager::resolveScoped());
-        class_exists(RequestReceived::class) && Event::listen(RequestReceived::class, fn () => ComponentManager::resolveScoped());
-
-        $this->app->scoped(
-            ColorManager::class,
-            fn () => new ColorManager,
-        );
-
-        $this->app->scoped(
-            IconManager::class,
-            fn () => new IconManager,
-        );
-
-        $this->app->scoped(
-            ViewManager::class,
-            fn () => new ViewManager,
-        );
-
-        $this->app->scoped(
-            HtmlSanitizerInterface::class,
-            fn (): HtmlSanitizer => new HtmlSanitizer(
-                (new HtmlSanitizerConfig)
-                    ->allowSafeElements()
-                    ->allowRelativeLinks()
-                    ->allowRelativeMedias()
-                    ->allowAttribute('class', allowedElements: '*')
-                    ->allowAttribute('style', allowedElements: '*')
-                    ->withMaxInputLength(500000),
-            ),
-        );
     }
 
     public function packageBooted(): void
@@ -165,6 +124,22 @@ class SupportServiceProvider extends PackageServiceProvider
 
                     return "<fg=red;options=bold>PUBLISHED:</> {$publishedViewPaths->join(', ')}";
                 },
+                'Blade Icons' => function (): string {
+                    return file_exists(app()->bootstrapPath('cache/blade-icons.php'))
+                        ? '<fg=green;options=bold>CACHED</>'
+                        : '<fg=yellow;options=bold>NOT CACHED</>';
+                },
+                'Form Components' => function (): string {
+                    if (! class_exists(CacheComponentsCommand::class)) {
+                        return '<options=bold>NOT AVAILABLE</>';
+                    }
+
+                    $path = app()->bootstrapPath('cache/filament/panels');
+
+                    return File::isDirectory($path) && !File::isEmptyDirectory($path)
+                        ? '<fg=green;options=bold>CACHED</>'
+                        : '<fg=yellow;options=bold>NOT CACHED</>';
+                },
             ]);
         }
 
@@ -173,5 +148,48 @@ class SupportServiceProvider extends PackageServiceProvider
                 $this->package->basePath('/../config/filament.php') => config_path('filament.php'),
             ], 'filament-config');
         }
+    }
+
+    public function packageRegistered(): void
+    {
+        $this->app->scoped(
+            AssetManager::class,
+            fn () => new AssetManager,
+        );
+
+        $this->app->scoped(
+            ScopedComponentManager::class,
+            fn () => $this->app->make(ComponentManager::class)->clone(),
+        );
+        $this->app->booted(fn () => ComponentManager::resolveScoped());
+        class_exists(RequestReceived::class) && Event::listen(RequestReceived::class, fn () => ComponentManager::resolveScoped());
+
+        $this->app->scoped(
+            ColorManager::class,
+            fn () => new ColorManager,
+        );
+
+        $this->app->scoped(
+            IconManager::class,
+            fn () => new IconManager,
+        );
+
+        $this->app->scoped(
+            ViewManager::class,
+            fn () => new ViewManager,
+        );
+
+        $this->app->scoped(
+            HtmlSanitizerInterface::class,
+            fn (): HtmlSanitizer => new HtmlSanitizer(
+                (new HtmlSanitizerConfig)
+                    ->allowSafeElements()
+                    ->allowRelativeLinks()
+                    ->allowRelativeMedias()
+                    ->allowAttribute('class', allowedElements: '*')
+                    ->allowAttribute('style', allowedElements: '*')
+                    ->withMaxInputLength(500000),
+            ),
+        );
     }
 }

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -8,6 +8,7 @@ use Filament\Support\Assets\AssetManager;
 use Filament\Support\Assets\Css;
 use Filament\Support\Assets\Js;
 use Filament\Support\Colors\ColorManager;
+use Filament\Support\Commands\AboutCommand as FilamentAboutCommand;
 use Filament\Support\Commands\Aliases\MakeIssueCommand as MakeIssueCommandAlias;
 use Filament\Support\Commands\AssetsCommand;
 use Filament\Support\Commands\CheckTranslationsCommand;
@@ -43,6 +44,7 @@ class SupportServiceProvider extends PackageServiceProvider
             ->hasCommands([
                 AssetsCommand::class,
                 CheckTranslationsCommand::class,
+                FilamentAboutCommand::class,
                 InstallCommand::class,
                 MakeIssueCommand::class,
                 MakeIssueCommandAlias::class,

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -127,7 +127,7 @@ class SupportServiceProvider extends PackageServiceProvider
                     return "<fg=red;options=bold>PUBLISHED:</> {$publishedViewPaths->join(', ')}";
                 },
                 'Blade Icons' => function (): string {
-                    return file_exists(app()->bootstrapPath('cache/blade-icons.php'))
+                    return File::exists(app()->bootstrapPath('cache/blade-icons.php'))
                         ? '<fg=green;options=bold>CACHED</>'
                         : '<fg=yellow;options=bold>NOT CACHED</>';
                 },

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -138,7 +138,7 @@ class SupportServiceProvider extends PackageServiceProvider
 
                     $path = app()->bootstrapPath('cache/filament/panels');
 
-                    return File::isDirectory($path) && !File::isEmptyDirectory($path)
+                    return File::isDirectory($path) && ! File::isEmptyDirectory($path)
                         ? '<fg=green;options=bold>CACHED</>'
                         : '<fg=yellow;options=bold>NOT CACHED</>';
                 },


### PR DESCRIPTION
## Description

This PR (as discussed in https://github.com/filamentphp/filament/discussions/14578#discussioncomment-11025979) adds caching details about the Blade icons as well as the cached form components and as well adds `filament:about` which runs `php artisan about --only=filament` 

## Visual changes

![Screenshot 2024-10-23 142450](https://github.com/user-attachments/assets/ce4e277d-8078-433b-93b0-dea123fb1d9d)

![Screenshot 2024-10-23 142524](https://github.com/user-attachments/assets/a8da3f57-dab2-4579-8ab9-9358c5f33116)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
