### PR TITLE
Remove escape chars on input columns

### DIFF
--- a/packages/tables/resources/views/columns/select-column.blade.php
+++ b/packages/tables/resources/views/columns/select-column.blade.php
@@ -34,7 +34,7 @@
                             return
                         }
 
-                        let newState = $refs.newState.value
+                        let newState = $refs.newState.value.replaceAll('\\'+String.fromCharCode(34), String.fromCharCode(34))
 
                         if (state === newState) {
                             return

--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -49,7 +49,7 @@
                             return
                         }
 
-                        let newState = $refs.newState.value
+                        let newState = $refs.newState.value.replaceAll('\\'+String.fromCharCode(34), String.fromCharCode(34))
 
                         if (state === newState) {
                             return


### PR DESCRIPTION
## Description
Both, the `TextInputColumn` and `SelectColumn` have an `<input type="hidden" x-ref="newState>` field.
This field stores the current state but escapes the `double quote` character with a `backslash`.
When the `TextInputColumn` contains double quotes and gets stored, the field renders the escape characters in the browser. On the next update, the escape characters also gets stored in the db.
Also, if someone decides to use the `SelectColumn` with an options key containing a `double quote`, that option cannot be selected.

I wasn't able to inject the `double quote` char without breaking the `x-init=""` attribute, so I used `String.fromCharCode(34)` instead. Maybe there is better solution.
 
## Visual changes
<img width="810" alt="image" src="https://github.com/user-attachments/assets/4c9e2760-c475-4d87-86b0-99de4c936e97">

<img width="810" alt="image" src="https://github.com/user-attachments/assets/c022c5c0-db2c-4657-a776-e31545999beb">



- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
