### PR TITLE
fix: call base isHidden method in addition to checking action

### DIFF
--- a/packages/forms/src/Components/Actions/ActionContainer.php
+++ b/packages/forms/src/Components/Actions/ActionContainer.php
@@ -2,10 +2,15 @@
 
 namespace Filament\Forms\Components\Actions;
 
+use Filament\Forms\Components\Concerns;
 use Filament\Forms\Components\Component;
 
 class ActionContainer extends Component
 {
+    use Concerns\CanBeHidden {
+        isHidden as baseIsHidden;
+    }
+
     protected string $view = 'filament-forms::components.actions.action-container';
 
     protected Action $action;
@@ -31,6 +36,6 @@ class ActionContainer extends Component
 
     public function isHidden(): bool
     {
-        return $this->action->isHidden();
+        return $this->baseIsHidden() || $this->action->isHidden();
     }
 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
Fixes an issue where an `Action` within a form could not be hidden.

Resolves https://github.com/filamentphp/filament/issues/15287

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
