### PR TITLE
Disable extra empty query in DefaultGlobalSearchProvider on page load/navigate  for every resource that can be searched globally

### DIFF
--- a/packages/panels/src/GlobalSearch/DefaultGlobalSearchProvider.php
+++ b/packages/panels/src/GlobalSearch/DefaultGlobalSearchProvider.php
@@ -3,6 +3,7 @@
 namespace Filament\GlobalSearch;
 
 use Filament\Facades\Filament;
+use Illuminate\Database\Eloquent\Collection;
 
 class DefaultGlobalSearchProvider implements Contracts\GlobalSearchProvider
 {
@@ -15,7 +16,7 @@ class DefaultGlobalSearchProvider implements Contracts\GlobalSearchProvider
                 continue;
             }
 
-            $resourceResults = $resource::getGlobalSearchResults($query);
+            $resourceResults = ($query) ? $resource::getGlobalSearchResults($query) : Collection::make();
 
             if (! $resourceResults->count()) {
                 continue;


### PR DESCRIPTION
## Description

when global search active for resources, an empty search query runs when the page loads, the following query is running for each resource available globally.

`select * from 'models' where ('name' like '%%') limit 50`

as it's not needed until the user searches.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->
Before :
![Screenshot 2024-11-18 at 11 09 54 AM](https://github.com/user-attachments/assets/ef4f6f00-19f7-41cf-8470-91dcfc5aeaa4)

After:
![Screenshot 2024-11-18 at 11 10 32 AM](https://github.com/user-attachments/assets/2b817405-627d-4ac9-a819-055755d6ddca)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.


if you don't want to use collection you can use an array instead
```php
$resourceResults = ($query) ? $resource::getGlobalSearchResults($query) : [];

if ($resourceResults && ! $resourceResults->count()) {
    continue;
}
```
