### PR TITLE
Add tables::header-cell.sort-button

### DIFF
--- a/packages/support/docs/03-icons.md
+++ b/packages/support/docs/03-icons.md
@@ -158,6 +158,7 @@ Alternatively, you may pass an SVG element into the component's slot instead of 
 - `tables::filters.query-builder.constraints.text` - Default icon for a text constraint in the query builder
 - `tables::filters.remove-all-button` - Button to remove all filters
 - `tables::grouping.collapse-button` - Button to collapse a group of records
+- `tables::header-cell.sort-button'` - Sort button of a column sorted in no active sort order
 - `tables::header-cell.sort-asc-button` - Sort button of a column sorted in ascending order
 - `tables::header-cell.sort-desc-button` - Sort button of a column sorted in descending order
 - `tables::reorder.handle` - Handle to grab in order to reorder a record with drag and drop

--- a/packages/support/docs/03-icons.md
+++ b/packages/support/docs/03-icons.md
@@ -158,8 +158,8 @@ Alternatively, you may pass an SVG element into the component's slot instead of 
 - `tables::filters.query-builder.constraints.text` - Default icon for a text constraint in the query builder
 - `tables::filters.remove-all-button` - Button to remove all filters
 - `tables::grouping.collapse-button` - Button to collapse a group of records
-- `tables::header-cell.sort-button'` - Sort button of a column sorted in no active sort order
 - `tables::header-cell.sort-asc-button` - Sort button of a column sorted in ascending order
+- `tables::header-cell.sort-button'` - Sort button of a column when it is currently not sorted
 - `tables::header-cell.sort-desc-button` - Sort button of a column sorted in descending order
 - `tables::reorder.handle` - Handle to grab in order to reorder a record with drag and drop
 - `tables::search-field` - Search input

--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -54,9 +54,9 @@
             <x-filament::icon
                 :alias="
                     match (true) {
-                        $activelySorted && $sortDirection === 'asc' => 'tables::header-cell.sort-asc-button',
-                        $activelySorted && $sortDirection === 'desc' => 'tables::header-cell.sort-desc-button',
-                        ! $activelySorted => 'tables::header-cell.sort-button'
+                        $activelySorted && ($sortDirection === 'asc') => 'tables::header-cell.sort-asc-button',
+                        $activelySorted && ($sortDirection === 'desc') => 'tables::header-cell.sort-desc-button',
+                        default => 'tables::header-cell.sort-button'
                     }
                 "
                 :icon="$activelySorted && $sortDirection === 'asc' ? 'heroicon-m-chevron-up' : 'heroicon-m-chevron-down'"

--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -52,7 +52,13 @@
 
         @if ($sortable)
             <x-filament::icon
-                :alias="$activelySorted && $sortDirection === 'asc' ? 'tables::header-cell.sort-asc-button' : 'tables::header-cell.sort-desc-button'"
+                :alias="
+                    match (true) {
+                        $activelySorted && $sortDirection === 'asc' => 'tables::header-cell.sort-asc-button',
+                        $activelySorted && $sortDirection === 'desc' => 'tables::header-cell.sort-desc-button',
+                        ! $activelySorted => 'tables::header-cell.sort-button'
+                    }
+                "
                 :icon="$activelySorted && $sortDirection === 'asc' ? 'heroicon-m-chevron-up' : 'heroicon-m-chevron-down'"
                 @class([
                     'fi-ta-header-cell-sort-icon h-5 w-5 shrink-0 transition duration-75',

--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -56,7 +56,7 @@
                     match (true) {
                         $activelySorted && ($sortDirection === 'asc') => 'tables::header-cell.sort-asc-button',
                         $activelySorted && ($sortDirection === 'desc') => 'tables::header-cell.sort-desc-button',
-                        default => 'tables::header-cell.sort-button'
+                        default => 'tables::header-cell.sort-button',
                     }
                 "
                 :icon="$activelySorted && $sortDirection === 'asc' ? 'heroicon-m-chevron-up' : 'heroicon-m-chevron-down'"


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

As discussed in https://github.com/filamentphp/filament/pull/14969 this provides a new icon alias that is applied on a table header when no sorting is active. The icon can be overwritten using:

```php
FilamentIcon::register([
    'tables::header-cell.sort-button' => 'heroicon-m-chevron-up-down',
]);
```

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
