### PR TITLE
Add MIME type mapping support to file upload component

### DIFF
--- a/packages/forms/docs/03-fields/09-file-upload.md
+++ b/packages/forms/docs/03-fields/09-file-upload.md
@@ -511,3 +511,19 @@ FileUpload::make('attachments')
     ->minFiles(2)
     ->maxFiles(5)
 ```
+
+## Custom MIME Type Mapping
+
+Some file formats may not be recognized correctly by the browser when uploading files. Filament allows you to manually define MIME types for specific file extensions using the `mimeTypeMap()` method:
+
+```php
+FileUpload::make('designs')
+    ->mimeTypeMap([
+        '3dm' => 'x-world/x-3dmf',
+        'skp' => 'application/vnd.sketchup.skp',
+    ])
+    ->acceptedFileTypes([
+        'x-world/x-3dmf',
+        'application/vnd.sketchup.skp',
+    ]);
+```

--- a/packages/forms/docs/03-fields/09-file-upload.md
+++ b/packages/forms/docs/03-fields/09-file-upload.md
@@ -460,6 +460,24 @@ FileUpload::make('image')
     ->image()
 ```
 
+#### Custom MIME type mapping
+
+Some file formats may not be recognized correctly by the browser when uploading files. Filament allows you to manually define MIME types for specific file extensions using the `mimeTypeMap()` method:
+
+```php
+use Filament\Forms\Components\FileUpload;
+
+FileUpload::make('designs')
+    ->acceptedFileTypes([
+        'x-world/x-3dmf',
+        'application/vnd.sketchup.skp',
+    ])
+    ->mimeTypeMap([
+        '3dm' => 'x-world/x-3dmf',
+        'skp' => 'application/vnd.sketchup.skp',
+    ]);
+```
+
 ### File size validation
 
 You may also restrict the size of uploaded files in kilobytes:
@@ -510,20 +528,4 @@ FileUpload::make('attachments')
     ->multiple()
     ->minFiles(2)
     ->maxFiles(5)
-```
-
-## Custom MIME Type Mapping
-
-Some file formats may not be recognized correctly by the browser when uploading files. Filament allows you to manually define MIME types for specific file extensions using the `mimeTypeMap()` method:
-
-```php
-FileUpload::make('designs')
-    ->mimeTypeMap([
-        '3dm' => 'x-world/x-3dmf',
-        'skp' => 'application/vnd.sketchup.skp',
-    ])
-    ->acceptedFileTypes([
-        'x-world/x-3dmf',
-        'application/vnd.sketchup.skp',
-    ]);
 ```

--- a/packages/forms/docs/05-validation.md
+++ b/packages/forms/docs/05-validation.md
@@ -602,3 +602,18 @@ Page::$reportValidationErrorUsing = function (ValidationException $exception) {
         ->send();
 };
 ```
+## Custom MIME Type Mapping
+
+Some file formats may not be recognized correctly by the browser when uploading files. Filament allows you to manually define MIME types for specific file extensions using the `mimeTypeMap()` method:
+
+```php
+FileUpload::make('designs')
+    ->mimeTypeMap([
+        '3dm' => 'x-world/x-3dmf',
+        'skp' => 'application/vnd.sketchup.skp',
+    ])
+    ->acceptedFileTypes([
+        'x-world/x-3dmf',
+        'application/vnd.sketchup.skp',
+    ]);
+```

--- a/packages/forms/docs/05-validation.md
+++ b/packages/forms/docs/05-validation.md
@@ -602,18 +602,3 @@ Page::$reportValidationErrorUsing = function (ValidationException $exception) {
         ->send();
 };
 ```
-## Custom MIME Type Mapping
-
-Some file formats may not be recognized correctly by the browser when uploading files. Filament allows you to manually define MIME types for specific file extensions using the `mimeTypeMap()` method:
-
-```php
-FileUpload::make('designs')
-    ->mimeTypeMap([
-        '3dm' => 'x-world/x-3dmf',
-        'skp' => 'application/vnd.sketchup.skp',
-    ])
-    ->acceptedFileTypes([
-        'x-world/x-3dmf',
-        'application/vnd.sketchup.skp',
-    ]);
-```

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -74,7 +74,6 @@ export default function fileUploadFormComponent({
     uploadUsing,
     mimeTypeMap,
 }) {
-
     return {
         fileKeyIndex: {},
 
@@ -204,8 +203,14 @@ export default function fileUploadFormComponent({
                 },
                 fileValidateTypeDetectType: (source, detectedType) => {
                     return new Promise((resolve, reject) => {
-                        const extension = source.name.split('.').pop().toLowerCase()
-                        const mimeType = mimeTypeMap[extension] || detectedType || mime.getType(extension)
+                        const extension = source.name
+                            .split('.')
+                            .pop()
+                            .toLowerCase()
+                        const mimeType =
+                            mimeTypeMap[extension] ||
+                            detectedType ||
+                            mime.getType(extension)
 
                         mimeType ? resolve(mimeType) : reject()
                     })

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -58,6 +58,7 @@ export default function fileUploadFormComponent({
     maxSize,
     minSize,
     maxParallelUploads,
+    mimeTypeMap,
     panelAspectRatio,
     panelLayout,
     placeholder,
@@ -72,7 +73,6 @@ export default function fileUploadFormComponent({
     uploadingMessage,
     uploadProgressIndicatorPosition,
     uploadUsing,
-    mimeTypeMap,
 }) {
     return {
         fileKeyIndex: {},

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -72,7 +72,9 @@ export default function fileUploadFormComponent({
     uploadingMessage,
     uploadProgressIndicatorPosition,
     uploadUsing,
+    mimeTypeMap,
 }) {
+
     return {
         fileKeyIndex: {},
 
@@ -202,9 +204,9 @@ export default function fileUploadFormComponent({
                 },
                 fileValidateTypeDetectType: (source, detectedType) => {
                     return new Promise((resolve, reject) => {
-                        const mimeType =
-                            detectedType ||
-                            mime.getType(source.name.split('.').pop())
+                        const extension = source.name.split('.').pop().toLowerCase()
+                        const mimeType = mimeTypeMap[extension] || detectedType || mime.getType(extension)
+
                         mimeType ? resolve(mimeType) : reject()
                     })
                 },

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -39,6 +39,7 @@
                     deleteUploadedFileUsing: async (fileKey) => {
                         return await $wire.deleteUploadedFile(@js($statePath), fileKey)
                     },
+                    mimeTypeMap: @js($getMimeTypeMap()),
                     getUploadedFilesUsing: async () => {
                         return await $wire.getFormUploadedFiles(@js($statePath))
                     },

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -39,7 +39,6 @@
                     deleteUploadedFileUsing: async (fileKey) => {
                         return await $wire.deleteUploadedFile(@js($statePath), fileKey)
                     },
-                    mimeTypeMap: @js($getMimeTypeMap()),
                     getUploadedFilesUsing: async () => {
                         return await $wire.getFormUploadedFiles(@js($statePath))
                     },
@@ -72,6 +71,7 @@
                     maxFiles: @js($getMaxFiles()),
                     maxSize: @js(($size = $getMaxSize()) ? "{$size}KB" : null),
                     minSize: @js(($size = $getMinSize()) ? "{$size}KB" : null),
+                    mimeTypeMap: @js($getMimeTypeMap()),
                     maxParallelUploads: @js($getMaxParallelUploads()),
                     removeUploadedFileUsing: async (fileKey) => {
                         return await $wire.removeFormUploadedFile(@js($statePath), fileKey)

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -76,9 +76,9 @@ class FileUpload extends BaseFileUpload
     protected array | Closure $imageEditorAspectRatios = [];
 
     /**
-     * @var array<string, string>
+     * @var array<string, string> | Closure
      */
-    protected array $mimeTypeMap = [];
+    protected array | Closure $mimeTypeMap = [];
 
     public function appendFiles(bool | Closure $condition = true): static
     {
@@ -595,9 +595,9 @@ class FileUpload extends BaseFileUpload
     }
 
     /**
-     * @param  array<string, string>  $mimeTypeMap
+     * @param  array<string, string> | Closure  $mimeTypeMap
      */
-    public function mimeTypeMap(array $mimeTypeMap): static
+    public function mimeTypeMap(array | Closure $mimeTypeMap): static
     {
         $this->mimeTypeMap = $mimeTypeMap;
 
@@ -609,6 +609,6 @@ class FileUpload extends BaseFileUpload
      */
     public function getMimeTypeMap(): array
     {
-        return $this->mimeTypeMap;
+        return $this->evaluate($this->mimeTypeMap);
     }
 }

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -75,6 +75,11 @@ class FileUpload extends BaseFileUpload
      */
     protected array | Closure $imageEditorAspectRatios = [];
 
+    /**
+     * @var array<string, string>
+     */
+    protected array $mimeTypeMap = [];
+
     public function appendFiles(bool | Closure $condition = true): static
     {
         $this->shouldAppendFiles = $condition;
@@ -470,7 +475,7 @@ class FileUpload extends BaseFileUpload
             )
             ->unique()
             ->mapWithKeys(fn (?string $ratio): array => [
-                $ratio ?? __('filament-forms::components.file_upload.editor.aspect_ratios.no_fixed.label') => $this->normalizeImageCroppingRatioForJs($ratio),
+                    $ratio ?? __('filament-forms::components.file_upload.editor.aspect_ratios.no_fixed.label') => $this->normalizeImageCroppingRatioForJs($ratio),
             ])
             ->filter(fn (float | string | false $ratio): bool => $ratio !== false)
             ->when(
@@ -587,5 +592,23 @@ class FileUpload extends BaseFileUpload
                 ],
             ],
         ];
+    }
+
+    /**
+     * @param array<string, string> $mimeTypeMap
+     */
+    public function mimeTypeMap(array $mimeTypeMap): static
+    {
+        $this->mimeTypeMap = $mimeTypeMap;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getMimeTypeMap(): array
+    {
+        return $this->mimeTypeMap;
     }
 }

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -475,7 +475,7 @@ class FileUpload extends BaseFileUpload
             )
             ->unique()
             ->mapWithKeys(fn (?string $ratio): array => [
-                    $ratio ?? __('filament-forms::components.file_upload.editor.aspect_ratios.no_fixed.label') => $this->normalizeImageCroppingRatioForJs($ratio),
+                $ratio ?? __('filament-forms::components.file_upload.editor.aspect_ratios.no_fixed.label') => $this->normalizeImageCroppingRatioForJs($ratio),
             ])
             ->filter(fn (float | string | false $ratio): bool => $ratio !== false)
             ->when(
@@ -595,7 +595,7 @@ class FileUpload extends BaseFileUpload
     }
 
     /**
-     * @param array<string, string> $mimeTypeMap
+     * @param  array<string, string>  $mimeTypeMap
      */
     public function mimeTypeMap(array $mimeTypeMap): static
     {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
I solved the [issue](https://github.com/filamentphp/filament/issues/15611) I posted recently, because I needed more customisability on how filepond resolves the mime type. They provide an example in their [docs](https://pqina.nl/filepond/docs/getting-started/examples/validate-file-type/):

```js
import { create, registerPlugin } from 'filepond';
import 'filepond/dist/filepond.css';

// Import the File Type Validation plugin
import FilePondPluginFileValidateType from 'filepond-plugin-file-validate-type';

// Register the plugin with FilePond
registerPlugin(FilePondPluginFileValidateType);

// Get a file input reference
const input = document.querySelector('input[type="file"]');

// Create a FilePond instance
create(input, {
    // Only accept images
    acceptedFileTypes: ['image/*'],

    fileValidateTypeDetectType: (source, type) =>
        new Promise((resolve, reject) => {
            // test if is xls file
            if (/\.xls$/.test(source.name)) return resolve('application/vnd.ms-excel');

            // accept detected type
            resolve(type);
        }),
});
```
This is exactly what I implemented but configurable from the `FileUpload.php` component.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

### Before
```php
FileUpload::make('designs')
    ->acceptedFileTypes([
        'application/octet-stream',
        'x-world/x-3dmf',
    ])
```
https://github.com/user-attachments/assets/c14fa18d-82f6-4639-913f-16b72014f298

### After
```php
FileUpload::make('designs')
    ->mimeTypeMap([
          '3dm' => 'x-world/x-3dmf'
      ])
    ->acceptedFileTypes([
        'application/octet-stream',
        'x-world/x-3dmf',
    ])
```
https://github.com/user-attachments/assets/516cb8ab-b9de-48ff-bbbd-8fd3428e3541

<!-- Add screenshots/recordings of before and after. -->

## Functional changes
You can now specify the mime type mapping (extension => mime type) on the `FileUpload.php` component like this:

```php
FileUpload::make('designs')
    ->mimeTypeMap([
        '3dm' => 'x-world/x-3dmf'
    ])
    ->acceptedFileTypes([
        'application/vnd.sketchup.skp',
        'application/octet-stream',
        'x-world/x-3dmf',
    ])
```
- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
