### PR TITLE
added command to generate multiple resources

### DIFF
--- a/packages/notifications/resources/js/components/notification.js
+++ b/packages/notifications/resources/js/components/notification.js
@@ -89,7 +89,8 @@ export default (Alpine) => {
                     // Calling `el.getBoundingClientRect()` from outside `requestAnimationFrame()` can
                     // occasionally cause the page to scroll to the top.
                     requestAnimationFrame(() => {
-                        const getTop = () => this.$el.getBoundingClientRect().top
+                        const getTop = () =>
+                            this.$el.getBoundingClientRect().top
                         const oldTop = getTop()
 
                         respond(() => {
@@ -105,7 +106,7 @@ export default (Alpine) => {
                                                 oldTop - getTop()
                                             }px)`,
                                         },
-                                        {transform: 'translateY(0px)'},
+                                        { transform: 'translateY(0px)' },
                                     ],
                                     {
                                         duration: this.transitionDuration,

--- a/packages/panels/docs/02-getting-started.md
+++ b/packages/panels/docs/02-getting-started.md
@@ -133,6 +133,11 @@ Use the following artisan command to create a new Filament resource for the `Pat
 ```bash
 php artisan make:filament-resource Patient
 ```
+Or if you want to generate all the resources at once, you can use the following command:
+```bash
+php artisan make:filament-resource-multi
+```
+it will ask you to select which model's resource need to be generated and then it will ask you to select options.
 
 This will create several files in the `app/Filament/Resources` directory:
 

--- a/packages/panels/src/Commands/Aliases/MakeResourceMultiCommand.php
+++ b/packages/panels/src/Commands/Aliases/MakeResourceMultiCommand.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Filament\Commands\Aliases;
+
+use Filament\Commands;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'filament:resource-multi')]
+class MakeResourceMultiCommand extends Commands\MakeResourceMultiCommand
+{
+    protected $hidden = true;
+
+    protected $signature = 'filament:resource-multi';
+}

--- a/packages/panels/src/Commands/MakeResourceMultiCommand.php
+++ b/packages/panels/src/Commands/MakeResourceMultiCommand.php
@@ -3,16 +3,15 @@
 namespace Filament\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 use Symfony\Component\Console\Attribute\AsCommand;
-use Illuminate\Container\Container;
-use Illuminate\Database\Eloquent\Model;
-use function Laravel\Prompts\multiselect;
-use function Laravel\Prompts\text;
-use function Psy\debug;
 
-#[AsCommand(name: "make:filament-resource-multi")]
+use function Laravel\Prompts\multiselect;
+
+#[AsCommand(name: 'make:filament-resource-multi')]
 class MakeResourceMultiCommand extends Command
 {
     /**
@@ -34,53 +33,58 @@ class MakeResourceMultiCommand extends Command
      */
     public function handle()
     {
-        $models = $this->getModels()->map(function ($model){ return array_reverse(explode("\\",$model))[0]; });
-        $this->info($models->count()." Found. Please Select Which Model You Want To Generate Resource For");
+        $models = $this->getModels()->map(function ($model) {
+            return array_reverse(explode('\\', $model))[0];
+        });
+        $this->info($models->count() . ' Found. Please Select Which Model You Want To Generate Resource For');
         $selectedModels = multiselect(
-            label: "Select Models",
+            label: 'Select Models',
             options: $models->toArray(),
-            required: "Please Select At least 1 Model or CTRL+C to Exit",
-            hint: "Press Space to Select, Enter to Confirm"
+            required: 'Please Select At least 1 Model or CTRL+C to Exit',
+            hint: 'Press Space to Select, Enter to Confirm'
         );
         $options = [
-            "--soft-deletes"=>"Enable Soft Deletes (--soft-deletes)",
-            "--view"=>"Generate Views (--view)",
-            "--generate"=>"Generate All (--generate)",
-            "--simple"=>"Generate Simple (--simple)",
-            "--model"=>"Model Name (--model)",
-            "--migration"=>"Generate Migration (--migration)",
-            "--factory"=>"Generate Factory (--factory)",
-            "--force"=>"Force (--force)"
+            '--soft-deletes' => 'Enable Soft Deletes (--soft-deletes)',
+            '--view' => 'Generate Views (--view)',
+            '--generate' => 'Generate All (--generate)',
+            '--simple' => 'Generate Simple (--simple)',
+            '--model' => 'Model Name (--model)',
+            '--migration' => 'Generate Migration (--migration)',
+            '--factory' => 'Generate Factory (--factory)',
+            '--force' => 'Force (--force)',
         ];
         $selectedOptions = multiselect(
-            label: "Select Options",
+            label: 'Select Options',
             options: $options,
-            required: "Please Select At least 1 Option or CTRL+C to Exit",
-            hint: "Press Space to Select, Enter to Confirm"
+            required: 'Please Select At least 1 Option or CTRL+C to Exit',
+            hint: 'Press Space to Select, Enter to Confirm'
         );
 
-        foreach($selectedModels as $model){
+        foreach ($selectedModels as $model) {
             $this->call('make:filament-resource', [
                 'name' => $model,
-                '--soft-deletes' => in_array("--soft-deletes", $selectedOptions),
-                '--view' => in_array("--view", $selectedOptions),
-                '--generate' => in_array("--generate", $selectedOptions),
-                '--simple' => in_array("--simple", $selectedOptions),
-                '--model' => in_array("--model", $selectedOptions),
-                '--migration' => in_array("--migration", $selectedOptions),
-                '--factory' => in_array("--factory", $selectedOptions),
-                '--force' => in_array("--force", $selectedOptions),
+                '--soft-deletes' => in_array('--soft-deletes', $selectedOptions),
+                '--view' => in_array('--view', $selectedOptions),
+                '--generate' => in_array('--generate', $selectedOptions),
+                '--simple' => in_array('--simple', $selectedOptions),
+                '--model' => in_array('--model', $selectedOptions),
+                '--migration' => in_array('--migration', $selectedOptions),
+                '--factory' => in_array('--factory', $selectedOptions),
+                '--force' => in_array('--force', $selectedOptions),
             ]);
         }
     }
+
     protected function getModels(): Collection
     {
         $models = collect(File::allFiles(app_path()))
             ->map(function ($item) {
                 $path = $item->getRelativePathName();
-                $class = sprintf('\%s%s',
+                $class = sprintf(
+                    '\%s%s',
                     Container::getInstance()->getNamespace(),
-                    strtr(substr($path, 0, strrpos($path, '.')), '/', '\\'));
+                    strtr(substr($path, 0, strrpos($path, '.')), '/', '\\')
+                );
 
                 return $class;
             })
@@ -90,7 +94,7 @@ class MakeResourceMultiCommand extends Command
                 if (class_exists($class)) {
                     $reflection = new \ReflectionClass($class);
                     $valid = $reflection->isSubclassOf(Model::class) &&
-                        !$reflection->isAbstract();
+                        ! $reflection->isAbstract();
                 }
 
                 return $valid;

--- a/packages/panels/src/Commands/MakeResourceMultiCommand.php
+++ b/packages/panels/src/Commands/MakeResourceMultiCommand.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Filament\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Model;
+use function Laravel\Prompts\multiselect;
+use function Laravel\Prompts\text;
+use function Psy\debug;
+
+#[AsCommand(name: "make:filament-resource-multi")]
+class MakeResourceMultiCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'make:filament-resource-multi';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Filament resource class and default page classes for multiple models';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $models = $this->getModels()->map(function ($model){ return array_reverse(explode("\\",$model))[0]; });
+        $this->info($models->count()." Found. Please Select Which Model You Want To Generate Resource For");
+        $selectedModels = multiselect(
+            label: "Select Models",
+            options: $models->toArray(),
+            required: "Please Select At least 1 Model or CTRL+C to Exit",
+            hint: "Press Space to Select, Enter to Confirm"
+        );
+        $options = [
+            "--soft-deletes"=>"Enable Soft Deletes (--soft-deletes)",
+            "--view"=>"Generate Views (--view)",
+            "--generate"=>"Generate All (--generate)",
+            "--simple"=>"Generate Simple (--simple)",
+            "--model"=>"Model Name (--model)",
+            "--migration"=>"Generate Migration (--migration)",
+            "--factory"=>"Generate Factory (--factory)",
+            "--force"=>"Force (--force)"
+        ];
+        $selectedOptions = multiselect(
+            label: "Select Options",
+            options: $options,
+            required: "Please Select At least 1 Option or CTRL+C to Exit",
+            hint: "Press Space to Select, Enter to Confirm"
+        );
+
+        foreach($selectedModels as $model){
+            $this->call('make:filament-resource', [
+                'name' => $model,
+                '--soft-deletes' => in_array("--soft-deletes", $selectedOptions),
+                '--view' => in_array("--view", $selectedOptions),
+                '--generate' => in_array("--generate", $selectedOptions),
+                '--simple' => in_array("--simple", $selectedOptions),
+                '--model' => in_array("--model", $selectedOptions),
+                '--migration' => in_array("--migration", $selectedOptions),
+                '--factory' => in_array("--factory", $selectedOptions),
+                '--force' => in_array("--force", $selectedOptions),
+            ]);
+        }
+    }
+    protected function getModels(): Collection
+    {
+        $models = collect(File::allFiles(app_path()))
+            ->map(function ($item) {
+                $path = $item->getRelativePathName();
+                $class = sprintf('\%s%s',
+                    Container::getInstance()->getNamespace(),
+                    strtr(substr($path, 0, strrpos($path, '.')), '/', '\\'));
+
+                return $class;
+            })
+            ->filter(function ($class) {
+                $valid = false;
+
+                if (class_exists($class)) {
+                    $reflection = new \ReflectionClass($class);
+                    $valid = $reflection->isSubclassOf(Model::class) &&
+                        !$reflection->isAbstract();
+                }
+
+                return $valid;
+            });
+
+        return $models->values();
+    }
+}

--- a/packages/panels/src/FilamentServiceProvider.php
+++ b/packages/panels/src/FilamentServiceProvider.php
@@ -114,6 +114,7 @@ class FilamentServiceProvider extends PackageServiceProvider
             Commands\MakeResourceCommand::class,
             Commands\MakeThemeCommand::class,
             Commands\MakeUserCommand::class,
+            Commands\MakeResourceMultiCommand::class,
         ];
 
         $aliases = [];


### PR DESCRIPTION
## Description

`php artisan make:filament-resource Customer` ( [filament-getting-started](https://filamentphp.com/docs/3.x/panels/resources/getting-started) )
this command takes model name to generate resource, 
i faced a challenge when i create multiple models together with blueprint and it generated 10-15 models and i had to create one by one all models, so i created a new command 
`php artisan make:filament-resource-multi`

## Visual changes

![filament-multi](https://github.com/user-attachments/assets/7cba4913-ca07-4157-b510-aabf619ae29e)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
