### PR TITLE
Fix: `RelationshipJoiner` raw & sub-query orders

### DIFF
--- a/packages/support/src/Services/RelationshipJoiner.php
+++ b/packages/support/src/Services/RelationshipJoiner.php
@@ -5,6 +5,7 @@ namespace Filament\Support\Services;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -91,15 +92,26 @@ class RelationshipJoiner
 
             /** @phpstan-ignore-next-line */
             foreach (($relationshipQuery->getQuery()->orders ?? []) as $order) {
-                if (! array_key_exists('column', $order)) {
+                // Regular orders: { column: string, direction: 'asc' | 'desc' }
+                // Raw orders: { type: 'Raw', sql: string }
+                // Sub-query orders look like: { column: Illuminate\Database\Query\Expression, direction: 'asc' | 'desc' }
+                if (! array_key_exists('column', $order) && ! array_key_exists('sql', $order)) {
                     continue;
                 }
 
-                if (is_string($order['column']) && str($order['column'])->startsWith("{$relationshipQuery->getModel()->getTable()}.")) {
+                $columnValue = $order['column'] ?? new Expression($order['sql']);
+
+                if ($columnValue instanceof Expression && str($columnValue->getValue($relationship->getGrammar()))->contains('?')) {
+                    // Heuristic to determine if the expression contains (a) binding(s), if so, as of
+                    // yet we cannot reliably determine (which) bindings are used in the expression.
                     continue;
                 }
 
-                $relationshipQuery->addSelect($order['column']);
+                if (str($columnValue instanceof Expression ? $columnValue->getValue($relationship->getGrammar()) : $columnValue)->startsWith("{$relationshipQuery->getModel()->getTable()}.")) {
+                    continue;
+                }
+
+                $relationshipQuery->addSelect($columnValue);
             }
         }
 

--- a/packages/support/src/Services/RelationshipJoiner.php
+++ b/packages/support/src/Services/RelationshipJoiner.php
@@ -93,8 +93,8 @@ class RelationshipJoiner
             /** @phpstan-ignore-next-line */
             foreach (($relationshipQuery->getQuery()->orders ?? []) as $order) {
                 // Regular orders: { column: string, direction: 'asc' | 'desc' }
-                // Raw orders: { type: 'Raw', sql: string }
                 // Sub-query orders look like: { column: Illuminate\Database\Query\Expression, direction: 'asc' | 'desc' }
+                // Raw orders: { type: 'Raw', sql: string }
                 if (! array_key_exists('column', $order) && ! array_key_exists('sql', $order)) {
                     continue;
                 }

--- a/packages/support/src/Services/RelationshipJoiner.php
+++ b/packages/support/src/Services/RelationshipJoiner.php
@@ -101,13 +101,19 @@ class RelationshipJoiner
 
                 $columnValue = $order['column'] ?? new Expression($order['sql']);
 
-                if ($columnValue instanceof Expression && str($columnValue->getValue($relationship->getGrammar()))->contains('?')) {
+                if (
+                    $columnValue instanceof Expression
+                    && str($columnValue->getValue($relationship->getGrammar()))->contains('?')
+                ) {
                     // Heuristic to determine if the expression contains (a) binding(s), if so, as of
                     // yet we cannot reliably determine (which) bindings are used in the expression.
                     continue;
                 }
 
-                if (str($columnValue instanceof Expression ? $columnValue->getValue($relationship->getGrammar()) : $columnValue)->startsWith("{$relationshipQuery->getModel()->getTable()}.")) {
+                if (
+                    str($columnValue instanceof Expression ? $columnValue->getValue($relationship->getGrammar()) : $columnValue)
+                        ->startsWith("{$relationshipQuery->getModel()->getTable()}.")
+                ) {
                     continue;
                 }
 

--- a/packages/support/src/Services/RelationshipJoiner.php
+++ b/packages/support/src/Services/RelationshipJoiner.php
@@ -95,7 +95,7 @@ class RelationshipJoiner
                     continue;
                 }
 
-                if (str($order['column'])->startsWith("{$relationshipQuery->getModel()->getTable()}.")) {
+                if (is_string($order['column']) && str($order['column'])->startsWith("{$relationshipQuery->getModel()->getTable()}.")) {
                     continue;
                 }
 

--- a/packages/support/src/Services/RelationshipJoiner.php
+++ b/packages/support/src/Services/RelationshipJoiner.php
@@ -93,7 +93,7 @@ class RelationshipJoiner
             /** @phpstan-ignore-next-line */
             foreach (($relationshipQuery->getQuery()->orders ?? []) as $order) {
                 // Regular orders: { column: string, direction: 'asc' | 'desc' }
-                // Sub-query orders look like: { column: Illuminate\Database\Query\Expression, direction: 'asc' | 'desc' }
+                // Sub-query orders: { column: Illuminate\Database\Query\Expression, direction: 'asc' | 'desc' }
                 // Raw orders: { type: 'Raw', sql: string }
                 if (! array_key_exists('column', $order) && ! array_key_exists('sql', $order)) {
                     continue;

--- a/tests/database/migrations/create_team_user_table.php
+++ b/tests/database/migrations/create_team_user_table.php
@@ -10,9 +10,9 @@ return new class extends Migration
     {
         Schema::create('team_user', function (Blueprint $table): void {
             $table->id();
-			$table->foreignId('team_id')->constrained();
-			$table->foreignId('user_id')->constrained();
-			$table->string('role')->nullable();
+            $table->foreignId('team_id')->constrained();
+            $table->foreignId('user_id')->constrained();
+            $table->string('role')->nullable();
             $table->timestamps();
         });
     }

--- a/tests/database/migrations/create_team_user_table.php
+++ b/tests/database/migrations/create_team_user_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('team_user', function (Blueprint $table): void {
+            $table->id();
+			$table->foreignId('team_id')->constrained();
+			$table->foreignId('user_id')->constrained();
+			$table->string('role')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('team_user');
+    }
+};

--- a/tests/src/Models/User.php
+++ b/tests/src/Models/User.php
@@ -9,6 +9,7 @@ use Filament\Tests\Database\Factories\UserFactory;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -34,6 +35,11 @@ class User extends Authenticatable implements FilamentUser, HasTenants, MustVeri
     public function posts(): HasMany
     {
         return $this->hasMany(Post::class, 'author_id');
+    }
+
+    public function teams(): BelongsToMany
+    {
+        return $this->belongsToMany(Team::class);
     }
 
     protected static function newFactory()

--- a/tests/src/Support/Services/RelationshipJoinerTest.php
+++ b/tests/src/Support/Services/RelationshipJoinerTest.php
@@ -16,14 +16,14 @@ it('can prepare query for no constraints for a BelongsToMany relationship', func
         ->getColumns()->toBe([])
         ->orders->toBeNull();
 
-    $query = app(RelationshipJoiner::class)->prepareQueryForNoConstraints($user->teams());
+    $preparedQuery = app(RelationshipJoiner::class)->prepareQueryForNoConstraints($user->teams());
 
-    expect($query->toBase())
+    expect($preparedQuery->toBase())
         ->distinct->toBeTrue()
         ->getColumns()->toBe(['teams.*'])
         ->orders->toBeNull();
 
-    $query = app(RelationshipJoiner::class)->prepareQueryForNoConstraints(
+    $preparedQuery = app(RelationshipJoiner::class)->prepareQueryForNoConstraints(
         $user
             ->teams()
             ->orderBy('id')
@@ -31,7 +31,7 @@ it('can prepare query for no constraints for a BelongsToMany relationship', func
             ->orderBy('team_user.role')
     );
 
-    expect($query->toBase())
+    expect($preparedQuery->toBase())
         ->distinct->toBeTrue()
         ->getColumns()->toBe([
             (new Team)->qualifyColumn('*'), // Default select...
@@ -54,11 +54,11 @@ it('can prepare query for no constraints for a BelongsToMany relationship', func
             ],
         ]);
 
-    $query = app(RelationshipJoiner::class)->prepareQueryForNoConstraints(
+    $preparedQuery = app(RelationshipJoiner::class)->prepareQueryForNoConstraints(
         $user->teams()->orderByRaw("CASE WHEN role = 'admin' THEN 1 ELSE 2 END")
     );
 
-    expect($query->toBase())
+    expect($preparedQuery->toBase())
         ->distinct->toBeTrue()
         ->getColumns()->toBe([
             (new Team)->qualifyColumn('*'),
@@ -71,18 +71,18 @@ it('can prepare query for no constraints for a BelongsToMany relationship', func
             ],
         ]);
 
-    $query = app(RelationshipJoiner::class)->prepareQueryForNoConstraints(
+    $preparedQuery = app(RelationshipJoiner::class)->prepareQueryForNoConstraints(
         $user->teams()->orderBy(new Expression("CASE WHEN role = 'some_other_role' THEN 1 ELSE 2 END"))
     );
 
-    expect($query->toBase())
+    expect($preparedQuery->toBase())
         ->distinct->toBeTrue()
         ->getColumns()->toBe([
             (new Team)->qualifyColumn('*'),
             "CASE WHEN role = 'user' THEN 1 ELSE 2 END", // Select added from `orderByRaw`...
         ])
         ->orders->toHaveCount(1)
-        ->and($query->toBase()->orders[0])
+        ->and($preparedQuery->toBase()->orders[0])
         ->column->getValue($user->teams()->getGrammar())->toBe("CASE WHEN role = 'some_other_role' THEN 1 ELSE 2 END")
         ->direction->toBe('asc');
 });

--- a/tests/src/Support/Services/RelationshipJoinerTest.php
+++ b/tests/src/Support/Services/RelationshipJoinerTest.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Query\Expression;
 
 uses(TestCase::class);
 
-it('can prepare query for no constraints', function () {
+it('can prepare query for no constraints for a BelongsToMany relationship', function () {
     $user = User::factory()->create();
 
     expect($user->teams()->toBase())
@@ -72,7 +72,7 @@ it('can prepare query for no constraints', function () {
         ]);
 
     $query = app(RelationshipJoiner::class)->prepareQueryForNoConstraints(
-		$user->teams()->orderBy(new Expression("CASE WHEN role = 'some_other_role' THEN 1 ELSE 2 END"))
+        $user->teams()->orderBy(new Expression("CASE WHEN role = 'some_other_role' THEN 1 ELSE 2 END"))
     );
 
     expect($query->toBase())
@@ -81,8 +81,8 @@ it('can prepare query for no constraints', function () {
             (new Team)->qualifyColumn('*'),
             "CASE WHEN role = 'user' THEN 1 ELSE 2 END", // Select added from `orderByRaw`...
         ])
-	    ->orders->toHaveCount(1)
-	    ->and($query->toBase()->orders[0])
-	    ->column->getValue($user->teams()->getGrammar())->toBe("CASE WHEN role = 'some_other_role' THEN 1 ELSE 2 END")
-	    ->direction->toBe('asc');
+        ->orders->toHaveCount(1)
+        ->and($query->toBase()->orders[0])
+        ->column->getValue($user->teams()->getGrammar())->toBe("CASE WHEN role = 'some_other_role' THEN 1 ELSE 2 END")
+        ->direction->toBe('asc');
 });

--- a/tests/src/Support/Services/RelationshipJoinerTest.php
+++ b/tests/src/Support/Services/RelationshipJoinerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use Filament\Support\Services\RelationshipJoiner;
+use Filament\Tests\Models\Team;
+use Filament\Tests\Models\User;
+use Filament\Tests\TestCase;
+use Illuminate\Database\Query\Expression;
+
+uses(TestCase::class);
+
+it('can prepare query for no constraints', function () {
+    $user = User::factory()->create();
+
+    expect($user->teams()->toBase())
+        ->distinct->toBeFalse()
+        ->getColumns()->toBe([])
+        ->orders->toBeNull();
+
+    $query = app(RelationshipJoiner::class)->prepareQueryForNoConstraints($user->teams());
+
+    expect($query->toBase())
+        ->distinct->toBeTrue()
+        ->getColumns()->toBe(['teams.*'])
+        ->orders->toBeNull();
+
+    $query = app(RelationshipJoiner::class)->prepareQueryForNoConstraints(
+        $user
+            ->teams()
+            ->orderBy('id')
+            ->orderBy((new Team)->qualifyColumn('name'))
+            ->orderBy('team_user.role')
+    );
+
+    expect($query->toBase())
+        ->distinct->toBeTrue()
+        ->getColumns()->toBe([
+            (new Team)->qualifyColumn('*'), // Default select...
+            'id', // Select without a qualified table also included just to be sure...
+            // Select for `team.name` not included as that is already included in the `team.*`...
+            'team_user.role', // Select for a qualitified other table included...
+        ])
+        ->orders->toBe([
+            [
+                'column' => 'id',
+                'direction' => 'asc',
+            ],
+            [
+                'column' => 'teams.name',
+                'direction' => 'asc',
+            ],
+            [
+                'column' => 'team_user.role',
+                'direction' => 'asc',
+            ],
+        ]);
+
+    $query = app(RelationshipJoiner::class)->prepareQueryForNoConstraints(
+        $user->teams()->orderByRaw("CASE WHEN role = 'admin' THEN 1 ELSE 2 END")
+    );
+
+    expect($query->toBase())
+        ->distinct->toBeTrue()
+        ->getColumns()->toBe([
+            (new Team)->qualifyColumn('*'),
+            "CASE WHEN role = 'admin' THEN 1 ELSE 2 END", // Select added from `orderByRaw`...
+        ])
+        ->orders->toBe([
+            [
+                'type' => 'Raw',
+                'sql' => "CASE WHEN role = 'admin' THEN 1 ELSE 2 END",
+            ],
+        ]);
+
+    $query = app(RelationshipJoiner::class)->prepareQueryForNoConstraints(
+		$user->teams()->orderBy(new Expression("CASE WHEN role = 'some_other_role' THEN 1 ELSE 2 END"))
+    );
+
+    expect($query->toBase())
+        ->distinct->toBeTrue()
+        ->getColumns()->toBe([
+            (new Team)->qualifyColumn('*'),
+            "CASE WHEN role = 'user' THEN 1 ELSE 2 END", // Select added from `orderByRaw`...
+        ])
+	    ->orders->toHaveCount(1)
+	    ->and($query->toBase()->orders[0])
+	    ->column->getValue($user->teams()->getGrammar())->toBe("CASE WHEN role = 'some_other_role' THEN 1 ELSE 2 END")
+	    ->direction->toBe('asc');
+});

--- a/tests/src/Support/Services/RelationshipJoinerTest.php
+++ b/tests/src/Support/Services/RelationshipJoinerTest.php
@@ -79,7 +79,7 @@ it('can prepare query for no constraints for a BelongsToMany relationship', func
         ->distinct->toBeTrue()
         ->getColumns()->toBe([
             (new Team)->qualifyColumn('*'),
-            "CASE WHEN role = 'user' THEN 1 ELSE 2 END", // Select added from `orderByRaw`...
+            "CASE WHEN role = 'some_other_role' THEN 1 ELSE 2 END", // Select added from `orderByRaw`...
         ])
         ->orders->toHaveCount(1)
         ->and($preparedQuery->toBase()->orders[0])


### PR DESCRIPTION
This PR fixes two situations in the `RelationshipJoiner` that did not work:

- `->orderByRaw("CASE WHEN role = 'PIC' THEN 1 ELSE 2 END")`
- `->orderBy(fn (Builder $query) => $query->selectRaw("CASE WHEN role = 'PIC' THEN 1 ELSE 2 END"))`

This PR fixes both cases to make the `RelationshipJoiner` handle them correctly. There might always be edge cases regarding this part of the `RelationshipJoiner`, like when the raw order by contains a binding, but at least this makes the joiner handle a few more common cases.