### PR TITLE
Modify panel default() method to accept closure

### DIFF
--- a/packages/panels/src/Panel.php
+++ b/packages/panels/src/Panel.php
@@ -45,7 +45,7 @@ class Panel extends Component
     use Panel\Concerns\HasUnsavedChangesAlerts;
     use Panel\Concerns\HasUserMenu;
 
-    protected bool $isDefault = false;
+    protected bool | Closure $isDefault = false;
 
     /**
      * @var array<array-key, Closure>
@@ -57,7 +57,7 @@ class Panel extends Component
         return app(static::class);
     }
 
-    public function default(bool $condition = true): static
+    public function default(bool | Closure $condition = true): static
     {
         $this->isDefault = $condition;
 
@@ -116,6 +116,6 @@ class Panel extends Component
 
     public function isDefault(): bool
     {
-        return $this->isDefault;
+        return (bool) $this->evaluate($this->isDefault);
     }
 }


### PR DESCRIPTION
I've got 2 separate domains with their own guards, panels and auth pages. I'm running into issues when Filament uses `default()` under the hood because each domain needs a different default panel. Closures make the default() method more flexible and allow for things like this:

```PHP
// Admin domain default panel
->default(fn (): bool => CurrentDomain::isAdminDomain())

// Member domain default panel
->default(fn (): bool => CurrentDomain::isMemberDomain())
```