### PR TITLE
Add ID attribute required for collapsed blade section component

### DIFF
--- a/packages/support/docs/09-blade-components/02-section.md
+++ b/packages/support/docs/09-blade-components/02-section.md
@@ -127,12 +127,13 @@ You can make the content of a section collapsible by using the `collapsible` att
 
 ### Making a section collapsed by default
 
-You can make a section collapsed by default by using the `collapsed` attribute:
+You can make a section collapsed by default by using the `collapsed` attribute, ensuring you also add an `id` attribute:
 
 ```blade
 <x-filament::section
     collapsible
     collapsed
+    id="user-details"
 >
     <x-slot name="heading">
         User details


### PR DESCRIPTION
The Section Blade Component attribute of `collapsed`, only works if there is also `id` provided

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The Section Blade Component attribute of `collapsed`, only works if there is also `id` provided

## Visual changes

n\a edited on GH

## Functional changes

- [ n\a edited on GH] Code style has been fixed by running the `composer cs` command.
- [ n\a edited on GH] Changes have been tested to not break existing functionality.
- [n\a edited on GH ] Documentation is up-to-date.
