### PR TITLE
Allow to disable a modal trigger

### DIFF
--- a/packages/support/docs/09-blade-components/02-modal.md
+++ b/packages/support/docs/09-blade-components/02-modal.md
@@ -231,7 +231,7 @@ By default, modals will autofocus on the first focusable element when opened. If
 
 ## Disabling the modal trigger button
 
-By default, the trigger button will open the modal even if it disabled, since the click event listener is registered on a wrapping element of the button itself. If you want to prevent the modal from opening, you should also use the `disabled` attribute on the trigger slot:
+By default, the trigger button will open the modal even if it is disabled, since the click event listener is registered on a wrapping element of the button itself. If you want to prevent the modal from opening, you should also use the `disabled` attribute on the trigger slot:
 
 ```blade
 <x-filament::modal>

--- a/packages/support/docs/09-blade-components/02-modal.md
+++ b/packages/support/docs/09-blade-components/02-modal.md
@@ -228,3 +228,19 @@ By default, modals will autofocus on the first focusable element when opened. If
     {{-- Modal content --}}
 </x-filament::modal>
 ```
+
+## Preventing the modal from being triggered
+
+By default, modals will be triggered even if button is disabled. If you want to disable the modal trigger itself, you can use the `disabled` attribute on the trigger:
+
+```blade
+<x-filament::modal>
+    <x-slot name="trigger" :disabled="true">
+        <x-filament::button :disabled="true">
+            Open modal
+        </x-filament::button>
+    </x-slot>
+    {{-- Modal content --}}
+</x-filament::modal>
+```
+

--- a/packages/support/docs/09-blade-components/02-modal.md
+++ b/packages/support/docs/09-blade-components/02-modal.md
@@ -229,13 +229,13 @@ By default, modals will autofocus on the first focusable element when opened. If
 </x-filament::modal>
 ```
 
-## Preventing the modal from being triggered
+## Disabling the modal trigger button
 
-By default, modals will be triggered even if button is disabled. If you want to disable the modal trigger itself, you can use the `disabled` attribute on the trigger:
+By default, the trigger button will open the modal even if it disabled, since the click event listener is registered on a wrapping element of the button itself. If you want to prevent the modal from opening, you should also use the `disabled` attribute on the trigger slot:
 
 ```blade
 <x-filament::modal>
-    <x-slot name="trigger" :disabled="true">
+    <x-slot name="trigger" disabled>
         <x-filament::button :disabled="true">
             Open modal
         </x-filament::button>

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -106,7 +106,7 @@
 >
     @if ($trigger)
         <div
-            @if(!$trigger->attributes['disabled'] ?? false)
+            @if (! $trigger->attributes->get('disabled'))
                 x-on:click="open"
             @endif
             {{ $trigger->attributes->class(['fi-modal-trigger flex cursor-pointer']) }}

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -106,7 +106,9 @@
 >
     @if ($trigger)
         <div
-            x-on:click="open"
+            @if(!$trigger->attributes['disabled'] ?? false)
+                x-on:click="open"
+            @endif
             {{ $trigger->attributes->class(['fi-modal-trigger flex cursor-pointer']) }}
         >
             {{ $trigger }}


### PR DESCRIPTION
## Description

Currently there is no way to prevent a modal from being triggered. Even if the trigger button is disabled, the modal would still open, as in this example:

```blade
<x-filament::modal id="modalTest">
    <x-slot name="trigger">
        <x-filament::button :disabled="true">I'm disabled</x-filament::button>
    </x-slot>
    Hello, I'm a modal
</x-filament::modal>
```

This PR lets users disable the trigger element like this:

```blade
<x-filament::modal id="modalTest">
    <x-slot name="trigger" :disabled="true">
        <x-filament::button :disabled="true">I'm disabled</x-filament::button>
    </x-slot>
    Hello, I'm a modal
</x-filament::modal>
```

It also adds documentation for this change.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
