### PR TITLE
stop headers misaligning when scrolling

### DIFF
--- a/packages/panels/resources/views/components/sidebar/index.blade.php
+++ b/packages/panels/resources/views/components/sidebar/index.blade.php
@@ -43,7 +43,7 @@
 >
     <div class="overflow-x-clip">
         <header
-            class="fi-sidebar-header flex h-16 items-center bg-white px-6 ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 lg:shadow-sm"
+            class="fi-sidebar-header sticky top-0 flex h-16 items-center bg-white px-6 ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 lg:shadow-sm"
         >
             <div
                 @if (filament()->isSidebarCollapsibleOnDesktop())


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

On scroll, the header's misalign between the sidebar and the main content resulting in a strange looking UI. This PR makes sure the sidebar header is sticky so when scrolling everything scrolls together, ensuring the headers are not misaligned.

## Visual changes

Before: 

<img width="1147" alt="Screenshot 2025-01-11 at 14 23 37" src="https://github.com/user-attachments/assets/e2a3b642-8818-4de0-98a4-7a15db680040" />

After: 

<img width="1157" alt="Screenshot 2025-01-11 at 14 26 08" src="https://github.com/user-attachments/assets/c908e0c0-4f96-4dcf-9a3f-dc2b8b80c318" />


## Functional changes

- [ ✅] Code style has been fixed by running the `composer cs` command.
- [ ✅] Changes have been tested to not break existing functionality.
- [ ✅] Documentation is up-to-date.
