### PR TITLE
fix: Import/export sync notifications

### DIFF
--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -240,7 +240,7 @@ trait CanExportRecords
                 )
                 ->dispatch();
 
-            if ($jobConnection !== 'sync') {
+            if (($jobConnection !== 'sync') || (blank($jobConnection) && (config('queue.default') !== 'sync'))) {
                 Notification::make()
                     ->title($action->getSuccessNotificationTitle())
                     ->body(trans_choice('filament-actions::export.notifications.started.body', $export->total_rows, [

--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -240,7 +240,10 @@ trait CanExportRecords
                 )
                 ->dispatch();
 
-            if (($jobConnection !== 'sync') || (blank($jobConnection) && (config('queue.default') !== 'sync'))) {
+            if (
+                (filled($jobConnection) && ($jobConnection !== 'sync')) ||
+                (blank($jobConnection) && (config('queue.default') !== 'sync'))
+            ) {
                 Notification::make()
                     ->title($action->getSuccessNotificationTitle())
                     ->body(trans_choice('filament-actions::export.notifications.started.body', $export->total_rows, [

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -269,7 +269,7 @@ trait CanImportRecords
                     filled($jobBatchName = $importer->getJobBatchName()),
                     fn (PendingBatch $batch) => $batch->name($jobBatchName),
                 )
-                ->finally(function () use ($import, $columnMap, $options) {
+                ->finally(function () use ($columnMap, $import, $jobConnection, $options) {
                     $import->touch('completed_at');
 
                     event(new ImportCompleted($import, $columnMap, $options));
@@ -307,17 +307,25 @@ trait CanImportRecords
                                     ->markAsRead(),
                             ]),
                         )
-                        ->sendToDatabase($import->user, isEventDispatched: true);
+                        ->when(
+                            ($jobConnection === 'sync') || (blank($jobConnection) && (config('queue.default') === 'sync')),
+                            fn (Notification $notification) => $notification
+                                ->persistent()
+                                ->send(),
+                            fn (Notification $notification) => $notification->sendToDatabase($import->user, isEventDispatched: true),
+                        );
                 })
                 ->dispatch();
 
-            Notification::make()
-                ->title($action->getSuccessNotificationTitle())
-                ->body(trans_choice('filament-actions::import.notifications.started.body', $import->total_rows, [
-                    'count' => Number::format($import->total_rows),
-                ]))
-                ->success()
-                ->send();
+            if (($jobConnection !== 'sync') || (blank($jobConnection) && (config('queue.default') !== 'sync'))) {
+                Notification::make()
+                    ->title($action->getSuccessNotificationTitle())
+                    ->body(trans_choice('filament-actions::import.notifications.started.body', $import->total_rows, [
+                        'count' => Number::format($import->total_rows),
+                    ]))
+                    ->success()
+                    ->send();
+            }
         });
 
         $this->registerModalActions([

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -308,7 +308,7 @@ trait CanImportRecords
                             ]),
                         )
                         ->when(
-                            (filled($jobConnection) && ($jobConnection === 'sync')) ||
+                            ($jobConnection === 'sync') ||
                                 (blank($jobConnection) && (config('queue.default') === 'sync')),
                             fn (Notification $notification) => $notification
                                 ->persistent()

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -308,7 +308,8 @@ trait CanImportRecords
                             ]),
                         )
                         ->when(
-                            ($jobConnection === 'sync') || (blank($jobConnection) && (config('queue.default') === 'sync')),
+                            (filled($jobConnection) && ($jobConnection === 'sync')) ||
+                                (blank($jobConnection) && (config('queue.default') === 'sync')),
                             fn (Notification $notification) => $notification
                                 ->persistent()
                                 ->send(),
@@ -317,7 +318,10 @@ trait CanImportRecords
                 })
                 ->dispatch();
 
-            if (($jobConnection !== 'sync') || (blank($jobConnection) && (config('queue.default') !== 'sync'))) {
+            if (
+                (filled($jobConnection) && ($jobConnection !== 'sync')) ||
+                (blank($jobConnection) && (config('queue.default') !== 'sync'))
+            ) {
                 Notification::make()
                     ->title($action->getSuccessNotificationTitle())
                     ->body(trans_choice('filament-actions::import.notifications.started.body', $import->total_rows, [

--- a/packages/actions/src/Exports/Jobs/ExportCompletion.php
+++ b/packages/actions/src/Exports/Jobs/ExportCompletion.php
@@ -75,7 +75,7 @@ class ExportCompletion implements ShouldQueue
                 )),
             )
             ->when(
-                $this->connection === 'sync',
+                ($this->connection === 'sync') || (blank($this->connection) && (config('queue.default') === 'sync')),
                 fn (Notification $notification) => $notification
                     ->persistent()
                     ->send(),

--- a/packages/actions/src/Exports/Jobs/ExportCompletion.php
+++ b/packages/actions/src/Exports/Jobs/ExportCompletion.php
@@ -75,7 +75,7 @@ class ExportCompletion implements ShouldQueue
                 )),
             )
             ->when(
-                (filled($this->connection) && ($this->connection === 'sync')) ||
+                ($this->connection === 'sync') ||
                     (blank($this->connection) && (config('queue.default') === 'sync')),
                 fn (Notification $notification) => $notification
                     ->persistent()

--- a/packages/actions/src/Exports/Jobs/ExportCompletion.php
+++ b/packages/actions/src/Exports/Jobs/ExportCompletion.php
@@ -75,7 +75,8 @@ class ExportCompletion implements ShouldQueue
                 )),
             )
             ->when(
-                ($this->connection === 'sync') || (blank($this->connection) && (config('queue.default') === 'sync')),
+                (filled($this->connection) && ($this->connection === 'sync')) ||
+                    (blank($this->connection) && (config('queue.default') === 'sync')),
                 fn (Notification $notification) => $notification
                     ->persistent()
                     ->send(),


### PR DESCRIPTION
If the imports/exports are using the default connection, which happens to be `sync`, instead of a customised connection, the notifications don't arrive anymore since #14854.