### PR TITLE
Select table records by pivot if needed

### DIFF
--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -349,10 +349,9 @@ trait HasBulkActions
 
         $table = $this->getTable();
 
-        if (
-            $shouldFetchSelectedRecords ||
-            (! ($table->getRelationship() instanceof BelongsToMany && $table->allowsDuplicates()))
-        ) {
+        $usePivotQuery = $table->getRelationship() instanceof BelongsToMany && $table->allowsDuplicates();
+
+        if (! $usePivotQuery) {
             $query = $table->getQuery()->whereKey($this->selectedTableRecords);
             $this->applySortingToTableQuery($query);
 

--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -349,9 +349,10 @@ trait HasBulkActions
 
         $table = $this->getTable();
 
-        $usePivotQuery = $table->getRelationship() instanceof BelongsToMany && $table->allowsDuplicates();
-
-        if (! $usePivotQuery) {
+        if (
+            (! $shouldFetchSelectedRecords) ||
+            (! ($table->getRelationship() instanceof BelongsToMany && $table->allowsDuplicates()))
+        ) {
             $query = $table->getQuery()->whereKey($this->selectedTableRecords);
             $this->applySortingToTableQuery($query);
 


### PR DESCRIPTION
## Description

If you define `allowDuplicates` on a BelongsToMany relation manager (the pivot table contains the `id`), and add a bulk action like `DetachBulkAction`. 

The action runs `getSelectedTableRecords` with `$shouldFetchSelectedRecords` set to `true`. 
In that case it always runs the wrong query, because it should use the pivot query.

This pull request should fix that, but im not sure if it could break other things.

I opted for a variable `$usePivotQuery` to make the `if` statement more readable, but I can also inline it if you want.
