### PR TITLE
4.x korean(한글) language support

### DIFF
--- a/packages/actions/resources/lang/ko/import.php
+++ b/packages/actions/resources/lang/ko/import.php
@@ -2,7 +2,7 @@
 
 return [
 
-    'label' => '가져오기',
+    'label' => ':label 가져오기',
 
     'modal' => [
 
@@ -13,6 +13,9 @@ return [
             'file' => [
                 'label' => '파일',
                 'placeholder' => 'CSV 파일 업로드',
+                'rules' => [
+                    'duplicate_columns' => '{0} 파일에 빈 열 헤더가 두 개 이상 있으면 안 됩니다.|{1,*} 파일에 중복된 열 헤더가 있으면 안 됩니다: :columns.',
+                ],
             ],
 
             'columns' => [
@@ -45,7 +48,7 @@ return [
             'actions' => [
 
                 'download_failed_rows_csv' => [
-                    'label' => '실패한 행에 대한 정보 다운로드|실패한 행에 대한 정보 다운로드',
+                    'label' => '실패한 행에 대한 정보 다운로드|실패한 행들에 대한 정보 다운로드',
                 ],
 
             ],
@@ -53,12 +56,12 @@ return [
         ],
 
         'max_rows' => [
-            'title' => '업로드된 CSV 파일이 너무 큽니다.',
-            'body' => '한 번에 1개 이상의 행을 가져올 수 없습니다.|한 번에 :count개 이상의 행을 가져올 수 없습니다.',
+            'title' => '업로드된 CSV 파일이 너무 큽니다',
+            'body' => '한 번에 1개의 행만 가져올 수 있습니다.|한 번에 :count개 이상의 행은 가져올 수 없습니다.',
         ],
 
         'started' => [
-            'title' => '가져오기가 시작되었습니다.',
+            'title' => '가져오기 시작됨',
             'body' => '가져오기가 시작되었으며 1개의 행이 백그라운드에서 처리됩니다.|가져오기가 시작되었으며 :count개의 행이 백그라운드에서 처리됩니다.',
         ],
 
@@ -71,7 +74,8 @@ return [
     'failure_csv' => [
         'file_name' => 'import-:import_id-:csv_name-failed-rows',
         'error_header' => '오류',
-        'system_error' => '시스템 오류입니다. 지원팀에 문의하세요.',
+        'system_error' => '시스템 오류가 발생했습니다. 지원팀에 문의하세요.',
+        'column_mapping_required_for_new_record' => '새 레코드를 생성하려면 :attribute 열이 파일의 열과 매핑되어야 합니다.',
     ],
 
 ];

--- a/packages/forms/resources/lang/ko/components.php
+++ b/packages/forms/resources/lang/ko/components.php
@@ -11,17 +11,64 @@ return [
             ],
 
             'add' => [
+
                 'label' => ':label 추가',
-            ],
 
+                'modal' => [
+
+                    'heading' => ':label 추가',
+
+                    'actions' => [
+
+                        'add' => [
+                            'label' => '추가',
+                        ],
+
+                    ],
+
+                ],
+            ],
             'add_between' => [
-                'label' => '블록 사이에 삽입',
-            ],
 
+                'label' => '블록 사이에 삽입',
+
+                'modal' => [
+
+                    'heading' => ':label 추가',
+
+                    'actions' => [
+
+                        'add' => [
+                            'label' => '추가',
+                        ],
+
+                    ],
+
+                ],
+            ],
             'delete' => [
                 'label' => '삭제',
             ],
 
+            'edit' => [
+
+                'label' => '수정',
+
+                'modal' => [
+
+                    'heading' => '블록 수정',
+
+                    'actions' => [
+
+                        'save' => [
+                            'label' => '변경사항 저장',
+                        ],
+
+                    ],
+
+                ],
+
+            ],
             'reorder' => [
                 'label' => '이동',
             ],
@@ -352,13 +399,14 @@ return [
 
     'select' => [
 
+
         'actions' => [
 
             'create_option' => [
 
                 'modal' => [
 
-                    'heading' => '만들기',
+                    'heading' => '새로 만들기',
 
                     'actions' => [
 
@@ -367,7 +415,7 @@ return [
                         ],
 
                         'create_another' => [
-                            'label' => '계속 만들기',
+                            'label' => '만들고 다른 것 만들기',
                         ],
 
                     ],
@@ -403,16 +451,15 @@ return [
 
         'loading_message' => '로드 중...',
 
-        'max_items_message' => ':count개 까지 선택할 수 있습니다.',
+        'max_items_message' => ':count개까지만 선택할 수 있습니다.',
 
-        'no_search_results_message' => '검색과 일치하는 옵션이 없습니다.',
+        'no_search_results_message' => '검색 결과가 없습니다.',
 
-        'placeholder' => '옵션 선택',
+        'placeholder' => '옵션을 선택하세요',
 
         'searching_message' => '검색 중...',
 
-        'search_prompt' => '이곳에 입력하여 검색 시작',
-
+        'search_prompt' => '검색어를 입력하세요...',
     ],
 
     'tags_input' => [

--- a/packages/tables/resources/lang/ko/table.php
+++ b/packages/tables/resources/lang/ko/table.php
@@ -10,6 +10,10 @@ return [
 
     'columns' => [
 
+        'actions' => [
+            'label' => '작업|작업들',
+        ],
+
         'text' => [
 
             'actions' => [
@@ -76,11 +80,11 @@ return [
     'actions' => [
 
         'disable_reordering' => [
-            'label' => '재정렬 완료',
+            'label' => '순서 변경 완료',
         ],
 
         'enable_reordering' => [
-            'label' => '항목 재정렬',
+            'label' => '항목 순서 변경',
         ],
 
         'filter' => [
@@ -134,7 +138,7 @@ return [
 
         'heading' => '필터',
 
-        'indicator' => '활성된 필터',
+        'indicator' => '활성화된 필터',
 
         'multi_select' => [
             'placeholder' => '전체',
@@ -224,5 +228,7 @@ return [
         ],
 
     ],
+
+    'default_model_label' => '항목',
 
 ];


### PR DESCRIPTION
## Description

This PR adds improvements and missing translations to the Korean (ko) language files for Filament 4.x. The changes include:

- Added missing modal-related translations in builder actions
- Added missing edit-related translations
- Improved natural language flow and consistency in Korean
- Enhanced clarity of system messages and prompts
- Standardized terminology throughout the translation

Used Claude AI to assist with the translation and refinement process, ensuring natural Korean language usage while maintaining technical accuracy.

## Visual changes

N/A - Translation updates only

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
