### PR TITLE
Fix: Undefined $maxParallelUploads Variable in v3.2.1.33 by Moving Logic to FileUpload Class

### DIFF
--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -46,8 +46,6 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
 
     protected int | Closure | null $minSize = null;
 
-    protected int | Closure | null $maxParallelUploads = null;
-
     protected int | Closure | null $maxFiles = null;
 
     protected int | Closure | null $minFiles = null;
@@ -395,13 +393,6 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
         return $this;
     }
 
-    public function maxParallelUploads(int | Closure | null $count): static
-    {
-        $this->maxParallelUploads = $count;
-
-        return $this;
-    }
-
     public function maxFiles(int | Closure | null $count): static
     {
         $this->maxFiles = $count;
@@ -547,11 +538,6 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
     public function getMinSize(): ?int
     {
         return $this->evaluate($this->minSize);
-    }
-
-    public function getMaxParallelUploads(): ?int
-    {
-        return $this->evaluate($this->maxParallelUploads);
     }
 
     public function getVisibility(): string

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -22,6 +22,8 @@ class FileUpload extends BaseFileUpload
      */
     protected string $view = 'filament-forms::components.file-upload';
 
+    protected int | Closure | null $maxParallelUploads = null;
+
     protected string | Closure | null $imageCropAspectRatio = null;
 
     protected string | Closure | null $imagePreviewHeight = null;
@@ -226,6 +228,18 @@ class FileUpload extends BaseFileUpload
         $this->uploadProgressIndicatorPosition = $position;
 
         return $this;
+    }
+
+    public function maxParallelUploads(int | Closure | null $count): static
+    {
+        $this->maxParallelUploads = $count;
+
+        return $this;
+    }
+
+    public function getMaxParallelUploads(): ?int
+    {
+        return $this->evaluate($this->maxParallelUploads);
     }
 
     public function getImageCropAspectRatio(): ?string


### PR DESCRIPTION
## Description

This pull request addresses an issue where the `$maxParallelUploads` variable was undefined in version **3.2.1.33**. The logic for the `$maxParallelUploads` feature has been moved from the `BaseFileUpload` class to the `FileUpload` class to resolve this issue.

## Visual Changes
Move this code from BaseFileUpload class  to FileUpload child class
```
  namespace Filament\Forms\Components;
  
  protected int | Closure | null $maxParallelUploads = null;
  
      public function maxParallelUploads(int | Closure | null $count): static
      {
          $this->maxParallelUploads = $count;
  
          return $this;
      }
      public function getMaxParallelUploads(): ?int
      {
          return $this->evaluate($this->maxParallelUploads);
      }
```

## Functional Changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.


---

### Summary of Changes

- Moved the `$maxParallelUploads` logic from `BaseFileUpload` to `FileUpload` to fix the undefined variable issue.
- Ensured code style consistency by running the `composer cs` command.


This fix ensures that the `$maxParallelUploads` variable is properly defined and functional, maintaining the integrity of the file upload feature in FilamentPHP.