### PR TITLE
Fix style table record actions on Grid layout

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -643,7 +643,7 @@
                                                 :actions="$actions"
                                                 :alignment="(! $contentGrid) ? 'start md:end' : Alignment::Start"
                                                 :record="$record"
-                                                wrap="-sm"
+                                                wrap
                                                 :class="$recordActionsClasses"
                                             />
                                         @endif


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

This  PR fixes an issue when arranging records into a grid. A problem occurs where "Record Actions" do not wrap automatically if there are too many actions because `wrap='-sm'` on `filament-tables::actions` enable  `sm:flex-nowrap` . This causes the actions to overflow the container (div) and results in a broken layout, especially on larger screens.


## Visual changes

<!-- Add screenshots/recordings of before and after. -->
_**before**_

![1](https://github.com/user-attachments/assets/b65eb0b9-10fd-4368-bd75-8d8c1f54f64b)

_**After**_

![after](https://github.com/user-attachments/assets/63d73239-e323-4e2f-a7eb-ecee38b21002)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
