### PR TITLE
Fix the missing repeater field alignement feature when using the simple layout

### DIFF
--- a/packages/forms/resources/views/components/repeater/simple.blade.php
+++ b/packages/forms/resources/views/components/repeater/simple.blade.php
@@ -1,5 +1,6 @@
 @php
     use Filament\Forms\Components\Actions\Action;
+    use Filament\Support\Enums\Alignment;
 
     $containers = $getChildComponentContainers();
 
@@ -117,7 +118,17 @@
         @endif
 
         @if ($isAddable && $addAction->isVisible())
-            <div class="flex justify-center">
+            <div 
+                @class([
+                    'flex',
+                    match ($getAddActionAlignment()) {
+                        Alignment::Start, Alignment::Left => 'justify-start',
+                        Alignment::Center, null => 'justify-center',
+                        Alignment::End, Alignment::Right => 'justify-end',
+                        default => $alignment,
+                    },
+                ])
+            >
                 {{ $addAction }}
             </div>
         @endif

--- a/packages/forms/resources/views/components/repeater/simple.blade.php
+++ b/packages/forms/resources/views/components/repeater/simple.blade.php
@@ -118,7 +118,7 @@
         @endif
 
         @if ($isAddable && $addAction->isVisible())
-            <div 
+            <div
                 @class([
                     'flex',
                     match ($getAddActionAlignment()) {


### PR DESCRIPTION
## Description

According to [this part of the documentation](https://filamentphp.com/docs/3.x/forms/fields/repeater#aligning-the-add-action-button), we are able to align the Add Button of a repeater. But it doesn't work when we use the simple layout.

This PR adds this feature, inspired by how it is made for the standard layout.

## Visual changes

![image](https://github.com/user-attachments/assets/cc17ee52-0d96-4ac8-b712-195ef9a3ad21)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
