### PR TITLE
Fix/fixe missing translation for french

### DIFF
--- a/packages/actions/resources/lang/fr/import.php
+++ b/packages/actions/resources/lang/fr/import.php
@@ -75,6 +75,7 @@ return [
         'file_name' => 'import-:import_id-:csv_name-failed-rows',
         'error_header' => 'error',
         'system_error' => 'Erreur système, veuillez contacter le support.',
+        'column_mapping_required_for_new_record' => 'La colonne n\'a pas été associée à une colonne dans le fichier, mais elle est requise pour créer de nouveaux enregistrements.',
     ],
 
 ];

--- a/packages/tables/resources/lang/fr/table.php
+++ b/packages/tables/resources/lang/fr/table.php
@@ -10,6 +10,10 @@ return [
 
     'columns' => [
 
+        'actions' => [
+            'label' => 'Action|Actions',
+        ],
+
         'text' => [
 
             'actions' => [


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR fixe the missing french translations for `column_mapping_required_for_new_record` in `import.php` file and 
`columns.actions.label` in `table.php` file . 

