### PR TITLE
Disallow EXIF data from uploads to be deleted when resizing

### DIFF
--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -116,6 +116,7 @@ export default function fileUploadFormComponent({
                 imageResizeTargetWidth,
                 imageResizeMode,
                 imageResizeUpscale,
+                imageTransformOutputStripImageHead: false,
                 itemInsertLocation: shouldAppendFiles ? 'after' : 'before',
                 ...(placeholder && { labelIdle: placeholder }),
                 maxFiles,


### PR DESCRIPTION
## Description

Atm, when you upload an image without transforming it, then all EXIF data is retained. As soon as a transformation happens, tho, the EXIF data is stripped due to the default setting for `imageTransformOutputStripImageHead` being `true`.  This PR just makes it consistent to always retain the EXIF data.

See https://pqina.nl/filepond/docs/api/plugins/image-transform/#properties

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
