### PR TITLE
feat: allow limiting column map in exports

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/09-export.md
+++ b/packages/actions/docs/07-prebuilt-actions/09-export.md
@@ -142,6 +142,31 @@ ExportAction::make()
     ->columnMapping(false)
 ```
 
+### Limiting selectable columns
+
+By default, the user will be asked which columns to export. You can limit the list of columns shown for export by using the `columns()` method:
+
+```php
+use App\Filament\Exports\ProductExporter;
+
+ExportAction::make()
+    ->exporter(ProductExporter::class)
+    ->columns([ 'name', 'sku', 'price'])
+])
+```
+
+In case you would like to disable the column selection functionality and only export the defined columns, you can combine the `columns()` method with `columnMapping(false)`:
+
+```php
+use App\Filament\Exports\ProductExporter;
+
+ExportAction::make()
+    ->exporter(ProductExporter::class)
+    ->columns([ 'name', 'sku', 'price'])
+    ->columnMapping(false)
+])
+```
+
 ### Calculated export column state
 
 Sometimes you need to calculate the state of a column, instead of directly reading it from a database column.

--- a/packages/actions/docs/07-prebuilt-actions/09-export.md
+++ b/packages/actions/docs/07-prebuilt-actions/09-export.md
@@ -151,7 +151,7 @@ use App\Filament\Exports\ProductExporter;
 
 ExportAction::make()
     ->exporter(ProductExporter::class)
-    ->columns([ 'name', 'sku', 'price'])
+    ->columns(['name', 'sku', 'price'])
 ])
 ```
 
@@ -162,7 +162,7 @@ use App\Filament\Exports\ProductExporter;
 
 ExportAction::make()
     ->exporter(ProductExporter::class)
-    ->columns([ 'name', 'sku', 'price'])
+    ->columns(['name', 'sku', 'price'])
     ->columnMapping(false)
 ])
 ```

--- a/packages/actions/resources/lang/id/import.php
+++ b/packages/actions/resources/lang/id/import.php
@@ -11,15 +11,15 @@ return [
         'form' => [
 
             'file' => [
-                
+
                 'label' => 'Berkas',
-                
+
                 'placeholder' => 'Unggah berkas CSV',
 
                 'rules' => [
                     'duplicate_columns' => '{0} Berkas tidak boleh memiliki lebih dari satu kolom header yang kosong.|{1,*} Berkas tidak boleh memiliki kolom header yang duplikat: :columns.',
                 ],
-                
+
             ],
 
             'columns' => [

--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -411,7 +411,7 @@ trait CanExportRecords
         return $this;
     }
 
-    public function columnMapping(bool | Closure | array $condition = true): static
+    public function columnMapping(bool | Closure $condition = true): static
     {
         $this->hasColumnMapping = $condition;
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR adds the option to limit the `ExportAction` to certain columns. Previously, the only choice we had to limit columns was to have a column mapping form where the user can choose columns. However, sometimes we either want the column mapping form not to show all columns, or to not show a column mapping form and directly export a subset of columns.

This adds a `->columns()` method that will allow the user to either:
- Specify which columns get shown in the column mapping form, if `->columnMapping(true)` (default).
- Specify which subset of columns get outputted in the export without showing a form, if `->columnMapping(false)`.

Basically the four choices are now:

```php
// Show column mapping form, include all columns
```

```php
// Show column mapping form, include only specified columns
->columns(['id', 'full_name', 'email'])
```

```php
// Hide column mapping form, export all columns
->columnMapping(false)
```

```php
// Hide column mapping form, export specified columns
->columns(['id', 'full_name', 'email'])
->columnMapping(false)
```

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
