### PR TITLE
fix: add Form and Table to prevent collision while creating a resource

### DIFF
--- a/packages/panels/src/Commands/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/MakeResourceCommand.php
@@ -239,8 +239,7 @@ class MakeResourceCommand extends Command
             'formSchema' => $this->indentString($this->option('generate') ? $this->getResourceFormSchema(
                 $modelNamespace . ($modelSubNamespace !== '' ? "\\{$modelSubNamespace}" : '') . '\\' . $modelClass,
             ) : '//', 4),
-            'model' => ($model === 'Resource') ? "{$modelNamespace}\\Resource as ResourceModel" : "{$modelNamespace}\\{$model}",
-            'modelClass' => ($model === 'Resource') ? 'ResourceModel' : $modelClass,
+            ...$this->generateModel($model, $modelNamespace, $modelClass),
             'namespace' => $namespace,
             'pages' => $this->indentString($pages, 3),
             'relations' => $this->indentString($relations, 1),
@@ -323,5 +322,21 @@ class MakeResourceCommand extends Command
         $this->components->info("Filament resource [{$resourcePath}] created successfully.");
 
         return static::SUCCESS;
+    }
+
+    protected function generateModel(string $model, string $modelNamespace, string $modelClass): array
+    {
+        $possibilities = ['Form', 'Table', 'Resource'];
+        $params = [];
+
+        if (in_array($model, $possibilities)) {
+            $params['model'] = "{$modelNamespace}\\{$model} as {$model}Model";
+            $params['modelClass'] = $model . 'Model';
+        } else {
+            $params['model'] = "{$modelNamespace}\\{$model}";
+            $params['modelClass'] = $modelClass;
+        }
+
+        return $params;
     }
 }

--- a/packages/panels/src/Commands/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/MakeResourceCommand.php
@@ -324,6 +324,9 @@ class MakeResourceCommand extends Command
         return static::SUCCESS;
     }
 
+    /**
+     * @return array<string, string>
+     */
     protected function generateModel(string $model, string $modelNamespace, string $modelClass): array
     {
         $possibilities = ['Form', 'Table', 'Resource'];


### PR DESCRIPTION
## Description

This prevents class collisions when the model is called "Form", "Table", or "Resource", as described in https://github.com/filamentphp/filament/issues/13552 

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
