### PR TITLE
Update HasBody trait's body() to accept HtmlString

### DIFF
--- a/packages/notifications/src/Concerns/HasBody.php
+++ b/packages/notifications/src/Concerns/HasBody.php
@@ -3,12 +3,13 @@
 namespace Filament\Notifications\Concerns;
 
 use Closure;
+use Illuminate\Support\HtmlString;
 
 trait HasBody
 {
-    protected string | Closure | null $body = null;
+    protected string | HtmlString | Closure | null $body = null;
 
-    public function body(string | Closure | null $body): static
+    public function body(string | HtmlString | Closure | null $body): static
     {
         $this->body = $body;
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The ->body() method already parses HtmlString but the function's param type is limited to string only.

## Visual changes

This is a screenshot of the notification body parsing HtmlString.

<img width="446" alt="Screenshot 2025-03-14 at 13 25 03" src="https://github.com/user-attachments/assets/f5503eef-7afe-4a38-81f2-38067c0ab106" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
