### PR TITLE
Update 01-getting-started.md

### DIFF
--- a/packages/panels/docs/03-resources/01-getting-started.md
+++ b/packages/panels/docs/03-resources/01-getting-started.md
@@ -98,6 +98,14 @@ If you'd like to save time when scaffolding your resources, Filament can also ge
 php artisan make:filament-resource Customer --model --migration --factory
 ```
 
+### Generating the Resource with Spatie Translatable Plugin support
+
+If you are using the official filament [Spatie Translatable Plugin](https://filamentphp.com/plugins/filament-spatie-translatable), Filament can also generate the resource with the required Spatie Translatable Plugin configurations, using the `--translatable` or `-t` flag:
+
+```bash
+php artisan make:filament-resource Customer -t
+```
+
 ## Record titles
 
 A `$recordTitleAttribute` may be set for your resource, which is the name of the column on your model that can be used to identify it from others.


### PR DESCRIPTION
## Description

add a section for using the -t flag when generating resources if the developer is using the  Spatie Translatable Plugin

## Visual changes

<img width="803" alt="Screenshot 2024-12-01 085009" src="https://github.com/user-attachments/assets/a53c698e-b320-423a-a4bc-c12ab99cb222">

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
