### PR TITLE
Add "flip" property to dropdown component

### DIFF
--- a/packages/support/resources/views/components/dropdown/index.blade.php
+++ b/packages/support/resources/views/components/dropdown/index.blade.php
@@ -1,6 +1,7 @@
 @props([
     'availableHeight' => null,
     'availableWidth' => null,
+    'flip' => true,
     'maxHeight' => null,
     'offset' => 8,
     'placement' => null,
@@ -48,7 +49,7 @@
     @if (! \Filament\Support\is_slot_empty($slot))
         <div
             x-cloak
-            x-float{{ $placement ? ".placement.{$placement}" : '' }}{{ $size ? '.size' : '' }}.flip{{ $shift ? '.shift' : '' }}{{ $teleport ? '.teleport' : '' }}{{ $offset ? '.offset' : '' }}="{ offset: {{ $offset }}, {{ $size ? ('size: ' . $sizeConfig) : '' }} }"
+            x-float{{ $placement ? ".placement.{$placement}" : '' }}{{ $size ? '.size' : '' }}{{ $flip ? '.flip' : '' }}{{ $shift ? '.shift' : '' }}{{ $teleport ? '.teleport' : '' }}{{ $offset ? '.offset' : '' }}="{ offset: {{ $offset }}, {{ $size ? ('size: ' . $sizeConfig) : '' }} }"
             x-ref="panel"
             x-transition:enter-start="opacity-0"
             x-transition:leave-end="opacity-0"


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This simple PR allows the possibility to override the "flip" floating-UI parameter for the "dropdown" blade component:

```blade
<x-filament::dropdown :flip="false">
    ...
</x-filament::dropdown>
```

This is useful in situations where the default "flip" effect would be undesirable.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
