### PR TITLE
feat: collapsible chart widget

### DIFF
--- a/packages/widgets/resources/views/chart-widget.blade.php
+++ b/packages/widgets/resources/views/chart-widget.blade.php
@@ -5,10 +5,11 @@
     $heading = $this->getHeading();
     $description = $this->getDescription();
     $filters = $this->getFilters();
+    $collapsible = $this->isCollapsible();
 @endphp
 
 <x-filament-widgets::widget class="fi-wi-chart">
-    <x-filament::section :description="$description" :heading="$heading">
+    <x-filament::section :description="$description" :heading="$heading" :collapsible="$collapsible">
         @if ($filters)
             <x-slot name="headerEnd">
                 <x-filament::input.wrapper

--- a/packages/widgets/resources/views/chart-widget.blade.php
+++ b/packages/widgets/resources/views/chart-widget.blade.php
@@ -16,6 +16,8 @@
                     inline-prefix
                     wire:target="filter"
                     class="w-max sm:-my-2"
+                    x-show="!isCollapsed"
+                    @click.stop=""
                 >
                     <x-filament::input.select
                         inline-prefix

--- a/packages/widgets/src/ChartWidget.php
+++ b/packages/widgets/src/ChartWidget.php
@@ -28,6 +28,8 @@ abstract class ChartWidget extends Widget
 
     protected static ?string $maxHeight = null;
 
+    protected static bool $collapsible = false;
+
     /**
      * @var array<string, mixed> | null
      */
@@ -82,6 +84,11 @@ abstract class ChartWidget extends Widget
     public function getDescription(): string | Htmlable | null
     {
         return static::$description;
+    }
+
+    public function isCollapsible() : bool
+    {
+        return static::$collapsible;
     }
 
     protected function getMaxHeight(): ?string


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This allows wide charts to be collapsed when not needed so they don't interfere with tables or anything else.

related : https://github.com/filamentphp/filament/discussions/10036


By default collapsible is false, but users can set it to collapsible, by adding the code below to the Chart Widget class

```php
protected static bool $collapsible = true;
```

or

```php
public function isCollapsible() : bool
{
   // return true;
   return static::$collapsible;
}
```

## Visual changes

Without filters.

https://github.com/user-attachments/assets/e6d4208c-adcc-4027-924b-5ae584956696

With filters.

https://github.com/user-attachments/assets/a04056a7-4431-42c9-91c8-da054b478bb5




## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
