### PR TITLE
Fix save action type

### DIFF
--- a/packages/panels/docs/03-resources/04-editing-records.md
+++ b/packages/panels/docs/03-resources/04-editing-records.md
@@ -305,7 +305,7 @@ To view the entire actions API, please visit the [pages section](../pages#adding
 
 ### Adding a save action button to the header
 
-The "Save" button can be moved to the header of the page by overriding the `getHeaderActions()` method and using `getSaveFormAction()`. You need to pass `formId()` to the action, to specify that the action should submit the form with the ID of `form`, which is the `<form>` ID used in the view of the page:
+The "Save" button can be added to the header of the page by overriding the `getHeaderActions()` method and using `getSaveFormAction()`. You need to pass `formId()` to the action, to specify that the action should submit the form with the ID of `form`, which is the `<form>` ID used in the view of the page:
 
 ```php
 protected function getHeaderActions(): array


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The save action is not "moved", as it still rightly remains in the footer, just like the section header states.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
