### PR TITLE
Prevent min width on not individually searchable table columns

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -944,7 +944,6 @@
                                 <x-filament-tables::cell
                                     @class([
                                         'fi-table-individual-search-cell-' . str($column->getName())->camel()->kebab(),
-                                        'min-w-48 px-3 py-2',
                                     ])
                                 >
                                     @if ($column->isIndividuallySearchable())
@@ -952,6 +951,7 @@
                                             :debounce="$searchDebounce"
                                             :on-blur="$isSearchOnBlur"
                                             wire-model="tableColumnSearches.{{ $column->getName() }}"
+                                            class="min-w-48 mx-3 my-2"
                                         />
                                     @endif
                                 </x-filament-tables::cell>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -951,7 +951,7 @@
                                             :debounce="$searchDebounce"
                                             :on-blur="$isSearchOnBlur"
                                             wire-model="tableColumnSearches.{{ $column->getName() }}"
-                                            class="min-w-48 mx-3 my-2"
+                                            class="mx-3 my-2 min-w-48"
                                         />
                                     @endif
                                 </x-filament-tables::cell>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -944,14 +944,14 @@
                                 <x-filament-tables::cell
                                     @class([
                                         'fi-table-individual-search-cell-' . str($column->getName())->camel()->kebab(),
+                                        'min-w-48 px-3 py-2' => $isIndividuallySearchable = $column->isIndividuallySearchable(),
                                     ])
                                 >
-                                    @if ($column->isIndividuallySearchable())
+                                    @if ($isIndividuallySearchable)
                                         <x-filament-tables::search-field
                                             :debounce="$searchDebounce"
                                             :on-blur="$isSearchOnBlur"
                                             wire-model="tableColumnSearches.{{ $column->getName() }}"
-                                            class="mx-3 my-2 min-w-48"
                                         />
                                     @endif
                                 </x-filament-tables::cell>


### PR DESCRIPTION
## Description
This PR prevents min-w-48 and padding to be applied to columns that are not individually searchable. 
It also prevents adding height to the search row if all individually searchable columns are hidden.

## Visual changes

### Before, 

With visible searchable column
Observe, width of first and second column.
<img width="1290" alt="image" src="https://github.com/user-attachments/assets/6ee7062f-350e-4c1a-bc36-5b1d6f30c6f8" />


With searchable column toggled
Observe, height of search row.
<img width="1290" alt="image" src="https://github.com/user-attachments/assets/1b3e0e6a-0136-4262-b3b4-0b258144ea5b" />

### After

With visible searchable column
Observe, width of first and second column.
<img width="1035" alt="image" src="https://github.com/user-attachments/assets/593c3fd3-144e-4e37-bdbb-e97d98416dec" />

With searchable column toggled
Observe, height of search row.
<img width="1035" alt="image" src="https://github.com/user-attachments/assets/66755449-f790-4a0e-bf5b-946dbe4826b5" />



## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
