### PR TITLE
[WIP] Allow injecting $options into modifyQueryUsing()

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/09-export.md
+++ b/packages/actions/docs/07-prebuilt-actions/09-export.md
@@ -345,6 +345,17 @@ ExportAction::make()
     ->modifyQueryUsing(fn (Builder $query) => $query->where('is_active', true))
 ```
 
+You may inject the `$options` argument into the function, which is an array of [options](#using-export-options) for that export:
+
+```php
+use App\Filament\Exports\ProductExporter;
+use Illuminate\Database\Eloquent\Builder;
+
+ExportAction::make()
+    ->exporter(ProductExporter::class)
+    ->modifyQueryUsing(fn (Builder $query, array $options) => $query->where('is_active', $options['isActive'] ?? true))
+```
+
 Alternatively, you can override the `modifyQuery()` method on the exporter class, which will modify the query for all actions that use that exporter:
 
 ```php

--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -115,9 +115,15 @@ trait CanExportRecords
 
             $query = $exporter::modifyQuery($query);
 
+            $options = array_merge(
+                $action->getOptions(),
+                Arr::except($data, ['columnMap']),
+            );
+
             if ($this->modifyQueryUsing) {
                 $query = $this->evaluate($this->modifyQueryUsing, [
                     'query' => $query,
+                    'options' => $options,
                 ]) ?? $query;
             }
 
@@ -139,11 +145,6 @@ trait CanExportRecords
             }
 
             $user = auth()->user();
-
-            $options = array_merge(
-                $action->getOptions(),
-                Arr::except($data, ['columnMap']),
-            );
 
             if ($action->hasColumnMapping()) {
                 $columnMap = collect($data['columnMap'])


### PR DESCRIPTION
Using the built-in export action, I couldn't find a way to filter my query based on user input. This allows for easy customization using the same form that lets users pick columns to export.

WIP because I don't currently have time to write tests / update docs, will complete later this week

## Description
This allows using options to modify the query. Example use case is filtering data based on user input:

```php
ExportAction::make('Export Leads')
  ->exporter(LeadExporter::class)
  ->options([
    'startDate' => now()->subDays(7),
    'endDate' => now(),
  ])
  ->modifyQueryUsing(function ($query, array $options) {
    return $query->whereBetween('created_at', [$options['startDate'], $options['endDate']]);
}),
```

## Visual changes

None

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
