### PR TITLE
Refactor Heroicon Icon Handling to Use Enums

### DIFF
--- a/docs-assets/app/app/Livewire/ActionsDemo.php
+++ b/docs-assets/app/app/Livewire/ActionsDemo.php
@@ -12,6 +12,7 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Schemas\Components\Wizard\Step;
 use Filament\Support\Enums\ActionSize;
 use Filament\Support\Enums\IconPosition;
+use Filament\Support\Icons\Heroicon;
 use Livewire\Component;
 
 class ActionsDemo extends Component implements HasActions, HasForms
@@ -36,7 +37,7 @@ class ActionsDemo extends Component implements HasActions, HasForms
     public function iconButtonAction(): Action
     {
         return Action::make('iconButton')
-            ->icon('heroicon-m-pencil-square')
+            ->icon(Heroicon::PencilSquare)
             ->iconButton();
     }
 
@@ -65,14 +66,14 @@ class ActionsDemo extends Component implements HasActions, HasForms
     {
         return Action::make('icon')
             ->label('Edit')
-            ->icon('heroicon-m-pencil-square');
+            ->icon(Heroicon::PencilSquare);
     }
 
     public function iconAfterAction(): Action
     {
         return Action::make('iconAfter')
             ->label('Edit')
-            ->icon('heroicon-m-pencil-square')
+            ->icon(Heroicon::PencilSquare)
             ->iconPosition(IconPosition::After);
     }
 
@@ -80,7 +81,7 @@ class ActionsDemo extends Component implements HasActions, HasForms
     {
         return Action::make('badged')
             ->iconButton()
-            ->icon('heroicon-m-funnel')
+            ->icon(Heroicon::Funnel)
             ->badge(5);
     }
 
@@ -88,7 +89,7 @@ class ActionsDemo extends Component implements HasActions, HasForms
     {
         return Action::make('successBadged')
             ->iconButton()
-            ->icon('heroicon-m-funnel')
+            ->icon(Heroicon::Funnel)
             ->badge(5)
             ->badgeColor('success');
     }
@@ -129,7 +130,7 @@ class ActionsDemo extends Component implements HasActions, HasForms
             ->color('danger')
             ->requiresConfirmation()
             ->action(fn () => null)
-            ->modalIcon('heroicon-o-trash');
+            ->modalIcon(Heroicon::OutlinedTrash);
     }
 
     public function modalFormAction(): Action

--- a/docs-assets/app/app/Livewire/Forms/FieldsDemo.php
+++ b/docs-assets/app/app/Livewire/Forms/FieldsDemo.php
@@ -28,6 +28,7 @@ use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Schemas\Components\Group;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\HtmlString;
 use Livewire\Component;
 
@@ -110,7 +111,7 @@ class FieldsDemo extends Component implements HasActions, HasForms
                         TextInput::make('textInputSuffixIcon')
                             ->label('Domain')
                             ->default('https://filamentphp.com')
-                            ->suffixIcon('heroicon-m-globe-alt'),
+                            ->suffixIcon(Heroicon::GlobeAlt),
                     ]),
                 Group::make()
                     ->id('textInputRevealablePassword')
@@ -264,7 +265,7 @@ class FieldsDemo extends Component implements HasActions, HasForms
                             ->options([
                                 'filament' => 'filamentphp',
                             ])
-                            ->suffixIcon('heroicon-m-globe-alt'),
+                            ->suffixIcon(Heroicon::GlobeAlt),
                     ]),
                 Group::make()
                     ->id('checkbox')
@@ -312,8 +313,8 @@ class FieldsDemo extends Component implements HasActions, HasForms
                     ->schema([
                         Toggle::make('toggleIcons')
                             ->label('Is admin')
-                            ->onIcon('heroicon-m-bolt')
-                            ->offIcon('heroicon-m-user'),
+                            ->onIcon(Heroicon::Bolt)
+                            ->offIcon(Heroicon::User),
                     ]),
                 Group::make()
                     ->id('toggleOffColor')
@@ -628,7 +629,7 @@ class FieldsDemo extends Component implements HasActions, HasForms
                     ->schema([
                         TimePicker::make('dateTimePickerPrefixIcon')
                             ->label('At')
-                            ->prefixIcon('heroicon-m-play')
+                            ->prefixIcon(Heroicon::Play)
                             ->default('2000-01-01'),
                     ]),
                 Group::make()
@@ -978,9 +979,9 @@ class FieldsDemo extends Component implements HasActions, HasForms
                                             ->label('Paragraph')
                                             ->required(),
                                     ])
-                                    ->icon('heroicon-m-bars-3-bottom-left'),
+                                    ->icon(Heroicon::Bars3BottomLeft),
                                 Builder\Block::make('image')
-                                    ->icon('heroicon-m-photo'),
+                                    ->icon(Heroicon::Photo),
                             ])
                             ->default([
                                 [
@@ -1006,7 +1007,7 @@ class FieldsDemo extends Component implements HasActions, HasForms
                                             ->label('Paragraph')
                                             ->required(),
                                     ])
-                                    ->icon('heroicon-m-bars-3-bottom-left'),
+                                    ->icon(Heroicon::Bars3BottomLeft),
                             ])
                             ->default([
                                 [
@@ -1045,7 +1046,7 @@ class FieldsDemo extends Component implements HasActions, HasForms
                                             ->label('Paragraph')
                                             ->required(),
                                     ])
-                                    ->icon('heroicon-m-bars-3-bottom-left'),
+                                    ->icon(Heroicon::Bars3BottomLeft),
                             ])
                             ->default([
                                 [
@@ -1084,7 +1085,7 @@ class FieldsDemo extends Component implements HasActions, HasForms
                                             ->label('Paragraph')
                                             ->required(),
                                     ])
-                                    ->icon('heroicon-m-bars-3-bottom-left'),
+                                    ->icon(Heroicon::Bars3BottomLeft),
                             ])
                             ->default([
                                 [
@@ -1216,9 +1217,9 @@ class FieldsDemo extends Component implements HasActions, HasForms
                                 'published' => 'Published',
                             ])
                             ->icons([
-                                'draft' => 'heroicon-o-pencil',
-                                'scheduled' => 'heroicon-o-clock',
-                                'published' => 'heroicon-o-check-circle',
+                                'draft' => Heroicon::OutlinedPencil,
+                                'scheduled' => Heroicon::OutlinedClock,
+                                'published' => Heroicon::OutlinedCheckCircle,
                             ])
                             ->default('scheduled'),
                     ]),
@@ -1337,7 +1338,7 @@ class FieldsDemo extends Component implements HasActions, HasForms
                             ->default('22.66')
                             ->suffixAction(
                                 Action::make('copyCostToPrice')
-                                    ->icon('heroicon-m-clipboard'),
+                                    ->icon(Heroicon::Clipboard),
                             ),
                     ]),
             ]);

--- a/docs-assets/app/app/Livewire/Infolists/EntriesDemo.php
+++ b/docs-assets/app/app/Livewire/Infolists/EntriesDemo.php
@@ -199,7 +199,7 @@ class EntriesDemo extends Component implements HasInfolists
                     ->schema([
                         IconEntry::make('status')
                             ->state('reviewing')
-                            ->icon(fn (string $state): string => match ($state) {
+                            ->icon(fn (string $state): Heroicon => match ($state) {
                                 'draft' => Heroicon::OutlinedPencil,
                                 'reviewing' => Heroicon::OutlinedClock,
                                 'published' => Heroicon::OutlinedCheckCircle,

--- a/docs-assets/app/app/Livewire/Infolists/EntriesDemo.php
+++ b/docs-assets/app/app/Livewire/Infolists/EntriesDemo.php
@@ -17,6 +17,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Enums\FontFamily;
 use Filament\Support\Enums\FontWeight;
 use Filament\Support\Enums\IconPosition;
+use Filament\Support\Icons\Heroicon;
 use Livewire\Component;
 
 class EntriesDemo extends Component implements HasInfolists
@@ -122,7 +123,7 @@ class EntriesDemo extends Component implements HasInfolists
                     ->schema([
                         TextEntry::make('email')
                             ->state('dan@filamentphp.com')
-                            ->icon('heroicon-m-envelope'),
+                            ->icon(Heroicon::Envelope),
                     ]),
                 Group::make()
                     ->id('textIconAfter')
@@ -132,7 +133,7 @@ class EntriesDemo extends Component implements HasInfolists
                     ->schema([
                         TextEntry::make('email')
                             ->state('dan@filamentphp.com')
-                            ->icon('heroicon-m-envelope')
+                            ->icon(Heroicon::Envelope)
                             ->iconPosition(IconPosition::After),
                     ]),
                 Group::make()
@@ -143,7 +144,7 @@ class EntriesDemo extends Component implements HasInfolists
                     ->schema([
                         TextEntry::make('email')
                             ->state('dan@filamentphp.com')
-                            ->icon('heroicon-m-envelope')
+                            ->icon(Heroicon::Envelope)
                             ->iconColor('primary'),
                     ]),
                 Group::make()
@@ -199,9 +200,9 @@ class EntriesDemo extends Component implements HasInfolists
                         IconEntry::make('status')
                             ->state('reviewing')
                             ->icon(fn (string $state): string => match ($state) {
-                                'draft' => 'heroicon-o-pencil',
-                                'reviewing' => 'heroicon-o-clock',
-                                'published' => 'heroicon-o-check-circle',
+                                'draft' => Heroicon::OutlinedPencil,
+                                'reviewing' => Heroicon::OutlinedClock,
+                                'published' => Heroicon::OutlinedCheckCircle,
                             }),
                     ]),
                 Group::make()
@@ -212,10 +213,10 @@ class EntriesDemo extends Component implements HasInfolists
                     ->schema([
                         IconEntry::make('status')
                             ->state('reviewing')
-                            ->icon(fn (string $state): string => match ($state) {
-                                'draft' => 'heroicon-o-pencil',
-                                'reviewing' => 'heroicon-o-clock',
-                                'published' => 'heroicon-o-check-circle',
+                            ->icon(fn (string $state): Heroicon => match ($state) {
+                                'draft' => Heroicon::OutlinedPencil,
+                                'reviewing' => Heroicon::OutlinedClock,
+                                'published' => Heroicon::OutlinedCheckCircle,
                             })
                             ->color(fn (string $state): string => match ($state) {
                                 'draft' => 'info',
@@ -232,10 +233,10 @@ class EntriesDemo extends Component implements HasInfolists
                     ->schema([
                         IconEntry::make('status')
                             ->state('reviewing')
-                            ->icon(fn (string $state): string => match ($state) {
-                                'draft' => 'heroicon-o-pencil',
-                                'reviewing' => 'heroicon-o-clock',
-                                'published' => 'heroicon-o-check-circle',
+                            ->icon(fn (string $state): Heroicon => match ($state) {
+                                'draft' => Heroicon::OutlinedPencil,
+                                'reviewing' => Heroicon::OutlinedClock,
+                                'published' => Heroicon::OutlinedCheckCircle,
                             })
                             ->color(fn (string $state): string => match ($state) {
                                 'draft' => 'danger',
@@ -267,13 +268,13 @@ class EntriesDemo extends Component implements HasInfolists
                         IconEntry::make('is_featured')
                             ->state(0)
                             ->boolean()
-                            ->trueIcon('heroicon-o-check-badge')
-                            ->falseIcon('heroicon-o-x-mark'),
+                            ->trueIcon(Heroicon::OutlinedCheckBadge)
+                            ->falseIcon(Heroicon::OutlinedXMark),
                         IconEntry::make('is_featured')
                             ->state(1)
                             ->boolean()
-                            ->trueIcon('heroicon-o-check-badge')
-                            ->falseIcon('heroicon-o-x-mark'),
+                            ->trueIcon(Heroicon::OutlinedCheckBadge)
+                            ->falseIcon(Heroicon::OutlinedXMark),
                     ]),
                 Group::make()
                     ->id('iconBooleanColor')
@@ -477,7 +478,7 @@ class EntriesDemo extends Component implements HasInfolists
                             ->default('22.66')
                             ->suffixAction(
                                 Action::make('copyCostToPrice')
-                                    ->icon('heroicon-m-clipboard'),
+                                    ->icon(Heroicon::Clipboard),
                             ),
                     ]),
             ])

--- a/docs-assets/app/app/Livewire/NotificationsDemo.php
+++ b/docs-assets/app/app/Livewire/NotificationsDemo.php
@@ -5,6 +5,7 @@ namespace App\Livewire;
 use App\Models\User;
 use Filament\Actions\Action;
 use Filament\Notifications\Notification;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Notifications\DatabaseNotification;
 use Livewire\Component;
 
@@ -31,7 +32,7 @@ class NotificationsDemo extends Component
     {
         Notification::make()
             ->title('Saved successfully')
-            ->icon('heroicon-o-document-text')
+            ->icon(Heroicon::OutlinedDocumentText)
             ->iconColor('success')
             ->send();
     }

--- a/docs-assets/app/app/Livewire/Schema/LayoutDemo.php
+++ b/docs-assets/app/app/Livewire/Schema/LayoutDemo.php
@@ -26,6 +26,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Enums\Alignment;
 use Filament\Support\Enums\IconPosition;
 use Filament\Support\Enums\VerticalAlignment;
+use Filament\Support\Icons\Heroicon;
 use Livewire\Component;
 
 class LayoutDemo extends Component implements HasActions, HasForms
@@ -104,7 +105,7 @@ class LayoutDemo extends Component implements HasActions, HasForms
                             ->statePath('tabsIcons')
                             ->schema([
                                 Tab::make('Notifications')
-                                    ->icon('heroicon-m-bell')
+                                    ->icon(Heroicon::Bell)
                                     ->schema([
                                         Checkbox::make('enabled')
                                             ->default(true),
@@ -115,9 +116,9 @@ class LayoutDemo extends Component implements HasActions, HasForms
                                             ]),
                                     ]),
                                 Tab::make('Security')
-                                    ->icon('heroicon-m-lock-closed'),
+                                    ->icon(Heroicon::LockClosed),
                                 Tab::make('Meta')
-                                    ->icon('heroicon-m-bars-3-center-left'),
+                                    ->icon(Heroicon::Bars3CenterLeft),
                             ]),
                     ]),
                 Group::make()
@@ -130,7 +131,7 @@ class LayoutDemo extends Component implements HasActions, HasForms
                             ->statePath('tabsIconsAfter')
                             ->schema([
                                 Tab::make('Notifications')
-                                    ->icon('heroicon-m-bell')
+                                    ->icon(Heroicon::Bell)
                                     ->iconPosition(IconPosition::After)
                                     ->schema([
                                         Checkbox::make('enabled')
@@ -142,10 +143,10 @@ class LayoutDemo extends Component implements HasActions, HasForms
                                             ]),
                                     ]),
                                 Tab::make('Security')
-                                    ->icon('heroicon-m-lock-closed')
+                                    ->icon(Heroicon::LockClosed)
                                     ->iconPosition(IconPosition::After),
                                 Tab::make('Meta')
-                                    ->icon('heroicon-m-bars-3-center-left')
+                                    ->icon(Heroicon::Bars3CenterLeft)
                                     ->iconPosition(IconPosition::After),
                             ]),
                     ]),
@@ -215,7 +216,7 @@ class LayoutDemo extends Component implements HasActions, HasForms
                     ->schema([
                         Wizard::make([
                             Wizard\Step::make('Order')
-                                ->icon('heroicon-m-shopping-bag')
+                                ->icon(Heroicon::ShoppingBag)
                                 ->schema([
                                     Repeater::make('items')
                                         ->hiddenLabel()
@@ -238,9 +239,9 @@ class LayoutDemo extends Component implements HasActions, HasForms
                                     Textarea::make('specialOrderNotes'),
                                 ]),
                             Wizard\Step::make('Delivery')
-                                ->icon('heroicon-m-truck'),
+                                ->icon(Heroicon::Truck),
                             Wizard\Step::make('Billing')
-                                ->icon('heroicon-m-credit-card'),
+                                ->icon(Heroicon::CreditCard),
                         ])
                             ->statePath('wizardIcons'),
                     ]),
@@ -252,14 +253,14 @@ class LayoutDemo extends Component implements HasActions, HasForms
                     ->schema([
                         Wizard::make([
                             Wizard\Step::make('Order')
-                                ->icon('heroicon-m-shopping-bag')
-                                ->completedIcon('heroicon-m-hand-thumb-up'),
+                                ->icon(Heroicon::ShoppingBag)
+                                ->completedIcon(Heroicon::HandThumbUp),
                             Wizard\Step::make('Delivery')
-                                ->icon('heroicon-m-truck')
-                                ->completedIcon('heroicon-m-hand-thumb-up'),
+                                ->icon(Heroicon::Truck)
+                                ->completedIcon(Heroicon::HandThumbUp),
                             Wizard\Step::make('Billing')
-                                ->icon('heroicon-m-credit-card')
-                                ->completedIcon('heroicon-m-hand-thumb-up')
+                                ->icon(Heroicon::CreditCard)
+                                ->completedIcon(Heroicon::HandThumbUp)
                                 ->schema([
                                     Repeater::make('items')
                                         ->hiddenLabel()
@@ -408,7 +409,7 @@ class LayoutDemo extends Component implements HasActions, HasForms
                     ->schema([
                         Section::make('Cart')
                             ->description('The items you have selected for purchase')
-                            ->icon('heroicon-m-shopping-bag')
+                            ->icon(Heroicon::ShoppingBag)
                             ->statePath('sectionIcons')
                             ->schema([
                                 Repeater::make('items')
@@ -542,9 +543,9 @@ class LayoutDemo extends Component implements HasActions, HasForms
                     ->schema([
                         Actions::make([
                             Action::make('star')
-                                ->icon('heroicon-m-star'),
+                                ->icon(Heroicon::Star),
                             Action::make('resetStars')
-                                ->icon('heroicon-m-x-mark')
+                                ->icon(Heroicon::XMark)
                                 ->color('danger'),
                         ]),
                     ]),
@@ -556,9 +557,9 @@ class LayoutDemo extends Component implements HasActions, HasForms
                     ->schema([
                         Actions::make([
                             Action::make('star')
-                                ->icon('heroicon-m-star'),
+                                ->icon(Heroicon::Star),
                             Action::make('resetStars')
-                                ->icon('heroicon-m-x-mark')
+                                ->icon(Heroicon::XMark)
                                 ->color('danger'),
                         ])->fullWidth(),
                     ]),
@@ -570,9 +571,9 @@ class LayoutDemo extends Component implements HasActions, HasForms
                     ->schema([
                         Actions::make([
                             Action::make('star')
-                                ->icon('heroicon-m-star'),
+                                ->icon(Heroicon::Star),
                             Action::make('resetStars')
-                                ->icon('heroicon-m-x-mark')
+                                ->icon(Heroicon::XMark)
                                 ->color('danger'),
                         ])->alignment(Alignment::Center),
                     ]),
@@ -588,9 +589,9 @@ class LayoutDemo extends Component implements HasActions, HasForms
                                     ->default('4572100479'),
                                 Actions::make([
                                     Action::make('star')
-                                        ->icon('heroicon-m-star'),
+                                        ->icon(Heroicon::Star),
                                     Action::make('resetStars')
-                                        ->icon('heroicon-m-x-mark')
+                                        ->icon(Heroicon::XMark)
                                         ->color('danger'),
                                 ])->verticalAlignment(VerticalAlignment::End),
                             ]),

--- a/docs-assets/app/app/Livewire/TablesDemo.php
+++ b/docs-assets/app/app/Livewire/TablesDemo.php
@@ -22,6 +22,7 @@ use Filament\Support\Enums\Alignment;
 use Filament\Support\Enums\FontFamily;
 use Filament\Support\Enums\FontWeight;
 use Filament\Support\Enums\IconPosition;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\CheckboxColumn;
 use Filament\Tables\Columns\ColorColumn;
 use Filament\Tables\Columns\ColumnGroup;
@@ -323,10 +324,10 @@ class TablesDemo extends Component implements HasForms, HasTable
                 ColumnGroup::make('Visibility', [
                     TextColumn::make('status')
                         ->badge()
-                        ->icon(fn (string $state): string => match ($state) {
-                            'draft' => 'heroicon-o-pencil',
-                            'reviewing' => 'heroicon-o-clock',
-                            'published' => 'heroicon-o-check-circle',
+                        ->icon(fn (string $state): Heroicon => match ($state) {
+                            'draft' => Heroicon::OutlinedPencil,
+                            'reviewing' => Heroicon::OutlinedClock,
+                            'published' => Heroicon::OutlinedCheckCircle,
                         })
                         ->color(fn (string $state): string => match ($state) {
                             'draft' => 'gray',
@@ -398,7 +399,7 @@ class TablesDemo extends Component implements HasForms, HasTable
             ->columns([
                 TextColumn::make('name'),
                 TextColumn::make('email')
-                    ->icon('heroicon-m-envelope'),
+                    ->icon(Heroicon::Envelope),
             ]);
     }
 
@@ -408,7 +409,7 @@ class TablesDemo extends Component implements HasForms, HasTable
             ->columns([
                 TextColumn::make('name'),
                 TextColumn::make('email')
-                    ->icon('heroicon-m-envelope')
+                    ->icon(Heroicon::Envelope)
                     ->iconPosition(IconPosition::After),
             ]);
     }
@@ -419,7 +420,7 @@ class TablesDemo extends Component implements HasForms, HasTable
             ->columns([
                 TextColumn::make('name'),
                 TextColumn::make('email')
-                    ->icon('heroicon-m-envelope')
+                    ->icon(Heroicon::Envelope)
                     ->iconColor('primary'),
             ]);
     }
@@ -470,10 +471,10 @@ class TablesDemo extends Component implements HasForms, HasTable
             ->columns([
                 TextColumn::make('title'),
                 IconColumn::make('status')
-                    ->icon(fn (string $state): string => match ($state) {
-                        'draft' => 'heroicon-o-pencil',
-                        'reviewing' => 'heroicon-o-clock',
-                        'published' => 'heroicon-o-check-circle',
+                    ->icon(fn (string $state): Heroicon => match ($state) {
+                        'draft' => Heroicon::OutlinedPencil,
+                        'reviewing' => Heroicon::OutlinedClock,
+                        'published' => Heroicon::OutlinedCheckCircle,
                     }),
             ]);
     }
@@ -484,10 +485,10 @@ class TablesDemo extends Component implements HasForms, HasTable
             ->columns([
                 TextColumn::make('title'),
                 IconColumn::make('status')
-                    ->icon(fn (string $state): string => match ($state) {
-                        'draft' => 'heroicon-o-pencil',
-                        'reviewing' => 'heroicon-o-clock',
-                        'published' => 'heroicon-o-check-circle',
+                    ->icon(fn (string $state): Heroicon => match ($state) {
+                        'draft' => Heroicon::OutlinedPencil,
+                        'reviewing' => Heroicon::OutlinedClock,
+                        'published' => Heroicon::OutlinedCheckCircle,
                     })
                     ->color(fn (string $state): string => match ($state) {
                         'draft' => 'info',
@@ -504,10 +505,10 @@ class TablesDemo extends Component implements HasForms, HasTable
             ->columns([
                 TextColumn::make('title'),
                 IconColumn::make('status')
-                    ->icon(fn (string $state): string => match ($state) {
-                        'draft' => 'heroicon-o-pencil',
-                        'reviewing' => 'heroicon-o-clock',
-                        'published' => 'heroicon-o-check-circle',
+                    ->icon(fn (string $state): Heroicon => match ($state) {
+                        'draft' => Heroicon::OutlinedPencil,
+                        'reviewing' => Heroicon::OutlinedClock,
+                        'published' => Heroicon::OutlinedCheckCircle,
                     })
                     ->size(IconColumn\Enums\IconColumnSize::Medium),
             ]);
@@ -530,8 +531,8 @@ class TablesDemo extends Component implements HasForms, HasTable
                 TextColumn::make('title'),
                 IconColumn::make('is_featured')
                     ->boolean()
-                    ->trueIcon('heroicon-o-check-badge')
-                    ->falseIcon('heroicon-o-x-mark'),
+                    ->trueIcon(Heroicon::OutlinedCheckBadge)
+                    ->falseIcon(Heroicon::OutlinedXMark),
             ]);
     }
 
@@ -713,10 +714,10 @@ class TablesDemo extends Component implements HasForms, HasTable
                 TextColumn::make('slug'),
                 TextColumn::make('status')
                     ->badge()
-                    ->icon(fn (string $state): string => match ($state) {
-                        'draft' => 'heroicon-o-pencil',
-                        'reviewing' => 'heroicon-o-clock',
-                        'published' => 'heroicon-o-check-circle',
+                    ->icon(fn (string $state): Heroicon => match ($state) {
+                        'draft' => Heroicon::OutlinedPencil,
+                        'reviewing' => Heroicon::OutlinedClock,
+                        'published' => Heroicon::OutlinedCheckCircle,
                     })
                     ->color(fn (string $state): string => match ($state) {
                         'draft' => 'gray',
@@ -835,10 +836,10 @@ class TablesDemo extends Component implements HasForms, HasTable
                 TextColumn::make('slug'),
                 TextColumn::make('status')
                     ->badge()
-                    ->icon(fn (string $state): string => match ($state) {
-                        'draft' => 'heroicon-o-pencil',
-                        'reviewing' => 'heroicon-o-clock',
-                        'published' => 'heroicon-o-check-circle',
+                    ->icon(fn (string $state): Heroicon => match ($state) {
+                        'draft' => Heroicon::OutlinedPencil,
+                        'reviewing' => Heroicon::OutlinedClock,
+                        'published' => Heroicon::OutlinedCheckCircle,
                     })
                     ->color(fn (string $state): string => match ($state) {
                         'draft' => 'gray',
@@ -972,7 +973,7 @@ class TablesDemo extends Component implements HasForms, HasTable
                     ViewAction::make(),
                     EditAction::make(),
                     DeleteAction::make(),
-                ])->icon('heroicon-m-ellipsis-horizontal'),
+                ])->icon(Heroicon::EllipsisHorizontal),
             ]);
     }
 
@@ -1042,17 +1043,17 @@ class TablesDemo extends Component implements HasForms, HasTable
                     ]),
                     Stack::make([
                         TextColumn::make('phone')
-                            ->icon('heroicon-m-phone'),
+                            ->icon(Heroicon::Phone),
                         TextColumn::make('email')
-                            ->icon('heroicon-m-envelope'),
+                            ->icon(Heroicon::Envelope),
                     ])
                         ->visibleFrom('md'),
                 ]),
                 Panel::make([
                     TextColumn::make('email')
-                        ->icon('heroicon-m-envelope'),
+                        ->icon(Heroicon::Envelope),
                     TextColumn::make('phone')
-                        ->icon('heroicon-m-phone'),
+                        ->icon(Heroicon::Phone),
                 ])->collapsible(),
             ]);
     }
@@ -1120,9 +1121,9 @@ class TablesDemo extends Component implements HasForms, HasTable
                         ->sortable(),
                     Stack::make([
                         TextColumn::make('phone')
-                            ->icon('heroicon-m-phone'),
+                            ->icon(Heroicon::Phone),
                         TextColumn::make('email')
-                            ->icon('heroicon-m-envelope'),
+                            ->icon(Heroicon::Envelope),
                     ]),
                 ])->from('md'),
             ]);
@@ -1142,9 +1143,9 @@ class TablesDemo extends Component implements HasForms, HasTable
                         ->sortable(),
                     Stack::make([
                         TextColumn::make('phone')
-                            ->icon('heroicon-m-phone'),
+                            ->icon(Heroicon::Phone),
                         TextColumn::make('email')
-                            ->icon('heroicon-m-envelope'),
+                            ->icon(Heroicon::Envelope),
                     ])->visibleFrom('md'),
                 ])->from('md'),
             ]);
@@ -1164,10 +1165,10 @@ class TablesDemo extends Component implements HasForms, HasTable
                         ->sortable(),
                     Stack::make([
                         TextColumn::make('phone')
-                            ->icon('heroicon-m-phone')
+                            ->icon(Heroicon::Phone)
                             ->grow(false),
                         TextColumn::make('email')
-                            ->icon('heroicon-m-envelope')
+                            ->icon(Heroicon::Envelope)
                             ->grow(false),
                     ])
                         ->alignment(Alignment::End)
@@ -1192,9 +1193,9 @@ class TablesDemo extends Component implements HasForms, HasTable
                 Panel::make([
                     Split::make([
                         TextColumn::make('phone')
-                            ->icon('heroicon-m-phone'),
+                            ->icon(Heroicon::Phone),
                         TextColumn::make('email')
-                            ->icon('heroicon-m-envelope'),
+                            ->icon(Heroicon::Envelope),
                     ])->from('md'),
                 ])->collapsible(),
             ]);
@@ -1240,10 +1241,10 @@ class TablesDemo extends Component implements HasForms, HasTable
                     ]),
                 TextColumn::make('status')
                     ->badge()
-                    ->icon(fn (string $state): string => match ($state) {
-                        'draft' => 'heroicon-o-pencil',
-                        'reviewing' => 'heroicon-o-clock',
-                        'published' => 'heroicon-o-check-circle',
+                    ->icon(fn (string $state): Heroicon => match ($state) {
+                        'draft' => Heroicon::OutlinedPencil,
+                        'reviewing' => Heroicon::OutlinedClock,
+                        'published' => Heroicon::OutlinedCheckCircle,
                     })
                     ->color(fn (string $state): string => match ($state) {
                         'draft' => 'gray',
@@ -1271,10 +1272,10 @@ class TablesDemo extends Component implements HasForms, HasTable
                     ->numeric(),
                 TextColumn::make('status')
                     ->badge()
-                    ->icon(fn (string $state): string => match ($state) {
-                        'draft' => 'heroicon-o-pencil',
-                        'reviewing' => 'heroicon-o-clock',
-                        'published' => 'heroicon-o-check-circle',
+                    ->icon(fn (string $state): Heroicon => match ($state) {
+                        'draft' => Heroicon::OutlinedPencil,
+                        'reviewing' => Heroicon::OutlinedClock,
+                        'published' => Heroicon::OutlinedCheckCircle,
                     })
                     ->color(fn (string $state): string => match ($state) {
                         'draft' => 'gray',
@@ -1297,10 +1298,10 @@ class TablesDemo extends Component implements HasForms, HasTable
                     ->numeric(),
                 TextColumn::make('status')
                     ->badge()
-                    ->icon(fn (string $state): string => match ($state) {
-                        'draft' => 'heroicon-o-pencil',
-                        'reviewing' => 'heroicon-o-clock',
-                        'published' => 'heroicon-o-check-circle',
+                    ->icon(fn (string $state): Heroicon => match ($state) {
+                        'draft' => Heroicon::OutlinedPencil,
+                        'reviewing' => Heroicon::OutlinedClock,
+                        'published' => Heroicon::OutlinedCheckCircle,
                     })
                     ->color(fn (string $state): string => match ($state) {
                         'draft' => 'gray',
@@ -1338,7 +1339,7 @@ class TablesDemo extends Component implements HasForms, HasTable
     public function emptyStateIcon(Table $table): Table
     {
         return $this->emptyStateDescription($table)
-            ->emptyStateIcon('heroicon-o-bookmark');
+            ->emptyStateIcon(Heroicon::OutlinedBookmark);
     }
 
     public function emptyStateActions(Table $table): Table
@@ -1347,7 +1348,7 @@ class TablesDemo extends Component implements HasForms, HasTable
             ->emptyStateActions([
                 Action::make('create')
                     ->label('Create post')
-                    ->icon('heroicon-m-plus')
+                    ->icon(Heroicon::Plus)
                     ->button(),
             ]);
     }
@@ -1366,10 +1367,10 @@ class TablesDemo extends Component implements HasForms, HasTable
                     ->numeric(),
                 TextColumn::make('status')
                     ->badge()
-                    ->icon(fn (string $state): string => match ($state) {
-                        'draft' => 'heroicon-o-pencil',
-                        'reviewing' => 'heroicon-o-clock',
-                        'published' => 'heroicon-o-check-circle',
+                    ->icon(fn (string $state): Heroicon => match ($state) {
+                        'draft' => Heroicon::OutlinedPencil,
+                        'reviewing' => Heroicon::OutlinedClock,
+                        'published' => Heroicon::OutlinedCheckCircle,
                     })
                     ->color(fn (string $state): string => match ($state) {
                         'draft' => 'gray',

--- a/docs-assets/app/app/Livewire/Topbar.php
+++ b/docs-assets/app/app/Livewire/Topbar.php
@@ -4,6 +4,7 @@ namespace App\Livewire;
 
 use Filament\Navigation\MenuItem;
 use Filament\Pages\Page;
+use Filament\Support\Icons\Heroicon;
 
 class Topbar extends Page
 {
@@ -17,7 +18,7 @@ class Topbar extends Page
                 MenuItem::make()
                     ->label('Settings')
                     ->url(fn (): string => '#')
-                    ->icon('heroicon-o-cog-6-tooth'),
+                    ->icon(Heroicon::OutlinedCog6Tooth),
             ]);
     }
 }

--- a/docs-assets/app/resources/views/livewire/actions.blade.php
+++ b/docs-assets/app/resources/views/livewire/actions.blade.php
@@ -84,7 +84,7 @@
                     \Filament\Actions\Action::make('delete'),
                 ]"
                 label="More actions"
-                icon="heroicon-m-ellipsis-vertical"
+                :icon="\Filament\Support\Icons\Heroicon::EllipsisVertical"
                 size="sm"
                 color="primary"
                 button

--- a/packages/actions/src/ActionGroup.php
+++ b/packages/actions/src/ActionGroup.php
@@ -15,6 +15,7 @@ use Filament\Support\Concerns\HasIcon;
 use Filament\Support\Concerns\HasTooltip;
 use Filament\Support\Enums\Width;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
@@ -216,7 +217,7 @@ class ActionGroup extends ViewComponent implements Arrayable, HasEmbeddedView
 
     public function getIcon(): string | BackedEnum
     {
-        return $this->getBaseIcon() ?? FilamentIcon::resolve('actions::action-group') ?? 'heroicon-m-ellipsis-vertical';
+        return $this->getBaseIcon() ?? FilamentIcon::resolve('actions::action-group') ?? Heroicon::EllipsisVertical;
     }
 
     public function isHidden(): bool

--- a/packages/actions/src/BulkActionGroup.php
+++ b/packages/actions/src/BulkActionGroup.php
@@ -3,6 +3,7 @@
 namespace Filament\Actions;
 
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 
 class BulkActionGroup extends ActionGroup
 {
@@ -12,7 +13,7 @@ class BulkActionGroup extends ActionGroup
 
         $this->label(__('filament-tables::table.actions.open_bulk_actions.label'));
 
-        $this->icon(FilamentIcon::resolve('tables::actions.open-bulk-actions') ?? 'heroicon-m-ellipsis-vertical');
+        $this->icon(FilamentIcon::resolve('tables::actions.open-bulk-actions') ?? Heroicon::EllipsisVertical);
 
         $this->color('gray');
 

--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -20,6 +20,7 @@ use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Split;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Contracts\HasTable;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Foundation\Bus\PendingChain;
@@ -75,7 +76,7 @@ trait CanExportRecords
 
         $this->modalSubmitActionLabel(__('filament-actions::export.modal.actions.export.label'));
 
-        $this->groupedIcon(FilamentIcon::resolve('actions::export-action.grouped') ?? 'heroicon-m-arrow-down-tray');
+        $this->groupedIcon(FilamentIcon::resolve('actions::export-action.grouped') ?? Heroicon::ArrowDownTray);
 
         $this->form(fn (ExportAction | ExportBulkAction $action): array => [
             ...($action->hasColumnMapping() ? [Fieldset::make(__('filament-actions::export.modal.form.columns.label'))

--- a/packages/actions/src/Concerns/CanOpenModal.php
+++ b/packages/actions/src/Concerns/CanOpenModal.php
@@ -8,6 +8,7 @@ use Filament\Actions\Action;
 use Filament\Support\Enums\Alignment;
 use Filament\Support\Enums\Width;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Support\View\Components\Modal;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View;
@@ -685,7 +686,7 @@ trait CanOpenModal
         }
 
         if ($this->isConfirmationRequired()) {
-            return FilamentIcon::resolve('actions::modal.confirmation') ?? 'heroicon-o-exclamation-triangle';
+            return FilamentIcon::resolve('actions::modal.confirmation') ?? Heroicon::OutlinedExclamationTriangle;
         }
 
         return null;

--- a/packages/actions/src/CreateAction.php
+++ b/packages/actions/src/CreateAction.php
@@ -8,6 +8,7 @@ use Filament\Actions\Contracts\HasActions;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -49,7 +50,7 @@ class CreateAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::create.single.notifications.created.title'));
 
-        $this->groupedIcon(FilamentIcon::resolve('actions::create-action.grouped') ?? 'heroicon-m-plus');
+        $this->groupedIcon(FilamentIcon::resolve('actions::create-action.grouped') ?? Heroicon::Plus);
 
         $this->record(null);
 

--- a/packages/actions/src/DeleteAction.php
+++ b/packages/actions/src/DeleteAction.php
@@ -4,6 +4,7 @@ namespace Filament\Actions;
 
 use Filament\Actions\Concerns\CanCustomizeProcess;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Database\Eloquent\Model;
 
 class DeleteAction extends Action
@@ -29,12 +30,12 @@ class DeleteAction extends Action
 
         $this->color('danger');
 
-        $this->tableIcon(FilamentIcon::resolve('actions::delete-action') ?? 'heroicon-m-trash');
-        $this->groupedIcon(FilamentIcon::resolve('actions::delete-action.grouped') ?? 'heroicon-m-trash');
+        $this->tableIcon(FilamentIcon::resolve('actions::delete-action') ?? Heroicon::Trash);
+        $this->groupedIcon(FilamentIcon::resolve('actions::delete-action.grouped') ?? Heroicon::Trash);
 
         $this->requiresConfirmation();
 
-        $this->modalIcon(FilamentIcon::resolve('actions::delete-action.modal') ?? 'heroicon-o-trash');
+        $this->modalIcon(FilamentIcon::resolve('actions::delete-action.modal') ?? Heroicon::OutlinedTrash);
 
         $this->keyBindings(['mod+d']);
 

--- a/packages/actions/src/DeleteBulkAction.php
+++ b/packages/actions/src/DeleteBulkAction.php
@@ -4,6 +4,7 @@ namespace Filament\Actions;
 
 use Filament\Actions\Concerns\CanCustomizeProcess;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Filters\TrashedFilter;
 use Illuminate\Database\Eloquent\Model;
@@ -56,11 +57,11 @@ class DeleteBulkAction extends BulkAction
 
         $this->color('danger');
 
-        $this->icon(FilamentIcon::resolve('actions::delete-action') ?? 'heroicon-m-trash');
+        $this->icon(FilamentIcon::resolve('actions::delete-action') ?? Heroicon::Trash);
 
         $this->requiresConfirmation();
 
-        $this->modalIcon(FilamentIcon::resolve('actions::delete-action.modal') ?? 'heroicon-o-trash');
+        $this->modalIcon(FilamentIcon::resolve('actions::delete-action.modal') ?? Heroicon::OutlinedTrash);
 
         $this->action(fn () => $this->processIndividualRecords(
             static fn (Model $record) => $record->delete(),

--- a/packages/actions/src/DetachAction.php
+++ b/packages/actions/src/DetachAction.php
@@ -4,6 +4,7 @@ namespace Filament\Actions;
 
 use Filament\Actions\Concerns\CanCustomizeProcess;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -31,11 +32,11 @@ class DetachAction extends Action
 
         $this->color('danger');
 
-        $this->icon(FilamentIcon::resolve('actions::detach-action') ?? 'heroicon-m-x-mark');
+        $this->icon(FilamentIcon::resolve('actions::detach-action') ?? Heroicon::XMark);
 
         $this->requiresConfirmation();
 
-        $this->modalIcon(FilamentIcon::resolve('actions::detach-action.modal') ?? 'heroicon-o-x-mark');
+        $this->modalIcon(FilamentIcon::resolve('actions::detach-action.modal') ?? Heroicon::OutlinedXMark);
 
         $this->action(function (): void {
             $this->process(function (Model $record, Table $table): void {

--- a/packages/actions/src/DetachBulkAction.php
+++ b/packages/actions/src/DetachBulkAction.php
@@ -4,6 +4,7 @@ namespace Filament\Actions;
 
 use Filament\Actions\Concerns\CanCustomizeProcess;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -32,11 +33,11 @@ class DetachBulkAction extends BulkAction
 
         $this->color('danger');
 
-        $this->icon(FilamentIcon::resolve('actions::detach-action') ?? 'heroicon-m-x-mark');
+        $this->icon(FilamentIcon::resolve('actions::detach-action') ?? Heroicon::XMark);
 
         $this->requiresConfirmation();
 
-        $this->modalIcon(FilamentIcon::resolve('actions::detach-action.modal') ?? 'heroicon-o-x-mark');
+        $this->modalIcon(FilamentIcon::resolve('actions::detach-action.modal') ?? Heroicon::OutlinedXMark);
 
         $this->action(function (): void {
             $this->process(function (Collection $records, Table $table): void {

--- a/packages/actions/src/DissociateAction.php
+++ b/packages/actions/src/DissociateAction.php
@@ -4,6 +4,7 @@ namespace Filament\Actions;
 
 use Filament\Actions\Concerns\CanCustomizeProcess;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -31,11 +32,11 @@ class DissociateAction extends Action
 
         $this->color('danger');
 
-        $this->icon(FilamentIcon::resolve('actions::dissociate-action') ?? 'heroicon-m-x-mark');
+        $this->icon(FilamentIcon::resolve('actions::dissociate-action') ?? Heroicon::XMark);
 
         $this->requiresConfirmation();
 
-        $this->modalIcon(FilamentIcon::resolve('actions::dissociate-action.modal') ?? 'heroicon-o-x-mark');
+        $this->modalIcon(FilamentIcon::resolve('actions::dissociate-action.modal') ?? Heroicon::OutlinedXMark);
 
         $this->action(function (): void {
             $this->process(function (Model $record, Table $table): void {

--- a/packages/actions/src/DissociateBulkAction.php
+++ b/packages/actions/src/DissociateBulkAction.php
@@ -4,6 +4,7 @@ namespace Filament\Actions;
 
 use Filament\Actions\Concerns\CanCustomizeProcess;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -32,11 +33,11 @@ class DissociateBulkAction extends BulkAction
 
         $this->color('danger');
 
-        $this->icon(FilamentIcon::resolve('actions::dissociate-action') ?? 'heroicon-m-x-mark');
+        $this->icon(FilamentIcon::resolve('actions::dissociate-action') ?? Heroicon::XMark);
 
         $this->requiresConfirmation();
 
-        $this->modalIcon(FilamentIcon::resolve('actions::dissociate-action.modal') ?? 'heroicon-o-x-mark');
+        $this->modalIcon(FilamentIcon::resolve('actions::dissociate-action.modal') ?? Heroicon::OutlinedXMark);
 
         $this->action(function (): void {
             $this->process(function (Collection $records, Table $table): void {

--- a/packages/actions/src/EditAction.php
+++ b/packages/actions/src/EditAction.php
@@ -7,6 +7,7 @@ use Filament\Actions\Concerns\CanCustomizeProcess;
 use Filament\Actions\Contracts\HasActions;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -35,8 +36,8 @@ class EditAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::edit.single.notifications.saved.title'));
 
-        $this->tableIcon(FilamentIcon::resolve('actions::edit-action') ?? 'heroicon-m-pencil-square');
-        $this->groupedIcon(FilamentIcon::resolve('actions::edit-action.grouped') ?? 'heroicon-m-pencil-square');
+        $this->tableIcon(FilamentIcon::resolve('actions::edit-action') ?? Heroicon::PencilSquare);
+        $this->groupedIcon(FilamentIcon::resolve('actions::edit-action.grouped') ?? Heroicon::PencilSquare);
 
         $this->fillForm(function (HasActions & HasSchemas $livewire, Model $record): array {
             if ($translatableContentDriver = $livewire->makeFilamentTranslatableContentDriver()) {

--- a/packages/actions/src/ForceDeleteAction.php
+++ b/packages/actions/src/ForceDeleteAction.php
@@ -4,6 +4,7 @@ namespace Filament\Actions;
 
 use Filament\Actions\Concerns\CanCustomizeProcess;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Database\Eloquent\Model;
 
 class ForceDeleteAction extends Action
@@ -27,12 +28,12 @@ class ForceDeleteAction extends Action
 
         $this->color('danger');
 
-        $this->tableIcon(FilamentIcon::resolve('actions::force-delete-action') ?? 'heroicon-m-trash');
-        $this->groupedIcon(FilamentIcon::resolve('actions::force-delete-action.grouped') ?? 'heroicon-m-trash');
+        $this->tableIcon(FilamentIcon::resolve('actions::force-delete-action') ?? Heroicon::Trash);
+        $this->groupedIcon(FilamentIcon::resolve('actions::force-delete-action.grouped') ?? Heroicon::Trash);
 
         $this->requiresConfirmation();
 
-        $this->modalIcon(FilamentIcon::resolve('actions::force-delete-action.modal') ?? 'heroicon-o-trash');
+        $this->modalIcon(FilamentIcon::resolve('actions::force-delete-action.modal') ?? Heroicon::OutlinedTrash);
 
         $this->action(function (): void {
             $result = $this->process(static fn (Model $record) => $record->forceDelete());

--- a/packages/actions/src/ForceDeleteBulkAction.php
+++ b/packages/actions/src/ForceDeleteBulkAction.php
@@ -4,6 +4,7 @@ namespace Filament\Actions;
 
 use Filament\Actions\Concerns\CanCustomizeProcess;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Filters\TrashedFilter;
 use Illuminate\Database\Eloquent\Model;
@@ -56,11 +57,11 @@ class ForceDeleteBulkAction extends BulkAction
 
         $this->color('danger');
 
-        $this->icon(FilamentIcon::resolve('actions::force-delete-action') ?? 'heroicon-m-trash');
+        $this->icon(FilamentIcon::resolve('actions::force-delete-action') ?? Heroicon::Trash);
 
         $this->requiresConfirmation();
 
-        $this->modalIcon(FilamentIcon::resolve('actions::force-delete-action.modal') ?? 'heroicon-o-trash');
+        $this->modalIcon(FilamentIcon::resolve('actions::force-delete-action.modal') ?? Heroicon::OutlinedTrash);
 
         $this->action(fn () => $this->processIndividualRecords(
             static fn (Model $record) => $record->forceDelete(),

--- a/packages/actions/src/ImportAction.php
+++ b/packages/actions/src/ImportAction.php
@@ -18,6 +18,7 @@ use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Support\ChunkIterator;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Support\Htmlable;
@@ -82,7 +83,7 @@ class ImportAction extends Action
 
         $this->modalSubmitActionLabel(__('filament-actions::import.modal.actions.import.label'));
 
-        $this->groupedIcon(FilamentIcon::resolve('actions::import-action.grouped') ?? 'heroicon-m-arrow-up-tray');
+        $this->groupedIcon(FilamentIcon::resolve('actions::import-action.grouped') ?? Heroicon::ArrowUpTray);
 
         $this->form(fn (ImportAction $action): array => array_merge([
             FileUpload::make('file')

--- a/packages/actions/src/ReplicateAction.php
+++ b/packages/actions/src/ReplicateAction.php
@@ -5,6 +5,7 @@ namespace Filament\Actions;
 use Closure;
 use Filament\Actions\Concerns\CanCustomizeProcess;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 
@@ -68,8 +69,8 @@ class ReplicateAction extends Action
             }
         });
 
-        $this->tableIcon(FilamentIcon::resolve('actions::replicate-action') ?? 'heroicon-m-square-2-stack');
-        $this->groupedIcon(FilamentIcon::resolve('actions::replicate-action.grouped') ?? 'heroicon-m-square-2-stack');
+        $this->tableIcon(FilamentIcon::resolve('actions::replicate-action') ?? Heroicon::Square2Stack);
+        $this->groupedIcon(FilamentIcon::resolve('actions::replicate-action.grouped') ?? Heroicon::Square2Stack);
     }
 
     public function beforeReplicaSaved(?Closure $callback): static

--- a/packages/actions/src/RestoreAction.php
+++ b/packages/actions/src/RestoreAction.php
@@ -4,6 +4,7 @@ namespace Filament\Actions;
 
 use Filament\Actions\Concerns\CanCustomizeProcess;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Database\Eloquent\Model;
 
 class RestoreAction extends Action
@@ -29,12 +30,12 @@ class RestoreAction extends Action
 
         $this->color('gray');
 
-        $this->tableIcon(FilamentIcon::resolve('actions::restore-action') ?? 'heroicon-m-arrow-uturn-left');
-        $this->groupedIcon(FilamentIcon::resolve('actions::restore-action.grouped') ?? 'heroicon-m-arrow-uturn-left');
+        $this->tableIcon(FilamentIcon::resolve('actions::restore-action') ?? Heroicon::ArrowUturnLeft);
+        $this->groupedIcon(FilamentIcon::resolve('actions::restore-action.grouped') ?? Heroicon::ArrowUturnLeft);
 
         $this->requiresConfirmation();
 
-        $this->modalIcon(FilamentIcon::resolve('actions::restore-action.modal') ?? 'heroicon-o-arrow-uturn-left');
+        $this->modalIcon(FilamentIcon::resolve('actions::restore-action.modal') ?? Heroicon::OutlinedArrowUturnLeft);
 
         $this->action(function (Model $record): void {
             if (! method_exists($record, 'restore')) {

--- a/packages/actions/src/RestoreBulkAction.php
+++ b/packages/actions/src/RestoreBulkAction.php
@@ -4,6 +4,7 @@ namespace Filament\Actions;
 
 use Filament\Actions\Concerns\CanCustomizeProcess;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Filters\TrashedFilter;
 use Illuminate\Database\Eloquent\Model;
@@ -56,11 +57,11 @@ class RestoreBulkAction extends BulkAction
 
         $this->color('gray');
 
-        $this->icon(FilamentIcon::resolve('actions::restore-action') ?? 'heroicon-m-arrow-uturn-left');
+        $this->icon(FilamentIcon::resolve('actions::restore-action') ?? Heroicon::ArrowUturnLeft);
 
         $this->requiresConfirmation();
 
-        $this->modalIcon(FilamentIcon::resolve('actions::restore-action.modal') ?? 'heroicon-o-arrow-uturn-left');
+        $this->modalIcon(FilamentIcon::resolve('actions::restore-action.modal') ?? Heroicon::OutlinedArrowUturnLeft);
 
         $this->action(fn () => $this->processIndividualRecords(
             static function (Model $record) {

--- a/packages/actions/src/Testing/TestsActions.php
+++ b/packages/actions/src/Testing/TestsActions.php
@@ -291,10 +291,13 @@ class TestsActions
     public function assertActionHasIcon(): Closure
     {
         return function (string | TestAction | array $actions, string | BackedEnum $icon): static {
+
+            $iconValue = $icon instanceof BackedEnum ? $icon->value : $icon;
+
             $this->assertActionExists(
                 $actions,
                 checkActionUsing: fn (Action $action): bool => $action->getIcon() === $icon,
-                generateMessageUsing: fn (string $prettyName, string $livewireClass): string => "Failed asserting that an action with name [{$prettyName}] has icon [{$icon}] on the [{$livewireClass}] component.",
+                generateMessageUsing: fn (string $prettyName, string $livewireClass): string => "Failed asserting that an action with name [{$prettyName}] has icon [{$iconValue}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -304,10 +307,13 @@ class TestsActions
     public function assertActionDoesNotHaveIcon(): Closure
     {
         return function (string | TestAction | array $actions, string | BackedEnum $icon): static {
+
+            $iconValue = $icon instanceof BackedEnum ? $icon->value : $icon;
+
             $this->assertActionExists(
                 $actions,
                 checkActionUsing: fn (Action $action): bool => $action->getIcon() !== $icon,
-                generateMessageUsing: fn (string $prettyName, string $livewireClass): string => "Failed asserting that an action with name [{$prettyName}] does not have icon [{$icon}] on the [{$livewireClass}] component.",
+                generateMessageUsing: fn (string $prettyName, string $livewireClass): string => "Failed asserting that an action with name [{$prettyName}] does not have icon [{$iconValue}] on the [{$livewireClass}] component.",
             );
 
             return $this;

--- a/packages/actions/src/ViewAction.php
+++ b/packages/actions/src/ViewAction.php
@@ -6,6 +6,7 @@ use Closure;
 use Filament\Actions\Contracts\HasActions;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Database\Eloquent\Model;
 
 class ViewAction extends Action
@@ -30,8 +31,8 @@ class ViewAction extends Action
 
         $this->color('gray');
 
-        $this->tableIcon(FilamentIcon::resolve('actions::view-action') ?? 'heroicon-m-eye');
-        $this->groupedIcon(FilamentIcon::resolve('actions::view-action.grouped') ?? 'heroicon-m-eye');
+        $this->tableIcon(FilamentIcon::resolve('actions::view-action') ?? Heroicon::Eye);
+        $this->groupedIcon(FilamentIcon::resolve('actions::view-action.grouped') ?? Heroicon::Eye);
 
         $this->disabledSchema();
 

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -101,7 +101,7 @@
             @if ($isSearchable)
                 <x-filament::input.wrapper
                     inline-prefix
-                    prefix-icon="heroicon-m-magnifying-glass"
+                    :prefix-icon="\Filament\Support\Icons\Heroicon::MagnifyingGlass"
                     prefix-icon-alias="forms:components.checkbox-list.search-field"
                     class="mb-4"
                 >

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -102,7 +102,7 @@
                                         tabindex="-1"
                                     >
                                         <x-filament::icon
-                                            icon="heroicon-m-bold"
+                                            :icon="\Filament\Support\Icons\Heroicon::Bold"
                                             class="h-5 w-5"
                                         />
                                     </x-filament-forms::rich-editor.toolbar.button>
@@ -116,7 +116,7 @@
                                         tabindex="-1"
                                     >
                                         <x-filament::icon
-                                            icon="heroicon-m-italic"
+                                            :icon="\Filament\Support\Icons\Heroicon::Italic"
                                             class="h-5 w-5"
                                         />
                                     </x-filament-forms::rich-editor.toolbar.button>
@@ -130,7 +130,7 @@
                                         tabindex="-1"
                                     >
                                         <x-filament::icon
-                                            icon="heroicon-m-underline"
+                                            :icon="\Filament\Support\Icons\Heroicon::Underline"
                                             class="h-5 w-5"
                                         />
                                     </x-filament-forms::rich-editor.toolbar.button>
@@ -144,7 +144,7 @@
                                         tabindex="-1"
                                     >
                                         <x-filament::icon
-                                            icon="heroicon-m-strikethrough"
+                                            :icon="\Filament\Support\Icons\Heroicon::Strikethrough"
                                             class="h-5 w-5"
                                         />
                                     </x-filament-forms::rich-editor.toolbar.button>
@@ -159,7 +159,7 @@
                                         tabindex="-1"
                                     >
                                         <x-filament::icon
-                                            icon="heroicon-m-link"
+                                            :icon="\Filament\Support\Icons\Heroicon::Link"
                                             class="h-5 w-5"
                                         />
                                     </x-filament-forms::rich-editor.toolbar.button>
@@ -178,7 +178,7 @@
                                         tabindex="-1"
                                     >
                                         <x-filament::icon
-                                            icon="heroicon-m-h1"
+                                            :icon="\Filament\Support\Icons\Heroicon::H1"
                                             class="h-5 w-5"
                                         />
                                     </x-filament-forms::rich-editor.toolbar.button>
@@ -191,7 +191,7 @@
                                         tabindex="-1"
                                     >
                                         <x-filament::icon
-                                            icon="heroicon-m-h2"
+                                            :icon="\Filament\Support\Icons\Heroicon::H2"
                                             class="h-5 w-5"
                                         />
                                     </x-filament-forms::rich-editor.toolbar.button>
@@ -204,7 +204,7 @@
                                         tabindex="-1"
                                     >
                                         <x-filament::icon
-                                            icon="heroicon-m-h3"
+                                            :icon="\Filament\Support\Icons\Heroicon::H3"
                                             class="h-5 w-5"
                                         />
                                     </x-filament-forms::rich-editor.toolbar.button>
@@ -223,7 +223,7 @@
                                         tabindex="-1"
                                     >
                                         <x-filament::icon
-                                            icon="heroicon-m-chat-bubble-bottom-center-text"
+                                            :icon="\Filament\Support\Icons\Heroicon::ChatBubbleBottomCenterText"
                                             class="h-5 w-5"
                                         />
                                     </x-filament-forms::rich-editor.toolbar.button>
@@ -236,7 +236,7 @@
                                         tabindex="-1"
                                     >
                                         <x-filament::icon
-                                            icon="heroicon-m-code-bracket"
+                                            :icon="\Filament\Support\Icons\Heroicon::CodeBracket"
                                             class="h-5 w-5"
                                         />
                                     </x-filament-forms::rich-editor.toolbar.button>
@@ -249,7 +249,7 @@
                                         tabindex="-1"
                                     >
                                         <x-filament::icon
-                                            icon="heroicon-m-list-bullet"
+                                            :icon="\Filament\Support\Icons\Heroicon::ListBullet"
                                             class="h-5 w-5"
                                         />
                                     </x-filament-forms::rich-editor.toolbar.button>
@@ -262,7 +262,7 @@
                                         tabindex="-1"
                                     >
                                         <x-filament::icon
-                                            icon="heroicon-m-numbered-list"
+                                            :icon="\Filament\Support\Icons\Heroicon::NumberedList"
                                             class="h-5 w-5"
                                         />
                                     </x-filament-forms::rich-editor.toolbar.button>
@@ -280,7 +280,7 @@
                                     tabindex="-1"
                                 >
                                     <x-filament::icon
-                                        icon="heroicon-m-photo"
+                                        :icon="\Filament\Support\Icons\Heroicon::Photo"
                                         class="h-5 w-5"
                                     />
                                 </x-filament-forms::rich-editor.toolbar.button>
@@ -299,7 +299,7 @@
                                         tabindex="-1"
                                     >
                                         <x-filament::icon
-                                            icon="heroicon-m-arrow-uturn-left"
+                                            :icon="\Filament\Support\Icons\Heroicon::ArrowUturnLeft"
                                             class="h-5 w-5"
                                         />
                                     </x-filament-forms::rich-editor.toolbar.button>
@@ -313,7 +313,7 @@
                                         tabindex="-1"
                                     >
                                         <x-filament::icon
-                                            icon="heroicon-m-arrow-uturn-right"
+                                            :icon="\Filament\Support\Icons\Heroicon::ArrowUturnRight"
                                             class="h-5 w-5"
                                         />
                                     </x-filament-forms::rich-editor.toolbar.button>

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -14,6 +14,7 @@ use Filament\Support\Enums\ActionSize;
 use Filament\Support\Enums\Alignment;
 use Filament\Support\Enums\Width;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
@@ -311,7 +312,7 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
     {
         $action = Action::make($this->getCloneActionName())
             ->label(__('filament-forms::components.builder.actions.clone.label'))
-            ->icon(FilamentIcon::resolve('forms::components.builder.actions.clone') ?? 'heroicon-m-square-2-stack')
+            ->icon(FilamentIcon::resolve('forms::components.builder.actions.clone') ?? Heroicon::Square2Stack)
             ->color('gray')
             ->action(function (array $arguments, Builder $component): void {
                 $newUuid = $component->generateUuid();
@@ -361,7 +362,7 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
     {
         $action = Action::make($this->getDeleteActionName())
             ->label(__('filament-forms::components.builder.actions.delete.label'))
-            ->icon(FilamentIcon::resolve('forms::components.builder.actions.delete') ?? 'heroicon-m-trash')
+            ->icon(FilamentIcon::resolve('forms::components.builder.actions.delete') ?? Heroicon::Trash)
             ->color('danger')
             ->action(function (array $arguments, Builder $component): void {
                 $items = $component->getState();
@@ -402,7 +403,7 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
     {
         $action = Action::make($this->getMoveDownActionName())
             ->label(__('filament-forms::components.builder.actions.move_down.label'))
-            ->icon(FilamentIcon::resolve('forms::components.builder.actions.move-down') ?? 'heroicon-m-arrow-down')
+            ->icon(FilamentIcon::resolve('forms::components.builder.actions.move-down') ?? Heroicon::ArrowDown)
             ->color('gray')
             ->action(function (array $arguments, Builder $component): void {
                 $items = array_move_after($component->getState(), $arguments['item']);
@@ -442,7 +443,7 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
     {
         $action = Action::make($this->getMoveUpActionName())
             ->label(__('filament-forms::components.builder.actions.move_up.label'))
-            ->icon(FilamentIcon::resolve('forms::components.builder.actions.move-up') ?? 'heroicon-m-arrow-up')
+            ->icon(FilamentIcon::resolve('forms::components.builder.actions.move-up') ?? Heroicon::ArrowUp)
             ->color('gray')
             ->action(function (array $arguments, Builder $component): void {
                 $items = array_move_before($component->getState(), $arguments['item']);
@@ -489,7 +490,7 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
     {
         $action = Action::make($this->getReorderActionName())
             ->label(__('filament-forms::components.builder.actions.reorder.label'))
-            ->icon(FilamentIcon::resolve('forms::components.builder.actions.reorder') ?? 'heroicon-m-arrows-up-down')
+            ->icon(FilamentIcon::resolve('forms::components.builder.actions.reorder') ?? Heroicon::ArrowsUpDown)
             ->color('gray')
             ->action(function (array $arguments, Builder $component): void {
                 $items = [
@@ -533,7 +534,7 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
     {
         $action = Action::make($this->getCollapseActionName())
             ->label(__('filament-forms::components.builder.actions.collapse.label'))
-            ->icon(FilamentIcon::resolve('forms::components.builder.actions.collapse') ?? 'heroicon-m-chevron-up')
+            ->icon(FilamentIcon::resolve('forms::components.builder.actions.collapse') ?? Heroicon::ChevronUp)
             ->color('gray')
             ->livewireClickHandlerEnabled(false)
             ->iconButton()
@@ -564,7 +565,7 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
     {
         $action = Action::make($this->getExpandActionName())
             ->label(__('filament-forms::components.builder.actions.expand.label'))
-            ->icon(FilamentIcon::resolve('forms::components.builder.actions.expand') ?? 'heroicon-m-chevron-down')
+            ->icon(FilamentIcon::resolve('forms::components.builder.actions.expand') ?? Heroicon::ChevronDown)
             ->color('gray')
             ->livewireClickHandlerEnabled(false)
             ->iconButton()
@@ -681,7 +682,7 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
                 $component->partiallyRender();
             })
             ->iconButton()
-            ->icon('heroicon-m-cog-6-tooth')
+            ->icon(Heroicon::Cog6Tooth)
             ->size(ActionSize::Small)
             ->visible(fn (Builder $component): bool => (! $component->isDisabled()) && $component->hasBlockPreviews());
 

--- a/packages/forms/src/Components/DateTimePicker.php
+++ b/packages/forms/src/Components/DateTimePicker.php
@@ -9,6 +9,7 @@ use Closure;
 use DateTime;
 use Filament\Schemas\Components\Contracts\HasAffixActions;
 use Filament\Support\Concerns\HasExtraAlpineAttributes;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Carbon;
 use Illuminate\View\ComponentAttributeBag;
 
@@ -185,7 +186,7 @@ class DateTimePicker extends Field implements HasAffixActions
     }
 
     /**
-     * @deprecated Use `suffixIcon('heroicon-m-calendar')` instead.
+     * @deprecated Use `suffixIcon(Heroicon::Calendar)` instead.
      */
     public function icon(string | BackedEnum | bool | null $icon = null): static
     {
@@ -193,7 +194,7 @@ class DateTimePicker extends Field implements HasAffixActions
             return $this;
         }
 
-        return $this->suffixIcon($icon ?? 'heroicon-m-calendar', isInline: true);
+        return $this->suffixIcon($icon ?? Heroicon::Calendar, isInline: true);
     }
 
     public function maxDate(CarbonInterface | string | Closure | null $date): static

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -7,6 +7,7 @@ use Exception;
 use Filament\Support\Concerns\HasAlignment;
 use Filament\Support\Concerns\HasExtraAlpineAttributes;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 
@@ -528,51 +529,51 @@ class FileUpload extends BaseFileUpload
                 ],
                 [
                     'label' => __('filament-forms::components.file_upload.editor.actions.zoom_in.label'),
-                    'iconHtml' => svg(FilamentIcon::resolve('forms::components.file-upload.editor.actions.zoom-in') ?? 'heroicon-m-magnifying-glass-plus', $iconSizeClasses)->toHtml(),
+                    'iconHtml' => svg(FilamentIcon::resolve('forms::components.file-upload.editor.actions.zoom-in') ?? Heroicon::MagnifyingGlassPlus, $iconSizeClasses)->toHtml(),
                     'alpineClickHandler' => 'editor.zoom(0.1)',
                 ],
                 [
                     'label' => __('filament-forms::components.file_upload.editor.actions.zoom_out.label'),
-                    'iconHtml' => svg(FilamentIcon::resolve('forms::components.file-upload.editor.actions.zoom-out') ?? 'heroicon-m-magnifying-glass-minus', $iconSizeClasses)->toHtml(),
+                    'iconHtml' => svg(FilamentIcon::resolve('forms::components.file-upload.editor.actions.zoom-out') ?? Heroicon::MagnifyingGlassMinus, $iconSizeClasses)->toHtml(),
                     'alpineClickHandler' => 'editor.zoom(-0.1)',
                 ],
                 [
                     'label' => __('filament-forms::components.file_upload.editor.actions.zoom_100.label'),
-                    'iconHtml' => svg(FilamentIcon::resolve('forms::components.file-upload.editor.actions.zoom-100') ?? 'heroicon-m-arrows-pointing-out', $iconSizeClasses)->toHtml(),
+                    'iconHtml' => svg(FilamentIcon::resolve('forms::components.file-upload.editor.actions.zoom-100') ?? Heroicon::ArrowsPointingOut, $iconSizeClasses)->toHtml(),
                     'alpineClickHandler' => 'editor.zoomTo(1)',
                 ],
             ],
             'move' => [
                 [
                     'label' => __('filament-forms::components.file_upload.editor.actions.move_left.label'),
-                    'iconHtml' => svg(FilamentIcon::resolve('forms::components.file-upload.editor.actions.move-left') ?? 'heroicon-m-arrow-left-circle', $iconSizeClasses)->toHtml(),
+                    'iconHtml' => svg(FilamentIcon::resolve('forms::components.file-upload.editor.actions.move-left') ?? Heroicon::ArrowLeftCircle, $iconSizeClasses)->toHtml(),
                     'alpineClickHandler' => 'editor.move(-10, 0)',
                 ],
                 [
                     'label' => __('filament-forms::components.file_upload.editor.actions.move_right.label'),
-                    'iconHtml' => svg(FilamentIcon::resolve('forms::components.file-upload.editor.actions.move-right') ?? 'heroicon-m-arrow-right-circle', $iconSizeClasses)->toHtml(),
+                    'iconHtml' => svg(FilamentIcon::resolve('forms::components.file-upload.editor.actions.move-right') ?? Heroicon::ArrowRightCircle, $iconSizeClasses)->toHtml(),
                     'alpineClickHandler' => 'editor.move(10, 0)',
                 ],
                 [
                     'label' => __('filament-forms::components.file_upload.editor.actions.move_up.label'),
-                    'iconHtml' => svg(FilamentIcon::resolve('forms::components.file-upload.editor.actions.move-up') ?? 'heroicon-m-arrow-up-circle', $iconSizeClasses)->toHtml(),
+                    'iconHtml' => svg(FilamentIcon::resolve('forms::components.file-upload.editor.actions.move-up') ?? Heroicon::ArrowUpCircle, $iconSizeClasses)->toHtml(),
                     'alpineClickHandler' => 'editor.move(0, -10)',
                 ],
                 [
                     'label' => __('filament-forms::components.file_upload.editor.actions.move_down.label'),
-                    'iconHtml' => svg(FilamentIcon::resolve('forms::components.file-upload.editor.actions.move-down') ?? 'heroicon-m-arrow-down-circle', $iconSizeClasses)->toHtml(),
+                    'iconHtml' => svg(FilamentIcon::resolve('forms::components.file-upload.editor.actions.move-down') ?? Heroicon::ArrowDownCircle, $iconSizeClasses)->toHtml(),
                     'alpineClickHandler' => 'editor.move(0, 10)',
                 ],
             ],
             'transform' => [
                 [
                     'label' => __('filament-forms::components.file_upload.editor.actions.rotate_left.label'),
-                    'iconHtml' => svg(FilamentIcon::resolve('forms::components.file-upload.editor.actions.rotate-left') ?? 'heroicon-m-arrow-uturn-left', $iconSizeClasses)->toHtml(),
+                    'iconHtml' => svg(FilamentIcon::resolve('forms::components.file-upload.editor.actions.rotate-left') ?? Heroicon::ArrowUturnLeft, $iconSizeClasses)->toHtml(),
                     'alpineClickHandler' => 'editor.rotate(-90)',
                 ],
                 [
                     'label' => __('filament-forms::components.file_upload.editor.actions.rotate_right.label'),
-                    'iconHtml' => svg(FilamentIcon::resolve('forms::components.file-upload.editor.actions.rotate-right') ?? 'heroicon-m-arrow-uturn-right', $iconSizeClasses)->toHtml(),
+                    'iconHtml' => svg(FilamentIcon::resolve('forms::components.file-upload.editor.actions.rotate-right') ?? Heroicon::ArrowUturnRight, $iconSizeClasses)->toHtml(),
                     'alpineClickHandler' => 'editor.rotate(90)',
                 ],
                 [

--- a/packages/forms/src/Components/KeyValue.php
+++ b/packages/forms/src/Components/KeyValue.php
@@ -9,6 +9,7 @@ use Filament\Support\Concerns\HasExtraAlpineAttributes;
 use Filament\Support\Concerns\HasReorderAnimationDuration;
 use Filament\Support\Enums\ActionSize;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 
 class KeyValue extends Field
 {
@@ -97,7 +98,7 @@ class KeyValue extends Field
     {
         $action = Action::make($this->getDeleteActionName())
             ->label(__('filament-forms::components.key_value.actions.delete.label'))
-            ->icon(FilamentIcon::resolve('forms::components.key-value.actions.delete') ?? 'heroicon-m-trash')
+            ->icon(FilamentIcon::resolve('forms::components.key-value.actions.delete') ?? Heroicon::Trash)
             ->color('danger')
             ->livewireClickHandlerEnabled(false)
             ->iconButton()
@@ -129,7 +130,7 @@ class KeyValue extends Field
     {
         $action = Action::make($this->getReorderActionName())
             ->label(__('filament-forms::components.key_value.actions.reorder.label'))
-            ->icon(FilamentIcon::resolve('forms::components.key-value.actions.reorder') ?? 'heroicon-m-arrows-up-down')
+            ->icon(FilamentIcon::resolve('forms::components.key-value.actions.reorder') ?? Heroicon::ArrowsUpDown)
             ->color('gray')
             ->livewireClickHandlerEnabled(false)
             ->iconButton()

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -16,6 +16,7 @@ use Filament\Support\Concerns\HasReorderAnimationDuration;
 use Filament\Support\Enums\ActionSize;
 use Filament\Support\Enums\Alignment;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -312,7 +313,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     {
         $action = Action::make($this->getCloneActionName())
             ->label(__('filament-forms::components.repeater.actions.clone.label'))
-            ->icon(FilamentIcon::resolve('forms::components.repeater.actions.clone') ?? 'heroicon-m-square-2-stack')
+            ->icon(FilamentIcon::resolve('forms::components.repeater.actions.clone') ?? Heroicon::Square2Stack)
             ->color('gray')
             ->action(function (array $arguments, Repeater $component): void {
                 $newUuid = $component->generateUuid();
@@ -362,7 +363,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     {
         $action = Action::make($this->getDeleteActionName())
             ->label(__('filament-forms::components.repeater.actions.delete.label'))
-            ->icon(FilamentIcon::resolve('forms::components.repeater.actions.delete') ?? 'heroicon-m-trash')
+            ->icon(FilamentIcon::resolve('forms::components.repeater.actions.delete') ?? Heroicon::Trash)
             ->color('danger')
             ->action(function (array $arguments, Repeater $component): void {
                 $items = $component->getState();
@@ -403,7 +404,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     {
         $action = Action::make($this->getMoveDownActionName())
             ->label(__('filament-forms::components.repeater.actions.move_down.label'))
-            ->icon(FilamentIcon::resolve('forms::components.repeater.actions.move-down') ?? 'heroicon-m-arrow-down')
+            ->icon(FilamentIcon::resolve('forms::components.repeater.actions.move-down') ?? Heroicon::ArrowDown)
             ->color('gray')
             ->action(function (array $arguments, Repeater $component): void {
                 $items = array_move_after($component->getState(), $arguments['item']);
@@ -443,7 +444,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     {
         $action = Action::make($this->getMoveUpActionName())
             ->label(__('filament-forms::components.repeater.actions.move_up.label'))
-            ->icon(FilamentIcon::resolve('forms::components.repeater.actions.move-up') ?? 'heroicon-m-arrow-up')
+            ->icon(FilamentIcon::resolve('forms::components.repeater.actions.move-up') ?? Heroicon::ArrowUp)
             ->color('gray')
             ->action(function (array $arguments, Repeater $component): void {
                 $items = array_move_before($component->getState(), $arguments['item']);
@@ -483,7 +484,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     {
         $action = Action::make($this->getReorderActionName())
             ->label(__('filament-forms::components.repeater.actions.reorder.label'))
-            ->icon(FilamentIcon::resolve('forms::components.repeater.actions.reorder') ?? 'heroicon-m-arrows-up-down')
+            ->icon(FilamentIcon::resolve('forms::components.repeater.actions.reorder') ?? Heroicon::ArrowsUpDown)
             ->color('gray')
             ->action(function (array $arguments, Repeater $component): void {
                 $items = [
@@ -527,7 +528,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     {
         $action = Action::make($this->getCollapseActionName())
             ->label(__('filament-forms::components.repeater.actions.collapse.label'))
-            ->icon(FilamentIcon::resolve('forms::components.repeater.actions.collapse') ?? 'heroicon-m-chevron-up')
+            ->icon(FilamentIcon::resolve('forms::components.repeater.actions.collapse') ?? Heroicon::ChevronUp)
             ->color('gray')
             ->livewireClickHandlerEnabled(false)
             ->iconButton()
@@ -558,7 +559,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     {
         $action = Action::make($this->getExpandActionName())
             ->label(__('filament-forms::components.repeater.actions.expand.label'))
-            ->icon(FilamentIcon::resolve('forms::components.repeater.actions.expand') ?? 'heroicon-m-chevron-down')
+            ->icon(FilamentIcon::resolve('forms::components.repeater.actions.expand') ?? Heroicon::ChevronDown)
             ->color('gray')
             ->livewireClickHandlerEnabled(false)
             ->iconButton()

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -15,6 +15,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Components\Attributes\ExposedLivewireMethod;
 use Filament\Support\Concerns\HasExtraAlpineAttributes;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Support\Services\RelationshipJoiner;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Htmlable;
@@ -317,7 +318,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
                 $action->halt();
             })
             ->color('gray')
-            ->icon(FilamentIcon::resolve('forms::components.select.actions.create-option') ?? 'heroicon-m-plus')
+            ->icon(FilamentIcon::resolve('forms::components.select.actions.create-option') ?? Heroicon::Plus)
             ->iconButton()
             ->modalHeading($this->getCreateOptionModalHeading() ?? __('filament-forms::components.select.actions.create_option.modal.heading'))
             ->modalSubmitActionLabel(__('filament-forms::components.select.actions.create_option.modal.actions.create.label'))
@@ -455,7 +456,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
                 $component->refreshSelectedOptionLabel();
             })
             ->color('gray')
-            ->icon(FilamentIcon::resolve('forms::components.select.actions.edit-option') ?? 'heroicon-m-pencil-square')
+            ->icon(FilamentIcon::resolve('forms::components.select.actions.edit-option') ?? Heroicon::PencilSquare)
             ->iconButton()
             ->modalHeading($this->getEditOptionModalHeading() ?? __('filament-forms::components.select.actions.edit_option.modal.heading'))
             ->modalSubmitActionLabel(__('filament-forms::components.select.actions.edit_option.modal.actions.save.label'));

--- a/packages/forms/src/Components/TextInput/Actions/HidePasswordAction.php
+++ b/packages/forms/src/Components/TextInput/Actions/HidePasswordAction.php
@@ -4,6 +4,7 @@ namespace Filament\Forms\Components\TextInput\Actions;
 
 use Filament\Actions\Action;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 
 class HidePasswordAction extends Action
 {
@@ -18,7 +19,7 @@ class HidePasswordAction extends Action
 
         $this->label(__('filament-forms::components.text_input.actions.hide_password.label'));
 
-        $this->icon(FilamentIcon::resolve('forms::components.text-input.actions.hide-password') ?? 'heroicon-m-eye-slash');
+        $this->icon(FilamentIcon::resolve('forms::components.text-input.actions.hide-password') ?? Heroicon::EyeSlash);
 
         $this->color('gray');
 

--- a/packages/forms/src/Components/TextInput/Actions/ShowPasswordAction.php
+++ b/packages/forms/src/Components/TextInput/Actions/ShowPasswordAction.php
@@ -4,6 +4,7 @@ namespace Filament\Forms\Components\TextInput\Actions;
 
 use Filament\Actions\Action;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 
 class ShowPasswordAction extends Action
 {
@@ -18,7 +19,7 @@ class ShowPasswordAction extends Action
 
         $this->label(__('filament-forms::components.text_input.actions.show_password.label'));
 
-        $this->icon(FilamentIcon::resolve('forms::components.text-input.actions.show-password') ?? 'heroicon-m-eye');
+        $this->icon(FilamentIcon::resolve('forms::components.text-input.actions.show-password') ?? Heroicon::Eye);
 
         $this->color('gray');
 

--- a/packages/forms/src/Components/ToggleButtons.php
+++ b/packages/forms/src/Components/ToggleButtons.php
@@ -7,6 +7,7 @@ use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
 use Filament\Schemas\Components\StateCasts\EnumArrayStateCast;
 use Filament\Schemas\Components\StateCasts\EnumStateCast;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 
 class ToggleButtons extends Field implements Contracts\CanDisableOptions
 {
@@ -68,8 +69,8 @@ class ToggleButtons extends Field implements Contracts\CanDisableOptions
         ]);
 
         $this->icons([
-            1 => FilamentIcon::resolve('forms::components.toggle-buttons.boolean.true') ?? 'heroicon-m-check',
-            0 => FilamentIcon::resolve('forms::components.toggle-buttons.boolean.false') ?? 'heroicon-m-x-mark',
+            1 => FilamentIcon::resolve('forms::components.toggle-buttons.boolean.true') ?? Heroicon::Check,
+            0 => FilamentIcon::resolve('forms::components.toggle-buttons.boolean.false') ?? Heroicon::XMark,
         ]);
 
         return $this;

--- a/packages/forms/src/Testing/TestsFormComponentActions.php
+++ b/packages/forms/src/Testing/TestsFormComponentActions.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Forms\Testing;
 
+use BackedEnum;
 use Closure;
 use Illuminate\Support\Arr;
 use Livewire\Features\SupportTesting\Testable;
@@ -155,7 +156,7 @@ class TestsFormComponentActions
 
     public function assertFormComponentActionHasIcon(): Closure
     {
-        return function (string | array $components, string | array $actions, string $icon, array $arguments = [], string $formName = 'form'): static {
+        return function (string | array $components, string | array $actions, string | BackedEnum $icon, array $arguments = [], string $formName = 'form'): static {
             /** @var array<array<string, mixed>> $actions */
             /** @phpstan-ignore-next-line */
             $actions = $this->parseNestedFormComponentActions($components, $actions, $formName, $arguments);
@@ -168,7 +169,7 @@ class TestsFormComponentActions
 
     public function assertFormComponentActionDoesNotHaveIcon(): Closure
     {
-        return function (string | array $components, string | array $actions, string $icon, array $arguments = [], string $formName = 'form'): static {
+        return function (string | array $components, string | array $actions, string | BackedEnum $icon, array $arguments = [], string $formName = 'form'): static {
             /** @var array<array<string, mixed>> $actions */
             /** @phpstan-ignore-next-line */
             $actions = $this->parseNestedFormComponentActions($components, $actions, $formName, $arguments);

--- a/packages/infolists/src/Components/IconEntry.php
+++ b/packages/infolists/src/Components/IconEntry.php
@@ -6,6 +6,7 @@ use BackedEnum;
 use Closure;
 use Filament\Infolists\Components\IconEntry\Enums\IconEntrySize;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 
 class IconEntry extends Entry
 {
@@ -169,7 +170,7 @@ class IconEntry extends Entry
     {
         return $this->evaluate($this->falseIcon)
             ?? FilamentIcon::resolve('infolists::components.icon-entry.false')
-            ?? 'heroicon-o-x-circle';
+            ?? Heroicon::OutlinedXCircle;
     }
 
     /**
@@ -184,7 +185,7 @@ class IconEntry extends Entry
     {
         return $this->evaluate($this->trueIcon)
             ?? FilamentIcon::resolve('infolists::components.icon-entry.true')
-            ?? 'heroicon-o-check-circle';
+            ?? Heroicon::OutlinedCheckCircle;
     }
 
     public function isBoolean(): bool

--- a/packages/infolists/src/Testing/TestsInfolistActions.php
+++ b/packages/infolists/src/Testing/TestsInfolistActions.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Infolists\Testing;
 
+use BackedEnum;
 use Closure;
 use Livewire\Features\SupportTesting\Testable;
 
@@ -154,7 +155,7 @@ class TestsInfolistActions
 
     public function assertInfolistActionHasIcon(): Closure
     {
-        return function (string $component, string | array $actions, string $icon, string $infolistName = 'infolist'): static {
+        return function (string $component, string | array $actions, string | BackedEnum $icon, string $infolistName = 'infolist'): static {
             /** @var array<array<string, mixed>> $actions */
             /** @phpstan-ignore-next-line */
             $actions = $this->parseNestedInfolistActions($component, $actions, $infolistName);
@@ -167,7 +168,7 @@ class TestsInfolistActions
 
     public function assertInfolistActionDoesNotHaveIcon(): Closure
     {
-        return function (string $component, string | array $actions, string $icon, string $infolistName = 'infolist'): static {
+        return function (string $component, string | array $actions, string | BackedEnum $icon, string $infolistName = 'infolist'): static {
             /** @var array<array<string, mixed>> $actions */
             /** @phpstan-ignore-next-line */
             $actions = $this->parseNestedInfolistActions($component, $actions, $infolistName);

--- a/packages/notifications/resources/views/components/close-button.blade.php
+++ b/packages/notifications/resources/views/components/close-button.blade.php
@@ -1,6 +1,6 @@
 <x-filament::icon-button
     color="gray"
-    icon="heroicon-m-x-mark"
+    :icon="\Filament\Support\Icons\Heroicon::XMark"
     icon-alias="notifications::notification.close-button"
     x-on:click="close"
     class="fi-no-notification-close-btn"

--- a/packages/notifications/resources/views/components/database/modal/index.blade.php
+++ b/packages/notifications/resources/views/components/database/modal/index.blade.php
@@ -15,7 +15,7 @@
     close-button
     :description="$hasNotifications ? null : __('filament-notifications::database.modal.empty.description')"
     :heading="$hasNotifications ? null : __('filament-notifications::database.modal.empty.heading')"
-    :icon="$hasNotifications ? null : 'heroicon-o-bell-slash'"
+    :icon="$hasNotifications ? null : \Filament\Support\Icons\Heroicon::OutlinedBellSlash"
     :icon-alias="$hasNotifications ? null : 'notifications::database.modal.empty-state'"
     :icon-color="$hasNotifications ? null : 'gray'"
     id="database-notifications"

--- a/packages/notifications/src/Concerns/HasIcon.php
+++ b/packages/notifications/src/Concerns/HasIcon.php
@@ -5,6 +5,7 @@ namespace Filament\Notifications\Concerns;
 use BackedEnum;
 use Filament\Support\Concerns\HasIcon as BaseTrait;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 
 trait HasIcon
 {
@@ -15,10 +16,10 @@ trait HasIcon
     public function getIcon(): string | BackedEnum | null
     {
         return $this->baseGetIcon() ?? match ($this->getStatus()) {
-            'danger' => FilamentIcon::resolve('notifications::notification.danger') ?? 'heroicon-o-x-circle',
-            'info' => FilamentIcon::resolve('notifications::notification.info') ?? 'heroicon-o-information-circle',
-            'success' => FilamentIcon::resolve('notifications::notification.success') ?? 'heroicon-o-check-circle',
-            'warning' => FilamentIcon::resolve('notifications::notification.warning') ?? 'heroicon-o-exclamation-circle',
+            'danger' => FilamentIcon::resolve('notifications::notification.danger') ?? Heroicon::OutlinedXCircle,
+            'info' => FilamentIcon::resolve('notifications::notification.info') ?? Heroicon::OutlinedInformationCircle,
+            'success' => FilamentIcon::resolve('notifications::notification.success') ?? Heroicon::OutlinedCheckCircle,
+            'warning' => FilamentIcon::resolve('notifications::notification.warning') ?? Heroicon::OutlinedExclamationCircle,
             default => null,
         };
     }

--- a/packages/panels/resources/views/components/global-search/field.blade.php
+++ b/packages/panels/resources/views/components/global-search/field.blade.php
@@ -13,7 +13,7 @@
     </label>
 
     <x-filament::input.wrapper
-        prefix-icon="heroicon-m-magnifying-glass"
+        :prefix-icon="\Filament\Support\Icons\Heroicon::MagnifyingGlass"
         prefix-icon-alias="panels::global-search.field"
         inline-prefix
         :suffix="$suffix"

--- a/packages/panels/resources/views/components/sidebar/group.blade.php
+++ b/packages/panels/resources/views/components/sidebar/group.blade.php
@@ -55,7 +55,7 @@
             @if ($collapsible)
                 <x-filament::icon-button
                     color="gray"
-                    icon="heroicon-m-chevron-up"
+                    :icon="\Filament\Support\Icons\Heroicon::ChevronUp"
                     icon-alias="panels::sidebar.group.collapse-button"
                     :label="$label"
                     x-bind:aria-expanded="! $store.sidebar.groupIsCollapsed(label)"

--- a/packages/panels/resources/views/components/tenant-menu.blade.php
+++ b/packages/panels/resources/views/components/tenant-menu.blade.php
@@ -71,7 +71,7 @@
             </span>
 
             <x-filament::icon
-                icon="heroicon-m-chevron-down"
+                :icon="\Filament\Support\Icons\Heroicon::ChevronDown"
                 icon-alias="panels::tenant-menu.toggle-button"
                 :x-show="filament()->isSidebarCollapsibleOnDesktop() ? '$store.sidebar.isOpen' : null"
                 class="ms-auto size-5 shrink-0 text-gray-400 transition duration-75 group-hover:text-gray-500 group-focus-visible:text-gray-500 dark:text-gray-500 dark:group-hover:text-gray-400 dark:group-focus-visible:text-gray-400"

--- a/packages/panels/resources/views/components/theme-switcher/index.blade.php
+++ b/packages/panels/resources/views/components/theme-switcher/index.blade.php
@@ -10,17 +10,17 @@
     class="fi-theme-switcher grid grid-flow-col gap-x-1"
 >
     <x-filament-panels::theme-switcher.button
-        icon="heroicon-m-sun"
+        :icon="\Filament\Support\Icons\Heroicon::Sun"
         theme="light"
     />
 
     <x-filament-panels::theme-switcher.button
-        icon="heroicon-m-moon"
+        :icon="\Filament\Support\Icons\Heroicon::Moon"
         theme="dark"
     />
 
     <x-filament-panels::theme-switcher.button
-        icon="heroicon-m-computer-desktop"
+        :icon="\Filament\Support\Icons\Heroicon::ComputerDesktop"
         theme="system"
     />
 </div>

--- a/packages/panels/resources/views/components/topbar/database-notifications-trigger.blade.php
+++ b/packages/panels/resources/views/components/topbar/database-notifications-trigger.blade.php
@@ -1,7 +1,7 @@
 <x-filament::icon-button
     :badge="$unreadNotificationsCount ?: null"
     color="gray"
-    icon="heroicon-o-bell"
+    :icon="\Filament\Support\Icons\Heroicon::OutlinedBell"
     icon-alias="panels::topbar.open-database-notifications-button"
     icon-size="lg"
     :label="__('filament-panels::layout.actions.open_database_notifications.label')"

--- a/packages/panels/resources/views/components/topbar/index.blade.php
+++ b/packages/panels/resources/views/components/topbar/index.blade.php
@@ -22,7 +22,7 @@
         @if (filament()->hasNavigation())
             <x-filament::icon-button
                 color="gray"
-                icon="heroicon-o-bars-3"
+                :icon="\Filament\Support\Icons\Heroicon::OutlinedBars3"
                 icon-alias="panels::topbar.open-sidebar-button"
                 icon-size="lg"
                 :label="__('filament-panels::layout.actions.sidebar.expand.label')"
@@ -38,7 +38,7 @@
 
             <x-filament::icon-button
                 color="gray"
-                icon="heroicon-o-x-mark"
+                :icon="\Filament\Support\Icons\Heroicon::OutlinedXMark"
                 icon-alias="panels::topbar.close-sidebar-button"
                 icon-size="lg"
                 :label="__('filament-panels::layout.actions.sidebar.collapse.label')"
@@ -54,7 +54,7 @@
             @if (filament()->isSidebarCollapsibleOnDesktop())
                 <x-filament::icon-button
                     color="gray"
-                    :icon="$isRtl ? 'heroicon-o-chevron-left' : 'heroicon-o-chevron-right'"
+                    :icon="$isRtl ? \Filament\Support\Icons\Heroicon::OutlinedChevronLeft : \Filament\Support\Icons\Heroicon::OutlinedChevronRight"
                     {{-- @deprecated Use `panels::sidebar.expand-button.rtl` instead of `panels::sidebar.expand-button` for RTL. --}}
                     :icon-alias="$isRtl ? ['panels::sidebar.expand-button.rtl', 'panels::sidebar.expand-button'] : 'panels::sidebar.expand-button'"
                     icon-size="lg"
@@ -70,7 +70,7 @@
             @if (filament()->isSidebarCollapsibleOnDesktop() || filament()->isSidebarFullyCollapsibleOnDesktop())
                 <x-filament::icon-button
                     color="gray"
-                    :icon="$isRtl ? 'heroicon-o-chevron-right' : 'heroicon-o-chevron-left'"
+                    :icon="$isRtl ? \Filament\Support\Icons\Heroicon::OutlinedChevronRight : \Filament\Support\Icons\Heroicon::OutlinedChevronLeft"
                     {{-- @deprecated Use `panels::sidebar.collapse-button.rtl` instead of `panels::sidebar.collapse-button` for RTL. --}}
                     :icon-alias="$isRtl ? ['panels::sidebar.collapse-button.rtl', 'panels::sidebar.collapse-button'] : 'panels::sidebar.collapse-button'"
                     icon-size="lg"

--- a/packages/panels/resources/views/components/topbar/item.blade.php
+++ b/packages/panels/resources/views/components/topbar/item.blade.php
@@ -64,7 +64,7 @@
 
         @if (! $url)
             <x-filament::icon
-                icon="heroicon-m-chevron-down"
+                :icon="\Filament\Support\Icons\Heroicon::ChevronDown"
                 icon-alias="panels::topbar.group.toggle-button"
                 @class([
                     'fi-topbar-group-toggle-icon size-5',

--- a/packages/panels/resources/views/widgets/account-widget.blade.php
+++ b/packages/panels/resources/views/widgets/account-widget.blade.php
@@ -28,7 +28,7 @@
 
                 <x-filament::button
                     color="gray"
-                    icon="heroicon-m-arrow-left-on-rectangle"
+                    :icon="\Filament\Support\Icons\Heroicon::ArrowLeftOnRectangle"
                     icon-alias="panels::widgets.account.logout-button"
                     labeled-from="sm"
                     tag="button"

--- a/packages/panels/resources/views/widgets/filament-info-widget.blade.php
+++ b/packages/panels/resources/views/widgets/filament-info-widget.blade.php
@@ -33,7 +33,7 @@
                 <x-filament::link
                     color="gray"
                     href="https://filamentphp.com/docs"
-                    icon="heroicon-m-book-open"
+                    :icon="\Filament\Support\Icons\Heroicon::BookOpen"
                     icon-alias="panels::widgets.filament-info.open-documentation-button"
                     rel="noopener noreferrer"
                     target="_blank"

--- a/packages/panels/src/Auth/MultiFactor/EmailCode/Actions/DisableEmailCodeAuthenticationAction.php
+++ b/packages/panels/src/Auth/MultiFactor/EmailCode/Actions/DisableEmailCodeAuthenticationAction.php
@@ -10,6 +10,7 @@ use Filament\Facades\Filament;
 use Filament\Forms\Components\OneTimeCodeInput;
 use Filament\Notifications\Notification;
 use Filament\Support\Enums\Width;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Facades\DB;
 
 class DisableEmailCodeAuthenticationAction
@@ -19,7 +20,7 @@ class DisableEmailCodeAuthenticationAction
         return Action::make('disableEmailCodeAuthentication')
             ->label(__('filament-panels::auth/multi-factor/email-code/actions/disable.label'))
             ->color('danger')
-            ->icon('heroicon-m-lock-open')
+            ->icon(Heroicon::LockOpen)
             ->link()
             ->mountUsing(function () use ($emailCodeAuthentication) {
                 /** @var HasEmailCodeAuthentication $user */
@@ -28,7 +29,7 @@ class DisableEmailCodeAuthenticationAction
                 $emailCodeAuthentication->sendCode($user);
             })
             ->modalWidth(Width::Medium)
-            ->modalIcon('heroicon-o-lock-open')
+            ->modalIcon(Heroicon::OutlinedLockOpen)
             ->modalHeading(__('filament-panels::auth/multi-factor/email-code/actions/disable.modal.heading'))
             ->modalDescription(__('filament-panels::auth/multi-factor/email-code/actions/disable.modal.description'))
             ->form([
@@ -73,7 +74,7 @@ class DisableEmailCodeAuthenticationAction
                 Notification::make()
                     ->title(__('filament-panels::auth/multi-factor/email-code/actions/disable.notifications.disabled.title'))
                     ->success()
-                    ->icon('heroicon-o-lock-open')
+                    ->icon(Heroicon::OutlinedLockOpen)
                     ->send();
             })
             ->rateLimit(5);

--- a/packages/panels/src/Auth/MultiFactor/EmailCode/Actions/SetUpEmailCodeAuthenticationAction.php
+++ b/packages/panels/src/Auth/MultiFactor/EmailCode/Actions/SetUpEmailCodeAuthenticationAction.php
@@ -11,6 +11,7 @@ use Filament\Facades\Filament;
 use Filament\Forms\Components\OneTimeCodeInput;
 use Filament\Notifications\Notification;
 use Filament\Support\Enums\Width;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\DB;
 
@@ -21,7 +22,7 @@ class SetUpEmailCodeAuthenticationAction
         return Action::make('setUpEmailCodeAuthentication')
             ->label(__('filament-panels::auth/multi-factor/email-code/actions/set-up.label'))
             ->color('primary')
-            ->icon('heroicon-m-lock-closed')
+            ->icon(Heroicon::LockClosed)
             ->link()
             ->mountUsing(function (HasActions $livewire) use ($emailCodeAuthentication) {
                 $livewire->mergeMountedActionArguments([
@@ -37,7 +38,7 @@ class SetUpEmailCodeAuthenticationAction
                 $emailCodeAuthentication->sendCode($user, $secret);
             })
             ->modalWidth(Width::Large)
-            ->modalIcon('heroicon-o-lock-closed')
+            ->modalIcon(Heroicon::OutlinedLockClosed)
             ->modalIconColor('primary')
             ->modalHeading(__('filament-panels::auth/multi-factor/email-code/actions/set-up.modal.heading'))
             ->modalDescription(__('filament-panels::auth/multi-factor/email-code/actions/set-up.modal.description'))
@@ -91,7 +92,7 @@ class SetUpEmailCodeAuthenticationAction
                 Notification::make()
                     ->title(__('filament-panels::auth/multi-factor/email-code/actions/set-up.notifications.enabled.title'))
                     ->success()
-                    ->icon('heroicon-o-lock-closed')
+                    ->icon(Heroicon::OutlinedLockClosed)
                     ->send();
             })
             ->rateLimit(5);

--- a/packages/panels/src/Auth/MultiFactor/GoogleTwoFactor/Actions/DisableGoogleTwoFactorAuthenticationAction.php
+++ b/packages/panels/src/Auth/MultiFactor/GoogleTwoFactor/Actions/DisableGoogleTwoFactorAuthenticationAction.php
@@ -14,6 +14,7 @@ use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Support\Enums\Width;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Facades\DB;
 
 class DisableGoogleTwoFactorAuthenticationAction
@@ -25,10 +26,10 @@ class DisableGoogleTwoFactorAuthenticationAction
         return Action::make('disableGoogleTwoFactorAuthentication')
             ->label(__('filament-panels::auth/multi-factor/google-two-factor/actions/disable.label'))
             ->color('danger')
-            ->icon('heroicon-m-lock-open')
+            ->icon(Heroicon::LockOpen)
             ->link()
             ->modalWidth(Width::Medium)
-            ->modalIcon('heroicon-o-lock-open')
+            ->modalIcon(Heroicon::OutlinedLockOpen)
             ->modalHeading(__('filament-panels::auth/multi-factor/google-two-factor/actions/disable.modal.heading'))
             ->modalDescription(__('filament-panels::auth/multi-factor/google-two-factor/actions/disable.modal.description'))
             ->form([
@@ -88,7 +89,7 @@ class DisableGoogleTwoFactorAuthenticationAction
                 Notification::make()
                     ->title(__('filament-panels::auth/multi-factor/google-two-factor/actions/disable.notifications.disabled.title'))
                     ->success()
-                    ->icon('heroicon-o-lock-open')
+                    ->icon(Heroicon::OutlinedLockOpen)
                     ->send();
             })
             ->rateLimit(5);

--- a/packages/panels/src/Auth/MultiFactor/GoogleTwoFactor/Actions/RegenerateGoogleTwoFactorAuthenticationRecoveryCodesAction.php
+++ b/packages/panels/src/Auth/MultiFactor/GoogleTwoFactor/Actions/RegenerateGoogleTwoFactorAuthenticationRecoveryCodesAction.php
@@ -17,6 +17,7 @@ use Filament\Schemas\Components\Text;
 use Filament\Schemas\Components\UnorderedList;
 use Filament\Support\Enums\FontFamily;
 use Filament\Support\Enums\Width;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Js;
@@ -28,10 +29,10 @@ class RegenerateGoogleTwoFactorAuthenticationRecoveryCodesAction
         return Action::make('regenerateGoogleTwoFactorAuthenticationRecoveryCodes')
             ->label(__('filament-panels::auth/multi-factor/google-two-factor/actions/regenerate-recovery-codes.label'))
             ->color('gray')
-            ->icon('heroicon-m-arrow-path')
+            ->icon(Heroicon::ArrowPath)
             ->link()
             ->modalWidth(Width::Large)
-            ->modalIcon('heroicon-o-arrow-path')
+            ->modalIcon(Heroicon::OutlinedArrowPath)
             ->modalIconColor('primary')
             ->modalHeading(__('filament-panels::auth/multi-factor/google-two-factor/actions/regenerate-recovery-codes.modal.heading'))
             ->modalDescription(__('filament-panels::auth/multi-factor/google-two-factor/actions/regenerate-recovery-codes.modal.description'))
@@ -75,7 +76,7 @@ class RegenerateGoogleTwoFactorAuthenticationRecoveryCodesAction
                 Notification::make()
                     ->title(__('filament-panels::auth/multi-factor/google-two-factor/actions/regenerate-recovery-codes.notifications.regenerated.title'))
                     ->success()
-                    ->icon('heroicon-o-arrow-path')
+                    ->icon(Heroicon::OutlinedArrowPath)
                     ->send();
             })
             ->registerModalActions([

--- a/packages/panels/src/Auth/MultiFactor/GoogleTwoFactor/Actions/SetUpGoogleTwoFactorAuthenticationAction.php
+++ b/packages/panels/src/Auth/MultiFactor/GoogleTwoFactor/Actions/SetUpGoogleTwoFactorAuthenticationAction.php
@@ -21,6 +21,7 @@ use Filament\Schemas\Components\UnorderedList;
 use Filament\Support\Enums\FontFamily;
 use Filament\Support\Enums\FontWeight;
 use Filament\Support\Enums\Width;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Facades\Blade;
@@ -35,7 +36,7 @@ class SetUpGoogleTwoFactorAuthenticationAction
         return Action::make('setUpGoogleTwoFactorAuthentication')
             ->label(__('filament-panels::auth/multi-factor/google-two-factor/actions/set-up.label'))
             ->color('primary')
-            ->icon('heroicon-m-lock-closed')
+            ->icon(Heroicon::LockClosed)
             ->link()
             ->mountUsing(function (HasActions $livewire, $action) use ($googleTwoFactorAuthentication) {
                 $livewire->mergeMountedActionArguments([
@@ -49,7 +50,7 @@ class SetUpGoogleTwoFactorAuthenticationAction
                 ]);
             })
             ->modalWidth(Width::Large)
-            ->modalIcon('heroicon-o-lock-closed')
+            ->modalIcon(Heroicon::OutlinedLockClosed)
             ->modalIconColor('primary')
             ->modalHeading(__('filament-panels::auth/multi-factor/google-two-factor/actions/set-up.modal.heading'))
             ->modalDescription(new HtmlString(Blade::render(__('filament-panels::auth/multi-factor/google-two-factor/actions/set-up.modal.description'))))
@@ -166,7 +167,7 @@ class SetUpGoogleTwoFactorAuthenticationAction
                 Notification::make()
                     ->title(__('filament-panels::auth/multi-factor/google-two-factor/actions/set-up.notifications.enabled.title'))
                     ->success()
-                    ->icon('heroicon-o-lock-closed')
+                    ->icon(Heroicon::OutlinedLockClosed)
                     ->send();
             })
             ->rateLimit(5);

--- a/packages/panels/src/Auth/Pages/PasswordReset/RequestPasswordReset.php
+++ b/packages/panels/src/Auth/Pages/PasswordReset/RequestPasswordReset.php
@@ -19,6 +19,7 @@ use Filament\Schemas\Components\NestedSchema;
 use Filament\Schemas\Components\RenderHook;
 use Filament\Schemas\Schema;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\View\PanelsRenderHook;
 use Illuminate\Contracts\Auth\CanResetPassword;
 use Illuminate\Contracts\Support\Htmlable;
@@ -142,8 +143,8 @@ class RequestPasswordReset extends SimplePage
             ->link()
             ->label(__('filament-panels::auth/pages/password-reset/request-password-reset.actions.login.label'))
             ->icon(match (__('filament-panels::layout.direction')) {
-                'rtl' => FilamentIcon::resolve('panels::pages.password-reset.request-password-reset.actions.login.rtl') ?? 'heroicon-m-arrow-right',
-                default => FilamentIcon::resolve('panels::pages.password-reset.request-password-reset.actions.login') ?? 'heroicon-m-arrow-left',
+                'rtl' => FilamentIcon::resolve('panels::pages.password-reset.request-password-reset.actions.login.rtl') ?? Heroicon::ArrowRight,
+                default => FilamentIcon::resolve('panels::pages.password-reset.request-password-reset.actions.login') ?? Heroicon::ArrowLeft,
             })
             ->url(filament()->getLoginUrl());
     }

--- a/packages/panels/src/Pages/Dashboard.php
+++ b/packages/panels/src/Pages/Dashboard.php
@@ -8,6 +8,7 @@ use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\NestedSchema;
 use Filament\Schemas\Schema;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Widgets\Widget;
 use Filament\Widgets\WidgetConfiguration;
 use Illuminate\Contracts\Support\Htmlable;
@@ -29,7 +30,7 @@ class Dashboard extends Page
     {
         return static::$navigationIcon
             ?? FilamentIcon::resolve('panels::pages.dashboard.navigation-item')
-            ?? (Filament::hasTopNavigation() ? 'heroicon-m-home' : 'heroicon-o-home');
+            ?? (Filament::hasTopNavigation() ? Heroicon::Home : Heroicon::OutlinedHome);
     }
 
     public static function getRoutePath(): string

--- a/packages/panels/src/Pages/Dashboard/Actions/FilterAction.php
+++ b/packages/panels/src/Pages/Dashboard/Actions/FilterAction.php
@@ -6,6 +6,7 @@ use Exception;
 use Filament\Actions\Action;
 use Filament\Pages\Dashboard;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Livewire\Component;
 
 class FilterAction extends Action
@@ -25,7 +26,7 @@ class FilterAction extends Action
 
         $this->modalSubmitActionLabel(__('filament-panels::pages/dashboard.actions.filter.modal.actions.apply.label'));
 
-        $this->icon(FilamentIcon::resolve('panels::pages.dashboard.actions.filter') ?? 'heroicon-m-funnel');
+        $this->icon(FilamentIcon::resolve('panels::pages.dashboard.actions.filter') ?? Heroicon::Funnel);
 
         $this->color('gray');
 

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -8,6 +8,7 @@ use Filament\Billing\Providers\Contracts\BillingProvider;
 use Filament\Facades\Filament;
 use Filament\Navigation\MenuItem;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Collection;
@@ -270,7 +271,7 @@ trait HasTenancy
 
         $action = Action::make('profile')
             ->label($page ? $page::getLabel() : Filament::getTenantName($currentTenant))
-            ->icon(FilamentIcon::resolve('panels::tenant-menu.profile-button') ?? 'heroicon-m-cog-6-tooth')
+            ->icon(FilamentIcon::resolve('panels::tenant-menu.profile-button') ?? Heroicon::Cog6Tooth)
             ->url($url = Filament::getTenantProfileUrl())
             ->visible(filament()->hasTenantProfile() && filled($url) && (blank($page) || $page::canView($currentTenant)))
             ->sort(-2);
@@ -289,7 +290,7 @@ trait HasTenancy
         $action = Action::make('billing')
             ->label(__('filament-panels::layout.actions.billing.label'))
             ->color('gray')
-            ->icon(FilamentIcon::resolve('panels::tenant-menu.billing-button') ?? 'heroicon-m-credit-card')
+            ->icon(FilamentIcon::resolve('panels::tenant-menu.billing-button') ?? Heroicon::CreditCard)
             ->url($url = Filament::getTenantBillingUrl())
             ->visible(filament()->hasTenantBilling() && filled($url))
             ->sort(-1);
@@ -309,7 +310,7 @@ trait HasTenancy
 
         $action = Action::make('register')
             ->label($page ? $page::getLabel() : null)
-            ->icon(FilamentIcon::resolve('panels::tenant-menu.registration-button') ?? 'heroicon-m-plus')
+            ->icon(FilamentIcon::resolve('panels::tenant-menu.registration-button') ?? Heroicon::Plus)
             ->url($url = Filament::getTenantRegistrationUrl())
             ->visible(filament()->hasTenantRegistration() && filled($url) && (blank($page) || $page::canView(Filament::getTenant())))
             ->sort(PHP_INT_MAX);

--- a/packages/panels/src/Panel/Concerns/HasUserMenu.php
+++ b/packages/panels/src/Panel/Concerns/HasUserMenu.php
@@ -7,6 +7,7 @@ use Filament\Actions\Action;
 use Filament\Facades\Filament;
 use Filament\Navigation\MenuItem;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Collection;
 
 trait HasUserMenu
@@ -35,7 +36,7 @@ trait HasUserMenu
 
         $action = Action::make('profile')
             ->label(($page ? $page::getLabel() : null) ?? Filament::getUserName(Filament::auth()->user()))
-            ->icon(FilamentIcon::resolve('panels::user-menu.profile-item') ?? 'heroicon-m-user-circle')
+            ->icon(FilamentIcon::resolve('panels::user-menu.profile-item') ?? Heroicon::UserCircle)
             ->url(Filament::getProfileUrl())
             ->sort(-1);
 
@@ -52,7 +53,7 @@ trait HasUserMenu
     {
         $action = Action::make('logout')
             ->label(__('filament-panels::layout.actions.logout.label'))
-            ->icon(FilamentIcon::resolve('panels::user-menu.logout-button') ?? 'heroicon-m-arrow-left-on-rectangle')
+            ->icon(FilamentIcon::resolve('panels::user-menu.logout-button') ?? Heroicon::ArrowLeftOnRectangle)
             ->url(Filament::getLogoutUrl())
             ->postToUrl()
             ->sort(PHP_INT_MAX);

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -20,6 +20,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Exceptions\Halt;
 use Filament\Support\Facades\FilamentIcon;
 use Filament\Support\Facades\FilamentView;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
@@ -49,7 +50,7 @@ class EditRecord extends Page
     {
         return static::$navigationIcon
             ?? FilamentIcon::resolve('panels::resources.pages.edit-record.navigation-item')
-            ?? 'heroicon-o-pencil-square';
+            ?? Heroicon::OutlinedPencilSquare;
     }
 
     public function getBreadcrumb(): string

--- a/packages/panels/src/Resources/Pages/ManageRelatedRecords.php
+++ b/packages/panels/src/Resources/Pages/ManageRelatedRecords.php
@@ -24,6 +24,7 @@ use Filament\Schemas\Components\RenderHook;
 use Filament\Schemas\Components\TableBuilder;
 use Filament\Schemas\Schema;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables;
 use Filament\View\PanelsRenderHook;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -76,7 +77,7 @@ class ManageRelatedRecords extends Page implements Tables\Contracts\HasTable
     {
         return static::$navigationIcon
             ?? FilamentIcon::resolve('panels::resources.pages.manage-related-records.navigation-item')
-            ?? 'heroicon-o-rectangle-stack';
+            ?? Heroicon::OutlinedRectangleStack;
     }
 
     public function mount(int | string $record): void

--- a/packages/panels/src/Resources/Pages/ViewRecord.php
+++ b/packages/panels/src/Resources/Pages/ViewRecord.php
@@ -13,6 +13,7 @@ use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\NestedSchema;
 use Filament\Schemas\Schema;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
@@ -34,7 +35,7 @@ class ViewRecord extends Page
     {
         return static::$navigationIcon
             ?? FilamentIcon::resolve('panels::resources.pages.view-record.navigation-item')
-            ?? 'heroicon-o-eye';
+            ?? Heroicon::OutlinedEye;
     }
 
     public function getBreadcrumb(): string

--- a/packages/schemas/resources/views/components/wizard.blade.php
+++ b/packages/schemas/resources/views/components/wizard.blade.php
@@ -174,7 +174,7 @@
 
                         <x-filament::icon
                             :alias="filled($completedIcon) ? null : 'schema::components.wizard.completed-step'"
-                            :icon="$completedIcon ?? 'heroicon-o-check'"
+                            :icon="$completedIcon ?? \Filament\Support\Icons\Heroicon::OutlinedCheck"
                             x-cloak="x-cloak"
                             x-show="getStepIndex(step) > {{ $loop->index }}"
                             class="fi-fo-wizard-header-step-icon size-6 text-white"

--- a/packages/spatie-laravel-settings-plugin/src/Commands/FileGenerators/SettingsPageClassGenerator.php
+++ b/packages/spatie-laravel-settings-plugin/src/Commands/FileGenerators/SettingsPageClassGenerator.php
@@ -84,8 +84,9 @@ class SettingsPageClassGenerator extends ClassGenerator
     protected function addNavigationIconPropertyToClass(ClassType $class): void
     {
         $this->namespace->addUse(BackedEnum::class);
+        $this->namespace->addUse(Heroicon::class);
 
-        $property = $class->addProperty('navigationIcon', Heroicon::OutlinedCog6Tooth)
+        $property = $class->addProperty('navigationIcon', new Literal('Heroicon::OutlinedCog6Tooth'))
             ->setProtected()
             ->setStatic()
             ->setType('string|BackedEnum|null');

--- a/packages/spatie-laravel-settings-plugin/src/Commands/FileGenerators/SettingsPageClassGenerator.php
+++ b/packages/spatie-laravel-settings-plugin/src/Commands/FileGenerators/SettingsPageClassGenerator.php
@@ -13,6 +13,7 @@ use Filament\Forms\Components\Toggle;
 use Filament\Pages\SettingsPage;
 use Filament\Schemas\Schema;
 use Filament\Support\Commands\FileGenerators\ClassGenerator;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Str;
 use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\Literal;
@@ -84,7 +85,7 @@ class SettingsPageClassGenerator extends ClassGenerator
     {
         $this->namespace->addUse(BackedEnum::class);
 
-        $property = $class->addProperty('navigationIcon', 'heroicon-o-cog-6-tooth')
+        $property = $class->addProperty('navigationIcon', Heroicon::OutlinedCog6Tooth)
             ->setProtected()
             ->setStatic()
             ->setType('string|BackedEnum|null');

--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -142,7 +142,7 @@
             }}
         >
             {{
-                \Filament\Support\generate_icon_html('heroicon-c-x-mark', alias: 'badge.delete-button', attributes: (new \Illuminate\View\ComponentAttributeBag([
+                \Filament\Support\generate_icon_html(\Filament\Support\Icons\Heroicon::XMark, alias: 'badge.delete-button', attributes: (new \Illuminate\View\ComponentAttributeBag([
                     'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $deleteButtonHasLoadingIndicator,
                     'wire:target' => $deleteButtonHasLoadingIndicator ? $deleteButtonLoadingIndicatorTarget : false,
                 ])), size: \Filament\Support\Enums\IconSize::ExtraSmall)

--- a/packages/support/resources/views/components/breadcrumbs.blade.php
+++ b/packages/support/resources/views/components/breadcrumbs.blade.php
@@ -14,13 +14,13 @@
             <li class="fi-breadcrumbs-item">
                 @if (! $loop->first)
                     {{
-                        generate_icon_html('heroicon-m-chevron-right', alias: 'breadcrumbs.separator', attributes: (new ComponentAttributeBag)->class([
+                        generate_icon_html(\Filament\Support\Icons\Heroicon::ChevronRight, alias: 'breadcrumbs.separator', attributes: (new ComponentAttributeBag)->class([
                             'fi-breadcrumbs-item-separator fi-ltr',
                         ]))
                     }}
 
                     {{
-                        generate_icon_html('heroicon-m-chevron-left', alias: 'breadcrubs.separator.rtl', attributes: (new ComponentAttributeBag)->class([
+                        generate_icon_html(\Filament\Support\Icons\Heroicon::ChevronLeft, alias: 'breadcrubs.separator.rtl', attributes: (new ComponentAttributeBag)->class([
                             'fi-breadcrumbs-item-separator fi-rtl',
                         ]))
                     }}

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -166,7 +166,7 @@
                             @if ($closeButton)
                                 <x-filament::icon-button
                                     color="gray"
-                                    icon="heroicon-o-x-mark"
+                                    :icon="\Filament\Support\Icons\Heroicon::OutlinedXMark"
                                     icon-alias="modal.close-button"
                                     icon-size="lg"
                                     :label="__('filament::components/modal.actions.close.label')"

--- a/packages/support/resources/views/components/pagination/index.blade.php
+++ b/packages/support/resources/views/components/pagination/index.blade.php
@@ -122,7 +122,7 @@
                 @if ($extremeLinks)
                     <x-filament::pagination.item
                         :aria-label="__('filament::components/pagination.actions.first.label')"
-                        :icon="$isRtl ? 'heroicon-m-chevron-double-right' : 'heroicon-m-chevron-double-left'"
+                        :icon="$isRtl ? \Filament\Support\Icons\Heroicon::ChevronDoubleRight : \Filament\Support\Icons\Heroicon::ChevronDoubleLeft"
                         :icon-alias="$isRtl ? 'pagination.first-button.rtl' : 'pagination.first-button'"
                         rel="first"
                         :wire:click="'gotoPage(1, \'' . $paginator->getPageName() . '\')'"
@@ -132,7 +132,7 @@
 
                 <x-filament::pagination.item
                     :aria-label="__('filament::components/pagination.actions.previous.label')"
-                    :icon="$isRtl ? 'heroicon-m-chevron-right' : 'heroicon-m-chevron-left'"
+                    :icon="$isRtl ? \Filament\Support\Icons\Heroicon::ChevronRight : \Filament\Support\Icons\Heroicon::ChevronLeft"
                     {{-- @deprecated Use `pagination.previous-button.rtl` instead of `pagination.previous-button` for RTL. --}}
                     :icon-alias="$isRtl ? ['pagination.previous-button.rtl', 'pagination.previous-button'] : 'pagination.previous-button'"
                     rel="prev"
@@ -162,7 +162,7 @@
             @if ($paginator->hasMorePages())
                 <x-filament::pagination.item
                     :aria-label="__('filament::components/pagination.actions.next.label')"
-                    :icon="$isRtl ? 'heroicon-m-chevron-left' : 'heroicon-m-chevron-right'"
+                    :icon="$isRtl ? \Filament\Support\Icons\Heroicon::ChevronLeft : \Filament\Support\Icons\Heroicon::ChevronRight"
                     {{-- @deprecated Use `pagination.next-button.rtl` instead of `pagination.next-button` for RTL. --}}
                     :icon-alias="$isRtl ? ['pagination.next-button.rtl', 'pagination.next-button'] : 'pagination.next-button'"
                     rel="next"
@@ -173,7 +173,7 @@
                 @if ($extremeLinks)
                     <x-filament::pagination.item
                         :aria-label="__('filament::components/pagination.actions.last.label')"
-                        :icon="$isRtl ? 'heroicon-m-chevron-double-left' : 'heroicon-m-chevron-double-right'"
+                        :icon="$isRtl ? \Filament\Support\Icons\Heroicon::ChevronDoubleLeft : \Filament\Support\Icons\Heroicon::ChevronDoubleRight"
                         :icon-alias="$isRtl ? 'pagination.last-button.rtl' : 'pagination.last-button'"
                         rel="last"
                         :wire:click="'gotoPage(' . $paginator->lastPage() . ', \'' . $paginator->getPageName() . '\')'"

--- a/packages/support/resources/views/components/section/index.blade.php
+++ b/packages/support/resources/views/components/section/index.blade.php
@@ -99,7 +99,7 @@
             @if ($collapsible)
                 <x-filament::icon-button
                     color="gray"
-                    icon="heroicon-m-chevron-down"
+                    :icon="\Filament\Support\Icons\Heroicon::ChevronDown"
                     icon-alias="section.collapse-button"
                     x-on:click.stop="isCollapsed = ! isCollapsed"
                     class="fi-section-collapse-btn"

--- a/packages/tables/resources/views/components/search-field.blade.php
+++ b/packages/tables/resources/views/components/search-field.blade.php
@@ -23,7 +23,7 @@
 
     <x-filament::input.wrapper
         inline-prefix
-        prefix-icon="heroicon-m-magnifying-glass"
+        :prefix-icon="\Filament\Support\Icons\Heroicon::MagnifyingGlass"
         prefix-icon-alias="tables::search-field"
         :wire:target="$wireModel"
     >

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -581,7 +581,7 @@
                         wire:target="removeTableFilters,removeTableFilter"
                         class="fi-icon-btn fi-size-sm"
                     >
-                        {{ \Filament\Support\generate_icon_html('heroicon-m-x-mark', alias: 'tables::filters.remove-all-button', size: \FIlament\Support\Enums\IconSize::Small) }}
+                        {{ \Filament\Support\generate_icon_html(\Filament\Support\Icons\Heroicon::XMark, alias: 'tables::filters.remove-all-button', size: \FIlament\Support\Enums\IconSize::Small) }}
                     </button>
                 @endif
             </div>
@@ -857,7 +857,7 @@
                                                 type="button"
                                                 class="fi-icon-btn fi-size-sm"
                                             >
-                                                {{ \Filament\Support\generate_icon_html('heroicon-m-chevron-up', alias: 'tables::grouping.collapse-button', size: \FIlament\Support\Enums\IconSize::Small) }}
+                                                {{ \Filament\Support\generate_icon_html(\Filament\Support\Icons\Heroicon::ChevronUp, alias: 'tables::grouping.collapse-button', size: \FIlament\Support\Enums\IconSize::Small) }}
                                             </button>
                                         @endif
                                     </div>
@@ -898,7 +898,7 @@
                                             class="fi-ta-reorder-handle fi-icon-btn"
                                             type="button"
                                         >
-                                            {{ \Filament\Support\generate_icon_html('heroicon-m-bars-2', alias: 'tables::reorder.handle') }}
+                                            {{ \Filament\Support\generate_icon_html(\Filament\Support\Icons\Heroicon::Bars2, alias: 'tables::reorder.handle') }}
                                         </button>
                                     @elseif ($isSelectionEnabled && $isRecordSelectable($record))
                                         <input
@@ -1003,7 +1003,7 @@
                                             x-on:click="isCollapsed = ! isCollapsed"
                                             class="fi-ta-record-collapse-btn fi-icon-btn"
                                         >
-                                            {{ \Filament\Support\generate_icon_html('heroicon-m-chevron-down', alias: 'tables::columns.collapse-button') }}
+                                            {{ \Filament\Support\generate_icon_html(\Filament\Support\Icons\Heroicon::ChevronDown, alias: 'tables::columns.collapse-button') }}
                                         </button>
                                     @endif
                                 </div>
@@ -1232,7 +1232,7 @@
                                                 {{ $columnLabel }}
 
                                                 {{
-                                                    \Filament\Support\generate_icon_html(($isColumnActivelySorted && $sortDirection === 'asc') ? 'heroicon-m-chevron-up' : 'heroicon-m-chevron-down', alias: match (true) {
+                                                    \Filament\Support\generate_icon_html(($isColumnActivelySorted && $sortDirection === 'asc') ? \Filament\Support\Icons\Heroicon::ChevronUp : \Filament\Support\Icons\Heroicon::ChevronDown, alias: match (true) {
                                                         $isColumnActivelySorted && ($sortDirection === 'asc') => 'tables::header-cell.sort-asc-button',
                                                         $isColumnActivelySorted && ($sortDirection === 'desc') => 'tables::header-cell.sort-desc-button',
                                                         default => 'tables::header-cell.sort-button',
@@ -1507,7 +1507,7 @@
                                                                 type="button"
                                                                 class="fi-icon-btn fi-size-sm"
                                                             >
-                                                                {{ \Filament\Support\generate_icon_html('heroicon-m-chevron-up', alias: 'tables::grouping.collapse-button', size: \FIlament\Support\Enums\IconSize::Small) }}
+                                                                {{ \Filament\Support\generate_icon_html(\Filament\Support\Icons\Heroicon::ChevronUp, alias: 'tables::grouping.collapse-button', size: \FIlament\Support\Enums\IconSize::Small) }}
                                                             </button>
                                                         @endif
                                                     </div>
@@ -1571,7 +1571,7 @@
                                                         class="fi-ta-reorder-handle fi-icon-btn"
                                                         type="button"
                                                     >
-                                                        {{ \Filament\Support\generate_icon_html('heroicon-m-bars-2', alias: 'tables::reorder.handle') }}
+                                                        {{ \Filament\Support\generate_icon_html(\Filament\Support\Icons\Heroicon::Bars2, alias: 'tables::reorder.handle') }}
                                                     </button>
                                                 </td>
                                             @endif

--- a/packages/tables/src/Columns/IconColumn.php
+++ b/packages/tables/src/Columns/IconColumn.php
@@ -8,6 +8,7 @@ use Filament\Support\Components\Contracts\HasEmbeddedView;
 use Filament\Support\Enums\Alignment;
 use Filament\Support\Enums\IconSize;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\IconColumn\Enums\IconColumnSize;
 use Filament\Tables\View\Components\Columns\IconColumn\Icon;
 use Illuminate\Contracts\Support\Arrayable;
@@ -211,7 +212,7 @@ class IconColumn extends Column implements HasEmbeddedView
     {
         return $this->evaluate($this->falseIcon)
             ?? FilamentIcon::resolve('tables::columns.icon-column.false')
-            ?? 'heroicon-o-x-circle';
+            ?? Heroicon::OutlinedXCircle;
     }
 
     /**
@@ -226,7 +227,7 @@ class IconColumn extends Column implements HasEmbeddedView
     {
         return $this->evaluate($this->trueIcon)
             ?? FilamentIcon::resolve('tables::columns.icon-column.true')
-            ?? 'heroicon-o-check-circle';
+            ?? Heroicon::OutlinedCheckCircle;
     }
 
     public function isBoolean(): bool

--- a/packages/tables/src/Columns/ToggleColumn.php
+++ b/packages/tables/src/Columns/ToggleColumn.php
@@ -5,6 +5,7 @@ namespace Filament\Tables\Columns;
 use Filament\Forms\Components\Concerns\HasToggleColors;
 use Filament\Forms\Components\Concerns\HasToggleIcons;
 use Filament\Support\Components\Contracts\HasEmbeddedView;
+use Filament\Support\Enums\IconSize;
 use Filament\Support\Facades\FilamentAsset;
 use Filament\Support\Facades\FilamentView;
 use Filament\Support\View\Components\Toggle;
@@ -104,14 +105,14 @@ class ToggleColumn extends Column implements Editable, HasEmbeddedView
             >
                 <div>
                     <div aria-hidden="true">
-                        <?= generate_icon_html($offIcon, size: \Filament\Support\Enums\IconSize::ExtraSmall)?->toHtml() ?>
+                        <?= generate_icon_html($offIcon, size: IconSize::ExtraSmall)?->toHtml() ?>
                     </div>
 
                     <div aria-hidden="true">
                         <?= generate_icon_html(
                             $onIcon,
                             attributes: (new ComponentAttributeBag)->merge(['x-cloak' => true], escape: false),
-                            size: \Filament\Support\Enums\IconSize::ExtraSmall,
+                            size: IconSize::ExtraSmall,
                         )?->toHtml() ?>
                     </div>
                 </div>

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/BooleanConstraint.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/BooleanConstraint.php
@@ -3,6 +3,7 @@
 namespace Filament\Tables\Filters\QueryBuilder\Constraints;
 
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Filters\QueryBuilder\Constraints\BooleanConstraint\Operators\IsTrueOperator;
 use Filament\Tables\Filters\QueryBuilder\Constraints\Operators\IsFilledOperator;
 
@@ -14,7 +15,7 @@ class BooleanConstraint extends Constraint
     {
         parent::setUp();
 
-        $this->icon(FilamentIcon::resolve('tables::filters.query-builder.constraints.boolean') ?? 'heroicon-m-check-circle');
+        $this->icon(FilamentIcon::resolve('tables::filters.query-builder.constraints.boolean') ?? Heroicon::CheckCircle);
 
         $this->operators([
             IsTrueOperator::class,

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/DateConstraint.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/DateConstraint.php
@@ -3,6 +3,7 @@
 namespace Filament\Tables\Filters\QueryBuilder\Constraints;
 
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Filters\QueryBuilder\Constraints\DateConstraint\Operators\IsAfterOperator;
 use Filament\Tables\Filters\QueryBuilder\Constraints\DateConstraint\Operators\IsBeforeOperator;
 use Filament\Tables\Filters\QueryBuilder\Constraints\DateConstraint\Operators\IsDateOperator;
@@ -18,7 +19,7 @@ class DateConstraint extends Constraint
     {
         parent::setUp();
 
-        $this->icon(FilamentIcon::resolve('tables::filters.query-builder.constraints.date') ?? 'heroicon-m-calendar');
+        $this->icon(FilamentIcon::resolve('tables::filters.query-builder.constraints.date') ?? Heroicon::Calendar);
 
         $this->operators([
             IsAfterOperator::class,

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/NumberConstraint.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/NumberConstraint.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Filters\QueryBuilder\Constraints;
 
 use Closure;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Filters\QueryBuilder\Constraints\NumberConstraint\Operators\EqualsOperator;
 use Filament\Tables\Filters\QueryBuilder\Constraints\NumberConstraint\Operators\IsMaxOperator;
 use Filament\Tables\Filters\QueryBuilder\Constraints\NumberConstraint\Operators\IsMinOperator;
@@ -24,7 +25,7 @@ class NumberConstraint extends Constraint
     {
         parent::setUp();
 
-        $this->icon(FilamentIcon::resolve('tables::filters.query-builder.constraints.number') ?? 'heroicon-m-variable');
+        $this->icon(FilamentIcon::resolve('tables::filters.query-builder.constraints.number') ?? Heroicon::Variable);
 
         $this->operators([
             IsMinOperator::class,

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/RelationshipConstraint.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/RelationshipConstraint.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Filters\QueryBuilder\Constraints;
 
 use Closure;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Filters\QueryBuilder\Constraints\RelationshipConstraint\Operators\EqualsOperator;
 use Filament\Tables\Filters\QueryBuilder\Constraints\RelationshipConstraint\Operators\HasMaxOperator;
 use Filament\Tables\Filters\QueryBuilder\Constraints\RelationshipConstraint\Operators\HasMinOperator;
@@ -20,7 +21,7 @@ class RelationshipConstraint extends Constraint
     {
         parent::setUp();
 
-        $this->icon(FilamentIcon::resolve('tables::filters.query-builder.constraints.relationship') ?? 'heroicon-m-arrows-pointing-out');
+        $this->icon(FilamentIcon::resolve('tables::filters.query-builder.constraints.relationship') ?? Heroicon::ArrowsPointingOut);
 
         $this->operators([
             HasMinOperator::make()

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/SelectConstraint.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/SelectConstraint.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Filters\QueryBuilder\Constraints;
 
 use Closure;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Filters\Concerns\HasOptions;
 use Filament\Tables\Filters\QueryBuilder\Constraints\Operators\IsFilledOperator;
 use Filament\Tables\Filters\QueryBuilder\Constraints\SelectConstraint\Operators\IsOperator;
@@ -27,7 +28,7 @@ class SelectConstraint extends Constraint
     {
         parent::setUp();
 
-        $this->icon(FilamentIcon::resolve('tables::filters.query-builder.constraints.select') ?? 'heroicon-m-chevron-up-down');
+        $this->icon(FilamentIcon::resolve('tables::filters.query-builder.constraints.select') ?? Heroicon::ChevronUpDown);
 
         $this->operators([
             IsOperator::class,

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint.php
@@ -3,6 +3,7 @@
 namespace Filament\Tables\Filters\QueryBuilder\Constraints;
 
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Filters\QueryBuilder\Constraints\Operators\IsFilledOperator;
 use Filament\Tables\Filters\QueryBuilder\Constraints\TextConstraint\Operators\ContainsOperator;
 use Filament\Tables\Filters\QueryBuilder\Constraints\TextConstraint\Operators\EndsWithOperator;
@@ -17,7 +18,7 @@ class TextConstraint extends Constraint
     {
         parent::setUp();
 
-        $this->icon(FilamentIcon::resolve('tables::filters.query-builder.constraints.text') ?? 'heroicon-m-language');
+        $this->icon(FilamentIcon::resolve('tables::filters.query-builder.constraints.text') ?? Heroicon::Language);
 
         $this->operators([
             ContainsOperator::class,

--- a/packages/tables/src/Filters/QueryBuilder/Forms/Components/RuleBuilder.php
+++ b/packages/tables/src/Filters/QueryBuilder/Forms/Components/RuleBuilder.php
@@ -8,6 +8,7 @@ use Filament\Forms\Components\Builder;
 use Filament\Forms\Components\Repeater;
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Filters\QueryBuilder\Concerns\HasConstraints;
 use Filament\Tables\Filters\QueryBuilder\Constraints\Constraint;
 use Illuminate\Support\Str;
@@ -57,7 +58,7 @@ class RuleBuilder extends Builder
 
                             return '(' . $itemLabels->implode(') ' . __('filament-tables::filters/query-builder.form.or_groups.block.or') . ' (') . ')';
                         })
-                        ->icon('heroicon-m-bars-4')
+                        ->icon(Heroicon::Bars4)
                         ->schema(fn (): array => [
                             Repeater::make(static::OR_BLOCK_GROUPS_REPEATER_NAME)
                                 ->label(__('filament-tables::filters/query-builder.form.or_groups.label'))
@@ -69,7 +70,7 @@ class RuleBuilder extends Builder
                                 ])
                                 ->addAction(fn (Action $action) => $action
                                     ->label(__('filament-tables::filters/query-builder.actions.add_rule_group.label'))
-                                    ->icon('heroicon-m-plus'))
+                                    ->icon(Heroicon::Plus))
                                 ->labelBetweenItems(__('filament-tables::filters/query-builder.item_separators.or'))
                                 ->collapsible()
                                 ->expandAllAction(fn (Action $action) => $action->hidden())
@@ -112,7 +113,7 @@ class RuleBuilder extends Builder
             })
             ->addAction(fn (Action $action) => $action
                 ->label(__('filament-tables::filters/query-builder.actions.add_rule.label'))
-                ->icon('heroicon-m-plus'))
+                ->icon(Heroicon::Plus))
             ->addBetweenAction(fn (Action $action) => $action->hidden())
             ->label(__('filament-tables::filters/query-builder.form.rules.label'))
             ->hiddenLabel()

--- a/packages/tables/src/Table/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Table/Concerns/CanGroupRecords.php
@@ -6,6 +6,7 @@ use Closure;
 use Filament\Actions\Action;
 use Filament\Support\Enums\ActionSize;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Grouping\Group;
 
 trait CanGroupRecords
@@ -99,7 +100,7 @@ trait CanGroupRecords
         $action = Action::make('groupRecords')
             ->label(__('filament-tables::table.actions.group.label'))
             ->iconButton()
-            ->icon(FilamentIcon::resolve('tables::actions.group') ?? 'heroicon-m-rectangle-stack')
+            ->icon(FilamentIcon::resolve('tables::actions.group') ?? Heroicon::RectangleStack)
             ->color('gray')
             ->livewireClickHandlerEnabled(false)
             ->table($this);

--- a/packages/tables/src/Table/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Table/Concerns/CanReorderRecords.php
@@ -6,6 +6,7 @@ use Closure;
 use Filament\Actions\Action;
 use Filament\Support\Concerns\HasReorderAnimationDuration;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 
 trait CanReorderRecords
 {
@@ -49,7 +50,7 @@ trait CanReorderRecords
         $action = Action::make('reorderRecords')
             ->label($isReordering ? __('filament-tables::table.actions.disable_reordering.label') : __('filament-tables::table.actions.enable_reordering.label'))
             ->iconButton()
-            ->icon($isReordering ? (FilamentIcon::resolve('tables::actions.disable-reordering') ?? 'heroicon-m-check') : (FilamentIcon::resolve('tables::actions.enable-reordering') ?? 'heroicon-m-arrows-up-down'))
+            ->icon($isReordering ? (FilamentIcon::resolve('tables::actions.disable-reordering') ?? Heroicon::Check) : (FilamentIcon::resolve('tables::actions.enable-reordering') ?? Heroicon::ArrowsUpDown))
             ->color('gray')
             ->action('toggleTableReordering')
             ->table($this);

--- a/packages/tables/src/Table/Concerns/CanToggleColumns.php
+++ b/packages/tables/src/Table/Concerns/CanToggleColumns.php
@@ -8,6 +8,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Enums\ActionSize;
 use Filament\Support\Enums\Width;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 
 trait CanToggleColumns
 {
@@ -58,7 +59,7 @@ trait CanToggleColumns
         $action = Action::make('toggleColumns')
             ->label(__('filament-tables::table.actions.toggle_columns.label'))
             ->iconButton()
-            ->icon(FilamentIcon::resolve('tables::actions.toggle-columns') ?? 'heroicon-m-view-columns')
+            ->icon(FilamentIcon::resolve('tables::actions.toggle-columns') ?? Heroicon::ViewColumns)
             ->color('gray')
             ->livewireClickHandlerEnabled(false)
             ->table($this);

--- a/packages/tables/src/Table/Concerns/HasEmptyState.php
+++ b/packages/tables/src/Table/Concerns/HasEmptyState.php
@@ -7,6 +7,7 @@ use Closure;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Arr;
@@ -120,6 +121,6 @@ trait HasEmptyState
     {
         return $this->evaluate($this->emptyStateIcon)
             ?? FilamentIcon::resolve('tables::empty-state')
-            ?? 'heroicon-o-x-mark';
+            ?? Heroicon::OutlinedXMark;
     }
 }

--- a/packages/tables/src/Table/Concerns/HasFilters.php
+++ b/packages/tables/src/Table/Concerns/HasFilters.php
@@ -9,6 +9,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Enums\ActionSize;
 use Filament\Support\Enums\Width;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Enums\FiltersLayout;
 use Filament\Tables\Filters\BaseFilter;
 
@@ -199,7 +200,7 @@ trait HasFilters
         $action = Action::make('openFilters')
             ->label(__('filament-tables::table.actions.filter.label'))
             ->iconButton()
-            ->icon(FilamentIcon::resolve('tables::actions.filter') ?? 'heroicon-m-funnel')
+            ->icon(FilamentIcon::resolve('tables::actions.filter') ?? Heroicon::Funnel)
             ->color('gray')
             ->livewireClickHandlerEnabled(false)
             ->modalSubmitAction(false)

--- a/packages/tables/src/Testing/TestsActions.php
+++ b/packages/tables/src/Testing/TestsActions.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Tables\Testing;
 
+use BackedEnum;
 use Closure;
 use Filament\Actions\Action;
 use Filament\Actions\Testing\TestsActions as BaseTestsActions;
@@ -201,7 +202,7 @@ class TestsActions
 
     public function assertTableActionHasIcon(): Closure
     {
-        return function (string | array $actions, string $icon, $record = null): static {
+        return function (string | array $actions, string | BackedEnum $icon, $record = null): static {
             /** @var array<array<string, mixed>> $actions */
             /** @phpstan-ignore-next-line */
             $actions = $this->parseNestedTableActions($actions, $record);
@@ -214,7 +215,7 @@ class TestsActions
 
     public function assertTableActionDoesNotHaveIcon(): Closure
     {
-        return function (string | array $actions, string $icon, $record = null): static {
+        return function (string | array $actions, string | BackedEnum $icon, $record = null): static {
             /** @var array<array<string, mixed>> $actions */
             /** @phpstan-ignore-next-line */
             $actions = $this->parseNestedTableActions($actions, $record);

--- a/packages/tables/src/Testing/TestsBulkActions.php
+++ b/packages/tables/src/Testing/TestsBulkActions.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Tables\Testing;
 
+use BackedEnum;
 use Closure;
 use Filament\Actions\BulkAction;
 use Filament\Tables\Contracts\HasTable;
@@ -188,7 +189,7 @@ class TestsBulkActions
 
     public function assertTableBulkActionHasIcon(): Closure
     {
-        return function (string | array $actions, string $icon): static {
+        return function (string | array $actions, string | BackedEnum $icon): static {
             /** @var array<array<string, mixed>> $actions */
             /** @phpstan-ignore-next-line */
             $actions = $this->parseNestedTableBulkActions($actions);
@@ -201,7 +202,7 @@ class TestsBulkActions
 
     public function assertTableBulkActionDoesNotHaveIcon(): Closure
     {
-        return function (string | array $actions, string $icon): static {
+        return function (string | array $actions, string | BackedEnum $icon): static {
             /** @var array<array<string, mixed>> $actions */
             /** @phpstan-ignore-next-line */
             $actions = $this->parseNestedTableBulkActions($actions);

--- a/packages/widgets/src/ChartWidget/Concerns/HasFiltersSchema.php
+++ b/packages/widgets/src/ChartWidget/Concerns/HasFiltersSchema.php
@@ -5,6 +5,7 @@ namespace Filament\Widgets\ChartWidget\Concerns;
 use Filament\Actions\Action;
 use Filament\Schemas\Schema;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 
 trait HasFiltersSchema
 {
@@ -20,7 +21,7 @@ trait HasFiltersSchema
         return Action::make('filter')
             ->label(__('filament-widgets::chart.actions.filter.label'))
             ->iconButton()
-            ->icon(FilamentIcon::resolve('widgets::chart-widget.filter') ?? 'heroicon-m-funnel')
+            ->icon(FilamentIcon::resolve('widgets::chart-widget.filter') ?? Heroicon::Funnel)
             ->color('gray')
             ->livewireClickHandlerEnabled(false);
     }

--- a/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest/it_can_generate_a_page_class.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest/it_can_generate_a_page_class.snap
@@ -6,11 +6,12 @@ use BackedEnum;
 use Filament\Forms;
 use Filament\Pages\SettingsPage;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Panels\Commands\Legacy\Settings;
 
 class ManageSettings extends SettingsPage
 {
-    protected static string|BackedEnum|null $navigationIcon = \Filament\Support\Icons\Heroicon::OutlinedCog6Tooth;
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCog6Tooth;
 
     protected static string $settings = Settings::class;
 

--- a/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest/it_can_generate_a_page_class.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest/it_can_generate_a_page_class.snap
@@ -10,7 +10,7 @@ use Filament\Tests\Panels\Commands\Legacy\Settings;
 
 class ManageSettings extends SettingsPage
 {
-    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-cog-6-tooth';
+    protected static string|BackedEnum|null $navigationIcon = \Filament\Support\Icons\Heroicon::OutlinedCog6Tooth;
 
     protected static string $settings = Settings::class;
 

--- a/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest/it_can_generate_a_page_class_in_a_cluster.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest/it_can_generate_a_page_class_in_a_cluster.snap
@@ -11,7 +11,7 @@ use Filament\Tests\Panels\Commands\Legacy\Settings;
 
 class ManageSettings extends SettingsPage
 {
-    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-cog-6-tooth';
+    protected static string|BackedEnum|null $navigationIcon = \Filament\Support\Icons\Heroicon::OutlinedCog6Tooth;
 
     protected static string $settings = Settings::class;
 

--- a/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest/it_can_generate_a_page_class_in_a_cluster.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest/it_can_generate_a_page_class_in_a_cluster.snap
@@ -7,11 +7,12 @@ use BackedEnum;
 use Filament\Forms;
 use Filament\Pages\SettingsPage;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Panels\Commands\Legacy\Settings;
 
 class ManageSettings extends SettingsPage
 {
-    protected static string|BackedEnum|null $navigationIcon = \Filament\Support\Icons\Heroicon::OutlinedCog6Tooth;
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCog6Tooth;
 
     protected static string $settings = Settings::class;
 

--- a/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest/it_can_generate_a_page_class_in_a_nested_directory.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest/it_can_generate_a_page_class_in_a_nested_directory.snap
@@ -6,11 +6,12 @@ use BackedEnum;
 use Filament\Forms;
 use Filament\Pages\SettingsPage;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Panels\Commands\Legacy\Settings;
 
 class ManageSettings extends SettingsPage
 {
-    protected static string|BackedEnum|null $navigationIcon = \Filament\Support\Icons\Heroicon::OutlinedCog6Tooth;
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCog6Tooth;
 
     protected static string $settings = Settings::class;
 

--- a/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest/it_can_generate_a_page_class_in_a_nested_directory.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest/it_can_generate_a_page_class_in_a_nested_directory.snap
@@ -10,7 +10,7 @@ use Filament\Tests\Panels\Commands\Legacy\Settings;
 
 class ManageSettings extends SettingsPage
 {
-    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-cog-6-tooth';
+    protected static string|BackedEnum|null $navigationIcon = \Filament\Support\Icons\Heroicon::OutlinedCog6Tooth;
 
     protected static string $settings = Settings::class;
 

--- a/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest/it_can_generate_a_page_class_with_a_generated_form_schema.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest/it_can_generate_a_page_class_with_a_generated_form_schema.snap
@@ -11,7 +11,7 @@ use Filament\Tests\Panels\Commands\Legacy\SettingsPropertyEnum;
 
 class ManageSettings extends SettingsPage
 {
-    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-cog-6-tooth';
+    protected static string|BackedEnum|null $navigationIcon = \Filament\Support\Icons\Heroicon::OutlinedCog6Tooth;
 
     protected static string $settings = Settings::class;
 

--- a/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest/it_can_generate_a_page_class_with_a_generated_form_schema.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest/it_can_generate_a_page_class_with_a_generated_form_schema.snap
@@ -6,12 +6,13 @@ use BackedEnum;
 use Filament\Forms;
 use Filament\Pages\SettingsPage;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Panels\Commands\Legacy\Settings;
 use Filament\Tests\Panels\Commands\Legacy\SettingsPropertyEnum;
 
 class ManageSettings extends SettingsPage
 {
-    protected static string|BackedEnum|null $navigationIcon = \Filament\Support\Icons\Heroicon::OutlinedCog6Tooth;
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCog6Tooth;
 
     protected static string $settings = Settings::class;
 

--- a/tests/.pest/snapshots/src/Panels/Commands/MakeSettingsPageCommandTest/it_can_generate_a_page_class.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/MakeSettingsPageCommandTest/it_can_generate_a_page_class.snap
@@ -5,11 +5,12 @@ namespace App\Filament\Pages;
 use BackedEnum;
 use Filament\Pages\SettingsPage;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Panels\Commands\Settings;
 
 class ManageSettings extends SettingsPage
 {
-    protected static string|BackedEnum|null $navigationIcon = \Filament\Support\Icons\Heroicon::OutlinedCog6Tooth;
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCog6Tooth;
 
     protected static string $settings = Settings::class;
 

--- a/tests/.pest/snapshots/src/Panels/Commands/MakeSettingsPageCommandTest/it_can_generate_a_page_class.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/MakeSettingsPageCommandTest/it_can_generate_a_page_class.snap
@@ -9,7 +9,7 @@ use Filament\Tests\Panels\Commands\Settings;
 
 class ManageSettings extends SettingsPage
 {
-    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-cog-6-tooth';
+    protected static string|BackedEnum|null $navigationIcon = \Filament\Support\Icons\Heroicon::OutlinedCog6Tooth;
 
     protected static string $settings = Settings::class;
 

--- a/tests/.pest/snapshots/src/Panels/Commands/MakeSettingsPageCommandTest/it_can_generate_a_page_class_in_a_cluster.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/MakeSettingsPageCommandTest/it_can_generate_a_page_class_in_a_cluster.snap
@@ -10,7 +10,7 @@ use Filament\Tests\Panels\Commands\Settings;
 
 class ManageSettings extends SettingsPage
 {
-    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-cog-6-tooth';
+    protected static string|BackedEnum|null $navigationIcon = \Filament\Support\Icons\Heroicon::OutlinedCog6Tooth;
 
     protected static string $settings = Settings::class;
 

--- a/tests/.pest/snapshots/src/Panels/Commands/MakeSettingsPageCommandTest/it_can_generate_a_page_class_in_a_cluster.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/MakeSettingsPageCommandTest/it_can_generate_a_page_class_in_a_cluster.snap
@@ -6,11 +6,12 @@ use App\Filament\Clusters\Site\SiteCluster;
 use BackedEnum;
 use Filament\Pages\SettingsPage;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Panels\Commands\Settings;
 
 class ManageSettings extends SettingsPage
 {
-    protected static string|BackedEnum|null $navigationIcon = \Filament\Support\Icons\Heroicon::OutlinedCog6Tooth;
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCog6Tooth;
 
     protected static string $settings = Settings::class;
 

--- a/tests/.pest/snapshots/src/Panels/Commands/MakeSettingsPageCommandTest/it_can_generate_a_page_class_in_a_nested_directory.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/MakeSettingsPageCommandTest/it_can_generate_a_page_class_in_a_nested_directory.snap
@@ -9,7 +9,7 @@ use Filament\Tests\Panels\Commands\Settings;
 
 class ManageSettings extends SettingsPage
 {
-    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-cog-6-tooth';
+    protected static string|BackedEnum|null $navigationIcon = \Filament\Support\Icons\Heroicon::OutlinedCog6Tooth;
 
     protected static string $settings = Settings::class;
 

--- a/tests/.pest/snapshots/src/Panels/Commands/MakeSettingsPageCommandTest/it_can_generate_a_page_class_in_a_nested_directory.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/MakeSettingsPageCommandTest/it_can_generate_a_page_class_in_a_nested_directory.snap
@@ -5,11 +5,12 @@ namespace App\Filament\Pages\Site;
 use BackedEnum;
 use Filament\Pages\SettingsPage;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Panels\Commands\Settings;
 
 class ManageSettings extends SettingsPage
 {
-    protected static string|BackedEnum|null $navigationIcon = \Filament\Support\Icons\Heroicon::OutlinedCog6Tooth;
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCog6Tooth;
 
     protected static string $settings = Settings::class;
 

--- a/tests/.pest/snapshots/src/Panels/Commands/MakeSettingsPageCommandTest/it_can_generate_a_page_class_with_a_generated_form_schema.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/MakeSettingsPageCommandTest/it_can_generate_a_page_class_with_a_generated_form_schema.snap
@@ -10,12 +10,13 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Pages\SettingsPage;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Panels\Commands\Settings;
 use Filament\Tests\Panels\Commands\SettingsPropertyEnum;
 
 class ManageSettings extends SettingsPage
 {
-    protected static string|BackedEnum|null $navigationIcon = \Filament\Support\Icons\Heroicon::OutlinedCog6Tooth;
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCog6Tooth;
 
     protected static string $settings = Settings::class;
 

--- a/tests/.pest/snapshots/src/Panels/Commands/MakeSettingsPageCommandTest/it_can_generate_a_page_class_with_a_generated_form_schema.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/MakeSettingsPageCommandTest/it_can_generate_a_page_class_with_a_generated_form_schema.snap
@@ -15,7 +15,7 @@ use Filament\Tests\Panels\Commands\SettingsPropertyEnum;
 
 class ManageSettings extends SettingsPage
 {
-    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-cog-6-tooth';
+    protected static string|BackedEnum|null $navigationIcon = \Filament\Support\Icons\Heroicon::OutlinedCog6Tooth;
 
     protected static string $settings = Settings::class;
 

--- a/tests/src/Actions/ActionTest.php
+++ b/tests/src/Actions/ActionTest.php
@@ -3,6 +3,7 @@
 use Filament\Actions\Action;
 use Filament\Actions\Testing\Fixtures\TestAction;
 use Filament\Notifications\Notification;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Actions\TestCase;
 use Filament\Tests\Fixtures\Pages\Actions;
 use Illuminate\Support\Str;
@@ -236,8 +237,8 @@ it('can disable an action', function () {
 
 it('can have an icon', function () {
     livewire(Actions::class)
-        ->assertActionHasIcon('hasIcon', 'heroicon-m-pencil-square')
-        ->assertActionDoesNotHaveIcon('hasIcon', 'heroicon-m-trash');
+        ->assertActionHasIcon('hasIcon', Heroicon::PencilSquare)
+        ->assertActionDoesNotHaveIcon('hasIcon', Heroicon::Trash);
 });
 
 it('can have a label', function () {

--- a/tests/src/Fixtures/Livewire/Actions.php
+++ b/tests/src/Fixtures/Livewire/Actions.php
@@ -9,6 +9,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Contracts\View\View;
 use Livewire\Component;
 
@@ -55,7 +56,7 @@ class Actions extends Component implements HasActions, HasForms
                             ->disabled(),
                         Action::make('enabled'),
                         Action::make('hasIcon')
-                            ->icon('heroicon-m-pencil-square'),
+                            ->icon(Heroicon::PencilSquare),
                         Action::make('hasLabel')
                             ->label('My Action'),
                         Action::make('hasColor')

--- a/tests/src/Fixtures/Livewire/InfolistActions.php
+++ b/tests/src/Fixtures/Livewire/InfolistActions.php
@@ -12,6 +12,7 @@ use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Concerns\InteractsWithInfolists;
 use Filament\Infolists\Contracts\HasInfolists;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Contracts\View\View;
 use Livewire\Component;
 
@@ -54,7 +55,7 @@ class InfolistActions extends Component implements HasActions, HasForms, HasInfo
                             ->disabled(),
                         Action::make('enabled'),
                         Action::make('hasIcon')
-                            ->icon('heroicon-m-pencil-square'),
+                            ->icon(Heroicon::PencilSquare),
                         Action::make('hasLabel')
                             ->label('My Action'),
                         Action::make('hasColor')

--- a/tests/src/Fixtures/Livewire/PostsTable.php
+++ b/tests/src/Fixtures/Livewire/PostsTable.php
@@ -18,6 +18,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Filament\Tests\Fixtures\Models\Post;
@@ -158,7 +159,7 @@ class PostsTable extends Component implements HasActions, HasForms, Tables\Contr
                     Action::make('groupedWithHiddenGroupCondition'),
                 ])->hidden(fn (?Model $record): bool => $record !== null),
                 Action::make('hasIcon')
-                    ->icon('heroicon-m-pencil-square'),
+                    ->icon(Heroicon::PencilSquare),
                 Action::make('hasLabel')
                     ->label('My Action'),
                 Action::make('hasColor')
@@ -303,7 +304,7 @@ class PostsTable extends Component implements HasActions, HasForms, Tables\Contr
                 BulkAction::make('disabled')
                     ->disabled(),
                 BulkAction::make('hasIcon')
-                    ->icon('heroicon-m-pencil-square'),
+                    ->icon(Heroicon::PencilSquare),
                 BulkAction::make('hasLabel')
                     ->label('My Action'),
                 BulkAction::make('hasColor')

--- a/tests/src/Fixtures/Pages/Actions.php
+++ b/tests/src/Fixtures/Pages/Actions.php
@@ -7,6 +7,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 
 class Actions extends Page
 {
@@ -121,7 +122,7 @@ class Actions extends Page
             Action::make('disabled')
                 ->disabled(),
             Action::make('hasIcon')
-                ->icon('heroicon-m-pencil-square'),
+                ->icon(Heroicon::PencilSquare),
             Action::make('hasLabel')
                 ->label('My Action'),
             Action::make('hasColor')

--- a/tests/src/Fixtures/Pages/Settings.php
+++ b/tests/src/Fixtures/Pages/Settings.php
@@ -7,12 +7,13 @@ use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 
 class Settings extends Page
 {
     protected static string $view = 'pages.settings';
 
-    protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-cog-6-tooth';
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedCog6Tooth;
 
     protected static ?int $navigationSort = 2;
 

--- a/tests/src/Fixtures/Resources/Departments/DepartmentResource.php
+++ b/tests/src/Fixtures/Resources/Departments/DepartmentResource.php
@@ -5,6 +5,7 @@ namespace Filament\Tests\Fixtures\Resources\Departments;
 use BackedEnum;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
 use Filament\Tests\Fixtures\Models\Department;
 use Filament\Tests\Fixtures\Resources\Departments\Pages\CreateDepartment;
@@ -21,7 +22,7 @@ class DepartmentResource extends Resource
 {
     protected static ?string $model = Department::class;
 
-    protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedRectangleStack;
 
     public static function form(Schema $schema): Schema
     {

--- a/tests/src/Fixtures/Resources/PostCategories/PostCategoryResource.php
+++ b/tests/src/Fixtures/Resources/PostCategories/PostCategoryResource.php
@@ -4,6 +4,7 @@ namespace Filament\Tests\Fixtures\Resources\PostCategories;
 
 use BackedEnum;
 use Filament\Resources\Resource;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Fixtures\Models\PostCategory;
 use Filament\Tests\Fixtures\Resources\PostCategories\Pages\CreatePostCategory;
 use Filament\Tests\Fixtures\Resources\PostCategories\Pages\EditPostCategory;
@@ -16,7 +17,7 @@ class PostCategoryResource extends Resource
 
     protected static ?string $navigationGroup = 'Blog';
 
-    protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedRectangleStack;
 
     public static function getPages(): array
     {

--- a/tests/src/Fixtures/Resources/Posts/PostResource.php
+++ b/tests/src/Fixtures/Resources/Posts/PostResource.php
@@ -10,6 +10,7 @@ use Filament\Actions\ViewAction;
 use Filament\Forms;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Filament\Tests\Fixtures\Models\Post;
@@ -25,7 +26,7 @@ class PostResource extends Resource
 
     protected static ?string $navigationGroup = 'Blog';
 
-    protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-document-text';
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedDocumentText;
 
     protected static ?string $recordTitleAttribute = 'title';
 

--- a/tests/src/Fixtures/Resources/Shop/Products/ProductResource.php
+++ b/tests/src/Fixtures/Resources/Shop/Products/ProductResource.php
@@ -4,6 +4,7 @@ namespace Filament\Tests\Fixtures\Resources\Shop\Products;
 
 use BackedEnum;
 use Filament\Resources\Resource;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Fixtures\Models\Product;
 use Filament\Tests\Fixtures\Resources\Shop\Products\Pages\CreateProduct;
 use Filament\Tests\Fixtures\Resources\Shop\Products\Pages\EditProduct;
@@ -16,7 +17,7 @@ class ProductResource extends Resource
 
     protected static ?string $navigationGroup = 'Shop';
 
-    protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-shopping-bag';
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedShoppingBag;
 
     public static function getPages(): array
     {

--- a/tests/src/Fixtures/Resources/TicketMessages/TicketMessageResource.php
+++ b/tests/src/Fixtures/Resources/TicketMessages/TicketMessageResource.php
@@ -5,6 +5,7 @@ namespace Filament\Tests\Fixtures\Resources\TicketMessages;
 use BackedEnum;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
 use Filament\Tests\Fixtures\Models\TicketMessage;
 use Filament\Tests\Fixtures\Resources\TicketMessages\Pages\CreateTicketMessage;
@@ -21,7 +22,7 @@ class TicketMessageResource extends Resource
 {
     protected static ?string $model = TicketMessage::class;
 
-    protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedRectangleStack;
 
     public static function form(Schema $schema): Schema
     {

--- a/tests/src/Fixtures/Resources/Tickets/TicketResource.php
+++ b/tests/src/Fixtures/Resources/Tickets/TicketResource.php
@@ -5,6 +5,7 @@ namespace Filament\Tests\Fixtures\Resources\Tickets;
 use BackedEnum;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
 use Filament\Tests\Fixtures\Models\Ticket;
 use Filament\Tests\Fixtures\Resources\Tickets\Pages\CreateTicket;
@@ -22,7 +23,7 @@ class TicketResource extends Resource
 {
     protected static ?string $model = Ticket::class;
 
-    protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedRectangleStack;
 
     public static function form(Schema $schema): Schema
     {

--- a/tests/src/Fixtures/Resources/Users/UserResource.php
+++ b/tests/src/Fixtures/Resources/Users/UserResource.php
@@ -9,6 +9,7 @@ use Filament\Actions\ViewAction;
 use Filament\Forms;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Filament\Tests\Fixtures\Models\User;
@@ -21,7 +22,7 @@ class UserResource extends Resource
 {
     protected static ?string $model = User::class;
 
-    protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-user';
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedUser;
 
     protected static ?int $navigationSort = 1;
 

--- a/tests/src/Forms/ActionTest.php
+++ b/tests/src/Forms/ActionTest.php
@@ -3,6 +3,7 @@
 use Filament\Actions\Action;
 use Filament\Actions\Testing\Fixtures\TestAction;
 use Filament\Forms\Components\TextInput;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Fixtures\Livewire\Actions;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Str;
@@ -129,12 +130,12 @@ it('can disable an action', function () {
 
 it('can have an icon', function () {
     livewire(Actions::class)
-        ->assertActionHasIcon(TestAction::make('hasIcon')->schemaComponent('form.textInput'), 'heroicon-m-pencil-square')
-        ->assertActionDoesNotHaveIcon(TestAction::make('hasIcon')->schemaComponent('form.textInput'), 'heroicon-m-trash');
+        ->assertActionHasIcon(TestAction::make('hasIcon')->schemaComponent('form.textInput'), Heroicon::PencilSquare)
+        ->assertActionDoesNotHaveIcon(TestAction::make('hasIcon')->schemaComponent('form.textInput'), Heroicon::Trash);
 
     livewire(Actions::class)
-        ->assertFormComponentActionHasIcon('textInput', 'hasIcon', 'heroicon-m-pencil-square')
-        ->assertFormComponentActionDoesNotHaveIcon('textInput', 'hasIcon', 'heroicon-m-trash');
+        ->assertFormComponentActionHasIcon('textInput', 'hasIcon', Heroicon::PencilSquare)
+        ->assertFormComponentActionDoesNotHaveIcon('textInput', 'hasIcon', Heroicon::Trash);
 });
 
 it('can have a label', function () {

--- a/tests/src/Infolists/ActionTest.php
+++ b/tests/src/Infolists/ActionTest.php
@@ -2,6 +2,7 @@
 
 use Filament\Actions\Action;
 use Filament\Actions\Testing\Fixtures\TestAction;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Fixtures\Livewire\InfolistActions;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Str;
@@ -104,12 +105,12 @@ it('can disable an action', function () {
 
 it('can have an icon', function () {
     livewire(InfolistActions::class)
-        ->assertActionHasIcon(TestAction::make('hasIcon')->schemaComponent('infolist.textEntry'), 'heroicon-m-pencil-square')
-        ->assertActionDoesNotHaveIcon(TestAction::make('hasIcon')->schemaComponent('infolist.textEntry'), 'heroicon-m-trash');
+        ->assertActionHasIcon(TestAction::make('hasIcon')->schemaComponent('infolist.textEntry'), Heroicon::PencilSquare)
+        ->assertActionDoesNotHaveIcon(TestAction::make('hasIcon')->schemaComponent('infolist.textEntry'), Heroicon::Trash);
 
     livewire(InfolistActions::class)
-        ->assertInfolistActionHasIcon('textEntry', 'hasIcon', 'heroicon-m-pencil-square')
-        ->assertInfolistActionDoesNotHaveIcon('textEntry', 'hasIcon', 'heroicon-m-trash');
+        ->assertInfolistActionHasIcon('textEntry', 'hasIcon', Heroicon::PencilSquare)
+        ->assertInfolistActionDoesNotHaveIcon('textEntry', 'hasIcon', Heroicon::Trash);
 });
 
 it('can have a label', function () {

--- a/tests/src/Panels/Navigation/NavigationBuilderTest.php
+++ b/tests/src/Panels/Navigation/NavigationBuilderTest.php
@@ -5,6 +5,7 @@ use Filament\Navigation\NavigationBuilder;
 use Filament\Navigation\NavigationGroup;
 use Filament\Navigation\NavigationItem;
 use Filament\Pages\Dashboard;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Fixtures\Pages\Settings;
 use Filament\Tests\Fixtures\Resources\PostCategories\PostCategoryResource;
 use Filament\Tests\Fixtures\Resources\Posts\PostResource;
@@ -44,13 +45,13 @@ it('can register navigation', function () {
                 ->sequence(
                     fn ($item) => $item
                         ->getLabel()->toBe('Dashboard')
-                        ->getIcon()->toBe('heroicon-o-home'),
+                        ->getIcon()->toBe(Heroicon::OutlinedHome),
                     fn ($item) => $item
                         ->getLabel()->toBe('Users')
-                        ->getIcon()->toBe('heroicon-o-user'),
+                        ->getIcon()->toBe(Heroicon::OutlinedUser),
                     fn ($item) => $item
                         ->getLabel()->toBe('Settings')
-                        ->getIcon()->toBe('heroicon-o-cog-6-tooth'),
+                        ->getIcon()->toBe(Heroicon::OutlinedCog6Tooth),
                 )
                 ->each->toBeInstanceOf(NavigationItem::class),
             fn ($group) => $group
@@ -60,10 +61,10 @@ it('can register navigation', function () {
                 ->sequence(
                     fn ($item) => $item
                         ->getLabel()->toBe('Posts')
-                        ->getIcon()->toBe('heroicon-o-document-text'),
+                        ->getIcon()->toBe(Heroicon::OutlinedDocumentText),
                     fn ($item) => $item
                         ->getLabel()->toBe('Post Categories')
-                        ->getIcon()->toBe('heroicon-o-rectangle-stack'),
+                        ->getIcon()->toBe(Heroicon::OutlinedRectangleStack),
                 )
                 ->each->toBeInstanceOf(NavigationItem::class),
             fn ($group) => $group
@@ -73,7 +74,7 @@ it('can register navigation', function () {
                 ->sequence(
                     fn ($item) => $item
                         ->getLabel()->toBe('Products')
-                        ->getIcon()->toBe('heroicon-o-shopping-bag'),
+                        ->getIcon()->toBe(Heroicon::OutlinedShoppingBag),
                 )
                 ->each->toBeInstanceOf(NavigationItem::class),
         );
@@ -97,10 +98,10 @@ it('can register navigation groups individually', function () {
                 ->sequence(
                     fn ($item) => $item
                         ->getLabel()->toBe('Posts')
-                        ->getIcon()->toBe('heroicon-o-document-text'),
+                        ->getIcon()->toBe(Heroicon::OutlinedDocumentText),
                     fn ($item) => $item
                         ->getLabel()->toBe('Post Categories')
-                        ->getIcon()->toBe('heroicon-o-rectangle-stack'),
+                        ->getIcon()->toBe(Heroicon::OutlinedRectangleStack),
                 )
                 ->each->toBeInstanceOf(NavigationItem::class),
         );

--- a/tests/src/Panels/Navigation/NavigationTest.php
+++ b/tests/src/Panels/Navigation/NavigationTest.php
@@ -3,6 +3,7 @@
 use Filament\Facades\Filament;
 use Filament\Navigation\NavigationGroup;
 use Filament\Navigation\NavigationItem;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Panels\Navigation\TestCase;
 
 uses(TestCase::class);
@@ -17,24 +18,24 @@ it('can register navigation items from resources and pages', function () {
                 ->sequence(
                     fn ($item) => $item
                         ->getLabel()->toBe('Dashboard')
-                        ->getIcon()->toBe('heroicon-o-home'),
+                        ->getIcon()->toBe(Heroicon::OutlinedHome),
                     fn ($item) => $item
                         ->getLabel()->toBe('Actions'),
                     fn ($item) => $item
                         ->getLabel()->toBe('Departments')
-                        ->getIcon()->toBe('heroicon-o-rectangle-stack'),
+                        ->getIcon()->toBe(Heroicon::OutlinedRectangleStack),
                     fn ($item) => $item
                         ->getLabel()->toBe('Tickets')
-                        ->getIcon()->toBe('heroicon-o-rectangle-stack'),
+                        ->getIcon()->toBe(Heroicon::OutlinedRectangleStack),
                     fn ($item) => $item
                         ->getLabel()->toBe('Ticket Messages')
-                        ->getIcon()->toBe('heroicon-o-rectangle-stack'),
+                        ->getIcon()->toBe(Heroicon::OutlinedRectangleStack),
                     fn ($item) => $item
                         ->getLabel()->toBe('Users')
-                        ->getIcon()->toBe('heroicon-o-user'),
+                        ->getIcon()->toBe(Heroicon::OutlinedUser),
                     fn ($item) => $item
                         ->getLabel()->toBe('Settings')
-                        ->getIcon()->toBe('heroicon-o-cog-6-tooth'),
+                        ->getIcon()->toBe(Heroicon::OutlinedCog6Tooth),
                 )
                 ->each->toBeInstanceOf(NavigationItem::class),
             fn ($group) => $group
@@ -44,10 +45,10 @@ it('can register navigation items from resources and pages', function () {
                 ->sequence(
                     fn ($item) => $item
                         ->getLabel()->toBe('Posts')
-                        ->getIcon()->toBe('heroicon-o-document-text'),
+                        ->getIcon()->toBe(Heroicon::OutlinedDocumentText),
                     fn ($item) => $item
                         ->getLabel()->toBe('Post Categories')
-                        ->getIcon()->toBe('heroicon-o-rectangle-stack'),
+                        ->getIcon()->toBe(Heroicon::OutlinedRectangleStack),
                 )
                 ->each->toBeInstanceOf(NavigationItem::class),
             fn ($group) => $group
@@ -57,7 +58,7 @@ it('can register navigation items from resources and pages', function () {
                 ->sequence(
                     fn ($item) => $item
                         ->getLabel()->toBe('Products')
-                        ->getIcon()->toBe('heroicon-o-shopping-bag'),
+                        ->getIcon()->toBe(Heroicon::OutlinedShoppingBag),
                 )
                 ->each->toBeInstanceOf(NavigationItem::class),
         );

--- a/tests/src/Tables/Actions/ActionTest.php
+++ b/tests/src/Tables/Actions/ActionTest.php
@@ -4,6 +4,7 @@ use Filament\Actions\Action;
 use Filament\Actions\AttachAction;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\Testing\Fixtures\TestAction;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Fixtures\Livewire\PostsTable;
 use Filament\Tests\Fixtures\Models\Post;
 use Filament\Tests\Tables\TestCase;
@@ -320,12 +321,12 @@ it('can disable an action', function () {
 
 it('can have an icon', function () {
     livewire(PostsTable::class)
-        ->assertActionHasIcon(TestAction::make('hasIcon')->table(), 'heroicon-m-pencil-square')
-        ->assertActionDoesNotHaveIcon(TestAction::make('hasIcon')->table(), 'heroicon-m-trash');
+        ->assertActionHasIcon(TestAction::make('hasIcon')->table(), Heroicon::PencilSquare)
+        ->assertActionDoesNotHaveIcon(TestAction::make('hasIcon')->table(), Heroicon::Trash);
 
     livewire(PostsTable::class)
-        ->assertTableActionHasIcon('hasIcon', 'heroicon-m-pencil-square')
-        ->assertTableActionDoesNotHaveIcon('hasIcon', 'heroicon-m-trash');
+        ->assertTableActionHasIcon('hasIcon', Heroicon::PencilSquare)
+        ->assertTableActionDoesNotHaveIcon('hasIcon', Heroicon::Trash);
 });
 
 it('can have a label', function () {

--- a/tests/src/Tables/Actions/BulkActionTest.php
+++ b/tests/src/Tables/Actions/BulkActionTest.php
@@ -2,6 +2,7 @@
 
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\Testing\Fixtures\TestAction;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Fixtures\Livewire\PostsTable;
 use Filament\Tests\Fixtures\Models\Post;
 use Filament\Tests\Tables\TestCase;
@@ -153,12 +154,12 @@ it('can disable a bulk action', function () {
 
 it('can have an icon', function () {
     livewire(PostsTable::class)
-        ->assertActionHasIcon(TestAction::make('hasIcon')->table()->bulk(), 'heroicon-m-pencil-square')
-        ->assertActionDoesNotHaveIcon(TestAction::make('hasIcon')->table()->bulk(), 'heroicon-m-trash');
+        ->assertActionHasIcon(TestAction::make('hasIcon')->table()->bulk(), Heroicon::PencilSquare)
+        ->assertActionDoesNotHaveIcon(TestAction::make('hasIcon')->table()->bulk(), Heroicon::Trash);
 
     livewire(PostsTable::class)
-        ->assertTableBulkActionHasIcon('hasIcon', 'heroicon-m-pencil-square')
-        ->assertTableBulkActionDoesNotHaveIcon('hasIcon', 'heroicon-m-trash');
+        ->assertTableBulkActionHasIcon('hasIcon', Heroicon::PencilSquare)
+        ->assertTableBulkActionDoesNotHaveIcon('hasIcon', Heroicon::Trash);
 });
 
 it('can have a label', function () {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Refactored Heroicon icon handling across the codebase to use Enums instead of string values:
- Updated PHP classes to reference Enums for icons.
- Modified Blade views to use Enums instead of string values.
- Adjusted tests / resolved icon type issues.
- Rebuilt snapshots.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
