### PR TITLE
Fix inconsistent escaping behaviour

### DIFF
--- a/packages/actions/src/Concerns/HasExtraModalWindowAttributes.php
+++ b/packages/actions/src/Concerns/HasExtraModalWindowAttributes.php
@@ -34,7 +34,7 @@ trait HasExtraModalWindowAttributes
         $temporaryAttributeBag = new ComponentAttributeBag;
 
         foreach ($this->extraModalWindowAttributes as $extraModalWindowAttributes) {
-            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraModalWindowAttributes));
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraModalWindowAttributes), escape: false);
         }
 
         return $temporaryAttributeBag->getAttributes();

--- a/packages/forms/resources/views/components/field-wrapper/index.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/index.blade.php
@@ -53,7 +53,7 @@
     data-field-wrapper
     {{
         $attributes
-            ->merge($field?->getExtraFieldWrapperAttributes() ?? [])
+            ->merge($field?->getExtraFieldWrapperAttributes() ?? [], escape: false)
             ->class(['fi-fo-field-wrp'])
     }}
 >

--- a/packages/forms/src/Components/Concerns/HasExtraFieldWrapperAttributes.php
+++ b/packages/forms/src/Components/Concerns/HasExtraFieldWrapperAttributes.php
@@ -34,7 +34,7 @@ trait HasExtraFieldWrapperAttributes
         $temporaryAttributeBag = new ComponentAttributeBag;
 
         foreach ($this->extraFieldWrapperAttributes as $extraFieldWrapperAttributes) {
-            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraFieldWrapperAttributes));
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraFieldWrapperAttributes), escape: false);
         }
 
         return $temporaryAttributeBag->getAttributes();

--- a/packages/forms/src/Components/Concerns/HasExtraInputAttributes.php
+++ b/packages/forms/src/Components/Concerns/HasExtraInputAttributes.php
@@ -34,7 +34,7 @@ trait HasExtraInputAttributes
         $temporaryAttributeBag = new ComponentAttributeBag;
 
         foreach ($this->extraInputAttributes as $extraInputAttributes) {
-            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraInputAttributes));
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraInputAttributes), escape: false);
         }
 
         return $temporaryAttributeBag->getAttributes();

--- a/packages/forms/src/Components/DateTimePicker.php
+++ b/packages/forms/src/Components/DateTimePicker.php
@@ -371,7 +371,7 @@ class DateTimePicker extends Field implements Contracts\HasAffixActions
         $temporaryAttributeBag = new ComponentAttributeBag;
 
         foreach ($this->extraTriggerAttributes as $extraTriggerAttributes) {
-            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraTriggerAttributes));
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraTriggerAttributes), escape: false);
         }
 
         return $temporaryAttributeBag->getAttributes();

--- a/packages/infolists/resources/views/components/entry-wrapper/index.blade.php
+++ b/packages/infolists/resources/views/components/entry-wrapper/index.blade.php
@@ -55,7 +55,7 @@
 <div
     {{
         $attributes
-            ->merge($entry?->getExtraEntryWrapperAttributes() ?? [])
+            ->merge($entry?->getExtraEntryWrapperAttributes() ?? [], escape: false)
             ->class(['fi-in-entry-wrp'])
     }}
 >

--- a/packages/infolists/src/Components/Concerns/HasExtraEntryWrapperAttributes.php
+++ b/packages/infolists/src/Components/Concerns/HasExtraEntryWrapperAttributes.php
@@ -34,7 +34,7 @@ trait HasExtraEntryWrapperAttributes
         $temporaryAttributeBag = new ComponentAttributeBag;
 
         foreach ($this->extraEntryWrapperAttributes as $extraEntryWrapperAttributes) {
-            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraEntryWrapperAttributes));
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraEntryWrapperAttributes), escape: false);
         }
 
         return $temporaryAttributeBag->getAttributes();

--- a/packages/support/src/Concerns/HasExtraAlpineAttributes.php
+++ b/packages/support/src/Concerns/HasExtraAlpineAttributes.php
@@ -34,7 +34,7 @@ trait HasExtraAlpineAttributes
         $temporaryAttributeBag = new ComponentAttributeBag;
 
         foreach ($this->extraAlpineAttributes as $extraAlpineAttributes) {
-            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraAlpineAttributes));
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraAlpineAttributes), escape: false);
         }
 
         return $temporaryAttributeBag->getAttributes();

--- a/packages/support/src/Concerns/HasExtraAttributes.php
+++ b/packages/support/src/Concerns/HasExtraAttributes.php
@@ -34,7 +34,7 @@ trait HasExtraAttributes
         $temporaryAttributeBag = new ComponentAttributeBag;
 
         foreach ($this->extraAttributes as $extraAttributes) {
-            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraAttributes));
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraAttributes), escape: false);
         }
 
         return $temporaryAttributeBag->getAttributes();

--- a/packages/support/src/Concerns/HasExtraSidebarAttributes.php
+++ b/packages/support/src/Concerns/HasExtraSidebarAttributes.php
@@ -34,7 +34,7 @@ trait HasExtraSidebarAttributes
         $temporaryAttributeBag = new ComponentAttributeBag;
 
         foreach ($this->extraSidebarAttributes as $extraSidebarAttributes) {
-            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraSidebarAttributes));
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraSidebarAttributes), escape: false);
         }
 
         return $temporaryAttributeBag->getAttributes();

--- a/packages/support/src/Concerns/HasExtraTopbarAttributes.php
+++ b/packages/support/src/Concerns/HasExtraTopbarAttributes.php
@@ -34,7 +34,7 @@ trait HasExtraTopbarAttributes
         $temporaryAttributeBag = new ComponentAttributeBag;
 
         foreach ($this->extraTopbarAttributes as $extraTopbarAttributes) {
-            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraTopbarAttributes));
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraTopbarAttributes), escape: false);
         }
 
         return $temporaryAttributeBag->getAttributes();

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -106,7 +106,7 @@ if (! function_exists('Filament\Support\prepare_inherited_attributes')) {
             collect($originalAttributes)
                 ->filter(fn ($value, string $name): bool => ! str($name)->startsWith(['x-', 'data-']))
                 ->mapWithKeys(fn ($value, string $name): array => [Str::camel($name) => $value])
-                ->merge($originalAttributes)
+                ->merge($originalAttributes, escape: false)
                 ->all(),
         );
 

--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -122,7 +122,7 @@
                                 isLoading = false
                             ',
                             'x-mask' . ($mask instanceof \Filament\Support\RawJs ? ':dynamic' : '') => filled($mask) ? $mask : null,
-                        ])
+                        ], escape: false)
                         ->class([
                             match ($alignment) {
                                 Alignment::Start => 'text-start',

--- a/packages/tables/src/Columns/Concerns/HasExtraCellAttributes.php
+++ b/packages/tables/src/Columns/Concerns/HasExtraCellAttributes.php
@@ -34,7 +34,7 @@ trait HasExtraCellAttributes
         $temporaryAttributeBag = new ComponentAttributeBag;
 
         foreach ($this->extraCellAttributes as $extraCellAttributes) {
-            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraCellAttributes));
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraCellAttributes), escape: false);
         }
 
         return $temporaryAttributeBag->getAttributes();

--- a/packages/tables/src/Columns/Concerns/HasExtraHeaderAttributes.php
+++ b/packages/tables/src/Columns/Concerns/HasExtraHeaderAttributes.php
@@ -34,7 +34,7 @@ trait HasExtraHeaderAttributes
         $temporaryAttributeBag = new ComponentAttributeBag;
 
         foreach ($this->extraHeaderAttributes as $extraHeaderAttributes) {
-            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraHeaderAttributes));
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraHeaderAttributes), escape: false);
         }
 
         return $temporaryAttributeBag->getAttributes();

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -242,7 +242,7 @@ class ImageColumn extends Column
         $temporaryAttributeBag = new ComponentAttributeBag;
 
         foreach ($this->extraImgAttributes as $extraImgAttributes) {
-            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraImgAttributes));
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraImgAttributes), escape: false);
         }
 
         return $temporaryAttributeBag->getAttributes();


### PR DESCRIPTION
There is some inconsistency with regards to how attributes are escaped. In most places they are already not escaped, this PR prevents the escaping on the rest of the places in the framework where we are using `->merge()`. 

This solves issues where eg `->extraEntryWrapperAttributes([
    'class' => '[&_dt>span]:text-gray-500',
])` is escaped and ends up as `[&amp...]` in the html.