### PR TITLE
docs: add Pest Livewire plugin installation instructions

### DIFF
--- a/packages/panels/docs/14-testing.md
+++ b/packages/panels/docs/14-testing.md
@@ -21,6 +21,13 @@ protected function setUp(): void
 }
 ```
 
+### Setting Up Pest for Livewire Testing
+Before using the livewire helper in your Pest tests, you need to install the Pest Livewire plugin. Run the following command:
+```
+composer require pestphp/pest-plugin-livewire --dev
+```
+This will enable the livewire helper function, allowing you to test Livewire components seamlessly.
+
 ### Testing multiple panels
 
 If you have multiple panels and you would like to test a non-default panel, you will need to tell Filament which panel you are testing. This can be done in the `setUp()` method of the test case, or you can do it at the start of a particular test. Filament usually does this in a middleware when you access the panel through a request, so if you're not making a request in your test like when testing a Livewire component, you need to set the current panel manually:


### PR DESCRIPTION
### Description

This PR adds clear instructions for setting up Pest with Livewire testing in the FilamentPHP documentation. Currently, the documentation assumes the `pest-plugin-livewire` package is already installed, which can lead to confusion and errors (e.g., `undefined method livewire`) for new learners. By including the installation command and a brief explanation, this PR ensures a smoother onboarding experience for developers.

### Why is this needed?

- **Missing Setup Instructions**: The current documentation does not mention the need to install the `pest-plugin-livewire` package, which is required for the `livewire` helper to work.
- **Helps New Learners**: Clear setup instructions will help beginners avoid common pitfalls and get started with testing in FilamentPHP more easily.
- **Improves Developer Experience**: Developers will spend less time debugging setup issues and more time writing tests.

### Visual Changes

N/A (This is a documentation update with no visual changes.)

### Functional Changes

- [x] Added installation instructions for the `pest-plugin-livewire` package.
- [x] Updated the testing example to include the necessary setup context.
- [x] Ensured the documentation is clear and beginner-friendly.

### Checklist

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.