### PR TITLE
fix: Exporter not caching export columns

### DIFF
--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -122,7 +122,7 @@ abstract class Exporter
      */
     public function getCachedColumns(): array
     {
-        return $this->cachedColumns ?? array_reduce(static::getColumns(), function (array $carry, ExportColumn $column): array {
+        return $this->cachedColumns ??= array_reduce(static::getColumns(), function (array $carry, ExportColumn $column): array {
             $carry[$column->getName()] = $column->exporter($this);
 
             return $carry;


### PR DESCRIPTION
## Description

This PR fixes ExportColumns not being correctly cached by the Exporter.