### PR TITLE
Update tabs/item.blade.php, add justify-center

### DIFF
--- a/packages/support/resources/views/components/tabs/item.blade.php
+++ b/packages/support/resources/views/components/tabs/item.blade.php
@@ -62,7 +62,7 @@
                 'role' => 'tab',
             ])
             ->class([
-                'fi-tabs-item group flex items-center gap-x-2 rounded-lg px-3 py-2 text-sm font-medium outline-none transition duration-75',
+                'fi-tabs-item group flex items-center justify-center gap-x-2 rounded-lg px-3 py-2 text-sm font-medium outline-none transition duration-75',
                 $inactiveItemClasses => (! $hasAlpineActiveClasses) && (! $active),
                 $activeItemClasses => (! $hasAlpineActiveClasses) && $active,
             ])


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
Tabs are not placed on center. `align-items` persist, but not `justify`.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->
![image](https://github.com/user-attachments/assets/1a256dc3-ac0d-4390-ad22-52ea0c2def8d)
![image](https://github.com/user-attachments/assets/e02037f2-c927-4caf-997f-71db976f08b9)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
