### PR TITLE
Conditionally set title attribute based on tooltip of icon button

### DIFF
--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -147,9 +147,9 @@
                     'wire:loading.attr' => 'disabled',
                     'wire:target' => ($hasLoadingIndicator && $loadingIndicatorTarget) ? $loadingIndicatorTarget : null,
                 ], escape: false)
-                ->merge([
-                    'title' => $label,
-                ], escape: true)
+                ->when(! $hasTooltip, function ($attributes) use ($label) {
+                    $attributes->merge(['title' => $label], escape: true);
+                })
                 ->class([$buttonClasses])
                 ->style([$buttonStyles])
         }}
@@ -212,9 +212,9 @@
         @endif
         {{
             $attributes
-                ->merge([
-                    'title' => $label,
-                ], escape: true)
+                ->when(! $hasTooltip, function ($attributes) use ($label) {
+                    $attributes->merge(['title' => $label], escape: true);
+                })
                 ->class([$buttonClasses])
                 ->style([$buttonStyles])
         }}

--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -148,7 +148,7 @@
                     'wire:target' => ($hasLoadingIndicator && $loadingIndicatorTarget) ? $loadingIndicatorTarget : null,
                 ], escape: false)
                 ->when(! $hasTooltip, function ($attributes) use ($label) {
-                    $attributes->merge(['title' => $label], escape: true);
+                    return $attributes->merge(['title' => $label], escape: true);
                 })
                 ->class([$buttonClasses])
                 ->style([$buttonStyles])
@@ -213,7 +213,7 @@
         {{
             $attributes
                 ->when(! $hasTooltip, function ($attributes) use ($label) {
-                    $attributes->merge(['title' => $label], escape: true);
+                    return $attributes->merge(['title' => $label], escape: true);
                 })
                 ->class([$buttonClasses])
                 ->style([$buttonStyles])


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR updates the icon button blade file to conditionally set the title attribute. The title will now be included only when a tooltip is not present.

## Visual changes
**Before**
![Screenshot from 2025-02-08 05-34-44](https://github.com/user-attachments/assets/50f3d1e2-2a1e-43f9-a5b2-c48863984a00)
**After**
![Screenshot from 2025-02-08 05-32-39](https://github.com/user-attachments/assets/b846ab3d-1f37-439f-bed2-c593a10fcbc0) ![Screenshot from 2025-02-08 05-33-33](https://github.com/user-attachments/assets/a41d7914-3b9e-4fc1-b42b-51fb5819e4a7)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
