### PR TITLE
StatsOverviewWidget using Filament::Grid

### DIFF
--- a/packages/widgets/docs/02-stats-overview.md
+++ b/packages/widgets/docs/02-stats-overview.md
@@ -165,3 +165,22 @@ To disable this behavior, you may override the `$isLazy` property on the widget 
 ```php
 protected static bool $isLazy = false;
 ```
+
+## Changing columns layout
+
+By default, a maximum of 4 stats will apper per row. If you have more than 4 stats, the rows will contain 3 stats each.
+
+You can override this using the `getColumns()` method. Different screen sizes can also be handled using this method.
+
+```php
+protected function getColumns(): int | array
+{
+    return [
+        'sm' => 1,
+        'md' => 2,
+        'lg' => 2,
+        'xl' => 3,
+        '2xl' => 3,
+    ];
+}
+```

--- a/packages/widgets/resources/views/stats-overview-widget.blade.php
+++ b/packages/widgets/resources/views/stats-overview-widget.blade.php
@@ -1,22 +1,28 @@
 @php
     $columns = $this->getColumns();
+    $columns = is_int($columns) ? ['default' => $columns] : $columns;
 @endphp
 
+@props([
+    'columns' => [
+        'lg' => 2,
+    ],
+    'data' => [],
+    'widgets' => [],
+])
+
 <x-filament-widgets::widget class="fi-wi-stats-overview">
-    <div
-        @if ($pollingInterval = $this->getPollingInterval())
-            wire:poll.{{ $pollingInterval }}
-        @endif
-        @class([
-            'fi-wi-stats-overview-stats-ctn grid gap-6',
-            'md:grid-cols-1' => $columns === 1,
-            'md:grid-cols-2' => $columns === 2,
-            'md:grid-cols-3' => $columns === 3,
-            'md:grid-cols-2 xl:grid-cols-4' => $columns === 4,
-        ])
+    <x-filament::grid
+        :default="$columns['default'] ?? 1"
+        :sm="$columns['sm'] ?? null"
+        :md="$columns['md'] ?? null"
+        :lg="$columns['lg'] ?? ($columns ? (is_array($columns) ? null : $columns) : 2)"
+        :xl="$columns['xl'] ?? null"
+        :two-xl="$columns['2xl'] ?? null"
+        :attributes="\Filament\Support\prepare_inherited_attributes($attributes)->class('fi-wi-stats-overview-stats-ctn gap-6')"
     >
         @foreach ($this->getCachedStats() as $stat)
             {{ $stat }}
         @endforeach
-    </div>
+    </x-filament::grid>
 </x-filament-widgets::widget>

--- a/packages/widgets/src/StatsOverviewWidget.php
+++ b/packages/widgets/src/StatsOverviewWidget.php
@@ -20,19 +20,19 @@ class StatsOverviewWidget extends Widget
      */
     protected static string $view = 'filament-widgets::stats-overview-widget';
 
-    protected function getColumns(): int
+    protected function getColumns(): int | array
     {
         $count = count($this->getCachedStats());
 
         if ($count < 3) {
-            return 3;
+            return ['default' => 3];
         }
 
         if (($count % 3) !== 1) {
-            return 3;
+            return ['default' => 3];
         }
 
-        return 4;
+        return ['default' => 4];
     }
 
     /**


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Change `StatsOverviewWidget` to use `Filament::Grid`

Before this change if a user tried to set `getColumns()` on `StatusOverviewWidget` to something greater than 4 it would not properly format the div and end up rendering a single line for each stat.

The code implements `Filament::Grid` and changes `getColumns()` to return `int | array`. For backwards compatibility `int` has been kept and handled in the blade.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

### Before

![image](https://github.com/user-attachments/assets/772ac7e6-3342-43ad-8cbd-56f76f7b9425)

### After

![image](https://github.com/user-attachments/assets/bc0df277-167b-4c6c-991a-0383599e35e6)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
