### PR TITLE
Prevent creating non-existent models from container

### DIFF
--- a/packages/forms/resources/js/components/select.js
+++ b/packages/forms/resources/js/components/select.js
@@ -97,21 +97,23 @@ export default function selectFormComponent({
 
             if (hasDynamicSearchResults) {
                 this.$refs.input.addEventListener('search', (event) => {
-                    if (! this.select._isSearching) {
+                    if (!this.select._isSearching) {
                         return
                     }
 
                     let search = event.detail.value?.trim()
 
-                    this.select._displayNotice([null, undefined, ''].includes(search)
-                        ? loadingMessage
-                        : searchingMessage)
+                    this.select._displayNotice(
+                        [null, undefined, ''].includes(search)
+                            ? loadingMessage
+                            : searchingMessage,
+                    )
                 })
 
                 this.$refs.input.addEventListener(
                     'search',
                     Alpine.debounce(async (event) => {
-                        if (! this.select._isSearching) {
+                        if (!this.select._isSearching) {
                             return
                         }
 
@@ -170,7 +172,7 @@ export default function selectFormComponent({
                 return
             }
 
-            if (! this.isEmpty) {
+            if (!this.isEmpty) {
                 this.select._clearNotice()
             }
 
@@ -184,7 +186,10 @@ export default function selectFormComponent({
                 this.select.setChoiceByValue(this.formatState(this.state))
             }
 
-            if (this.isEmpty && (! [null, undefined, ''].includes(config.search))) {
+            if (
+                this.isEmpty &&
+                ![null, undefined, ''].includes(config.search)
+            ) {
                 this.select._displayNotice(noSearchResultsMessage)
             }
         },
@@ -210,7 +215,7 @@ export default function selectFormComponent({
 
             let results = []
 
-            if (! [null, undefined, ''].includes(search)) {
+            if (![null, undefined, ''].includes(search)) {
                 results = await getSearchResultsUsing(search)
             } else {
                 results = await getOptionsUsing()

--- a/packages/support/src/Concerns/EvaluatesClosures.php
+++ b/packages/support/src/Concerns/EvaluatesClosures.php
@@ -84,7 +84,7 @@ trait EvaluatesClosures
 
         if (
             filled($typedParameterClassName)
-            && ! is_subclass_of($typedParameterClassName, Model::class)
+            && (! is_subclass_of($typedParameterClassName, Model::class) || app()->bound($typedParameterClassName))
         ) {
             return app()->make($typedParameterClassName);
         }

--- a/packages/support/src/Concerns/EvaluatesClosures.php
+++ b/packages/support/src/Concerns/EvaluatesClosures.php
@@ -4,6 +4,7 @@ namespace Filament\Support\Concerns;
 
 use Closure;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Database\Eloquent\Model;
 use ReflectionFunction;
 use ReflectionNamedType;
 use ReflectionParameter;
@@ -81,7 +82,10 @@ trait EvaluatesClosures
             return $this;
         }
 
-        if (filled($typedParameterClassName)) {
+        if (
+            filled($typedParameterClassName)
+            && ! is_subclass_of($parameter->getType()->getName(), Model::class)
+        ) {
             return app()->make($typedParameterClassName);
         }
 

--- a/packages/support/src/Concerns/EvaluatesClosures.php
+++ b/packages/support/src/Concerns/EvaluatesClosures.php
@@ -84,7 +84,7 @@ trait EvaluatesClosures
 
         if (
             filled($typedParameterClassName)
-            && ! is_subclass_of($parameter->getType()->getName(), Model::class)
+            && ! is_subclass_of($typedParameterClassName, Model::class)
         ) {
             return app()->make($typedParameterClassName);
         }

--- a/tests/src/Fixtures/Resources/PostCategories/PostCategoryResource.php
+++ b/tests/src/Fixtures/Resources/PostCategories/PostCategoryResource.php
@@ -4,10 +4,6 @@ namespace Filament\Tests\Fixtures\Resources\PostCategories;
 
 use Filament\Resources\Resource;
 use Filament\Tests\Fixtures\Models\PostCategory;
-use Filament\Tests\Fixtures\Resources\PostCategories\Pages\CreatePostCategory;
-use Filament\Tests\Fixtures\Resources\PostCategories\Pages\EditPostCategory;
-use Filament\Tests\Fixtures\Resources\PostCategories\Pages\ListPostCategories;
-use Filament\Tests\Fixtures\Resources\PostCategories\Pages\ViewPostCategory;
 
 class PostCategoryResource extends Resource
 {
@@ -20,10 +16,10 @@ class PostCategoryResource extends Resource
     public static function getPages(): array
     {
         return [
-            'index' => ListPostCategories::route('/'),
-            'create' => CreatePostCategory::route('/create'),
-            'view' => ViewPostCategory::route('/{record}'),
-            'edit' => EditPostCategory::route('/{record}/edit'),
+            'index' => Pages\ListPostCategories::route('/'),
+            'create' => Pages\CreatePostCategory::route('/create'),
+            'view' => Pages\ViewPostCategory::route('/{record}'),
+            'edit' => Pages\EditPostCategory::route('/{record}/edit'),
         ];
     }
 }

--- a/tests/src/Fixtures/Resources/Posts/PostResource.php
+++ b/tests/src/Fixtures/Resources/Posts/PostResource.php
@@ -12,10 +12,6 @@ use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Filament\Tests\Fixtures\Models\Post;
-use Filament\Tests\Fixtures\Resources\Posts\Pages\CreatePost;
-use Filament\Tests\Fixtures\Resources\Posts\Pages\EditPost;
-use Filament\Tests\Fixtures\Resources\Posts\Pages\ListPosts;
-use Filament\Tests\Fixtures\Resources\Posts\Pages\ViewPost;
 use Illuminate\Database\Eloquent\Builder;
 
 class PostResource extends Resource
@@ -74,10 +70,10 @@ class PostResource extends Resource
     public static function getPages(): array
     {
         return [
-            'index' => ListPosts::route('/'),
-            'create' => CreatePost::route('/create'),
-            'view' => ViewPost::route('/{record}'),
-            'edit' => EditPost::route('/{record}/edit'),
+            'index' => Pages\ListPosts::route('/'),
+            'create' => Pages\CreatePost::route('/create'),
+            'view' => Pages\ViewPost::route('/{record}'),
+            'edit' => Pages\EditPost::route('/{record}/edit'),
         ];
     }
 }

--- a/tests/src/Fixtures/Resources/Shop/Products/ProductResource.php
+++ b/tests/src/Fixtures/Resources/Shop/Products/ProductResource.php
@@ -4,10 +4,6 @@ namespace Filament\Tests\Fixtures\Resources\Shop\Products;
 
 use Filament\Resources\Resource;
 use Filament\Tests\Fixtures\Models\Product;
-use Filament\Tests\Fixtures\Resources\Shop\Products\Pages\CreateProduct;
-use Filament\Tests\Fixtures\Resources\Shop\Products\Pages\EditProduct;
-use Filament\Tests\Fixtures\Resources\Shop\Products\Pages\ListProducts;
-use Filament\Tests\Fixtures\Resources\Shop\Products\Pages\ViewProduct;
 
 class ProductResource extends Resource
 {
@@ -20,10 +16,10 @@ class ProductResource extends Resource
     public static function getPages(): array
     {
         return [
-            'index' => ListProducts::route('/'),
-            'create' => CreateProduct::route('/create'),
-            'view' => ViewProduct::route('/{record}'),
-            'edit' => EditProduct::route('/{record}/edit'),
+            'index' => Pages\ListProducts::route('/'),
+            'create' => Pages\CreateProduct::route('/create'),
+            'view' => Pages\ViewProduct::route('/{record}'),
+            'edit' => Pages\EditProduct::route('/{record}/edit'),
         ];
     }
 }

--- a/tests/src/Fixtures/Resources/Users/UserResource.php
+++ b/tests/src/Fixtures/Resources/Users/UserResource.php
@@ -11,10 +11,6 @@ use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Filament\Tests\Fixtures\Models\User;
-use Filament\Tests\Fixtures\Resources\Users\Pages\CreateUser;
-use Filament\Tests\Fixtures\Resources\Users\Pages\EditUser;
-use Filament\Tests\Fixtures\Resources\Users\Pages\ListUsers;
-use Filament\Tests\Fixtures\Resources\Users\Pages\ViewUser;
 
 class UserResource extends Resource
 {
@@ -72,10 +68,10 @@ class UserResource extends Resource
     public static function getPages(): array
     {
         return [
-            'index' => ListUsers::route('/'),
-            'create' => CreateUser::route('/create'),
-            'view' => ViewUser::route('/{record}'),
-            'edit' => EditUser::route('/{record}/edit'),
+            'index' => Pages\ListUsers::route('/'),
+            'create' => Pages\CreateUser::route('/create'),
+            'view' => Pages\ViewUser::route('/{record}'),
+            'edit' => Pages\EditUser::route('/{record}/edit'),
         ];
     }
 }

--- a/tests/src/Support/EvaluatesClosuresTest.php
+++ b/tests/src/Support/EvaluatesClosuresTest.php
@@ -67,6 +67,42 @@ it('will not instantiate empty Models from container', function () {
     });
 });
 
+it('will instantiate empty Models from container if bound', function () {
+    $isEvaluatingClosures = new IsEvaluatingClosures;
+
+    $boundRecordModel = new RecordModel;
+
+    app()->bind(RecordModel::class, fn () => $boundRecordModel);
+
+    $isEvaluatingClosures->evaluate(function (RecordModel $recordModel) use ($boundRecordModel) {
+        expect($recordModel)->toBe($boundRecordModel);
+    });
+});
+
+it('will instantiate empty Models from container if bound as singleton', function () {
+    $isEvaluatingClosures = new IsEvaluatingClosures;
+
+    $boundRecordModel = new RecordModel;
+
+    app()->singleton(RecordModel::class, fn () => $boundRecordModel);
+
+    $isEvaluatingClosures->evaluate(function (RecordModel $recordModel) use ($boundRecordModel) {
+        expect($recordModel)->toBe($boundRecordModel);
+    });
+});
+
+it('will instantiate empty Models from container if bound as scoped', function () {
+    $isEvaluatingClosures = new IsEvaluatingClosures;
+
+    $boundRecordModel = new RecordModel;
+
+    app()->scoped(RecordModel::class, fn () => $boundRecordModel);
+
+    $isEvaluatingClosures->evaluate(function (RecordModel $recordModel) use ($boundRecordModel) {
+        expect($recordModel)->toBe($boundRecordModel);
+    });
+});
+
 class RecordModel extends Model
 {
     //

--- a/tests/src/Support/EvaluatesClosuresTest.php
+++ b/tests/src/Support/EvaluatesClosuresTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use Filament\Support;
+use Filament\Tests\TestCase;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Database\Eloquent\Model;
+
+uses(TestCase::class);
+
+it('will make any object from container', function () {
+    $isEvaluatingClosures = new IsEvaluatingClosures;
+
+    $isEvaluatingClosures->evaluate(function (IsEvaluatingClosures $isEvaluatingClosures) {
+        $this->expectNotToPerformAssertions();
+    });
+});
+
+it('will instantiate Eloquent Models provided by name', function () {
+    $isEvaluatingClosures = new IsEvaluatingClosures(
+		record: $recordModel = new RecordModel,
+	    shouldResolveDefaultClosureDependencyForEvaluationByName: true,
+	    shouldResolveDefaultClosureDependencyForEvaluationByType: false,
+    );
+
+    $isEvaluatingClosures->evaluate(function (RecordModel $record) {
+        $this->expectNotToPerformAssertions();
+    });
+});
+
+it('will not instantiate Eloquent Models not provided by name', function () {
+    $isEvaluatingClosures = new IsEvaluatingClosures(
+		record: $recordModel = new RecordModel,
+	    shouldResolveDefaultClosureDependencyForEvaluationByName: true,
+	    shouldResolveDefaultClosureDependencyForEvaluationByType: false,
+    );
+
+    $this->expectException(BindingResolutionException::class);
+
+    $isEvaluatingClosures->evaluate(function (RecordModel $recordModel) {
+        throw new RuntimeException('Should not be called because named parameter not provided.');
+    });
+});
+
+it('will instantiate Eloquent Models provided by type', function () {
+	$isEvaluatingClosures = new IsEvaluatingClosures(
+		record: $recordModel = new RecordModel,
+		shouldResolveDefaultClosureDependencyForEvaluationByName: false,
+		shouldResolveDefaultClosureDependencyForEvaluationByType: true,
+	);
+	
+	$isEvaluatingClosures->evaluate(function (RecordModel $record) use ($recordModel) {
+		expect($record)->toBe($recordModel);
+	});
+	
+	$isEvaluatingClosures->evaluate(function (RecordModel $recordModelWithDifferentName) use ($recordModel) {
+		expect($recordModelWithDifferentName)->toBe($recordModel);
+	});
+});
+
+it('will not instantiate empty Models from container', function () {
+    $isEvaluatingClosures = new IsEvaluatingClosures;
+
+    $this->expectException(BindingResolutionException::class);
+
+    $isEvaluatingClosures->evaluate(function (RecordModel $recordModel) {
+        throw new RuntimeException('Should not be called.');
+    });
+});
+
+class RecordModel extends Model
+{
+    //
+}
+
+class IsEvaluatingClosures
+{
+    public function __construct(
+        public ?RecordModel $record = null,
+        public bool $shouldResolveDefaultClosureDependencyForEvaluationByName = false,
+        public bool $shouldResolveDefaultClosureDependencyForEvaluationByType = false,
+    ) {}
+
+    use Support\Concerns\EvaluatesClosures;
+
+    protected function resolveDefaultClosureDependencyForEvaluationByName(string $parameterName): array
+    {
+        return match (true) {
+            $this->shouldResolveDefaultClosureDependencyForEvaluationByName && $parameterName === 'record' => [$this->record],
+            default => [],
+        };
+    }
+
+    protected function resolveDefaultClosureDependencyForEvaluationByType(string $parameterType): array
+    {
+        return match (true) {
+            $this->shouldResolveDefaultClosureDependencyForEvaluationByType && $parameterType === $this->record::class => [$this->record],
+            default => [],
+        };
+    }
+}

--- a/tests/src/Support/EvaluatesClosuresTest.php
+++ b/tests/src/Support/EvaluatesClosuresTest.php
@@ -22,8 +22,8 @@ it('will instantiate Eloquent Models provided by name', function () {
         shouldResolveDefaultClosureDependencyForEvaluationByType: false,
     );
 
-    $isEvaluatingClosures->evaluate(function (RecordModel $record) {
-        $this->expectNotToPerformAssertions();
+    $isEvaluatingClosures->evaluate(function (RecordModel $record) use ($recordModel) {
+        expect($record)->toBe($recordModel);
     });
 });
 

--- a/tests/src/Support/EvaluatesClosuresTest.php
+++ b/tests/src/Support/EvaluatesClosuresTest.php
@@ -17,9 +17,9 @@ it('will make any object from container', function () {
 
 it('will instantiate Eloquent Models provided by name', function () {
     $isEvaluatingClosures = new IsEvaluatingClosures(
-		record: $recordModel = new RecordModel,
-	    shouldResolveDefaultClosureDependencyForEvaluationByName: true,
-	    shouldResolveDefaultClosureDependencyForEvaluationByType: false,
+        record: $recordModel = new RecordModel,
+        shouldResolveDefaultClosureDependencyForEvaluationByName: true,
+        shouldResolveDefaultClosureDependencyForEvaluationByType: false,
     );
 
     $isEvaluatingClosures->evaluate(function (RecordModel $record) {
@@ -29,9 +29,9 @@ it('will instantiate Eloquent Models provided by name', function () {
 
 it('will not instantiate Eloquent Models not provided by name', function () {
     $isEvaluatingClosures = new IsEvaluatingClosures(
-		record: $recordModel = new RecordModel,
-	    shouldResolveDefaultClosureDependencyForEvaluationByName: true,
-	    shouldResolveDefaultClosureDependencyForEvaluationByType: false,
+        record: $recordModel = new RecordModel,
+        shouldResolveDefaultClosureDependencyForEvaluationByName: true,
+        shouldResolveDefaultClosureDependencyForEvaluationByType: false,
     );
 
     $this->expectException(BindingResolutionException::class);
@@ -42,19 +42,19 @@ it('will not instantiate Eloquent Models not provided by name', function () {
 });
 
 it('will instantiate Eloquent Models provided by type', function () {
-	$isEvaluatingClosures = new IsEvaluatingClosures(
-		record: $recordModel = new RecordModel,
-		shouldResolveDefaultClosureDependencyForEvaluationByName: false,
-		shouldResolveDefaultClosureDependencyForEvaluationByType: true,
-	);
-	
-	$isEvaluatingClosures->evaluate(function (RecordModel $record) use ($recordModel) {
-		expect($record)->toBe($recordModel);
-	});
-	
-	$isEvaluatingClosures->evaluate(function (RecordModel $recordModelWithDifferentName) use ($recordModel) {
-		expect($recordModelWithDifferentName)->toBe($recordModel);
-	});
+    $isEvaluatingClosures = new IsEvaluatingClosures(
+        record: $recordModel = new RecordModel,
+        shouldResolveDefaultClosureDependencyForEvaluationByName: false,
+        shouldResolveDefaultClosureDependencyForEvaluationByType: true,
+    );
+
+    $isEvaluatingClosures->evaluate(function (RecordModel $record) use ($recordModel) {
+        expect($record)->toBe($recordModel);
+    });
+
+    $isEvaluatingClosures->evaluate(function (RecordModel $recordModelWithDifferentName) use ($recordModel) {
+        expect($recordModelWithDifferentName)->toBe($recordModel);
+    });
 });
 
 it('will not instantiate empty Models from container', function () {
@@ -74,13 +74,13 @@ class RecordModel extends Model
 
 class IsEvaluatingClosures
 {
+    use Support\Concerns\EvaluatesClosures;
+
     public function __construct(
         public ?RecordModel $record = null,
         public bool $shouldResolveDefaultClosureDependencyForEvaluationByName = false,
         public bool $shouldResolveDefaultClosureDependencyForEvaluationByType = false,
     ) {}
-
-    use Support\Concerns\EvaluatesClosures;
 
     protected function resolveDefaultClosureDependencyForEvaluationByName(string $parameterName): array
     {


### PR DESCRIPTION
Currently, the closure evaluation system works great by resolving any dependencies not provided by name or type from the container. This is very useful. However, there is one situation where it isn't useful and that is when it is evaluating empty/non-existent Eloquent models from the container.

For example, in Filament V3 we had the nice feature of being able to type an Eloquent model as both `User $record` and `User $user`, which would both work nicely. However, sometimes there are situations where you _think_ you have a `$record`, but actually for some reason you don't (or you have a different type of record when working with eg relationships or repeaters). If you would then still type it as `User $user`, you would get an empty/non-existent Eloquent model from the container. This has caught me in very complex forms out quite a few times and therefore I generally prefer `User $record` now just for this, whilst for the cleanliness I would prefer `User $user`. 

This PR fixes the issue by preventing the container from instantiating an empty Eloquent model if it was not able to resolve dependency using type or name. This prevents users from typing things like `User $user`, thinking they have the record but they actually don't. It should not really impact users, as no one would instantiate their empty models using the container and would only help to prevent bugs. I also added a test to prove the behavior.

Thanks!