### PR TITLE
Fixed: PHP syntax error in CreateAction

### DIFF
--- a/packages/tables/src/Actions/CreateAction.php
+++ b/packages/tables/src/Actions/CreateAction.php
@@ -67,9 +67,9 @@ class CreateAction extends Action
 
                 if (
                     (! $relationship) ||
-                   class_exists(HasOneOrManyThrough::class)
-                        ? $relationship instanceof HasOneOrManyThrough
-                        : $relationship instanceof HasManyThrough
+                   (class_exists(HasOneOrManyThrough::class)
+                        ? ($relationship instanceof HasOneOrManyThrough)
+                        : ($relationship instanceof HasManyThrough))
                 ) {
                     $record->save();
 

--- a/packages/tables/src/Actions/CreateAction.php
+++ b/packages/tables/src/Actions/CreateAction.php
@@ -67,7 +67,9 @@ class CreateAction extends Action
 
                 if (
                     (! $relationship) ||
-                    $relationship instanceof (class_exists(HasOneOrManyThrough::class) ? HasOneOrManyThrough::class : HasManyThrough::class)
+                   class_exists(HasOneOrManyThrough::class)
+                        ? $relationship instanceof HasOneOrManyThrough
+                        : $relationship instanceof HasManyThrough
                 ) {
                     $record->save();
 


### PR DESCRIPTION
Original syntax error with stack trace:

https://flareapp.io/share/lm24xgq7

Error:

ParseError

PHP 8.3.16
Laravel 12.1.1

Error:
`syntax error, unexpected token "("`


## Description

This is a bug fix. I was getting a PHP syntax error on PHP 8.3.16

It was getting confused over the nested parentheses within the if statement.

Similar code is elsewhere in Filament [like here](https://github.com/filamentphp/filament/blob/4aedecb48c584de91e0b58f26e37bb9e7101d036/packages/tables/src/Filters/Concerns/HasRelationship.php#L114), but since it is the only statement in the `if` it's not producing a syntax error.

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
