### PR TITLE
Hide Wizard Action buttons using x-bind:class instead of x-show so it…

### DIFF
--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -292,12 +292,12 @@
                     )
                 "
             @endif
-            x-show="! isLastStep()"
+            x-bind:class="{ 'hidden': isLastStep(), 'block': !isLastStep() }"
         >
             {{ $nextAction }}
         </span>
 
-        <span x-show="isLastStep()">
+        <span x-bind:class="{ 'hidden': !isLastStep(), 'block': isLastStep() }">
             {{ $getSubmitAction() }}
         </span>
     </div>


### PR DESCRIPTION
… works with hidden Steps

There was a bug with the action buttons in a wizard. When the last step of a wizard was hidden and then becomes visible, the **submit** button stays visible while it should be replaced by the **next** button.

This is due to an issue with `x-show`. Replacing it with `x-bind:class` makes it react to the changes correctly.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
When the hidden step became visible, users were unable to proceed to the next step using the action buttons.

## Functional changes
Updated the way action buttons are displayed in the Wizard component.

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
