### PR TITLE
v4 fix: remove static from the $heading property

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -1026,7 +1026,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
                 ]);
 
                 if (! empty($state)) {
-                    $relationship::noConstraints(function () use ($component, $record, $state, $modifyQueryUsing) {
+                    $relationship::noConstraints(function () use ($component, $record, $state, $modifyQueryUsing): void {
                         $relationship = $component->getRelationship();
 
                         $query = $relationship->getQuery()->whereIn($relationship->getLocalKeyName(), Arr::wrap($state));

--- a/packages/widgets/src/Commands/FileGenerators/ChartWidgetClassGenerator.php
+++ b/packages/widgets/src/Commands/FileGenerators/ChartWidgetClassGenerator.php
@@ -66,7 +66,6 @@ class ChartWidgetClassGenerator extends ClassGenerator
                 ->title(),
         )
             ->setProtected()
-            ->setStatic()
             ->setType('?string');
         $this->configureHeadingProperty($property);
     }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Remove static from the `$heading` property.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
