### PR TITLE
Docs - Actions - Testing - Signature of setActionData()

### DIFF
--- a/packages/actions/docs/09-testing.md
+++ b/packages/actions/docs/09-testing.md
@@ -62,7 +62,7 @@ it('can send invoices', function () {
         'invoice' => $invoice,
     ])
         ->mountAction('send')
-        ->setActionData('send', data: [
+        ->setActionData([
             'email' => $email = fake()->email(),
         ])
 });

--- a/packages/forms/docs/09-testing.md
+++ b/packages/forms/docs/09-testing.md
@@ -390,7 +390,7 @@ it('can send invoices', function () {
         'invoice' => $invoice,
     ])
         ->mountFormComponentAction('customer_id', 'send')
-        ->setFormComponentActionData('customer_id', 'send', data: [
+        ->setFormComponentActionData([
             'email' => $email = fake()->email(),
         ])
 });

--- a/packages/infolists/docs/08-testing.md
+++ b/packages/infolists/docs/08-testing.md
@@ -62,7 +62,7 @@ it('can send invoices', function () {
         'invoice' => $invoice,
     ])
         ->mountInfolistAction('customer', 'send')
-        ->setInfolistActionData('customer', 'send', data: [
+        ->setInfolistActionData([
             'email' => $email = fake()->email(),
         ])
 });


### PR DESCRIPTION
## Description

The `setActionData` function only expects an array of the data because it depends on the currently mounted action. Currently, the action name is also provided as the first parameter. 

## Functional changes

- [x] Documentation is up-to-date.
