### PR TITLE
Fix "When using QueryBuilder with Actions memory exhausts almost instantly"

### DIFF
--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -326,6 +326,9 @@ trait InteractsWithForms
      */
     protected function cacheForms(): array
     {
+        if($this->isCachingForms()){
+            return [];
+        }
         $this->isCachingForms = true;
 
         $this->cachedForms = collect($this->getForms())

--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -326,7 +326,7 @@ trait InteractsWithForms
      */
     protected function cacheForms(): array
     {
-        if($this->isCachingForms()){
+        if ($this->isCachingForms()) {
             return [];
         }
         $this->isCachingForms = true;

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -177,7 +177,7 @@ namespace Livewire\Features\SupportTesting {
 
         public function assertCanNotSeeTableRecords(array | Collection $records): static {}
 
-        public function queryBuilderTable(string $column, string $operator, $data = null): static {}
+        public function queryBuilderTable(string $filter, string $operator, $data = null): static {}
 
         public function assertCountTableRecords(int $count): static {}
 

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -177,6 +177,8 @@ namespace Livewire\Features\SupportTesting {
 
         public function assertCanNotSeeTableRecords(array | Collection $records): static {}
 
+        public function queryBuilderTable(string $column, string $operator, $data = null): static {}
+
         public function assertCountTableRecords(int $count): static {}
 
         public function loadTable(): static {}

--- a/packages/tables/src/TablesServiceProvider.php
+++ b/packages/tables/src/TablesServiceProvider.php
@@ -8,6 +8,7 @@ use Filament\Tables\Testing\TestsActions;
 use Filament\Tables\Testing\TestsBulkActions;
 use Filament\Tables\Testing\TestsColumns;
 use Filament\Tables\Testing\TestsFilters;
+use Filament\Tables\Testing\TestsQueryBuilders;
 use Filament\Tables\Testing\TestsRecords;
 use Filament\Tables\Testing\TestsSummaries;
 use Illuminate\Filesystem\Filesystem;
@@ -44,6 +45,7 @@ class TablesServiceProvider extends PackageServiceProvider
         Testable::mixin(new TestsBulkActions);
         Testable::mixin(new TestsColumns);
         Testable::mixin(new TestsFilters);
+        Testable::mixin(new TestsQueryBuilders);
         Testable::mixin(new TestsRecords);
         Testable::mixin(new TestsSummaries);
     }

--- a/packages/tables/src/Testing/TestsQueryBuilders.php
+++ b/packages/tables/src/Testing/TestsQueryBuilders.php
@@ -3,7 +3,7 @@
 namespace Filament\Tables\Testing;
 
 use Closure;
-use Filament\Tables\Filters\QueryBuilder\Concerns\HasConstraints;
+use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Filters\QueryBuilder\Constraints\Constraint;
 use Filament\Tables\Filters\QueryBuilder\Constraints\DateConstraint;
 use Filament\Tables\Filters\QueryBuilder\Constraints\NumberConstraint;
@@ -13,7 +13,7 @@ use Illuminate\Testing\Assert;
 use Livewire\Features\SupportTesting\Testable;
 
 /**
- * @method HasConstraints instance()
+ * @method HasTable instance()
  *
  * @mixin Testable
  */

--- a/packages/tables/src/Testing/TestsQueryBuilders.php
+++ b/packages/tables/src/Testing/TestsQueryBuilders.php
@@ -32,7 +32,7 @@ class TestsQueryBuilders
                 'data' => [
                     'operator' => $operator,
                     'settings' => [],
-                ]
+                ],
             ];
             if ($constraint instanceof TextConstraint) {
                 if ($data) {

--- a/packages/tables/src/Testing/TestsQueryBuilders.php
+++ b/packages/tables/src/Testing/TestsQueryBuilders.php
@@ -70,7 +70,7 @@ class TestsQueryBuilders
             Assert::assertInstanceOf(
                 Constraint::class,
                 $filter,
-                message: "Failed asserting that a query builder with name [{$name}] exists on the [{$livewireClass}] component.",
+                "Failed asserting that a query builder with name [{$name}] exists on the [{$livewireClass}] component.",
             );
 
             return $this;

--- a/packages/tables/src/Testing/TestsQueryBuilders.php
+++ b/packages/tables/src/Testing/TestsQueryBuilders.php
@@ -5,6 +5,9 @@ namespace Filament\Tables\Testing;
 use Closure;
 use Filament\Tables\Filters\QueryBuilder\Concerns\HasConstraints;
 use Filament\Tables\Filters\QueryBuilder\Constraints\Constraint;
+use Filament\Tables\Filters\QueryBuilder\Constraints\DateConstraint;
+use Filament\Tables\Filters\QueryBuilder\Constraints\NumberConstraint;
+use Filament\Tables\Filters\QueryBuilder\Constraints\SelectConstraint;
 use Filament\Tables\Filters\QueryBuilder\Constraints\TextConstraint;
 use Illuminate\Testing\Assert;
 use Livewire\Features\SupportTesting\Testable;
@@ -18,23 +21,34 @@ class TestsQueryBuilders
 {
     public function queryBuilderTable(): Closure
     {
-        return function (string $column, string $operator, $data = null): static {
+        return function (string $filter, string $operator, $data = null): static {
             /** @phpstan-ignore-next-line */
-            $this->assertTableConstraintExists($column);
+            $this->assertTableConstraintExists($filter);
 
-            $constraint = $this->instance()->getTable()->getFilter('queryBuilder')->getConstraint($column);
+            $constraint = $this->instance()->getTable()->getFilter('queryBuilder')->getConstraint($filter);
 
+            $queryBuilder = [
+                'type' => $filter,
+                'data' => [
+                    'operator' => $operator,
+                    'settings' => [],
+                ]
+            ];
             if ($constraint instanceof TextConstraint) {
-                $queryBuilder = [
-                    'type' => $column,
-                    'data' => [
-                        'operator' => $operator,
-                        'settings' => [],
-                    ]
-                ];
-
                 if ($data) {
                     $queryBuilder['data']['settings'] = ['text' => $data];
+                }
+            } elseif ($constraint instanceof NumberConstraint) {
+                if ($data) {
+                    $queryBuilder['data']['settings'] = ['number' => $data];
+                }
+            } elseif ($constraint instanceof DateConstraint) {
+                if ($data) {
+                    $queryBuilder['data']['settings'] = ['date' => $data];
+                }
+            } elseif ($constraint instanceof SelectConstraint) {
+                if ($data) {
+                    $queryBuilder['data']['settings'] = ['values' => $data];
                 }
             }
 
@@ -46,15 +60,15 @@ class TestsQueryBuilders
 
     public function assertTableConstraintExists(): Closure
     {
-        return function (string $column): static {
-            $filter = $this->instance()->getTable()->getFilter('queryBuilder')->getConstraint($column);
+        return function (string $name): static {
+            $filter = $this->instance()->getTable()->getFilter('queryBuilder')->getConstraint($name);
 
             $livewireClass = $this->instance()::class;
 
             Assert::assertInstanceOf(
                 Constraint::class,
                 $filter,
-                message: "Failed asserting that a table filter with name [{$column}] exists on the [{$livewireClass}] component.",
+                message: "Failed asserting that a query builder with name [{$name}] exists on the [{$livewireClass}] component.",
             );
 
             return $this;

--- a/packages/tables/src/Testing/TestsQueryBuilders.php
+++ b/packages/tables/src/Testing/TestsQueryBuilders.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Filament\Tables\Testing;
+
+use Closure;
+use Filament\Tables\Filters\QueryBuilder\Concerns\HasConstraints;
+use Filament\Tables\Filters\QueryBuilder\Constraints\Constraint;
+use Filament\Tables\Filters\QueryBuilder\Constraints\TextConstraint;
+use Illuminate\Testing\Assert;
+use Livewire\Features\SupportTesting\Testable;
+
+/**
+ * @method HasConstraints instance()
+ *
+ * @mixin Testable
+ */
+class TestsQueryBuilders
+{
+    public function queryBuilderTable(): Closure
+    {
+        return function (string $column, string $operator, $data = null): static {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableConstraintExists($column);
+
+            $constraint = $this->instance()->getTable()->getFilter('queryBuilder')->getConstraint($column);
+
+            if ($constraint instanceof TextConstraint) {
+                $queryBuilder = [
+                    'type' => $column,
+                    'data' => [
+                        'operator' => $operator,
+                        'settings' => [],
+                    ]
+                ];
+
+                if ($data) {
+                    $queryBuilder['data']['settings'] = ['text' => $data];
+                }
+            }
+
+            $this->set("tableFilters.queryBuilder.rules.{$constraint->getName()}", $queryBuilder);
+
+            return $this;
+        };
+    }
+
+    public function assertTableConstraintExists(): Closure
+    {
+        return function (string $column): static {
+            $filter = $this->instance()->getTable()->getFilter('queryBuilder')->getConstraint($column);
+
+            $livewireClass = $this->instance()::class;
+
+            Assert::assertInstanceOf(
+                Constraint::class,
+                $filter,
+                message: "Failed asserting that a table filter with name [{$column}] exists on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+}

--- a/packages/tables/src/Testing/TestsQueryBuilders.php
+++ b/packages/tables/src/Testing/TestsQueryBuilders.php
@@ -25,6 +25,7 @@ class TestsQueryBuilders
             /** @phpstan-ignore-next-line */
             $this->assertTableConstraintExists($filter);
 
+            /** @phpstan-ignore-next-line */
             $constraint = $this->instance()->getTable()->getFilter('queryBuilder')->getConstraint($filter);
 
             $queryBuilder = [
@@ -61,6 +62,7 @@ class TestsQueryBuilders
     public function assertTableConstraintExists(): Closure
     {
         return function (string $name): static {
+            /** @phpstan-ignore-next-line */
             $filter = $this->instance()->getTable()->getFilter('queryBuilder')->getConstraint($name);
 
             $livewireClass = $this->instance()::class;

--- a/tests/src/Tables/Filters/QueryBuilderTest.php
+++ b/tests/src/Tables/Filters/QueryBuilderTest.php
@@ -79,5 +79,5 @@ it('can modal actions during text constraint', function () {
         ->queryBuilderTable('content', 'contains', $content)
         ->assertCanSeeTableRecords($post->get())
         ->callTableAction(DeleteAction::class, $post->first())
-        ->assertCanNotSeeTableRecords([$posts->first()]);
+        ->assertCanNotSeeTableRecords($post->get());
 });

--- a/tests/src/Tables/Filters/QueryBuilderTest.php
+++ b/tests/src/Tables/Filters/QueryBuilderTest.php
@@ -4,7 +4,9 @@ use Filament\Tests\Models\Post;
 use Filament\Tests\Tables\Fixtures\PostsQueryBuilderTable;
 use Filament\Tests\Tables\TestCase;
 
+use Filament\Tables\Actions\DeleteAction;
 use function Filament\Tests\livewire;
+use function Pest\Laravel\assertSoftDeleted;
 
 uses(TestCase::class);
 
@@ -66,4 +68,17 @@ it('can filter text constraint by `isFilled`', function () {
         ->queryBuilderTable('content', 'isFilled')
         ->assertCanSeeTableRecords(Post::where('content', '<>', null)->where('content', '<>', '')->get())
         ->assertCanNotSeeTableRecords(Post::where('content', null)->orWhere('content', '')->get());
+});
+
+it('can modal actions during text constraint', function () {
+    $posts = Post::factory()->count(10)->create();
+    $content = $posts->first()->content;
+    $post = Post::where('content', $content);
+
+    livewire(PostsQueryBuilderTable::class)
+        ->assertCanSeeTableRecords($posts)
+        ->queryBuilderTable('content', 'contains', $content)
+        ->assertCanSeeTableRecords($post->get())
+        ->callTableAction(DeleteAction::class, $post->first())
+        ->assertCanNotSeeTableRecords([$posts->first()]);
 });

--- a/tests/src/Tables/Filters/QueryBuilderTest.php
+++ b/tests/src/Tables/Filters/QueryBuilderTest.php
@@ -1,0 +1,142 @@
+<?php
+
+use Filament\Tables\Actions\DeleteAction;
+use Filament\Tests\Models\Post;
+use Filament\Tests\Tables\Fixtures\PostsQueryBuilderTable;
+use Filament\Tests\Tables\TestCase;
+use function Filament\Tests\livewire;
+use function Pest\Laravel\assertSoftDeleted;
+
+uses(TestCase::class);
+
+it('can filter text constraint for `contains`', function () {
+    $posts = Post::factory(10)->create();
+    $content = $posts->random()->content;
+    $filter = substr($content, 2, 7);
+
+    livewire(PostsQueryBuilderTable::class)
+        ->assertCanSeeTableRecords($posts)
+        ->queryBuilderTable('content', 'contains', $filter)
+        ->assertCanSeeTableRecords(Post::where('content', 'like', '%' . $filter . '%')->get())
+        ->assertCanNotSeeTableRecords(Post::where('content', 'not like', '%' . $filter . '%')->get());
+});
+
+it('can filter text constraint for `not contains`', function () {
+    $posts = Post::factory(10)->create();
+    $content = $posts->random()->content;
+    $filter = substr($content, 2, 7);
+
+    livewire(PostsQueryBuilderTable::class)
+        ->assertCanSeeTableRecords($posts)
+        ->queryBuilderTable('content', 'contains.inverse', $filter)
+        ->assertCanSeeTableRecords(Post::where('content', 'not like', '%' . $filter . '%')->get())
+        ->assertCanNotSeeTableRecords(Post::where('content', 'like', '%' . $filter . '%')->get());
+});
+
+it('can filter text constraint for `startsWith`', function () {
+    $posts = Post::factory(10)->create();
+    $content = $posts->random()->content;
+    $filter = substr($content, 0, 5);
+
+    livewire(PostsQueryBuilderTable::class)
+        ->assertCanSeeTableRecords($posts)
+        ->queryBuilderTable('content', 'startsWith', $filter)
+        ->assertCanSeeTableRecords(Post::where('content', 'like', $filter . '%')->get())
+        ->assertCanNotSeeTableRecords(Post::where('content', 'not like', $filter . '%')->get());
+});
+
+it('can filter text constraint for `not startsWith`', function () {
+    $posts = Post::factory(10)->create();
+    $content = $posts->random()->content;
+    $filter = substr($content, 0, 5);
+
+    livewire(PostsQueryBuilderTable::class)
+        ->assertCanSeeTableRecords($posts)
+        ->queryBuilderTable('content', 'startsWith.inverse', $filter)
+        ->assertCanSeeTableRecords(Post::where('content', 'not like', $filter . '%')->get())
+        ->assertCanNotSeeTableRecords(Post::where('content', 'like', $filter . '%')->get());
+});
+
+it('can filter text constraint for `endsWith`', function () {
+    $posts = Post::factory(10)->create();
+    $content = $posts->random()->content;
+    $filter = substr($content, -5);
+
+    livewire(PostsQueryBuilderTable::class)
+        ->assertCanSeeTableRecords($posts)
+        ->queryBuilderTable('content', 'endsWith', $filter)
+        ->assertCanSeeTableRecords(Post::where('content', 'like', '%' . $filter)->get())
+        ->assertCanNotSeeTableRecords(Post::where('content', 'not like', '%' . $filter)->get());
+});
+
+it('can filter text constraint for `not endsWith`', function () {
+    $posts = Post::factory(10)->create();
+    $content = $posts->random()->content;
+    $filter = substr($content, -5);
+
+    livewire(PostsQueryBuilderTable::class)
+        ->assertCanSeeTableRecords($posts)
+        ->queryBuilderTable('content', 'endsWith.inverse', $filter)
+        ->assertCanSeeTableRecords(Post::where('content', 'not like', '%' . $filter)->get())
+        ->assertCanNotSeeTableRecords(Post::where('content', 'like', '%' . $filter)->get());
+});
+
+it('can filter text constraint for `equals`', function () {
+    $posts = Post::factory(10)->create();
+    $content = $posts->random()->content;
+
+    livewire(PostsQueryBuilderTable::class)
+        ->assertCanSeeTableRecords($posts)
+        ->queryBuilderTable('content', 'equals', $content)
+        ->assertCanSeeTableRecords(Post::where('content', $content)->get())
+        ->assertCanNotSeeTableRecords(Post::where('content', '<>', $content)->get());
+});
+
+it('can filter text constraint for `not equals`', function () {
+    $posts = Post::factory(10)->create();
+    $content = $posts->random()->content;
+
+    livewire(PostsQueryBuilderTable::class)
+        ->assertCanSeeTableRecords($posts)
+        ->queryBuilderTable('content', 'equals.inverse', $content)
+        ->assertCanSeeTableRecords(Post::where('content', '<>', $content)->get())
+        ->assertCanNotSeeTableRecords(Post::where('content', $content)->get());
+});
+
+it('can filter text constraint for `isFilled`', function () {
+    Post::factory(8)->create();
+    Post::factory()->create(['content' => null]);
+    Post::factory()->create(['content' => '']);
+
+    livewire(PostsQueryBuilderTable::class)
+        ->assertCanSeeTableRecords(Post::all())
+        ->queryBuilderTable('content', 'isFilled')
+        ->assertCanSeeTableRecords(Post::where('content', '<>', null)->where('content', '<>', '')->get())
+        ->assertCanNotSeeTableRecords(Post::where('content', null)->orWhere('content', '')->get());
+});
+
+it('can filter text constraint for `not isFilled`', function () {
+    Post::factory(8)->create();
+    Post::factory()->create(['content' => null]);
+    Post::factory()->create(['content' => '']);
+
+    livewire(PostsQueryBuilderTable::class)
+        ->assertCanSeeTableRecords(Post::all())
+        ->queryBuilderTable('content', 'isFilled.inverse')
+        ->assertCanSeeTableRecords(Post::where('content', null)->orWhere('content', '')->get())
+        ->assertCanNotSeeTableRecords(Post::where('content', '<>', null)->where('content', '<>', '')->get());
+});
+
+// it('can filter records by text constraint in the query builder with modal action', function () {
+//     $posts = Post::factory()->count(10)->create();
+//     $content = $posts->first()->content;
+//     $post = Post::where('content', $content);
+
+//     livewire(PostsQueryBuilderTable::class)
+//         ->assertCanSeeTableRecords($posts)
+//         ->queryBuilderTable('content', 'contains', $content)
+//         ->assertCanSeeTableRecords($post->get())
+//         ->callTableAction(DeleteAction::class, $post->first());
+
+//     assertSoftDeleted($post->first());
+// });

--- a/tests/src/Tables/Filters/QueryBuilderTest.php
+++ b/tests/src/Tables/Filters/QueryBuilderTest.php
@@ -7,7 +7,7 @@ use function Filament\Tests\livewire;
 
 uses(TestCase::class);
 
-it('can filter text constraint for `contains`', function () {
+it('can filter text constraint by `contains`', function () {
     $posts = Post::factory(10)->create();
     $content = $posts->random()->content;
     $start = fake()->numberBetween(0, strlen($content));
@@ -20,7 +20,7 @@ it('can filter text constraint for `contains`', function () {
         ->assertCanNotSeeTableRecords(Post::where('content', 'not like', '%' . $filter . '%')->get());
 });
 
-it('can filter text constraint for `startsWith`', function () {
+it('can filter text constraint by `startsWith`', function () {
     $posts = Post::factory(10)->create();
     $content = $posts->random()->content;
     $filter = substr($content, 0, fake()->numberBetween(1, strlen($content)));
@@ -32,7 +32,7 @@ it('can filter text constraint for `startsWith`', function () {
         ->assertCanNotSeeTableRecords(Post::where('content', 'not like', $filter . '%')->get());
 });
 
-it('can filter text constraint for `endsWith`', function () {
+it('can filter text constraint by `endsWith`', function () {
     $posts = Post::factory(10)->create();
     $content = $posts->random()->content;
     $filter = substr($content, -(fake()->numberBetween(1, strlen($content))));
@@ -44,7 +44,7 @@ it('can filter text constraint for `endsWith`', function () {
         ->assertCanNotSeeTableRecords(Post::where('content', 'not like', '%' . $filter)->get());
 });
 
-it('can filter text constraint for `equals`', function () {
+it('can filter text constraint by `equals`', function () {
     $posts = Post::factory(10)->create();
     $content = $posts->random()->content;
 
@@ -55,7 +55,7 @@ it('can filter text constraint for `equals`', function () {
         ->assertCanNotSeeTableRecords(Post::where('content', '<>', $content)->get());
 });
 
-it('can filter text constraint for `isFilled`', function () {
+it('can filter text constraint by `isFilled`', function () {
     Post::factory()->create();
     Post::factory()->create(['content' => null]);
     Post::factory()->create(['content' => '']);

--- a/tests/src/Tables/Filters/QueryBuilderTest.php
+++ b/tests/src/Tables/Filters/QueryBuilderTest.php
@@ -3,6 +3,7 @@
 use Filament\Tests\Models\Post;
 use Filament\Tests\Tables\Fixtures\PostsQueryBuilderTable;
 use Filament\Tests\Tables\TestCase;
+
 use function Filament\Tests\livewire;
 
 uses(TestCase::class);

--- a/tests/src/Tables/Filters/QueryBuilderTest.php
+++ b/tests/src/Tables/Filters/QueryBuilderTest.php
@@ -1,18 +1,17 @@
 <?php
 
-use Filament\Tables\Actions\DeleteAction;
 use Filament\Tests\Models\Post;
 use Filament\Tests\Tables\Fixtures\PostsQueryBuilderTable;
 use Filament\Tests\Tables\TestCase;
 use function Filament\Tests\livewire;
-use function Pest\Laravel\assertSoftDeleted;
 
 uses(TestCase::class);
 
 it('can filter text constraint for `contains`', function () {
     $posts = Post::factory(10)->create();
     $content = $posts->random()->content;
-    $filter = substr($content, 2, 7);
+    $start = fake()->numberBetween(0, strlen($content));
+    $filter = substr($content, $start, fake()->numberBetween($start, strlen($content)));
 
     livewire(PostsQueryBuilderTable::class)
         ->assertCanSeeTableRecords($posts)
@@ -21,22 +20,10 @@ it('can filter text constraint for `contains`', function () {
         ->assertCanNotSeeTableRecords(Post::where('content', 'not like', '%' . $filter . '%')->get());
 });
 
-it('can filter text constraint for `not contains`', function () {
-    $posts = Post::factory(10)->create();
-    $content = $posts->random()->content;
-    $filter = substr($content, 2, 7);
-
-    livewire(PostsQueryBuilderTable::class)
-        ->assertCanSeeTableRecords($posts)
-        ->queryBuilderTable('content', 'contains.inverse', $filter)
-        ->assertCanSeeTableRecords(Post::where('content', 'not like', '%' . $filter . '%')->get())
-        ->assertCanNotSeeTableRecords(Post::where('content', 'like', '%' . $filter . '%')->get());
-});
-
 it('can filter text constraint for `startsWith`', function () {
     $posts = Post::factory(10)->create();
     $content = $posts->random()->content;
-    $filter = substr($content, 0, 5);
+    $filter = substr($content, 0, fake()->numberBetween(1, strlen($content)));
 
     livewire(PostsQueryBuilderTable::class)
         ->assertCanSeeTableRecords($posts)
@@ -45,40 +32,16 @@ it('can filter text constraint for `startsWith`', function () {
         ->assertCanNotSeeTableRecords(Post::where('content', 'not like', $filter . '%')->get());
 });
 
-it('can filter text constraint for `not startsWith`', function () {
-    $posts = Post::factory(10)->create();
-    $content = $posts->random()->content;
-    $filter = substr($content, 0, 5);
-
-    livewire(PostsQueryBuilderTable::class)
-        ->assertCanSeeTableRecords($posts)
-        ->queryBuilderTable('content', 'startsWith.inverse', $filter)
-        ->assertCanSeeTableRecords(Post::where('content', 'not like', $filter . '%')->get())
-        ->assertCanNotSeeTableRecords(Post::where('content', 'like', $filter . '%')->get());
-});
-
 it('can filter text constraint for `endsWith`', function () {
     $posts = Post::factory(10)->create();
     $content = $posts->random()->content;
-    $filter = substr($content, -5);
+    $filter = substr($content, -(fake()->numberBetween(1, strlen($content))));
 
     livewire(PostsQueryBuilderTable::class)
         ->assertCanSeeTableRecords($posts)
         ->queryBuilderTable('content', 'endsWith', $filter)
         ->assertCanSeeTableRecords(Post::where('content', 'like', '%' . $filter)->get())
         ->assertCanNotSeeTableRecords(Post::where('content', 'not like', '%' . $filter)->get());
-});
-
-it('can filter text constraint for `not endsWith`', function () {
-    $posts = Post::factory(10)->create();
-    $content = $posts->random()->content;
-    $filter = substr($content, -5);
-
-    livewire(PostsQueryBuilderTable::class)
-        ->assertCanSeeTableRecords($posts)
-        ->queryBuilderTable('content', 'endsWith.inverse', $filter)
-        ->assertCanSeeTableRecords(Post::where('content', 'not like', '%' . $filter)->get())
-        ->assertCanNotSeeTableRecords(Post::where('content', 'like', '%' . $filter)->get());
 });
 
 it('can filter text constraint for `equals`', function () {
@@ -92,19 +55,8 @@ it('can filter text constraint for `equals`', function () {
         ->assertCanNotSeeTableRecords(Post::where('content', '<>', $content)->get());
 });
 
-it('can filter text constraint for `not equals`', function () {
-    $posts = Post::factory(10)->create();
-    $content = $posts->random()->content;
-
-    livewire(PostsQueryBuilderTable::class)
-        ->assertCanSeeTableRecords($posts)
-        ->queryBuilderTable('content', 'equals.inverse', $content)
-        ->assertCanSeeTableRecords(Post::where('content', '<>', $content)->get())
-        ->assertCanNotSeeTableRecords(Post::where('content', $content)->get());
-});
-
 it('can filter text constraint for `isFilled`', function () {
-    Post::factory(8)->create();
+    Post::factory()->create();
     Post::factory()->create(['content' => null]);
     Post::factory()->create(['content' => '']);
 
@@ -114,29 +66,3 @@ it('can filter text constraint for `isFilled`', function () {
         ->assertCanSeeTableRecords(Post::where('content', '<>', null)->where('content', '<>', '')->get())
         ->assertCanNotSeeTableRecords(Post::where('content', null)->orWhere('content', '')->get());
 });
-
-it('can filter text constraint for `not isFilled`', function () {
-    Post::factory(8)->create();
-    Post::factory()->create(['content' => null]);
-    Post::factory()->create(['content' => '']);
-
-    livewire(PostsQueryBuilderTable::class)
-        ->assertCanSeeTableRecords(Post::all())
-        ->queryBuilderTable('content', 'isFilled.inverse')
-        ->assertCanSeeTableRecords(Post::where('content', null)->orWhere('content', '')->get())
-        ->assertCanNotSeeTableRecords(Post::where('content', '<>', null)->where('content', '<>', '')->get());
-});
-
-// it('can filter records by text constraint in the query builder with modal action', function () {
-//     $posts = Post::factory()->count(10)->create();
-//     $content = $posts->first()->content;
-//     $post = Post::where('content', $content);
-
-//     livewire(PostsQueryBuilderTable::class)
-//         ->assertCanSeeTableRecords($posts)
-//         ->queryBuilderTable('content', 'contains', $content)
-//         ->assertCanSeeTableRecords($post->get())
-//         ->callTableAction(DeleteAction::class, $post->first());
-
-//     assertSoftDeleted($post->first());
-// });

--- a/tests/src/Tables/Filters/QueryBuilderTest.php
+++ b/tests/src/Tables/Filters/QueryBuilderTest.php
@@ -1,12 +1,11 @@
 <?php
 
+use Filament\Tables\Actions\DeleteAction;
 use Filament\Tests\Models\Post;
 use Filament\Tests\Tables\Fixtures\PostsQueryBuilderTable;
 use Filament\Tests\Tables\TestCase;
 
-use Filament\Tables\Actions\DeleteAction;
 use function Filament\Tests\livewire;
-use function Pest\Laravel\assertSoftDeleted;
 
 uses(TestCase::class);
 

--- a/tests/src/Tables/Fixtures/PostsQueryBuilderTable.php
+++ b/tests/src/Tables/Fixtures/PostsQueryBuilderTable.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Filament\Tests\Tables\Fixtures;
+
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Tables;
+use Filament\Tables\Filters\QueryBuilder;
+use Filament\Tables\Filters\QueryBuilder\Constraints\TextConstraint;
+use Filament\Tables\Table;
+use Filament\Tests\Models\Post;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+
+class PostsQueryBuilderTable extends Component implements HasForms, Tables\Contracts\HasTable
+{
+    use InteractsWithForms;
+    use Tables\Concerns\InteractsWithTable;
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->query(Post::query())
+            ->columns([
+                Tables\Columns\TextColumn::make('title')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('author.name')
+                    ->sortable()
+                    ->searchable(),
+            ])
+            ->filters([
+                QueryBuilder::make()
+                    ->constraints([
+                        TextConstraint::make('content')
+                            ->nullable(),
+                    ]),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }
+
+    public function render(): View
+    {
+        return view('tables.fixtures.table');
+    }
+}


### PR DESCRIPTION
## Description

This fix is related to #12554 and  #15720. 

This fixes the issue #12554 using the tests from #15720 (slighlty modified, but not my strong skill, so worth a double check ) 

## Visual changes

No visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
