### PR TITLE
Add class to target logout action

### DIFF
--- a/packages/panels/resources/views/components/user-menu.blade.php
+++ b/packages/panels/resources/views/components/user-menu.blade.php
@@ -90,6 +90,7 @@
             :icon="$logoutItem?->getIcon() ?? \Filament\Support\Facades\FilamentIcon::resolve('panels::user-menu.logout-button') ?? 'heroicon-m-arrow-left-on-rectangle'"
             method="post"
             tag="form"
+            class="fi-user-menu-logout-form"
         >
             {{ $logoutItem?->getLabel() ?? __('filament-panels::layout.actions.logout.label') }}
         </x-filament::dropdown.list.item>


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

A way to be able to target the logout button/form without having to override the user menu view (instead of #15051).

## Visual changes

None

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
