### PR TITLE
Filament session key improvement

### DIFF
--- a/packages/panels/src/Pages/Dashboard/Concerns/HasFilters.php
+++ b/packages/panels/src/Pages/Dashboard/Concerns/HasFilters.php
@@ -78,7 +78,7 @@ trait HasFilters
 
     public function getFiltersSessionKey(): string
     {
-        $livewire = class_basename($this::class);
+        $livewire = hash('sha256', $this::class);
 
         return "{$livewire}_filters";
     }

--- a/packages/panels/src/Pages/Dashboard/Concerns/HasFilters.php
+++ b/packages/panels/src/Pages/Dashboard/Concerns/HasFilters.php
@@ -78,7 +78,7 @@ trait HasFilters
 
     public function getFiltersSessionKey(): string
     {
-        $livewire = hash('sha256', $this::class);
+        $livewire = hash('md5', $this::class);
 
         return "{$livewire}_filters";
     }

--- a/packages/tables/src/Concerns/CanPaginateRecords.php
+++ b/packages/tables/src/Concerns/CanPaginateRecords.php
@@ -87,7 +87,7 @@ trait CanPaginateRecords
 
     public function getTablePerPageSessionKey(): string
     {
-        $table = hash('sha256', $this::class);
+        $table = hash('md5', $this::class);
 
         return "tables.{$table}_per_page";
     }

--- a/packages/tables/src/Concerns/CanPaginateRecords.php
+++ b/packages/tables/src/Concerns/CanPaginateRecords.php
@@ -87,7 +87,7 @@ trait CanPaginateRecords
 
     public function getTablePerPageSessionKey(): string
     {
-        $table = class_basename($this::class);
+        $table = hash('sha256', $this::class);
 
         return "tables.{$table}_per_page";
     }

--- a/packages/tables/src/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Concerns/CanSearchRecords.php
@@ -273,14 +273,14 @@ trait CanSearchRecords
 
     public function getTableSearchSessionKey(): string
     {
-        $table = class_basename($this::class);
+        $table = hash('sha256', $this::class);
 
         return "tables.{$table}_search";
     }
 
     public function getTableColumnSearchesSessionKey(): string
     {
-        $table = class_basename($this::class);
+        $table = hash('sha256', $this::class);
 
         return "tables.{$table}_column_search";
     }

--- a/packages/tables/src/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Concerns/CanSearchRecords.php
@@ -273,14 +273,14 @@ trait CanSearchRecords
 
     public function getTableSearchSessionKey(): string
     {
-        $table = hash('sha256', $this::class);
+        $table = hash('md5', $this::class);
 
         return "tables.{$table}_search";
     }
 
     public function getTableColumnSearchesSessionKey(): string
     {
-        $table = hash('sha256', $this::class);
+        $table = hash('md5', $this::class);
 
         return "tables.{$table}_column_search";
     }

--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -142,7 +142,7 @@ trait CanSortRecords
 
     public function getTableSortSessionKey(): string
     {
-        $table = class_basename($this::class);
+        $table = hash('sha256', $this::class);
 
         return "tables.{$table}_sort";
     }

--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -142,7 +142,7 @@ trait CanSortRecords
 
     public function getTableSortSessionKey(): string
     {
-        $table = hash('sha256', $this::class);
+        $table = hash('md5', $this::class);
 
         return "tables.{$table}_sort";
     }

--- a/packages/tables/src/Concerns/CanToggleColumns.php
+++ b/packages/tables/src/Concerns/CanToggleColumns.php
@@ -80,7 +80,7 @@ trait CanToggleColumns
 
     public function getTableColumnToggleFormStateSessionKey(): string
     {
-        $table = class_basename($this::class);
+        $table = hash('sha256', static::class);
 
         return "tables.{$table}_toggled_columns";
     }

--- a/packages/tables/src/Concerns/CanToggleColumns.php
+++ b/packages/tables/src/Concerns/CanToggleColumns.php
@@ -80,7 +80,7 @@ trait CanToggleColumns
 
     public function getTableColumnToggleFormStateSessionKey(): string
     {
-        $table = hash('sha256', static::class);
+        $table = hash('sha256', $this::class);
 
         return "tables.{$table}_toggled_columns";
     }

--- a/packages/tables/src/Concerns/CanToggleColumns.php
+++ b/packages/tables/src/Concerns/CanToggleColumns.php
@@ -80,7 +80,7 @@ trait CanToggleColumns
 
     public function getTableColumnToggleFormStateSessionKey(): string
     {
-        $table = hash('sha256', $this::class);
+        $table = hash('md5', $this::class);
 
         return "tables.{$table}_toggled_columns";
     }

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -178,7 +178,7 @@ trait HasFilters
 
     public function getTableFiltersSessionKey(): string
     {
-        $table = class_basename($this::class);
+        $table = hash('sha256', $this::class);
 
         return "tables.{$table}_filters";
     }

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -178,7 +178,7 @@ trait HasFilters
 
     public function getTableFiltersSessionKey(): string
     {
-        $table = hash('sha256', $this::class);
+        $table = hash('md5', $this::class);
 
         return "tables.{$table}_filters";
     }


### PR DESCRIPTION
## Description

In some scenarios, the default behavior of the table session, which keeps track of enabled and disabled columns, does not work as expected.

### Issue  
In our use case, we have multiple Livewire components in different directories with the same class name, for example:  

- `App\Livewire\Admin\ManualDeployment\Index.php`  
- `App\Livewire\Admin\Users\Index.php`  
- `App\Livewire\Admin\ExposureRequests\Index.php`  

Each of these classes has its own Filament table and uses the `InteractsWithForms` trait. However, they all share the same session key from the `getTableColumnToggleFormStateSessionKey` function.  

#### Cause  
This happens because `class_basename($this::class);` returns `"Index"` for all three classes. As a result, when an ID column is marked as `->toggable()`, its visibility state is shared across all tables.  

For example:  
- Enabling the ID column in one table will also enable it in the other two tables.  
- Disabling the ID column in one table will hide it in all tables.  

This unintended behavior causes inconsistencies when toggling columns across different tables.  

---

## Solution  

To resolve this, the session key should be based on the fully qualified class name rather than just the basename. However, to prevent overly long session keys—especially in projects with deeply nested directories—we apply hashing.  

### Previous Implementation  
```php
$table = class_basename($this::class); // -> "Index"
```

### Updated Implementation
```php
$table = hash('sha256', $this::class); // -> "619b97a8ad39037aa755dfc64a1fc00782020e23a7cd4013c8209cd29afe534b"
```
By using a SHA-256 hash of the full class name, we ensure that each table gets a unique session key while keeping it manageable in length.

## Functional Changes  

- [x] Code style has been fixed using `composer cs`.  
- [x] Changes have been tested to ensure no existing functionality breaks.  
- [x] Documentation is up to date.  

Let me know if any additional details are needed! 😊  

