### PR TITLE
Fix: Add conditions to DISTINCT and modify reorder conditions in PostgreSQL

### DIFF
--- a/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
+++ b/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
@@ -69,7 +69,7 @@ class PrepareCsvExport implements ShouldQueue
 
         if ($databaseConnection->getDriverName() === 'pgsql') {
             $originalOrders = collect($query->getQuery()->orders)
-                ->reject(fn (array $order): bool => in_array($order['column'] ?? null, [$qualifiedKeyName]))
+                ->reject(fn (array $order): bool => ($order['column'] ?? null) === $qualifiedKeyName)
                 ->unique('column');
 
             /** @var array<string, mixed> $originalBindings */


### PR DESCRIPTION


<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
This is a fix for issue #14814.

The problem was that in PostgreSQL, the results were always ordered by `id`. I added a condition to sort by the value specified on the screen if sorting is applied; otherwise, the results will fall back to sorting by `id`.

Additionally, the `DISTINCT` clause was always applied to `id`. A condition was added to handle cases where sorting is based on id.
<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
