### PR TITLE
Fix padded appearance near sub-navigation select element

### DIFF
--- a/packages/panels/resources/views/components/page/index.blade.php
+++ b/packages/panels/resources/views/components/page/index.blade.php
@@ -64,7 +64,7 @@
             ])
         >
             @if ($subNavigation)
-                <div class="md:hidden">
+                <div class="contents md:hidden">
                     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_SUB_NAVIGATION_SELECT_BEFORE, scopes: $this->getRenderHookScopes()) }}
                 </div>
 
@@ -72,7 +72,7 @@
                     :navigation="$subNavigation"
                 />
 
-                <div class="md:hidden">
+                <div class="contents md:hidden">
                     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_SUB_NAVIGATION_SELECT_AFTER, scopes: $this->getRenderHookScopes()) }}
                 </div>
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

With 1e65d98, on mobile the sub-navigation select element appears to have padding above and below when the render hooks for `PAGE_SUB_NAVIGATION_SELECT` are empty.

This is because the wrappers for the hooks, even when empty, are affected by the flexbox gap.

This PR adds `display: contents` to each to undo this effect.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

| Before | After |
|:------:|:-----:|
| ![before](https://github.com/user-attachments/assets/89a30bb2-df3e-40f1-a8f5-60a8f5092e88) | ![after](https://github.com/user-attachments/assets/bcf5b89d-4858-48e9-9237-074008a039c0) |

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
