### PR TITLE
fix: respect the model label defined in the resource class when using ExportAction 3.x

### DIFF
--- a/packages/actions/src/Concerns/InteractsWithRecord.php
+++ b/packages/actions/src/Concerns/InteractsWithRecord.php
@@ -188,7 +188,7 @@ trait InteractsWithRecord
             return $label;
         }
 
-        $singularLabel = $this->getLivewire()?->getTable()?->getModelLabel() ?? $this->getModelLabel();
+        $singularLabel = $this->getLivewire()->getTable()->getModelLabel() ?? $this->getModelLabel();
 
         if (blank($singularLabel)) {
             return null;

--- a/packages/actions/src/Concerns/InteractsWithRecord.php
+++ b/packages/actions/src/Concerns/InteractsWithRecord.php
@@ -188,7 +188,7 @@ trait InteractsWithRecord
             return $label;
         }
 
-        $singularLabel = $this->getModelLabel();
+        $singularLabel = $this->getLivewire()?->getTable()?->getModelLabel() ?? $this->getModelLabel();
 
         if (blank($singularLabel)) {
             return null;


### PR DESCRIPTION
## Description

As described in https://github.com/filamentphp/filament/issues/13643, I'm not sure if this approach is the best, but it does fix the bug.

The thing is, the only way I found to get the model label is through the Livewire / table component. Is there another way to do this?

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
