### PR TITLE
Add missing section "Lifecycle hooks" for ViewRecord

### DIFF
--- a/packages/panels/docs/03-resources/05-viewing-records.md
+++ b/packages/panels/docs/03-resources/05-viewing-records.md
@@ -102,6 +102,30 @@ protected function mutateFormDataBeforeFill(array $data): array
 
 Alternatively, if you're viewing records in a modal action, check out the [Actions documentation](../../actions/prebuilt-actions/view#customizing-data-before-filling-the-form).
 
+## Lifecycle hooks
+Hooks may be used to execute code at various points within a page's lifecycle, like before a form is filled. To set up a hook, create a protected method on the View page class with the name of the hook:
+
+There are several available hooks for the View pages:
+
+```php
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewUser extends ViewRecord
+{
+    // ...
+
+    protected function beforeFill(): void
+    {
+        // Runs before the form fields are populated from the database.
+    }
+
+    protected function afterFill(): void
+    {
+        // Runs after the form fields are populated from the database.
+    }
+}
+```
+
 ## Authorization
 
 For authorization, Filament will observe any [model policies](https://laravel.com/docs/authorization#creating-policies) that are registered in your app.

--- a/packages/panels/docs/03-resources/05-viewing-records.md
+++ b/packages/panels/docs/03-resources/05-viewing-records.md
@@ -103,9 +103,8 @@ protected function mutateFormDataBeforeFill(array $data): array
 Alternatively, if you're viewing records in a modal action, check out the [Actions documentation](../../actions/prebuilt-actions/view#customizing-data-before-filling-the-form).
 
 ## Lifecycle hooks
-Hooks may be used to execute code at various points within a page's lifecycle, like before a form is filled. To set up a hook, create a protected method on the View page class with the name of the hook:
 
-There are several available hooks for the View pages:
+Hooks may be used to execute code at various points within a page's lifecycle, like before a form is filled. To set up a hook, create a protected method on the View page class with the name of the hook:
 
 ```php
 use Filament\Resources\Pages\ViewRecord;
@@ -116,12 +115,12 @@ class ViewUser extends ViewRecord
 
     protected function beforeFill(): void
     {
-        // Runs before the form fields are populated from the database.
+        // Runs before the disabled form fields are populated from the database. Not run on pages using an infolist.
     }
 
     protected function afterFill(): void
     {
-        // Runs after the form fields are populated from the database.
+        // Runs after the disabled form fields are populated from the database. Not run on pages using an infolist.
     }
 }
 ```


### PR DESCRIPTION
## Description

This PR adds the section "Lifecycle hooks" for ViewRecord page documentation. ViewRecord page supports `beforeFill` and `afterFill` hooks but the documentation did not mention it. I recently needed and found that these hooks are supported by digging into source code. I think it will be beneficial to mention in docs. 

## Visual changes



## Functional changes
NA
