### PR TITLE
Allow closure based table `Group` labels

### DIFF
--- a/packages/tables/src/Grouping/Concerns/BelongsToTable.php
+++ b/packages/tables/src/Grouping/Concerns/BelongsToTable.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Filament\Tables\Grouping\Concerns;
+
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+
+trait BelongsToTable
+{
+    protected Table $table;
+
+    public function table(Table $table): static
+    {
+        $this->table = $table;
+
+        return $this;
+    }
+
+    public function getTable(): Table
+    {
+        return $this->table;
+    }
+
+    public function getLivewire(): HasTable
+    {
+        return $this->getTable()->getLivewire();
+    }
+}

--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -17,6 +17,8 @@ use Illuminate\Support\Arr;
 
 class Group extends Component
 {
+    use Concerns\BelongsToTable;
+
     protected ?string $column;
 
     protected ?Closure $getDescriptionFromRecordUsing = null;
@@ -33,7 +35,7 @@ class Group extends Component
 
     protected ?Closure $scopeQueryByKeyUsing = null;
 
-    protected string | Closure | null $label;
+    protected string | Closure | null $label = null;
 
     protected string $id;
 
@@ -470,5 +472,17 @@ class Group extends Component
         }
 
         return $query->with([$relationshipName]);
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    protected function resolveDefaultClosureDependencyForEvaluationByName(string $parameterName): array
+    {
+        return match ($parameterName) {
+            'livewire' => [$this->getLivewire()],
+            'table' => [$this->getTable()],
+            default => parent::resolveDefaultClosureDependencyForEvaluationByName($parameterName),
+        };
     }
 }

--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -33,7 +33,7 @@ class Group extends Component
 
     protected ?Closure $scopeQueryByKeyUsing = null;
 
-    protected ?string $label;
+    protected string | Closure | null $label;
 
     protected string $id;
 
@@ -42,6 +42,8 @@ class Group extends Component
     protected bool $isTitlePrefixedWithLabel = true;
 
     protected bool $isDate = false;
+
+    protected string $evaluationIdentifier = 'group';
 
     final public function __construct(?string $id = null)
     {
@@ -84,7 +86,7 @@ class Group extends Component
         return $this;
     }
 
-    public function label(?string $label): static
+    public function label(string | Closure | null $label): static
     {
         $this->label = $label;
 
@@ -179,7 +181,7 @@ class Group extends Component
 
     public function getLabel(): string
     {
-        return $this->label ?? (string) str($this->getId())
+        return $this->evaluate($this->label) ?? (string) str($this->getId())
             ->beforeLast('.')
             ->afterLast('.')
             ->kebab()

--- a/packages/tables/src/Table/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Table/Concerns/CanGroupRecords.php
@@ -72,6 +72,10 @@ trait CanGroupRecords
 
     public function defaultGroup(string | Group | null $group): static
     {
+        if ($group instanceof Group) {
+            $group->table($this);
+        }
+
         $this->defaultGroup = $group;
 
         return $this;
@@ -82,6 +86,12 @@ trait CanGroupRecords
      */
     public function groups(array | Closure $groups): static
     {
+        foreach ($groups as $group) {
+            if ($group instanceof Group) {
+                $group->table($this);
+            }
+        }
+
         $this->groups = $groups;
 
         return $this;
@@ -159,7 +169,8 @@ trait CanGroupRecords
             return $group;
         }
 
-        return Group::make($this->defaultGroup);
+        return Group::make($this->defaultGroup)
+            ->table($this);
     }
 
     /**
@@ -171,7 +182,8 @@ trait CanGroupRecords
             $this->evaluate($this->groups),
             function (array $carry, $group): array {
                 if (! $group instanceof Group) {
-                    $group = Group::make($group);
+                    $group = Group::make($group)
+                        ->table($this);
                 }
 
                 $carry[$group->getId()] = $group;

--- a/packages/tables/src/Table/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Table/Concerns/CanGroupRecords.php
@@ -72,10 +72,6 @@ trait CanGroupRecords
 
     public function defaultGroup(string | Group | null $group): static
     {
-        if ($group instanceof Group) {
-            $group->table($this);
-        }
-
         $this->defaultGroup = $group;
 
         return $this;
@@ -86,12 +82,6 @@ trait CanGroupRecords
      */
     public function groups(array | Closure $groups): static
     {
-        foreach ($groups as $group) {
-            if ($group instanceof Group) {
-                $group->table($this);
-            }
-        }
-
         $this->groups = $groups;
 
         return $this;
@@ -160,7 +150,7 @@ trait CanGroupRecords
         }
 
         if ($this->defaultGroup instanceof Group) {
-            return $this->defaultGroup;
+            return $this->defaultGroup->table($this);
         }
 
         $group = $this->getGroup($this->defaultGroup);
@@ -182,11 +172,10 @@ trait CanGroupRecords
             $this->evaluate($this->groups),
             function (array $carry, $group): array {
                 if (! $group instanceof Group) {
-                    $group = Group::make($group)
-                        ->table($this);
+                    $group = Group::make($group);
                 }
 
-                $carry[$group->getId()] = $group;
+                $carry[$group->getId()] = $group->table($this);
 
                 return $carry;
             },

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -24,6 +24,10 @@ class PostsTable extends Component implements HasForms, Tables\Contracts\HasTabl
     {
         return $table
             ->query(Post::query())
+            ->groups(fn () => [
+                Tables\Grouping\Group::make('author.name')
+                    ->label(fn (Tables\Table $table) => 'Dynamic label'),
+            ])
             ->columns([
                 Tables\Columns\TextColumn::make('title')
                     ->sortable()

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -26,7 +26,7 @@ class PostsTable extends Component implements HasForms, Tables\Contracts\HasTabl
             ->query(Post::query())
             ->groups(fn () => [
                 Tables\Grouping\Group::make('author.name')
-                    ->label(fn (Tables\Table $table) => 'Dynamic label'),
+                    ->label(fn (Table $table, self $livewire) => 'Dynamic label'),
             ])
             ->columns([
                 Tables\Columns\TextColumn::make('title')

--- a/tests/src/Tables/GroupingTest.php
+++ b/tests/src/Tables/GroupingTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Filament\Tables;
+use Filament\Tests\Models\Post;
+use Filament\Tests\Tables\Fixtures\PostsTable;
+use Filament\Tests\Tables\TestCase;
+use Livewire\Features\SupportTesting\Testable;
+use function Filament\Tests\livewire;
+
+uses(TestCase::class);
+
+it('can evaluate table groups', function () {
+	$posts = Post::factory()->count(20)->create();
+	
+	livewire(PostsTable::class)
+		->tap(function (Testable $testable) {
+		/** @var PostsTable $livewire */
+		$livewire = $testable->instance();
+		
+		/** @var Tables\Table $table */
+		$table = invade($livewire)->table;
+		
+		expect($table)
+			->getGrouping()->toBeNull();
+		
+		$groups = $table->getGroups();
+		
+		expect($groups['author.name'])
+			->getLabel()->toBe('Dynamic label');
+	})
+		->set('tableGrouping', 'author.name')
+		->tap(function (Testable $testable) {
+		/** @var PostsTable $livewire */
+		$livewire = $testable->instance();
+		
+		/** @var Tables\Table $table */
+		$table = invade($livewire)->table;
+		
+		expect($table)
+			->getGrouping()->toBeInstanceOf(Tables\Grouping\Group::class)
+			->and($table->getGrouping())->getLabel()->toBe('Dynamic label');
+	});
+});

--- a/tests/src/Tables/GroupingTest.php
+++ b/tests/src/Tables/GroupingTest.php
@@ -10,7 +10,7 @@ use function Filament\Tests\livewire;
 
 uses(TestCase::class);
 
-it('can evaluate table groups', function () {
+it('can group a table', function () {
     $posts = Post::factory()->count(20)->create();
 
     livewire(PostsTable::class)

--- a/tests/src/Tables/GroupingTest.php
+++ b/tests/src/Tables/GroupingTest.php
@@ -39,6 +39,7 @@ it('can group a table', function () {
 
             expect($table)
                 ->getGrouping()->toBeInstanceOf(Tables\Grouping\Group::class)
-                ->and($table->getGrouping())->getLabel()->toBe('Dynamic label');
+                ->and($table->getGrouping())
+                ->getLabel()->toBe('Dynamic label');
         });
 });

--- a/tests/src/Tables/GroupingTest.php
+++ b/tests/src/Tables/GroupingTest.php
@@ -18,8 +18,7 @@ it('can group a table', function () {
             /** @var PostsTable $livewire */
             $livewire = $testable->instance();
 
-            /** @var Tables\Table $table */
-            $table = invade($livewire)->table;
+            $table = $livewire->getTable();
 
             expect($table)
                 ->getGrouping()->toBeNull();
@@ -34,8 +33,7 @@ it('can group a table', function () {
             /** @var PostsTable $livewire */
             $livewire = $testable->instance();
 
-            /** @var Tables\Table $table */
-            $table = invade($livewire)->table;
+            $table =$livewire->getTable();
 
             expect($table)
                 ->getGrouping()->toBeInstanceOf(Tables\Grouping\Group::class)

--- a/tests/src/Tables/GroupingTest.php
+++ b/tests/src/Tables/GroupingTest.php
@@ -5,39 +5,40 @@ use Filament\Tests\Models\Post;
 use Filament\Tests\Tables\Fixtures\PostsTable;
 use Filament\Tests\Tables\TestCase;
 use Livewire\Features\SupportTesting\Testable;
+
 use function Filament\Tests\livewire;
 
 uses(TestCase::class);
 
 it('can evaluate table groups', function () {
-	$posts = Post::factory()->count(20)->create();
-	
-	livewire(PostsTable::class)
-		->tap(function (Testable $testable) {
-		/** @var PostsTable $livewire */
-		$livewire = $testable->instance();
-		
-		/** @var Tables\Table $table */
-		$table = invade($livewire)->table;
-		
-		expect($table)
-			->getGrouping()->toBeNull();
-		
-		$groups = $table->getGroups();
-		
-		expect($groups['author.name'])
-			->getLabel()->toBe('Dynamic label');
-	})
-		->set('tableGrouping', 'author.name')
-		->tap(function (Testable $testable) {
-		/** @var PostsTable $livewire */
-		$livewire = $testable->instance();
-		
-		/** @var Tables\Table $table */
-		$table = invade($livewire)->table;
-		
-		expect($table)
-			->getGrouping()->toBeInstanceOf(Tables\Grouping\Group::class)
-			->and($table->getGrouping())->getLabel()->toBe('Dynamic label');
-	});
+    $posts = Post::factory()->count(20)->create();
+
+    livewire(PostsTable::class)
+        ->tap(function (Testable $testable) {
+            /** @var PostsTable $livewire */
+            $livewire = $testable->instance();
+
+            /** @var Tables\Table $table */
+            $table = invade($livewire)->table;
+
+            expect($table)
+                ->getGrouping()->toBeNull();
+
+            $groups = $table->getGroups();
+
+            expect($groups['author.name'])
+                ->getLabel()->toBe('Dynamic label');
+        })
+        ->set('tableGrouping', 'author.name')
+        ->tap(function (Testable $testable) {
+            /** @var PostsTable $livewire */
+            $livewire = $testable->instance();
+
+            /** @var Tables\Table $table */
+            $table = invade($livewire)->table;
+
+            expect($table)
+                ->getGrouping()->toBeInstanceOf(Tables\Grouping\Group::class)
+                ->and($table->getGrouping())->getLabel()->toBe('Dynamic label');
+        });
 });

--- a/tests/src/Tables/GroupingTest.php
+++ b/tests/src/Tables/GroupingTest.php
@@ -33,7 +33,7 @@ it('can group a table', function () {
             /** @var PostsTable $livewire */
             $livewire = $testable->instance();
 
-            $table =$livewire->getTable();
+            $table = $livewire->getTable();
 
             expect($table)
                 ->getGrouping()->toBeInstanceOf(Tables\Grouping\Group::class)

--- a/tests/src/Tables/TestCase.php
+++ b/tests/src/Tables/TestCase.php
@@ -3,7 +3,6 @@
 namespace Filament\Tests\Tables;
 
 use Filament\Tests\TestCase as BaseTestCase;
-use Kirschbaum\PowerJoins\PowerJoinsServiceProvider;
 
 class TestCase extends BaseTestCase
 {
@@ -12,7 +11,6 @@ class TestCase extends BaseTestCase
         return [
             ...parent::getPackageProviders($app),
             TablesServiceProvider::class,
-            PowerJoinsServiceProvider::class,
         ];
     }
 }

--- a/tests/src/Tables/TestCase.php
+++ b/tests/src/Tables/TestCase.php
@@ -3,6 +3,7 @@
 namespace Filament\Tests\Tables;
 
 use Filament\Tests\TestCase as BaseTestCase;
+use Kirschbaum\PowerJoins\PowerJoinsServiceProvider;
 
 class TestCase extends BaseTestCase
 {
@@ -11,6 +12,7 @@ class TestCase extends BaseTestCase
         return [
             ...parent::getPackageProviders($app),
             TablesServiceProvider::class,
+            PowerJoinsServiceProvider::class,
         ];
     }
 }

--- a/tests/src/TestCase.php
+++ b/tests/src/TestCase.php
@@ -16,6 +16,7 @@ use Filament\Tables\TablesServiceProvider;
 use Filament\Tests\Models\User;
 use Filament\Widgets\WidgetsServiceProvider;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Kirschbaum\PowerJoins\PowerJoinsServiceProvider;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase as BaseTestCase;
@@ -38,6 +39,7 @@ abstract class TestCase extends BaseTestCase
             InfolistsServiceProvider::class,
             LivewireServiceProvider::class,
             NotificationsServiceProvider::class,
+            PowerJoinsServiceProvider::class,
             SpatieLaravelSettingsPluginServiceProvider::class,
             SpatieLaravelTranslatablePluginServiceProvider::class,
             SupportServiceProvider::class,


### PR DESCRIPTION
This PR allows the `getLabel()` method of Table Groups to be based on a closure. It also ensures that the group evaluation parameters for `$table`/`$livewire` are correctly received. In line with other code the table is set on the group as soon as possible (when pushing the groups), or on instantiation of the groups when only providing the string attribute.

Thanks!