### PR TITLE
fix: handle a possible issue from output buffer

### DIFF
--- a/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
+++ b/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
@@ -26,6 +26,7 @@ class XlsxDownloader implements Downloader
         if ($disk->exists($filePath = $directory . DIRECTORY_SEPARATOR . $fileName)) {
             $response = $disk->download($filePath);
             ob_end_clean();
+            
             return $response;
         }
 

--- a/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
+++ b/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
@@ -24,7 +24,9 @@ class XlsxDownloader implements Downloader
         $fileName = $export->file_name . '.xlsx';
 
         if ($disk->exists($filePath = $directory . DIRECTORY_SEPARATOR . $fileName)) {
-            return $disk->download($filePath);
+            $response = $disk->download($filePath);
+            ob_end_clean();
+            return $response;
         }
 
         $writer = app(Writer::class);


### PR DESCRIPTION
## Description

When exporting an xlsx file, sometimes the output buffer is not cleaned up properly, generating an inaccessible  excel file when downloaded. This is caused by an extra space that is added to the file. 
Calling the ob_end_clean() function before sending the download response fix this problem.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
