### PR TITLE
Improve sync connection support for `ExportAction`

### DIFF
--- a/packages/actions/resources/lang/id/import.php
+++ b/packages/actions/resources/lang/id/import.php
@@ -11,15 +11,15 @@ return [
         'form' => [
 
             'file' => [
-                
+
                 'label' => 'Berkas',
-                
+
                 'placeholder' => 'Unggah berkas CSV',
 
                 'rules' => [
                     'duplicate_columns' => '{0} Berkas tidak boleh memiliki lebih dari satu kolom header yang kosong.|{1,*} Berkas tidak boleh memiliki kolom header yang duplikat: :columns.',
                 ],
-                
+
             ],
 
             'columns' => [

--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -240,13 +240,15 @@ trait CanExportRecords
                 )
                 ->dispatch();
 
-            Notification::make()
-                ->title($action->getSuccessNotificationTitle())
-                ->body(trans_choice('filament-actions::export.notifications.started.body', $export->total_rows, [
-                    'count' => Number::format($export->total_rows),
-                ]))
-                ->success()
-                ->send();
+            if ($jobConnection !== 'sync') {
+                Notification::make()
+                    ->title($action->getSuccessNotificationTitle())
+                    ->body(trans_choice('filament-actions::export.notifications.started.body', $export->total_rows, [
+                        'count' => Number::format($export->total_rows),
+                    ]))
+                    ->success()
+                    ->send();
+            }
         });
 
         $this->color('gray');

--- a/packages/actions/src/Exports/Jobs/ExportCompletion.php
+++ b/packages/actions/src/Exports/Jobs/ExportCompletion.php
@@ -74,6 +74,14 @@ class ExportCompletion implements ShouldQueue
                     $this->formats,
                 )),
             )
-            ->sendToDatabase($this->export->user, isEventDispatched: true);
+            ->when(
+                $this->connection === 'sync',
+                fn (Notification $notification) => $notification->persistent()
+            )
+            ->when(
+                $this->connection === 'sync',
+                fn (Notification $notification) => $notification->send(),
+                fn (Notification $notification) => $notification->sendToDatabase($this->export->user, isEventDispatched: true),
+            );
     }
 }

--- a/packages/actions/src/Exports/Jobs/ExportCompletion.php
+++ b/packages/actions/src/Exports/Jobs/ExportCompletion.php
@@ -76,11 +76,9 @@ class ExportCompletion implements ShouldQueue
             )
             ->when(
                 $this->connection === 'sync',
-                fn (Notification $notification) => $notification->persistent()
-            )
-            ->when(
-                $this->connection === 'sync',
-                fn (Notification $notification) => $notification->send(),
+                fn (Notification $notification) => $notification
+                    ->persistent()
+                    ->send(),
                 fn (Notification $notification) => $notification->sendToDatabase($this->export->user, isEventDispatched: true),
             );
     }


### PR DESCRIPTION
It can be very helpful to run an export on the sync queue if it does not take too long and then immediately display a notification to download it, instead of needing to wait on a job being picked up by a queue and then monitoring the notifications bell icon. In my tests running an export in sync was even quicker than waiting for an (empty) queue to pick it, process all the individual batch parts and then send back to the user. Particularly for less tech-savvy users this is not intuitive.

The ExportAction can already run on the `sync` connection, but this PR improves support for that by removing the first export started notification and changing the export completed notification to a persistent in-page notification.

<img width="413" alt="Scherm­afbeelding 2024-11-20 om 21 11 51" src="https://github.com/user-attachments/assets/1377e732-9c03-4dd1-a929-9388d4da5060">

Thanks!
