### PR TITLE
Avoid division by zero in FileUpload.php

### DIFF
--- a/packages/forms/resources/lang/tr/components.php
+++ b/packages/forms/resources/lang/tr/components.php
@@ -412,7 +412,7 @@ return [
         'searching_message' => 'Aranıyor...',
 
         'search_prompt' => 'Aramak için yazmaya başlayın...',
-    
+
     ],
 
     'tags_input' => [

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -421,7 +421,7 @@ class FileUpload extends BaseFileUpload
     {
         $targetWidth = (int) $this->getImageResizeTargetWidth();
 
-        if($targetWidth === 0) {
+        if ($targetWidth === 0) {
             return 1;
         }
 

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -417,9 +417,15 @@ class FileUpload extends BaseFileUpload
         return $this->evaluate($this->imageEditorViewportWidth);
     }
 
-    protected function getParentTargetSizes(int $withOrHeight): float
+    protected function getParentTargetSizes(int $widthOrHeight): int | float
     {
-        return $withOrHeight > 1 ? 360 / (int) ($this->getImageResizeTargetWidth() ?? 1) : 1;
+        $targetWidth = (int) $this->getImageResizeTargetWidth();
+
+        if($targetWidth === 0) {
+            return 1;
+        }
+
+        return $widthOrHeight > 1 ? 360 / $targetWidth : 1;
     }
 
     public function getImageEditorMode(): int

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -419,7 +419,7 @@ class FileUpload extends BaseFileUpload
 
     protected function getParentTargetSizes(int $withOrHeight): float
     {
-        return $withOrHeight > 1 ? 360 / (int) $this->getImageResizeTargetWidth() : 1;
+        return $withOrHeight > 1 ? 360 / (int) ($this->getImageResizeTargetWidth() ?? 1) : 1;
     }
 
     public function getImageEditorMode(): int


### PR DESCRIPTION
If anyone sets resize target height, but not width, FileUpload throws division by zero error

Example:
```php
SpatieMediaLibraryFileUpload::make('logo')
      //not set->imageResizeTargetWidth(300)
      ->imageResizeTargetHeight(300)
```
