### PR TITLE
Disable cells while table loading

### DIFF
--- a/packages/tables/resources/views/columns/checkbox-column.blade.php
+++ b/packages/tables/resources/views/columns/checkbox-column.blade.php
@@ -82,5 +82,6 @@
             \Filament\Support\prepare_inherited_attributes($attributes)
                 ->merge($getExtraInputAttributes(), escape: false)
         "
+        wire:loading.attr="disabled"
     />
 </div>

--- a/packages/tables/resources/views/columns/select-column.blade.php
+++ b/packages/tables/resources/views/columns/select-column.blade.php
@@ -96,6 +96,7 @@
                 isLoading = false
             "
             :attributes="\Filament\Support\prepare_inherited_attributes($getExtraInputAttributeBag())"
+            wire:loading.attr="disabled"
         >
             @if ($canSelectPlaceholder)
                 <option value="">{{ $getPlaceholder() }}</option>

--- a/packages/tables/resources/views/columns/select-column.blade.php
+++ b/packages/tables/resources/views/columns/select-column.blade.php
@@ -62,7 +62,7 @@
     />
 
     <x-filament::input.wrapper
-        :alpine-disabled="'isLoading || ' . \Illuminate\Support\Js::from($isDisabled)"
+        :alpine-disabled="'isLoading'"
         alpine-valid="error === undefined"
         x-tooltip="
             error === undefined

--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -136,6 +136,7 @@
                         ])
                 )
             "
+            wire:loading.attr="disabled"
         />
         {{-- format-ignore-end --}}
     </x-filament::input.wrapper>


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Closes #7294, reopens #13961. As @zepfietje mentioned, further research needs to be made to check if it works with disabled attribute.

EDIT: It appears to be working. Also made a minor UI change for the disabled state of the select column (I showed after and before).

## Visual changes


https://github.com/user-attachments/assets/4c04ff25-4576-41ef-a4d4-4928ba4a6634


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
