### PR TITLE
Fix: configure using emptyStateDescription

### DIFF
--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -85,9 +85,15 @@ class Table extends ViewComponent
     {
         parent::setUp();
 
-        $this->emptyStateDescription(function (Table $table): ?string {
+        $configuredDescription = $this->getEmptyStateDescription() ?? null;
+
+        $this->emptyStateDescription(function (Table $table) use ($configuredDescription): ?string {
             if (! $table->hasAction('create')) {
-                return null;
+                return $configuredDescription ?? null;
+            }
+
+            if ($configuredDescription) {
+                return $configuredDescription;
             }
 
             return __('filament-tables::table.empty.description', [

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -85,15 +85,15 @@ class Table extends ViewComponent
     {
         parent::setUp();
 
-        $configuredDescription = $this->getEmptyStateDescription() ?? null;
+        $emptyStateDescription = $this->getEmptyStateDescription() ?? null;
 
-        $this->emptyStateDescription(function (Table $table) use ($configuredDescription): ?string {
+        $this->emptyStateDescription(function (Table $table) use ($emptyStateDescription): ?string {
             if (! $table->hasAction('create')) {
-                return $configuredDescription ?? null;
+                return $emptyStateDescription ?? null;
             }
 
-            if ($configuredDescription) {
-                return $configuredDescription;
+            if ($emptyStateDescription) {
+                return $emptyStateDescription;
             }
 
             return __('filament-tables::table.empty.description', [


### PR DESCRIPTION
## Description

As described in https://github.com/filamentphp/filament/issues/14990, I'm not sure if this is the expected behavior. At least for me, it seems to be. @danharrin 

This is the current priority order:

1. Resource
2. Configure using
3. If nothing is set, but the create action is there, it will display the "Create a %% to get started." text.

## Visual changes

https://youtu.be/1gzuXzNHWDs

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
