### PR TITLE
Remove the trailing periods from the command descriptions

### DIFF
--- a/packages/support/src/Commands/AssetsCommand.php
+++ b/packages/support/src/Commands/AssetsCommand.php
@@ -13,7 +13,7 @@ class AssetsCommand extends Command
 {
     use CanManipulateFiles;
 
-    protected $description = 'Set up Filament assets.';
+    protected $description = 'Set up Filament assets';
 
     protected $signature = 'filament:assets';
 

--- a/packages/support/src/Commands/InstallCommand.php
+++ b/packages/support/src/Commands/InstallCommand.php
@@ -20,7 +20,7 @@ class InstallCommand extends Command
 
     protected $signature = 'filament:install {--scaffold} {--actions} {--forms} {--infolists} {--notifications} {--panels} {--tables} {--widgets} {--F|force}';
 
-    protected $description = 'Install Filament.';
+    protected $description = 'Install Filament';
 
     public function __invoke(): int
     {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Remove the trailing periods off of the command descriptions. Laravel also does not use periods at the end. Those were two remaining descriptions with trailing periods (in the `filament` namespace. Now they are all unified. 🤓

## Visual changes

![Screenshot 2024-10-24 103332](https://github.com/user-attachments/assets/0584e2b6-9553-4499-836e-2e90519836b7)

![Screenshot 2024-10-24 103319](https://github.com/user-attachments/assets/1cbde0e4-d260-44b4-bb5e-89b201692eb6)


## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
