### PR TITLE
allowing to add a closure to handle visibility for some actions

### DIFF
--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -613,7 +613,7 @@ Repeater::make('members')
 
 ### Action Visibility
 
-You can modifiy the visibiltiy for (add, add between, delete, clone, move up, move down, reorder) actions by using the related methods:
+You can modify the visibiltiy for (add, add between, delete, clone, move up, move down, reorder) actions by using the related methods:
 
 ```php
 use Filament\Forms\Components\Repeater;

--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -262,6 +262,7 @@ Repeater::make('qualifications')
     ->orderColumn('sort')
 ```
 
+
 If you use something like [`spatie/eloquent-sortable`](https://github.com/spatie/eloquent-sortable) with an order column such as `order_column`, you may pass this in to `orderColumn()`:
 
 ```php
@@ -608,6 +609,26 @@ Repeater::make('members')
     ->collapseAllAction(
         fn (Action $action) => $action->label('Collapse all members'),
     )
+```
+
+### Action Visibility
+
+You can modifiy the visibiltiy for (add, add between, delete, clone, move up, move down, reorder) actions by using the related methods:
+
+```php
+use Filament\Forms\Components\Repeater;
+
+Repeater::make('qualifications')
+    ->schema([
+        // ...
+    ])
+    ->addActionVisibility(fn ($state) => // return true or false)
+    ->addBetweenActionVisibility(fn ($state) => // return true or false)
+    ->cloneActionVisibility(fn ($state) => // return true or false)
+    ->deleteActionVisibility(fn ($state) => // return true or false)
+    ->moveDownActionVisibility(fn ($state) => // return true or false)
+    ->moveUpActionVisibility(fn ($state) => // return true or false)
+    ->reorderActionVisibility(fn ($state) => // return true or false)
 ```
 
 ### Confirming repeater actions with a modal

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -62,17 +62,31 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
 
     protected ?Closure $modifyAddActionUsing = null;
 
+    protected ?Closure $modifyAddActionVisibilityUsing = null;
+
     protected ?Closure $modifyAddBetweenActionUsing = null;
+
+    protected ?Closure $modifyAddBetweenActionVisibilityUsing = null;
 
     protected ?Closure $modifyCloneActionUsing = null;
 
+    protected ?Closure $modifyCloneActionVisibilityUsing = null;
+
     protected ?Closure $modifyDeleteActionUsing = null;
+
+    protected ?Closure $modifyDeleteActionVisibilityUsing = null;
 
     protected ?Closure $modifyMoveDownActionUsing = null;
 
+    protected ?Closure $modifyMoveDownActionVisibilityUsing = null;
+
     protected ?Closure $modifyMoveUpActionUsing = null;
 
+    protected ?Closure $modifyMoveUpActionVisibilityUsing = null;
+
     protected ?Closure $modifyReorderActionUsing = null;
+
+    protected ?Closure $modifyReorderActionVisibilityUsing = null;
 
     protected ?Closure $modifyCollapseActionUsing = null;
 
@@ -188,7 +202,15 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
             })
             ->button()
             ->size(ActionSize::Small)
-            ->visible(fn (Repeater $component): bool => $component->isAddable());
+            ->visible(function (Repeater $component, $state, $arguments): bool {
+                if ($this->modifyAddActionVisibilityUsing) {
+                    return $this->evaluate($this->modifyAddActionVisibilityUsing, [
+                        'state' => $state[$arguments['item']],
+                    ]) ?? $component->isAddable();
+                }
+
+                return $component->isAddable();
+            });
 
         if ($this->modifyAddActionUsing) {
             $action = $this->evaluate($this->modifyAddActionUsing, [
@@ -263,7 +285,15 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
             })
             ->button()
             ->size(ActionSize::Small)
-            ->visible(false);
+            ->visible(function ($state, $arguments): bool {
+                if ($this->modifyAddBetweenActionVisibilityUsing) {
+                    return $this->evaluate($this->modifyAddBetweenActionVisibilityUsing, [
+                        'state' => $state[$arguments['item']],
+                    ]) ?? false;
+                }
+
+                return false;
+            });
 
         if ($this->modifyAddBetweenActionUsing) {
             $action = $this->evaluate($this->modifyAddBetweenActionUsing, [
@@ -323,7 +353,15 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
             })
             ->iconButton()
             ->size(ActionSize::Small)
-            ->visible(fn (Repeater $component): bool => $component->isCloneable());
+            ->visible(function (Repeater $component, $state, $arguments): bool {
+                if ($this->modifyCloneActionVisibilityUsing) {
+                    return $this->evaluate($this->modifyCloneActionVisibilityUsing, [
+                        'state' => $state[$arguments['item']],
+                    ]) ?? $component->isCloneable();
+                }
+
+                return $component->isCloneable();
+            });
 
         if ($this->modifyCloneActionUsing) {
             $action = $this->evaluate($this->modifyCloneActionUsing, [
@@ -362,7 +400,15 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
             })
             ->iconButton()
             ->size(ActionSize::Small)
-            ->visible(fn (Repeater $component): bool => $component->isDeletable());
+            ->visible(function (Repeater $component, $state, $arguments): bool {
+                if ($this->modifyDeleteActionVisibilityUsing) {
+                    return $this->evaluate($this->modifyDeleteActionVisibilityUsing, [
+                        'state' => $state[$arguments['item']],
+                    ]) ?? $component->isDeletable();
+                }
+
+                return $component->isDeletable();
+            });
 
         if ($this->modifyDeleteActionUsing) {
             $action = $this->evaluate($this->modifyDeleteActionUsing, [
@@ -400,7 +446,15 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
             })
             ->iconButton()
             ->size(ActionSize::Small)
-            ->visible(fn (Repeater $component): bool => $component->isReorderable());
+            ->visible(function (Repeater $component, $state, $arguments): bool {
+                if ($this->modifyMoveDownActionVisibilityUsing) {
+                    return $this->evaluate($this->modifyMoveDownActionVisibilityUsing, [
+                        'state' => $state[$arguments['item']],
+                    ]) ?? $component->isReorderable();
+                }
+
+                return $component->isReorderable();
+            });
 
         if ($this->modifyMoveDownActionUsing) {
             $action = $this->evaluate($this->modifyMoveDownActionUsing, [
@@ -438,7 +492,15 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
             })
             ->iconButton()
             ->size(ActionSize::Small)
-            ->visible(fn (Repeater $component): bool => $component->isReorderable());
+            ->visible(function (Repeater $component, $state, $arguments): bool {
+                if ($this->modifyMoveUpActionVisibilityUsing) {
+                    return $this->evaluate($this->modifyMoveUpActionVisibilityUsing, [
+                        'state' => $state[$arguments['item']],
+                    ]) ?? $component->isReorderable();
+                }
+
+                return $component->isReorderable();
+            });
 
         if ($this->modifyMoveUpActionUsing) {
             $action = $this->evaluate($this->modifyMoveUpActionUsing, [
@@ -1287,5 +1349,54 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
     public function getRawItemState(string $uuid): array
     {
         return $this->getChildComponentContainer($uuid)->getRawState();
+    }
+
+    public function addActionVisibility(Closure $condition): static
+    {
+        $this->modifyAddActionVisibilityUsing = $condition;
+
+        return $this;
+    }
+
+    public function addBetweenActionVisibility(Closure $condition): static
+    {
+        $this->modifyAddBetweenActionVisibilityUsing = $condition;
+
+        return $this;
+    }
+
+    public function cloneActionVisibility(Closure $condition): static
+    {
+        $this->modifyCloneActionVisibilityUsing = $condition;
+
+        return $this;
+    }
+
+    public function deleteActionVisibility(Closure $condition): static
+    {
+        $this->modifyDeleteActionVisibilityUsing = $condition;
+
+        return $this;
+    }
+
+    public function moveDownActionVisibility(Closure $condition): static
+    {
+        $this->modifyMoveDownActionVisibilityUsing = $condition;
+
+        return $this;
+    }
+
+    public function moveUpActionVisibility(Closure $condition): static
+    {
+        $this->modifyMoveUpActionVisibilityUsing = $condition;
+
+        return $this;
+    }
+
+    public function reorderActionVisibility(Closure $condition): static
+    {
+        $this->modifyReorderActionVisibilityUsing = $condition;
+
+        return $this;
     }
 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Problem: can't control the visibility of some actions in repeater form field without using the (deleteAction, addAction...) methods. also the ($state) of each item isn't evaluated like other fields as expected.

Solution: adding ability to pass a Closure to visibility method for actions

- add action
- add between action
- delete action
- clone action
- move down action
- move up action
- reorder action

and evaluate the state to directly get the state of the item using 
`
$state[$arguments['item']]
`

## Visual changes
here are some photos for delete action

before:
![Screenshot from 2024-12-20 13-50-14](https://github.com/user-attachments/assets/c08d1814-93a5-4368-bf0b-6074cc21726a)

after:
![Screenshot from 2024-12-20 13-51-23](https://github.com/user-attachments/assets/08662168-4719-44fb-bf41-467b41d0f947)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
