### PR TITLE
Update 02-select.md

### DIFF
--- a/packages/tables/docs/04-filters/02-select.md
+++ b/packages/tables/docs/04-filters/02-select.md
@@ -117,3 +117,20 @@ SelectFilter::make('status')
     ->default('draft')
     ->selectablePlaceholder(false)
 ```
+## Applying select filters by default
+
+You may set a select filter to be enabled by default, using the `default()` method. If using a single-select filter, the `default()` method accepts a single value (see above). If using a `multiple()` select filter, the `default()` method accepts and array:
+
+```php
+use Filament\Tables\Filters\SelectFilter;
+
+SelectFilter::make('status')
+    ->options([
+        'draft' => 'Draft',
+        'reviewing' => 'Reviewing',
+        'published' => 'Published',
+    ])
+    ->default(['draft','reviewing'])
+    ->selectablePlaceholder(false)
+```
+

--- a/packages/tables/docs/04-filters/02-select.md
+++ b/packages/tables/docs/04-filters/02-select.md
@@ -117,9 +117,10 @@ SelectFilter::make('status')
     ->default('draft')
     ->selectablePlaceholder(false)
 ```
+
 ## Applying select filters by default
 
-You may set a select filter to be enabled by default, using the `default()` method. If using a single-select filter, the `default()` method accepts a single value (see above). If using a `multiple()` select filter, the `default()` method accepts and array:
+You may set a select filter to be enabled by default, using the `default()` method. If using a single select filter, the `default()` method accepts a single option value. If using a `multiple()` select filter, the `default()` method accepts an array of option values:
 
 ```php
 use Filament\Tables\Filters\SelectFilter;
@@ -130,7 +131,15 @@ SelectFilter::make('status')
         'reviewing' => 'Reviewing',
         'published' => 'Published',
     ])
-    ->default(['draft','reviewing'])
-    ->selectablePlaceholder(false)
+    ->default('draft')
+
+SelectFilter::make('status')
+    ->options([
+        'draft' => 'Draft',
+        'reviewing' => 'Reviewing',
+        'published' => 'Published',
+    ])
+    ->multiple()
+    ->default(['draft', 'reviewing'])
 ```
 


### PR DESCRIPTION
Adding in specific documentation for select filter default values, both for single select filters and multi-select filters.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

I noticed there was zero mention of how specifically to apply a default to a select filter, whether single or multi-select. 

## Visual changes

Added section of documentation specifying default select filter values. 

## Functional changes

- [n/a] Code style has been fixed by running the `composer cs` command.
- [n/a ] Changes have been tested to not break existing functionality.
- [x ] Documentation is up-to-date.
