### PR TITLE
[Docs] Added docs for `disableOptionWhen` second argument

### DIFF
--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -580,6 +580,23 @@ Repeater::make('members')
 
 This method will automatically enable the `distinct()` and `live()` methods on the field.
 
+In case you want to add another disable condition, you can chain `disableOptionWhen` method, and set the second argument to `true`:
+
+```php
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Select;
+
+Repeater::make('members')
+    ->schema([
+        Select::make('role')
+            ->options([
+                // ...
+            ])
+            ->disableOptionsWhenSelectedInSiblingRepeaterItems()
+            ->disableOptionWhen(fn (string $value): bool => $value === 'published', true),
+    ])
+```
+
 ## Customizing the repeater item actions
 
 This field uses action objects for easy customization of buttons within it. You can customize these buttons by passing a function to an action registration method. The function has access to the `$action` object, which you can use to [customize it](../../actions/trigger-button). The following methods are available to customize the actions:

--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -580,7 +580,7 @@ Repeater::make('members')
 
 This method will automatically enable the `distinct()` and `live()` methods on the field.
 
-In case you want to add another disable condition, you can chain `disableOptionWhen` method, and set the second argument to `true`:
+In case you want to add another condition to [disable options](../select#disabling-specific-options) with, you can chain `disableOptionWhen()` with the `merge: true` argument:
 
 ```php
 use Filament\Forms\Components\Repeater;
@@ -593,7 +593,7 @@ Repeater::make('members')
                 // ...
             ])
             ->disableOptionsWhenSelectedInSiblingRepeaterItems()
-            ->disableOptionWhen(fn (string $value): bool => $value === 'published', true),
+            ->disableOptionWhen(fn (string $value): bool => $value === 'super_admin', merge: true),
     ])
 ```
 


### PR DESCRIPTION
## Description

Docs for `disableOptionWhen` second argument.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
