### PR TITLE
Add data attribute for modal id to modal windows

### DIFF
--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -176,7 +176,7 @@
                         x-transition:leave-end="scale-95 opacity-0"
                     @endif
                     @if ($id)
-                        data-modal-id="{{ $id }}"
+                        data-fi-modal-id="{{ $id }}"
                     @endif
                     {{
                         ($extraModalWindowAttributeBag ?? new \Illuminate\View\ComponentAttributeBag)->class([

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -93,6 +93,7 @@
     @if ($id)
         x-on:{{ $closeEventName }}.window="if ($event.detail.id === '{{ $id }}') close()"
         x-on:{{ $openEventName }}.window="if ($event.detail.id === '{{ $id }}') open()"
+        data-fi-modal-id="{{ $id }}"
     @endif
     x-trap.noscroll{{ $autofocus ? '' : '.noautofocus' }}="isOpen"
     x-bind:class="{
@@ -174,9 +175,6 @@
                         x-transition:enter-end="scale-100 opacity-100"
                         x-transition:leave-start="scale-100 opacity-100"
                         x-transition:leave-end="scale-95 opacity-0"
-                    @endif
-                    @if ($id)
-                        data-fi-modal-id="{{ $id }}"
                     @endif
                     {{
                         ($extraModalWindowAttributeBag ?? new \Illuminate\View\ComponentAttributeBag)->class([

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -175,6 +175,9 @@
                         x-transition:leave-start="scale-100 opacity-100"
                         x-transition:leave-end="scale-95 opacity-0"
                     @endif
+                    @if ($id)
+                        data-modal-id="{{ $id }}"
+                    @endif
                     {{
                         ($extraModalWindowAttributeBag ?? new \Illuminate\View\ComponentAttributeBag)->class([
                             'fi-modal-window pointer-events-auto relative row-start-2 flex w-full cursor-default flex-col bg-white shadow-xl ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10',


### PR DESCRIPTION
Action modals have a unique id based on wire:key, making them hard to target programmatically from another action. I'm using JS to extract modal ids but it's brittle because there's no attribute containing the value. This PR adds a data attribute for the modal id to modal windows. See the before and after js below to see the difference.

I called the data attribute `data-fi-modal-id` instead of `data-modal-id` to avoid potential conflicts with other packages.

Several other people have had this issue:
https://discord.com/channels/883083792112300104/1273718758812422215
https://discord.com/channels/883083792112300104/1276522496862191681

**Before:**
```JS
/*
Helper for closing Filament action modals.

Requires setting a unique class on the modal window using extraModalWindowAttributes(),
and passing it to this function

Example PHP usage: $this->js('window.closeFilamentModal(".my-modal")');
*/
window.closeFilamentModal = function(selector) {
    // Find the modal by the provided selector
    const modal = document.querySelector(selector);
    if (!modal) {
        console.error(`Modal not found with selector: ${selector}`);
        return false;
    }

    // Extract the ID from the escape key handler attribute
    const escapeAttr = modal.getAttribute('x-on:keydown.window.escape');
    if (!escapeAttr) {
        console.error('Escape attribute not found on modal');
        return false;
    }

    // Parse out the ID - it's inside the dispatch call
    const idMatch = escapeAttr.match(/id: ['"]([^'"]+)['"]/);
    if (!idMatch || !idMatch[1]) {
        console.error('Could not extract modal ID from', escapeAttr);
        return false;
    }

    const modalId = idMatch[1];

    // Dispatch the close-modal event with the extracted ID
    document.dispatchEvent(
        new CustomEvent('close-modal', {
            bubbles: true,
            detail: { id: modalId }
        })
    );

    return true;
};
```

**After**
```JS
...
    // Get the ID from the data attribute
    const modalId = modal.getAttribute('data-fi-modal-id');
    if (!modalId) {
        console.error('Modal ID not found on modal element');
        return false;
    }
...
```
