### PR TITLE
Add backed enum for $abilities type

### DIFF
--- a/packages/actions/src/Concerns/CanBeHidden.php
+++ b/packages/actions/src/Concerns/CanBeHidden.php
@@ -39,10 +39,10 @@ trait CanBeHidden
     }
 
     /**
-     * @param  string | array<string> | BackedEnum  $abilities
+     * @param  string | BackedEnum | array<string>  $abilities
      * @param  Model | array<mixed> | null  $arguments
      */
-    public function authorizeAny(string | array | BackedEnum $abilities, Model | array | null $arguments = null): static
+    public function authorizeAny(string | BackedEnum | array $abilities, Model | array | null $arguments = null): static
     {
         if ($abilities instanceof BackedEnum) {
             $abilities = $abilities->value;

--- a/packages/actions/src/Concerns/CanBeHidden.php
+++ b/packages/actions/src/Concerns/CanBeHidden.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Actions\Concerns;
 
+use BackedEnum;
 use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
@@ -20,6 +21,10 @@ trait CanBeHidden
      */
     public function authorize(mixed $abilities, Model | string | array | null $arguments = null): static
     {
+        if ($abilities instanceof BackedEnum) {
+            $abilities = $abilities->value;
+        }
+
         if (is_string($abilities) || is_array($abilities)) {
             $this->authorization = [
                 'type' => 'all',
@@ -34,11 +39,15 @@ trait CanBeHidden
     }
 
     /**
-     * @param  string | array<string>  $abilities
+     * @param  string | array<string> | BackedEnum  $abilities
      * @param  Model | array<mixed> | null  $arguments
      */
-    public function authorizeAny(string | array $abilities, Model | array | null $arguments = null): static
+    public function authorizeAny(string | array | BackedEnum $abilities, Model | array | null $arguments = null): static
     {
+        if ($abilities instanceof BackedEnum) {
+            $abilities = $abilities->value;
+        }
+
         $this->authorization = [
             'type' => 'any',
             'abilities' => Arr::wrap($abilities),


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Laravel v11.23 added BackedEnum support to Gate methods, this PR adds it to filament as well for consistency.

(I added the logic so as not to cause BC changes for pre v11.23 versions)

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [n/a] Changes have been tested to not break existing functionality.
- [n/a] Documentation is up-to-date.
