### PR TITLE
Feat: add nullable() method for ToggleButtons

### DIFF
--- a/packages/forms/docs/03-fields/18-toggle-buttons.md
+++ b/packages/forms/docs/03-fields/18-toggle-buttons.md
@@ -211,3 +211,21 @@ ToggleButtons::make('status')
     ->disableOptionWhen(fn (string $value): bool => $value === 'published')
     ->in(fn (ToggleButtons $component): array => array_keys($component->getEnabledOptions()))
 ```
+
+## Resetting the Selected Option (Nullable)
+
+In single selection mode, the toggle buttons input does not allow deselecting a chosen option by default. With the new `nullable()` method, you can enable a reset behavior so that clicking on an already selected button resets the input to `null`.
+
+This functionality is only available in single selection mode (using radio buttons) and will not affect the multiple selection mode.
+
+```php
+use Filament\Forms\Components\ToggleButtons;
+
+ToggleButtons::make('status')
+    ->label('Select status')
+    ->options([
+        'active' => 'Active',
+        'inactive' => 'Inactive',
+    ])
+    ->nullable();
+```

--- a/packages/forms/resources/views/components/toggle-buttons/index.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/index.blade.php
@@ -7,6 +7,7 @@
     $isMultiple = $isMultiple();
     $statePath = $getStatePath();
     $areButtonLabelsHidden = $areButtonLabelsHidden();
+    $nullable = $isNullable();
 @endphp
 
 <x-dynamic-component
@@ -73,6 +74,16 @@
                     :icon="$getIcon($value)"
                     :label-sr-only="$areButtonLabelsHidden"
                     tag="label"
+                    x-on:click="
+                        if ({{ json_encode($nullable) }}) {
+                            let current = $wire.get('{{ $statePath }}');
+                            if (current == {{ json_encode($value) }}) {
+                                $wire.set('{{ $statePath }}', null);
+                                $event.stopPropagation();
+                                $event.preventDefault();
+                            }
+                        }
+                    "
                 >
                     {{ $label }}
                 </x-filament::button>

--- a/packages/forms/src/Components/ToggleButtons.php
+++ b/packages/forms/src/Components/ToggleButtons.php
@@ -28,6 +28,8 @@ class ToggleButtons extends Field implements Contracts\CanDisableOptions
 
     protected bool | Closure $isInline = false;
 
+    protected bool | Closure $isNullable = false;
+
     protected bool | Closure $areButtonLabelsHidden = false;
 
     protected function setUp(): void
@@ -119,5 +121,17 @@ class ToggleButtons extends Field implements Contracts\CanDisableOptions
         }
 
         return $state;
+    }
+
+    public function nullable(bool | Closure $condition = true): static
+    {
+        $this->isNullable = $condition;
+
+        return $this;
+    }
+
+    public function isNullable(): bool
+    {
+        return ! $this->isMultiple() && (bool) $this->evaluate($this->isNullable);
     }
 }


### PR DESCRIPTION
## Description

This pull request introduces a new `nullable()` method for the `ToggleButtons` component. With this enhancement, in single selection mode, clicking on an already active button will reset the value to `null`. This feature improves usability by allowing users to deselect an option, which is not possible by default with radio buttons.

## Visual changes

![nullable-togglebuttons](https://github.com/user-attachments/assets/d47d22f8-4485-47d5-90a7-0f0572f7c656)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.