### PR TITLE
Fix/missing translation for arabic

### DIFF
--- a/packages/actions/resources/lang/ar/import.php
+++ b/packages/actions/resources/lang/ar/import.php
@@ -75,6 +75,7 @@ return [
         'file_name' => 'import-:import_id-:csv_name-failed-rows',
         'error_header' => 'خطأ',
         'system_error' => 'خطأ في النظام، يرجى الاتصال بالدعم.',
+        'column_mapping_required_for_new_record' => 'لم يتم تعيين العمود :attribut إلى عمود في الملف، ولكنه مطلوب لإنشاء سجلات جديدة.',
     ],
 
 ];

--- a/packages/tables/resources/lang/ar/table.php
+++ b/packages/tables/resources/lang/ar/table.php
@@ -10,6 +10,10 @@ return [
 
     'columns' => [
 
+        'actions' => [
+            'label' => 'إجراء | إجراءات',
+        ],
+
         'text' => [
 
             'actions' => [


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR fixe the missing Arabic translations for columns.actions.label in table.php file and failure_csv.column_mapping_required_for_new_record in import.php file .
