### PR TITLE
Refactor: `assertTableFilterExists` to allow passing in a callback

### DIFF
--- a/packages/support/resources/views/components/tabs/item.blade.php
+++ b/packages/support/resources/views/components/tabs/item.blade.php
@@ -62,7 +62,7 @@
                 'role' => 'tab',
             ])
             ->class([
-                'fi-tabs-item group flex items-center justify-center gap-x-2 rounded-lg px-3 py-2 text-sm font-medium outline-none whitespace-nowrap transition duration-75',
+                'fi-tabs-item group flex items-center justify-center gap-x-2 whitespace-nowrap rounded-lg px-3 py-2 text-sm font-medium outline-none transition duration-75',
                 $inactiveItemClasses => (! $hasAlpineActiveClasses) && (! $active),
                 $activeItemClasses => (! $hasAlpineActiveClasses) && $active,
             ])

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -167,6 +167,8 @@ namespace Livewire\Features\SupportTesting {
 
         public function removeTableFilters(): static {}
 
+        public function assertTableFilterExists(string $name, ?Closure $checkFilterUsing = null): static {}
+
         public function assertCanSeeTableRecords(array | Collection $records, bool $inOrder = false): static {}
 
         public function assertCanNotSeeTableRecords(array | Collection $records): static {}

--- a/packages/tables/docs/12-testing.md
+++ b/packages/tables/docs/12-testing.md
@@ -349,6 +349,33 @@ it('can remove all table filters', function () {
 });
 ```
 
+### Existence
+
+To ensure that a filter exists, you can use the `assertTableFilterExists()` method:
+
+```php
+use function Pest\Livewire\livewire;
+
+it('has an author filter', function () {
+    livewire(PostResource\Pages\ListPosts::class)
+        ->assertTableFilterExists('author');
+});
+```
+
+You may pass a function as an additional argument in order to assert that a filter passes a given "truth test". This is useful for asserting that a filter has a specific configuration:
+
+```php
+use function Pest\Livewire\livewire;
+use Filament\Tables\Filters\SelectFilter;
+
+it('has an author filter', function () {    
+    livewire(PostResource\Pages\ListPosts::class)
+        ->assertTableFilterExists('author', function (SelectFilter $column): bool {
+            return $column->getLabel() === 'Select Author';
+        });
+});
+```
+
 ## Actions
 
 ### Calling actions

--- a/packages/tables/docs/12-testing.md
+++ b/packages/tables/docs/12-testing.md
@@ -371,7 +371,7 @@ use Filament\Tables\Filters\SelectFilter;
 it('has an author filter', function () {    
     livewire(PostResource\Pages\ListPosts::class)
         ->assertTableFilterExists('author', function (SelectFilter $column): bool {
-            return $column->getLabel() === 'Select Author';
+            return $column->getLabel() === 'Select author';
         });
 });
 ```

--- a/packages/tables/src/Testing/TestsFilters.php
+++ b/packages/tables/src/Testing/TestsFilters.php
@@ -90,18 +90,16 @@ class TestsFilters
 
             $livewireClass = $this->instance()::class;
 
-            $failMessage = "Failed asserting that a table filter with name [{$name}] exists on the [{$livewireClass}] component.";
-
             Assert::assertInstanceOf(
                 BaseFilter::class,
                 $filter,
-                message: $failMessage,
+                message: "Failed asserting that a table filter with name [{$name}] exists on the [{$livewireClass}] component.",
             );
 
             if ($checkFilterUsing) {
                 Assert::assertTrue(
                     $checkFilterUsing($filter),
-                    $failMessage
+                    "Failed asserting that a table filter with name [{$name}] and provided configuration exists on the [{$livewireClass}] component.",
                 );
             }
 

--- a/packages/tables/src/Testing/TestsFilters.php
+++ b/packages/tables/src/Testing/TestsFilters.php
@@ -83,18 +83,27 @@ class TestsFilters
 
     public function assertTableFilterExists(): Closure
     {
-        return function (string $name): static {
+        return function (string $name, ?Closure $checkFilterUsing = null): static {
             $name = $this->instance()->parseTableFilterName($name);
 
             $filter = $this->instance()->getTable()->getFilter($name);
 
             $livewireClass = $this->instance()::class;
 
+            $failMessage = "Failed asserting that a table filter with name [{$name}] exists on the [{$livewireClass}] component.";
+
             Assert::assertInstanceOf(
                 BaseFilter::class,
                 $filter,
-                message: "Failed asserting that a table filter with name [{$name}] exists on the [{$livewireClass}] component.",
+                message: $failMessage,
             );
+
+            if ($checkFilterUsing) {
+                Assert::assertTrue(
+                    $checkFilterUsing($filter),
+                    $failMessage
+                );
+            }
 
             return $this;
         };

--- a/tests/src/Tables/Filters/FilterTest.php
+++ b/tests/src/Tables/Filters/FilterTest.php
@@ -103,7 +103,7 @@ it('can use a custom attribute for the `SelectFilter`', function () {
         ->assertCanNotSeeTableRecords($unpublishedPosts);
 });
 
-it('access the filter in `assertTableFilterExists`', function () {
+it('can assert a filter exists with a given configuration', function () {
     livewire(PostsTable::class)
         ->assertTableFilterExists('is_published', function (Filter $filter): bool {
             return $filter->getLabel() === 'Is published';

--- a/tests/src/Tables/Filters/FilterTest.php
+++ b/tests/src/Tables/Filters/FilterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\Filter;
 use Filament\Tests\Models\Post;
 use Filament\Tests\Tables\Fixtures\PostsTable;
 use Filament\Tests\Tables\TestCase;
@@ -105,7 +105,7 @@ it('can use a custom attribute for the `SelectFilter`', function () {
 
 it('access the filter in `assertTableFilterExists`', function () {
     livewire(PostsTable::class)
-        ->assertTableFilterExists('select_filter_attribute', function (SelectFilter $filter): bool {
-            return $filter->isMultiple();
+        ->assertTableFilterExists('is_published', function (Filter $filter): bool {
+            return $filter->getLabel() === 'Is published';
         });
 });

--- a/tests/src/Tables/Filters/FilterTest.php
+++ b/tests/src/Tables/Filters/FilterTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Filament\Tables\Filters\SelectFilter;
 use Filament\Tests\Models\Post;
 use Filament\Tests\Tables\Fixtures\PostsTable;
 use Filament\Tests\Tables\TestCase;
@@ -100,4 +101,11 @@ it('can use a custom attribute for the `SelectFilter`', function () {
         ->assertCanSeeTableRecords($unpublishedPosts)
         ->filterTable('select_filter_attribute', true)
         ->assertCanNotSeeTableRecords($unpublishedPosts);
+});
+
+it('access the filter in `assertTableFilterExists`', function () {
+    livewire(PostsTable::class)
+        ->assertTableFilterExists('select_filter_attribute', function (SelectFilter $filter): bool {
+            return $filter->isMultiple();
+        });
 });


### PR DESCRIPTION
## Description

I've refactored the `assertTableFilterExists` test function to allow you to pass a callback function, so that you can access the filter itself like you can do with the `assertTableColumnExists`.

I couldn't see `assertTableFilterExists` in the docs so I've added it in as well as docs on the new functionality.

I also couldn't see the stub anywhere so I've added that as well.

I think this feature will be useful if you want to test a specific part of your filter, for example making sure that the label is right.

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
