### PR TITLE
bug: Fix type error in Asset

### DIFF
--- a/packages/support/src/Assets/Asset.php
+++ b/packages/support/src/Assets/Asset.php
@@ -13,15 +13,15 @@ abstract class Asset
 
     protected string $package;
 
-    protected ?string $path = null;
+    protected string $path = null;
 
-    final public function __construct(string $id, ?string $path = null)
+    final public function __construct(string $id, ?string $path = '/')
     {
         $this->id = $id;
         $this->path = $path;
     }
 
-    public static function make(string $id, ?string $path = null): static
+    public static function make(string $id, ?string $path = '/'): static
     {
         return app(static::class, ['id' => $id, 'path' => $path]);
     }

--- a/packages/support/src/Assets/Asset.php
+++ b/packages/support/src/Assets/Asset.php
@@ -9,19 +9,19 @@ abstract class Asset
 {
     protected string $id;
 
+    protected string $path;
+
     protected bool $isLoadedOnRequest = false;
 
     protected string $package;
 
-    protected string $path = null;
-
-    final public function __construct(string $id, ?string $path = '/')
+    final public function __construct(string $id, string $path)
     {
         $this->id = $id;
         $this->path = $path;
     }
 
-    public static function make(string $id, ?string $path = '/'): static
+    public static function make(string $id, string $path): static
     {
         return app(static::class, ['id' => $id, 'path' => $path]);
     }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The `$path` class property is `null` by default but the accessor method can't return `null` which causes a `TypeError`

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

None

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
