### PR TITLE
Fix injection of `$livewire` in infolists

### DIFF
--- a/packages/infolists/src/ComponentContainer.php
+++ b/packages/infolists/src/ComponentContainer.php
@@ -46,11 +46,11 @@ class ComponentContainer extends ViewComponent
     {
         return match ($parameterName) {
             'livewire' => [$this->getLivewire()],
-	        'record' => [$this->getRecord()],
+            'record' => [$this->getRecord()],
             default => parent::resolveDefaultClosureDependencyForEvaluationByName($parameterName),
         };
     }
-	
+
     /**
      * @return array<mixed>
      */

--- a/packages/infolists/src/ComponentContainer.php
+++ b/packages/infolists/src/ComponentContainer.php
@@ -45,11 +45,12 @@ class ComponentContainer extends ViewComponent
     protected function resolveDefaultClosureDependencyForEvaluationByName(string $parameterName): array
     {
         return match ($parameterName) {
-            'record' => [$this->getRecord()],
+            'livewire' => [$this->getLivewire()],
+	        'record' => [$this->getRecord()],
             default => parent::resolveDefaultClosureDependencyForEvaluationByName($parameterName),
         };
     }
-
+	
     /**
      * @return array<mixed>
      */

--- a/packages/infolists/src/Components/Component.php
+++ b/packages/infolists/src/Components/Component.php
@@ -36,6 +36,7 @@ class Component extends ViewComponent
     protected function resolveDefaultClosureDependencyForEvaluationByName(string $parameterName): array
     {
         return match ($parameterName) {
+	        'livewire' => [$this->getLivewire()],
             'record' => [$this->getRecord()],
             'state' => [$this->getState()],
             default => parent::resolveDefaultClosureDependencyForEvaluationByName($parameterName),

--- a/packages/infolists/src/Components/Component.php
+++ b/packages/infolists/src/Components/Component.php
@@ -36,7 +36,7 @@ class Component extends ViewComponent
     protected function resolveDefaultClosureDependencyForEvaluationByName(string $parameterName): array
     {
         return match ($parameterName) {
-	        'livewire' => [$this->getLivewire()],
+            'livewire' => [$this->getLivewire()],
             'record' => [$this->getRecord()],
             'state' => [$this->getState()],
             default => parent::resolveDefaultClosureDependencyForEvaluationByName($parameterName),

--- a/tests/src/Infolists/Fixtures/Livewire.php
+++ b/tests/src/Infolists/Fixtures/Livewire.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Filament\Tests\Infolists\Fixtures;
+
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Infolists\Concerns\InteractsWithInfolists;
+use Filament\Infolists\Contracts\HasInfolists;
+use Livewire\Component;
+
+class Livewire extends Component implements HasForms, HasInfolists
+{
+	use InteractsWithForms;
+	use InteractsWithInfolists;
+	
+	public $data;
+	
+	public static function make(): static
+	{
+		return new static;
+	}
+	
+	public function data($data): static
+	{
+		$this->data = $data;
+		
+		return $this;
+	}
+	
+	public function getData()
+	{
+		return $this->data;
+	}
+}

--- a/tests/src/Infolists/Fixtures/Livewire.php
+++ b/tests/src/Infolists/Fixtures/Livewire.php
@@ -10,25 +10,25 @@ use Livewire\Component;
 
 class Livewire extends Component implements HasForms, HasInfolists
 {
-	use InteractsWithForms;
-	use InteractsWithInfolists;
-	
-	public $data;
-	
-	public static function make(): static
-	{
-		return new static;
-	}
-	
-	public function data($data): static
-	{
-		$this->data = $data;
-		
-		return $this;
-	}
-	
-	public function getData()
-	{
-		return $this->data;
-	}
+    use InteractsWithForms;
+    use InteractsWithInfolists;
+
+    public $data;
+
+    public static function make(): static
+    {
+        return new static;
+    }
+
+    public function data($data): static
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    public function getData()
+    {
+        return $this->data;
+    }
 }

--- a/tests/src/Infolists/LivewireTest.php
+++ b/tests/src/Infolists/LivewireTest.php
@@ -14,7 +14,9 @@ it('can inject the correct `$livewire` for infolists outside a panel', function 
         ->assertSee('First Entry Label')
         ->assertSee('First Entry State')
         ->assertSee('Second Entry Label')
-        ->assertSee('Second Entry State');
+        ->assertSee('Second Entry State')
+	    		->assertSee('Third Entry Label')
+	    		->assertSee('Third Entry State (dynamic)');
 });
 
 class TestComponentWithInfolist extends Livewire
@@ -51,6 +53,13 @@ class TestComponentWithInfolist extends Livewire
                 return [
                     Infolists\Components\TextEntry::make('second_entry')
                         ->label('Second Entry Label'),
+                    Infolists\Components\TextEntry::make('third_entry')
+                        ->label('Third Entry Label')
+                    ->getStateUsing(function (TestComponentWithInfolist $livewire) {
+						expect($livewire)->toBe($this);
+						
+						return 'Third Entry State (dynamic)';
+                    }),
                 ];
             });
     }

--- a/tests/src/Infolists/LivewireTest.php
+++ b/tests/src/Infolists/LivewireTest.php
@@ -8,7 +8,7 @@ use function Filament\Tests\livewire;
 
 uses(TestCase::class);
 
-it('can inject the correct `$livewire` for infolists outside a panel', function () {
+it('can inject the correct `$livewire` for infolists', function () {
     livewire(TestComponentWithInfolist::class)
         ->assertOk()
         ->assertSee('First Entry Label')

--- a/tests/src/Infolists/LivewireTest.php
+++ b/tests/src/Infolists/LivewireTest.php
@@ -15,8 +15,8 @@ it('can inject the correct `$livewire` for infolists outside a panel', function 
         ->assertSee('First Entry State')
         ->assertSee('Second Entry Label')
         ->assertSee('Second Entry State')
-	    		->assertSee('Third Entry Label')
-	    		->assertSee('Third Entry State (dynamic)');
+        ->assertSee('Third Entry Label')
+        ->assertSee('Third Entry State (dynamic)');
 });
 
 class TestComponentWithInfolist extends Livewire
@@ -55,11 +55,11 @@ class TestComponentWithInfolist extends Livewire
                         ->label('Second Entry Label'),
                     Infolists\Components\TextEntry::make('third_entry')
                         ->label('Third Entry Label')
-                    ->getStateUsing(function (TestComponentWithInfolist $livewire) {
-						expect($livewire)->toBe($this);
-						
-						return 'Third Entry State (dynamic)';
-                    }),
+                        ->getStateUsing(function (TestComponentWithInfolist $livewire) {
+                            expect($livewire)->toBe($this);
+
+                            return 'Third Entry State (dynamic)';
+                        }),
                 ];
             });
     }

--- a/tests/src/Infolists/LivewireTest.php
+++ b/tests/src/Infolists/LivewireTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use Filament\Infolists;
+use Filament\Tests\Infolists\Fixtures\Livewire;
+use Filament\Tests\TestCase;
+
+use function Filament\Tests\livewire;
+
+uses(TestCase::class);
+
+it('can inject the correct `$livewire` for infolists outside a panel', function () {
+    livewire(TestComponentWithInfolist::class)
+        ->assertOk()
+        ->assertSee('First Entry Label')
+        ->assertSee('First Entry State')
+        ->assertSee('Second Entry Label')
+        ->assertSee('Second Entry State');
+});
+
+class TestComponentWithInfolist extends Livewire
+{
+    public function mount(): void
+    {
+        $this->data([
+            'first_entry' => 'First Entry State',
+            'second_entry' => 'Second Entry State',
+        ]);
+    }
+
+    public function infolist(Infolists\Infolist $infolist): Infolists\Infolist
+    {
+        return $infolist
+            ->state($this->data)
+            ->schema(function (TestComponentWithInfolist $livewire) {
+                expect($livewire)->toBe($this);
+
+                return [
+                    Infolists\Components\TextEntry::make('first_entry')
+                        ->label('First Entry Label'),
+                ];
+            });
+    }
+
+    public function infolistWithCustomName(Infolists\Infolist $infolist): Infolists\Infolist
+    {
+        return $infolist
+            ->state($this->data)
+            ->schema(function (TestComponentWithInfolist $livewire) {
+                expect($livewire)->toBe($this);
+
+                return [
+                    Infolists\Components\TextEntry::make('second_entry')
+                        ->label('Second Entry Label'),
+                ];
+            });
+    }
+
+    public function render(): string
+    {
+        return <<<'BLADE'
+		{{ $this->infolist }}
+		{{ $this->infolistWithCustomName }}
+		BLADE;
+    }
+}

--- a/tests/src/Infolists/LivewireTest.php
+++ b/tests/src/Infolists/LivewireTest.php
@@ -33,7 +33,7 @@ class TestComponentWithInfolist extends Livewire
     {
         return $infolist
             ->state($this->data)
-            ->schema(function (TestComponentWithInfolist $livewire) {
+            ->schema(function (self $livewire) {
                 expect($livewire)->toBe($this);
 
                 return [
@@ -47,7 +47,7 @@ class TestComponentWithInfolist extends Livewire
     {
         return $infolist
             ->state($this->data)
-            ->schema(function (TestComponentWithInfolist $livewire) {
+            ->schema(function (self $livewire) {
                 expect($livewire)->toBe($this);
 
                 return [
@@ -55,7 +55,7 @@ class TestComponentWithInfolist extends Livewire
                         ->label('Second Entry Label'),
                     Infolists\Components\TextEntry::make('third_entry')
                         ->label('Third Entry Label')
-                        ->getStateUsing(function (TestComponentWithInfolist $livewire) {
+                        ->getStateUsing(function (self $livewire) {
                             expect($livewire)->toBe($this);
 
                             return 'Third Entry State (dynamic)';

--- a/tests/src/Infolists/LivewireTest.php
+++ b/tests/src/Infolists/LivewireTest.php
@@ -8,7 +8,7 @@ use function Filament\Tests\livewire;
 
 uses(TestCase::class);
 
-it('can inject the correct `$livewire` for infolists', function () {
+it('can evaluate livewire closure dependency by name', function () {
     livewire(TestComponentWithInfolist::class)
         ->assertOk()
         ->assertSee('First Entry Label')


### PR DESCRIPTION
Noticed that in Infolists the injection of `$livewire` would return a newly instantiated component from the container instead of the actual `$livewire` component. The reason for this behaviour turned out to be that the `livewire` parameter was not included in the respective `resolveDefaultClosureDependencyForEvaluationByName()` methods.