### PR TITLE
fix: global search in SPA mode when switching tenants

### DIFF
--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -152,13 +152,13 @@
         @endif
 
         <div
-            x-persist="topbar.end"
+            x-persist="topbar.end{{ filament()->hasTenancy() ? '-' . filament()->getTenant()->getKey() : '' }}"
             class="ms-auto flex items-center gap-x-4"
         >
             {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::GLOBAL_SEARCH_BEFORE) }}
 
             @if (filament()->isGlobalSearchEnabled())
-                @livewire(Filament\Livewire\GlobalSearch::class, key('global-search' . (filament()->hasTenancy() ? '-' . filament()->getTenant()->getKey() : '')))
+                @livewire(Filament\Livewire\GlobalSearch::class)
             @endif
 
             {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::GLOBAL_SEARCH_AFTER) }}

--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -152,7 +152,11 @@
         @endif
 
         <div
-            x-persist="topbar.end{{ filament()->hasTenancy() ? '-' . filament()->getTenant()->getKey() : '' }}"
+            @if (filament()->hasTenancy())
+                x-persist="topbar.end-{{ filament()->getTenant()->getKey() }}"
+            @else
+                x-persist="topbar.end"
+            @endif
             class="ms-auto flex items-center gap-x-4"
         >
             {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::GLOBAL_SEARCH_BEFORE) }}

--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -158,7 +158,7 @@
             {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::GLOBAL_SEARCH_BEFORE) }}
 
             @if (filament()->isGlobalSearchEnabled())
-                @livewire(Filament\Livewire\GlobalSearch::class)
+                @livewire(Filament\Livewire\GlobalSearch::class, key('global-search' . (filament()->hasTenancy() ? '-' . filament()->getTenant()->getKey() : '')))
             @endif
 
             {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::GLOBAL_SEARCH_AFTER) }}

--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -153,7 +153,7 @@
 
         <div
             @if (filament()->hasTenancy())
-                x-persist="topbar.end-{{ filament()->getTenant()->getKey() }}"
+                x-persist="topbar.end.tenant-{{ filament()->getTenant()?->getKey() }}"
             @else
                 x-persist="topbar.end"
             @endif

--- a/packages/tables/resources/lang/az/table.php
+++ b/packages/tables/resources/lang/az/table.php
@@ -120,7 +120,6 @@ return [
                 'label' => 'Filtrləri tətbiq et',
             ],
 
-
             'remove' => [
                 'label' => 'Filtri yığışdır',
             ],


### PR DESCRIPTION
## Description

This PR fixes the global search issue, where the GlobalSearch is not reset after switching tenants in SPA mode. The reason that it was not taking the new `Filament::getTenant()` is that the component was inside an `x-persist`, so that means that it was not re-mounted and that it would keep the previous URL path also with the previous tenant inside it. As Livewire mocks the original request, this resulted in the previous tenant being used for search.

This solution changes it by adding the current tenant ID to the `x-persist` identifier, so that the topbar end is persisted when navigating within the same tenant, but is refreshed and re-mounted when switching tenants.

Another benefit is that this will re-load the notifications and the user menu, so in case the user avatar or something changed, that would also benefit from the re-load and not getting persisted.

PS: Also, I'm not sure if `x-persist` is officially documented, so perhaps better to switch to `@persist` (though you likely have had your reasons/preference).

Thanks!

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
