### PR TITLE
Fix TagsInput closing filters when removing tag from list

### DIFF
--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -128,7 +128,7 @@
 
                                     <x-slot
                                         name="deleteButton"
-                                        x-on:click="deleteTag(tag)"
+                                        x-on:click.stop="deleteTag(tag)"
                                     ></x-slot>
                                 </x-filament::badge>
                             </template>


### PR DESCRIPTION
## Description

Hello,

When using `TagsInput` to make a custom table filter, clicking the "X" to remove a tag causes the filters to close. 
If the user needs to remove more than one tag they have to open the filters again and remove the tags one by one (or reset the filters and insert again what to keep)

Stopping the event propagation on click prevents this side effect

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
