### PR TITLE
Add ActionGroup Support To Header/Footer Actions On Infolists

### DIFF
--- a/packages/infolists/src/Components/Actions/ActionContainer.php
+++ b/packages/infolists/src/Components/Actions/ActionContainer.php
@@ -8,12 +8,12 @@ class ActionContainer extends Component
 {
     protected string $view = 'filament-infolists::components.actions.action-container';
 
-    final public function __construct(Action $action)
+    final public function __construct(Action | ActionGroup $action)
     {
         $this->action($action);
     }
 
-    public static function make(Action $action): static
+    public static function make(Action | ActionGroup $action): static
     {
         $static = app(static::class, ['action' => $action]);
         $static->configure();

--- a/packages/infolists/src/Components/Actions/ActionGroup.php
+++ b/packages/infolists/src/Components/Actions/ActionGroup.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Filament\Infolists\Components\Actions;
+
+use Filament\Actions\ActionGroup as BaseActionGroup;
+
+/**
+ * @method array<Action> getFlatActions()
+ * @method static actions(Array<Action | ActionGroup> $actions)
+ * @method array<Action | ActionGroup> getActions()
+ * @method array<Action> getFlatActions()
+ *
+ * @property array<Action | ActionGroup> $actions
+ * @property array<Action> $flatActions
+ */
+class ActionGroup extends BaseActionGroup
+{
+    use Concerns\BelongsToInfolist;
+
+    public function toInfolistComponent(): ActionContainer
+    {
+        return ActionContainer::make($this);
+    }
+}

--- a/packages/infolists/src/Components/Concerns/HasActions.php
+++ b/packages/infolists/src/Components/Concerns/HasActions.php
@@ -4,6 +4,7 @@ namespace Filament\Infolists\Components\Concerns;
 
 use Closure;
 use Filament\Infolists\Components\Actions\Action;
+use Filament\Infolists\Components\Actions\ActionGroup;
 use Filament\Infolists\Components\Contracts\HasAffixActions;
 use Filament\Infolists\Components\Contracts\HasFooterActions;
 use Filament\Infolists\Components\Contracts\HasHeaderActions;
@@ -137,6 +138,14 @@ trait HasActions
             ];
         }
 
+        foreach ($this->cachedActions as $cachedAction) {
+            if ($cachedAction instanceof ActionGroup) {
+                foreach ($cachedAction->getFlatActions() as $action) {
+                    $this->cachedActions[$action->getName()] = $this->prepareAction($action);
+                }
+            }
+        }
+
         foreach ($this->actions as $registeredAction) {
             foreach (Arr::wrap($this->evaluate($registeredAction)) as $action) {
                 $this->cachedActions[$action->getName()] = $this->prepareAction($action);
@@ -146,7 +155,7 @@ trait HasActions
         return $this->cachedActions;
     }
 
-    public function prepareAction(Action $action): Action
+    public function prepareAction(Action | ActionGroup $action): Action | ActionGroup
     {
         return $action->component($this);
     }

--- a/packages/infolists/src/Components/Concerns/HasActions.php
+++ b/packages/infolists/src/Components/Concerns/HasActions.php
@@ -118,17 +118,27 @@ trait HasActions
         }
 
         if ($this instanceof HasFooterActions) {
-            $this->cachedActions = [
-                ...$this->cachedActions,
-                ...$this->getFooterActions(),
-            ];
+            foreach ($this->getFooterActions() as $key => $value) {
+                if ($value instanceof ActionGroup) {
+                    foreach ($value->getFlatActions() as $action) {
+                        $this->cachedActions[$action->getName()] = $this->prepareAction($action);
+                    }
+                } elseif (is_string($key)) {
+                    $this->cachedActions[$key] = $value;
+                }
+            }
         }
 
         if ($this instanceof HasHeaderActions) {
-            $this->cachedActions = [
-                ...$this->cachedActions,
-                ...$this->getHeaderActions(),
-            ];
+            foreach ($this->getHeaderActions() as $key => $value) {
+                if ($value instanceof ActionGroup) {
+                    foreach ($value->getFlatActions() as $action) {
+                        $this->cachedActions[$action->getName()] = $this->prepareAction($action);
+                    }
+                } elseif (is_string($key)) {
+                    $this->cachedActions[$key] = $value;
+                }
+            }
         }
 
         if ($this instanceof HasHintActions) {
@@ -136,14 +146,6 @@ trait HasActions
                 ...$this->cachedActions,
                 ...$this->getHintActions(),
             ];
-        }
-
-        foreach ($this->cachedActions as $cachedAction) {
-            if ($cachedAction instanceof ActionGroup) {
-                foreach ($cachedAction->getFlatActions() as $action) {
-                    $this->cachedActions[$action->getName()] = $this->prepareAction($action);
-                }
-            }
         }
 
         foreach ($this->actions as $registeredAction) {

--- a/packages/infolists/src/Components/Concerns/HasFooterActions.php
+++ b/packages/infolists/src/Components/Concerns/HasFooterActions.php
@@ -4,6 +4,7 @@ namespace Filament\Infolists\Components\Concerns;
 
 use Closure;
 use Filament\Infolists\Components\Actions\Action;
+use Filament\Infolists\Components\Actions\ActionGroup;
 use Filament\Support\Concerns\HasFooterActionsAlignment;
 use Illuminate\Support\Arr;
 
@@ -12,17 +13,17 @@ trait HasFooterActions
     use HasFooterActionsAlignment;
 
     /**
-     * @var array<Action> | null
+     * @var array<Action | ActionGroup> | null
      */
     protected ?array $cachedFooterActions = null;
 
     /**
-     * @var array<Action | Closure>
+     * @var array<Action | ActionGroup | Closure>
      */
     protected array $footerActions = [];
 
     /**
-     * @param  array<Action | Closure>  $actions
+     * @param  array<Action | ActionGroup | Closure>  $actions
      */
     public function footerActions(array $actions): static
     {
@@ -35,7 +36,7 @@ trait HasFooterActions
     }
 
     /**
-     * @return array<Action>
+     * @return array<Action | ActionGroup>
      */
     public function getFooterActions(): array
     {
@@ -43,7 +44,7 @@ trait HasFooterActions
     }
 
     /**
-     * @return array<Action>
+     * @return array<Action | ActionGroup>
      */
     public function cacheFooterActions(): array
     {
@@ -51,7 +52,13 @@ trait HasFooterActions
 
         foreach ($this->footerActions as $footerAction) {
             foreach (Arr::wrap($this->evaluate($footerAction)) as $action) {
-                $this->cachedFooterActions[$action->getName()] = $this->prepareAction($action);
+                if ($action instanceof Action) {
+                    $this->cachedFooterActions[$action->getName()] = $this->prepareAction($action);
+                }
+
+                if ($action instanceof ActionGroup) {
+                    $this->cachedFooterActions[] = $this->prepareAction($action);
+                }
             }
         }
 

--- a/packages/infolists/src/Components/Concerns/HasHeaderActions.php
+++ b/packages/infolists/src/Components/Concerns/HasHeaderActions.php
@@ -4,22 +4,23 @@ namespace Filament\Infolists\Components\Concerns;
 
 use Closure;
 use Filament\Infolists\Components\Actions\Action;
+use Filament\Infolists\Components\Actions\ActionGroup;
 use Illuminate\Support\Arr;
 
 trait HasHeaderActions
 {
     /**
-     * @var array<Action> | null
+     * @var array<Action | ActionGroup> | null
      */
     protected ?array $cachedHeaderActions = null;
 
     /**
-     * @var array<Action | Closure>
+     * @var array<Action | ActionGroup | Closure>
      */
     protected array $headerActions = [];
 
     /**
-     * @param  array<Action | Closure>  $actions
+     * @param  array<Action | ActionGroup | Closure>  $actions
      */
     public function headerActions(array $actions): static
     {
@@ -32,7 +33,7 @@ trait HasHeaderActions
     }
 
     /**
-     * @return array<Action>
+     * @return array<Action | ActionGroup>
      */
     public function getHeaderActions(): array
     {
@@ -40,7 +41,7 @@ trait HasHeaderActions
     }
 
     /**
-     * @return array<Action>
+     * @return array<Action | ActionGroup>
      */
     public function cacheHeaderActions(): array
     {
@@ -48,7 +49,17 @@ trait HasHeaderActions
 
         foreach ($this->headerActions as $headerAction) {
             foreach (Arr::wrap($this->evaluate($headerAction)) as $action) {
-                $this->cachedHeaderActions[$action->getName()] = $this->prepareAction($action);
+                if ($action instanceof Action) {
+                    $this->cachedHeaderActions[$action->getName()] = $this->prepareAction($action);
+                }
+
+                if ($action instanceof ActionGroup) {
+                    $this->cachedHeaderActions[] = $this->prepareAction($action);
+
+                    foreach ($action->getFlatActions() as $action) {
+                        $this->prepareAction($action);
+                    }
+                }
             }
         }
 

--- a/packages/infolists/src/Components/Contracts/HasFooterActions.php
+++ b/packages/infolists/src/Components/Contracts/HasFooterActions.php
@@ -3,11 +3,12 @@
 namespace Filament\Infolists\Components\Contracts;
 
 use Filament\Infolists\Components\Actions\Action;
+use Filament\Infolists\Components\Actions\ActionGroup;
 
 interface HasFooterActions
 {
     /**
-     * @return array<Action>
+     * @return array<Action | ActionGroup>
      */
     public function getFooterActions(): array;
 }

--- a/packages/infolists/src/Components/Contracts/HasHeaderActions.php
+++ b/packages/infolists/src/Components/Contracts/HasHeaderActions.php
@@ -3,11 +3,12 @@
 namespace Filament\Infolists\Components\Contracts;
 
 use Filament\Infolists\Components\Actions\Action;
+use Filament\Infolists\Components\Actions\ActionGroup;
 
 interface HasHeaderActions
 {
     /**
-     * @return array<Action>
+     * @return array<Action | ActionGroup>
      */
     public function getHeaderActions(): array;
 }

--- a/tests/src/Infolists/ActionTest.php
+++ b/tests/src/Infolists/ActionTest.php
@@ -94,3 +94,11 @@ it('can state whether a form component action exists', function () {
         ->assertInfolistActionExists('textEntry', 'exists')
         ->assertInfolistActionDoesNotExist('textEntry', 'doesNotExist');
 });
+
+it('can call an action within a group', function () {
+    livewire(Actions::class)
+        ->callInfolistAction('section', 'header-grouped')
+        ->assertDispatched('foo')
+        ->callInfolistAction('section', 'footer-grouped')
+        ->assertDispatched('bar');
+});

--- a/tests/src/Infolists/Fixtures/Actions.php
+++ b/tests/src/Infolists/Fixtures/Actions.php
@@ -6,6 +6,8 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Infolists\Components\Actions\Action;
+use Filament\Infolists\Components\Actions\ActionGroup;
+use Filament\Infolists\Components\Section;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Concerns\InteractsWithInfolists;
 use Filament\Infolists\Contracts\HasInfolists;
@@ -63,6 +65,24 @@ class Actions extends Component implements HasForms, HasInfolists
                         Action::make('urlNotInNewTab')
                             ->url('https://filamentphp.com'),
                         Action::make('exists'),
+                    ]),
+                Section::make()
+                    ->key('section')
+                    ->headerActions([
+                        ActionGroup::make([
+                            Action::make('header-grouped')
+                                ->action(function () {
+                                    $this->dispatch('foo');
+                                }),
+                        ]),
+                    ])
+                    ->footerActions([
+                        ActionGroup::make([
+                            Action::make('footer-grouped')
+                                ->action(function () {
+                                    $this->dispatch('bar');
+                                }),
+                        ]),
                     ]),
             ]);
     }


### PR DESCRIPTION
## Description

I was surprised when I tried to use an ActionGroup in my code last week to discover an except about a missing `getName()` method. I searched through the existing issues and found a couple of other people who had the same issue ([1](https://github.com/filamentphp/filament/discussions/11946), [2](https://github.com/filamentphp/filament/discussions/11859), [3](https://github.com/filamentphp/filament/discussions/14807)). I had some time over the weekend to dig into it and get everything hooked up.

I had noticed #13172 and used that as a jumping off point to get familiar with the relevant code. My first attempt was a more direct attempt to solve the missing name problem, but an ActionGroup needing a name didn't feel great to work with. Instead, I reconsidered why it needed a name in the first place. The names are used so that an action can be retrieved later with [`getAction()`](https://github.com/Magnesium38/filament/blob/721b77cdfe111083a4d3203209e8b0a075aee3cc/packages/infolists/src/Components/Concerns/HasActions.php#L55). Since the group shouldn't have a reason to be retrieved I put them onto the array without a name by using the numeric index instead. This does create a mixed array, but all of the code in this package handles it okay already. Additionally, the docblock of `array<Action | ActionGroup>` omits the key parameter which implies `array<int | string, Action | ActionGroup>` so there isn't any breakage here.

I did write a basic test to prove that grouped header and footer actions can be invoked and installed this fork into a local project and tested it manually as well and had no issues.

I know that there's also requests for this feature on the forms side (#13234) and I'm open to doing a PR for that side as well, but I needed the infolist side so I started here. If this gets accepted I'll likely quick knock out the same changes on the forms side. That PR should then be able to close #14155.

One thing that I have not done is make any documentation changes yet. From what I've seen, it appears that most people try group actions after finding the [Actions `Grouping Actions`](https://filamentphp.com/docs/3.x/actions/grouping-actions) documentation. I would be open to writing up the documentation using the [table's grouping actions documentation](https://filamentphp.com/docs/3.x/tables/actions#grouping-actions) as a starting point, but I didn't want to spend all the time capturing screenshots and all that if this wasn't going to be accepted.

## Visual changes

This is the block that I was using to test whether things were working when used on a real project.

```php
ActionGroup::make([
	Action::make('first')
		->action(fn (array $data) => dd('this', $data))
		->form([
			TextInput::make('text'),
		]),
]),
Action::make('test')
	->action(fn (array $data) => dd('this', $data))
	->form([
		TextInput::make('text'),
	]),
ActionGroup::make([
	Action::make('second')
		->action(fn (array $data) => dd('this', $data))
		->form([
			TextInput::make('text'),
		]),
]),
```

![image](https://github.com/user-attachments/assets/c600d0fe-1dd0-40ce-9572-de6bb572b84b)
![image](https://github.com/user-attachments/assets/d49e5bb8-537f-4ffc-a8e8-6f9846220dd3)

They resulted in header actions that were grouped and sorted as expected.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
