### PR TITLE
Split logout item from user menu

### DIFF
--- a/packages/panels/resources/views/components/logout-item.blade.php
+++ b/packages/panels/resources/views/components/logout-item.blade.php
@@ -1,0 +1,13 @@
+@props([
+    'logoutItem' => null,
+])
+
+<x-filament::dropdown.list.item
+    :action="$logoutItem?->getUrl() ?? filament()->getLogoutUrl()"
+    :color="$logoutItem?->getColor()"
+    :icon="$logoutItem?->getIcon() ?? \Filament\Support\Facades\FilamentIcon::resolve('panels::user-menu.logout-button') ?? 'heroicon-m-arrow-left-on-rectangle'"
+    method="post"
+    tag="form"
+>
+    {{ $logoutItem?->getLabel() ?? __('filament-panels::layout.actions.logout.label') }}
+</x-filament::dropdown.list.item>

--- a/packages/panels/resources/views/components/user-menu.blade.php
+++ b/packages/panels/resources/views/components/user-menu.blade.php
@@ -84,7 +84,7 @@
             </x-filament::dropdown.list.item>
         @endforeach
 
-        <x-filament-panels::logout-item :item="$logoutItem" />
+        <x-filament-panels::logout-item :logout-item="$logoutItem" />
     </x-filament::dropdown.list>
 </x-filament::dropdown>
 

--- a/packages/panels/resources/views/components/user-menu.blade.php
+++ b/packages/panels/resources/views/components/user-menu.blade.php
@@ -84,15 +84,7 @@
             </x-filament::dropdown.list.item>
         @endforeach
 
-        <x-filament::dropdown.list.item
-            :action="$logoutItem?->getUrl() ?? filament()->getLogoutUrl()"
-            :color="$logoutItem?->getColor()"
-            :icon="$logoutItem?->getIcon() ?? \Filament\Support\Facades\FilamentIcon::resolve('panels::user-menu.logout-button') ?? 'heroicon-m-arrow-left-on-rectangle'"
-            method="post"
-            tag="form"
-        >
-            {{ $logoutItem?->getLabel() ?? __('filament-panels::layout.actions.logout.label') }}
-        </x-filament::dropdown.list.item>
+        <x-filament-panels::logout-item :item="$logoutItem" />
     </x-filament::dropdown.list>
 </x-filament::dropdown>
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Split logout item into its own component in oder to easier override and customize its behavior by overriding a more specific view.

Usecase: need to remove certain items from local storage when a user logs out

## Visual changes

None

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
