### PR TITLE
Added TimePicker and time method with generate argument

### DIFF
--- a/packages/forms/src/Commands/Concerns/CanGenerateForms.php
+++ b/packages/forms/src/Commands/Concerns/CanGenerateForms.php
@@ -44,6 +44,7 @@ trait CanGenerateForms
             $componentData['type'] = match (true) {
                 $type['name'] === 'boolean' => Forms\Components\Toggle::class,
                 $type['name'] === 'date' => Forms\Components\DatePicker::class,
+                $type['name'] === 'time' => Forms\Components\TimePicker::class,
                 in_array($type['name'], ['datetime', 'timestamp']) => Forms\Components\DateTimePicker::class,
                 $type['name'] === 'text' => Forms\Components\Textarea::class,
                 $columnName === 'image', str($columnName)->startsWith('image_'), str($columnName)->contains('_image_'), str($columnName)->endsWith('_image') => Forms\Components\FileUpload::class,

--- a/packages/tables/src/Commands/Concerns/CanGenerateTables.php
+++ b/packages/tables/src/Commands/Concerns/CanGenerateTables.php
@@ -92,6 +92,13 @@ trait CanGenerateTables
                 }
 
                 if (in_array($type['name'], [
+                    'time',
+                ])) {
+                    $columnData['time'] = [];
+                    $columnData['sortable'] = [];
+                }
+
+                if (in_array($type['name'], [
                     'datetime',
                     'timestamp',
                 ])) {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When using `--generate` with `php artisan make:filament-resource`, it detects `date`, `datetime`, and `timestamps` but not `time`.
So, I added the time field and column generation.

## Visual changes

The description seems clear but here is what it generates:

<img width="582" alt="image" src="https://github.com/user-attachments/assets/0b59f522-7c16-4d7a-8ea0-d144acc246b6" />

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
