### PR TITLE
Hide option Remove all filters

### DIFF
--- a/packages/tables/resources/views/components/filters/indicators.blade.php
+++ b/packages/tables/resources/views/components/filters/indicators.blade.php
@@ -31,7 +31,7 @@
         </div>
     </div>
 
-    @if (collect($indicators)->contains(fn ($indicator) => $indicator->isRemovable()))
+    @if (collect($indicators)->contains(fn (\Filament\Tables\Filters\Indicator $indicator): bool => $indicator->isRemovable()))
         <div class="mt-0.5">
             <x-filament::icon-button
                 color="gray"

--- a/packages/tables/resources/views/components/filters/indicators.blade.php
+++ b/packages/tables/resources/views/components/filters/indicators.blade.php
@@ -1,15 +1,19 @@
 @props([
-    'indicators' => [],
+    "indicators" => [],
 ])
 
+@php
+    $showRemoveAll = collect($indicators)->contains(fn ($indicator) => $indicator->isRemovable());
+@endphp
+
 <div
-    {{ $attributes->class(['fi-ta-filter-indicators flex items-start justify-between gap-x-3 bg-gray-50 px-3 py-1.5 dark:bg-white/5 sm:px-6']) }}
+    {{ $attributes->class(["fi-ta-filter-indicators flex items-start justify-between gap-x-3 bg-gray-50 px-3 py-1.5 dark:bg-white/5 sm:px-6"]) }}
 >
     <div class="flex flex-col gap-x-3 gap-y-1 sm:flex-row">
         <span
             class="whitespace-nowrap text-sm font-medium leading-6 text-gray-700 dark:text-gray-200"
         >
-            {{ __('filament-tables::table.filters.indicator') }}
+            {{ __("filament-tables::table.filters.indicator") }}
         </span>
 
         <div class="flex flex-wrap gap-1.5">
@@ -31,15 +35,17 @@
         </div>
     </div>
 
-    <div class="mt-0.5">
-        <x-filament::icon-button
-            color="gray"
-            icon="heroicon-m-x-mark"
-            icon-alias="tables::filters.remove-all-button"
-            size="sm"
-            :tooltip="__('filament-tables::table.filters.actions.remove_all.tooltip')"
-            wire:click="removeTableFilters"
-            wire:target="removeTableFilters,removeTableFilter"
-        />
-    </div>
+    @if ($showRemoveAll)
+        <div class="mt-0.5">
+            <x-filament::icon-button
+                color="gray"
+                icon="heroicon-m-x-mark"
+                icon-alias="tables::filters.remove-all-button"
+                size="sm"
+                :tooltip="__('filament-tables::table.filters.actions.remove_all.tooltip')"
+                wire:click="removeTableFilters"
+                wire:target="removeTableFilters,removeTableFilter"
+            />
+        </div>
+    @endif
 </div>

--- a/packages/tables/resources/views/components/filters/indicators.blade.php
+++ b/packages/tables/resources/views/components/filters/indicators.blade.php
@@ -1,19 +1,15 @@
 @props([
-    "indicators" => [],
+    'indicators' => [],
 ])
 
-@php
-    $showRemoveAll = collect($indicators)->contains(fn ($indicator) => $indicator->isRemovable());
-@endphp
-
 <div
-    {{ $attributes->class(["fi-ta-filter-indicators flex items-start justify-between gap-x-3 bg-gray-50 px-3 py-1.5 dark:bg-white/5 sm:px-6"]) }}
+    {{ $attributes->class(['fi-ta-filter-indicators flex items-start justify-between gap-x-3 bg-gray-50 px-3 py-1.5 dark:bg-white/5 sm:px-6']) }}
 >
     <div class="flex flex-col gap-x-3 gap-y-1 sm:flex-row">
         <span
             class="whitespace-nowrap text-sm font-medium leading-6 text-gray-700 dark:text-gray-200"
         >
-            {{ __("filament-tables::table.filters.indicator") }}
+            {{ __('filament-tables::table.filters.indicator') }}
         </span>
 
         <div class="flex flex-wrap gap-1.5">
@@ -35,7 +31,7 @@
         </div>
     </div>
 
-    @if ($showRemoveAll)
+    @if (collect($indicators)->contains(fn ($indicator) => $indicator->isRemovable()))
         <div class="mt-0.5">
             <x-filament::icon-button
                 color="gray"


### PR DESCRIPTION
## Description

Evaluate if all filter indicators can be removed; hide option to remove all filters if none are removable `$indicator->isRemovable() = false`

## Visual changes
Hide option.
![image](https://github.com/user-attachments/assets/ffe79808-0d86-4f4e-8432-5ba7d7afa14e)

Show option.
![image](https://github.com/user-attachments/assets/a132fc93-6567-4c82-865c-b268572f6472)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
