### PR TITLE
Support table empty state icon color

### DIFF
--- a/packages/tables/resources/views/components/empty-state/index.blade.php
+++ b/packages/tables/resources/views/components/empty-state/index.blade.php
@@ -7,6 +7,7 @@
     'description' => null,
     'heading',
     'icon',
+    'iconColor' => 'gray',
 ])
 
 <div
@@ -20,7 +21,7 @@
         >
             <x-filament::icon
                 :icon="$icon"
-                class="fi-ta-empty-state-icon h-6 w-6 text-gray-500 dark:text-gray-400"
+                class="fi-ta-empty-state-icon h-6 w-6 text-{{ $iconColor }}-500 dark:text-{{ $iconColor }}-400"
             />
         </div>
 

--- a/packages/tables/src/Table/Concerns/HasEmptyState.php
+++ b/packages/tables/src/Table/Concerns/HasEmptyState.php
@@ -21,6 +21,8 @@ trait HasEmptyState
 
     protected string | Closure | null $emptyStateIcon = null;
 
+    protected string | array | Closure | null $emptyStateIconColor = null;
+
     /**
      * @var array<Action | ActionGroup>
      */
@@ -90,6 +92,13 @@ trait HasEmptyState
         return $this;
     }
 
+    public function emptyStateIconColor(string | array | Closure | null $iconColor): static
+    {
+        $this->emptyStateIconColor = $iconColor;
+
+        return $this;
+    }
+
     public function getEmptyState(): View | Htmlable | null
     {
         return $this->evaluate($this->emptyState);
@@ -120,5 +129,10 @@ trait HasEmptyState
         return $this->evaluate($this->emptyStateIcon)
             ?? FilamentIcon::resolve('tables::empty-state')
             ?? 'heroicon-o-x-mark';
+    }
+
+    public function getEmptyStateIconColor(): string | array | null
+    {
+        return $this->evaluate($this->emptyStateIconColor);
     }
 }


### PR DESCRIPTION
## Description

Support table empty state icon color

`->emptyStateIconColor('primary')`

## Visual changes

<img width="637" alt="Screenshot 2024-11-27 at 12 33 15" src="https://github.com/user-attachments/assets/02fd99b1-487a-4779-b067-ceb4469f07e1">


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
