### PR TITLE
Fix: Prevent column groups table row from appearing if all columns in every group are (toggled) hidden

### DIFF
--- a/packages/tables/src/Table/Concerns/HasColumns.php
+++ b/packages/tables/src/Table/Concerns/HasColumns.php
@@ -154,7 +154,7 @@ trait HasColumns
             }
         }
 
-        // If all columns within in every column group are (toggled)
+        // If all columns within every column group are (toggled)
         // hidden, then not include the table column groups row.
         return false;
     }

--- a/packages/tables/src/Table/Concerns/HasColumns.php
+++ b/packages/tables/src/Table/Concerns/HasColumns.php
@@ -145,17 +145,19 @@ trait HasColumns
         }
 
         foreach ($this->getVisibleColumns() as $column) {
-            if (! ($columnGroup = $column->getGroup())) {
+            $columnGroup = $column->getGroup();
+            
+            if (! $columnGroup) {
                 continue;
             }
 
-            if (filled($columnGroup->getVisibleColumns())) {
-                return true;
+            if (empty($columnGroup->getVisibleColumns())) {
+                continue;
             }
+
+            return true;
         }
 
-        // If all columns within every column group are (toggled)
-        // hidden, then not include the table column groups row.
         return false;
     }
 

--- a/packages/tables/src/Table/Concerns/HasColumns.php
+++ b/packages/tables/src/Table/Concerns/HasColumns.php
@@ -140,7 +140,23 @@ trait HasColumns
 
     public function hasColumnGroups(): bool
     {
-        return $this->hasColumnGroups;
+        if (! $this->hasColumnGroups) {
+            return false;
+        }
+
+        foreach ($this->getVisibleColumns() as $column) {
+            if (! ($columnGroup = $column->getGroup())) {
+                continue;
+            }
+
+            if (filled($columnGroup->getVisibleColumns())) {
+                return true;
+            }
+        }
+
+        // If all columns within in every column group are (toggled)
+        // hidden, then not include the table column groups row.
+        return false;
     }
 
     public function hasColumnsLayout(): bool


### PR DESCRIPTION
This PR fixes an issue where this empty bar would appear if you have a `ColumnGroup`, but all columns inside the group are either `->hidden()` (e.g. via a closure) or toggled hidden by the toggleable setting.

![CleanShot 2025-01-15 at 18 10 27@2x](https://github.com/user-attachments/assets/4080bc8b-a89c-4f0e-9aa4-b3688f2e18d9)

I am not sure if it's for performance reasons, but I would say that it should be possible e.g. in V4 to refactor away from this manual setting of a boolean when pushing a new `ColumnGroup`.

Thanks!