### PR TITLE
fix: checking if widget property has been initialized on lazy mode

### DIFF
--- a/packages/widgets/resources/views/table-widget.blade.php
+++ b/packages/widgets/resources/views/table-widget.blade.php
@@ -1,7 +1,7 @@
 <x-filament-widgets::widget class="fi-wi-table">
     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\Widgets\View\WidgetsRenderHook::TABLE_WIDGET_START, scopes: static::class) }}
 
-    {{ $this->table }}
+    {{ isset($this->table) ? $this->table : null }}
 
     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\Widgets\View\WidgetsRenderHook::TABLE_WIDGET_END, scopes: static::class) }}
 </x-filament-widgets::widget>


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When table widget is lazy or has not been initialized, and then got a laravel-echo event to refresh it, will got this error:
Typed property Filament\\Widgets\\TableWidget::$table must not be accessed before initialization

## Visual changes

no visual changes

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
