### PR TITLE
Dot in key inside key-value field

### DIFF
--- a/packages/forms/resources/js/components/key-value.js
+++ b/packages/forms/resources/js/components/key-value.js
@@ -81,6 +81,7 @@ export default function keyValueFormComponent({ state }) {
             let rows = []
 
             for (let [key, value] of Object.entries(this.state ?? {})) {
+                key = String(key).replace(/\./g, '\.')
                 rows.push({
                     key,
                     value,

--- a/packages/forms/resources/js/components/key-value.js
+++ b/packages/forms/resources/js/components/key-value.js
@@ -55,12 +55,13 @@ export default function keyValueFormComponent({ state }) {
 
             this.updateState()
         },
-
+        escapeString: function (string) {
+            return String(string).replace(/\./g, '\.');
+        },
         reorderRows: function (event) {
             const rows = Alpine.raw(this.rows)
 
             this.rows = []
-
             const reorderedRow = rows.splice(event.oldIndex, 1)[0]
             rows.splice(event.newIndex, 0, reorderedRow)
 
@@ -81,7 +82,8 @@ export default function keyValueFormComponent({ state }) {
             let rows = []
 
             for (let [key, value] of Object.entries(this.state ?? {})) {
-                key = String(key).replace(/\./g, '\.')
+                key = this.escapeString(key)
+                value = this.escapeString(value)
                 rows.push({
                     key,
                     value,
@@ -99,8 +101,9 @@ export default function keyValueFormComponent({ state }) {
                     return
                 }
 
-                state[row.key] = row.value
+                state[this.escapeString(row.key)] = this.escapeString(row.value)
             })
+
 
             // This is a hack to prevent the component from updating rows again
             // after a state update, which would otherwise be done by the `state`
@@ -110,6 +113,6 @@ export default function keyValueFormComponent({ state }) {
             this.shouldUpdateRows = false
 
             this.state = state
-        },
+        }
     }
 }

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -101,6 +101,8 @@
                 })"
         wire:ignore
         x-ignore
+        @mouseover="pond.allowPaste = true"
+        @mouseleave="pond.allowPaste = false"
         {{
             $attributes
                 ->merge([

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -101,8 +101,6 @@
                 })"
         wire:ignore
         x-ignore
-        @mouseover="pond.allowPaste = true"
-        @mouseleave="pond.allowPaste = false"
         {{
             $attributes
                 ->merge([


### PR DESCRIPTION
[Problem in this issue](https://github.com/filamentphp/filament/issues/12116#issuecomment-2220484103)

## Description

When trying to save key-value field and has a dot in key field, i have error "No synthesizer found for key" from Livewire, couse strings with dot converts to objects

![image](https://github.com/user-attachments/assets/fbee25a2-57e8-4555-99f3-fbd9e947d262)

## Visual changes

No visual changes

## Functional changes

- [ X ] Code style has been fixed by running the `composer cs` command.
- [ X ] Changes have been tested to not break existing functionality.
- [ X ] Documentation is up-to-date.
