### PR TITLE
Sushi Compatible Summarizers

### DIFF
--- a/packages/support/resources/views/components/tabs/item.blade.php
+++ b/packages/support/resources/views/components/tabs/item.blade.php
@@ -62,7 +62,7 @@
                 'role' => 'tab',
             ])
             ->class([
-                'fi-tabs-item group flex items-center justify-center gap-x-2 rounded-lg px-3 py-2 text-sm font-medium outline-none whitespace-nowrap transition duration-75',
+                'fi-tabs-item group flex items-center justify-center gap-x-2 whitespace-nowrap rounded-lg px-3 py-2 text-sm font-medium outline-none transition duration-75',
                 $inactiveItemClasses => (! $hasAlpineActiveClasses) && (! $active),
                 $activeItemClasses => (! $hasAlpineActiveClasses) && $active,
             ])

--- a/packages/tables/src/Columns/Summarizers/Summarizer.php
+++ b/packages/tables/src/Columns/Summarizers/Summarizer.php
@@ -111,7 +111,7 @@ class Summarizer extends ViewComponent
                 ->prepend('pivot_');
 
             $isPivotAttributeSelected = collect($query->getQuery()->getColumns())
-                ->contains(fn(string $column): bool => str($column)->endsWith(" as {$pivotAttribute}"));
+                ->contains(fn (string $column): bool => str($column)->endsWith(" as {$pivotAttribute}"));
 
             $attribute = $isPivotAttributeSelected ? $pivotAttribute : $attribute;
 
@@ -119,7 +119,7 @@ class Summarizer extends ViewComponent
             if ($isPivotAttributeSelected) {
                 $query->getQuery()->columns = array_filter(
                     $query->getQuery()->columns,
-                    fn(mixed $column): bool => $column !== "{$query->getQuery()->joins[0]->table}.*",
+                    fn (mixed $column): bool => $column !== "{$query->getQuery()->joins[0]->table}.*",
                 );
             }
         }

--- a/packages/tables/src/Columns/Summarizers/Summarizer.php
+++ b/packages/tables/src/Columns/Summarizers/Summarizer.php
@@ -7,7 +7,6 @@ use Filament\Support\Components\ViewComponent;
 use Filament\Support\Concerns\HasExtraAttributes;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Query\Builder;
-use Illuminate\Support\Facades\DB;
 
 class Summarizer extends ViewComponent
 {
@@ -112,7 +111,7 @@ class Summarizer extends ViewComponent
                 ->prepend('pivot_');
 
             $isPivotAttributeSelected = collect($query->getQuery()->getColumns())
-                ->contains(fn (string $column): bool => str($column)->endsWith(" as {$pivotAttribute}"));
+                ->contains(fn(string $column): bool => str($column)->endsWith(" as {$pivotAttribute}"));
 
             $attribute = $isPivotAttributeSelected ? $pivotAttribute : $attribute;
 
@@ -120,14 +119,14 @@ class Summarizer extends ViewComponent
             if ($isPivotAttributeSelected) {
                 $query->getQuery()->columns = array_filter(
                     $query->getQuery()->columns,
-                    fn (mixed $column): bool => $column !== "{$query->getQuery()->joins[0]->table}.*",
+                    fn(mixed $column): bool => $column !== "{$query->getQuery()->joins[0]->table}.*",
                 );
             }
         }
 
         $asName = (string) str($query->getModel()->getTable())->afterLast('.');
 
-        $query = DB::connection($query->getModel()->getConnectionName())
+        $query = $query->getModel()->resolveConnection()
             ->table($query->toBase(), $asName);
 
         if ($this->hasQueryModification()) {

--- a/packages/tables/src/Concerns/CanSummarizeRecords.php
+++ b/packages/tables/src/Concerns/CanSummarizeRecords.php
@@ -7,7 +7,6 @@ use Filament\Support\Services\RelationshipJoiner;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use stdClass;
 
@@ -71,7 +70,7 @@ trait CanSummarizeRecords
         $queryToJoin = $query->clone();
         $joins = [];
 
-        $query = DB::connection($query->getModel()->getConnectionName())
+        $query = $query->getModel()->resolveConnection()
             ->table($query->toBase(), $query->getModel()->getTable());
 
         if ($modifyQueryUsing) {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

I couldn't use the summarizers when I used Sushi models.



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
