### PR TITLE
Accept a closure for `$format` on `date()`, `dateTime()`, `time()`, `dateTooltip()`, `dateTimeTooltip()` and `timeTooltip()` methods

### DIFF
--- a/packages/infolists/src/Components/Concerns/CanFormatState.php
+++ b/packages/infolists/src/Components/Concerns/CanFormatState.php
@@ -52,7 +52,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function date(?string $format = null, ?string $timezone = null): static
+    public function date(string | Closure | null $format = null, ?string $timezone = null): static
     {
         $this->isDate = true;
 
@@ -65,13 +65,13 @@ trait CanFormatState
 
             return Carbon::parse($state)
                 ->setTimezone($timezone ?? $component->getTimezone())
-                ->translatedFormat($format);
+                ->translatedFormat($component->evaluate($format));
         });
 
         return $this;
     }
 
-    public function dateTime(?string $format = null, ?string $timezone = null): static
+    public function dateTime(string | Closure | null $format = null, ?string $timezone = null): static
     {
         $this->isDateTime = true;
 
@@ -212,7 +212,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function time(?string $format = null, ?string $timezone = null): static
+    public function time(string | Closure | null $format = null, ?string $timezone = null): static
     {
         $this->isTime = true;
 

--- a/packages/infolists/src/Components/Concerns/CanFormatState.php
+++ b/packages/infolists/src/Components/Concerns/CanFormatState.php
@@ -99,7 +99,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function dateTooltip(?string $format = null, ?string $timezone = null): static
+    public function dateTooltip(string | Closure | null $format = null, ?string $timezone = null): static
     {
         $format ??= Infolist::$defaultDateDisplayFormat;
 
@@ -110,13 +110,13 @@ trait CanFormatState
 
             return Carbon::parse($state)
                 ->setTimezone($timezone ?? $component->getTimezone())
-                ->translatedFormat($format);
+                ->translatedFormat($component->evaluate($format));
         });
 
         return $this;
     }
 
-    public function dateTimeTooltip(?string $format = null, ?string $timezone = null): static
+    public function dateTimeTooltip(string | Closure | null $format = null, ?string $timezone = null): static
     {
         $format ??= Infolist::$defaultDateTimeDisplayFormat;
 
@@ -125,7 +125,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function timeTooltip(?string $format = null, ?string $timezone = null): static
+    public function timeTooltip(string | Closure | null $format = null, ?string $timezone = null): static
     {
         $format ??= Infolist::$defaultTimeDisplayFormat;
 

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -99,7 +99,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function dateTooltip(?string $format = null, ?string $timezone = null): static
+    public function dateTooltip(string | Closure | null $format = null, ?string $timezone = null): static
     {
         $format ??= Table::$defaultDateDisplayFormat;
 
@@ -110,13 +110,13 @@ trait CanFormatState
 
             return Carbon::parse($state)
                 ->setTimezone($timezone ?? $column->getTimezone())
-                ->translatedFormat($format);
+                ->translatedFormat($column->evaluate($format));
         });
 
         return $this;
     }
 
-    public function dateTimeTooltip(?string $format = null, ?string $timezone = null): static
+    public function dateTimeTooltip(string | Closure | null $format = null, ?string $timezone = null): static
     {
         $format ??= Table::$defaultDateTimeDisplayFormat;
 
@@ -125,7 +125,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function timeTooltip(?string $format = null, ?string $timezone = null): static
+    public function timeTooltip(string | Closure | null $format = null, ?string $timezone = null): static
     {
         $format ??= Table::$defaultTimeDisplayFormat;
 

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -52,7 +52,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function date(?string $format = null, ?string $timezone = null): static
+    public function date(string | Closure | null $format = null, ?string $timezone = null): static
     {
         $this->isDate = true;
 
@@ -65,13 +65,13 @@ trait CanFormatState
 
             return Carbon::parse($state)
                 ->setTimezone($timezone ?? $column->getTimezone())
-                ->translatedFormat($format);
+                ->translatedFormat($column->evaluate($format));
         });
 
         return $this;
     }
 
-    public function dateTime(?string $format = null, ?string $timezone = null): static
+    public function dateTime(string | Closure | null $format = null, ?string $timezone = null): static
     {
         $this->isDateTime = true;
 
@@ -212,7 +212,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function time(?string $format = null, ?string $timezone = null): static
+    public function time(string | Closure | null $format = null, ?string $timezone = null): static
     {
         $this->isTime = true;
 


### PR DESCRIPTION
## Description

This PR adds the ability to pass a closure to `$format` on the `date()`, `dateTime()`, `time()`,  `dateTooltip()`, `dateTimeTooltip()` and `timeTooltip()` methods.

![carbon](https://github.com/user-attachments/assets/2171aa61-9eb5-4acc-81c1-6219f25ac27b)
![carbon (1)](https://github.com/user-attachments/assets/f19aa27c-9540-42a1-8928-95e62abe6111)


## Visual changes

### Before:
#### Table:
![image](https://github.com/user-attachments/assets/fc0c4c03-e654-4d41-87cd-f4d9314ed735)


#### Infolist:
![image](https://github.com/user-attachments/assets/11728e68-3138-4c0f-9859-8c7d6b92c5aa)


### After:
#### Table:
![image](https://github.com/user-attachments/assets/8a71abdb-6f48-40b4-829e-e06ce7672c49)
![image](https://github.com/user-attachments/assets/151b0fd6-85a8-4c4e-8c74-c3e1b58be829)
![image](https://github.com/user-attachments/assets/7ae16735-a898-4695-97bf-ad33ea8ab653)

#### Infolist:
![image](https://github.com/user-attachments/assets/b9c9e594-8feb-4961-91c2-34331723b2f1)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
