### PR TITLE
Get user by the panel guard.

### DIFF
--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -146,6 +146,10 @@ trait CanExportRecords
 
             $user = auth()->user();
 
+            if (function_exists('filament')) {
+                $user = auth(filament()->getAuthGuard())->user();
+            }
+
             if ($action->hasColumnMapping()) {
                 $columnMap = collect($data['columnMap'])
                     ->dot()

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -214,6 +214,10 @@ trait CanImportRecords
 
             $user = auth()->user();
 
+            if (function_exists('filament')) {
+                $user = auth(filament()->getAuthGuard())->user();
+            }
+
             $import = app(Import::class);
             $import->user()->associate($user);
             $import->file_name = $csvFile->getClientOriginalName();

--- a/packages/actions/src/Exports/Http/Controllers/DownloadExport.php
+++ b/packages/actions/src/Exports/Http/Controllers/DownloadExport.php
@@ -17,7 +17,13 @@ class DownloadExport
         if (filled(Gate::getPolicyFor($export::class))) {
             authorize('view', $export);
         } else {
-            abort_unless($export->user()->is(auth()->user()), 403);
+            $user = auth()->user();
+
+            if (function_exists('filament')) {
+                $user = auth(filament()->getAuthGuard())->user();
+            }
+
+            abort_unless($export->user()->is($user), 403);
         }
 
         $format = ExportFormat::tryFrom($request->query('format'));


### PR DESCRIPTION
Add Getting user by the panel guard for different guards and assert the filament function exists for panel usage


## Description
Add Getting user by the panel guard for different guards and assert the filament function exists for panel usage.
Because the code was written to get the default guard only, the added code can check if filament exists so if the import and export actions have been used alone or with filament both cases will be handled

## Visual changes

![image](https://github.com/user-attachments/assets/8a9563a7-93a0-4508-92ef-662792f59ada)
![image](https://github.com/user-attachments/assets/ed9552ad-abfb-445a-acd8-327375b7718d)

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
