### PR TITLE
Fix: pin tailwindcss to version 3 in artisan command `make:filament-theme`

### DIFF
--- a/packages/actions/docs/01-installation.md
+++ b/packages/actions/docs/01-installation.md
@@ -47,7 +47,7 @@ php artisan filament:install --actions
 Run the following command to install Tailwind CSS with the Tailwind Forms and Typography plugins:
 
 ```bash
-npm install tailwindcss @tailwindcss/forms @tailwindcss/typography postcss postcss-nesting autoprefixer --save-dev
+npm install tailwindcss@3 @tailwindcss/forms @tailwindcss/typography postcss postcss-nesting autoprefixer --save-dev
 ```
 
 Create a new `tailwind.config.js` file and add the Filament `preset` *(includes the Filament color scheme and the required Tailwind plugins)*:

--- a/packages/forms/docs/01-installation.md
+++ b/packages/forms/docs/01-installation.md
@@ -47,7 +47,7 @@ php artisan filament:install --forms
 Run the following command to install Tailwind CSS with the Tailwind Forms and Typography plugins:
 
 ```bash
-npm install tailwindcss @tailwindcss/forms @tailwindcss/typography postcss postcss-nesting autoprefixer --save-dev
+npm install tailwindcss@3 @tailwindcss/forms @tailwindcss/typography postcss postcss-nesting autoprefixer --save-dev
 ```
 
 Create a new `tailwind.config.js` file and add the Filament `preset` *(includes the Filament color scheme and the required Tailwind plugins)*:

--- a/packages/infolists/docs/01-installation.md
+++ b/packages/infolists/docs/01-installation.md
@@ -47,7 +47,7 @@ php artisan filament:install --infolists
 Run the following command to install Tailwind CSS with the Tailwind Forms and Typography plugins:
 
 ```bash
-npm install tailwindcss @tailwindcss/forms @tailwindcss/typography postcss postcss-nesting autoprefixer --save-dev
+npm install tailwindcss@3 @tailwindcss/forms @tailwindcss/typography postcss postcss-nesting autoprefixer --save-dev
 ```
 
 Create a new `tailwind.config.js` file and add the Filament `preset` *(includes the Filament color scheme and the required Tailwind plugins)*:

--- a/packages/notifications/docs/01-installation.md
+++ b/packages/notifications/docs/01-installation.md
@@ -45,7 +45,7 @@ php artisan filament:install --notifications
 Run the following command to install Tailwind CSS with the Tailwind Forms and Typography plugins:
 
 ```bash
-npm install tailwindcss @tailwindcss/forms @tailwindcss/typography postcss postcss-nesting autoprefixer --save-dev
+npm install tailwindcss@3 @tailwindcss/forms @tailwindcss/typography postcss postcss-nesting autoprefixer --save-dev
 ```
 
 Create a new `tailwind.config.js` file and add the Filament `preset` *(includes the Filament color scheme and the required Tailwind plugins)*:

--- a/packages/panels/src/Commands/MakeThemeCommand.php
+++ b/packages/panels/src/Commands/MakeThemeCommand.php
@@ -40,7 +40,7 @@ class MakeThemeCommand extends Command
             default => "{$pm} install",
         };
 
-        exec("{$installCommand} tailwindcss @tailwindcss/forms @tailwindcss/typography postcss postcss-nesting autoprefixer --save-dev");
+        exec("{$installCommand} tailwindcss@3 @tailwindcss/forms @tailwindcss/typography postcss postcss-nesting autoprefixer --save-dev");
 
         $panel = $this->argument('panel');
 

--- a/packages/tables/docs/01-installation.md
+++ b/packages/tables/docs/01-installation.md
@@ -47,7 +47,7 @@ php artisan filament:install --tables
 Run the following command to install Tailwind CSS with the Tailwind Forms and Typography plugins:
 
 ```bash
-npm install tailwindcss @tailwindcss/forms @tailwindcss/typography postcss postcss-nesting autoprefixer --save-dev
+npm install tailwindcss@3 @tailwindcss/forms @tailwindcss/typography postcss postcss-nesting autoprefixer --save-dev
 ```
 
 Create a new `tailwind.config.js` file and add the Filament `preset` *(includes the Filament color scheme and the required Tailwind plugins)*:

--- a/packages/widgets/docs/01-installation.md
+++ b/packages/widgets/docs/01-installation.md
@@ -47,7 +47,7 @@ php artisan filament:install --widgets
 Run the following command to install Tailwind CSS with the Tailwind Forms and Typography plugins:
 
 ```bash
-npm install tailwindcss @tailwindcss/forms @tailwindcss/typography postcss postcss-nesting autoprefixer --save-dev
+npm install tailwindcss@3 @tailwindcss/forms @tailwindcss/typography postcss postcss-nesting autoprefixer --save-dev
 ```
 
 Create a new `tailwind.config.js` file and add the Filament `preset` *(includes the Filament color scheme and the required Tailwind plugins)*:


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
<!-- Describe the addressed issue or the need for the new or updated functionality. -->
Before the changes the artisan command `make:filament-theme` would install the latest tailwindcss version which is the 4.0.0 at the current date, this would create an incompatibility as filament 3 uses tailwindcss 3 and there are some breaking changes in the syntax and plugins of this newest version of tailwindcss.

Trying to run `npm run build` or `npm run dev` with tailwindcss 4.0.0 installed would result in an error like this:

```
[vite:css] Failed to load PostCSS config (searchPath: D:/folder/subfolder/filament-project): [Error] Loading PostCSS Plugin failed: Package subpath './nesting' is not defined by "exports" in D:\folder\subfolder\filament-project\node_modules\tailwindcss\package.json

Error: Loading PostCSS Plugin failed: Package subpath './nesting' is not defined by "exports" in D:\folder\subfolder\filament-project\node_modules\tailwindcss\package.json

(@D:\folder\subfolder\filament-project\postcss.config.js)
    at load (file:///D:/folder/subfolder/filament-project/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:33602:11)       
    at file:///D:/folder/subfolder/filament-project/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:33627:16
    at Array.map (<anonymous>)
    at plugins (file:///D:/folder/subfolder/filament-project/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:33626:8)     
    at processResult (file:///D:/folder/subfolder/filament-project/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:33696:14)
    at file:///D:/folder/subfolder/filament-project/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:33826:14
file: D:\folder\subfolder\filament-project\resources\css\filament\admin\theme.css
```
## Functional changes

- [ ] Updated the artisan command `make:filament-theme` to explicitly install tailwindcss@3
- [ ] Ensures compatibility and avoids potential breaking changes from future versions

