### PR TITLE
fix: icon button should be disabled while loading

### DIFF
--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -144,6 +144,8 @@
                     'disabled' => $disabled,
                     'form' => $formId,
                     'type' => $type,
+                    'wire:loading.attr' => 'disabled',
+                    'wire:target' => ($hasLoadingIndicator && $loadingIndicatorTarget) ? $loadingIndicatorTarget : null,
                 ], escape: false)
                 ->merge([
                     'title' => $label,


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Icon button should be disabled once clicked, just like the standard button.

Noticed the issue when a customer double-clicked on an icon-button to create an option from a form select component: the modal form is opened twice and the validation process fails.

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
