### PR TITLE
Add table reorder callbacks

### DIFF
--- a/packages/tables/src/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Concerns/CanReorderRecords.php
@@ -18,7 +18,7 @@ trait CanReorderRecords
             return;
         }
 
-        $this->getTable()->callBeforeReorderCallback();
+        $this->getTable()->callBeforeReorderCallback($order);
 
         $orderColumn = (string) str($this->getTable()->getReorderColumn())->afterLast('.');
 
@@ -51,7 +51,7 @@ trait CanReorderRecords
                 ]);
         });
 
-        $this->getTable()->callAfterReorderCallback();
+        $this->getTable()->callAfterReorderCallback($order);
     }
 
     public function toggleTableReordering(): void

--- a/packages/tables/src/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Concerns/CanReorderRecords.php
@@ -18,6 +18,8 @@ trait CanReorderRecords
             return;
         }
 
+        $this->getTable()->callBeforeReorderCallback();
+
         $orderColumn = (string) str($this->getTable()->getReorderColumn())->afterLast('.');
 
         DB::transaction(function () use ($order, $orderColumn) {
@@ -48,6 +50,8 @@ trait CanReorderRecords
                     ),
                 ]);
         });
+
+        $this->getTable()->callAfterReorderCallback();
     }
 
     public function toggleTableReordering(): void

--- a/packages/tables/src/Table/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Table/Concerns/CanReorderRecords.php
@@ -19,6 +19,10 @@ trait CanReorderRecords
 
     protected ?Closure $modifyReorderRecordsTriggerActionUsing = null;
 
+    protected ?Closure $beforeReorderCallback = null;
+
+    protected ?Closure $afterReorderCallback = null;
+
     public function reorderRecordsTriggerAction(?Closure $callback): static
     {
         $this->modifyReorderRecordsTriggerActionUsing = $callback;
@@ -26,13 +30,16 @@ trait CanReorderRecords
         return $this;
     }
 
-    public function reorderable(string | Closure | null $column = null, bool | Closure | null $condition = null): static
+    public function reorderable(string | Closure | null $column = null, bool | Closure | null $condition = null, ?Closure $beforeReorder = null, ?Closure $afterReorder = null): static
     {
         $this->reorderColumn = $column;
 
         if ($condition !== null) {
             $this->isReorderable = $condition;
         }
+
+        $this->beforeReorderCallback = $beforeReorder;
+        $this->afterReorderCallback = $afterReorder;
 
         return $this;
     }
@@ -82,5 +89,19 @@ trait CanReorderRecords
     public function isReorderAuthorized(): bool
     {
         return (bool) $this->evaluate($this->isReorderAuthorized);
+    }
+
+    public function callBeforeReorderCallback(): void
+    {
+        if ($this->beforeReorderCallback !== null) {
+            $this->evaluate($this->beforeReorderCallback);
+        }
+    }
+
+    public function callAfterReorderCallback(): void
+    {
+        if ($this->afterReorderCallback !== null) {
+            $this->evaluate($this->afterReorderCallback);
+        }
     }
 }

--- a/packages/tables/src/Table/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Table/Concerns/CanReorderRecords.php
@@ -91,17 +91,23 @@ trait CanReorderRecords
         return (bool) $this->evaluate($this->isReorderAuthorized);
     }
 
-    public function callBeforeReorderCallback(): void
+    /**
+     * @param  array<int | string>  $order
+     */
+    public function callBeforeReorderCallback(array $order): void
     {
         if ($this->beforeReorderCallback !== null) {
-            $this->evaluate($this->beforeReorderCallback);
+            $this->evaluate($this->beforeReorderCallback, ['order' => $order]);
         }
     }
 
-    public function callAfterReorderCallback(): void
+    /**
+     * @param  array<int | string>  $order
+     */
+    public function callAfterReorderCallback(array $order): void
     {
         if ($this->afterReorderCallback !== null) {
-            $this->evaluate($this->afterReorderCallback);
+            $this->evaluate($this->afterReorderCallback, ['order' => $order]);
         }
     }
 }


### PR DESCRIPTION
## Description

Since #6208 model events are not triggered anymore when reordering table records. It is a problem when using Laravel Scout for example.
This PR adds a before and after reorder callback.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.


Hopefully this is close enough to the Filament way of doing things. I wasn't sure if the callbacks should be parameters of the `reorderable` method or separate methods themselves. Tell me if I need to refactor anything.

I'd need help for the documentation if it is required. English is not my primary language.

