### PR TITLE
Fi: Sub Navigation Icon Fallback

### DIFF
--- a/packages/panels/src/Resources/Pages/ManageRelatedRecords.php
+++ b/packages/panels/src/Resources/Pages/ManageRelatedRecords.php
@@ -68,7 +68,7 @@ class ManageRelatedRecords extends Page implements Tables\Contracts\HasTable
     {
         return static::$navigationIcon
             ?? FilamentIcon::resolve('panels::resources.pages.manage-related-records.navigation-item')
-            ?? 'heroicon-o-rectangle-stack';
+            ?? null;
     }
 
     public function mount(int | string $record): void


### PR DESCRIPTION
When using sub-navigation, you can usually omit a navigation icon, and a dot with a line will be displayed. However, when combining Pages with a ManageRelatedRecords page, omitting the icon from ManageRelatedRecords defaults to a rectangular icon, disrupting the consistent appearance. For clarity it seems that ManageRelatedRecords pages in the Sub Navigation falls back to the rectangle icon. 

Before:
<img width="235" alt="Screenshot 2025-01-14 at 21 43 54" src="https://github.com/user-attachments/assets/5e3d4752-49dd-4cb6-8343-61b1dfd8817f" />

After:
<img width="220" alt="Screenshot 2025-01-14 at 21 43 40" src="https://github.com/user-attachments/assets/f003a0bf-1c4e-4751-9041-84193a85bb23" />
