### PR TITLE
Improve table header cell design

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -857,7 +857,6 @@
                                         ->class([
                                             'fi-table-header-cell-' . str($column->getName())->camel()->kebab(),
                                             'w-full' => blank($columnWidth) && $column->canGrow(default: false),
-                                            '[&:not(:first-of-type)]:border-s [&:not(:last-of-type)]:border-e border-gray-200 dark:border-white/5' => $column->getGroup(),
                                             $getHiddenClasses($column),
                                         ])
                                         ->style([


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When using table column groups, all header cells would get a border.
This isn't needed since the group cells already have borders around them.

## Visual changes

### Before

<img width="1142" alt="Screenshot 2024-11-14 at 10 49 20" src="https://github.com/user-attachments/assets/91779742-7450-4117-8a61-609aeb314ac8">

### After

<img width="1142" alt="Screenshot 2024-11-14 at 10 47 22" src="https://github.com/user-attachments/assets/9e6c5748-c913-4e54-bc25-d81ecbe23a90">

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
