### PR TITLE
Fix forced case search with uppercase string

### DIFF
--- a/packages/spatie-laravel-translatable-plugin/src/SpatieLaravelTranslatableContentDriver.php
+++ b/packages/spatie-laravel-translatable-plugin/src/SpatieLaravelTranslatableContentDriver.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 
 use function Filament\Support\generate_search_column_expression;
+use function Filament\Support\generate_search_term_expression;
 
 class SpatieLaravelTranslatableContentDriver implements TranslatableContentDriver
 {
@@ -118,10 +119,12 @@ class SpatieLaravelTranslatableContentDriver implements TranslatableContentDrive
             default => "json_extract({$column}, \"$.{$this->activeLocale}\")",
         };
 
+        $search = generate_search_term_expression($search, $isCaseInsensitivityForced, $databaseConnection);
+
         return $query->{$whereClause}(
             generate_search_column_expression($column, $isCaseInsensitivityForced, $databaseConnection),
             'like',
-            (string) str($search)->wrap('%'),
+            str($search)->wrap('%')->toString(),
         );
     }
 }


### PR DESCRIPTION
## Description
When using `->forceSearchCaseInsensitive()` on a column that is accessed via json extraction it doesn't return results if terms searched are in uppercase.

## Visual changes
None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
