### PR TITLE
fix: prevent multiple evaluations when getStateUsing is called #14852

### DIFF
--- a/packages/support/src/Concerns/HasCellState.php
+++ b/packages/support/src/Concerns/HasCellState.php
@@ -76,7 +76,7 @@ trait HasCellState
         }
 
         $state = ($this->getStateUsing !== null) ?
-            $this->evaluate($this->getStateUsing) :
+            $this->getStateUsing :
             $this->getStateFromRecord();
 
         if (is_string($state) && ($separator = $this->getSeparator())) {


### PR DESCRIPTION
## Description

As mentioned in https://github.com/filamentphp/filament/issues/14852, this issue was causing multiple evaluations. This fix ensures that only the final evaluation is performed, which I believe is the correct approach.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
