### PR TITLE
Add CSS class to tags input

### DIFF
--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -102,10 +102,7 @@
                                 x-sortable
                                 data-sortable-animation-duration="{{ $getReorderAnimationDuration() }}"
                             @endif
-                            @class([
-                                'flex w-full flex-wrap gap-1.5 p-2',
-                                'border-t border-t-gray-200 dark:border-t-white/10',
-                            ])
+                            class="fi-fo-tags-input-tags-ctn flex w-full flex-wrap gap-1.5 border-t border-t-gray-200 p-2 dark:border-t-white/10"
                         >
                             <template
                                 x-for="(tag, index) in state"


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Adds a missing CSS class to hook into and simplifies the class attribute.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
