### PR TITLE
Add ability to hook into a clone

### DIFF
--- a/packages/forms/src/Components/Concerns/Cloneable.php
+++ b/packages/forms/src/Components/Concerns/Cloneable.php
@@ -23,14 +23,13 @@ trait Cloneable
 
         return $this;
     }
-	
-	
-	public function afterClone(Closure $callback): static
-	{
-		$this->cloneCallbacks[] = $callback;
-		
-		return $this;
-	}
+
+    public function afterClone(Closure $callback): static
+    {
+        $this->cloneCallbacks[] = $callback;
+
+        return $this;
+    }
 
     public function getClone(): static
     {

--- a/packages/forms/src/Components/Concerns/Cloneable.php
+++ b/packages/forms/src/Components/Concerns/Cloneable.php
@@ -38,10 +38,10 @@ trait Cloneable
         $clone->cloneChildComponents();
 
         foreach ($this->cloneCallbacks as $callback) {
-            $clone->evaluate($callback->bindTo($clone), [
-                'clone' => $clone,
-                'original' => $this,
-            ]);
+            $clone->evaluate(
+                value: $callback->bindTo($clone),
+                namedInjections: ['clone' => $clone, 'original' => $this]
+            );
         }
 
         return $clone;

--- a/packages/forms/src/Concerns/Cloneable.php
+++ b/packages/forms/src/Concerns/Cloneable.php
@@ -2,10 +2,16 @@
 
 namespace Filament\Forms\Concerns;
 
+use Closure;
 use Filament\Forms\Components\Component;
 
 trait Cloneable
 {
+	/**
+	 * @var array<Closure>
+	 */
+	protected array $cloneCallbacks = [];
+	
     protected function cloneComponents(): static
     {
         if (is_array($this->components)) {
@@ -19,12 +25,26 @@ trait Cloneable
 
         return $this;
     }
+	
+	public function afterClone(Closure $callback): static
+	{
+		$this->cloneCallbacks[] = $callback;
+		
+		return $this;
+	}
 
     public function getClone(): static
     {
         $clone = clone $this;
         $clone->flushCachedAbsoluteStatePath();
         $clone->cloneComponents();
+	    
+	    foreach ($this->cloneCallbacks as $callback) {
+		    $clone->evaluate($callback->bindTo($clone), [
+			    'clone' => $clone,
+			    'original' => $this,
+		    ]);
+	    }
 
         return $clone;
     }

--- a/packages/forms/src/Concerns/Cloneable.php
+++ b/packages/forms/src/Concerns/Cloneable.php
@@ -40,10 +40,10 @@ trait Cloneable
         $clone->cloneComponents();
 
         foreach ($this->cloneCallbacks as $callback) {
-            $clone->evaluate($callback->bindTo($clone), [
-                'clone' => $clone,
-                'original' => $this,
-            ]);
+            $clone->evaluate(
+                value: $callback->bindTo($clone),
+                namedInjections: ['clone' => $clone, 'original' => $this]
+            );
         }
 
         return $clone;

--- a/packages/forms/src/Concerns/Cloneable.php
+++ b/packages/forms/src/Concerns/Cloneable.php
@@ -7,11 +7,11 @@ use Filament\Forms\Components\Component;
 
 trait Cloneable
 {
-	/**
-	 * @var array<Closure>
-	 */
-	protected array $cloneCallbacks = [];
-	
+    /**
+     * @var array<Closure>
+     */
+    protected array $cloneCallbacks = [];
+
     protected function cloneComponents(): static
     {
         if (is_array($this->components)) {
@@ -25,26 +25,26 @@ trait Cloneable
 
         return $this;
     }
-	
-	public function afterClone(Closure $callback): static
-	{
-		$this->cloneCallbacks[] = $callback;
-		
-		return $this;
-	}
+
+    public function afterClone(Closure $callback): static
+    {
+        $this->cloneCallbacks[] = $callback;
+
+        return $this;
+    }
 
     public function getClone(): static
     {
         $clone = clone $this;
         $clone->flushCachedAbsoluteStatePath();
         $clone->cloneComponents();
-	    
-	    foreach ($this->cloneCallbacks as $callback) {
-		    $clone->evaluate($callback->bindTo($clone), [
-			    'clone' => $clone,
-			    'original' => $this,
-		    ]);
-	    }
+
+        foreach ($this->cloneCallbacks as $callback) {
+            $clone->evaluate($callback->bindTo($clone), [
+                'clone' => $clone,
+                'original' => $this,
+            ]);
+        }
 
         return $clone;
     }

--- a/packages/infolists/src/Components/Concerns/Cloneable.php
+++ b/packages/infolists/src/Components/Concerns/Cloneable.php
@@ -2,10 +2,16 @@
 
 namespace Filament\Infolists\Components\Concerns;
 
+use Closure;
 use Filament\Infolists\Components\Component;
 
 trait Cloneable
 {
+	/**
+	 * @var array<Closure>
+	 */
+	protected array $cloneCallbacks = [];
+	
     protected function cloneChildComponents(): static
     {
         if (is_array($this->childComponents)) {
@@ -17,12 +23,26 @@ trait Cloneable
 
         return $this;
     }
-
+	
+	public function afterClone(Closure $callback): static
+	{
+		$this->cloneCallbacks[] = $callback;
+		
+		return $this;
+	}
+	
     public function getClone(): static
     {
         $clone = clone $this;
         $clone->flushCachedAbsoluteStatePath();
         $clone->cloneChildComponents();
+	    
+	    foreach ($this->cloneCallbacks as $callback) {
+		    $clone->evaluate($callback->bindTo($clone), [
+			    'clone' => $clone,
+			    'original' => $this,
+		    ]);
+	    }
 
         return $clone;
     }

--- a/packages/infolists/src/Components/Concerns/Cloneable.php
+++ b/packages/infolists/src/Components/Concerns/Cloneable.php
@@ -7,11 +7,11 @@ use Filament\Infolists\Components\Component;
 
 trait Cloneable
 {
-	/**
-	 * @var array<Closure>
-	 */
-	protected array $cloneCallbacks = [];
-	
+    /**
+     * @var array<Closure>
+     */
+    protected array $cloneCallbacks = [];
+
     protected function cloneChildComponents(): static
     {
         if (is_array($this->childComponents)) {
@@ -23,26 +23,26 @@ trait Cloneable
 
         return $this;
     }
-	
-	public function afterClone(Closure $callback): static
-	{
-		$this->cloneCallbacks[] = $callback;
-		
-		return $this;
-	}
-	
+
+    public function afterClone(Closure $callback): static
+    {
+        $this->cloneCallbacks[] = $callback;
+
+        return $this;
+    }
+
     public function getClone(): static
     {
         $clone = clone $this;
         $clone->flushCachedAbsoluteStatePath();
         $clone->cloneChildComponents();
-	    
-	    foreach ($this->cloneCallbacks as $callback) {
-		    $clone->evaluate($callback->bindTo($clone), [
-			    'clone' => $clone,
-			    'original' => $this,
-		    ]);
-	    }
+
+        foreach ($this->cloneCallbacks as $callback) {
+            $clone->evaluate($callback->bindTo($clone), [
+                'clone' => $clone,
+                'original' => $this,
+            ]);
+        }
 
         return $clone;
     }

--- a/packages/infolists/src/Components/Concerns/Cloneable.php
+++ b/packages/infolists/src/Components/Concerns/Cloneable.php
@@ -38,10 +38,10 @@ trait Cloneable
         $clone->cloneChildComponents();
 
         foreach ($this->cloneCallbacks as $callback) {
-            $clone->evaluate($callback->bindTo($clone), [
-                'clone' => $clone,
-                'original' => $this,
-            ]);
+            $clone->evaluate(
+                value: $callback->bindTo($clone),
+                namedInjections: ['clone' => $clone, 'original' => $this]
+            );
         }
 
         return $clone;

--- a/packages/infolists/src/Concerns/Cloneable.php
+++ b/packages/infolists/src/Concerns/Cloneable.php
@@ -36,10 +36,10 @@ trait Cloneable
         $clone->cloneComponents();
 
         foreach ($this->cloneCallbacks as $callback) {
-            $clone->evaluate($callback->bindTo($clone), [
-                'clone' => $clone,
-                'original' => $this,
-            ]);
+            $clone->evaluate(
+                value: $callback->bindTo($clone),
+                namedInjections: ['clone' => $clone, 'original' => $this]
+            );
         }
 
         return $clone;

--- a/tests/src/Forms/ComponentTest.php
+++ b/tests/src/Forms/ComponentTest.php
@@ -71,25 +71,25 @@ it('can have meta', function () {
 
 it('can clone', function () {
     $cloneCallbackCount = 0;
-	$cloneCallbackClone = null;
-	$cloneCallbackOriginal = null;
+    $cloneCallbackClone = null;
+    $cloneCallbackOriginal = null;
 
     $component = (new Component)
         ->afterClone(function (Component $clone, Component $original) use (&$cloneCallbackCount, &$cloneCallbackClone, &$cloneCallbackOriginal) {
             $cloneCallbackCount++;
-			$cloneCallbackClone = $clone;
-			$cloneCallbackOriginal = $original;
+            $cloneCallbackClone = $clone;
+            $cloneCallbackOriginal = $original;
         });
-	
-	$clone = $component->getClone();
-	
-	expect($cloneCallbackCount)
-		->toBe(1);
-	
-	expect($cloneCallbackClone)
-		->not->toBe($component)
-		->toBe($clone);
-	
-	expect($cloneCallbackOriginal)
-		->toBe($component);
+
+    $clone = $component->getClone();
+
+    expect($cloneCallbackCount)
+        ->toBe(1);
+
+    expect($cloneCallbackClone)
+        ->not->toBe($component)
+        ->toBe($clone);
+
+    expect($cloneCallbackOriginal)
+        ->toBe($component);
 });

--- a/tests/src/Forms/ComponentTest.php
+++ b/tests/src/Forms/ComponentTest.php
@@ -68,3 +68,28 @@ it('can have meta', function () {
             'bob' => 'baz',
         ]);
 });
+
+it('can clone', function () {
+    $cloneCallbackCount = 0;
+	$cloneCallbackClone = null;
+	$cloneCallbackOriginal = null;
+
+    $component = (new Component)
+        ->afterClone(function (Component $clone, Component $original) use (&$cloneCallbackCount, &$cloneCallbackClone, &$cloneCallbackOriginal) {
+            $cloneCallbackCount++;
+			$cloneCallbackClone = $clone;
+			$cloneCallbackOriginal = $original;
+        });
+	
+	$clone = $component->getClone();
+	
+	expect($cloneCallbackCount)
+		->toBe(1);
+	
+	expect($cloneCallbackClone)
+		->not->toBe($component)
+		->toBe($clone);
+	
+	expect($cloneCallbackOriginal)
+		->toBe($component);
+});

--- a/tests/src/Infolists/ComponentTest.php
+++ b/tests/src/Infolists/ComponentTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Filament\Infolists\Components\Component;
+use Filament\Tests\TestCase;
+
+uses(TestCase::class);
+
+it('can clone', function () {
+    $cloneCallbackCount = 0;
+    $cloneCallbackClone = null;
+    $cloneCallbackOriginal = null;
+
+    $component = (new Component)
+        ->afterClone(function (Component $clone, Component $original) use (&$cloneCallbackCount, &$cloneCallbackClone, &$cloneCallbackOriginal) {
+            $cloneCallbackCount++;
+            $cloneCallbackClone = $clone;
+            $cloneCallbackOriginal = $original;
+        });
+
+    $clone = $component->getClone();
+
+    expect($cloneCallbackCount)
+        ->toBe(1);
+
+    expect($cloneCallbackClone)
+        ->not->toBe($component)
+        ->toBe($clone);
+
+    expect($cloneCallbackOriginal)
+        ->toBe($component);
+});


### PR DESCRIPTION
Currently, it is not possible to add custom macros on e.g. form components that persist a custom property. For example, take the following set of macro:

```php
Filament\Support\Components\ViewComponent::macro('someIdentifier', function (string $identifier) {
       // Where to store? Dynamic properties are deprecated from 8.2 on and cause many file system log writes.
});

Filament\Support\Components\ViewComponent::macro('getSomeIdentifier', function () {
       // Where to retrieve?
});
```

A solution I tried was to make a singleton object to store the identifiers based on e.g. in a `WeakMap`, however that does not work because (it seems) that components are cloned and therefore then there is no way to hook them also into the WeakMap.

This PR adds some tests for the cloning and the ability to run a callback any time a component is cloned, thus providing the ability to have a form of "persistent" properties throughout a macro.

Thanks!