### PR TITLE
Fix missing comma in docs

### DIFF
--- a/packages/forms/docs/09-testing.md
+++ b/packages/forms/docs/09-testing.md
@@ -227,7 +227,7 @@ Section::make('Comments')
 ```php
 use function Pest\Livewire\livewire;
 
-test('comments section exists' function () {
+test('comments section exists', function () {
     livewire(EditPost::class)
         ->assertFormComponentExists('comments-section');
 });

--- a/packages/forms/docs/09-testing.md
+++ b/packages/forms/docs/09-testing.md
@@ -251,7 +251,7 @@ use Filament\Forms\Components\Component;
 
 use function Pest\Livewire\livewire;
 
-test('comments section has heading' function () {
+test('comments section has heading', function () {
     livewire(EditPost::class)
         ->assertFormComponentExists(
             'comments-section',
@@ -270,7 +270,7 @@ use Illuminate\Testing\Assert;
 
 use function Pest\Livewire\livewire;
 
-test('comments section is enabled' function () {
+test('comments section is enabled', function () {
     livewire(EditPost::class)
         ->assertFormComponentExists(
             'comments-section',


### PR DESCRIPTION
Adds missing comma.

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
