### PR TITLE
Fix: Allow to override ExportFormat with custom enum instance

### DIFF
--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -5,6 +5,7 @@ namespace Filament\Actions\Concerns;
 use AnourValar\EloquentSerialize\Facades\EloquentSerializeFacade;
 use Closure;
 use Filament\Actions\ExportAction;
+use Filament\Actions\Exports\Enums\Contracts\ExportFormat as ExportFormatInterface;
 use Filament\Actions\Exports\Enums\ExportFormat;
 use Filament\Actions\Exports\ExportColumn;
 use Filament\Actions\Exports\Exporter;
@@ -54,7 +55,7 @@ trait CanExportRecords
     protected string | Closure | null $fileName = null;
 
     /**
-     * @var array<ExportFormat> | Closure | null
+     * @var array<ExportFormatInterface> | Closure | null
      */
     protected array | Closure | null $formats = null;
 
@@ -382,7 +383,7 @@ trait CanExportRecords
     }
 
     /**
-     * @param  array<ExportFormat> | Closure | null  $formats
+     * @param  array<ExportFormatInterface> | Closure | null  $formats
      */
     public function formats(array | Closure | null $formats): static
     {
@@ -392,7 +393,7 @@ trait CanExportRecords
     }
 
     /**
-     * @return array<ExportFormat> | null
+     * @return array<ExportFormatInterface> | null
      */
     public function getFormats(): ?array
     {

--- a/packages/actions/src/Exports/Contracts/ExportEnum.php
+++ b/packages/actions/src/Exports/Contracts/ExportEnum.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Filament\Actions\Exports\Contracts;
+
+use Filament\Actions\Exports\Downloaders\Contracts\Downloader;
+use Filament\Actions\Exports\Models\Export;
+use Filament\Notifications\Actions\Action as NotificationAction;
+
+interface ExportEnum
+{
+    public function getDownloader(): Downloader;
+
+    public function getDownloadNotificationAction(Export $export): NotificationAction;
+}

--- a/packages/actions/src/Exports/Enums/Contracts/ExportFormat.php
+++ b/packages/actions/src/Exports/Enums/Contracts/ExportFormat.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Filament\Actions\Exports\Contracts;
+namespace Filament\Actions\Exports\Enums\Contracts;
 
 use Filament\Actions\Exports\Downloaders\Contracts\Downloader;
 use Filament\Actions\Exports\Models\Export;
 use Filament\Notifications\Actions\Action as NotificationAction;
 
-interface ExportEnum
+interface ExportFormat
 {
     public function getDownloader(): Downloader;
 

--- a/packages/actions/src/Exports/Enums/ExportFormat.php
+++ b/packages/actions/src/Exports/Enums/ExportFormat.php
@@ -2,13 +2,14 @@
 
 namespace Filament\Actions\Exports\Enums;
 
+use Filament\Actions\Exports\Contracts\ExportEnum;
 use Filament\Actions\Exports\Downloaders\Contracts\Downloader;
 use Filament\Actions\Exports\Downloaders\CsvDownloader;
 use Filament\Actions\Exports\Downloaders\XlsxDownloader;
 use Filament\Actions\Exports\Models\Export;
 use Filament\Notifications\Actions\Action as NotificationAction;
 
-enum ExportFormat: string
+enum ExportFormat: string implements ExportEnum
 {
     case Csv = 'csv';
 

--- a/packages/actions/src/Exports/Enums/ExportFormat.php
+++ b/packages/actions/src/Exports/Enums/ExportFormat.php
@@ -2,14 +2,14 @@
 
 namespace Filament\Actions\Exports\Enums;
 
-use Filament\Actions\Exports\Contracts\ExportEnum;
+use Filament\Actions\Exports\Enums\Contracts\ExportFormat as ExportFormatEnum;
 use Filament\Actions\Exports\Downloaders\Contracts\Downloader;
 use Filament\Actions\Exports\Downloaders\CsvDownloader;
 use Filament\Actions\Exports\Downloaders\XlsxDownloader;
 use Filament\Actions\Exports\Models\Export;
 use Filament\Notifications\Actions\Action as NotificationAction;
 
-enum ExportFormat: string implements ExportEnum
+enum ExportFormat: string implements ExportFormatEnum
 {
     case Csv = 'csv';
 

--- a/packages/actions/src/Exports/Enums/ExportFormat.php
+++ b/packages/actions/src/Exports/Enums/ExportFormat.php
@@ -2,14 +2,14 @@
 
 namespace Filament\Actions\Exports\Enums;
 
-use Filament\Actions\Exports\Enums\Contracts\ExportFormat as ExportFormatEnum;
 use Filament\Actions\Exports\Downloaders\Contracts\Downloader;
 use Filament\Actions\Exports\Downloaders\CsvDownloader;
 use Filament\Actions\Exports\Downloaders\XlsxDownloader;
+use Filament\Actions\Exports\Enums\Contracts\ExportFormat as ExportFormatInterface;
 use Filament\Actions\Exports\Models\Export;
 use Filament\Notifications\Actions\Action as NotificationAction;
 
-enum ExportFormat: string implements ExportFormatEnum
+enum ExportFormat: string implements ExportFormatInterface
 {
     case Csv = 'csv';
 

--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -3,6 +3,7 @@
 namespace Filament\Actions\Exports;
 
 use Carbon\CarbonInterface;
+use Filament\Actions\Exports\Enums\Contracts\ExportFormat as ExportFormatInterface;
 use Filament\Actions\Exports\Enums\ExportFormat;
 use Filament\Actions\Exports\Models\Export;
 use Filament\Forms\Components\Component;
@@ -172,7 +173,7 @@ abstract class Exporter
     }
 
     /**
-     * @return array<ExportFormat>
+     * @return array<ExportFormatInterface>
      */
     public function getFormats(): array
     {

--- a/packages/actions/src/Exports/Http/Controllers/DownloadExport.php
+++ b/packages/actions/src/Exports/Http/Controllers/DownloadExport.php
@@ -21,14 +21,14 @@ class DownloadExport
             abort_unless($export->user()->is(auth()->user()), 403);
         }
 
-        $format = $this->getFormatFromRequest($request);
+        $format = $this->resolveFormatFromRequest($request);
 
         abort_unless($format !== null, 404);
 
         return $format->getDownloader()($export);
     }
 
-     protected function getFormatFromRequest(Request $request): ?ExportFormatInterface
+     protected function resolveFormatFromRequest(Request $request): ?ExportFormatInterface
      {
         return ExportFormat::tryFrom($request->query('format'));
      }

--- a/packages/actions/src/Exports/Http/Controllers/DownloadExport.php
+++ b/packages/actions/src/Exports/Http/Controllers/DownloadExport.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Actions\Exports\Http\Controllers;
 
+use Filament\Actions\Exports\Enums\Contracts\ExportFormat as ExportFormatInterface;
 use Filament\Actions\Exports\Enums\ExportFormat;
 use Filament\Actions\Exports\Models\Export;
 use Illuminate\Http\Request;
@@ -20,10 +21,15 @@ class DownloadExport
             abort_unless($export->user()->is(auth()->user()), 403);
         }
 
-        $format = ExportFormat::tryFrom($request->query('format'));
+        $format = $this->getFormatFromRequest($request);
 
         abort_unless($format !== null, 404);
 
         return $format->getDownloader()($export);
     }
+
+     protected function getFormatFromRequest(Request $request): ?ExportFormatInterface
+     {
+        return ExportFormat::tryFrom($request->query('format'));
+     }
 }

--- a/packages/actions/src/Exports/Jobs/ExportCompletion.php
+++ b/packages/actions/src/Exports/Jobs/ExportCompletion.php
@@ -2,7 +2,7 @@
 
 namespace Filament\Actions\Exports\Jobs;
 
-use Filament\Actions\Exports\Contracts\ExportEnum;
+use Filament\Actions\Exports\Enums\Contracts\ExportFormat;
 use Filament\Actions\Exports\Exporter;
 use Filament\Actions\Exports\Models\Export;
 use Filament\Notifications\Actions\Action as NotificationAction;
@@ -27,7 +27,7 @@ class ExportCompletion implements ShouldQueue
 
     /**
      * @param  array<string, string>  $columnMap
-     * @param  array<ExportEnum>  $formats
+     * @param  array<ExportFormat>  $formats
      * @param  array<string, mixed>  $options
      */
     public function __construct(
@@ -70,7 +70,7 @@ class ExportCompletion implements ShouldQueue
             ->when(
                 $failedRowsCount < $this->export->total_rows,
                 fn (Notification $notification) => $notification->actions(array_map(
-                    fn (ExportEnum $format): NotificationAction => $format->getDownloadNotificationAction($this->export),
+                    fn (ExportFormat $format): NotificationAction => $format->getDownloadNotificationAction($this->export),
                     $this->formats,
                 )),
             )

--- a/packages/actions/src/Exports/Jobs/ExportCompletion.php
+++ b/packages/actions/src/Exports/Jobs/ExportCompletion.php
@@ -2,7 +2,7 @@
 
 namespace Filament\Actions\Exports\Jobs;
 
-use Filament\Actions\Exports\Enums\ExportFormat;
+use Filament\Actions\Exports\Contracts\ExportEnum;
 use Filament\Actions\Exports\Exporter;
 use Filament\Actions\Exports\Models\Export;
 use Filament\Notifications\Actions\Action as NotificationAction;
@@ -27,7 +27,7 @@ class ExportCompletion implements ShouldQueue
 
     /**
      * @param  array<string, string>  $columnMap
-     * @param  array<ExportFormat>  $formats
+     * @param  array<ExportEnum>  $formats
      * @param  array<string, mixed>  $options
      */
     public function __construct(
@@ -70,7 +70,7 @@ class ExportCompletion implements ShouldQueue
             ->when(
                 $failedRowsCount < $this->export->total_rows,
                 fn (Notification $notification) => $notification->actions(array_map(
-                    fn (ExportFormat $format): NotificationAction => $format->getDownloadNotificationAction($this->export),
+                    fn (ExportEnum $format): NotificationAction => $format->getDownloadNotificationAction($this->export),
                     $this->formats,
                 )),
             )


### PR DESCRIPTION
## Description
This code allow to override the ExportFormat enum by implementing a common interface on a new enum.
This allows the developer to create a custom exporter with other formats than the default specified in ExportFormat enum.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
