### PR TITLE
Add missing Spanish translation for columns.label in table.php

### DIFF
--- a/packages/tables/resources/lang/es/table.php
+++ b/packages/tables/resources/lang/es/table.php
@@ -10,6 +10,10 @@ return [
 
     'columns' => [
 
+        'actions' => [
+            'label' => 'Acción|Acciones',
+        ],
+
         'text' => [
 
             'actions' => [


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR fixe the missing Spanish translations for columns.actions.label in table.php file .
