### PR TITLE
feat : ignore cache control

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasComponents.php
+++ b/packages/panels/src/Panel/Concerns/HasComponents.php
@@ -101,10 +101,11 @@ trait HasComponents
 
     /**
      * @param  array<class-string>  $pages
+     * @param  bool  $ignoreCached
      */
-    public function pages(array $pages): static
+    public function pages(array $pages, bool $ignoreCached = false): static
     {
-        if ($this->hasCachedComponents()) {
+        if ($this->hasCachedComponents() && !$ignoreCached) {
             return $this;
         }
 
@@ -123,10 +124,11 @@ trait HasComponents
 
     /**
      * @param  array<class-string>  $resources
+     * @param  bool  $ignoreCached
      */
-    public function resources(array $resources): static
+    public function resources(array $resources, bool $ignoreCached = false): static
     {
-        if ($this->hasCachedComponents()) {
+        if ($this->hasCachedComponents() && !$ignoreCached) {
             return $this;
         }
 
@@ -161,10 +163,11 @@ trait HasComponents
 
     /**
      * @param  array<class-string<Widget> | WidgetConfiguration>  $widgets
+     * @param  bool  $ignoreCached
      */
-    public function widgets(array $widgets): static
+    public function widgets(array $widgets, bool $ignoreCached = false): static
     {
-        if ($this->hasCachedComponents()) {
+        if ($this->hasCachedComponents() && !$ignoreCached) {
             return $this;
         }
 


### PR DESCRIPTION
## Description

Add a parameter to bypass the cache system when running the `widgets`, `pages`, or `resources` methods. This can be used for a dynamic system that wants to keep the static content cached but load independent dynamic modules alongside.

## Visual changes

Before : 
`$panel->resources($resources);`

After : 
`$panel->resources($resources, ignoreCached: true);`

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
