### PR TITLE
Update dark mode background color.

### DIFF
--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -168,7 +168,7 @@
                                     type="number"
                                     inputmode="numeric"
                                     x-model.debounce="focusedYear"
-                                    class="w-16 border-none bg-transparent p-0 text-right text-sm text-gray-950 focus:ring-0 dark:text-white"
+                                    class="w-16 border-none bg-transparent p-0 text-right text-sm text-gray-950 focus:ring-0 dark:text-white dark:bg-gray-800"
                                 />
                             </div>
 
@@ -239,7 +239,7 @@
                                     type="number"
                                     inputmode="numeric"
                                     x-model.debounce="hour"
-                                    class="me-1 w-10 border-none bg-transparent p-0 text-center text-sm text-gray-950 focus:ring-0 dark:text-white"
+                                    class="me-1 w-10 border-none bg-transparent p-0 text-center text-sm text-gray-950 focus:ring-0 dark:text-white dark:bg-gray-800"
                                 />
 
                                 <span
@@ -255,7 +255,7 @@
                                     type="number"
                                     inputmode="numeric"
                                     x-model.debounce="minute"
-                                    class="me-1 w-10 border-none bg-transparent p-0 text-center text-sm text-gray-950 focus:ring-0 dark:text-white"
+                                    class="me-1 w-10 border-none bg-transparent p-0 text-center text-sm text-gray-950 focus:ring-0 dark:text-white dark:bg-gray-800"
                                 />
 
                                 @if ($hasSeconds())
@@ -272,7 +272,7 @@
                                         type="number"
                                         inputmode="numeric"
                                         x-model.debounce="second"
-                                        class="me-1 w-10 border-none bg-transparent p-0 text-center text-sm text-gray-950 focus:ring-0 dark:text-white"
+                                        class="me-1 w-10 border-none bg-transparent p-0 text-center text-sm text-gray-950 focus:ring-0 dark:text-white dark:bg-gray-800"
                                     />
                                 @endif
                             </div>

--- a/packages/support/resources/views/components/input/index.blade.php
+++ b/packages/support/resources/views/components/input/index.blade.php
@@ -6,7 +6,7 @@
 <input
     {{
         $attributes->class([
-            'fi-input block w-full border-none py-1.5 text-base text-gray-950 transition duration-75 placeholder:text-gray-400 focus:ring-0 disabled:text-gray-500 disabled:[-webkit-text-fill-color:theme(colors.gray.500)] disabled:placeholder:[-webkit-text-fill-color:theme(colors.gray.400)] dark:text-white dark:placeholder:text-gray-500 dark:disabled:text-gray-400 dark:disabled:[-webkit-text-fill-color:theme(colors.gray.400)] dark:disabled:placeholder:[-webkit-text-fill-color:theme(colors.gray.500)] sm:text-sm sm:leading-6',
+            'fi-input block w-full border-none py-1.5 text-base text-gray-950 transition duration-75 placeholder:text-gray-400 focus:ring-0 disabled:text-gray-500 disabled:[-webkit-text-fill-color:theme(colors.gray.500)] disabled:placeholder:[-webkit-text-fill-color:theme(colors.gray.400)] dark:text-white dark:bg-gray-800 dark:placeholder:text-gray-500 dark:disabled:text-gray-400 dark:disabled:[-webkit-text-fill-color:theme(colors.gray.400)] dark:disabled:placeholder:[-webkit-text-fill-color:theme(colors.gray.500)] sm:text-sm sm:leading-6',
             // A fully transparent white background color is used
             // instead of transparent to fix a Safari bug
             // where the date/time input "placeholder" colors too dark.


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Update default dark mode background color for input and datepicker select button

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

Correcting background color for dark mode to be darker (from white to bg-gray-800)

<!-- Add screenshots/recordings of before and after. -->

before 

![Screenshot 2025-01-24 at 7 53 05 PM](https://github.com/user-attachments/assets/4dfe291e-c9a8-4a9a-b1a5-ddcc6571d3f0)

after 

![Screenshot 2025-01-24 at 7 53 16 PM](https://github.com/user-attachments/assets/7e2d34f2-1a63-444d-9a5a-76b64df7417d)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
