### PR TITLE
Prevent stacked, editable table columns to trigger wrapping a.href 

### DIFF
--- a/packages/tables/resources/views/columns/checkbox-column.blade.php
+++ b/packages/tables/resources/views/columns/checkbox-column.blade.php
@@ -4,7 +4,7 @@
 @endphp
 
 <div
-        x-data="{
+    x-data="{
         error: undefined,
 
         isLoading: false,
@@ -15,8 +15,8 @@
 
         state: @js($state),
     }"
-        x-on:click.stop.prevent=""
-        x-init="
+    x-on:click.stop.prevent=""
+    x-init="
         () => {
             Livewire.hook('commit', ({ component, commit, succeed, fail, respond }) => {
                 succeed(({ snapshot, effect }) => {
@@ -41,23 +41,23 @@
             })
         }
     "
-        {{
-            $attributes
-                ->merge($getExtraAttributes(), escape: false)
-                ->class([
-                    'fi-ta-checkbox flex items-center',
-                    'px-3 py-4' => ! $isInline(),
-                ])
-        }}
+    {{
+        $attributes
+            ->merge($getExtraAttributes(), escape: false)
+            ->class([
+                'fi-ta-checkbox flex items-center',
+                'px-3 py-4' => ! $isInline(),
+            ])
+    }}
 >
-    <input type="hidden" value="{{ $state ? 1 : 0 }}" x-ref="newState"/>
+    <input type="hidden" value="{{ $state ? 1 : 0 }}" x-ref="newState" />
 
     <x-filament::input.checkbox
-            alpine-valid="! error"
-            :disabled="$isDisabled"
-            :x-bind:disabled="$isDisabled ? null : 'isLoading'"
-            x-model="state"
-            x-on:change="
+        alpine-valid="! error"
+        :disabled="$isDisabled"
+        :x-bind:disabled="$isDisabled ? null : 'isLoading'"
+        x-model="state"
+        x-on:change="
             isLoading = true
 
             const response = await $wire.updateTableColumnState(
@@ -70,7 +70,7 @@
 
             isLoading = false
         "
-            x-tooltip="
+        x-tooltip="
             error === undefined
                 ? false
                 : {
@@ -78,8 +78,8 @@
                     theme: $store.theme,
                 }
         "
-            x-on:click.stop=""
-            :attributes="
+        x-on:click.stop=""
+        :attributes="
             \Filament\Support\prepare_inherited_attributes($attributes)
                 ->merge($getExtraInputAttributes(), escape: false)
         "

--- a/packages/tables/resources/views/columns/checkbox-column.blade.php
+++ b/packages/tables/resources/views/columns/checkbox-column.blade.php
@@ -4,7 +4,7 @@
 @endphp
 
 <div
-    x-data="{
+        x-data="{
         error: undefined,
 
         isLoading: false,
@@ -15,7 +15,8 @@
 
         state: @js($state),
     }"
-    x-init="
+        x-on:click.stop.prevent=""
+        x-init="
         () => {
             Livewire.hook('commit', ({ component, commit, succeed, fail, respond }) => {
                 succeed(({ snapshot, effect }) => {
@@ -40,23 +41,23 @@
             })
         }
     "
-    {{
-        $attributes
-            ->merge($getExtraAttributes(), escape: false)
-            ->class([
-                'fi-ta-checkbox flex items-center',
-                'px-3 py-4' => ! $isInline(),
-            ])
-    }}
+        {{
+            $attributes
+                ->merge($getExtraAttributes(), escape: false)
+                ->class([
+                    'fi-ta-checkbox flex items-center',
+                    'px-3 py-4' => ! $isInline(),
+                ])
+        }}
 >
-    <input type="hidden" value="{{ $state ? 1 : 0 }}" x-ref="newState" />
+    <input type="hidden" value="{{ $state ? 1 : 0 }}" x-ref="newState"/>
 
     <x-filament::input.checkbox
-        alpine-valid="! error"
-        :disabled="$isDisabled"
-        :x-bind:disabled="$isDisabled ? null : 'isLoading'"
-        x-model="state"
-        x-on:change="
+            alpine-valid="! error"
+            :disabled="$isDisabled"
+            :x-bind:disabled="$isDisabled ? null : 'isLoading'"
+            x-model="state"
+            x-on:change="
             isLoading = true
 
             const response = await $wire.updateTableColumnState(
@@ -69,7 +70,7 @@
 
             isLoading = false
         "
-        x-tooltip="
+            x-tooltip="
             error === undefined
                 ? false
                 : {
@@ -77,8 +78,8 @@
                     theme: $store.theme,
                 }
         "
-        x-on:click.stop=""
-        :attributes="
+            x-on:click.stop=""
+            :attributes="
             \Filament\Support\prepare_inherited_attributes($attributes)
                 ->merge($getExtraInputAttributes(), escape: false)
         "

--- a/packages/tables/resources/views/columns/select-column.blade.php
+++ b/packages/tables/resources/views/columns/select-column.blade.php
@@ -10,7 +10,7 @@
 @endphp
 
 <div
-    x-data="{
+        x-data="{
         error: undefined,
 
         isLoading: false,
@@ -21,7 +21,7 @@
 
         state: @js($state),
     }"
-    x-init="
+        x-init="
         () => {
             Livewire.hook('commit', ({ component, commit, succeed, fail, respond }) => {
                 succeed(({ snapshot, effect }) => {
@@ -46,25 +46,25 @@
             })
         }
     "
-    {{
-        $attributes
-            ->merge($getExtraAttributes(), escape: false)
-            ->class([
-                'fi-ta-select w-full min-w-48',
-                'px-3 py-4' => ! $isInline(),
-            ])
-    }}
+        {{
+            $attributes
+                ->merge($getExtraAttributes(), escape: false)
+                ->class([
+                    'fi-ta-select w-full min-w-48',
+                    'px-3 py-4' => ! $isInline(),
+                ])
+        }}
 >
     <input
-        type="hidden"
-        value="{{ str($state)->replace('"', '\\"') }}"
-        x-ref="newState"
+            type="hidden"
+            value="{{ str($state)->replace('"', '\\"') }}"
+            x-ref="newState"
     />
 
     <x-filament::input.wrapper
-        :alpine-disabled="'isLoading || ' . \Illuminate\Support\Js::from($isDisabled)"
-        alpine-valid="error === undefined"
-        x-tooltip="
+            :alpine-disabled="'isLoading || ' . \Illuminate\Support\Js::from($isDisabled)"
+            alpine-valid="error === undefined"
+            x-tooltip="
             error === undefined
                 ? false
                 : {
@@ -72,13 +72,13 @@
                     theme: $store.theme,
                 }
         "
-        x-on:click.stop=""
+            x-on:click.stop.prevent=""
     >
         <x-filament::input.select
-            :disabled="$isDisabled"
-            :x-bind:disabled="$isDisabled ? null : 'isLoading'"
-            x-model="state"
-            x-on:change="
+                :disabled="$isDisabled"
+                :x-bind:disabled="$isDisabled ? null : 'isLoading'"
+                x-model="state"
+                x-on:change="
                 isLoading = true
 
                 const response = await $wire.updateTableColumnState(
@@ -95,7 +95,7 @@
 
                 isLoading = false
             "
-            :attributes="\Filament\Support\prepare_inherited_attributes($getExtraInputAttributeBag())"
+                :attributes="\Filament\Support\prepare_inherited_attributes($getExtraInputAttributeBag())"
         >
             @if ($canSelectPlaceholder)
                 <option value="">{{ $getPlaceholder() }}</option>
@@ -103,8 +103,8 @@
 
             @foreach ($getOptions() as $value => $label)
                 <option
-                    @disabled($isOptionDisabled($value, $label))
-                    value="{{ $value }}"
+                        @disabled($isOptionDisabled($value, $label))
+                        value="{{ $value }}"
                 >
                     {{ $label }}
                 </option>

--- a/packages/tables/resources/views/columns/select-column.blade.php
+++ b/packages/tables/resources/views/columns/select-column.blade.php
@@ -10,7 +10,7 @@
 @endphp
 
 <div
-        x-data="{
+    x-data="{
         error: undefined,
 
         isLoading: false,
@@ -21,7 +21,7 @@
 
         state: @js($state),
     }"
-        x-init="
+    x-init="
         () => {
             Livewire.hook('commit', ({ component, commit, succeed, fail, respond }) => {
                 succeed(({ snapshot, effect }) => {
@@ -46,25 +46,25 @@
             })
         }
     "
-        {{
-            $attributes
-                ->merge($getExtraAttributes(), escape: false)
-                ->class([
-                    'fi-ta-select w-full min-w-48',
-                    'px-3 py-4' => ! $isInline(),
-                ])
-        }}
+    {{
+        $attributes
+            ->merge($getExtraAttributes(), escape: false)
+            ->class([
+                'fi-ta-select w-full min-w-48',
+                'px-3 py-4' => ! $isInline(),
+            ])
+    }}
 >
     <input
-            type="hidden"
-            value="{{ str($state)->replace('"', '\\"') }}"
-            x-ref="newState"
+        type="hidden"
+        value="{{ str($state)->replace('"', '\\"') }}"
+        x-ref="newState"
     />
 
     <x-filament::input.wrapper
-            :alpine-disabled="'isLoading || ' . \Illuminate\Support\Js::from($isDisabled)"
-            alpine-valid="error === undefined"
-            x-tooltip="
+        :alpine-disabled="'isLoading || ' . \Illuminate\Support\Js::from($isDisabled)"
+        alpine-valid="error === undefined"
+        x-tooltip="
             error === undefined
                 ? false
                 : {
@@ -72,13 +72,13 @@
                     theme: $store.theme,
                 }
         "
-            x-on:click.stop.prevent=""
+        x-on:click.stop.prevent=""
     >
         <x-filament::input.select
-                :disabled="$isDisabled"
-                :x-bind:disabled="$isDisabled ? null : 'isLoading'"
-                x-model="state"
-                x-on:change="
+            :disabled="$isDisabled"
+            :x-bind:disabled="$isDisabled ? null : 'isLoading'"
+            x-model="state"
+            x-on:change="
                 isLoading = true
 
                 const response = await $wire.updateTableColumnState(
@@ -95,7 +95,7 @@
 
                 isLoading = false
             "
-                :attributes="\Filament\Support\prepare_inherited_attributes($getExtraInputAttributeBag())"
+            :attributes="\Filament\Support\prepare_inherited_attributes($getExtraInputAttributeBag())"
         >
             @if ($canSelectPlaceholder)
                 <option value="">{{ $getPlaceholder() }}</option>
@@ -103,8 +103,8 @@
 
             @foreach ($getOptions() as $value => $label)
                 <option
-                        @disabled($isOptionDisabled($value, $label))
-                        value="{{ $value }}"
+                    @disabled($isOptionDisabled($value, $label))
+                    value="{{ $value }}"
                 >
                     {{ $label }}
                 </option>

--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -80,12 +80,12 @@
             :alpine-disabled="'isLoading || ' . \Illuminate\Support\Js::from($isDisabled)"
             alpine-valid="error === undefined"
             x-tooltip="
-            error === undefined
-                ? false
-                : {
-                    content: error,
-                    theme: $store.theme,
-                }
+        error === undefined
+            ? false
+            : {
+                content: error,
+                theme: $store.theme,
+            }
         "
             x-on:click.stop.prevent=""
     >

--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -80,27 +80,27 @@
         :alpine-disabled="'isLoading || ' . \Illuminate\Support\Js::from($isDisabled)"
         alpine-valid="error === undefined"
         x-tooltip="
-        error === undefined
-            ? false
-            : {
-                content: error,
-                theme: $store.theme,
-            }
+            error === undefined
+                ? false
+                : {
+                    content: error,
+                    theme: $store.theme,
+                }
         "
         x-on:click.stop.prevent=""
     >
         {{-- format-ignore-start --}}
         <x-filament::input
-                :disabled="$isDisabled"
-                :input-mode="$getInputMode()"
-                :placeholder="$getPlaceholder()"
-                :step="$getStep()"
-                :type="$type"
-                :x-bind:disabled="$isDisabled ? null : 'isLoading'"
-                x-model="state"
-                x-on:blur="isEditing = false"
-                x-on:focus="isEditing = true"
-                :attributes="
+            :disabled="$isDisabled"
+            :input-mode="$getInputMode()"
+            :placeholder="$getPlaceholder()"
+            :step="$getStep()"
+            :type="$type"
+            :x-bind:disabled="$isDisabled ? null : 'isLoading'"
+            x-model="state"
+            x-on:blur="isEditing = false"
+            x-on:focus="isEditing = true"
+            :attributes="
                 \Filament\Support\prepare_inherited_attributes(
                     $getExtraInputAttributeBag()
                         ->merge([

--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -19,7 +19,7 @@
 @endphp
 
 <div
-    x-data="{
+        x-data="{
         error: undefined,
 
         isEditing: false,
@@ -32,7 +32,7 @@
 
         state: @js($state),
     }"
-    x-init="
+        x-init="
         () => {
             Livewire.hook('commit', ({ component, commit, succeed, fail, respond }) => {
                 succeed(({ snapshot, effect }) => {
@@ -61,25 +61,25 @@
             })
         }
     "
-    {{
-        $attributes
-            ->merge($getExtraAttributes(), escape: false)
-            ->class([
-                'fi-ta-text-input w-full min-w-48',
-                'px-3 py-4' => ! $isInline(),
-            ])
-    }}
+        {{
+            $attributes
+                ->merge($getExtraAttributes(), escape: false)
+                ->class([
+                    'fi-ta-text-input w-full min-w-48',
+                    'px-3 py-4' => ! $isInline(),
+                ])
+        }}
 >
     <input
-        type="hidden"
-        value="{{ str($state)->replace('"', '\\"') }}"
-        x-ref="newState"
+            type="hidden"
+            value="{{ str($state)->replace('"', '\\"') }}"
+            x-ref="newState"
     />
 
     <x-filament::input.wrapper
-        :alpine-disabled="'isLoading || ' . \Illuminate\Support\Js::from($isDisabled)"
-        alpine-valid="error === undefined"
-        x-tooltip="
+            :alpine-disabled="'isLoading || ' . \Illuminate\Support\Js::from($isDisabled)"
+            alpine-valid="error === undefined"
+            x-tooltip="
             error === undefined
                 ? false
                 : {
@@ -87,20 +87,20 @@
                     theme: $store.theme,
                 }
         "
-        x-on:click.stop=""
+            x-on:click.stop.prevent=""
     >
         {{-- format-ignore-start --}}
         <x-filament::input
-            :disabled="$isDisabled"
-            :input-mode="$getInputMode()"
-            :placeholder="$getPlaceholder()"
-            :step="$getStep()"
-            :type="$type"
-            :x-bind:disabled="$isDisabled ? null : 'isLoading'"
-            x-model="state"
-            x-on:blur="isEditing = false"
-            x-on:focus="isEditing = true"
-            :attributes="
+                :disabled="$isDisabled"
+                :input-mode="$getInputMode()"
+                :placeholder="$getPlaceholder()"
+                :step="$getStep()"
+                :type="$type"
+                :x-bind:disabled="$isDisabled ? null : 'isLoading'"
+                x-model="state"
+                x-on:blur="isEditing = false"
+                x-on:focus="isEditing = true"
+                :attributes="
                 \Filament\Support\prepare_inherited_attributes(
                     $getExtraInputAttributeBag()
                         ->merge([

--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -19,7 +19,7 @@
 @endphp
 
 <div
-        x-data="{
+    x-data="{
         error: undefined,
 
         isEditing: false,
@@ -32,7 +32,7 @@
 
         state: @js($state),
     }"
-        x-init="
+    x-init="
         () => {
             Livewire.hook('commit', ({ component, commit, succeed, fail, respond }) => {
                 succeed(({ snapshot, effect }) => {
@@ -61,25 +61,25 @@
             })
         }
     "
-        {{
-            $attributes
-                ->merge($getExtraAttributes(), escape: false)
-                ->class([
-                    'fi-ta-text-input w-full min-w-48',
-                    'px-3 py-4' => ! $isInline(),
-                ])
-        }}
+    {{
+        $attributes
+            ->merge($getExtraAttributes(), escape: false)
+            ->class([
+                'fi-ta-text-input w-full min-w-48',
+                'px-3 py-4' => ! $isInline(),
+            ])
+    }}
 >
     <input
-            type="hidden"
-            value="{{ str($state)->replace('"', '\\"') }}"
-            x-ref="newState"
+        type="hidden"
+        value="{{ str($state)->replace('"', '\\"') }}"
+        x-ref="newState"
     />
 
     <x-filament::input.wrapper
-            :alpine-disabled="'isLoading || ' . \Illuminate\Support\Js::from($isDisabled)"
-            alpine-valid="error === undefined"
-            x-tooltip="
+        :alpine-disabled="'isLoading || ' . \Illuminate\Support\Js::from($isDisabled)"
+        alpine-valid="error === undefined"
+        x-tooltip="
         error === undefined
             ? false
             : {
@@ -87,7 +87,7 @@
                 theme: $store.theme,
             }
         "
-            x-on:click.stop.prevent=""
+        x-on:click.stop.prevent=""
     >
         {{-- format-ignore-start --}}
         <x-filament::input

--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -19,7 +19,7 @@
 @endphp
 
 <div
-    x-data="{
+        x-data="{
         error: undefined,
 
         isEditing: false,
@@ -32,7 +32,7 @@
 
         state: @js($state),
     }"
-    x-init="
+        x-init="
         () => {
             Livewire.hook('commit', ({ component, commit, succeed, fail, respond }) => {
                 succeed(({ snapshot, effect }) => {
@@ -61,25 +61,25 @@
             })
         }
     "
-    {{
-        $attributes
-            ->merge($getExtraAttributes(), escape: false)
-            ->class([
-                'fi-ta-text-input w-full min-w-48',
-                'px-3 py-4' => ! $isInline(),
-            ])
-    }}
+        {{
+            $attributes
+                ->merge($getExtraAttributes(), escape: false)
+                ->class([
+                    'fi-ta-text-input w-full min-w-48',
+                    'px-3 py-4' => ! $isInline(),
+                ])
+        }}
 >
     <input
-        type="hidden"
-        value="{{ str($state)->replace('"', '\\"') }}"
-        x-ref="newState"
+            type="hidden"
+            value="{{ str($state)->replace('"', '\\"') }}"
+            x-ref="newState"
     />
 
     <x-filament::input.wrapper
-        :alpine-disabled="'isLoading || ' . \Illuminate\Support\Js::from($isDisabled)"
-        alpine-valid="error === undefined"
-        x-tooltip="
+            :alpine-disabled="'isLoading || ' . \Illuminate\Support\Js::from($isDisabled)"
+            alpine-valid="error === undefined"
+            x-tooltip="
             error === undefined
                 ? false
                 : {
@@ -87,7 +87,7 @@
                     theme: $store.theme,
                 }
         "
-        x-on:click.stop.prevent=""
+            x-on:click.stop.prevent=""
     >
         {{-- format-ignore-start --}}
         <x-filament::input

--- a/packages/tables/resources/views/columns/text-input-column.blade.php
+++ b/packages/tables/resources/views/columns/text-input-column.blade.php
@@ -19,7 +19,7 @@
 @endphp
 
 <div
-        x-data="{
+    x-data="{
         error: undefined,
 
         isEditing: false,
@@ -32,7 +32,7 @@
 
         state: @js($state),
     }"
-        x-init="
+    x-init="
         () => {
             Livewire.hook('commit', ({ component, commit, succeed, fail, respond }) => {
                 succeed(({ snapshot, effect }) => {
@@ -61,25 +61,25 @@
             })
         }
     "
-        {{
-            $attributes
-                ->merge($getExtraAttributes(), escape: false)
-                ->class([
-                    'fi-ta-text-input w-full min-w-48',
-                    'px-3 py-4' => ! $isInline(),
-                ])
-        }}
+    {{
+        $attributes
+            ->merge($getExtraAttributes(), escape: false)
+            ->class([
+                'fi-ta-text-input w-full min-w-48',
+                'px-3 py-4' => ! $isInline(),
+            ])
+    }}
 >
     <input
-            type="hidden"
-            value="{{ str($state)->replace('"', '\\"') }}"
-            x-ref="newState"
+        type="hidden"
+        value="{{ str($state)->replace('"', '\\"') }}"
+        x-ref="newState"
     />
 
     <x-filament::input.wrapper
-            :alpine-disabled="'isLoading || ' . \Illuminate\Support\Js::from($isDisabled)"
-            alpine-valid="error === undefined"
-            x-tooltip="
+        :alpine-disabled="'isLoading || ' . \Illuminate\Support\Js::from($isDisabled)"
+        alpine-valid="error === undefined"
+        x-tooltip="
             error === undefined
                 ? false
                 : {
@@ -87,7 +87,7 @@
                     theme: $store.theme,
                 }
         "
-            x-on:click.stop.prevent=""
+        x-on:click.stop.prevent=""
     >
         {{-- format-ignore-start --}}
         <x-filament::input

--- a/packages/tables/resources/views/columns/toggle-column.blade.php
+++ b/packages/tables/resources/views/columns/toggle-column.blade.php
@@ -4,23 +4,23 @@
 @endphp
 
 <div
-        wire:key="{{ $this->getId() }}.table.record.{{ $recordKey }}.column.{{ $getName() }}.toggle-column.{{ $state ? 'true' : 'false' }}"
+    wire:key="{{ $this->getId() }}.table.record.{{ $recordKey }}.column.{{ $getName() }}.toggle-column.{{ $state ? 'true' : 'false' }}"
 >
     <div
-            x-data="{
+        x-data="{
             error: undefined,
             state: @js((bool) $state),
             isLoading: false,
         }"
-            wire:ignore
-            {{
-                $attributes
-                    ->merge($getExtraAttributes(), escape: false)
-                    ->class([
-                        'fi-ta-toggle',
-                        'px-3 py-4' => ! $isInline(),
-                    ])
-            }}
+        wire:ignore
+        {{
+            $attributes
+                ->merge($getExtraAttributes(), escape: false)
+                ->class([
+                    'fi-ta-toggle',
+                    'px-3 py-4' => ! $isInline(),
+                ])
+        }}
     >
         @php
             $offColor = $getOffColor() ?? 'gray';
@@ -28,12 +28,12 @@
         @endphp
 
         <div
-                role="switch"
-                aria-checked="false"
-                x-bind:aria-checked="state.toString()"
-                wire:loading.attr="disabled"
-                @if (! $isDisabled)
-                    x-on:click.stop.prevent="
+            role="switch"
+            aria-checked="false"
+            x-bind:aria-checked="state.toString()"
+            wire:loading.attr="disabled"
+            @if (! $isDisabled)
+                x-on:click.stop.prevent="
                     if (isLoading || $el.hasAttribute('disabled')) {
                         return
                     }
@@ -73,8 +73,8 @@
                               theme: $store.theme,
                           }
                 "
-                @endif
-                x-bind:class="
+            @endif
+            x-bind:class="
                 (state
                     ? '{{
                         \Illuminate\Support\Arr::toCssClasses([
@@ -96,7 +96,7 @@
                     }}') +
                     (isLoading ? ' opacity-70 pointer-events-none' : '')
             "
-                x-bind:style="
+            x-bind:style="
                 state
                     ? '{{
                         \Filament\Support\get_color_css_variables(
@@ -113,29 +113,29 @@
                         )
                     }}'
             "
-                @class([
-                    'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent outline-none transition-colors duration-200 ease-in-out',
-                    'pointer-events-none opacity-70' => $isDisabled,
-                ])
+            @class([
+                'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent outline-none transition-colors duration-200 ease-in-out',
+                'pointer-events-none opacity-70' => $isDisabled,
+            ])
         >
             <span
-                    class="pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                    x-bind:class="{
+                class="pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+                x-bind:class="{
                     'translate-x-5 rtl:-translate-x-5': state,
                     'translate-x-0': ! state,
                 }"
             >
                 <span
-                        class="absolute inset-0 flex h-full w-full items-center justify-center transition-opacity"
-                        aria-hidden="true"
-                        x-bind:class="{
+                    class="absolute inset-0 flex h-full w-full items-center justify-center transition-opacity"
+                    aria-hidden="true"
+                    x-bind:class="{
                         'opacity-0 ease-out duration-100': state,
                         'opacity-100 ease-in duration-200': ! state,
                     }"
                 >
                     @if ($hasOffIcon())
                         <x-filament::icon
-                                :icon="$getOffIcon()"
+                            :icon="$getOffIcon()"
                             @class([
                                 'fi-ta-toggle-off-icon h-3 w-3',
                                 match ($offColor) {
@@ -148,17 +148,17 @@
                 </span>
 
                 <span
-                        class="absolute inset-0 flex h-full w-full items-center justify-center transition-opacity"
-                        aria-hidden="true"
-                        x-bind:class="{
+                    class="absolute inset-0 flex h-full w-full items-center justify-center transition-opacity"
+                    aria-hidden="true"
+                    x-bind:class="{
                         'opacity-100 ease-in duration-200': state,
                         'opacity-0 ease-out duration-100': ! state,
                     }"
                 >
                     @if ($hasOnIcon())
                         <x-filament::icon
-                                :icon="$getOnIcon()"
-                                x-cloak="x-cloak"
+                            :icon="$getOnIcon()"
+                            x-cloak="x-cloak"
                             @class([
                                 'fi-ta-toggle-on-icon h-3 w-3',
                                 match ($onColor) {

--- a/packages/tables/resources/views/columns/toggle-column.blade.php
+++ b/packages/tables/resources/views/columns/toggle-column.blade.php
@@ -4,23 +4,23 @@
 @endphp
 
 <div
-    wire:key="{{ $this->getId() }}.table.record.{{ $recordKey }}.column.{{ $getName() }}.toggle-column.{{ $state ? 'true' : 'false' }}"
+        wire:key="{{ $this->getId() }}.table.record.{{ $recordKey }}.column.{{ $getName() }}.toggle-column.{{ $state ? 'true' : 'false' }}"
 >
     <div
-        x-data="{
+            x-data="{
             error: undefined,
             state: @js((bool) $state),
             isLoading: false,
         }"
-        wire:ignore
-        {{
-            $attributes
-                ->merge($getExtraAttributes(), escape: false)
-                ->class([
-                    'fi-ta-toggle',
-                    'px-3 py-4' => ! $isInline(),
-                ])
-        }}
+            wire:ignore
+            {{
+                $attributes
+                    ->merge($getExtraAttributes(), escape: false)
+                    ->class([
+                        'fi-ta-toggle',
+                        'px-3 py-4' => ! $isInline(),
+                    ])
+            }}
     >
         @php
             $offColor = $getOffColor() ?? 'gray';
@@ -28,12 +28,13 @@
         @endphp
 
         <div
-            role="switch"
-            aria-checked="false"
-            x-bind:aria-checked="state.toString()"
-            @if (! $isDisabled)
-                x-on:click.stop="
-                    if (isLoading) {
+                role="switch"
+                aria-checked="false"
+                x-bind:aria-checked="state.toString()"
+                wire:loading.attr="disabled"
+                @if (! $isDisabled)
+                    x-on:click.stop.prevent="
+                    if (isLoading || $el.hasAttribute('disabled')) {
                         return
                     }
 
@@ -72,8 +73,8 @@
                               theme: $store.theme,
                           }
                 "
-            @endif
-            x-bind:class="
+                @endif
+                x-bind:class="
                 (state
                     ? '{{
                         \Illuminate\Support\Arr::toCssClasses([
@@ -95,7 +96,7 @@
                     }}') +
                     (isLoading ? ' opacity-70 pointer-events-none' : '')
             "
-            x-bind:style="
+                x-bind:style="
                 state
                     ? '{{
                         \Filament\Support\get_color_css_variables(
@@ -112,29 +113,29 @@
                         )
                     }}'
             "
-            @class([
-                'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent outline-none transition-colors duration-200 ease-in-out',
-                'pointer-events-none opacity-70' => $isDisabled,
-            ])
+                @class([
+                    'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent outline-none transition-colors duration-200 ease-in-out',
+                    'pointer-events-none opacity-70' => $isDisabled,
+                ])
         >
             <span
-                class="pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                x-bind:class="{
+                    class="pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+                    x-bind:class="{
                     'translate-x-5 rtl:-translate-x-5': state,
                     'translate-x-0': ! state,
                 }"
             >
                 <span
-                    class="absolute inset-0 flex h-full w-full items-center justify-center transition-opacity"
-                    aria-hidden="true"
-                    x-bind:class="{
+                        class="absolute inset-0 flex h-full w-full items-center justify-center transition-opacity"
+                        aria-hidden="true"
+                        x-bind:class="{
                         'opacity-0 ease-out duration-100': state,
                         'opacity-100 ease-in duration-200': ! state,
                     }"
                 >
                     @if ($hasOffIcon())
                         <x-filament::icon
-                            :icon="$getOffIcon()"
+                                :icon="$getOffIcon()"
                             @class([
                                 'fi-ta-toggle-off-icon h-3 w-3',
                                 match ($offColor) {
@@ -147,17 +148,17 @@
                 </span>
 
                 <span
-                    class="absolute inset-0 flex h-full w-full items-center justify-center transition-opacity"
-                    aria-hidden="true"
-                    x-bind:class="{
+                        class="absolute inset-0 flex h-full w-full items-center justify-center transition-opacity"
+                        aria-hidden="true"
+                        x-bind:class="{
                         'opacity-100 ease-in duration-200': state,
                         'opacity-0 ease-out duration-100': ! state,
                     }"
                 >
                     @if ($hasOnIcon())
                         <x-filament::icon
-                            :icon="$getOnIcon()"
-                            x-cloak="x-cloak"
+                                :icon="$getOnIcon()"
+                                x-cloak="x-cloak"
                             @class([
                                 'fi-ta-toggle-on-icon h-3 w-3',
                                 match ($onColor) {


### PR DESCRIPTION
## Description
Fixes: If you have your table columns stacked, and click on an editable column the outer `a.href` will be triggered and the record will open instead of editing the value of the column.

## Visual changes
None

## Functional changes
-  The editable column becomes editable instead of only triggering the redirect.

- [ ] Code style has been fixed by running the `composer cs` command.
No, tried multiple times, still spaces are added that were not there before, sorry...


- [X] Changes have been tested to not break existing functionality.
yes, 
- Checkbox:  `click.stop.prevent` was needed on the wrapping div. Else `a.href` is triggered if `Alpine.isLoading` is `true`
- Text input, Toogle and Select columns was enough with adding `.prevent `on the existing `x-on:click.stop`

-[X] Documentation is up-to-date.
