### PR TITLE
fix(Page): allow the use of MaxWidth enum

### DIFF
--- a/packages/panels/src/Pages/Concerns/HasMaxWidth.php
+++ b/packages/panels/src/Pages/Concerns/HasMaxWidth.php
@@ -6,7 +6,7 @@ use Filament\Support\Enums\MaxWidth;
 
 trait HasMaxWidth
 {
-    protected ?string $maxWidth = null;
+    protected MaxWidth | string | null $maxWidth = null;
 
     public function getMaxWidth(): MaxWidth | string | null
     {


### PR DESCRIPTION
## Description

Currently, both the view and property getter allows the use of the MaxWidth enum, however, the class property only allows string or null.

This PR fixes that.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
