### PR TITLE
Add Customizable Column Display for Export Modal in Filament

### DIFF
--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -62,6 +62,8 @@ trait CanExportRecords
 
     protected bool | Closure $hasColumnMapping = true;
 
+    protected array | int | string | Closure $columns = 1;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -76,7 +78,7 @@ trait CanExportRecords
 
         $this->form(fn (ExportAction | ExportTableAction | ExportTableBulkAction $action): array => [
             ...($action->hasColumnMapping() ? [Fieldset::make(__('filament-actions::export.modal.form.columns.label'))
-                ->columns(1)
+                ->columns($this->getColumns())
                 ->inlineLabel()
                 ->schema(function () use ($action): array {
                     return array_map(
@@ -306,6 +308,13 @@ trait CanExportRecords
         return $this;
     }
 
+    public function columns(array | int | string | Closure $columns): static
+    {
+        $this->columns = $columns;
+
+        return $this;
+    }
+
     /**
      * @return class-string<Exporter>
      */
@@ -330,6 +339,11 @@ trait CanExportRecords
     public function getMaxRows(): ?int
     {
         return $this->evaluate($this->maxRows);
+    }
+
+    public function getColumns(): array | int | string
+    {
+        return $this->evaluate($this->columns);
     }
 
     /**


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This pull request introduces the option to customize the number of columns displayed in the export modal's column selection view. With this enhancement, users can now define how many columns they wish to show, providing a more flexible and user-friendly export experience. This feature is particularly helpful for users managing large datasets, as it improves the readability and usability of the selection modal.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

![image](https://github.com/user-attachments/assets/04d0d6aa-18b4-432f-8688-3b813677ca7d)

![image](https://github.com/user-attachments/assets/a05a2b71-fa97-430f-8818-95e6a9ed306b)


<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
