### PR TITLE
Feature: Allow TextColumn size property to apply when badge() is used

### DIFF
--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -23,6 +23,7 @@
     'target' => null,
     'tooltip' => null,
     'type' => 'button',
+    'textSize' => null,
 ])
 
 @php
@@ -162,7 +163,7 @@
     @endif
 
     <span class="grid">
-        <span class="truncate">
+        <span @class(["truncate", $textSize])>
             {{ $slot }}
         </span>
     </span>

--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -192,6 +192,13 @@
                                 :color="$color"
                                 :icon="$icon"
                                 :icon-position="$iconPosition"
+                                :text-size="match ($size) {
+                                            TextColumnSize::ExtraSmall, 'xs', null => 'text-xs',
+                                            TextColumnSize::Small, 'sm' => 'text-sm',
+                                            TextColumnSize::Medium, 'base', 'md' => 'text-base',
+                                            TextColumnSize::Large, 'lg' => 'text-lg',
+                                            default => $size,
+                                        },"
                             >
                                 {{ $formattedState }}
                             </x-filament::badge>


### PR DESCRIPTION

## Description

TextColumn's `size()` property was not taking effect when `badge()` was applied. This happened because `badge()` and `size()` are handled as different components.

Now, the `size()` property will correctly apply, even when `badge()` is used. the extras `TextColumnSize::ExtraSmall` is set as default as it is right now with one size.

```php
      Tables\Columns\TextColumn::make('priority.name')
                    ->badge()
                    ->color(fn($record) => Color::hex($record->priority->color))
                    ->size(TextColumnSize::Large)
```

## Visual changes

![Screenshot 2025-01-30 033235](https://github.com/user-attachments/assets/c9a9ad9d-7598-4a8c-857b-099cf79ea13a)

## Functional changes

- ✅ Code style has been fixed by running the `composer cs` command.
- ✅ Changes have been tested to not break existing functionality.
- ❌ Documentation is up-to-date.
