### PR TITLE
Fix form field focusing on modal actions in relation managers

### DIFF
--- a/packages/panels/resources/views/components/resources/relation-managers.blade.php
+++ b/packages/panels/resources/views/components/resources/relation-managers.blade.php
@@ -72,7 +72,6 @@
             @if (count($managers) > 1)
                 id="relationManager{{ ucfirst($activeManager) }}"
                 role="tabpanel"
-                tabindex="0"
             @endif
             wire:key="{{ $this->getId() }}.relation-managers.active"
             class="flex flex-col gap-y-4"


### PR DESCRIPTION
## Description
Opening a modal from a relation manager causes focus issues with form fields. Some of the symptoms of this bug are:

1. When any RM modal is opened (header action, table action, filters in a slideover, etc.), text fields remains selected even after clicking out of the field. 
2. Typing after clicking out of the field continues to update the field.
3. Since the text field remains selected, trying to trigger buttons, toggles, doesn’t work.
4. If your form is long and scrolls, clicking a button at the bottom will scroll you back to the still selected field.
5. To trigger a button/toggle/radio deck etc. you have to double click quickly, which apparentetly breaks through the focus issue (however only for that click).

I’ve tracked this down to the `tabindex="0"` on the relation manager when multiple relation managers are used. The tabindex seems to be conflicting with the modal's focusing. 

This is probably some type of conflict/bug with livewire or alpine.js's focus trap, as `tabindex="0"` has been in core for more than 2 years. But ultimately, I'm unsure as to why `tabindex="0"` is used at all. You can already tab to the RM's buttons/links without it. And Filament doesn't add tabindex to subnavigation groups for example. (That said I'm not an accesibility expert either).

This is only an issue when multiple relation managers (or relation manager groups) are on the page (ie when the tab navigation component is displayed). Displaying a single relation manager or single relation manager group doesn't cause this issue as `tabindex="0"` is only added conditionaly when more than one RM are displayed via tabs.

I did try rolling back filament and livewire as far as I could go and still ran into this issue so not sure what version of filament/livewire/alpine this was introduced in

## Visual changes
Here's a video of the issue from Filament's demo page, but this issue has also been confirmed in our production app, as well as my plugin demo app.

https://github.com/user-attachments/assets/9992d084-0dc0-4a13-9f4d-548bd53f261e


## Functional changes
This PR just removes `tabindex="0"` from the conditional. 

I've also tested that:
1. The relation manager's actions, links, etc. can still be tabbed to,
2. When opening a modal, the autofocus is still applied to the first element, 
3. Focus trapping still works. 
4. `->modalAutoFocus(false)` also continues to work

If there is a better way to handle this then let me know. 

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.

After doing some more investigating this should also address and close https://github.com/filamentphp/filament/issues/15289, https://github.com/filamentphp/filament/issues/14999, https://github.com/filamentphp/filament/issues/14913

There could be other issues out there, but that's as far as I looked.
