### PR TITLE
Add keyBindings feature to Repeater field's addAction button

### DIFF
--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Support\Str;
+use Illuminate\Support\Arr;
 
 use function Filament\Forms\array_move_after;
 use function Filament\Forms\array_move_before;

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -32,6 +32,8 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
 
     protected string | Closure | null $addActionLabel = null;
 
+    protected string | array | Closure | null $addActionKeyBindings = null;
+
     protected string | Closure | null $addBetweenActionLabel = null;
 
     protected bool | Closure $isAddable = true;
@@ -166,6 +168,7 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
     {
         $action = Action::make($this->getAddActionName())
             ->label(fn (Repeater $component) => $component->getAddActionLabel())
+            ->keyBindings(fn (Repeater $component) => $component->getAddActionKeyBindings())
             ->color('gray')
             ->action(function (Repeater $component): void {
                 $newUuid = $component->generateUuid();
@@ -632,6 +635,13 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
         return $this;
     }
 
+    public function addActionKeyBindings(string | array | Closure | null $bindings): static
+    {
+        $this->addActionKeyBindings = $bindings;
+
+        return $this;
+    }
+
     /**
      * @deprecated Use `addActionLabel()` instead.
      */
@@ -818,6 +828,11 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
         return $this->evaluate($this->addActionLabel) ?? __('filament-forms::components.repeater.actions.add.label', [
             'label' => Str::lcfirst($this->getLabel()),
         ]);
+    }
+
+    public function getAddActionKeyBindings(): array
+    {
+        return $this->evaluate($this->addActionKeyBindings) ?? [];
     }
 
     public function isReorderable(): bool

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -32,6 +32,9 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
 
     protected string | Closure | null $addActionLabel = null;
 
+    /**
+     * @var string | array<string> | Closure | null
+     */
     protected string | array | Closure | null $addActionKeyBindings = null;
 
     protected string | Closure | null $addBetweenActionLabel = null;
@@ -635,6 +638,9 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
         return $this;
     }
 
+    /**
+     * @param  string | array<string> | Closure | null  $bindings
+     */
     public function addActionKeyBindings(string | array | Closure | null $bindings): static
     {
         $this->addActionKeyBindings = $bindings;
@@ -830,9 +836,14 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
         ]);
     }
 
-    public function getAddActionKeyBindings(): array
+    /**
+     * @return array<string> | null
+     */
+    public function getAddActionKeyBindings(): ?array
     {
-        return $this->evaluate($this->addActionKeyBindings) ?? [];
+        $keyBindings = Arr::wrap($this->evaluate($this->addActionKeyBindings));
+        
+        return count($keyBindings) ? $keyBindings : null;
     }
 
     public function isReorderable(): bool


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Add keyBindings feature to Repeater field's addAction button

## Visual changes

![image](https://github.com/user-attachments/assets/03660ea5-f4b3-4c15-8055-cbf56380a874)

https://github.com/user-attachments/assets/9da97348-5c4c-4132-b0ae-2d4a124e30a2

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
