### PR TITLE
Fix str_getcsv(): the $escape parameter must be provided as its default value will change after updating to PHP 8.4

### DIFF
--- a/packages/support/src/Commands/Concerns/CanReadModelSchemas.php
+++ b/packages/support/src/Commands/Concerns/CanReadModelSchemas.php
@@ -132,7 +132,7 @@ trait CanReadModelSchemas
         };
 
         $values = str_contains($column['type'], '(')
-            ? str_getcsv(Str::between($column['type'], '(', ')'), ',', "'")
+            ? str_getcsv(Str::between($column['type'], '(', ')'), enclosure: "'", escape: '\\')
             : null;
 
         $values = is_null($values) ? [] : match ($type) {

--- a/packages/tables/src/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Concerns/CanSearchRecords.php
@@ -110,7 +110,7 @@ trait CanSearchRecords
     protected function extractTableSearchWords(string $search): array
     {
         return array_filter(
-            str_getcsv(preg_replace('/\s+/', ' ', $search), ' ', escape: "\\"),
+            str_getcsv(preg_replace('/\s+/', ' ', $search), separator: ' ', escape: "\\"),
             fn ($word): bool => filled($word),
         );
     }

--- a/packages/tables/src/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Concerns/CanSearchRecords.php
@@ -110,7 +110,7 @@ trait CanSearchRecords
     protected function extractTableSearchWords(string $search): array
     {
         return array_filter(
-            str_getcsv(preg_replace('/\s+/', ' ', $search), ' ', "\\"),
+            str_getcsv(preg_replace('/\s+/', ' ', $search), ' ', escape: "\\"),
             fn ($word): bool => filled($word),
         );
     }

--- a/packages/tables/src/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Concerns/CanSearchRecords.php
@@ -110,7 +110,7 @@ trait CanSearchRecords
     protected function extractTableSearchWords(string $search): array
     {
         return array_filter(
-            str_getcsv(preg_replace('/\s+/', ' ', $search), ' '),
+            str_getcsv(preg_replace('/\s+/', ' ', $search), ' ', "\\"),
             fn ($word): bool => filled($word),
         );
     }


### PR DESCRIPTION
## Description

After updating to PHP 8.4, I keep getting the following message in Sentry (hundreds of them)

"Fix str_getcsv(): the $escape parameter must be provided as its default value will change"

"str_getcsv(): the $escape parameter must be provided as its default value will change"

![CleanShot 2025-01-19 at 10 32 05@2x](https://github.com/user-attachments/assets/53273cf2-881d-4ee0-8008-57f253f071ae)


So after some googling around, I found this drupal discussion about it and provided a default value

https://www.drupal.org/project/drupal/issues/3477324

The default value I provide is the 1 in PHP.net (which is the current default, but I guess the default could change in the future hence that warning)

https://www.php.net/manual/en/function.str-getcsv.php

![CleanShot 2025-01-19 at 10 34 41@2x](https://github.com/user-attachments/assets/684b2bff-ecd3-4d43-81b2-0796ffa170e3)

![CleanShot 2025-01-19 at 10 54 40@2x](https://github.com/user-attachments/assets/466137bd-6c5c-4772-81bf-d95911f54036)

The official php documentation recommends setting $escape to empty string instead of the default `"\\"` but I did not set to empty string to preserve existing behaviour (`"\\"`) out of caution. It is possible that empty string is the better choice & won't break things but I do not know enough to make that judgement

![CleanShot 2025-01-19 at 10 55 19@2x](https://github.com/user-attachments/assets/693deed3-f569-4f21-b7d2-94d0585bd8df)


## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
