### PR TITLE
Adds the ability to utilise Livewire's prefetch page on hover feature

### DIFF
--- a/packages/panels/docs/09-configuration.md
+++ b/packages/panels/docs/09-configuration.md
@@ -161,6 +161,21 @@ public function panel(Panel $panel): Panel
 }
 ```
 
+### Prefetching links on hover
+
+By default, when enabling SPA mode, Filament uses Livewire's default gentle [prefetching](https://livewire.laravel.com/docs/navigate#prefetching-links) on-click strategy. If you would like to use the more aggressive prefetching approach by prefetching the next page on hover, you can pass the `prefetch: true` option to the `spa()` method:
+
+```php
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->spa(prefetch: true);
+}
+```
+
 ### Disabling SPA navigation for specific URLs
 
 By default, when enabling SPA mode, any URL that lives on the same domain as the current request will be navigated to using Livewire's [`wire:navigate`](https://livewire.laravel.com/docs/navigate) feature. If you want to disable this for specific URLs, you can use the `spaUrlExceptions()` method:

--- a/packages/panels/src/Panel.php
+++ b/packages/panels/src/Panel.php
@@ -87,7 +87,7 @@ class Panel extends Component
 
         FilamentIcon::register($this->getIcons());
 
-        FilamentView::spa($this->hasSpaMode());
+        FilamentView::spa($this->hasSpaMode(), $this->hasSpaPrefetch());
         FilamentView::spaUrlExceptions($this->getSpaUrlExceptions());
 
         $this->registerRenderHooks();

--- a/packages/panels/src/Panel/Concerns/HasSpaMode.php
+++ b/packages/panels/src/Panel/Concerns/HasSpaMode.php
@@ -8,14 +8,17 @@ trait HasSpaMode
 {
     protected bool | Closure $hasSpaMode = false;
 
+    protected bool | Closure $hasSpaPrefetch = false;
+
     /**
      * @var array<string> | Closure
      */
     protected array | Closure $spaModeUrlExceptions = [];
 
-    public function spa(bool | Closure $condition = true): static
+    public function spa(bool | Closure $condition = true, bool | Closure $prefetch = false): static
     {
         $this->hasSpaMode = $condition;
+        $this->hasSpaPrefetch = $prefetch;
 
         return $this;
     }
@@ -33,6 +36,11 @@ trait HasSpaMode
     public function hasSpaMode(): bool
     {
         return (bool) $this->evaluate($this->hasSpaMode);
+    }
+
+    public function hasSpaPrefetch(): bool
+    {
+        return (bool) $this->evaluate($this->hasSpaPrefetch);
     }
 
     /**

--- a/packages/support/src/Facades/FilamentView.php
+++ b/packages/support/src/Facades/FilamentView.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static bool hasSpaMode(?string $url = null)
+ * @method static bool hasSpaPrefetch()
  * @method static Htmlable renderHook(string $name, string | array | null $scopes = null)
  *
  * @see ViewManager
@@ -30,10 +31,10 @@ class FilamentView extends Facade
         });
     }
 
-    public static function spa(bool $condition = true): void
+    public static function spa(bool $condition = true, bool $prefetch = false): void
     {
-        static::resolved(function (ViewManager $viewManager) use ($condition) {
-            $viewManager->spa($condition);
+        static::resolved(function (ViewManager $viewManager) use ($condition, $prefetch) {
+            $viewManager->spa($condition, $prefetch);
         });
     }
 

--- a/packages/support/src/View/ViewManager.php
+++ b/packages/support/src/View/ViewManager.php
@@ -18,6 +18,8 @@ class ViewManager
 
     protected bool $hasSpaMode = false;
 
+    protected bool $hasSpaPrefetch = false;
+
     /**
      * @var array<string>
      */
@@ -76,9 +78,10 @@ class ViewManager
         return new HtmlString(implode('', $hooks));
     }
 
-    public function spa(bool $condition = true): void
+    public function spa(bool $condition = true, bool $prefetch = false): void
     {
         $this->hasSpaMode = $condition;
+        $this->hasSpaPrefetch = $prefetch;
     }
 
     /**
@@ -107,5 +110,10 @@ class ViewManager
         }
 
         return is_app_url($url);
+    }
+
+    public function hasSpaPrefetch(): bool
+    {
+        return $this->hasSpaPrefetch;
     }
 }

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -149,6 +149,10 @@ if (! function_exists('Filament\Support\generate_href_html')) {
             $html .= ' target="_blank"';
         } elseif ($shouldOpenInSpaMode ?? (FilamentView::hasSpaMode($url))) {
             $html .= ' wire:navigate';
+
+            if (FilamentView::hasSpaPrefetch()) {
+                $html .= '.hover';
+            }
         }
 
         return new HtmlString($html);


### PR DESCRIPTION
## Description

This PR adds the ability to use Livewire's [prefetch page on hover](https://livewire.laravel.com/docs/wire-navigate#prefetching-pages-on-hover) feature by passing the `prefetch: true` argument to the `->spa()` method.

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
