### PR TITLE
Display exact datetime title for notifications

### DIFF
--- a/packages/notifications/resources/views/notification.blade.php
+++ b/packages/notifications/resources/views/notification.blade.php
@@ -10,6 +10,7 @@
     $title = $getTitle();
     $hasTitle = filled($title);
     $date = $getDate();
+    $exactDate = $getExactDate();
     $hasDate = filled($date);
     $body = $getBody();
     $hasBody = filled($body);
@@ -90,7 +91,10 @@
             @endif
 
             @if ($hasDate)
-                <x-filament-notifications::date @class(['mt-1' => $hasTitle])>
+                <x-filament-notifications::date
+                    @class(['mt-1' => $hasTitle])
+                    title="{{ $exactDate }}"
+                >
                     {{ $date }}
                 </x-filament-notifications::date>
             @endif

--- a/packages/notifications/src/Concerns/HasDate.php
+++ b/packages/notifications/src/Concerns/HasDate.php
@@ -8,9 +8,12 @@ trait HasDate
 {
     protected string | Closure | null $date = null;
 
-    public function date(string | Closure | null $date): static
+    protected string | Closure | null $exactDate = null;
+
+    public function date(string | Closure | null $date, ?string $exactDate = null): static
     {
         $this->date = $date;
+        $this->exactDate = $exactDate;
 
         return $this;
     }
@@ -18,5 +21,10 @@ trait HasDate
     public function getDate(): ?string
     {
         return $this->evaluate($this->date);
+    }
+
+    public function getExactDate(): ?string
+    {
+        return $this->evaluate($this->exactDate);
     }
 }

--- a/packages/notifications/src/Livewire/DatabaseNotifications.php
+++ b/packages/notifications/src/Livewire/DatabaseNotifications.php
@@ -137,13 +137,20 @@ class DatabaseNotifications extends Component
 
     public function getNotification(DatabaseNotification $notification): Notification
     {
+        $date = $notification->getAttributeValue('created_at');
+
         return Notification::fromDatabase($notification)
-            ->date($this->formatNotificationDate($notification->getAttributeValue('created_at')));
+            ->date($this->formatNotificationDate($date), $this->formatExactNotificationDate($date));
     }
 
     protected function formatNotificationDate(CarbonInterface $date): string
     {
         return $date->diffForHumans();
+    }
+
+    protected function formatExactNotificationDate(CarbonInterface $date): string
+    {
+        return $date->toString();
     }
 
     public static function trigger(?string $trigger): void


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

My use-case was when debugging a Laravel queue job that sends Filament database notifications and needed to know the exact time the notification was sent, relative to the time the job ran. Notification time is displayed using Carbon's `diffForHumans()`, which does not help in my case above.

I figured it will be helpful and more informative if we can have something similar to how GitHub shows exact time on hover of displayed times on GitHub comments like in the screenshot below:

![image](https://github.com/user-attachments/assets/76f0adc4-d125-4e79-aa4b-ddbf3c60186f)


## Visual changes

![image](https://github.com/user-attachments/assets/4a445847-ac92-4134-a580-118a7c1d1b06)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
