### PR TITLE
docs: update installation docs to mention testing

### DIFF
--- a/packages/panels/docs/01-installation.md
+++ b/packages/panels/docs/01-installation.md
@@ -86,7 +86,7 @@ You should also consider optimizing your Laravel app for production by running `
 
 ### Allowing users to access a panel
 
-By default, all `User` models can access Filament locally. However, when testing or deploying to production, you must update your `App\Models\User.php` to implement the `FilamentUser` contract — ensuring that only the correct users can access your panel:
+By default, all `User` models can access Filament locally. However, when deploying to production or running unit tests, you must update your `App\Models\User.php` to implement the `FilamentUser` contract — ensuring that only the correct users can access your panel:
 
 ```php
 <?php

--- a/packages/panels/docs/01-installation.md
+++ b/packages/panels/docs/01-installation.md
@@ -86,7 +86,7 @@ You should also consider optimizing your Laravel app for production by running `
 
 ### Allowing users to access a panel
 
-By default, all `User` models can access Filament locally. However, when deploying to production, you must update your `App\Models\User.php` to implement the `FilamentUser` contract — ensuring that only the correct users can access your panel:
+By default, all `User` models can access Filament locally. However, when testing or deploying to production, you must update your `App\Models\User.php` to implement the `FilamentUser` contract — ensuring that only the correct users can access your panel:
 
 ```php
 <?php


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When testing a Laravel app, the application environment automatically switches to `testing`, so if `canAccessPanel` is not implemented, tests will fail (as they should) but the developer might not know why instantly.

Feel free to keep it shorter if you think this change don't add much value.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

None

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
