### PR TITLE
Allow rendering HTML in CheckboxList label

### DIFF
--- a/packages/forms/docs/03-fields/06-checkbox-list.md
+++ b/packages/forms/docs/03-fields/06-checkbox-list.md
@@ -45,6 +45,26 @@ class App extends Model
 }
 ```
 
+## Allowing HTML in the option labels
+
+By default, Filament will escape any HTML in the option labels. If you'd like to allow HTML, you can use the `allowHtml()` method:
+
+```php
+use Filament\Forms\Components\CheckboxList;
+
+CheckboxList::make('technology')
+    ->options([
+        'tailwind' => '<span class="text-blue-500">Tailwind</span>',
+        'alpine' => '<span class="text-green-500">Alpine</span>',
+        'laravel' => '<span class="text-red-500">Laravel</span>',
+        'livewire' => '<span class="text-pink-500">Livewire</span>',
+    ])
+    ->searchable()
+    ->allowHtml()
+```
+
+Be aware that you will need to ensure that the HTML is safe to render, otherwise your application will be vulnerable to XSS attacks.
+
 ## Setting option descriptions
 
 You can optionally provide descriptions to each option using the `descriptions()` method. This method accepts an array of plain text strings, or instances of `Illuminate\Support\HtmlString` or `Illuminate\Contracts\Support\Htmlable`. This allows you to render HTML, or even markdown, in the descriptions:

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -202,7 +202,7 @@
                             <span
                                 class="fi-fo-checkbox-list-option-label overflow-hidden break-words font-medium text-gray-950 dark:text-white"
                             >
-                                @if ($isHtmlAllowed)
+                                @if ($isHtmlAllowed())
                                     {!! $label !!}
                                 @else
                                     {{ $label }}

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -202,7 +202,11 @@
                             <span
                                 class="fi-fo-checkbox-list-option-label overflow-hidden break-words font-medium text-gray-950 dark:text-white"
                             >
-                                {{ $label }}
+                                @if ($isHtmlAllowed)
+                                    {!! $label !!}
+                                @else
+                                    {{ $label }}
+                                @endif
                             </span>
 
                             @if ($hasDescription($value))

--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -4,6 +4,7 @@ namespace Filament\Forms\Components;
 
 use Closure;
 use Filament\Forms\Components\Actions\Action;
+use Filament\Forms\Components\Concerns\CanAllowHtml;
 use Filament\Support\Enums\ActionSize;
 use Filament\Support\Services\RelationshipJoiner;
 use Illuminate\Contracts\Support\Htmlable;
@@ -15,6 +16,7 @@ use Illuminate\Support\Str;
 
 class CheckboxList extends Field implements Contracts\CanDisableOptions, Contracts\HasNestedRecursiveValidationRules
 {
+    use CanAllowHtml;
     use Concerns\CanBeSearchable;
     use Concerns\CanDisableOptions;
     use Concerns\CanDisableOptionsWhenSelectedInSiblingRepeaterItems;

--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -4,7 +4,6 @@ namespace Filament\Forms\Components;
 
 use Closure;
 use Filament\Forms\Components\Actions\Action;
-use Filament\Forms\Components\Concerns\CanAllowHtml;
 use Filament\Support\Enums\ActionSize;
 use Filament\Support\Services\RelationshipJoiner;
 use Illuminate\Contracts\Support\Htmlable;
@@ -16,7 +15,7 @@ use Illuminate\Support\Str;
 
 class CheckboxList extends Field implements Contracts\CanDisableOptions, Contracts\HasNestedRecursiveValidationRules
 {
-    use CanAllowHtml;
+    use Concerns\CanAllowHtml;
     use Concerns\CanBeSearchable;
     use Concerns\CanDisableOptions;
     use Concerns\CanDisableOptionsWhenSelectedInSiblingRepeaterItems;


### PR DESCRIPTION
## Description

Allows you to use `allowHtml()` with the `CheckboxList`.

```php
$this->allowHtml()
    ->getOptionLabelFromRecordUsing(function (Model $record) {
        return view('custom-view', [])->render();
    });
```

## Visual changes
![Scherm­afbeelding 2024-11-05 om 19 37 43](https://github.com/user-attachments/assets/8fef3316-87ab-4d7e-9084-072a1524fa2d)

![Scherm­afbeelding 2024-11-05 om 19 35 54](https://github.com/user-attachments/assets/04f68d93-4208-4754-8658-620346d146e4)


## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
