### PR TITLE
Convert the CheckTranslationsCommand to use the new Laravel command components & Laravel Prompts

### DIFF
--- a/docs-assets/app/app/Exceptions/Handler.php
+++ b/docs-assets/app/app/Exceptions/Handler.php
@@ -3,6 +3,7 @@
 namespace App\Exceptions;
 
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Psr\Log\LogLevel;
 use Throwable;
 
 class Handler extends ExceptionHandler
@@ -10,7 +11,7 @@ class Handler extends ExceptionHandler
     /**
      * A list of exception types with their corresponding custom log levels.
      *
-     * @var array<class-string<\Throwable>, \Psr\Log\LogLevel::*>
+     * @var array<class-string<Throwable>, LogLevel::*>
      */
     protected $levels = [
         //
@@ -19,7 +20,7 @@ class Handler extends ExceptionHandler
     /**
      * A list of the exception types that are not reported.
      *
-     * @var array<int, class-string<\Throwable>>
+     * @var array<int, class-string<Throwable>>
      */
     protected $dontReport = [
         //

--- a/docs-assets/app/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/docs-assets/app/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -13,7 +13,7 @@ class RedirectIfAuthenticated
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next, string ...$guards): Response
     {

--- a/packages/infolists/src/Concerns/InteractsWithInfolists.php
+++ b/packages/infolists/src/Concerns/InteractsWithInfolists.php
@@ -4,7 +4,6 @@ namespace Filament\Infolists\Concerns;
 
 use Exception;
 use Filament\Actions\Contracts\HasActions;
-use Filament\Forms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Forms\Form;
 use Filament\Infolists\Components\Actions\Action;
@@ -350,7 +349,7 @@ trait InteractsWithInfolists
     }
 
     /**
-     * @return array<string, Forms\Form>
+     * @return array<string, Form>
      */
     protected function getInteractsWithInfolistsForms(): array
     {

--- a/packages/support/src/Commands/CheckTranslationsCommand.php
+++ b/packages/support/src/Commands/CheckTranslationsCommand.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Finder\SplFileInfo;
+
 use function Laravel\Prompts\info;
 use function Laravel\Prompts\table;
 use function Laravel\Prompts\warning;

--- a/packages/support/src/Commands/CheckTranslationsCommand.php
+++ b/packages/support/src/Commands/CheckTranslationsCommand.php
@@ -3,6 +3,7 @@
 namespace Filament\Support\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -10,9 +11,12 @@ use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Finder\SplFileInfo;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\table;
+use function Laravel\Prompts\warning;
 
 #[AsCommand(name: 'filament:check-translations')]
-class CheckTranslationsCommand extends Command
+class CheckTranslationsCommand extends Command implements PromptsForMissingInput
 {
     protected $signature = 'filament:check-translations
                             {locales* : The locales to check.}
@@ -71,29 +75,21 @@ class CheckTranslationsCommand extends Command
                 $path = implode(DIRECTORY_SEPARATOR, [$localeRootDirectory, $locale]);
 
                 if ($missingFiles->count() > 0 && $removedFiles->count() > 0) {
-                    $this->warn("[!] Package filament/{$package} has {$missingFiles->count()} missing translation " . Str::plural('file', $missingFiles->count()) . " and {$removedFiles->count()} removed translation " . Str::plural('file', $missingFiles->count()) . ' for ' . locale_get_display_name($locale, 'en') . ".\n");
-
-                    $this->newLine();
+                    warning("[!] Package filament/{$package} has {$missingFiles->count()} missing translation " . Str::plural('file', $missingFiles->count()) . " and {$removedFiles->count()} removed translation " . Str::plural('file', $missingFiles->count()) . ' for ' . locale_get_display_name($locale, 'en') . ".\n");
                 } elseif ($missingFiles->count() > 0) {
-                    $this->warn("[!] Package filament/{$package} has {$missingFiles->count()} missing translation " . Str::plural('file', $missingFiles->count()) . ' for ' . locale_get_display_name($locale, 'en') . ".\n");
-
-                    $this->newLine();
+                    warning("[!] Package filament/{$package} has {$missingFiles->count()} missing translation " . Str::plural('file', $missingFiles->count()) . ' for ' . locale_get_display_name($locale, 'en') . ".\n");
                 } elseif ($removedFiles->count() > 0) {
-                    $this->warn("[!] Package filament/{$package} has {$removedFiles->count()} removed translation " . Str::plural('file', $removedFiles->count()) . ' for ' . locale_get_display_name($locale, 'en') . ".\n");
-
-                    $this->newLine();
+                    warning("[!] Package filament/{$package} has {$removedFiles->count()} removed translation " . Str::plural('file', $removedFiles->count()) . ' for ' . locale_get_display_name($locale, 'en') . ".\n");
                 }
 
                 if ($missingFiles->count() > 0 || $removedFiles->count() > 0) {
-                    $this->table(
+                    table(
                         [$path, ''],
                         array_merge(
                             array_map(fn (string $file): array => [$file, 'Missing'], $missingFiles->toArray()),
                             array_map(fn (string $file): array => [$file, 'Removed'], $removedFiles->toArray()),
                         ),
                     );
-
-                    $this->newLine();
                 }
 
                 collect($files)
@@ -124,29 +120,24 @@ class CheckTranslationsCommand extends Command
                         $locale = locale_get_display_name($locale, 'en');
 
                         if ($missingKeysCount == 0 && $removedKeysCount == 0) {
-                            $this->info("[✓] Package filament/{$package} has no missing or removed translation keys for {$locale}!\n");
-
-                            $this->newLine();
+                            info("[✓] Package filament/{$package} has no missing or removed translation keys for {$locale}!\n");
                         } elseif ($missingKeysCount > 0 && $removedKeysCount > 0) {
-                            $this->warn("[!] Package filament/{$package} has {$missingKeysCount} missing translation " . Str::plural('key', $missingKeysCount) . " and {$removedKeysCount} removed translation " . Str::plural('key', $removedKeysCount) . " for {$locale}.\n");
+                            warning("[!] Package filament/{$package} has {$missingKeysCount} missing translation " . Str::plural('key', $missingKeysCount) . " and {$removedKeysCount} removed translation " . Str::plural('key', $removedKeysCount) . " for {$locale}.\n");
                         } elseif ($missingKeysCount > 0) {
-                            $this->warn("[!] Package filament/{$package} has {$missingKeysCount} missing translation " . Str::plural('key', $missingKeysCount) . " for {$locale}.\n");
+                            warning("[!] Package filament/{$package} has {$missingKeysCount} missing translation " . Str::plural('key', $missingKeysCount) . " for {$locale}.\n");
                         } elseif ($removedKeysCount > 0) {
-                            $this->warn("[!] Package filament/{$package} has {$removedKeysCount} removed translation " . Str::plural('key', $removedKeysCount) . " for {$locale}.\n");
+                            warning("[!] Package filament/{$package} has {$removedKeysCount} removed translation " . Str::plural('key', $removedKeysCount) . " for {$locale}.\n");
                         }
                     })
                     ->filter(static fn ($keys): bool => count($keys['missing']) || count($keys['removed']))
                     ->each(function ($keys, string $file) {
-                        $this->table(
+                        table(
                             [$file, ''],
                             [
                                 ...array_map(fn (string $key): array => [$key, 'Missing'], $keys['missing']),
                                 ...array_map(fn (string $key): array => [$key, 'Removed'], $keys['removed']),
                             ],
-                            'box',
                         );
-
-                        $this->newLine();
                     });
             });
     }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

#14825 Convert the CheckTranslationsCommand to use the new Laravel command components & Laravel Prompts

<!-- Describe the addressed issue or the need for the new or updated functionality. -->


<!-- Add screenshots/recordings of before and after. -->
Small demo

https://github.com/user-attachments/assets/ae659511-d1b8-47e7-bf3b-bf163df3fbfb

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
