### PR TITLE
fix: handle tag switching for non-ASCII characters

### DIFF
--- a/packages/forms/src/Components/Tabs/Tab.php
+++ b/packages/forms/src/Components/Tabs/Tab.php
@@ -21,7 +21,7 @@ class Tab extends Component implements CanConcealComponents
     final public function __construct(string $label)
     {
         $this->label($label);
-        $this->id(Str::slug($label));
+        $this->id(Str::slug(Str::transliterate($label, strict: true)));
     }
 
     public static function make(string $label): static

--- a/packages/forms/src/Components/Wizard/Step.php
+++ b/packages/forms/src/Components/Wizard/Step.php
@@ -27,7 +27,7 @@ class Step extends Component implements CanConcealComponents
     final public function __construct(string $label)
     {
         $this->label($label);
-        $this->id(Str::slug($label));
+        $this->id(Str::slug(Str::transliterate($label, strict: true)));
     }
 
     public static function make(string $label): static

--- a/packages/infolists/src/Components/Tabs/Tab.php
+++ b/packages/infolists/src/Components/Tabs/Tab.php
@@ -20,7 +20,7 @@ class Tab extends Component
     final public function __construct(string $label)
     {
         $this->label($label);
-        $this->id(Str::slug($label));
+        $this->id(Str::slug(Str::transliterate($label, strict: true)));
     }
 
     public static function make(string $label): static


### PR DESCRIPTION
## Description

Fixed an issue where tabs or steps could not be switched when non-ASCII characters (e.g., Chinese) were used as their titles.

#14080 

## Visual changes

none

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
