### PR TITLE
[4.x] Add decimalPlaces argument to component money function

### DIFF
--- a/packages/infolists/src/Components/Concerns/CanFormatState.php
+++ b/packages/infolists/src/Components/Concerns/CanFormatState.php
@@ -217,11 +217,11 @@ trait CanFormatState
         return $this;
     }
 
-    public function money(string | Closure | null $currency = null, int $divideBy = 0, string | Closure | null $locale = null): static
+    public function money(string | Closure | null $currency = null, int $divideBy = 0, string | Closure | null $locale = null, int | Closure | null $decimalPlaces = null): static
     {
         $this->isMoney = true;
 
-        $this->formatStateUsing(static function (TextEntry $component, $state) use ($currency, $divideBy, $locale): ?string {
+        $this->formatStateUsing(static function (TextEntry $component, $state) use ($currency, $divideBy, $locale, $decimalPlaces): ?string {
             if (blank($state)) {
                 return null;
             }
@@ -232,12 +232,13 @@ trait CanFormatState
 
             $currency = $component->evaluate($currency) ?? Schema::$defaultCurrency;
             $locale = $component->evaluate($locale) ?? Schema::$defaultNumberLocale ?? config('app.locale');
+            $decimalPlaces = $component->evaluate($decimalPlaces);
 
             if ($divideBy) {
                 $state /= $divideBy;
             }
 
-            return Number::currency($state, $currency, $locale);
+            return Number::currency($state, $currency, $locale, $decimalPlaces);
         });
 
         return $this;

--- a/packages/schemas/docs/03-infolists/02-text.md
+++ b/packages/schemas/docs/03-infolists/02-text.md
@@ -278,6 +278,15 @@ use Filament\Infolists\Infolist;
 Infolist::$defaultNumberLocale = 'nl';
 ```
 
+If you would like to customize the number of decimal places used to format the number with, you can use the `decimalPlaces` argument:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextEntry::make('price')
+    ->money('EUR', decimalPlaces: 3)
+```
+
 ## Limiting text length
 
 You may `limit()` the length of the entry's value:

--- a/packages/schemas/docs/03-infolists/02-text.md
+++ b/packages/schemas/docs/03-infolists/02-text.md
@@ -281,7 +281,7 @@ Infolist::$defaultNumberLocale = 'nl';
 If you would like to customize the number of decimal places used to format the number with, you can use the `decimalPlaces` argument:
 
 ```php
-use Filament\Tables\Columns\TextColumn;
+use Filament\Infolists\Components\TextEntry;
 
 TextEntry::make('price')
     ->money('EUR', decimalPlaces: 3)

--- a/packages/tables/docs/02-columns/02-text.md
+++ b/packages/tables/docs/02-columns/02-text.md
@@ -175,6 +175,15 @@ use Filament\Tables\Table;
 Table::$defaultNumberLocale = 'nl';
 ```
 
+If you would like to customize the number of decimal places used to format the number with, you can use the `decimalPlaces` argument:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('price')
+    ->money('EUR', decimalPlaces: 3)
+```
+
 ## Limiting text length
 
 You may `limit()` the length of the cell's value:

--- a/packages/tables/docs/06-summaries.md
+++ b/packages/tables/docs/06-summaries.md
@@ -303,6 +303,15 @@ use Filament\Tables\Table;
 Table::$defaultNumberLocale = 'nl';
 ```
 
+If you would like to customize the number of decimal places used to format the number with, you can use the `decimalPlaces` argument:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('price')
+    ->summarize(Sum::make()->money('EUR', decimalPlaces: 3))
+```
+
 ### Limiting text length
 
 You may `limit()` the length of the summary's value:

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -215,11 +215,11 @@ trait CanFormatState
         return $this;
     }
 
-    public function money(string | Closure | null $currency = null, int $divideBy = 0, string | Closure | null $locale = null): static
+    public function money(string | Closure | null $currency = null, int $divideBy = 0, string | Closure | null $locale = null, int | Closure | null $decimalPlaces = null): static
     {
         $this->isMoney = true;
 
-        $this->formatStateUsing(static function (TextColumn $column, $state) use ($currency, $divideBy, $locale): ?string {
+        $this->formatStateUsing(static function (TextColumn $column, $state) use ($currency, $divideBy, $locale, $decimalPlaces): ?string {
             if (blank($state)) {
                 return null;
             }
@@ -230,12 +230,13 @@ trait CanFormatState
 
             $currency = $column->evaluate($currency) ?? Table::$defaultCurrency;
             $locale = $column->evaluate($locale) ?? Table::$defaultNumberLocale ?? config('app.locale');
+            $decimalPlaces = $column->evaluate($decimalPlaces);
 
             if ($divideBy) {
                 $state /= $divideBy;
             }
 
-            return Number::currency($state, $currency, $locale);
+            return Number::currency($state, $currency, $locale, $decimalPlaces);
         });
 
         return $this;

--- a/packages/tables/src/Columns/Summarizers/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Summarizers/Concerns/CanFormatState.php
@@ -48,9 +48,9 @@ trait CanFormatState
         return $this;
     }
 
-    public function money(string | Closure | null $currency = null, int $divideBy = 0, string | Closure | null $locale = null): static
+    public function money(string | Closure | null $currency = null, int $divideBy = 0, string | Closure | null $locale = null, int | Closure | null $decimalPlaces = null): static
     {
-        $this->formatStateUsing(static function ($state, Summarizer $summarizer) use ($currency, $divideBy, $locale): ?string {
+        $this->formatStateUsing(static function ($state, Summarizer $summarizer) use ($currency, $divideBy, $locale, $decimalPlaces): ?string {
             if (blank($state)) {
                 return null;
             }
@@ -61,12 +61,13 @@ trait CanFormatState
 
             $currency = $summarizer->evaluate($currency) ?? Table::$defaultCurrency;
             $locale = $summarizer->evaluate($locale) ?? Table::$defaultNumberLocale ?? config('app.locale');
+            $decimalPlaces = $summarizer->evaluate($decimalPlaces);
 
             if ($divideBy) {
                 $state /= $divideBy;
             }
 
-            return Number::currency($state, $currency, $locale);
+            return Number::currency($state, $currency, $locale, $decimalPlaces);
         });
 
         return $this;


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The `Number::currency()` function had the `precision` argument added in Laravel 11.42.

Named the new argument `decimalPlaces` to match the `->numeric()` function.

### Infolist

Adds `decimalPlaces` argument:

```php
use Filament\Infolists\Components\TextEntry;

TextEntry::make('price')
    ->money('EUR', decimalPlaces: 3)
```

### Table

Adds `decimalPlaces` argument:

```php
use Filament\Tables\Columns\TextColumn;

TextColumn::make('price')
    ->money('EUR', decimalPlaces: 3)
```

### Table Summarizer

Adds `decimalPlaces` argument:

```php
use Filament\Tables\Columns\TextColumn;

TextColumn::make('price')
    ->summarize(Sum::make()->money('EUR', decimalPlaces: 3))
```

## Visual changes

- None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
