### PR TITLE
feat: add getCurrentPage method to Filament facade

### DIFF
--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -284,6 +284,14 @@ class FilamentManager
         return $this->getCurrentPanel()->getPages();
     }
 
+    /**
+     * @return string | null
+     */
+    public function getCurrentPage(): ?string
+    {
+        return $this->getCurrentPanel()?->getCurrentPage();
+    }
+
     public function getPanel(?string $id = null, bool $isStrict = true): Panel
     {
         return app(PanelRegistry::class)->get($id, $isStrict);

--- a/packages/panels/src/Panel/Concerns/HasComponents.php
+++ b/packages/panels/src/Panel/Concerns/HasComponents.php
@@ -8,6 +8,7 @@ use Filament\Livewire\DatabaseNotifications;
 use Filament\Livewire\GlobalSearch;
 use Filament\Livewire\Notifications;
 use Filament\Pages\Auth\EditProfile;
+use Filament\Pages\BasePage;
 use Filament\Pages\Page;
 use Filament\Resources\Pages\Page as ResourcePage;
 use Filament\Resources\RelationManagers\RelationGroup;
@@ -232,6 +233,22 @@ trait HasComponents
             ...array_map(fn (string $namespace): string => "{$namespace}\Pages", array_values($this->clusters)),
             ...$this->pageNamespaces,
         ];
+    }
+
+    /**
+     * @return string | null
+     */
+    public function getCurrentPage(): ?string
+    {
+        if (! $route = app('router')->current()) {
+            return null;
+        }
+
+        $controllerClass = $route->getControllerClass();
+
+        return $controllerClass && is_subclass_of($controllerClass, BasePage::class)
+            ? $controllerClass
+            : null;
     }
 
     public function discoverClusters(string $in, string $for): static


### PR DESCRIPTION
## Description

This Pull Request is adding new `getCurrentPage()` method to the Filament facade to allow easy **access to the current page** class from anywhere in the application. Really useful for determining the current page context, when working with multiple pages and implementing **conditional logic based on the active page**.

## Implementation Details

- Added `getCurrentPage()` method to `FilamentManager` that delegates to the current panel
- Method returns `?string` representing the current page class or null if none found
- Maintains type safety with nullable return type

## Example Usage

```php
use Filament\Facades\Filament;
  
public function getPage(): ?string
{
    return Filament::getCurrentPage();
}