### PR TITLE
Modifying declarations of canAccess function

### DIFF
--- a/packages/panels/docs/04-pages.md
+++ b/packages/panels/docs/04-pages.md
@@ -23,7 +23,7 @@ Page classes are all full-page [Livewire](https://livewire.laravel.com) componen
 You can prevent pages from appearing in the menu by overriding the `canAccess()` method in your Page class. This is useful if you want to control which users can see the page in the navigation, and also which users can visit the page directly:
 
 ```php
-public static function canAccess(): bool
+public static function canAccess(array $parameters = []): bool
 {
     return auth()->user()->canManageSettings();
 }


### PR DESCRIPTION


<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
- PHP Version: 8.4.3
- Laravel Version: 11.41.3

When adding canAccess() function in the EditPage of my resource, I have an incompatible declaration issue.
Solution: Update the canAccess declaration to canAccess(array $parameters = [])

## Visual changes

![image](https://github.com/user-attachments/assets/a48adef3-c606-445d-8c2d-a7bfa7689eba)

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
