### PR TITLE
fix: add maxlenght 1000 to global search & table search 3.x

### DIFF
--- a/packages/panels/resources/views/components/global-search/field.blade.php
+++ b/packages/panels/resources/views/components/global-search/field.blade.php
@@ -21,9 +21,9 @@
         wire:target="search"
     >
         <x-filament::input
-            maxlength="1000"
             autocomplete="off"
             inline-prefix
+            maxlength="1000"
             :placeholder="__('filament-panels::global-search.field.placeholder')"
             type="search"
             wire:key="global-search.field.input"

--- a/packages/panels/resources/views/components/global-search/field.blade.php
+++ b/packages/panels/resources/views/components/global-search/field.blade.php
@@ -21,6 +21,7 @@
         wire:target="search"
     >
         <x-filament::input
+            maxlength="1000"
             autocomplete="off"
             inline-prefix
             :placeholder="__('filament-panels::global-search.field.placeholder')"

--- a/packages/tables/resources/views/components/search-field.blade.php
+++ b/packages/tables/resources/views/components/search-field.blade.php
@@ -28,6 +28,7 @@
         :wire:target="$wireModel"
     >
         <x-filament::input
+            maxlength="1000"
             :attributes="
                 (new ComponentAttributeBag)->merge([
                     'autocomplete' => 'off',

--- a/packages/tables/resources/views/components/search-field.blade.php
+++ b/packages/tables/resources/views/components/search-field.blade.php
@@ -28,11 +28,11 @@
         :wire:target="$wireModel"
     >
         <x-filament::input
-            maxlength="1000"
             :attributes="
                 (new ComponentAttributeBag)->merge([
                     'autocomplete' => 'off',
                     'inlinePrefix' => true,
+                    'maxlength' => 1000,
                     'placeholder' => $placeholder,
                     'type' => 'search',
                     'wire:key' => $this->getId() . '.table.' . $wireModel . '.field.input',


### PR DESCRIPTION
## Description

Just added maxlenght=1000 to table search and global search requested in https://github.com/filamentphp/filament/issues/13071

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
