### PR TITLE
Allow multiple disable option conditions

### DIFF
--- a/packages/forms/src/Components/Concerns/CanDisableOptions.php
+++ b/packages/forms/src/Components/Concerns/CanDisableOptions.php
@@ -3,21 +3,22 @@
 namespace Filament\Forms\Components\Concerns;
 
 use Closure;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
 trait CanDisableOptions
 {
     /**
-     * @var array<bool|Closure>
+     * @var array<bool | Closure>
      */
     protected array $isOptionDisabled = [];
 
-    public function disableOptionWhen(bool | Closure $callback, bool $merge = false): static
+    public function disableOptionWhen(bool | Closure | null $callback, bool $merge = false): static
     {
         if ($merge) {
             $this->isOptionDisabled[] = $callback;
         } else {
-            $this->isOptionDisabled = [$callback];
+            $this->isOptionDisabled = Arr::wrap($callback);
         }
 
         return $this;
@@ -46,7 +47,7 @@ trait CanDisableOptions
     public function isOptionDisabled($value, string $label): bool
     {
         return collect($this->isOptionDisabled)
-            ->contains(fn ($isOptionDisabled) => $this->evaluate($isOptionDisabled, [
+            ->contains(fn (bool | Closure $isOptionDisabled): bool => (bool) $this->evaluate($isOptionDisabled, [
                 'label' => $label,
                 'value' => $value,
             ]));
@@ -55,6 +56,6 @@ trait CanDisableOptions
     public function hasDynamicDisabledOptions(): bool
     {
         return collect($this->isOptionDisabled)
-            ->contains(fn ($isOptionDisabled) => $isOptionDisabled instanceof Closure);
+            ->contains(fn (bool | Closure $isOptionDisabled): bool => $isOptionDisabled instanceof Closure);
     }
 }

--- a/packages/forms/src/Components/Concerns/CanDisableOptions.php
+++ b/packages/forms/src/Components/Concerns/CanDisableOptions.php
@@ -45,8 +45,8 @@ trait CanDisableOptions
      */
     public function isOptionDisabled($value, string $label): bool
     {
-        return (bool) collect($this->isOptionDisabled)
-            ->first(fn ($isOptionDisabled) => $this->evaluate($isOptionDisabled, [
+        return collect($this->isOptionDisabled)
+            ->contains(fn ($isOptionDisabled) => $this->evaluate($isOptionDisabled, [
                 'label' => $label,
                 'value' => $value,
             ]));
@@ -54,7 +54,7 @@ trait CanDisableOptions
 
     public function hasDynamicDisabledOptions(): bool
     {
-        return (bool) collect($this->isOptionDisabled)
-            ->first(fn ($isOptionDisabled) => $isOptionDisabled instanceof Closure);
+        return collect($this->isOptionDisabled)
+            ->contains(fn ($isOptionDisabled) => $isOptionDisabled instanceof Closure);
     }
 }


### PR DESCRIPTION
## Description

I have the following use case: repeater that has `Select` column and `RichEditor` which used to select a locale and sets its content.

I want to use the `disableOptionsWhenSelectedInSiblingRepeaterItems` to make it unique, and add extra condition to disable a specific locale from being selected by user but displayable if exists (ai generated content, which has specific locale identifier).

In other words, i need extra condition on top of `disableOptionsWhenSelectedInSiblingRepeaterItems`.

## Functional changes

Modified the trait `CanDisableOptions` to have similar structure as the `HasExtraAttributes` which allows multiple conditions to be added optionally.

```PHP
->disableOptionsWhenSelectedInSiblingRepeaterItems()
->disableOptionWhen(fn(string $value): bool => str($value)->contains('ai'), true)
```

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
