### PR TITLE
Update indicator.blade.php - format $allSelectableRecordsCount

### DIFF
--- a/packages/tables/resources/views/components/selection/indicator.blade.php
+++ b/packages/tables/resources/views/components/selection/indicator.blade.php
@@ -49,7 +49,7 @@
                 {{-- Make sure the Alpine attributes get re-evaluated after a Livewire request: --}}
                 :wire:key="$this->getId() . 'table.selection.indicator.actions.select-all.' . $allSelectableRecordsCount . '.' . $page"
             >
-                {{ trans_choice('filament-tables::table.selection_indicator.actions.select_all.label', $allSelectableRecordsCount) }}
+                {{ trans_choice('filament-tables::table.selection_indicator.actions.select_all.label', \Illuminate\Support\Number::format($allSelectableRecordsCount)) }}
             </x-filament::link>
 
             <x-filament::link


### PR DESCRIPTION
## Description

With tables containing more than 999 records, the Number facade can be used to enhance the user experience by formatting the numbers.

## Visual changes

| Before                                                                                   | After                                                                                   |
|------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
| ![image](https://github.com/user-attachments/assets/b50a3fed-126a-41f0-9ba9-dcfe878c2aa4) | ![image](https://github.com/user-attachments/assets/ef3665c3-3771-4e68-8db9-2c265baad4dc) |

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
