### PR TITLE
Fix header padding for modal without footer

### DIFF
--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -35,8 +35,10 @@
 
 @php
     $hasDescription = filled($description);
+    $hasFooter = (! \Filament\Support\is_slot_empty($footer)) || (is_array($footerActions) && count($footerActions)) || (! is_array($footerActions) && (! \Filament\Support\is_slot_empty($footerActions)));
     $hasHeading = filled($heading);
     $hasIcon = filled($icon);
+    $hasSlot = ! \Filament\Support\is_slot_empty($slot);
 
     if (! $alignment instanceof Alignment) {
         $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
@@ -212,6 +214,7 @@
                         <div
                             @class([
                                 'fi-modal-header flex px-6 pt-6',
+                                'pb-6' => (! $hasSlot) && (! $hasFooter),
                                 'fi-sticky sticky top-0 z-10 border-b border-gray-200 bg-white pb-6 dark:border-white/10 dark:bg-gray-900' => $stickyHeader,
                                 'rounded-t-xl' => $stickyHeader && ! ($slideOver || ($width === MaxWidth::Screen)),
                                 match ($alignment) {
@@ -310,7 +313,7 @@
                         </div>
                     @endif
 
-                    @if (! \Filament\Support\is_slot_empty($slot))
+                    @if ($hasSlot)
                         <div
                             @class([
                                 'fi-modal-content flex flex-col gap-y-4 py-6',
@@ -323,7 +326,7 @@
                         </div>
                     @endif
 
-                    @if ((! \Filament\Support\is_slot_empty($footer)) || (is_array($footerActions) && count($footerActions)) || (! is_array($footerActions) && (! \Filament\Support\is_slot_empty($footerActions))))
+                    @if ($hasFooter)
                         <div
                             @class([
                                 'fi-modal-footer w-full',
@@ -332,7 +335,7 @@
                                 'fi-sticky sticky bottom-0 border-t border-gray-200 bg-white py-5 dark:border-white/10 dark:bg-gray-900' => $stickyFooter,
                                 'rounded-b-xl' => $stickyFooter && ! ($slideOver || ($width === MaxWidth::Screen)),
                                 'pb-6' => ! $stickyFooter,
-                                'mt-6' => (! $stickyFooter) && \Filament\Support\is_slot_empty($slot),
+                                'mt-6' => (! $stickyFooter) && (! $hasSlot),
                                 'mt-auto' => $slideOver,
                             ])
                         >


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Modals with header but without footer would have no spacing below the header.
This PR fixes that.

## Visual changes

### Before

<img width="576" src="https://github.com/user-attachments/assets/ab81685d-ccbf-48fa-b470-e5e72b604a90">

### After

<img width="576" src="https://github.com/user-attachments/assets/9f4ebe8f-7055-4d2c-b763-13f10cdab770">

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
