### PR TITLE
add a new helper method for actions for add body text

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/01-create.md
+++ b/packages/actions/docs/07-prebuilt-actions/01-create.md
@@ -101,6 +101,13 @@ CreateAction::make()
     ->successNotificationTitle('User registered')
 ```
 
+To customize the body of this notification, use the `successNotificationBody()` method:
+
+```php
+CreateAction::make()
+    ->successNotificationBody('The user has been successfully registered!')
+```
+
 You may customize the entire notification using the `successNotification()` method:
 
 ```php

--- a/packages/actions/docs/07-prebuilt-actions/02-edit.md
+++ b/packages/actions/docs/07-prebuilt-actions/02-edit.md
@@ -114,6 +114,13 @@ EditAction::make()
     ->successNotificationTitle('User updated')
 ```
 
+To customize the body of this notification, use the `successNotificationBody()` method:
+
+```php
+EditAction::make()
+    ->successNotificationBody('The user has been successfully updated!')
+```
+
 You may customize the entire notification using the `successNotification()` method:
 
 ```php

--- a/packages/actions/docs/07-prebuilt-actions/04-delete.md
+++ b/packages/actions/docs/07-prebuilt-actions/04-delete.md
@@ -57,6 +57,13 @@ DeleteAction::make()
     ->successNotificationTitle('User deleted')
 ```
 
+To customize the body of this notification, use the `successNotificationBody()` method:
+
+```php
+DeleteAction::make()
+    ->successNotificationBody('The user has been successfully deleted')
+```
+
 You may customize the entire notification using the `successNotification()` method:
 
 ```php

--- a/packages/actions/docs/07-prebuilt-actions/05-replicate.md
+++ b/packages/actions/docs/07-prebuilt-actions/05-replicate.md
@@ -82,6 +82,13 @@ ReplicateAction::make()
     ->successNotificationTitle('Category replicated')
 ```
 
+To customize the body of this notification, use the `successNotificationBody()` method:
+
+```php
+ReplicateAction::make()
+    ->successNotificationBody('The category has been successfully replicated')
+```
+
 You may customize the entire notification using the `successNotification()` method:
 
 ```php

--- a/packages/actions/docs/07-prebuilt-actions/06-force-delete.md
+++ b/packages/actions/docs/07-prebuilt-actions/06-force-delete.md
@@ -57,6 +57,13 @@ ForceDeleteAction::make()
     ->successNotificationTitle('User force-deleted')
 ```
 
+To customize the body of this notification, use the `successNotificationBody()` method:
+
+```php
+ForceDeleteAction::make()
+    ->successNotificationBody('The user has been permanently deleted')
+```
+
 You may customize the entire notification using the `successNotification()` method:
 
 ```php

--- a/packages/actions/docs/07-prebuilt-actions/07-restore.md
+++ b/packages/actions/docs/07-prebuilt-actions/07-restore.md
@@ -57,6 +57,13 @@ RestoreAction::make()
     ->successNotificationTitle('User restored')
 ```
 
+To customize the body of this notification, use the `successNotificationBody()` method:
+
+```php
+RestoreAction::make()
+    ->successNotificationBody('The user has been restore back with it data')
+```
+
 You may customize the entire notification using the `successNotification()` method:
 
 ```php

--- a/packages/actions/src/Concerns/CanNotify.php
+++ b/packages/actions/src/Concerns/CanNotify.php
@@ -13,14 +13,19 @@ trait CanNotify
 
     protected string | Closure | null $failureNotificationTitle = null;
 
+    protected string | Closure | null $failureNotificationBody = null;
+
     protected string | Closure | null $successNotificationTitle = null;
+
+    protected string | Closure | null $successNotificationBody = null;
 
     public function sendFailureNotification(): static
     {
         $notification = $this->evaluate($this->failureNotification, [
             'notification' => Notification::make()
                 ->danger()
-                ->title($this->getFailureNotificationTitle()),
+                ->title($this->getFailureNotificationTitle())
+                ->body($this->getFailureNotificationBody()),
         ]);
 
         if (filled($notification?->getTitle())) {
@@ -52,12 +57,20 @@ trait CanNotify
         return $this;
     }
 
+    public function failureNotificationBody(string | Closure | null $body): static
+    {
+        $this->failureNotificationBody = $body;
+
+        return $this;
+    }
+
     public function sendSuccessNotification(): static
     {
         $notification = $this->evaluate($this->successNotification, [
             'notification' => Notification::make()
                 ->success()
-                ->title($this->getSuccessNotificationTitle()),
+                ->title($this->getSuccessNotificationTitle())
+                ->body($this->getSuccessNotificationBody()),
         ]);
 
         if (filled($notification?->getTitle())) {
@@ -89,13 +102,30 @@ trait CanNotify
         return $this;
     }
 
+    public function successNotificationBody(string | Closure | null $body): static
+    {
+        $this->successNotificationBody = $body;
+
+        return $this;
+    }
+
     public function getSuccessNotificationTitle(): ?string
     {
         return $this->evaluate($this->successNotificationTitle);
     }
 
+    public function getSuccessNotificationBody(): ?string
+    {
+        return $this->evaluate($this->successNotificationBody);
+    }
+
     public function getFailureNotificationTitle(): ?string
     {
         return $this->evaluate($this->failureNotificationTitle);
+    }
+
+    public function getFailureNotificationBody(): ?string
+    {
+        return $this->evaluate($this->failureNotificationBody);
     }
 }


### PR DESCRIPTION
## Description
Hello,

I’ve added two new helper methods, successNotificationBody and failureNotificationBody, to simplify the process of adding body text to notifications. These methods make it easier to define a clean and concise body for notifications when needed.

Both methods are completely optional—if no body text is provided, the body will default to null and will not be displayed. This ensures flexibility while keeping the notification system lightweight and user-friendly.
## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ * ] Code style has been fixed by running the `composer cs` command.
- [ * ] Changes have been tested to not break existing functionality.
- [ * ] Documentation is up-to-date.
