### PR TITLE
ensures `filament.xxx.home` is always available

### DIFF
--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -92,7 +92,8 @@ Route::name('filament.')
                                             $routes($panel);
                                         }
 
-                                        Route::get('/', RedirectToHomeController::class)->name('home');
+                                        Route::get('/', RedirectToHomeController::class);
+                                        Route::get('/redirect-to-home', RedirectToHomeController::class)->name('home');
 
                                         Route::name('tenant.')->group(function () use ($panel): void {
                                             if ($panel->hasTenantBilling()) {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Addresses #15257

1. Ensures that the route name `filament.<panel-id>.home` won't be overwritten when the dashboard page is used
2. The route `/` still works with or without the dashboard, so backwards compatible

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
