### PR TITLE
Fix forced lower case search for json field

### DIFF
--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -181,6 +181,12 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
         };
 
         if ($isSearchForcedCaseInsensitive) {
+            if (in_array($driverName, ['mysql', 'mariadb'], true) && str_contains($column, '->')) {
+                [$field, $path] = invade($databaseConnection->getQueryGrammar())->wrapJsonFieldAndPath($column);
+
+                $column = "json_extract({$field}{$path})";
+            }
+
             $column = "lower({$column})";
         }
 

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -181,7 +181,7 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
         };
 
         if ($isSearchForcedCaseInsensitive) {
-            if (in_array($driverName, ['mysql', 'mariadb'], true) && str_contains($column, '->')) {
+            if (in_array($driverName, ['mysql', 'mariadb'], true) && str($column)->contains('->')) {
                 [$field, $path] = invade($databaseConnection->getQueryGrammar())->wrapJsonFieldAndPath($column); /** @phpstan-ignore-line */
 
                 $column = "json_extract({$field}{$path})";

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -181,7 +181,7 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
         };
 
         if ($isSearchForcedCaseInsensitive) {
-            if (in_array($driverName, ['mysql', 'mariadb'], true) && str($column)->contains('->')) {
+            if (in_array($driverName, ['mysql', 'mariadb'], true) && str($column)->contains('->') && ! str($column)->startsWith('json_extract(')) {
                 [$field, $path] = invade($databaseConnection->getQueryGrammar())->wrapJsonFieldAndPath($column); /** @phpstan-ignore-line */
 
                 $column = "json_extract({$field}{$path})";

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -182,7 +182,7 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
 
         if ($isSearchForcedCaseInsensitive) {
             if (in_array($driverName, ['mysql', 'mariadb'], true) && str_contains($column, '->')) {
-                [$field, $path] = invade($databaseConnection->getQueryGrammar())->wrapJsonFieldAndPath($column);
+                [$field, $path] = invade($databaseConnection->getQueryGrammar())->wrapJsonFieldAndPath($column); /** @phpstan-ignore-line */
 
                 $column = "json_extract({$field}{$path})";
             }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When using `->forceSearchCaseInsensitive()` on a column that is accessed via json extraction (eg. `data.field`), it results in an exception. This is because `lower(data->field)` does not work for mysql (and mariadb), it should be ```lower(json_extract(`data`, '$."field"'))```.

## Visual changes

None

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
