### PR TITLE
Fix typo in the Notification testing documentation

### DIFF
--- a/packages/notifications/docs/06-testing.md
+++ b/packages/notifications/docs/06-testing.md
@@ -76,7 +76,7 @@ it('does not send a notification', function () {
         // or
         ->assertNotNotified('Unable to create post')
         // or
-        ->assertNotified(
+        ->assertNotNotified(
             Notification::make()
                 ->danger()
                 ->title('Unable to create post')


### PR DESCRIPTION
Fixes typo in code example when describing how to pass Notification to test it is notNotified

## Description

The docs have a typo in them. It is using the assertNotified method however should be assertNotNotified

## Visual changes

Happy to do this if it is actually needed but it is a simple 3 character change to the docs

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
