### PR TITLE
fix: Update tailwind.config.preset.js darkMode selector

### DIFF
--- a/packages/support/tailwind.config.preset.js
+++ b/packages/support/tailwind.config.preset.js
@@ -2,7 +2,7 @@ import forms from '@tailwindcss/forms'
 import typography from '@tailwindcss/typography'
 
 export default {
-    darkMode: 'class',
+    darkMode: 'selector',
     content: ['./vendor/filament/**/*.blade.php'],
     theme: {
         extend: {


### PR DESCRIPTION
## Description

Tailwind v 3.4.1 changed its darkMode selector behavior.  The Filament tailwind.config.preset doesn't work with the base.blade.php themeing behaviour as expected.

https://github.com/tailwindlabs/tailwindcss/pull/12717 notes the new 'selector' mode.

The Filament JS in base.blade.php sets a 'dark' class on the top document element, and the tailwind.config 'selector' behaviour will look for that 'dark' class to determine if dark mode variants will be used, as opposed to the system-specified preferences.  

The core issue was having a system-specified 'dark model' would not allow the 'light' theme to work.  This *may* only have affected custom themes - unsure about that.

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
