### PR TITLE
feat: run when pressing enter in search table

### DIFF
--- a/packages/tables/resources/views/components/search-field.blade.php
+++ b/packages/tables/resources/views/components/search-field.blade.php
@@ -5,12 +5,21 @@
 @props([
     'debounce' => '500ms',
     'onBlur' => false,
+    'onEnter' => false,
+    'suffixOnEnter' => null,
     'placeholder' => __('filament-tables::table.fields.search.placeholder'),
     'wireModel' => 'tableSearch',
 ])
 
 @php
     $wireModelAttribute = $onBlur ? 'wire:model.blur' : "wire:model.live.debounce.{$debounce}";
+    $suffixOnEnterKdb = '';
+
+    if ($onEnter) {
+        $suffixOnEnterKdb = ! empty($suffixOnEnter) ? $suffixOnEnter : '⏎';
+        $wireModelAttribute = 'wire:model.lazy';
+    }
+
 @endphp
 
 <div
@@ -25,6 +34,7 @@
         inline-prefix
         prefix-icon="heroicon-m-magnifying-glass"
         prefix-icon-alias="tables::search-field"
+        :suffix="$suffixOnEnterKdb"
         :wire:target="$wireModel"
     >
         <x-filament::input

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -71,6 +71,8 @@
     $toggleColumnsTriggerAction = $getToggleColumnsTriggerAction();
     $page = $this->getTablePage();
     $defaultSortOptionLabel = $getDefaultSortOptionLabel();
+    $isSearchOnEnter = $isSearchOnEnter();
+    $suffixSearchOnEnter = $getSuffixSearchEnter();
 
     if (count($actions) && (! $isReordering)) {
         $columnsCount++;
@@ -223,6 +225,8 @@
                             <x-filament-tables::search-field
                                 :debounce="$searchDebounce"
                                 :on-blur="$isSearchOnBlur"
+                                :on-enter="$isSearchOnEnter"
+                                :suffix-on-enter="$suffixSearchOnEnter"
                                 :placeholder="$getSearchPlaceholder()"
                             />
                         @endif

--- a/packages/tables/src/Table/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSearchRecords.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Table\Concerns;
 
 use Closure;
 use Filament\Tables\Filters\Indicator;
+use Illuminate\Contracts\Support\Htmlable;
 
 trait CanSearchRecords
 {
@@ -18,6 +19,10 @@ trait CanSearchRecords
     protected ?string $searchDebounce = null;
 
     protected bool | Closure $isSearchOnBlur = false;
+
+    protected bool | Closure $isSearchOnEnter = false;
+
+    protected string | Htmlable | Closure | null $suffixSearchOnEnter = null;
 
     public function persistSearchInSession(bool | Closure $condition = true): static
     {
@@ -86,6 +91,7 @@ trait CanSearchRecords
         return (bool) $this->evaluate($this->persistsSearchInSession);
     }
 
+
     public function persistsColumnSearchesInSession(): bool
     {
         return (bool) $this->evaluate($this->persistsColumnSearchesInSession);
@@ -136,5 +142,29 @@ trait CanSearchRecords
     public function isSearchOnBlur(): bool
     {
         return (bool) $this->evaluate($this->isSearchOnBlur);
+    }
+
+    public function searchOnEnter(bool | Closure $condition = true): static
+    {
+        $this->isSearchOnEnter = $condition;
+
+        return $this;
+    }
+
+    public function isSearchOnEnter(): bool
+    {
+        return (bool) $this->evaluate($this->isSearchOnEnter);
+    }
+
+    public function suffixSearchOnEnter(string | Htmlable | Closure | null $suffixSearchOnEnter): static
+    {
+        $this->suffixSearchOnEnter = $suffixSearchOnEnter;
+
+        return $this;
+    }
+
+    public function getSuffixSearchEnter(): string | Htmlable | null
+    {
+        return $this->evaluate($this->suffixSearchOnEnter) ?? '';
     }
 }


### PR DESCRIPTION
## Description

This pull request adds the functionality of dynamic search in columns that have the searchable property enabled. The search will only be executed when the Enter key is pressed, preventing unnecessary requests with each keystroke.

The searchOnBlur method has the same behavior as searchOnEnter, but it has been retained for semantic purposes and allows customization as well.

Additionally, an option has been added to customize the search field suffix when this functionality is enabled, enhancing the user experience.

## Visual changes

https://github.com/user-attachments/assets/e29195fa-9c36-476f-ade5-f93ec5990835

When the ->searchOnEnter() option is enabled in the table, the search field will display a search icon as shown in the preview image.

![image](https://github.com/user-attachments/assets/4edfa8c5-6f00-4e47-9ecc-f192be5ccbfb)

![image](https://github.com/user-attachments/assets/fb0f8d44-329a-45aa-bfb0-9fdf405a91ee)

When the ->suffixSearchOnEnter() option is enabled, the search field will display a customizable suffix, such as "Enter," as shown in the preview image.

![image](https://github.com/user-attachments/assets/a4c7ba06-2283-4399-b576-eec92ae1973e)

![image](https://github.com/user-attachments/assets/aa73ef33-2998-42c0-a3cf-b5ee65cbe2ae)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
