### PR TITLE
Add warning to documentation about checking for authenticated users in `shouldRegisterNavigation` and `canAccess` methods

### DIFF
--- a/packages/panels/docs/04-pages.md
+++ b/packages/panels/docs/04-pages.md
@@ -25,9 +25,11 @@ You can prevent pages from appearing in the menu by overriding the `canAccess()`
 ```php
 public static function canAccess(): bool
 {
-    return auth()->user()->canManageSettings();
+    return auth()->check() && auth()->user()->canManageSettings();
 }
 ```
+
+> The canAccess method is called whether or not there is a currently authenticated user. If you are checking user permissions in this method you should always make sure to check if there is also a currently authenticated user. I.e `auth()->check() && auth()->user()->can('viewAny', Blog::class)`
 
 ## Adding actions to pages
 

--- a/packages/panels/docs/06-navigation.md
+++ b/packages/panels/docs/06-navigation.md
@@ -299,6 +299,8 @@ public static function shouldRegisterNavigation(): bool
 
 Please note that these methods do not control direct access to the resource or page. They only control whether the resource or page will show up in the navigation. If you want to also control access, then you should use [resource authorization](resources/getting-started#authorization) or [page authorization](pages#authorization).
 
+> The `shouldRegisterNavigation` method is called whether or not there is a currently authenticated user. If you are checking user permissions in this method you should always make sure to check if there is also a currently authenticated user. I.e `auth()->check() && auth()->user()->can('viewAny', Blog::class)`
+
 ## Using top navigation
 
 By default, Filament will use a sidebar navigation. You may use a top navigation instead by using the [configuration](configuration):

--- a/packages/panels/src/Http/Responses/Auth/LogoutResponse.php
+++ b/packages/panels/src/Http/Responses/Auth/LogoutResponse.php
@@ -10,8 +10,6 @@ class LogoutResponse implements Responsable
 {
     public function toResponse($request): RedirectResponse
     {
-        return redirect()->to(
-            Filament::hasLogin() ? Filament::getLoginUrl() : Filament::getUrl(),
-        );
+        return redirect(Filament::getUrl());
     }
 }

--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -167,13 +167,13 @@ trait HasRoutes
 
     public function getUrl(?Model $tenant = null): ?string
     {
-        if ((! $this->auth()->check()) && $this->hasLogin()) {
-            return $this->getLoginUrl();
+        if (! $this->auth()->hasUser()) {
+            return $this->hasLogin() ? $this->getLoginUrl() : url($this->getPath());
         }
 
         $hasTenancy = $this->hasTenancy();
 
-        if ((! $tenant) && $hasTenancy && $this->auth()->hasUser()) {
+        if ((! $tenant) && $hasTenancy) {
             $tenant = Filament::getUserDefaultTenant($this->auth()->user());
         }
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

See readme for https://github.com/coleshirley/filament-logout-bug and this filament discord report: https://discord.com/channels/883083792112300104/1272884452254810163

## Visual changes

none

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
