### PR TITLE
Add support for dashboard tabs

### DIFF
--- a/packages/panels/docs/05-dashboard.md
+++ b/packages/panels/docs/05-dashboard.md
@@ -215,6 +215,32 @@ class Dashboard extends BaseDashboard
 
 Handling data from the filter action is the same as handling data from the filters header form, except that the data is validated before being passed to the widget. The `InteractsWithPageFilters` trait still applies.
 
+You may group widgets into tabs to keep the dashboard organized. To do this, each widget class contains a `$tab` property that may be used to change the tab it belongs to on the page:
+
+```php
+protected static ?string $tab = 'Overview';
+```
+
+In the case of a dashboard with tabs, the widgets without a tab will be grouped on front under tab called 'General'.
+
+In order to customize the tabs or change the order of the tabs, you can override the `getTabs()` method in the `Dashboard` class:
+
+```php
+use Filament\Pages\Dashboard as BaseDashboard;
+
+class Dashboard extends BaseDashboard
+{
+    public function getTabs(): array
+    {
+        return [
+            BaseDashboard\Components\Tab::make('Overview'),
+            BaseDashboard\Components\Tab::make('Orders')
+                ->icon('heroicon-m-shopping-bag'),
+        ];
+    }
+}
+```
+
 ## Disabling the default widgets
 
 By default, two widgets are displayed on the dashboard. These widgets can be disabled by updating the `widgets()` array of the [configuration](configuration):

--- a/packages/panels/resources/lang/en/pages/dashboard.php
+++ b/packages/panels/resources/lang/en/pages/dashboard.php
@@ -30,4 +30,14 @@ return [
 
     ],
 
+    'tabs' => [
+
+        'default' => [
+
+            'label' => 'General',
+
+        ],
+
+    ],
+
 ];

--- a/packages/panels/resources/views/pages/dashboard.blade.php
+++ b/packages/panels/resources/views/pages/dashboard.blade.php
@@ -5,24 +5,24 @@
     @if (method_exists($this, 'filtersForm'))
         {{ $this->filtersForm }}
     @endif
-    
+
     @php
         $tabs = $this->getCachedTabs();
     @endphp
-    
+
     @if (count($tabs))
         @php
             $renderHookScopes = $this->getRenderHookScopes();
         @endphp
-        
+
         <x-filament::tabs>
             {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGES_DASHBOARD_TABS_START, scopes: $renderHookScopes) }}
-            
+
             @foreach ($tabs as $tabKey => $tab)
                 @php
                     $tabKey = strval($tabKey);
                 @endphp
-                
+
                 <x-filament::tabs.item
                     :alpine-active="'activeTab === ' . \Illuminate\Support\JS::from($tabKey)"
                     :badge="$tab->getBadge()"
@@ -37,28 +37,28 @@
                     {{ $tab->getLabel() ?? $this->generateTabLabel($tabKey) }}
                 </x-filament::tabs.item>
             @endforeach
-            
+
             {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGES_DASHBOARD_TABS_END, scopes: $renderHookScopes) }}
         </x-filament::tabs>
     @endif
-    
+
     @forelse ($tabs as $tabKey => $tab)
         @php
             $tabKey = strval($tabKey);
         @endphp
-        
+
         <x-filament-widgets::widgets
-                :columns="$this->getColumns()"
-                :data="
+            :columns="$this->getColumns()"
+            :data="
                 [
                     ...(property_exists($this, 'filters') ? ['filters' => $this->filters] : []),
                     ...$this->getWidgetData(),
                 ]
             "
-                :x-show="'activeTab === ' . \Illuminate\Support\JS::from($tabKey)"
-                :x-cloak="! $loop->first"
-                :widgets="$this->getVisibleWidgets($tab->getLabel() ?? $this->generateTabLabel($tabKey))"
-                :wire:key="$tabKey"
+            :x-show="'activeTab === ' . \Illuminate\Support\JS::from($tabKey)"
+            :x-cloak="! $loop->first"
+            :widgets="$this->getVisibleWidgets($tab->getLabel() ?? $this->generateTabLabel($tabKey))"
+            :wire:key="$tabKey"
         />
     @empty
         <x-filament-widgets::widgets

--- a/packages/panels/resources/views/pages/dashboard.blade.php
+++ b/packages/panels/resources/views/pages/dashboard.blade.php
@@ -6,11 +6,7 @@
         {{ $this->filtersForm }}
     @endif
 
-    @php
-        $tabs = $this->getCachedTabs();
-    @endphp
-
-    @if (count($tabs))
+    @if (count($tabs = $this->getCachedTabs()))
         @php
             $renderHookScopes = $this->getRenderHookScopes();
         @endphp

--- a/packages/panels/resources/views/pages/dashboard.blade.php
+++ b/packages/panels/resources/views/pages/dashboard.blade.php
@@ -1,16 +1,75 @@
-<x-filament-panels::page class="fi-dashboard-page">
+<x-filament-panels::page
+    class="fi-dashboard-page"
+    :x-data="'{ activeTab: ' . \Illuminate\Support\JS::from(strval($this->getDefaultActiveTab())) . ' }'"
+>
     @if (method_exists($this, 'filtersForm'))
         {{ $this->filtersForm }}
     @endif
-
-    <x-filament-widgets::widgets
-        :columns="$this->getColumns()"
-        :data="
-            [
-                ...(property_exists($this, 'filters') ? ['filters' => $this->filters] : []),
-                ...$this->getWidgetData(),
-            ]
-        "
-        :widgets="$this->getVisibleWidgets()"
-    />
+    
+    @php
+        $tabs = $this->getCachedTabs();
+    @endphp
+    
+    @if (count($tabs))
+        @php
+            $renderHookScopes = $this->getRenderHookScopes();
+        @endphp
+        
+        <x-filament::tabs>
+            {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGES_DASHBOARD_TABS_START, scopes: $renderHookScopes) }}
+            
+            @foreach ($tabs as $tabKey => $tab)
+                @php
+                    $tabKey = strval($tabKey);
+                @endphp
+                
+                <x-filament::tabs.item
+                    :alpine-active="'activeTab === ' . \Illuminate\Support\JS::from($tabKey)"
+                    :badge="$tab->getBadge()"
+                    :badge-color="$tab->getBadgeColor()"
+                    :badge-icon="$tab->getBadgeIcon()"
+                    :badge-icon-position="$tab->getBadgeIconPosition()"
+                    :icon="$tab->getIcon()"
+                    :icon-position="$tab->getIconPosition()"
+                    :x-on:click="'activeTab = ' . \Illuminate\Support\JS::from($tabKey)"
+                    :attributes="$tab->getExtraAttributeBag()"
+                >
+                    {{ $tab->getLabel() ?? $this->generateTabLabel($tabKey) }}
+                </x-filament::tabs.item>
+            @endforeach
+            
+            {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGES_DASHBOARD_TABS_END, scopes: $renderHookScopes) }}
+        </x-filament::tabs>
+    @endif
+    
+    @forelse ($tabs as $tabKey => $tab)
+        @php
+            $tabKey = strval($tabKey);
+        @endphp
+        
+        <x-filament-widgets::widgets
+                :columns="$this->getColumns()"
+                :data="
+                [
+                    ...(property_exists($this, 'filters') ? ['filters' => $this->filters] : []),
+                    ...$this->getWidgetData(),
+                ]
+            "
+                :x-show="'activeTab === ' . \Illuminate\Support\JS::from($tabKey)"
+                :x-cloak="! $loop->first"
+                :widgets="$this->getVisibleWidgets($tab->getLabel() ?? $this->generateTabLabel($tabKey))"
+                :wire:key="$tabKey"
+        />
+    @empty
+        <x-filament-widgets::widgets
+            :columns="$this->getColumns()"
+            :data="
+                [
+                    ...(property_exists($this, 'filters') ? ['filters' => $this->filters] : []),
+                    ...$this->getWidgetData(),
+                ]
+            "
+            :widgets="$this->getVisibleWidgets()"
+        />
+    @endforelse
 </x-filament-panels::page>

--- a/packages/panels/src/Pages/Dashboard.php
+++ b/packages/panels/src/Pages/Dashboard.php
@@ -59,12 +59,8 @@ class Dashboard extends Page
             $defaultActiveTab = $this->getDefaultActiveTab();
 
             $defaultActiveTabLabel = $this->getCachedTabs()[$defaultActiveTab]->getLabel() ?? $this->generateTabLabel($defaultActiveTab);
-
-            return array_filter($visibleWidgets, function (string | WidgetConfiguration $widget) use ($tab, $defaultActiveTabLabel): bool {
-                if (blank($tab)) {
-                    return true;
-                }
-
+	        
+	        $visibleWidgets = array_filter($visibleWidgets, function (string | WidgetConfiguration $widget) use ($tab, $defaultActiveTabLabel): bool {
                 $widgetTab = $this->normalizeWidgetClass($widget)::getTab();
 
                 if (blank($widgetTab)) {

--- a/packages/panels/src/Pages/Dashboard.php
+++ b/packages/panels/src/Pages/Dashboard.php
@@ -59,8 +59,8 @@ class Dashboard extends Page
             $defaultActiveTab = $this->getDefaultActiveTab();
 
             $defaultActiveTabLabel = $this->getCachedTabs()[$defaultActiveTab]->getLabel() ?? $this->generateTabLabel($defaultActiveTab);
-	        
-	        $visibleWidgets = array_filter($visibleWidgets, function (string | WidgetConfiguration $widget) use ($tab, $defaultActiveTabLabel): bool {
+
+            $visibleWidgets = array_filter($visibleWidgets, function (string | WidgetConfiguration $widget) use ($tab, $defaultActiveTabLabel): bool {
                 $widgetTab = $this->normalizeWidgetClass($widget)::getTab();
 
                 if (blank($widgetTab)) {

--- a/packages/panels/src/Pages/Dashboard/Components/Tab.php
+++ b/packages/panels/src/Pages/Dashboard/Components/Tab.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Filament\Pages\Dashboard\Components;
+
+use Closure;
+use Filament\Support\Components\Component;
+use Filament\Support\Concerns\HasBadge;
+use Filament\Support\Concerns\HasExtraAttributes;
+use Filament\Support\Concerns\HasIcon;
+
+class Tab extends Component
+{
+    use HasBadge;
+    use HasExtraAttributes;
+    use HasIcon;
+
+    protected string | Closure | null $label = null;
+
+    public function __construct(string | Closure | null $label = null)
+    {
+        $this->label($label);
+    }
+
+    public static function make(string | Closure | null $label = null): static
+    {
+        $static = app(static::class, ['label' => $label]);
+        $static->configure();
+
+        return $static;
+    }
+
+    public function label(string | Closure | null $label): static
+    {
+        $this->label = $label;
+
+        return $this;
+    }
+
+    public function getLabel(): ?string
+    {
+        return $this->evaluate($this->label);
+    }
+}

--- a/packages/panels/src/Pages/Dashboard/Concerns/HasTabs.php
+++ b/packages/panels/src/Pages/Dashboard/Concerns/HasTabs.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Filament\Pages\Dashboard\Concerns;
+
+use Filament\Pages\Dashboard\Components\Tab;
+
+trait HasTabs
+{
+    /**
+     * @var array<string | int, Tab>
+     */
+    protected array $cachedTabs;
+
+    /**
+     * @return array<string | int, Tab>
+     */
+    public function getTabs(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string | int, Tab>
+     */
+    public function getCachedTabs(): array
+    {
+        return $this->cachedTabs ??= $this->getTabs();
+    }
+
+    public function getDefaultActiveTab(): string | int | null
+    {
+        return array_key_first($this->getCachedTabs());
+    }
+
+    public function generateTabLabel(string $key): string
+    {
+        return (string) str($key)
+            ->replace(['_', '-'], ' ')
+            ->ucfirst();
+    }
+}

--- a/packages/panels/src/Pages/Dashboard/Concerns/HasTabs.php
+++ b/packages/panels/src/Pages/Dashboard/Concerns/HasTabs.php
@@ -3,6 +3,7 @@
 namespace Filament\Pages\Dashboard\Concerns;
 
 use Filament\Pages\Dashboard\Components\Tab;
+use Illuminate\Support\Arr;
 
 trait HasTabs
 {
@@ -16,7 +17,27 @@ trait HasTabs
      */
     public function getTabs(): array
     {
-        return [];
+        $tabs = [];
+
+        foreach ($this->getVisibleWidgets() as $widget) {
+            $tabs[] = $this->normalizeWidgetClass($widget)::getTab();
+        }
+		
+		$tabs = array_unique($tabs);
+		
+        if (in_array(null, $tabs)) {
+			if (count($tabs) === 1) {
+				// If no widget has a tab specified other than `null`, return.
+				return [];
+			}
+			
+            $tabs = Arr::prepend($tabs, $this->getDefaultTabLabel());
+        }
+
+        return array_map(
+            fn (string $tab) => Tab::make($tab),
+            array_unique(array_filter($tabs))
+        );
     }
 
     /**
@@ -31,6 +52,11 @@ trait HasTabs
     {
         return array_key_first($this->getCachedTabs());
     }
+	
+	public function getDefaultTabLabel(): string
+	{
+		return __('filament-panels::pages/dashboard.tabs.default.label');
+	}
 
     public function generateTabLabel(string $key): string
     {

--- a/packages/panels/src/Pages/Dashboard/Concerns/HasTabs.php
+++ b/packages/panels/src/Pages/Dashboard/Concerns/HasTabs.php
@@ -22,20 +22,20 @@ trait HasTabs
         foreach ($this->getVisibleWidgets() as $widget) {
             $tabs[] = $this->normalizeWidgetClass($widget)::getTab();
         }
-		
-		$tabs = array_unique($tabs);
-		
+
+        $tabs = array_unique($tabs);
+
         if (in_array(null, $tabs)) {
-			if (count($tabs) === 1) {
-				// If no widget has a tab specified other than `null`, return.
-				return [];
-			}
-			
+            if (count($tabs) === 1) {
+                // If no widget has a tab specified other than `null`, return.
+                return [];
+            }
+
             $tabs = Arr::prepend($tabs, $this->getDefaultTabLabel());
         }
 
         return array_map(
-            fn (string $tab) => Tab::make($tab),
+            fn (string $tab): Tab => Tab::make($tab),
             array_unique(array_filter($tabs))
         );
     }
@@ -52,11 +52,11 @@ trait HasTabs
     {
         return array_key_first($this->getCachedTabs());
     }
-	
-	public function getDefaultTabLabel(): string
-	{
-		return __('filament-panels::pages/dashboard.tabs.default.label');
-	}
+
+    public function getDefaultTabLabel(): string
+    {
+        return __('filament-panels::pages/dashboard.tabs.default.label');
+    }
 
     public function generateTabLabel(string $key): string
     {

--- a/packages/panels/src/View/PanelsRenderHook.php
+++ b/packages/panels/src/View/PanelsRenderHook.php
@@ -78,6 +78,10 @@ class PanelsRenderHook
 
     const PAGE_SUB_NAVIGATION_END_BEFORE = 'panels::page.sub-navigation.end.before';
 
+    const PAGES_DASHBOARD_TABS_START = 'panels::pages.dashboard.tabs.start';
+
+    const PAGES_DASHBOARD_TABS_END = 'panels::pages.dashboard.tabs.end';
+
     const RESOURCE_PAGES_LIST_RECORDS_TABLE_AFTER = 'panels::resource.pages.list-records.table.after';
 
     const RESOURCE_PAGES_LIST_RECORDS_TABLE_BEFORE = 'panels::resource.pages.list-records.table.before';

--- a/packages/widgets/src/Widget.php
+++ b/packages/widgets/src/Widget.php
@@ -19,6 +19,8 @@ abstract class Widget extends Component
      */
     protected static string $view;
 
+    protected static ?string $tab = null;
+
     /**
      * @var int | string | array<string, int | null>
      */
@@ -37,6 +39,11 @@ abstract class Widget extends Component
     public static function getSort(): int
     {
         return static::$sort ?? -1;
+    }
+
+    public static function getTab(): ?string
+    {
+        return static::$tab;
     }
 
     /**


### PR DESCRIPTION
This PR adds support for adding tabs on your dashboard. In case you have many widgets, it makes sense to split them by separate tabs. The implementation is based on the Resource tabs implementation, with the only difference that the Dashboard tabs are implemented on the Alpine-side instead of Livewire due to performance (if Livewire is still (lazy) loading widget on a tab, then switching tabs would be unresponsive until all (slow) widgets are completely loaded).

Users can mark their widgets as belonging to a tab using a `protected static ?string $tab = 'Label';` property. This is the same principle as eg the `$navigationGroup` property, that also matches navigation group by it's label.

https://github.com/user-attachments/assets/727b5260-7859-4d00-866b-d6b6e5a4d3c0

Thanks!