### PR TITLE
Widget command livewire path

### DIFF
--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -163,7 +163,11 @@ class MakeWidgetCommand extends Command
 
         $path = (string) str($widget)
             ->prepend('/')
-            ->prepend($resource === null ? $path : "{$resourcePath}\\{$resource}\\Widgets\\")
+            ->prepend(
+                ! $panel 
+                    ? app_path('Livewire/')  // Always use Livewire path when no panel is selected
+                    : ($resource === null ? $path : "{$resourcePath}\\{$resource}\\Widgets\\")
+            )
             ->replace('\\', '/')
             ->replace('//', '/')
             ->append('.php');

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -164,7 +164,7 @@ class MakeWidgetCommand extends Command
         $path = (string) str($widget)
             ->prepend('/')
             ->prepend(
-                ! $panel 
+                ! $panel
                     ? app_path('Livewire/')  // Always use Livewire path when no panel is selected
                     : ($resource === null ? $path : "{$resourcePath}\\{$resource}\\Widgets\\")
             )

--- a/tests/src/Commands/WidgetCommandLivewireTest.php
+++ b/tests/src/Commands/WidgetCommandLivewireTest.php
@@ -3,8 +3,9 @@
 namespace Filament\Tests\Commands;
 
 use Filament\Tests\TestCase;
-use function Pest\Laravel\artisan;
 use Illuminate\Support\Facades\File;
+
+use function Pest\Laravel\artisan;
 
 uses(TestCase::class)
     ->group('integration')

--- a/tests/src/Commands/WidgetCommandLivewireTest.php
+++ b/tests/src/Commands/WidgetCommandLivewireTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Filament\Tests\Commands;
+
+use Filament\Tests\TestCase;
+use function Pest\Laravel\artisan;
+use Illuminate\Support\Facades\File;
+
+uses(TestCase::class)
+    ->group('integration')
+    ->beforeEach(function () {
+        File::deleteDirectory($this->app->basePath('app/Livewire'));
+    });
+
+it('can create a table widget in livewire directory', function () {
+    artisan('make:filament-widget', [
+        'name' => 'TestWidget',
+        '--force' => true,
+        '--resource' => 'InvoiceResource',
+    ])
+        ->expectsQuestion('What type of widget do you want to create?', 'Table')
+        ->expectsQuestion('Where would you like to create this?', 'App\\Livewire alongside other Livewire components')
+        ->assertSuccessful();
+
+    $widgetPath = $this->app->basePath('app/Livewire/TestWidget.php');
+    expect(file_exists($widgetPath))->toBeTrue();
+});


### PR DESCRIPTION
Hello.

This is a solution to this Github issue:  [https://github.com/filamentphp/filament/issues/14637](url) 

### **Description**

When the `make:filament-widget` command is run to create a new widget and the resource is provided and when the user selects `[App\Livewire] alongside other Livewire components` after selecting `Table` from the first prompt, a file permission error was thrown and the directory was not being created. The solution now creates a new file `TestWidget.php` within the `app/Livewire` directory when it's prompted by the user.

### **Visual Changes**

**After the solution:**

<img width="751" alt="widget-command-livewire-solution" src="https://github.com/user-attachments/assets/cba2685e-6dac-4508-85b2-69d33e19168c" />

**Before the solution:**

<img width="1012" alt="widget-command-livewire-solution-before" src="https://github.com/user-attachments/assets/283ebd11-2380-4f8e-9986-2285966ca782" />

### **Functional Changes**

I've fixed the style with the `composer cs` command, the file changes have been tested.
