### PR TITLE
Fix: Respect nullified record action and url in tables

### DIFF
--- a/packages/panels/src/Resources/Concerns/InteractsWithRelationshipTable.php
+++ b/packages/panels/src/Resources/Concerns/InteractsWithRelationshipTable.php
@@ -54,11 +54,14 @@ trait InteractsWithRelationshipTable
 
     protected function makeTable(): Table
     {
-        return $this->makeBaseTable()
+        $table = $this->makeBaseTable()
             ->relationship(fn (): Relation | Builder => $this->getRelationship())
             ->modifyQueryUsing($this->modifyQueryWithActiveTab(...))
-            ->queryStringIdentifier(Str::lcfirst(class_basename(static::class)))
-            ->recordAction(function (Model $record, Table $table): ?string {
+            ->queryStringIdentifier(Str::lcfirst(class_basename(static::class)));
+
+        // Only set recordAction and recordUrl if they haven't been explicitly set
+        if (! $table->hasRecordActionBeenSet()) {
+            $table->recordAction(function (Model $record, Table $table): ?string {
                 foreach (['view', 'edit'] as $action) {
                     $action = $table->getAction($action);
 
@@ -80,8 +83,11 @@ trait InteractsWithRelationshipTable
                 }
 
                 return null;
-            })
-            ->recordUrl(function (Model $record, Table $table): ?string {
+            });
+        }
+
+        if (! $table->hasRecordUrlBeenSet()) {
+            $table->recordUrl(function (Model $record, Table $table): ?string {
                 foreach (['view', 'edit'] as $action) {
                     $action = $table->getAction($action);
 
@@ -105,7 +111,9 @@ trait InteractsWithRelationshipTable
                 }
 
                 return null;
-            })
-            ->authorizeReorder(fn (): bool => $this->canReorder());
+            });
+        }
+
+        return $table->authorizeReorder(fn (): bool => $this->canReorder());
     }
 }

--- a/packages/panels/src/Resources/Pages/ListRecords.php
+++ b/packages/panels/src/Resources/Pages/ListRecords.php
@@ -239,12 +239,15 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
 
     protected function makeTable(): Table
     {
-        return $this->makeBaseTable()
+        $table = $this->makeBaseTable()
             ->query(fn (): Builder => $this->getTableQuery())
             ->modifyQueryUsing($this->modifyQueryWithActiveTab(...))
             ->modelLabel($this->getModelLabel() ?? static::getResource()::getModelLabel())
-            ->pluralModelLabel($this->getPluralModelLabel() ?? static::getResource()::getPluralModelLabel())
-            ->recordAction(function (Model $record, Table $table): ?string {
+            ->pluralModelLabel($this->getPluralModelLabel() ?? static::getResource()::getPluralModelLabel());
+
+        // Only set recordAction and recordUrl if they haven't been explicitly set
+        if (! $table->hasRecordActionBeenSet()) {
+            $table->recordAction(function (Model $record, Table $table): ?string {
                 foreach (['view', 'edit'] as $action) {
                     $action = $table->getAction($action);
 
@@ -270,9 +273,13 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
                 }
 
                 return null;
-            })
-            ->recordTitle(fn (Model $record): string => static::getResource()::getRecordTitle($record))
-            ->recordUrl($this->getTableRecordUrlUsing() ?? function (Model $record, Table $table): ?string {
+            });
+        }
+
+        $table->recordTitle(fn (Model $record): string => static::getResource()::getRecordTitle($record));
+
+        if (! $table->hasRecordUrlBeenSet()) {
+            $table->recordUrl($this->getTableRecordUrlUsing() ?? function (Model $record, Table $table): ?string {
                 foreach (['view', 'edit'] as $action) {
                     $action = $table->getAction($action);
 
@@ -314,8 +321,10 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
                 }
 
                 return null;
-            })
-            ->authorizeReorder(static::getResource()::canReorder());
+            });
+        }
+
+        return $table->authorizeReorder(static::getResource()::canReorder());
     }
 
     /**

--- a/packages/tables/src/Table/Concerns/HasRecordAction.php
+++ b/packages/tables/src/Table/Concerns/HasRecordAction.php
@@ -10,11 +10,19 @@ trait HasRecordAction
 {
     protected string | Closure | null $recordAction = null;
 
+    protected bool $hasRecordActionBeenSet = false;
+
     public function recordAction(string | Closure | null $action): static
     {
         $this->recordAction = $action;
+        $this->hasRecordActionBeenSet = true;
 
         return $this;
+    }
+
+    public function hasRecordActionBeenSet(): bool
+    {
+        return $this->hasRecordActionBeenSet;
     }
 
     public function getRecordAction(Model $record): ?string

--- a/packages/tables/src/Table/Concerns/HasRecordUrl.php
+++ b/packages/tables/src/Table/Concerns/HasRecordUrl.php
@@ -11,6 +11,8 @@ trait HasRecordUrl
 
     protected string | Closure | null $recordUrl = null;
 
+    protected bool $hasRecordUrlBeenSet = false;
+
     public function openRecordUrlInNewTab(bool | Closure $condition = true): static
     {
         $this->shouldOpenRecordUrlInNewTab = $condition;
@@ -22,8 +24,14 @@ trait HasRecordUrl
     {
         $this->openRecordUrlInNewTab($shouldOpenInNewTab);
         $this->recordUrl = $url;
+        $this->hasRecordUrlBeenSet = true;
 
         return $this;
+    }
+
+    public function hasRecordUrlBeenSet(): bool
+    {
+        return $this->hasRecordUrlBeenSet;
     }
 
     public function getRecordUrl(Model $record): ?string

--- a/tests/Tables/TableConfigurationTest.php
+++ b/tests/Tables/TableConfigurationTest.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Filament\Tests\Tables;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Filament\Tests\TestCase;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Mockery;
+
+class TestOwnerModel extends Model
+{
+    protected $table = 'test_owners';
+    public $timestamps = false;
+    protected $fillable = ['name'];
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(TestItemModel::class, 'owner_id');
+    }
+}
+
+class TestItemModel extends Model
+{
+    protected $table = 'test_items';
+    public $timestamps = false;
+    protected $fillable = ['name', 'owner_id'];
+}
+
+uses(TestCase::class)->group('tables');
+
+beforeEach(function () {
+    $this->livewire = Mockery::mock(HasTable::class);
+
+    Schema::create('test_owners', function (Blueprint $table) {
+        $table->id();
+        $table->string('name')->nullable();
+    });
+
+    Schema::create('test_items', function (Blueprint $table) {
+        $table->id();
+        $table->foreignId('owner_id')->nullable()->constrained('test_owners')->cascadeOnDelete();
+        $table->string('name')->nullable();
+    });
+});
+
+afterEach(function () {
+    Mockery::close();
+    Schema::dropIfExists('test_items');
+    Schema::dropIfExists('test_owners');
+});
+
+it('can nullify table record action', function () {
+    Table::configureUsing(fn (Table $table) => $table
+        ->recordAction(null)
+    );
+
+    $table = Table::make($this->livewire);
+
+    expect($table)
+        ->hasRecordActionBeenSet()->toBeTrue()
+        ->getRecordAction(new TestItemModel())->toBeNull();
+});
+
+it('can nullify table record url', function () {
+    Table::configureUsing(fn (Table $table) => $table
+        ->recordUrl(null)
+    );
+
+    $table = Table::make($this->livewire);
+
+    expect($table)
+        ->hasRecordUrlBeenSet()->toBeTrue()
+        ->getRecordUrl(new TestItemModel())->toBeNull();
+});
+
+it('can set table record action and url together', function () {
+    Table::configureUsing(fn (Table $table) => $table
+        ->recordAction('edit')
+        ->recordUrl('/edit/1')
+    );
+
+    $table = Table::make($this->livewire);
+
+    expect($table)
+        ->hasRecordActionBeenSet()->toBeTrue()
+        ->hasRecordUrlBeenSet()->toBeTrue()
+        ->getRecordAction(new TestItemModel())->toBe('edit')
+        ->getRecordUrl(new TestItemModel())->toBe('/edit/1');
+});
+
+it('can nullify table record action and url together', function () {
+    Table::configureUsing(fn (Table $table) => $table
+        ->recordAction(null)
+        ->recordUrl(null)
+    );
+
+    $table = Table::make($this->livewire);
+
+    expect($table)
+        ->hasRecordActionBeenSet()->toBeTrue()
+        ->hasRecordUrlBeenSet()->toBeTrue()
+        ->getRecordAction(new TestItemModel())->toBeNull()
+        ->getRecordUrl(new TestItemModel())->toBeNull();
+});
+
+it('respects closure values for record action and url', function () {
+    $model = new TestItemModel();
+
+    Table::configureUsing(fn (Table $table) => $table
+        ->recordAction(fn (Model $record) => 'edit-' . $record::class)
+        ->recordUrl(fn (Model $record) => '/edit/' . $record::class)
+    );
+
+    $table = Table::make($this->livewire);
+
+    expect($table)
+        ->hasRecordActionBeenSet()->toBeTrue()
+        ->hasRecordUrlBeenSet()->toBeTrue()
+        ->getRecordAction($model)->toBe('edit-' . $model::class)
+        ->getRecordUrl($model)->toBe('/edit/' . $model::class);
+});
+
+it('respects nullified record url in relation manager', function () {
+    $owner = TestOwnerModel::create(['name' => 'Test Owner']);
+
+    $relationManager = Mockery::mock(RelationManager::class)
+        ->makePartial()
+        ->shouldAllowMockingProtectedMethods();
+
+    $relationManager->shouldReceive('getRelationship')
+        ->andReturn($owner->items());
+
+    $relationManager->shouldReceive('table')
+        ->andReturnUsing(function (Table $table) {
+            return $table->recordUrl(null);
+        });
+
+    $table = Table::make($relationManager);
+    $table = $relationManager->table($table);
+
+    expect($table)
+        ->hasRecordUrlBeenSet()->toBeTrue()
+        ->getRecordUrl(new TestItemModel())->toBeNull();
+});
+
+it('respects nullified record action in relation manager', function () {
+    $owner = TestOwnerModel::create(['name' => 'Test Owner']);
+
+    $relationManager = Mockery::mock(RelationManager::class)
+        ->makePartial()
+        ->shouldAllowMockingProtectedMethods();
+
+    $relationManager->shouldReceive('getRelationship')
+        ->andReturn($owner->items());
+
+    $relationManager->shouldReceive('table')
+        ->andReturnUsing(function (Table $table) {
+            return $table->recordAction(null);
+        });
+
+    $table = Table::make($relationManager);
+    $table = $relationManager->table($table);
+
+    expect($table)
+        ->hasRecordActionBeenSet()->toBeTrue()
+        ->getRecordAction(new TestItemModel())->toBeNull();
+});
+
+it('respects custom record url in relation manager', function () {
+    $owner = TestOwnerModel::create(['name' => 'Test Owner']);
+
+    $relationManager = Mockery::mock(RelationManager::class)
+        ->makePartial()
+        ->shouldAllowMockingProtectedMethods();
+
+    $relationManager->shouldReceive('getRelationship')
+        ->andReturn($owner->items());
+
+    $relationManager->shouldReceive('table')
+        ->andReturnUsing(function (Table $table) {
+            return $table->recordUrl('/custom/url');
+        });
+
+    $table = Table::make($relationManager);
+    $table = $relationManager->table($table);
+
+    expect($table)
+        ->hasRecordUrlBeenSet()->toBeTrue()
+        ->getRecordUrl(new TestItemModel())->toBe('/custom/url');
+});
+
+it('respects custom record action in relation manager', function () {
+    $owner = TestOwnerModel::create(['name' => 'Test Owner']);
+
+    $relationManager = Mockery::mock(RelationManager::class)
+        ->makePartial()
+        ->shouldAllowMockingProtectedMethods();
+
+    $relationManager->shouldReceive('getRelationship')
+        ->andReturn($owner->items());
+
+    $relationManager->shouldReceive('table')
+        ->andReturnUsing(function (Table $table) {
+            return $table->recordAction('custom-action');
+        });
+
+    $table = Table::make($relationManager);
+    $table = $relationManager->table($table);
+
+    expect($table)
+        ->hasRecordActionBeenSet()->toBeTrue()
+        ->getRecordAction(new TestItemModel())->toBe('custom-action');
+});


### PR DESCRIPTION
This PR fixes an issue where setting `recordAction` or `recordUrl` to `null` in a table configuration would be overridden by the default values.

## Changes

1. Added tracking of whether `recordAction` and `recordUrl` have been explicitly set:
   - Added `hasRecordActionBeenSet` and `hasRecordUrlBeenSet` flags
   - Added getter methods to check these flags

2. Modified table builders to respect user configuration:
   - Only apply default values when the user hasn't set these values explicitly
   - This allows nullification to work properly

3. Added comprehensive tests:
   - Tests for basic table configuration
   - Tests for relation manager table configuration
   - Tests for both nullification and custom values
   - Tests for closure-based values

## Testing

Added a new test file `tests/Tables/TableConfigurationTest.php` that verifies:
- Record actions and URLs can be nullified
- Both settings can be set together
- Both settings can be nullified together
- Closure values are properly evaluated
- RelationManager respects all these settings

## Breaking Changes

None. This change fixes a bug where user configuration was being ignored, restoring the expected behavior.

## Security Impact

None. This is a purely functional change that does not affect security.