### PR TITLE
Fix: QueryBuilder's TextConstraint for Postgres

### DIFF
--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/ContainsOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/ContainsOperator.php
@@ -61,12 +61,18 @@ class ContainsOperator extends Operator
 
         $isPostgres = $databaseConnection->getDriverName() === 'pgsql';
 
-        if ((Str::lower($qualifiedColumn) !== $qualifiedColumn) && $isPostgres) {
-            $qualifiedColumn = (string) str($qualifiedColumn)->wrap('"');
-        }
-
         if ($isPostgres) {
-            $qualifiedColumn = new Expression("lower({$qualifiedColumn}::text)");
+            [$table, $column] = explode('.', $qualifiedColumn);
+
+            if (Str::lower($table) !== $table) {
+                $table = (string) str($table)->wrap('"');
+            }
+
+            if (Str::lower($column) !== $column) {
+                $column = (string) str($column)->wrap('"');
+            }
+
+            $qualifiedColumn = new Expression("lower({$table}.{$column}::text)");
             $text = Str::lower($text);
         }
 

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EndsWithOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EndsWithOperator.php
@@ -61,12 +61,18 @@ class EndsWithOperator extends Operator
 
         $isPostgres = $databaseConnection->getDriverName() === 'pgsql';
 
-        if ((Str::lower($qualifiedColumn) !== $qualifiedColumn) && $isPostgres) {
-            $qualifiedColumn = (string) str($qualifiedColumn)->wrap('"');
-        }
-
         if ($isPostgres) {
-            $qualifiedColumn = new Expression("lower({$qualifiedColumn}::text)");
+            [$table, $column] = explode('.', $qualifiedColumn);
+
+            if (Str::lower($table) !== $table) {
+                $table = (string) str($table)->wrap('"');
+            }
+
+            if (Str::lower($column) !== $column) {
+                $column = (string) str($column)->wrap('"');
+            }
+
+            $qualifiedColumn = new Expression("lower({$table}.{$column}::text)");
             $text = Str::lower($text);
         }
 

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EqualsOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EqualsOperator.php
@@ -61,12 +61,18 @@ class EqualsOperator extends Operator
 
         $isPostgres = $databaseConnection->getDriverName() === 'pgsql';
 
-        if ((Str::lower($qualifiedColumn) !== $qualifiedColumn) && $isPostgres) {
-            $qualifiedColumn = (string) str($qualifiedColumn)->wrap('"');
-        }
-
         if ($isPostgres) {
-            $qualifiedColumn = new Expression("lower({$qualifiedColumn}::text)");
+            [$table, $column] = explode('.', $qualifiedColumn);
+
+            if (Str::lower($table) !== $table) {
+                $table = (string) str($table)->wrap('"');
+            }
+
+            if (Str::lower($column) !== $column) {
+                $column = (string) str($column)->wrap('"');
+            }
+
+            $qualifiedColumn = new Expression("lower({$table}.{$column}::text)");
             $text = Str::lower($text);
         }
 

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/StartsWithOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/StartsWithOperator.php
@@ -61,12 +61,18 @@ class StartsWithOperator extends Operator
 
         $isPostgres = $databaseConnection->getDriverName() === 'pgsql';
 
-        if ((Str::lower($qualifiedColumn) !== $qualifiedColumn) && $isPostgres) {
-            $qualifiedColumn = (string) str($qualifiedColumn)->wrap('"');
-        }
-
         if ($isPostgres) {
-            $qualifiedColumn = new Expression("lower({$qualifiedColumn}::text)");
+            [$table, $column] = explode('.', $qualifiedColumn);
+
+            if (Str::lower($table) !== $table) {
+                $table = (string) str($table)->wrap('"');
+            }
+
+            if (Str::lower($column) !== $column) {
+                $column = (string) str($column)->wrap('"');
+            }
+
+            $qualifiedColumn = new Expression("lower({$table}.{$column}::text)");
             $text = Str::lower($text);
         }
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When a table name or column name contains uppercase letters, both table name and column name gets wrapped between double quotes inside any `TextContraint` operator.

for example: `Flight` table name with `code` field name becomes `"Flight.code"` which results in column not found error. Instead, it should be `"Flight".code`, and if column name contains uppercase letters, it should be `"Flight"."Code"`.

Example error: ```Undefined column: 7 ERROR:  column "Flight.code" does not exist
LINE 1: ...count(*) as aggregate from "Flight" where (lower("Flight.c...
                                                             ^ (Connection: pgsql, SQL: select count(*) as aggregate from "Flight" where (lower("Flight.code"::text)::text like search_string%))```

It might not be very common when it comes to Laravel naming conventions, but I encountered this issue while building a dashboard for an app that was initially developed with Next.js and prisma, where this naming convention is common.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
