### PR TITLE
[3.x] add translatable option to make resource and make relation manager commands 

### DIFF
--- a/packages/panels/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/panels/src/Commands/MakeRelationManagerCommand.php
@@ -27,10 +27,10 @@ class MakeRelationManagerCommand extends Command
     {
         $resource = (string) str(
             $this->argument('resource') ?? text(
-            label: 'What is the resource you would like to create this in?',
-            placeholder: 'DepartmentResource',
-            required: true,
-        ),
+                label: 'What is the resource you would like to create this in?',
+                placeholder: 'DepartmentResource',
+                required: true,
+            ),
         )
             ->studly()
             ->trim('/')
@@ -105,8 +105,8 @@ class MakeRelationManagerCommand extends Command
             ->append('.php');
 
         if (! $this->option('force') && $this->checkForCollision([
-                $path,
-            ])) {
+            $path,
+        ])) {
             return static::INVALID;
         }
 
@@ -126,7 +126,6 @@ class MakeRelationManagerCommand extends Command
         if ($this->option('translatable')) {
             $tableHeaderActions[] = 'Tables\Actions\LocaleSwitcher::make(),';
         }
-
 
         $tableHeaderActions = implode(PHP_EOL, $tableHeaderActions);
 
@@ -153,8 +152,6 @@ class MakeRelationManagerCommand extends Command
             $tableActions[] = 'Tables\Actions\RestoreAction::make(),';
         }
 
-
-
         $tableActions = implode(PHP_EOL, $tableActions);
 
         $tableBulkActions = [];
@@ -179,7 +176,6 @@ class MakeRelationManagerCommand extends Command
             $tableBulkActions[] = 'Tables\Actions\ForceDeleteBulkAction::make(),';
             $tableBulkActions[] = 'Tables\Actions\RestoreBulkAction::make(),';
         }
-
 
         $tableBulkActions = implode(PHP_EOL, $tableBulkActions);
 

--- a/packages/panels/src/Commands/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/MakeResourceCommand.php
@@ -148,13 +148,13 @@ class MakeResourceCommand extends Command
         $viewResourcePagePath = "{$resourcePagesDirectory}/{$viewResourcePageClass}.php";
 
         if (! $this->option('force') && $this->checkForCollision([
-                $resourcePath,
-                $listResourcePagePath,
-                $manageResourcePagePath,
-                $createResourcePagePath,
-                $editResourcePagePath,
-                $viewResourcePagePath,
-            ])) {
+            $resourcePath,
+            $listResourcePagePath,
+            $manageResourcePagePath,
+            $createResourcePagePath,
+            $editResourcePagePath,
+            $viewResourcePagePath,
+        ])) {
             return static::INVALID;
         }
 
@@ -262,11 +262,8 @@ class MakeResourceCommand extends Command
             'translatable' => $translatable,
         ]);
 
-
-
-
         if ($this->option('simple')) {
-            $translatableManagePage  = $this->option('translatable') ? 'use ManageRecords\Concerns\Translatable;' : '';
+            $translatableManagePage = $this->option('translatable') ? 'use ManageRecords\Concerns\Translatable;' : '';
 
             $managePageActions = [];
 

--- a/packages/panels/stubs/RelationManager.stub
+++ b/packages/panels/stubs/RelationManager.stub
@@ -9,9 +9,12 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Filament\Resources\RelationManagers\Concerns\Translatable;
 
 class {{ managerClass }} extends RelationManager
 {
+    {{ translatable }}
+
     protected static string $relationship = '{{ relationship }}';
 
     public function form(Form $form): Form

--- a/packages/panels/stubs/Resource.stub
+++ b/packages/panels/stubs/Resource.stub
@@ -12,9 +12,12 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
+{{ translatableImport }}
 
 class {{ resourceClass }} extends Resource
 {
+    {{ translatable }}
+
     protected static ?string $model = {{ modelClass }}::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';{{ clusterAssignment }}

--- a/packages/panels/stubs/ResourceEditPage.stub
+++ b/packages/panels/stubs/ResourceEditPage.stub
@@ -8,6 +8,8 @@ use {{ baseResourcePage }};
 
 class {{ resourcePageClass }} extends {{ baseResourcePageClass }}
 {
+    {{ translatableEditPage }}
+
     protected static string $resource = {{ resourceClass }}::class;
 
     protected function getHeaderActions(): array

--- a/packages/panels/stubs/ResourceListPage.stub
+++ b/packages/panels/stubs/ResourceListPage.stub
@@ -8,11 +8,13 @@ use {{ baseResourcePage }};
 
 class {{ resourcePageClass }} extends {{ baseResourcePageClass }}
 {
+    {{ translatableListPage }}
     protected static string $resource = {{ resourceClass }}::class;
 
     protected function getHeaderActions(): array
     {
         return [
+{{ actions }}
             Actions\CreateAction::make(),
         ];
     }

--- a/packages/panels/stubs/ResourceManagePage.stub
+++ b/packages/panels/stubs/ResourceManagePage.stub
@@ -8,11 +8,14 @@ use {{ baseResourcePage }};
 
 class {{ resourcePageClass }} extends {{ baseResourcePageClass }}
 {
+    {{ translatableManagePage }}
+
     protected static string $resource = {{ resourceClass }}::class;
 
     protected function getHeaderActions(): array
     {
         return [
+{{ actions }}
             Actions\CreateAction::make(),
         ];
     }

--- a/packages/panels/stubs/ResourcePage.stub
+++ b/packages/panels/stubs/ResourcePage.stub
@@ -8,5 +8,13 @@ use {{ baseResourcePage }};
 
 class {{ resourcePageClass }} extends {{ baseResourcePageClass }}
 {
+    {{ translatableResourcePage }}
     protected static string $resource = {{ resourceClass }}::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+{{ actions }}
+        ];
+    }
 }

--- a/packages/panels/stubs/ResourceViewPage.stub
+++ b/packages/panels/stubs/ResourceViewPage.stub
@@ -8,11 +8,13 @@ use {{ baseResourcePage }};
 
 class {{ resourcePageClass }} extends {{ baseResourcePageClass }}
 {
+    {{ translatableViewPage }}
     protected static string $resource = {{ resourceClass }}::class;
 
     protected function getHeaderActions(): array
     {
         return [
+{{ actions }}
             Actions\EditAction::make(),
         ];
     }


### PR DESCRIPTION
## Description

I added an option for developers to add -t or translatable when they create new resource or relation manager if they are using the official filament Spatie Translatable plugin, this option will add the needed configuration for resources and relation manager and it pages to support the Spatie Translatable plugin easily.


## Visual changes

make:filament-resource 

https://github.com/user-attachments/assets/4a3d3e08-59a5-4f19-b7af-8eb7acb8873e



make:filament-relation-manager 

https://github.com/user-attachments/assets/e7eb487c-7843-45d4-84e1-e754791fd241




## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
