### PR TITLE
Add icon indicating that there is no active sorting

### DIFF
--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -53,7 +53,11 @@
         @if ($sortable)
             <x-filament::icon
                 :alias="$activelySorted && $sortDirection === 'asc' ? 'tables::header-cell.sort-asc-button' : 'tables::header-cell.sort-desc-button'"
-                :icon="$activelySorted && $sortDirection === 'asc' ? 'heroicon-m-chevron-up' : 'heroicon-m-chevron-down'"
+                :icon="match (true) {
+                        $activelySorted && $sortDirection === 'asc' => 'heroicon-m-chevron-up',
+                        $activelySorted && $sortDirection === 'desc' =>  'heroicon-m-chevron-down',
+                        !$activelySorted => 'heroicon-m-chevron-up-down'
+                }"
                 @class([
                     'fi-ta-header-cell-sort-icon h-5 w-5 shrink-0 transition duration-75',
                     'text-gray-950 dark:text-white' => $activelySorted,

--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -53,11 +53,13 @@
         @if ($sortable)
             <x-filament::icon
                 :alias="$activelySorted && $sortDirection === 'asc' ? 'tables::header-cell.sort-asc-button' : 'tables::header-cell.sort-desc-button'"
-                :icon="match (true) {
+                :icon="
+                    match (true) {
                         $activelySorted && $sortDirection === 'asc' => 'heroicon-m-chevron-up',
-                        $activelySorted && $sortDirection === 'desc' =>  'heroicon-m-chevron-down',
-                        !$activelySorted => 'heroicon-m-chevron-up-down'
-                }"
+                        $activelySorted && $sortDirection === 'desc' => 'heroicon-m-chevron-down',
+                        ! $activelySorted => 'heroicon-m-chevron-up-down'
+                    }
+                "
                 @class([
                     'fi-ta-header-cell-sort-icon h-5 w-5 shrink-0 transition duration-75',
                     'text-gray-950 dark:text-white' => $activelySorted,


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
Add visible indication that the table is not being sorted on initial state. This fixes https://github.com/filamentphp/filament/discussions/9627


## Visual changes

<!-- Add screenshots/recordings of before and after. -->
Before (initial not sorted state)
![image](https://github.com/user-attachments/assets/dcb89959-cb3b-43e8-a275-a905fa67a0f0)

After (initial not sorted state)
![image](https://github.com/user-attachments/assets/4b45902a-7995-470a-a48b-2624204b7383)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date. -> Does this need a documentation update?
