### PR TITLE
fix: allow text-columns to read a nested array value

### DIFF
--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -43,7 +43,18 @@
             $arrayState = implode(
                 ', ',
                 array_map(
-                    fn ($value) => $value instanceof \Filament\Support\Contracts\HasLabel ? $value->getLabel() : $value,
+                    function ($value): Stringable | string | null {
+
+                        if ($value instanceof \Filament\Support\Contracts\HasLabel) {
+                            return $value->getLabel();
+                        }
+
+                        if (is_array($value)) {
+                            return json_encode($value);
+                        }
+
+                        return $value;
+                    },
                     $arrayState,
                 ),
             );

--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -43,8 +43,7 @@
             $arrayState = implode(
                 ', ',
                 array_map(
-                    function ($value): Stringable | string | null {
-
+                    function ($value) {
                         if ($value instanceof \Filament\Support\Contracts\HasLabel) {
                             return $value->getLabel();
                         }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When a Filament Text column reads a JSON attribute which contains a nested array, it throws an `Array to string conversion` exception.

I tracked down the issue to occuring in `resources/views/columns/text-column.blade.php`, where the `arrayState` is mapped and imploded. It goes through the given array and attempts to grab the value of each item. This works fine for single level arrays, as each value will be something stringable.

However, if one of the values was an array (such as storing a list of integers), then the implode fails.

There is already a check for Filament Enums with Labels for the text column, and collections can be coerced into strings. This PR adds an additional check for if the value being mapped for implosion is an array and if so, then encode it into json. Additionally, it adds a return type to the closure to enforce that the map returns a nullable string.

## Visual changes

### Short example of data:
![image](https://github.com/user-attachments/assets/e73d40da-3822-48ac-a532-d81660c2aacf)

### Before the Fix
![image](https://github.com/user-attachments/assets/2d9c70d5-f1d1-4612-95e5-4c714f4db822)

## After the Fix
![Screenshot 2024-12-04 114039](https://github.com/user-attachments/assets/f948733c-4b09-4109-acea-6ace3e6b69ab)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
