### PR TITLE
Docs: Add repeater action item testing documentation

### DIFF
--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -743,21 +743,22 @@ livewire(EditPost::class, ['record' => $post])
 $undoRepeaterFake();
 ```
 
-### Testing Repeater Actions
+### Testing repeater actions
 
-In order to validate repeater actions are working as expected, you can utilize the `mountFormComponentAction` method to call your repeater actions and then perform additional validations (e.g. [modal content assertions](../../actions/testing#modal-content)).
+In order to test that repeater actions are working as expected, you can utilize the `callFormComponentAction()` method to call your repeater actions and then [perform additional assertions](../testing#actions).
 
-To reflect the argument data that is passed in to the action when interacting with the repeater item, you can pass in the ID of the repeater-item using the `arguments` arguemnt.  The data structure is `['item' => 'record-' . $id] where the `$id` is the repeater-item's id:  
+To interact with an action on a particular repeater item, you need to pass in the `item` argument with the key of that repeater item. If your repeater is reading from a relationship, you should prefix the ID (key) of the related record with `record-` to form the key of the repeater item:  
 
 ```php
 use App\Models\Quote;
 use Filament\Forms\Components\Repeater;
 use function Pest\Livewire\livewire;
 
-$quote = Quote::find(1);
+$quote = Quote::first();
 
 livewire(EditPost::class, ['record' => $post])
-    ->mountFormComponentAction("quotes", "copyQuote", arguments: [
-        'item' => 'record-' . $quote->id,
-    ])->assertSee('Quote copied!');
+    ->callFormComponentAction('quotes', 'sendQuote', arguments: [
+        'item' => "record-{$quote->getKey()}",
+    ])
+    ->assertNotified('Quote sent!');
 ```

--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -742,3 +742,22 @@ livewire(EditPost::class, ['record' => $post])
 
 $undoRepeaterFake();
 ```
+
+### Testing Repeater Actions
+
+In order to validate repeater actions are working as expected, you can utilize the `mountFormComponentAction` method to call your repeater actions and then perform additional validations (e.g. [modal content assertions](../../actions/testing#modal-content)).
+
+To determine which repater item's action to test, you must pass in the ID of the repeater-item using the `arguments` arguemnt.  The required data structure is `['item' => 'record-' . $id] where the `$id` is the repeater-item's id:  
+
+```php
+use App\Models\Quote;
+use Filament\Forms\Components\Repeater;
+use function Pest\Livewire\livewire;
+
+$quote = Quote::find(1);
+
+livewire(EditPost::class, ['record' => $post])
+    ->mountFormComponentAction("quotes", "copyQuote", arguments: [
+        'item' => 'record-' . $quote->id,
+    ])->assertSee('Quote copied!');
+```

--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -747,7 +747,7 @@ $undoRepeaterFake();
 
 In order to validate repeater actions are working as expected, you can utilize the `mountFormComponentAction` method to call your repeater actions and then perform additional validations (e.g. [modal content assertions](../../actions/testing#modal-content)).
 
-To determine which repater item's action to test, you must pass in the ID of the repeater-item using the `arguments` arguemnt.  The required data structure is `['item' => 'record-' . $id] where the `$id` is the repeater-item's id:  
+To reflect the argument data that is passed in to the action when interacting with the repeater item, you can pass in the ID of the repeater-item using the `arguments` arguemnt.  The data structure is `['item' => 'record-' . $id] where the `$id` is the repeater-item's id:  
 
 ```php
 use App\Models\Quote;


### PR DESCRIPTION
## Description

There is no documentation on how to test individual repeater item actions, however, they can contain somewhat complex use-cases that need good validation.  Thankfully, everything you need is already available in the testing methods, so this simply points out the data-structure as it's passed in to a live environment.

## Visual changes

None

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
