### PR TITLE
Fix incorrect spelling of 'BMW' in text input docs

### DIFF
--- a/packages/forms/docs/03-fields/02-text-input.md
+++ b/packages/forms/docs/03-fields/02-text-input.md
@@ -95,7 +95,7 @@ You may specify [datalist](https://developer.mozilla.org/en-US/docs/Web/HTML/Ele
 ```php
 TextInput::make('manufacturer')
     ->datalist([
-        'BWM',
+        'BMW',
         'Ford',
         'Mercedes-Benz',
         'Porsche',


### PR DESCRIPTION
## Description

The documentation for text input fields contained an incorrect spelling of the car brand BMW where the last 2 characters were swapped. I've changed that to correctly reflect the brand.

## Visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
