### PR TITLE
fix: use app() to create new instance of ResetPassword-Notification

### DIFF
--- a/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
+++ b/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
@@ -68,7 +68,7 @@ class RequestPasswordReset extends SimplePage
                     throw new Exception("Model [{$userClass}] does not have a [notify()] method.");
                 }
 
-                $notification = new ResetPasswordNotification($token);
+                $notification = app(ResetPasswordNotification::class, ['token' => $token]);
                 $notification->url = Filament::getResetPasswordUrl($token, $user);
 
                 $user->notify($notification);


### PR DESCRIPTION
## Description

Currently, it is not possible to overwrite the `ResetPasswordNotification` notification without implementing an entirely new custom reset password page. This limitation restricts flexibility when customizing the reset password process.