### PR TITLE
Refactor: To allow passing in a callback function to `assertTableActionDataSet` and `assertTableBulkActionDataSet`

### DIFF
--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -13,7 +13,7 @@ namespace Livewire\Features\SupportTesting {
 
         public function setTableActionData(array $data): static {}
 
-        public function assertTableActionDataSet(array $data): static {}
+        public function assertTableActionDataSet(array | Closure $state): static {}
 
         public function callTableAction(string | array $name, $record = null, array $data = [], array $arguments = []): static {}
 

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -53,7 +53,7 @@ namespace Livewire\Features\SupportTesting {
 
         public function setTableBulkActionData(array $data): static {}
 
-        public function assertTableBulkActionDataSet(array $data): static {}
+        public function assertTableBulkActionDataSet(array | Closure $state): static {}
 
         public function callTableBulkAction(string $name, array | Collection $records, array $data = [], array $arguments = []): static {}
 

--- a/packages/tables/docs/12-testing.md
+++ b/packages/tables/docs/12-testing.md
@@ -489,6 +489,28 @@ it('can load existing post data for editing', function () {
 });
 ```
 
+You may also find it useful to pass a function to the `assertTableActionDataSet()` and `assertTableBulkActionDataSet()` method, which allows you to access the form `$state` and perform additional assertions:
+
+```php
+use Illuminate\Support\Str;
+use function Pest\Livewire\livewire;
+
+it('can automatically generate a slug from the title without any spaces', function () {
+    $post = Post::factory()->create();
+
+    livewire(PostResource\Pages\ListPosts::class)
+        ->mountTableAction(EditAction::class, $post)
+        ->assertTableActionDataSet(function (array $state) use($post): array {
+            expect($state['slug'])
+                ->not->toContain(' ');
+                
+            return [
+                'slug' => Str::slug($post->title),
+            ];
+        });
+});
+```
+
 ### Action state
 
 To ensure that an action or bulk action exists or doesn't in a table, you can use the `assertTableActionExists()` / `assertTableActionDoesNotExist()` or  `assertTableBulkActionExists()` / `assertTableBulkActionDoesNotExist()` method:

--- a/packages/tables/docs/12-testing.md
+++ b/packages/tables/docs/12-testing.md
@@ -489,7 +489,7 @@ it('can load existing post data for editing', function () {
 });
 ```
 
-You may also find it useful to pass a function to the `assertTableActionDataSet()` and `assertTableBulkActionDataSet()` method, which allows you to access the form `$state` and perform additional assertions:
+You may also find it useful to pass a function to the `assertTableActionDataSet()` and `assertTableBulkActionDataSet()` methods, which allow you to access the form `$state` and perform additional assertions:
 
 ```php
 use Illuminate\Support\Str;
@@ -500,7 +500,7 @@ it('can automatically generate a slug from the title without any spaces', functi
 
     livewire(PostResource\Pages\ListPosts::class)
         ->mountTableAction(EditAction::class, $post)
-        ->assertTableActionDataSet(function (array $state) use($post): array {
+        ->assertTableActionDataSet(function (array $state) use ($post): array {
             expect($state['slug'])
                 ->not->toContain(' ');
                 

--- a/packages/tables/src/TablesServiceProvider.php
+++ b/packages/tables/src/TablesServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Tables;
 
-use Filament\Support\Assets\AlpineComponent;
 use Filament\Support\Assets\Js;
 use Filament\Support\Facades\FilamentAsset;
 use Filament\Tables\Testing\TestsActions;

--- a/packages/tables/src/Testing/TestsActions.php
+++ b/packages/tables/src/Testing/TestsActions.php
@@ -85,14 +85,14 @@ class TestsActions
     {
         return function (array | Closure $state): static {
             $mountedTableActionsData = $this->instance()->mountedTableActionsData;
-            $arrayKey = array_key_last($mountedTableActionsData);
+            $mountedTableActionIndex = array_key_last($mountedTableActionsData);
 
             if ($state instanceof Closure) {
-                $state = $state($mountedTableActionsData[$arrayKey]);
+                $state = $state($mountedTableActionsData[$mountedTableActionIndex] ?? []);
             }
 
             if (is_array($state)) {
-                foreach (Arr::dot($state, prepend: 'mountedTableActionsData.' . $arrayKey . '.') as $key => $value) {
+                foreach (Arr::dot($state, prepend: "mountedTableActionsData.{$mountedTableActionIndex}.") as $key => $value) {
                     $this->assertSet($key, $value);
                 }
             }

--- a/packages/tables/src/Testing/TestsActions.php
+++ b/packages/tables/src/Testing/TestsActions.php
@@ -83,9 +83,18 @@ class TestsActions
 
     public function assertTableActionDataSet(): Closure
     {
-        return function (array $data): static {
-            foreach (Arr::dot($data, prepend: 'mountedTableActionsData.' . array_key_last($this->instance()->mountedTableActionsData) . '.') as $key => $value) {
-                $this->assertSet($key, $value);
+        return function (array | Closure $state): static {
+            $mountedTableActionsData = $this->instance()->mountedTableActionsData;
+            $arrayKey = array_key_last($mountedTableActionsData);
+
+            if ($state instanceof Closure) {
+                $state = $state($mountedTableActionsData[$arrayKey]);
+            }
+
+            if (is_array($state)) {
+                foreach (Arr::dot($state, prepend: 'mountedTableActionsData.' . $arrayKey . '.') as $key => $value) {
+                    $this->assertSet($key, $value);
+                }
             }
 
             return $this;

--- a/packages/tables/src/Testing/TestsBulkActions.php
+++ b/packages/tables/src/Testing/TestsBulkActions.php
@@ -70,9 +70,15 @@ class TestsBulkActions
 
     public function assertTableBulkActionDataSet(): Closure
     {
-        return function (array $data): static {
-            foreach (Arr::dot($data, prepend: 'mountedTableBulkActionData.') as $key => $value) {
-                $this->assertSet($key, $value);
+        return function (array | Closure $state): static {
+            if ($state instanceof Closure) {
+                $state = $state($this->get('mountedTableBulkActionData'));
+            }
+
+            if (is_array($state)) {
+                foreach (Arr::dot($state, prepend: 'mountedTableBulkActionData.') as $key => $value) {
+                    $this->assertSet($key, $value);
+                }
             }
 
             return $this;

--- a/tests/src/Tables/Actions/ActionTest.php
+++ b/tests/src/Tables/Actions/ActionTest.php
@@ -56,7 +56,10 @@ it('can set default action data when mounted', function () {
         ->mountTableAction('data')
         ->assertTableActionDataSet([
             'foo' => 'bar',
-        ]);
+        ])
+        ->assertTableActionDataSet(function (array $data): bool {
+            return $data['foo'] === 'bar';
+        });
 });
 
 it('can call an action with arguments', function () {

--- a/tests/src/Tables/Actions/BulkActionTest.php
+++ b/tests/src/Tables/Actions/BulkActionTest.php
@@ -53,7 +53,10 @@ it('can set default bulk action data when mounted', function () {
         ->mountTableBulkAction('data', records: $posts)
         ->assertTableBulkActionDataSet([
             'foo' => 'bar',
-        ]);
+        ])
+        ->assertTableBulkActionDataSet(function (array $data): bool {
+            return $data['foo'] === 'bar';
+        });
 });
 
 it('can call a bulk action with arguments', function () {


### PR DESCRIPTION
## Description

This PR refactors the `assertTableActionDataSet` and `assertTableBulkActionDataSet` so that you can pass in a callback to get access to the data that is currently set in the table action, like you can with the `assertFormSet`.
 
I think this feature will be useful for testing the `FileUpload` as currently I don't know how you would test that a image is set with `assertTableActonDataSet` because it uses UUIDs so you can't assert that the right file has been set.

Also when I ran `composer cs`, it removed this `use Filament\Support\Assets\AlpineComponent;` from `packages/tables/src/TablesServiceProvider.php`, I checked and I couldn't see it being used anywhere. I commited it even though its not related to my PR, not sure if I should have. If not then please let me know and I'll revert.

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
