### PR TITLE
Enhancement: Add Closure support to HasTopbar trait

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasTopbar.php
+++ b/packages/panels/src/Panel/Concerns/HasTopbar.php
@@ -2,11 +2,13 @@
 
 namespace Filament\Panel\Concerns;
 
+use Closure;
+
 trait HasTopbar
 {
-    protected bool $hasTopbar = true;
+    protected bool | Closure $hasTopbar = true;
 
-    public function topbar(bool $condition = true): static
+    public function topbar(bool | Closure $condition = true): static
     {
         $this->hasTopbar = $condition;
 
@@ -15,6 +17,6 @@ trait HasTopbar
 
     public function hasTopbar(): bool
     {
-        return $this->hasTopbar;
+        return (bool) $this->evaluate($this->hasTopbar);
     }
 }


### PR DESCRIPTION
## Description

I've modified the `HasTopbar` trait to accept a Closure as a parameter, similar to other conditional features in Filament. 

The changes include:
1. Adding the `use Closure` statement
2. Updating the property and method type hints to support both `bool` and `Closure`
3. Using the `evaluate()` method to properly handle the Closure when checking if the topbar should be displayed

### Motivation

While implementing Filament in our application, we needed to dynamically control the visibility of the topbar based on the authenticated user's role. The current implementation only supports boolean values, which limits the ability to make runtime decisions about topbar visibility.

## Visual changes

No changes.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [*] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
