### PR TITLE
Add option to force horizonal steps header in form wizard

### DIFF
--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -134,6 +134,7 @@
         role="list"
         @class([
             'fi-fo-wizard-header grid divide-y divide-gray-200 dark:divide-white/5 md:grid-flow-col md:divide-y-0 md:overflow-x-auto',
+            'grid-flow-col overflow-x-auto' => $forceHorizontalStepsHeader,
             'border-b border-gray-200 dark:border-white/10' => $isContained,
             'rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10' => ! $isContained,
         ])

--- a/packages/forms/src/Components/Wizard.php
+++ b/packages/forms/src/Components/Wizard.php
@@ -280,7 +280,7 @@ class Wizard extends Component
         return $this;
     }
 
-    public function isForceHorizontalStepsHeader():
+    public function isForceHorizontalStepsHeader(): bool
     {
         return (bool) $this->evaluate($this->forceHorizontalStepsHeader);
     }

--- a/packages/forms/src/Components/Wizard.php
+++ b/packages/forms/src/Components/Wizard.php
@@ -32,6 +32,8 @@ class Wizard extends Component
 
     protected int $currentStepIndex = 0;
 
+    protected bool | Closure $forceHorizontalStepsHeader = false;
+
     /**
      * @var view-string
      */
@@ -269,6 +271,18 @@ class Wizard extends Component
     public function getCurrentStepIndex(): int
     {
         return $this->currentStepIndex;
+    }
+
+    public function forceHorizontalStepsHeader(bool | Closure $condition = true): static
+    {
+        $this->forceHorizontalStepsHeader = $condition;
+
+        return $this;
+    }
+
+    public function isForceHorizontalStepsHeader():
+    {
+        return (bool) $this->evaluate($this->forceHorizontalStepsHeader);
     }
 
     protected function setCurrentStepIndex(int $index): static


### PR DESCRIPTION
## Description

Currently on mobile devices, form wizard steps header is almost always vertically stacked even if I hide the all step header labels with ->hiddenLabel(). This makes the form wizard look unpleasant as can be seen below

![CleanShot 2025-01-21 at 21 14 34](https://github.com/user-attachments/assets/6853f19f-e0f9-4a58-9795-a2b20649c1ae)

What my PR does is you can now do this:

```php
Wizard::make($steps)
    ->forceHorizontalStepsHeader();
```

And the horizontal steps header will be forced. Looking like this

![CleanShot 2025-01-21 at 21 20 12](https://github.com/user-attachments/assets/af6bd642-d7ae-4414-9ba8-706b81888320)


The horizontal scroll bar if not all can fit into the screen

![CleanShot 2025-01-21 at 21 20 45](https://github.com/user-attachments/assets/64f446ca-7e64-4b24-acfc-681871ab8d4d)

Hence making it better for those of us who didn't like the vertically stacked steps header look and want to force horizontal at all times even on mobile