### PR TITLE
Fixed bug on windows where the system puts \ instead of / while forming the s3 url (Import action).

### DIFF
--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -398,7 +398,7 @@ trait CanImportRecords
 
             invade($s3Adapter)->client->registerStreamWrapper(); /** @phpstan-ignore-line */
             
-            $fileS3Path = str_replace('\\','/','s3://' . config("filesystems.disks.{$fileDisk}.bucket") . '/' . $filePath);
+            $fileS3Path = (string) str('s3://' . config("filesystems.disks.{$fileDisk}.bucket") . '/' . $filePath)->replace('\\', '/');
 
             $resource = fopen($fileS3Path, mode: 'r', context: stream_context_create([
                 's3' => [

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -397,7 +397,8 @@ trait CanImportRecords
             $s3Adapter = Storage::disk($fileDisk)->getAdapter();
 
             invade($s3Adapter)->client->registerStreamWrapper(); /** @phpstan-ignore-line */
-            $fileS3Path = 's3://' . config("filesystems.disks.{$fileDisk}.bucket") . '/' . $filePath;
+            
+            $fileS3Path = str_replace('\\','/','s3://' . config("filesystems.disks.{$fileDisk}.bucket") . '/' . $filePath);
 
             $resource = fopen($fileS3Path, mode: 'r', context: stream_context_create([
                 's3' => [


### PR DESCRIPTION
Fixed bug on windows where the system puts \ instead of / while forming the s3 url.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When using the import action on windows, it throws an error when trying to get the file from the s3 storage. This happens because windows tries to build the url with \ instead of /. This commit fixes it.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

None

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
