### PR TITLE
Feature/issues 14876 add footer content tables docs

### DIFF
--- a/packages/tables/docs/10-advanced.md
+++ b/packages/tables/docs/10-advanced.md
@@ -268,21 +268,7 @@ public function table(Table $table): Table
         ]);
 ```
 
-## Polling table content
-
-You may poll table content so that it refreshes at a set interval, using the `$table->poll()` method:
-
-```php
-use Filament\Tables\Table;
-
-public function table(Table $table): Table
-{
-    return $table
-        ->poll('10s');
-}
-```
-
-## Customizing the table footer
+## Add content to table footer
 
 You can add a footer to a table using the `$table->contentFooter()` method:
 
@@ -303,6 +289,7 @@ Be careful because you'll need to add a `<td>` element in your view, with the nu
 
 Note that this is not necessary if you're using `Split` layout for your columns.
 
+This is how your view should be structured:
 ```php
 @props([
     'columns',
@@ -310,8 +297,22 @@ Note that this is not necessary if you're using `Split` layout for your columns.
 ])
 
 <td colspan="{{ count($columns) }}">
-    Your footer content
+    Footer content
 </td>
+```
+
+## Polling table content
+
+You may poll table content so that it refreshes at a set interval, using the `$table->poll()` method:
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->poll('10s');
+}
 ```
 
 ## Deferring loading

--- a/packages/tables/docs/10-advanced.md
+++ b/packages/tables/docs/10-advanced.md
@@ -304,8 +304,6 @@ Be careful because you'll need to add a `<td>` element in your view, with the nu
 Note that this is not necessary if you're using `Split` layout for your columns.
 
 ```php
-use Filament\Tables\Table;
-
 @props([
     'columns',
     'records'

--- a/packages/tables/docs/10-advanced.md
+++ b/packages/tables/docs/10-advanced.md
@@ -282,6 +282,40 @@ public function table(Table $table): Table
 }
 ```
 
+## Customizing the table footer
+
+You can add a footer to a table using the `$table->contentFooter()` method:
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->contentFooter(view('tables.footer'))
+        ->columns([
+            // ...
+        ]);
+}
+```
+
+Be careful because you'll need to add a `<td>` element in your view, with the number of columns.
+
+Note that this is not necessary if you're using `Split` layout for your columns.
+
+```php
+use Filament\Tables\Table;
+
+@props([
+    'columns',
+    'records'
+])
+
+<td colspan="{{ count($columns) }}">
+    Your footer content
+</td>
+```
+
 ## Deferring loading
 
 Tables with lots of data might take a while to load, in which case you can load the table data asynchronously using the `deferLoading()` method:


### PR DESCRIPTION
## Description

Add contentFooter to tables/advanced docs with a brief description regarding the issue discussed in https://github.com/filamentphp/filament/issues/14876

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
