### PR TITLE
Fix summarizer connection resolver on non-default connections

### DIFF
--- a/packages/tables/src/Columns/Summarizers/Summarizer.php
+++ b/packages/tables/src/Columns/Summarizers/Summarizer.php
@@ -126,7 +126,7 @@ class Summarizer extends ViewComponent
 
         $asName = (string) str($query->getModel()->getTable())->afterLast('.');
 
-        $query = $query->getModel()->getConnection()
+        $query = $query->getModel()->resolveConnection($query->getModel()->getConnectionName())
             ->table($query->toBase(), $asName);
 
         if ($this->hasQueryModification()) {

--- a/packages/tables/src/Columns/Summarizers/Summarizer.php
+++ b/packages/tables/src/Columns/Summarizers/Summarizer.php
@@ -126,7 +126,7 @@ class Summarizer extends ViewComponent
 
         $asName = (string) str($query->getModel()->getTable())->afterLast('.');
 
-        $query = $query->getModel()->resolveConnection()
+        $query = $query->getModel()->getConnection()
             ->table($query->toBase(), $asName);
 
         if ($this->hasQueryModification()) {

--- a/packages/tables/src/Concerns/CanSummarizeRecords.php
+++ b/packages/tables/src/Concerns/CanSummarizeRecords.php
@@ -70,7 +70,7 @@ trait CanSummarizeRecords
         $queryToJoin = $query->clone();
         $joins = [];
 
-        $query = $query->getModel()->getConnection()
+        $query = $query->getModel()->resolveConnection($query->getModel()->getConnectionName())
             ->table($query->toBase(), $query->getModel()->getTable());
 
         if ($modifyQueryUsing) {

--- a/packages/tables/src/Concerns/CanSummarizeRecords.php
+++ b/packages/tables/src/Concerns/CanSummarizeRecords.php
@@ -70,7 +70,7 @@ trait CanSummarizeRecords
         $queryToJoin = $query->clone();
         $joins = [];
 
-        $query = $query->getModel()->resolveConnection()
+        $query = $query->getModel()->getConnection()
             ->table($query->toBase(), $query->getModel()->getTable());
 
         if ($modifyQueryUsing) {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

Laravel model method `resolveConnection`, when called without arguments, returns default database connection, even if model has another connection set. 

Usually it doesn't matter if syntax is the same between connections but in our case it was returning `MariaDbConnection` instead of `SqlServerConnection`, which has different char escaping.

Laravel itself manually passes connection name to `resolveConnection` like here: https://github.com/laravel/framework/blob/6e0e2cbd584a2988348409fe15bb2ead87aeafec/src/Illuminate/Database/Eloquent/Model.php#L1817

I believe it is better to use `getConnection` as it sets connection properly as in example above.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
