### PR TITLE
Add labels for create and edit option actions  in Select input to show label on sr-only for current local.

### DIFF
--- a/packages/forms/resources/lang/ar/components.php
+++ b/packages/forms/resources/lang/ar/components.php
@@ -404,6 +404,8 @@ return [
 
             'create_option' => [
 
+                'label' => 'إضافة',
+
                 'modal' => [
 
                     'heading' => 'إضافة',
@@ -425,6 +427,8 @@ return [
             ],
 
             'edit_option' => [
+
+                'label' => 'تعديل',
 
                 'modal' => [
 

--- a/packages/forms/resources/lang/en/components.php
+++ b/packages/forms/resources/lang/en/components.php
@@ -408,6 +408,8 @@ return [
 
             'create_option' => [
 
+                'label' => 'Create',
+
                 'modal' => [
 
                     'heading' => 'Create',
@@ -429,6 +431,8 @@ return [
             ],
 
             'edit_option' => [
+
+                'label' => 'Edit',
 
                 'modal' => [
 

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -275,6 +275,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
         }
 
         $action = Action::make($this->getCreateOptionActionName())
+            ->label(__('filament-forms::components.select.actions.create_option.modal.heading'))
             ->form(function (Select $component, Form $form): array | Form | null {
                 return $component->getCreateOptionActionForm($form->model(
                     $component->getRelationship() ? $component->getRelationship()->getModel()::class : null,
@@ -429,6 +430,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
         }
 
         $action = Action::make($this->getEditOptionActionName())
+            ->label(__('filament-forms::components.select.actions.edit_option.modal.heading'))
             ->form(function (Select $component, Form $form): array | Form | null {
                 return $component->getEditOptionActionForm(
                     $form->model($component->getSelectedRecord()),

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -275,7 +275,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
         }
 
         $action = Action::make($this->getCreateOptionActionName())
-            ->label(__('filament-forms::components.select.actions.create_option.modal.heading'))
+            ->label(__('filament-forms::components.select.actions.create_option.label'))
             ->form(function (Select $component, Form $form): array | Form | null {
                 return $component->getCreateOptionActionForm($form->model(
                     $component->getRelationship() ? $component->getRelationship()->getModel()::class : null,
@@ -430,7 +430,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
         }
 
         $action = Action::make($this->getEditOptionActionName())
-            ->label(__('filament-forms::components.select.actions.edit_option.modal.heading'))
+            ->label(__('filament-forms::components.select.actions.edit_option.label'))
             ->form(function (Select $component, Form $form): array | Form | null {
                 return $component->getEditOptionActionForm(
                     $form->model($component->getSelectedRecord()),


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

I just add label on createOption and editOption Actions to show icon button label on sr-only for current local.





## Visual changes

<!-- Add screenshots/recordings of before and after. -->

### **Before**
English en
![145](https://github.com/user-attachments/assets/5724e9d5-4e1e-458f-82b0-d20467a78014)

 Arabic ar
![ar_before](https://github.com/user-attachments/assets/f16c0964-c299-4e58-8a00-5530fd806143)

### After

English en
![en_after](https://github.com/user-attachments/assets/fd6a8f57-c977-4246-ae13-ece9be12f267)

Arabic ar
![create_ar_after](https://github.com/user-attachments/assets/5626a0f3-92b2-465f-8ba7-6aec5cf8ee3a)
![edit_ar_after](https://github.com/user-attachments/assets/b21f3c96-e4a9-45eb-92eb-e749fca75db8)





## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
