### PR TITLE
update getSearchResultsUsing documentation

### DIFF
--- a/packages/forms/docs/03-fields/03-select.md
+++ b/packages/forms/docs/03-fields/03-select.md
@@ -63,19 +63,21 @@ Select::make('author_id')
 
 ### Returning custom search results
 
-If you have lots of options and want to populate them based on a database search or other external data source, you can use the `getSearchResultsUsing()` and `getOptionLabelUsing()` methods instead of `options()`.
+If you have lots of options and want to populate them based on a database search or other external data source, you can use the `getSearchResultsUsing()` method instead of `options()`.
 
 The `getSearchResultsUsing()` method accepts a callback that returns search results in `$key => $value` format. The current user's search is available as `$search`, and you should use that to filter your results.
 
-The `getOptionLabelUsing()` method accepts a callback that transforms the selected option `$value` into a label. This is used when the form is first loaded when the user has not made a search yet. Otherwise, the label used to display the currently selected option would not be available.
-
-Both `getSearchResultsUsing()` and `getOptionLabelUsing()` must be used on the select if you want to provide custom search results:
+To customize the label of each option, you can use the `mapWithKeys()` method on the options collection. 
 
 ```php
 Select::make('author_id')
     ->searchable()
-    ->getSearchResultsUsing(fn (string $search): array => User::where('name', 'like', "%{$search}%")->limit(50)->pluck('name', 'id')->toArray())
-    ->getOptionLabelUsing(fn ($value): ?string => User::find($value)?->name),
+    ->getSearchResultsUsing(fn (string $search): array =>
+        User::where('name', 'like', "%{$search}%")
+            ->limit(50)
+            ->mapWithKeys(fn (User $user) => [$user->id => $user->name.': '.$user->email])
+            ->toArray()
+    ),
 ```
 
 ## Multi-select


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The documentation provided in 03-select.md regarding getSearchResultsUsing() and getOptionLabelUsing() produces inconsistent results. In this example:

```
            Forms\Components\Select::make('product_id')
                ->label('Product')
                ->searchable()
                ->live()
                ->getSearchResultsUsing(function (string $search): array {
                    return Product::query()
                        ->where('name', 'like', '%'.$search.'%')
                        ->get()
                        ->toArray();
                })
                ->getOptionLabelUsing(function ($value): string {
                    $product = Product::find($value);
                    return $product->name.': '.$product->price.'$';
                })
                ->afterStateUpdated(function (Set $set, Get $get) {
                    if ($get('product_id')) {
                        $set('contract_price', Product::find($get('product_id'))?->price);
                    }
                })
                ->hidden(fn (Get $get) => $get('is_product') === false),
```
              
 I was only able to get the label specified in the getOptionLabelUsing() method to render  using the following steps.
 

1. Select an option
2. hide that select component via is_product togle
3. show it again via using the toggle a second time. 

This PR updates the doc to suggest using mapWithKeys() as follows on the search results collection to modify the label, which I have found to be more robust:

```php
Select::make('author_id')
    ->searchable()
    ->getSearchResultsUsing(fn (string $search): array =>
        User::where('name', 'like', "%{$search}%")
            ->limit(50)
            ->mapWithKeys(fn (User $user) => [$user->id => $user->name.': '.$user->email])
            ->toArray()
    ),
```

It is possible this is a skill issue on my end, but I threw a debugging statements all over this and was only able to get the getOptionLabel() callback to execute when the component was being rendered.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->


## Functional changes

- [ ]  03-select.md has been updated with a working method for customizing the labels in searchable select components.
