### PR TITLE
Fix: Add expanded close tag option in datalist (bug in Chrome)

### DIFF
--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -107,7 +107,7 @@
     @if ($datalistOptions)
         <datalist id="{{ $id }}-list">
             @foreach ($datalistOptions as $option)
-                <option value="{{ $option }}" />
+                <option value="{{ $option }}"></option>
             @endforeach
         </datalist>
     @endif


### PR DESCRIPTION
## Description

This fixes a bug that occurs when using a datalist in Chrome, which throws the following error:

"filamentphp uncaught typeerror: cannot read properties of null (reading 'before')"

demo: https://youtu.be/CNnH1AI8tbk

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
