### PR TITLE
Use `local` instead of `public` disk for exports where available

### DIFF
--- a/packages/actions/docs/01-installation.md
+++ b/packages/actions/docs/01-installation.md
@@ -147,14 +147,6 @@ Create a new `resources/views/components/layouts/app.blade.php` layout file for 
 </html>
 ```
 
-## Deploying to production
-
-### Using a production-ready storage disk
-
-Filament has a storage disk defined in the [configuration](#publishing-configuration), which by default is set to `public`. You can set the `FILAMENT_FILESYSTEM_DISK` environment variable to change this.
-
-The `public` disk, while great for easy local development, is not suitable for production. It does not support file visibility, so features of Filament such as [exports](prebuilt-actions/export) will create public files. In production, you need to use a production-ready disk such as `s3` with a private access policy, to prevent unauthorized access to the exported files.
-
 ## Publishing configuration
 
 You can publish the package configuration using the following command (optional):

--- a/packages/actions/docs/07-prebuilt-actions/09-export.md
+++ b/packages/actions/docs/07-prebuilt-actions/09-export.md
@@ -4,8 +4,6 @@ title: Export action
 
 ## Overview
 
-> Please note that this feature uses the Filament filesystem to store exported files. The disk used by the Filament filesystem is defined in the [configuration file](../installation#publishing-configuration). By default, the disk is set to `public` for easy local development, so when using Filament exports in production, please make sure that you use a production-ready disk such as `s3` with a private access policy. You may also consider [customizing the storage disk](#customizing-the-storage-disk) for exports only.
-
 Filament v3.2 introduced a prebuilt action that is able to export rows to a CSV or XLSX file. When the trigger button is clicked, a modal asks for the columns that they want to export, and what they should be labeled. This feature uses [job batches](https://laravel.com/docs/queues#job-batching) and [database notifications](../../notifications/database-notifications#overview), so you need to publish those migrations from Laravel. Also, you need to publish the migrations for tables that Filament uses to store information about exports:
 
 ```bash
@@ -380,7 +378,11 @@ public static function modifyQuery(Builder $query): Builder
 
 ### Customizing the storage disk
 
-By default, exported files will be uploaded to the storage disk defined in the [configuration file](../installation#publishing-configuration), which is `public` by default. You can set the `FILAMENT_FILESYSTEM_DISK` environment variable to change this. In production, you need to use a production-ready disk such as `s3` with a private access policy, to prevent unauthorized access to the exported files.
+By default, exported files will be uploaded to the storage disk defined in the [configuration file](../installation#publishing-configuration), which is `public` by default. You can set the `FILAMENT_FILESYSTEM_DISK` environment variable to change this.
+
+While using the `public` disk a good default for many parts of Filament, using it for exports would result in exported files being stored in a public location. As such, if the default filesystem disk is `public` and a `local` disk exists in your `config/filesystems.php`, Filament will use the `local` disk for exports instead. If you override the disk to be `public` for an `ExportAction` or inside an exporter class, Filament will use that.
+
+In production, you should use a disk such as `s3` with a private access policy, to prevent unauthorized access to the exported files.
 
 If you want to use a different disk for a specific export, you can pass the disk name to the `disk()` method on the action:
 

--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -143,7 +143,13 @@ abstract class Exporter
 
     public function getFileDisk(): string
     {
-        return config('filament.default_filesystem_disk');
+        $disk = config('filament.default_filesystem_disk');
+
+        if (($disk === 'public') && array_key_exists('local', config('filesystems.disks'))) {
+            return 'local';
+        }
+
+        return $disk;
     }
 
     public function getFileName(Export $export): string

--- a/packages/panels/docs/01-installation.md
+++ b/packages/panels/docs/01-installation.md
@@ -116,7 +116,7 @@ Learn more about [users](users).
 
 Filament has a storage disk defined in the [configuration](#publishing-configuration), which by default is set to `public`. You can set the `FILAMENT_FILESYSTEM_DISK` environment variable to change this.
 
-The `public` disk, while great for easy local development, is not suitable for production. It does not support file visibility, so features of Filament such as [exports](../actions/prebuilt-actions/export) will create public files. In production, you need to use a production-ready disk such as `s3` with a private access policy, to prevent unauthorized access to the exported files.
+The `public` disk, while great for easy local development, is not suitable for production. It does not support file visibility, so features of Filament such as [file uploads](../forms/fields/file-upload) will create public files. In production, you need to use a production-ready disk such as `s3` with a private access policy, to prevent unauthorized access to the uploaded files.
 
 ## Publishing configuration
 


### PR DESCRIPTION
All Filament features that interact with storage use the `default_filesystem_disk` config option. This allows the user to easily swap their storage driver to something production-ready like `s3` when deploying their app, without having to touch multiple configuration options and potentially forgetting about some.

The default disk is set to `public` when you first install Filament, since this allows users to quickly get started developing with a functional disk that allows features such as file upload previews locally without the need to set up an S3 disk with temporary URL support.

However, some features of Filament such as exports also rely on storage, and the files that are stored contain data that should often not be public. This is not an issue for the many deployed applications, since many use a secure default disk such as S3 in production. However, [CWE-1188](https://cwe.mitre.org/data/definitions/1188.html) suggests that having the `public` disk as the default disk in Filament is a security vulnerability itself:

> Developers often choose default values that leave the product as open and easy to use as possible out-of-the-box, under the assumption that the administrator can (or should) change the default value. However, this ease-of-use comes at a cost when the default is insecure and the administrator does not change it.

As such, we have implemented a measure to protect users whereby if the `public` disk is set as the default disk, the exports feature will automatically swap it out for the `local` disk, if that exists. Users who set the default disk to `local` or `s3` already are not affected. If a user wants to continue to use the `public` disk for exports, they can by [setting the export disk](https://filamentphp.com/docs/3.x/actions/prebuilt-actions/export#customizing-the-storage-disk) deliberately.