### PR TITLE
Add override possibility to page aware widgets

### DIFF
--- a/packages/panels/src/Widgets/Concerns/InteractsWithPageTable.php
+++ b/packages/panels/src/Widgets/Concerns/InteractsWithPageTable.php
@@ -60,6 +60,11 @@ trait InteractsWithPageTable
         throw new Exception('You must define a `getTablePage()` method on your widget that returns the name of a Livewire component.');
     }
 
+    protected function getTablePageMountParameters(): array
+    {
+        return [];
+    }
+
     protected function getTablePageInstance(): HasTable
     {
         if (isset($this->tablePage)) {
@@ -68,7 +73,7 @@ trait InteractsWithPageTable
 
         /** @var HasTable $tableComponent */
         $page = app('livewire')->new($this->getTablePage());
-        trigger('mount', $page, [], null, null);
+        trigger('mount', $page, $this->getTablePageMountParameters(), null, null);
 
         $page->activeTab = $this->activeTab;
         $page->paginators = $this->paginators;

--- a/packages/panels/src/Widgets/Concerns/InteractsWithPageTable.php
+++ b/packages/panels/src/Widgets/Concerns/InteractsWithPageTable.php
@@ -60,6 +60,9 @@ trait InteractsWithPageTable
         throw new Exception('You must define a `getTablePage()` method on your widget that returns the name of a Livewire component.');
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     protected function getTablePageMountParameters(): array
     {
         return [];


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

For some resource list pages, I have extra logic and parameters in the `mount` method. In order for widgets to be able to render correctly, some data has to be passed into the mount method params. This makes it possible to implement this logic easily.

## Visual changes

None.

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
