### PR TITLE
SelectFilter: allowHtml added

### DIFF
--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -3,6 +3,7 @@
 namespace Filament\Tables\Filters;
 
 use Closure;
+use Filament\Forms\Components\Concerns\CanAllowHtml;
 use Filament\Forms\Components\Select;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
@@ -13,6 +14,7 @@ class SelectFilter extends BaseFilter
     use Concerns\HasOptions;
     use Concerns\HasPlaceholder;
     use Concerns\HasRelationship;
+    use CanAllowHtml;
 
     protected string | Closure | null $attribute = null;
 
@@ -268,6 +270,10 @@ class SelectFilter extends BaseFilter
             ->preload($this->isPreloaded())
             ->native($this->isNative())
             ->optionsLimit($this->getOptionsLimit());
+
+        if ($this->isHtmlAllowed()){
+            $field->allowHtml();
+        }
 
         if ($this->queriesRelationships()) {
             $field


### PR DESCRIPTION
## Description

Added the `CanAllowHtml` trait to the `SelectFilter` class and updated the `getFormField` function to support HTML in filters. Previously, while the `Select` form component allowed HTML in options, it was not possible to use `SelectFilter` with HTML, making the feature inconsistent.

## Visual changes
### Before
![image](https://github.com/user-attachments/assets/7f15f98b-6894-4eef-9b1f-1436defa3ab7)

### After
![image](https://github.com/user-attachments/assets/62545110-074e-4d6d-8178-072671f76929)

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Added the `CanAllowHtml` trait to `SelectFilter`.
- [ ] Updated the `getFormField` method: Now checks if HTML is allowed using `isHtmlAllowed()`. Calls `$field->allowHtml()` when HTML is enabled.
 
