### PR TITLE
Run optimize command under `filament` key in `artisan optimize`

### DIFF
--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -154,7 +154,7 @@ class SupportServiceProvider extends PackageServiceProvider
                 $this->optimizes(
                     optimize: 'filament:optimize', /** @phpstan-ignore-line */
                     clear: 'filament:optimize-clear', /** @phpstan-ignore-line */
-                    key: 'filament'
+                    key: 'filament', /** @phpstan-ignore-line */
                 );
             }
         }

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -154,6 +154,7 @@ class SupportServiceProvider extends PackageServiceProvider
                 $this->optimizes(
                     optimize: 'filament:optimize', /** @phpstan-ignore-line */
                     clear: 'filament:optimize-clear', /** @phpstan-ignore-line */
+                    key: 'filament'
                 );
             }
         }


### PR DESCRIPTION
Currently the output looks like this, which leaves it unclear what `support` exactly is. I suspected already Filament support, but replacing that with a key called `filament` would make it more clear.
```
   INFO  Caching framework bootstrap, configuration, and metadata.  

  config ..................................................................................................... 43.80ms DONE
  events ...................................................................................................... 0.90ms DONE
  routes ..................................................................................................... 78.01ms DONE
  views ..................................................................................................... 488.54ms DONE
  blade-icons ................................................................................................ 18.25ms DONE
  support .................................................................................................... 20.48ms DONE
  laravel-data ............................................................................................... 17.66ms DONE
```