### PR TITLE
Feat: Add `unmountTableBulkAction()` testing method

### DIFF
--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -3,10 +3,10 @@
 namespace Livewire\Features\SupportTesting {
 
     use Closure;
-    use Illuminate\Database\Eloquent\Model;
     use Illuminate\Support\Collection;
 
-    class Testable {
+    class Testable
+    {
         public function mountTableAction(string | array $name, $record = null): static {}
 
         public function unmountTableAction(): static {}
@@ -50,6 +50,8 @@ namespace Livewire\Features\SupportTesting {
         public function assertHasNoTableActionErrors(array $keys = []): static {}
 
         public function mountTableBulkAction(string $name, array | Collection $records): static {}
+
+        public function unmountTableBulkAction(): static {}
 
         public function setTableBulkActionData(array $data): static {}
 

--- a/packages/tables/src/Testing/TestsBulkActions.php
+++ b/packages/tables/src/Testing/TestsBulkActions.php
@@ -56,15 +56,15 @@ class TestsBulkActions
             return $this;
         };
     }
-	
-	public function unmountTableBulkAction(): Closure
-	{
-		return function (): static {
-			$this->call('unmountTableBulkAction');
-			
-			return $this;
-		};
-	}
+
+    public function unmountTableBulkAction(): Closure
+    {
+        return function (): static {
+            $this->call('unmountTableBulkAction');
+
+            return $this;
+        };
+    }
 
     public function setTableBulkActionData(): Closure
     {

--- a/packages/tables/src/Testing/TestsBulkActions.php
+++ b/packages/tables/src/Testing/TestsBulkActions.php
@@ -56,6 +56,15 @@ class TestsBulkActions
             return $this;
         };
     }
+	
+	public function unmountTableBulkAction(): Closure
+	{
+		return function (): static {
+			$this->call('unmountTableBulkAction');
+			
+			return $this;
+		};
+	}
 
     public function setTableBulkActionData(): Closure
     {

--- a/tests/src/Tables/Actions/BulkActionTest.php
+++ b/tests/src/Tables/Actions/BulkActionTest.php
@@ -22,6 +22,16 @@ it('can call bulk action', function () {
     }
 });
 
+it('can unmount bulk action', function () {
+    $posts = Post::factory()->count(10)->create();
+
+    livewire(PostsTable::class)
+	    ->mountTableBulkAction(DeleteBulkAction::class, $posts)
+	    ->assertTableBulkActionMounted(DeleteBulkAction::class)
+	    ->unmountTableBulkAction()
+	    ->assertTableBulkActionNotMounted(DeleteBulkAction::class);
+});
+
 it('can call a bulk action with data', function () {
     $posts = Post::factory()->count(10)->create();
 

--- a/tests/src/Tables/Actions/BulkActionTest.php
+++ b/tests/src/Tables/Actions/BulkActionTest.php
@@ -7,6 +7,7 @@ use Filament\Tests\Tables\TestCase;
 use Illuminate\Support\Str;
 
 use function Filament\Tests\livewire;
+use function Pest\Laravel\assertNotSoftDeleted;
 use function Pest\Laravel\assertSoftDeleted;
 
 uses(TestCase::class);
@@ -26,10 +27,14 @@ it('can unmount bulk action', function () {
     $posts = Post::factory()->count(10)->create();
 
     livewire(PostsTable::class)
-	    ->mountTableBulkAction(DeleteBulkAction::class, $posts)
-	    ->assertTableBulkActionMounted(DeleteBulkAction::class)
-	    ->unmountTableBulkAction()
-	    ->assertTableBulkActionNotMounted(DeleteBulkAction::class);
+        ->mountTableBulkAction(DeleteBulkAction::class, $posts)
+        ->assertTableBulkActionMounted(DeleteBulkAction::class)
+        ->unmountTableBulkAction()
+        ->assertTableBulkActionNotMounted(DeleteBulkAction::class);
+
+    foreach ($posts as $post) {
+        assertNotSoftDeleted($post);
+    }
 });
 
 it('can call a bulk action with data', function () {


### PR DESCRIPTION
I noticed this `unmountTableBulkAction()` method was missing still.

Thanks!