### PR TITLE
Config option to set default pagination values

### DIFF
--- a/packages/support/config/filament.php
+++ b/packages/support/config/filament.php
@@ -86,4 +86,14 @@ return [
 
     'livewire_loading_delay' => 'default',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Default Table Pagination
+    |--------------------------------------------------------------------------
+    |
+    | This sets the default table pagination.
+    |
+    */
+
+    'default_pagination' => [5, 10, 25, 50, 'all'],
 ];

--- a/packages/tables/src/Table/Concerns/CanPaginateRecords.php
+++ b/packages/tables/src/Table/Concerns/CanPaginateRecords.php
@@ -88,7 +88,8 @@ trait CanPaginateRecords
      */
     public function getPaginationPageOptions(): array
     {
-        return $this->evaluate($this->paginationPageOptions) ?? [5, 10, 25, 50, 'all'];
+        return $this->evaluate($this->paginationPageOptions) ??
+            config('filament.default_pagination', [5, 10, 25, 50, 'all']);
     }
 
     public function isPaginated(): bool

--- a/tests/src/Tables/Concerns/CanPaginateRecordsTest.php
+++ b/tests/src/Tables/Concerns/CanPaginateRecordsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Filament\Tables\Table\Concerns\CanPaginateRecords;
+use Filament\Tests\Tables\TestCase;
+use Illuminate\Support\Facades\Config;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    $this->trait = new class
+    {
+        use CanPaginateRecords;
+
+        public function evaluate(...$args): mixed
+        {
+            return null;
+        }
+    };
+});
+
+it('can load default pagination values', function () {
+    expect($this->trait->getPaginationPageOptions())->toBe([5, 10, 25, 50, 'all']);
+});
+
+it('can load config pagination values', function () {
+    Config::set('filament.default_pagination', [5, 10, 25, 50]);
+
+    expect($this->trait->getPaginationPageOptions())->toBe([5, 10, 25, 50]);
+});


### PR DESCRIPTION
## Description

Ability to change default pagination rather than having to change it in each `Table` object. 

## Visual changes

No Visual changes to be added. 

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

Not sure about documentation. Are the `filament.php` file descriptions are enough? Because I don't see documentation for other configuration there.
