### PR TITLE
Make ToggleButtons can display only icons

### DIFF
--- a/packages/forms/docs/03-fields/18-toggle-buttons.md
+++ b/packages/forms/docs/03-fields/18-toggle-buttons.md
@@ -68,17 +68,7 @@ If you are using an enum for the options, you can use the [`HasIcon` interface](
 
 <AutoScreenshot name="forms/fields/toggle-buttons/icons" alt="Toggle buttons with icons" version="3.x" />
 
-You can use `onlyIcons()` to hide the option labels and display only icons, You can also choose to consider the option label as an icon if you prefer not to use `icons()`.
-
-```php
-ToggleButtons::make('status')
-    ->options([
-        'draft' => 'heroicon-o-pencil',
-        'scheduled' => 'heroicon-o-clock',
-        'published' => 'heroicon-o-check-circle',
-    ])
-    ->onlyIcons(optionLabelAsIcon: true)
-```
+If you want to display only icons, you can use `hiddenButtonLabels()` to hide the option labels.
 
 ## Boolean options
 

--- a/packages/forms/docs/03-fields/18-toggle-buttons.md
+++ b/packages/forms/docs/03-fields/18-toggle-buttons.md
@@ -68,6 +68,18 @@ If you are using an enum for the options, you can use the [`HasIcon` interface](
 
 <AutoScreenshot name="forms/fields/toggle-buttons/icons" alt="Toggle buttons with icons" version="3.x" />
 
+You can use `onlyIcons()` to hide the option labels and display only icons, You can also choose to consider the option label as an icon if you prefer not to use `icons()`.
+
+```php
+ToggleButtons::make('status')
+    ->options([
+        'draft' => 'heroicon-o-pencil',
+        'scheduled' => 'heroicon-o-clock',
+        'published' => 'heroicon-o-check-circle',
+    ])
+    ->onlyIcons(optionLabelAsIcon: true)
+```
+
 ## Boolean options
 
 If you want a simple boolean toggle button group, with "Yes" and "No" options, you can use the `boolean()` method:

--- a/packages/forms/resources/views/components/toggle-buttons/grouped.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/grouped.blade.php
@@ -4,6 +4,8 @@
     $isDisabled = $isDisabled();
     $isMultiple = $isMultiple();
     $statePath = $getStatePath();
+    $hasOnlyIcons = $hasOnlyIcons();
+    $isOptionLabelAsIcon = $hasOnlyIcons ? $isOptionLabelAsIcon() : false;
 @endphp
 
 <x-dynamic-component
@@ -51,10 +53,11 @@
                 :disabled="$shouldOptionBeDisabled"
                 :for="$inputId"
                 grouped
-                :icon="$getIcon($value)"
+                :icon="$isOptionLabelAsIcon ? $label : $getIcon($value)"
+                :label-sr-only="$hasOnlyIcons"
                 tag="label"
             >
-                {{ $label }}
+                {{ $isOptionLabelAsIcon ? '' : $label }}
             </x-filament::button>
         @endforeach
     </x-filament::button.group>

--- a/packages/forms/resources/views/components/toggle-buttons/grouped.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/grouped.blade.php
@@ -4,8 +4,7 @@
     $isDisabled = $isDisabled();
     $isMultiple = $isMultiple();
     $statePath = $getStatePath();
-    $hasOnlyIcons = $hasOnlyIcons();
-    $isOptionLabelAsIcon = $hasOnlyIcons ? $isOptionLabelAsIcon() : false;
+    $areButtonLabelsHidden = $areButtonLabelsHidden();
 @endphp
 
 <x-dynamic-component
@@ -53,11 +52,11 @@
                 :disabled="$shouldOptionBeDisabled"
                 :for="$inputId"
                 grouped
-                :icon="$isOptionLabelAsIcon ? $label : $getIcon($value)"
-                :label-sr-only="$hasOnlyIcons"
+                :icon="$getIcon($value)"
+                :label-sr-only="$areButtonLabelsHidden"
                 tag="label"
             >
-                {{ $isOptionLabelAsIcon ? '' : $label }}
+                {{ $label }}
             </x-filament::button>
         @endforeach
     </x-filament::button.group>

--- a/packages/forms/resources/views/components/toggle-buttons/index.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/index.blade.php
@@ -6,6 +6,8 @@
     $isInline = $isInline();
     $isMultiple = $isMultiple();
     $statePath = $getStatePath();
+    $hasOnlyIcons = $hasOnlyIcons();
+    $isOptionLabelAsIcon = $hasOnlyIcons ? $isOptionLabelAsIcon() : false;
 @endphp
 
 <x-dynamic-component
@@ -69,10 +71,11 @@
                     :color="$getColor($value)"
                     :disabled="$shouldOptionBeDisabled"
                     :for="$inputId"
-                    :icon="$getIcon($value)"
+                    :icon="$isOptionLabelAsIcon ? $label : $getIcon($value)"
+                    :label-sr-only="$hasOnlyIcons"
                     tag="label"
                 >
-                    {{ $label }}
+                    {{ $isOptionLabelAsIcon ? '' : $label }}
                 </x-filament::button>
             </div>
         @endforeach

--- a/packages/forms/resources/views/components/toggle-buttons/index.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/index.blade.php
@@ -6,8 +6,7 @@
     $isInline = $isInline();
     $isMultiple = $isMultiple();
     $statePath = $getStatePath();
-    $hasOnlyIcons = $hasOnlyIcons();
-    $isOptionLabelAsIcon = $hasOnlyIcons ? $isOptionLabelAsIcon() : false;
+    $areButtonLabelsHidden = $areButtonLabelsHidden();
 @endphp
 
 <x-dynamic-component
@@ -71,11 +70,11 @@
                     :color="$getColor($value)"
                     :disabled="$shouldOptionBeDisabled"
                     :for="$inputId"
-                    :icon="$isOptionLabelAsIcon ? $label : $getIcon($value)"
-                    :label-sr-only="$hasOnlyIcons"
+                    :icon="$getIcon($value)"
+                    :label-sr-only="$areButtonLabelsHidden"
                     tag="label"
                 >
-                    {{ $isOptionLabelAsIcon ? '' : $label }}
+                    {{ $label }}
                 </x-filament::button>
             </div>
         @endforeach

--- a/packages/forms/src/Components/ToggleButtons.php
+++ b/packages/forms/src/Components/ToggleButtons.php
@@ -28,6 +28,10 @@ class ToggleButtons extends Field implements Contracts\CanDisableOptions
 
     protected bool | Closure $isInline = false;
 
+    protected bool | Closure $hasOnlyIcons = false;
+
+    protected bool $isOptionLabelAsIcon = false;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -82,6 +86,25 @@ class ToggleButtons extends Field implements Contracts\CanDisableOptions
     public function isInline(): bool
     {
         return (bool) $this->evaluate($this->isInline);
+    }
+
+    public function onlyIcons(bool | Closure $condition = true, bool $optionLabelAsIcon = false): static
+    {
+        $this->hasOnlyIcons = $condition;
+
+        $this->isOptionLabelAsIcon = $optionLabelAsIcon;
+
+        return $this;
+    }
+
+    public function hasOnlyIcons(): bool
+    {
+        return (bool) $this->evaluate($this->hasOnlyIcons);
+    }
+
+    public function isOptionLabelAsIcon(): bool
+    {
+        return $this->isOptionLabelAsIcon;
     }
 
     public function multiple(bool | Closure $condition = true): static

--- a/packages/forms/src/Components/ToggleButtons.php
+++ b/packages/forms/src/Components/ToggleButtons.php
@@ -28,9 +28,7 @@ class ToggleButtons extends Field implements Contracts\CanDisableOptions
 
     protected bool | Closure $isInline = false;
 
-    protected bool | Closure $hasOnlyIcons = false;
-
-    protected bool $isOptionLabelAsIcon = false;
+    protected bool | Closure $areButtonLabelsHidden = false;
 
     protected function setUp(): void
     {
@@ -88,23 +86,16 @@ class ToggleButtons extends Field implements Contracts\CanDisableOptions
         return (bool) $this->evaluate($this->isInline);
     }
 
-    public function onlyIcons(bool | Closure $condition = true, bool $optionLabelAsIcon = false): static
+    public function hiddenButtonLabels(bool | Closure $condition = true): static
     {
-        $this->hasOnlyIcons = $condition;
-
-        $this->isOptionLabelAsIcon = $optionLabelAsIcon;
+        $this->areButtonLabelsHidden = $condition;
 
         return $this;
     }
 
-    public function hasOnlyIcons(): bool
+    public function areButtonLabelsHidden(): bool
     {
-        return (bool) $this->evaluate($this->hasOnlyIcons);
-    }
-
-    public function isOptionLabelAsIcon(): bool
-    {
-        return $this->isOptionLabelAsIcon;
+        return (bool) $this->evaluate($this->areButtonLabelsHidden);
     }
 
     public function multiple(bool | Closure $condition = true): static


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Add `onlyIcons()` to ToggleButtons to hide option labels and display only icons:
- Hides button labels by setting them as sr-only.
- Optionally consider option labels as icons when using `options()` to skip the use of `icons()`.

```php
use Filament\Forms\Components\ToggleButtons;

ToggleButtons::make('status')
    ->options([
        'draft' => 'Draft',
        'scheduled' => 'Scheduled',
        'published' => 'Published'
    ])
    ->icons([
        'draft' => 'heroicon-o-pencil',
        'scheduled' => 'heroicon-o-clock',
        'published' => 'heroicon-o-check-circle',
    ])
    ->onlyIcons()
```
Or
```php
ToggleButtons::make('status')
    ->options([
        'draft' => 'heroicon-o-pencil',
        'scheduled' => 'heroicon-o-clock',
        'published' => 'heroicon-o-check-circle',
    ])
    ->onlyIcons(optionLabelAsIcon: true)
```
<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes
**Before:** option label is an empty string
![before](https://github.com/user-attachments/assets/68079d2f-cca9-45b7-a8b0-b9c4622cd7c4)
**After:** use `onlyIcons()`
![after](https://github.com/user-attachments/assets/6d86960e-c46c-4715-ab39-2e7f936e57c8)

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
