### PR TITLE
✨ docs: added authorization section in 10-clusters.md

### DIFF
--- a/packages/panels/docs/10-clusters.md
+++ b/packages/panels/docs/10-clusters.md
@@ -62,6 +62,17 @@ use App\Filament\Clusters\Settings;
 protected static ?string $cluster = Settings::class;
 ```
 
+## Authorization
+
+You can prevent clusters from appearing in the menu by overriding the `canAccess()` method in your Cluster class. This is useful if you want to control which users can see the cluster in the navigation, and also which users can visit the cluster directly:
+
+```php
+public static function canAccess(): bool
+{
+    return auth()->user()->canManageSettings();
+}
+```
+
 ## Code structure recommendations for panels using clusters
 
 When using clusters, it is recommended that you move all of your resources and pages into a directory with the same name as the cluster. For example, here is a directory structure for a panel that uses a cluster called `Settings`, containing a `ColorResource` and two custom pages:


### PR DESCRIPTION
## Description

Introduced `canAccess()` method to control cluster visibility. Just a copy and paste with a `s/page/cluster/i` of the authorization section of the Page docs. 

!! I ran `composer cs` and it oddly changed (only) the line endings in 900+ files when I only added around 10 lines to the cluster docs page. Using PHPStorm and not seen this before so not sure why it'd do that. (I ran this after the commit in this PR so those line ending changes discarded)

## Visual changes

![image](https://github.com/user-attachments/assets/c7d948cf-ffb9-40e2-9ff5-24010dfb94f6)

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
