### PR TITLE
Added TimePicker and time method with generate argument

### DIFF
--- a/packages/forms/src/Commands/FileGenerators/Concerns/CanGenerateModelForms.php
+++ b/packages/forms/src/Commands/FileGenerators/Concerns/CanGenerateModelForms.php
@@ -8,6 +8,7 @@ use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\TimePicker;
 use Filament\Forms\Components\Toggle;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
@@ -89,6 +90,7 @@ trait CanGenerateModelForms
             $componentData['type'] = match (true) {
                 $type['name'] === 'boolean' => Toggle::class,
                 $type['name'] === 'date' => DatePicker::class,
+                $type['name'] === 'time' => TimePicker::class,
                 in_array($type['name'], ['datetime', 'timestamp']) => DateTimePicker::class,
                 $type['name'] === 'text' => Textarea::class,
                 $componentName === 'image', str($componentName)->startsWith('image_'), str($componentName)->contains('_image_'), str($componentName)->endsWith('_image') => FileUpload::class,

--- a/packages/tables/src/Commands/FileGenerators/Concerns/CanGenerateModelTables.php
+++ b/packages/tables/src/Commands/FileGenerators/Concerns/CanGenerateModelTables.php
@@ -143,6 +143,13 @@ trait CanGenerateModelTables
                 }
 
                 if (in_array($type['name'], [
+                    'time',
+                ])) {
+                    $columnData['time'] = [];
+                    $columnData['sortable'] = [];
+                }
+
+                if (in_array($type['name'], [
                     'datetime',
                     'timestamp',
                 ])) {

--- a/packages/tables/src/Commands/FileGenerators/Concerns/CanGenerateModelTables.php
+++ b/packages/tables/src/Commands/FileGenerators/Concerns/CanGenerateModelTables.php
@@ -135,16 +135,12 @@ trait CanGenerateModelTables
                     $columnData['searchable'] = [];
                 }
 
-                if (in_array($type['name'], [
-                    'date',
-                ])) {
+                if ($type['name'] === 'date') {
                     $columnData['date'] = [];
                     $columnData['sortable'] = [];
                 }
 
-                if (in_array($type['name'], [
-                    'time',
-                ])) {
+                if ($type['name'] === 'time') {
                     $columnData['time'] = [];
                     $columnData['sortable'] = [];
                 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When using `--generate` with `php artisan make:filament-resource`, it detects `date`, `datetime`, and `timestamps` but not `time`.
So, I added the time field and column generation.

## Visual changes

The description seems clear but here is what it generates:

<img width="483" alt="image" src="https://github.com/user-attachments/assets/35657557-1232-4845-a317-e20bbf10ef7b" />

<img width="488" alt="image" src="https://github.com/user-attachments/assets/c614e53c-3659-4a36-a817-57f06b60d291" />

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
