### PR TITLE
Add nestedRecursiveRules to ToggleButtons

### DIFF
--- a/packages/forms/resources/lang/tr/components.php
+++ b/packages/forms/resources/lang/tr/components.php
@@ -412,7 +412,7 @@ return [
         'searching_message' => 'Aranıyor...',
 
         'search_prompt' => 'Aramak için yazmaya başlayın...',
-    
+
     ],
 
     'tags_input' => [

--- a/packages/forms/src/Components/ToggleButtons.php
+++ b/packages/forms/src/Components/ToggleButtons.php
@@ -15,6 +15,7 @@ class ToggleButtons extends Field implements Contracts\CanDisableOptions
     use Concerns\HasGridDirection;
     use Concerns\HasIcons;
     use Concerns\HasOptions;
+    use Concerns\HasNestedRecursiveValidationRules;
 
     public const GROUPED_VIEW = 'filament-forms::components.toggle-buttons.grouped';
 

--- a/packages/forms/src/Components/ToggleButtons.php
+++ b/packages/forms/src/Components/ToggleButtons.php
@@ -14,8 +14,8 @@ class ToggleButtons extends Field implements Contracts\CanDisableOptions
     use Concerns\HasExtraInputAttributes;
     use Concerns\HasGridDirection;
     use Concerns\HasIcons;
-    use Concerns\HasOptions;
     use Concerns\HasNestedRecursiveValidationRules;
+    use Concerns\HasOptions;
 
     public const GROUPED_VIEW = 'filament-forms::components.toggle-buttons.grouped';
 


### PR DESCRIPTION
## Description

This PR adds the missing trait to be able to define array rules on `ToggleButtons::make('foo')->multiple()`

