### PR TITLE
Add input and affix CSS classes to input wrapper

### DIFF
--- a/packages/support/resources/views/components/input/wrapper.blade.php
+++ b/packages/support/resources/views/components/input/wrapper.blade.php
@@ -106,7 +106,7 @@
                 wire:key="{{ \Illuminate\Support\Str::random() }}" {{-- Makes sure the loading indicator gets hidden again. --}}
             @endif
             @class([
-                'items-center gap-x-3 ps-3',
+                'fi-input-wrp-prefix items-center gap-x-3 ps-3',
                 'flex' => $hasPrefix,
                 'hidden' => ! $hasPrefix,
                 'pe-1' => $inlinePrefix && filled($prefix),
@@ -169,7 +169,7 @@
             wire:target="{{ $loadingIndicatorTarget }}"
         @endif
         @class([
-            'min-w-0 flex-1',
+            'fi-input-wrp-input min-w-0 flex-1',
             'ps-3' => $hasLoadingIndicator && (! $hasPrefix) && $inlinePrefix,
         ])
     >
@@ -179,7 +179,7 @@
     @if ($hasSuffix)
         <div
             @class([
-                'flex items-center gap-x-3 pe-3',
+                'fi-input-wrp-suffix flex items-center gap-x-3 pe-3',
                 'ps-1' => $inlineSuffix && filled($suffix),
                 'ps-2' => $inlineSuffix && blank($suffix),
                 'border-s border-gray-200 ps-3 dark:border-white/10' => ! $inlineSuffix,


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

There's currently no reliable way to target affixes and inputs from the input wrapper.
This pull request adds missing CSS classes to hook into.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
