### PR TITLE
DatePicker is set to readOnly(), but it still can clicked and open calendar popup

### DIFF
--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -248,7 +248,7 @@ export default function fileUploadFormComponent({
                     .map((file) =>
                         file.source instanceof File
                             ? file.serverId
-                            : (this.uploadedFileIndex[file.source] ?? null),
+                            : this.uploadedFileIndex[file.source] ?? null,
                     ) // file.serverId is null for a file that is not yet uploaded
                     .filter((fileKey) => fileKey)
 

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -101,12 +101,14 @@
 
                 <button
                     x-ref="button"
-                    x-on:click="togglePanelVisibility()"
-                    x-on:keydown.enter.stop.prevent="
-                        if (! $el.disabled) {
-                            isOpen() ? selectDate() : togglePanelVisibility()
-                        }
-                    "
+                    @if (! $isReadOnly())
+                        x-on:click="togglePanelVisibility()"
+                        x-on:keydown.enter.stop.prevent="
+                            if (! $el.disabled) {
+                                isOpen() ? selectDate() : togglePanelVisibility()
+                            }
+                        "
+                    @endif
                     x-on:keydown.arrow-left.stop.prevent="if (! $el.disabled) focusPreviousDay()"
                     x-on:keydown.arrow-right.stop.prevent="if (! $el.disabled) focusNextDay()"
                     x-on:keydown.arrow-up.stop.prevent="if (! $el.disabled) focusPreviousWeek()"

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -101,14 +101,12 @@
 
                 <button
                     x-ref="button"
-                    @if (! $isReadOnly())
-                        x-on:click="togglePanelVisibility()"
-                        x-on:keydown.enter.stop.prevent="
-                            if (! $el.disabled) {
-                                isOpen() ? selectDate() : togglePanelVisibility()
-                            }
-                        "
-                    @endif
+                    x-on:click="togglePanelVisibility()"
+                    x-on:keydown.enter.stop.prevent="
+                        if (! $el.disabled) {
+                            isOpen() ? selectDate() : togglePanelVisibility()
+                        }
+                    "
                     x-on:keydown.arrow-left.stop.prevent="if (! $el.disabled) focusPreviousDay()"
                     x-on:keydown.arrow-right.stop.prevent="if (! $el.disabled) focusNextDay()"
                     x-on:keydown.arrow-up.stop.prevent="if (! $el.disabled) focusPreviousWeek()"
@@ -119,7 +117,7 @@
                     aria-label="{{ $getPlaceholder() }}"
                     type="button"
                     tabindex="-1"
-                    @disabled($isDisabled)
+                    @disabled($isDisabled || $isReadOnly())
                     {{
                         $getExtraTriggerAttributeBag()->class([
                             'w-full',

--- a/packages/panels/resources/views/components/unsaved-action-changes-alert.blade.php
+++ b/packages/panels/resources/views/components/unsaved-action-changes-alert.blade.php
@@ -8,13 +8,11 @@
 
                 if (
                     [
-                        ...(@js($this instanceof \Filament\Actions\Contracts\HasActions) ? ($wire.mountedActions ?? []) : []),
+                        ...(@js($this instanceof \Filament\Actions\Contracts\HasActions) ? $wire.mountedActions ?? [] : []),
                         ...(@js($this instanceof \Filament\Forms\Contracts\HasForms)
-                            ? ($wire.mountedFormComponentActions ?? [])
+                            ? $wire.mountedFormComponentActions ?? []
                             : []),
-                        ...(@js($this instanceof \Filament\Infolists\Contracts\HasInfolists)
-                            ? ($wire.mountedInfolistActions ?? [])
-                            : []),
+                        ...(@js($this instanceof \Filament\Infolists\Contracts\HasInfolists) ? $wire.mountedInfolistActions ?? [] : []),
                         ...(@js($this instanceof \Filament\Tables\Contracts\HasTable)
                             ? [
                                   ...($wire.mountedTableActions ?? []),


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
I'm using DatePicker with readOnly() and native(false) options, but I can still do the Click action and it displays the calendar popup.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes
No visual changes.

<!-- Add screenshots/recordings of before and after. -->

## Functional changes
Just add IF if it isReadOnly.

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
