### PR TITLE
Use `replaceState` instead of `pushState` for `forms` and `infolists` tab updates

### DIFF
--- a/packages/forms/resources/views/components/tabs.blade.php
+++ b/packages/forms/resources/views/components/tabs.blade.php
@@ -26,7 +26,7 @@
             const url = new URL(window.location.href)
             url.searchParams.set(@js($getTabQueryStringKey()), this.tab)
 
-            history.pushState(null, document.title, url.toString())
+            history.replaceState(null, document.title, url.toString())
         },
     }"
     x-init="

--- a/packages/infolists/resources/views/components/tabs.blade.php
+++ b/packages/infolists/resources/views/components/tabs.blade.php
@@ -25,7 +25,7 @@
             const url = new URL(window.location.href)
             url.searchParams.set(@js($getTabQueryStringKey()), this.tab)
 
-            history.pushState(null, document.title, url.toString())
+            history.replaceState(null, document.title, url.toString())
         },
     }"
     x-init="


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Closes #15363 

This update modifies the tab behavior for `forms` and `infolists` to use `replaceState` instead of `pushState`. This change prevents unnecessary entries in the browser history, ensuring a smoother user experience when navigating between tabs.

## Visual changes

NA

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
