### PR TITLE
Add missing focus state highlighting in Toggle component

### DIFF
--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -68,7 +68,7 @@
                     ], escape: false)
                     ->merge($getExtraAttributes(), escape: false)
                     ->merge($getExtraAlpineAttributes(), escape: false)
-                    ->class(['fi-fo-toggle relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent outline-none transition-colors duration-200 ease-in-out disabled:pointer-events-none disabled:opacity-70 focus-visible:ring-primary-500 focus-visible:ring-2'])
+                    ->class(['fi-fo-toggle relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent outline-none transition-colors duration-200 ease-in-out disabled:pointer-events-none disabled:opacity-70 focus-visible:ring-primary-500 focus-visible:ring-offset-1 focus-visible:ring-2'])
             }}
         >
             <span

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -68,7 +68,7 @@
                     ], escape: false)
                     ->merge($getExtraAttributes(), escape: false)
                     ->merge($getExtraAlpineAttributes(), escape: false)
-                    ->class(['fi-fo-toggle relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent outline-none transition-colors duration-200 ease-in-out disabled:pointer-events-none disabled:opacity-70 focus-visible:ring-primary-500 focus-visible:ring-offset-1 focus-visible:ring-2'])
+                    ->class(['fi-fo-toggle relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent outline-none transition-colors duration-200 ease-in-out disabled:pointer-events-none disabled:opacity-70 focus-visible:ring-primary-600 focus-visible:ring-offset-1 focus-visible:ring-2 dark:focus-visible:ring-primary-500 dark:focus-visible:ring-offset-gray-900'])
             }}
         >
             <span

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -68,7 +68,7 @@
                     ], escape: false)
                     ->merge($getExtraAttributes(), escape: false)
                     ->merge($getExtraAlpineAttributes(), escape: false)
-                    ->class(['fi-fo-toggle relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent outline-none transition-colors duration-200 ease-in-out disabled:pointer-events-none disabled:opacity-70'])
+                    ->class(['fi-fo-toggle relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent outline-none transition-colors duration-200 ease-in-out disabled:pointer-events-none disabled:opacity-70 focus-visible:outline-primary-600'])
             }}
         >
             <span

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -68,7 +68,7 @@
                     ], escape: false)
                     ->merge($getExtraAttributes(), escape: false)
                     ->merge($getExtraAlpineAttributes(), escape: false)
-                    ->class(['fi-fo-toggle relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent outline-none transition-colors duration-200 ease-in-out disabled:pointer-events-none disabled:opacity-70 focus-visible:outline-primary-600'])
+                    ->class(['fi-fo-toggle relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent outline-none transition-colors duration-200 ease-in-out disabled:pointer-events-none disabled:opacity-70 focus-visible:ring-primary-500 focus-visible:ring-2'])
             }}
         >
             <span

--- a/packages/tables/resources/views/columns/toggle-column.blade.php
+++ b/packages/tables/resources/views/columns/toggle-column.blade.php
@@ -28,22 +28,26 @@
         @endphp
 
         <div
-            x-data="{
-                async updateState () {
-                    if (this.isLoading || $el.hasAttribute('disabled')) {
+            role="switch"
+            aria-checked="false"
+            x-bind:aria-checked="state.toString()"
+            wire:loading.attr="disabled"
+            @if (! $isDisabled)
+                x-on:click.stop.prevent="
+                    if (isLoading || $el.hasAttribute('disabled')) {
                         return
                     }
 
-                    const updatedState = ! this.state
+                    const updatedState = ! state
 
                     // Only update the state if the toggle is being turned off,
                     // otherwise it will flicker on twice when Livewire replaces
                     // the element.
-                    if (this.state) {
-                        this.state = false
+                    if (state) {
+                        state = false
                     }
 
-                    this.isLoading = true
+                    isLoading = true
 
                     const response = await $wire.updateTableColumnState(
                         @js($getName()),
@@ -55,21 +59,12 @@
 
                     // The state is only updated on the frontend if the toggle is
                     // being turned off, so we only need to reset it then.
-                    if (! this.state && error) {
-                        this.state = ! this.state
+                    if (! state && error) {
+                        state = ! state
                     }
 
-                    this.isLoading = false
-                }
-            }"
-            role="switch"
-            aria-checked="false"
-            x-bind:aria-checked="state.toString()"
-            wire:loading.attr="disabled"
-            @if (! $isDisabled)
-                tabindex="0"
-                x-on:keydown.space="updateState"
-                x-on:click.stop="updateState"
+                    isLoading = false
+                "
                 x-tooltip="
                     error === undefined
                         ? false
@@ -119,7 +114,7 @@
                     }}'
             "
             @class([
-                'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent outline-none transition-colors duration-200 ease-in-out focus-visible:ring-primary-600 focus-visible:ring-offset-1 focus-visible:ring-2 dark:focus-visible:ring-primary-500 dark:focus-visible:ring-offset-gray-900',
+                'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent outline-none transition-colors duration-200 ease-in-out',
                 'pointer-events-none opacity-70' => $isDisabled,
             ])
         >

--- a/packages/tables/resources/views/columns/toggle-column.blade.php
+++ b/packages/tables/resources/views/columns/toggle-column.blade.php
@@ -30,7 +30,7 @@
         <div
             x-data="{
                 async updateState () {
-                    if (this.isLoading) {
+                    if (this.isLoading || $el.hasAttribute('disabled')) {
                         return
                     }
 

--- a/packages/tables/resources/views/columns/toggle-column.blade.php
+++ b/packages/tables/resources/views/columns/toggle-column.blade.php
@@ -28,26 +28,22 @@
         @endphp
 
         <div
-            role="switch"
-            aria-checked="false"
-            x-bind:aria-checked="state.toString()"
-            wire:loading.attr="disabled"
-            @if (! $isDisabled)
-                x-on:click.stop.prevent="
-                    if (isLoading || $el.hasAttribute('disabled')) {
+            x-data="{
+                async updateState () {
+                    if (this.isLoading) {
                         return
                     }
 
-                    const updatedState = ! state
+                    const updatedState = ! this.state
 
                     // Only update the state if the toggle is being turned off,
                     // otherwise it will flicker on twice when Livewire replaces
                     // the element.
-                    if (state) {
-                        state = false
+                    if (this.state) {
+                        this.state = false
                     }
 
-                    isLoading = true
+                    this.isLoading = true
 
                     const response = await $wire.updateTableColumnState(
                         @js($getName()),
@@ -59,12 +55,21 @@
 
                     // The state is only updated on the frontend if the toggle is
                     // being turned off, so we only need to reset it then.
-                    if (! state && error) {
-                        state = ! state
+                    if (! this.state && error) {
+                        this.state = ! this.state
                     }
 
-                    isLoading = false
-                "
+                    this.isLoading = false
+                }
+            }"
+            role="switch"
+            aria-checked="false"
+            x-bind:aria-checked="state.toString()"
+            wire:loading.attr="disabled"
+            @if (! $isDisabled)
+                tabindex="0"
+                x-on:keydown.space="updateState"
+                x-on:click.stop="updateState"
                 x-tooltip="
                     error === undefined
                         ? false
@@ -114,7 +119,7 @@
                     }}'
             "
             @class([
-                'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent outline-none transition-colors duration-200 ease-in-out',
+                'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent outline-none transition-colors duration-200 ease-in-out focus-visible:ring-primary-600 focus-visible:ring-offset-1 focus-visible:ring-2 dark:focus-visible:ring-primary-500 dark:focus-visible:ring-offset-gray-900',
                 'pointer-events-none opacity-70' => $isDisabled,
             ])
         >


### PR DESCRIPTION
## Description
Moving Focus to a Toggle Input by tabbing is possible, but does not come with any visual Feedback at all.

This Behavior can be observerd in the Demo Application (Status Section => Visible Toggle):
https://demo.filamentphp.com/shop/products/products/1/edit

## Visual changes

**Before (light):**
![image](https://github.com/user-attachments/assets/b03c0d18-eb3b-47bb-a6e6-b4f9648a6c85)

**After (light)**
![image](https://github.com/user-attachments/assets/2310e79d-1a79-4cb4-ad45-5a1f943ffc71)

**Before (Dark)**
![image](https://github.com/user-attachments/assets/41a22b4f-901e-4748-b11c-09566c9f26f3)

**After (Dark).**
![image](https://github.com/user-attachments/assets/f0eedd6c-9e01-46b3-9a91-5693aa27e103)

## Functional changes
No functional Changes.
Only one added CSS-Class

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
