### PR TITLE
Add missing extra attributes to Livewire infolist component

### DIFF
--- a/packages/infolists/resources/views/components/livewire.blade.php
+++ b/packages/infolists/resources/views/components/livewire.blade.php
@@ -1,4 +1,12 @@
-<div {{ $attributes->merge($getExtraAttributes(), escape: false) }}>
+<div
+    {{
+        $attributes
+            ->merge([
+                'id' => $getId(),
+            ], escape: false)
+            ->merge($getExtraAttributes(), escape: false)
+    }}
+>
     @if (filled($key = $getKey()))
         @livewire($getComponent(), $getComponentProperties(), key($key))
     @else

--- a/packages/infolists/resources/views/components/livewire.blade.php
+++ b/packages/infolists/resources/views/components/livewire.blade.php
@@ -1,4 +1,4 @@
-<div>
+<div {{ $attributes->merge($getExtraAttributes(), escape: false) }}>
     @if (filled($key = $getKey()))
         @livewire($getComponent(), $getComponentProperties(), key($key))
     @else


### PR DESCRIPTION
## Description

Fixes: `Livewire` Infolist component uses the `HasExtraAttributes` trait, but it does not apply the attributes in its blade view.

## Visual changes
In my case I need a fixed width and height on the wrapping div in order to display an OSM map.

```php
$infolist->schema([
    Livewire::make(ShowBookedBookablesOnMap::class)
        ->columnSpanFull()
        ->extraAttributes(['class' => 'relative w-full max-w-screen-xl h-[576px]']),
]),
```


Before:
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/0f3bb350-abef-4456-8098-981d6965e5bd">


After:
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/a9fa1cdd-8f87-4c2f-987d-6c94fa403f9d">


## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
