### PR TITLE
Remove `x-ignore` from table/index.blade.php

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -113,7 +113,6 @@
     @if (! $isLoaded)
         wire:init="loadTable"
     @endif
-    x-ignore
     @if (FilamentView::hasSpaMode())
         ax-load="visible"
     @else


### PR DESCRIPTION
Fix for Livewire v3.5.13 bug that screen goes black after table action see discussion - https://github.com/filamentphp/filament/discussions/14901



## Caution
I did test this on my own project, which has multiple tables, modals, filters, etc, and everything worked as expected. However, I don't know *why* the `x-ignore` attribute was there is the first place. So it would be great to get this tested by others.

## Description

Fixes bug reported https://discord.com/channels/883083792112300104/956270111176679516/1311365505776488458 and https://discord.com/channels/883083792112300104/1313209203564871710/1313209203564871710

I think this bug was introduced by Livewire bumping the Alpine version containing [this commit](https://github.com/alpinejs/alpine/pull/4428/commits/463f2770ed5efb66b6487c9a33dfb7c8d116765d) which prevents initialising components inside an `x-ignore` attribute.

You can view the original discussion here - https://github.com/filamentphp/filament/discussions/14901

## Visual changes
Before: screen goes black (as 5 modal backdrops display).
After: no modal backdrops and you can use the panel as normal.

## Functional changes

- [x ] Code style has been fixed by running the `composer cs` command.
- [x ] Changes have been tested to not break existing functionality.
- [x ] Documentation is up-to-date.
