### PR TITLE
Wrap the exception handler around getVisibility()

### DIFF
--- a/packages/forms/src/Components/Concerns/HasFileAttachments.php
+++ b/packages/forms/src/Components/Concerns/HasFileAttachments.php
@@ -117,15 +117,15 @@ trait HasFileAttachments
             return null;
         }
 
-        if ($storage->getVisibility($file) === 'private') {
-            try {
+        try {
+            if ($storage->getVisibility($file) === 'private') {
                 return $storage->temporaryUrl(
                     $file,
                     now()->addMinutes(5),
                 );
-            } catch (Throwable $exception) {
-                // This driver does not support creating temporary URLs.
             }
+        } catch (Throwable $exception) {
+            // This driver does not support creating temporary URLs.
         }
 
         return $storage->url($file);


### PR DESCRIPTION
## Description

When uploading files into the markdown editor of the Forms package, the code attempts to get a temporary URL for the uploaded file.

https://github.com/filamentphp/filament/blob/6d82ca5aeebea89e473a3002adf32cf39f95092c/packages/forms/src/Components/Concerns/HasFileAttachments.php#L120-L129

It calls `$storage->getVisibility($file)`, but not all filesystem drivers (such as Azure) support this, and throw an exception.

https://github.com/Azure-OSS/azure-storage-php-adapter-flysystem/blob/f79c31dd0d0c24670076ea6301cc1c980e05e149/src/AzureBlobStorageAdapter.php#L186-L189

This PR wraps the exception around both the visibility check, and the temporary URL check to capture failures in either.

## Visual changes

No visual changes.

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
