### PR TITLE
fix: incorrect loaded state with HasOneOrMany select

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -862,7 +862,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
 
                 $component->state(
                     $relatedRecords
-                        ->pluck($relationship->getForeignKeyName())
+                        ->pluck($relationship->getLocalKeyName())
                         ->all(),
                 );
 
@@ -874,7 +874,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
 
                 $component->state(
                     $relatedModel?->getAttribute(
-                        $relationship->getForeignKeyName(),
+                        $relationship->getLocalKeyName(),
                     ),
                 );
 

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -988,7 +988,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
         $this->saveRelationshipsUsing(static function (Select $component, Model $record, $state) use ($modifyQueryUsing) {
             $relationship = $component->getRelationship();
 
-            if ($relationship instanceof HasOne || $relationship instanceof HasMany) {
+            if (($relationship instanceof HasOne) || ($relationship instanceof HasMany)) {
                 $query = $relationship->getQuery();
 
                 if ($modifyQueryUsing) {

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -1016,7 +1016,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
                         }
 
                         $query->update([
-                            $relationship->getForeignKeyName() => $record->getKey(),
+                            $relationship->getForeignKeyName() => $record->getAttribute($relationship->getLocalKeyName()),
                         ]);
                     });
                 }

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -988,6 +988,42 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
         $this->saveRelationshipsUsing(static function (Select $component, Model $record, $state) use ($modifyQueryUsing) {
             $relationship = $component->getRelationship();
 
+            if ($relationship instanceof HasOne || $relationship instanceof HasMany) {
+                $query = $relationship->getQuery();
+
+                if ($modifyQueryUsing) {
+                    $component->evaluate($modifyQueryUsing, [
+                        'query' => $query,
+                        'search' => null,
+                    ]);
+                }
+
+                $query->update([
+                    $relationship->getForeignKeyName() => null,
+                ]);
+
+                if (! empty($state)) {
+                    $relationship::noConstraints(function () use ($component, $record, $state, $modifyQueryUsing) {
+                        $relationship = $component->getRelationship();
+
+                        $query = $relationship->getQuery()->whereIn($relationship->getLocalKeyName(), Arr::wrap($state));
+
+                        if ($modifyQueryUsing) {
+                            $component->evaluate($modifyQueryUsing, [
+                                'query' => $query,
+                                'search' => null,
+                            ]);
+                        }
+
+                        $query->update([
+                            $relationship->getForeignKeyName() => $record->getKey(),
+                        ]);
+                    });
+                }
+
+                return;
+            }
+
             if (
                 ($relationship instanceof HasOneOrMany) ||
                 ($relationship instanceof (class_exists(HasOneOrManyThrough::class) ? HasOneOrManyThrough::class : HasManyThrough::class)) ||


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When using the `Select` component on a HasMany (or HasOne) relationship, the loaded records are incorrect. The `loadStateFromRelationshipsUsing` callback implementation uses the foreign key value when it should use the local key of the related model.

For example, if you have a Group (id,name) model and a User (id,name,group_id) model. right now it plucks the `group_id` values of the related users.

```php
class Group extends Model
{
    protected $guarded = ['id'];

    public function users(): HasMany
    {
        return $this->hasMany(User::class);
    }
}

class GroupResource extends Resource
{
    protected static ?string $model = Group::class;

    public static function form(Form $form): Form
    {
        return $form
            ->schema([
                Forms\Components\TextInput::make('name')
                    ->required(),
                Forms\Components\Select::make('users')
                    ->relationship('users', 'name')
                    ->searchable()
                    ->multiple(),
            ]);
    }
}
```

## Visual changes

**Before**
![image](https://github.com/user-attachments/assets/a62ff735-80bd-4f37-8a71-63151aaa2905)

**After**
![image](https://github.com/user-attachments/assets/01c1572c-7b37-4f7c-85b3-703768ecd924)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
