### PR TITLE
New: `assertTableActionFormFieldExists` and `assertTableActionFormFieldDoesNotExist` test method

### DIFF
--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -17,6 +17,8 @@ namespace Livewire\Features\SupportTesting {
 
         public function assertTableActionFormFieldExists(string $fieldName, ?Closure $checkFieldUsing = null): static {}
 
+        public function assertTableActionFormFieldDoesNotExist(string $fieldName): static {}
+
         public function callTableAction(string | array $name, $record = null, array $data = [], array $arguments = []): static {}
 
         public function callTableColumnAction(string $name, $record = null): static {}

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -15,6 +15,8 @@ namespace Livewire\Features\SupportTesting {
 
         public function assertTableActionDataSet(array | Closure $state): static {}
 
+        public function assertTableActionFormFieldExists(string $fieldName, ?Closure $checkFieldUsing = null): static {}
+
         public function callTableAction(string | array $name, $record = null, array $data = [], array $arguments = []): static {}
 
         public function callTableColumnAction(string $name, $record = null): static {}

--- a/packages/tables/docs/12-testing.md
+++ b/packages/tables/docs/12-testing.md
@@ -550,6 +550,38 @@ it('can automatically generate a slug from the title without any spaces', functi
         });
 });
 ```
+### Form field existence
+
+To ensure that a form field exists on a mounted table action form, you can use the `assertTableActionFormFieldExists()` method:
+
+```php
+use function Pest\Livewire\livewire;
+
+it('has a slug field', function () {
+    $post = Post::factory()->create();
+    
+    livewire(PostsTable::class)
+        ->mountTableAction(EditAction::class, $post)
+        ->assertTableActionFormFieldExists('slug');
+});
+```
+
+You may pass a function as an additional argument in order to assert that a form field passes a given "truth test". This is useful for asserting that a form field has a specific configuration:
+
+```php
+use Filament\Forms\Components\TextInput;
+use function Pest\Livewire\livewire;
+
+it('has a slug field', function () {    
+    $post = Post::factory()->create();
+    
+    livewire(PostsTable::class)
+        ->mountTableAction(EditAction::class, $post)
+        ->assertTableActionFormFieldExists('slug', function (TextInput $slug): bool {
+            return $slug->isRequired();
+        });
+});
+```
 
 ### Action state
 

--- a/packages/tables/docs/12-testing.md
+++ b/packages/tables/docs/12-testing.md
@@ -583,6 +583,20 @@ it('has a slug field', function () {
 });
 ```
 
+To assert that a form field does not exist on a mounted table action form, you can use the `assertTableActionFormFieldDoesNotExist()` method:
+
+```php
+use function Pest\Livewire\livewire;
+
+it('does not have a conditional field', function () {
+    $post = Post::factory()->create();
+    
+    livewire(PostsTable::class)
+        ->mountTableAction(EditAction::class, $post)
+        ->assertTableActionFormFieldDoesNotExist('no-such-field');
+});
+```
+
 ### Action state
 
 To ensure that an action or bulk action exists or doesn't in a table, you can use the `assertTableActionExists()` / `assertTableActionDoesNotExist()` or  `assertTableBulkActionExists()` / `assertTableBulkActionDoesNotExist()` method:

--- a/packages/tables/src/Testing/TestsActions.php
+++ b/packages/tables/src/Testing/TestsActions.php
@@ -147,7 +147,6 @@ class TestsActions
         };
     }
 
-
     public function callTableAction(): Closure
     {
         return function (string | array $name, $record = null, array $data = [], array $arguments = []): static {

--- a/packages/tables/src/Testing/TestsActions.php
+++ b/packages/tables/src/Testing/TestsActions.php
@@ -115,13 +115,13 @@ class TestsActions
             Assert::assertInstanceOf(
                 Field::class,
                 $field,
-                "Failed asserting that a field with the name [{$fieldName}] exists on the form of a table action with the name [{$tableActionName}] on the [{$livewireClass}] component."
+                "Failed asserting that a field with the name [{$fieldName}] exists on the form of a table action named [{$tableActionName}] on the [{$livewireClass}] component."
             );
 
             if ($checkFieldUsing) {
                 Assert::assertTrue(
                     $checkFieldUsing($field),
-                    "Failed asserting that a field with the name [{$fieldName}] and provided configuration exists on the form of a table action with the name [{$tableActionName}] on the [{$livewireClass}] component."
+                    "Failed asserting that a field with the name [{$fieldName}] and provided configuration exists on the form of a table action named [{$tableActionName}] on the [{$livewireClass}] component."
                 );
             }
 

--- a/packages/tables/src/Testing/TestsActions.php
+++ b/packages/tables/src/Testing/TestsActions.php
@@ -129,6 +129,25 @@ class TestsActions
         };
     }
 
+    public function assertTableActionFormFieldDoesNotExist(): Closure
+    {
+        return function (string $fieldName): static {
+            $fields = $this->instance()->getMountedTableActionForm()->getFlatFields(withHidden: false);
+            $tableActionName = $this->instance()->getMountedTableAction()->getName();
+
+            $livewireClass = $this->instance()::class;
+
+            Assert::assertArrayNotHasKey(
+                $fieldName,
+                $fields,
+                "Failed asserting that a field with the name [{$fieldName}] does not exists on the form of a table action named [{$tableActionName}] on the [{$livewireClass}] component."
+            );
+
+            return $this;
+        };
+    }
+
+
     public function callTableAction(): Closure
     {
         return function (string | array $name, $record = null, array $data = [], array $arguments = []): static {

--- a/packages/tables/src/Testing/TestsActions.php
+++ b/packages/tables/src/Testing/TestsActions.php
@@ -5,6 +5,7 @@ namespace Filament\Tables\Testing;
 use Closure;
 use Filament\Actions\Contracts\HasRecord;
 use Filament\Actions\Testing\TestsActions as BaseTestsActions;
+use Filament\Forms\Components\Field;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Contracts\HasTable;
 use Illuminate\Database\Eloquent\Model;
@@ -95,6 +96,33 @@ class TestsActions
                 foreach (Arr::dot($state, prepend: "mountedTableActionsData.{$mountedTableActionIndex}.") as $key => $value) {
                     $this->assertSet($key, $value);
                 }
+            }
+
+            return $this;
+        };
+    }
+
+    public function assertTableActionFormFieldExists(): Closure
+    {
+        return function (string $fieldName, ?Closure $checkFieldUsing = null): static {
+            /** @var ?Field $field */
+            $field = $this->instance()->getMountedTableActionForm()->getFlatFields(withHidden: true)[$fieldName] ?? null;
+
+            $tableActionName = $this->instance()->getMountedTableAction()->getName();
+
+            $livewireClass = $this->instance()::class;
+
+            Assert::assertInstanceOf(
+                Field::class,
+                $field,
+                "Failed asserting that a field with the name [{$fieldName}] exists on the form of a table action with the name [{$tableActionName}] on the [{$livewireClass}] component."
+            );
+
+            if ($checkFieldUsing) {
+                Assert::assertTrue(
+                    $checkFieldUsing($field),
+                    "Failed asserting that a field with the name [{$fieldName}] and provided configuration exists on the form of a table action with the name [{$tableActionName}] on the [{$livewireClass}] component."
+                );
             }
 
             return $this;

--- a/tests/src/Tables/Actions/ActionTest.php
+++ b/tests/src/Tables/Actions/ActionTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Filament\Forms\Components\TextInput;
 use Filament\Tables\Actions\AttachAction;
 use Filament\Tables\Actions\DeleteAction;
 use Filament\Tests\Models\Post;
@@ -60,6 +61,13 @@ it('can set default action data when mounted', function () {
         ->assertTableActionDataSet(function (array $data): bool {
             return $data['foo'] === 'bar';
         });
+});
+
+it('can assert that a form field exists with a given configuration on a mounted table action', function () {
+    livewire(PostsTable::class)
+        ->mountTableAction('data')
+        ->assertTableActionFormFieldExists('payload')
+        ->assertTableActionFormFieldExists('payload', fn (TextInput $field) => $field->isRequired());
 });
 
 it('can call an action with arguments', function () {

--- a/tests/src/Tables/Actions/ActionTest.php
+++ b/tests/src/Tables/Actions/ActionTest.php
@@ -70,6 +70,12 @@ it('can assert that a form field exists with a given configuration on a mounted 
         ->assertTableActionFormFieldExists('payload', fn (TextInput $field) => $field->isRequired());
 });
 
+it('can assert that a field doesnt exists on a mounted table action form', function () {
+    livewire(PostsTable::class)
+        ->mountTableAction('data')
+        ->assertTableActionFormFieldDoesNotExist('non_existent_field');
+});
+
 it('can call an action with arguments', function () {
     livewire(PostsTable::class)
         ->callTableAction('arguments', arguments: [


### PR DESCRIPTION
## Description

This PR introduces a new `assertTableActionFormFieldExists` test method, allowing you to verify the presence of a specific field within action modal forms, similar to how `assertFormFieldExists` works.

I've also added `assertTableActionFormFieldDoesNotExist` which allows you to check that field does not exist on the form.

I've tried to match the logic of `assertFormFieldExists` and `assertFormFieldDoesNotExist` so that it is consistant

These features is particularly useful for ensuring that a field is present with the expected configuration or isn't present at all in a modal form. This is especially relevant when working with `--simple` resources, as I’m currently unaware of any method to verify form fields when editing a record in the modal.


## Visual changes

No visual changes.

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
