### PR TITLE
Mitigate Carbon Month Overflow Bug on 31st of a month

### DIFF
--- a/packages/tables/src/Filters/QueryBuilder/Constraints/DateConstraint/Operators/IsMonthOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/DateConstraint/Operators/IsMonthOperator.php
@@ -56,7 +56,7 @@ class IsMonthOperator extends Operator
     {
         return collect(range(1, 12))
             ->mapWithKeys(fn (int $month): array => [
-                $month => now()->setMonth($month)->getTranslatedMonthName(),
+                $month => now()->setMonth($month)->setDay(1)->getTranslatedMonthName(),
             ])
             ->all();
     }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

On the 31st of each month, the month selector for for the month filter breaks. The months retrieved in getMonths() will output:

```php
January
March
March
May
May
July
July
August
October
October
December
December
```

To mitigate this, we set the day to the first day of the month.

Related Carbon Issues: https://github.com/briannesbitt/Carbon/issues/3097, https://github.com/briannesbitt/Carbon/issues/2317

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

none

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
