### PR TITLE
Add automatic scrolling of wizard steps

### DIFF
--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -39,9 +39,9 @@
 
         scroll: function () {
             this.$nextTick(() => {
-                this.$root.scrollIntoView({ behavior: 'smooth', block: 'start' })
-
-                this.$refs.header.children[this.getStepIndex(this.step)].scrollIntoView({ behavior: 'smooth', block: 'start' })
+                this.$refs.header.children[
+                    this.getStepIndex(this.step)
+                ].scrollIntoView({ behavior: 'smooth', block: 'start' })
             })
         },
 

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -41,7 +41,7 @@
             this.$nextTick(() => {
                 this.$root.scrollIntoView({ behavior: 'smooth', block: 'start' })
 
-                this.$refs.headerSteps.children[this.getStepIndex(this.step)].scrollIntoView({ behavior: 'smooth', block: 'start' })
+                this.$refs.header.children[this.getStepIndex(this.step)].scrollIntoView({ behavior: 'smooth', block: 'start' })
             })
         },
 
@@ -137,7 +137,7 @@
             'border-b border-gray-200 dark:border-white/10' => $isContained,
             'rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10' => ! $isContained,
         ])
-        x-ref="headerSteps"
+        x-ref="header"
     >
         @foreach ($getChildComponentContainer()->getComponents() as $step)
             <li

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -21,7 +21,7 @@
             this.step = this.getSteps()[nextStepIndex]
 
             this.autofocusFields()
-            this.scrollToTop()
+            this.scroll()
         },
 
         previousStep: function () {
@@ -34,13 +34,15 @@
             this.step = this.getSteps()[previousStepIndex]
 
             this.autofocusFields()
-            this.scrollToTop()
+            this.scroll()
         },
 
-        scrollToTop: function () {
-            this.$nextTick(() =>
-                this.$root.scrollIntoView({ behavior: 'smooth', block: 'start' }),
-            )
+        scroll: function () {
+            this.$nextTick(() => {
+                this.$root.scrollIntoView({ behavior: 'smooth', block: 'start' })
+
+                this.$refs.headerSteps.children[this.getStepIndex(this.step)].scrollIntoView({ behavior: 'smooth', block: 'start' })
+            })
         },
 
         autofocusFields: function () {
@@ -135,6 +137,7 @@
             'border-b border-gray-200 dark:border-white/10' => $isContained,
             'rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10' => ! $isContained,
         ])
+        x-ref="headerSteps"
     >
         @foreach ($getChildComponentContainer()->getComponents() as $step)
             <li


### PR DESCRIPTION
## Description

This PR ensures the wizard scrolls the current step into view when moving between steps.

https://github.com/filamentphp/filament/issues/14665

## Visual changes

https://github.com/user-attachments/assets/9239f0f4-0c9e-4e0c-9b28-9f99118fac0b

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
