### PR TITLE
Prevent catching side-effects of database transactions being committed

### DIFF
--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -102,8 +102,6 @@ trait InteractsWithActions
             $result = $action->callAfter() ?? $result;
 
             $this->afterActionCalled();
-
-            $action->commitDatabaseTransaction();
         } catch (Halt $exception) {
             $exception->shouldRollbackDatabaseTransaction() ?
                 $action->rollBackDatabaseTransaction() :
@@ -130,6 +128,8 @@ trait InteractsWithActions
 
             throw $exception;
         }
+
+        $action->commitDatabaseTransaction();
 
         if (store($this)->has('redirect')) {
             return $result;

--- a/packages/forms/src/Concerns/HasFormComponentActions.php
+++ b/packages/forms/src/Concerns/HasFormComponentActions.php
@@ -81,8 +81,6 @@ trait HasFormComponentActions
             ]);
 
             $result = $action->callAfter() ?? $result;
-
-            $action->commitDatabaseTransaction();
         } catch (Halt $exception) {
             $exception->shouldRollbackDatabaseTransaction() ?
                 $action->rollBackDatabaseTransaction() :
@@ -109,6 +107,8 @@ trait HasFormComponentActions
 
             throw $exception;
         }
+
+        $action->commitDatabaseTransaction();
 
         if (store($this)->has('redirect')) {
             return $result;

--- a/packages/infolists/src/Concerns/InteractsWithInfolists.php
+++ b/packages/infolists/src/Concerns/InteractsWithInfolists.php
@@ -124,8 +124,6 @@ trait InteractsWithInfolists
             ]);
 
             $result = $action->callAfter() ?? $result;
-
-            $action->commitDatabaseTransaction();
         } catch (Halt $exception) {
             $exception->shouldRollbackDatabaseTransaction() ?
                 $action->rollBackDatabaseTransaction() :
@@ -152,6 +150,8 @@ trait InteractsWithInfolists
 
             throw $exception;
         }
+
+        $action->commitDatabaseTransaction();
 
         if (store($this)->has('redirect')) {
             return $result;

--- a/packages/panels/src/Pages/Auth/EditProfile.php
+++ b/packages/panels/src/Pages/Auth/EditProfile.php
@@ -160,8 +160,6 @@ class EditProfile extends Page
             $this->handleRecordUpdate($this->getUser(), $data);
 
             $this->callHook('afterSave');
-
-            $this->commitDatabaseTransaction();
         } catch (Halt $exception) {
             $exception->shouldRollbackDatabaseTransaction() ?
                 $this->rollBackDatabaseTransaction() :
@@ -173,6 +171,8 @@ class EditProfile extends Page
 
             throw $exception;
         }
+
+        $this->commitDatabaseTransaction();
 
         if (request()->hasSession() && array_key_exists('password', $data)) {
             request()->session()->put([

--- a/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
+++ b/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
@@ -125,8 +125,6 @@ abstract class EditTenantProfile extends Page
             $this->handleRecordUpdate($this->tenant, $data);
 
             $this->callHook('afterSave');
-
-            $this->commitDatabaseTransaction();
         } catch (Halt $exception) {
             $exception->shouldRollbackDatabaseTransaction() ?
                 $this->rollBackDatabaseTransaction() :
@@ -138,6 +136,8 @@ abstract class EditTenantProfile extends Page
 
             throw $exception;
         }
+
+        $this->commitDatabaseTransaction();
 
         $this->getSavedNotification()?->send();
 

--- a/packages/panels/src/Pages/Tenancy/RegisterTenant.php
+++ b/packages/panels/src/Pages/Tenancy/RegisterTenant.php
@@ -91,8 +91,6 @@ abstract class RegisterTenant extends SimplePage
             $this->form->model($this->tenant)->saveRelationships();
 
             $this->callHook('afterRegister');
-
-            $this->commitDatabaseTransaction();
         } catch (Halt $exception) {
             $exception->shouldRollbackDatabaseTransaction() ?
                 $this->rollBackDatabaseTransaction() :
@@ -104,6 +102,8 @@ abstract class RegisterTenant extends SimplePage
 
             throw $exception;
         }
+
+        $this->commitDatabaseTransaction();
 
         if ($redirectUrl = $this->getRedirectUrl()) {
             $this->redirect($redirectUrl, navigate: FilamentView::hasSpaMode() && is_app_url($redirectUrl));

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -96,8 +96,6 @@ class CreateRecord extends Page
             $this->form->model($this->getRecord())->saveRelationships();
 
             $this->callHook('afterCreate');
-
-            $this->commitDatabaseTransaction();
         } catch (Halt $exception) {
             $exception->shouldRollbackDatabaseTransaction() ?
                 $this->rollBackDatabaseTransaction() :
@@ -109,6 +107,8 @@ class CreateRecord extends Page
 
             throw $exception;
         }
+
+        $this->commitDatabaseTransaction();
 
         $this->rememberData();
 

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -153,8 +153,6 @@ class EditRecord extends Page
             $this->handleRecordUpdate($this->getRecord(), $data);
 
             $this->callHook('afterSave');
-
-            $this->commitDatabaseTransaction();
         } catch (Halt $exception) {
             $exception->shouldRollbackDatabaseTransaction() ?
                 $this->rollBackDatabaseTransaction() :
@@ -166,6 +164,8 @@ class EditRecord extends Page
 
             throw $exception;
         }
+
+        $this->commitDatabaseTransaction();
 
         $this->rememberData();
 
@@ -202,8 +202,6 @@ class EditRecord extends Page
             $this->handleRecordUpdate($this->getRecord(), $data);
 
             $this->callHook('afterSave');
-
-            $this->commitDatabaseTransaction();
         } catch (Halt $exception) {
             $exception->shouldRollbackDatabaseTransaction() ?
                 $this->rollBackDatabaseTransaction() :
@@ -215,6 +213,8 @@ class EditRecord extends Page
 
             throw $exception;
         }
+
+        $this->commitDatabaseTransaction();
 
         $this->rememberData();
     }

--- a/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
+++ b/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
@@ -81,8 +81,6 @@ class SettingsPage extends Page
             $settings->save();
 
             $this->callHook('afterSave');
-
-            $this->commitDatabaseTransaction();
         } catch (Halt $exception) {
             $exception->shouldRollbackDatabaseTransaction() ?
                 $this->rollBackDatabaseTransaction() :
@@ -94,6 +92,8 @@ class SettingsPage extends Page
 
             throw $exception;
         }
+
+        $this->commitDatabaseTransaction();
 
         $this->rememberData();
 

--- a/packages/support/src/Commands/CheckTranslationsCommand.php
+++ b/packages/support/src/Commands/CheckTranslationsCommand.php
@@ -116,7 +116,7 @@ class CheckTranslationsCommand extends Command implements PromptsForMissingInput
                     })
                     ->tap(function (Collection $files) use ($locale, $package) {
                         $missingKeysCount = $files->sum(fn ($file): int => count($file['missing']));
-                        $removedKeysCount = $files->sum(fn ($file): int => $file['removed'] ? count($file['removed']) : 0);
+                        $removedKeysCount = $files->sum(fn ($file): int => count($file['removed']));
 
                         $locale = locale_get_display_name($locale, 'en');
 

--- a/packages/support/src/Commands/CheckTranslationsCommand.php
+++ b/packages/support/src/Commands/CheckTranslationsCommand.php
@@ -116,7 +116,7 @@ class CheckTranslationsCommand extends Command implements PromptsForMissingInput
                     })
                     ->tap(function (Collection $files) use ($locale, $package) {
                         $missingKeysCount = $files->sum(fn ($file): int => count($file['missing']));
-                        $removedKeysCount = $files->sum(fn ($file): int => count($file['removed']));
+                        $removedKeysCount = $files->sum(fn ($file): int => $file['removed'] ? count($file['removed']) : 0);
 
                         $locale = locale_get_display_name($locale, 'en');
 

--- a/packages/tables/src/Concerns/HasActions.php
+++ b/packages/tables/src/Concerns/HasActions.php
@@ -113,8 +113,6 @@ trait HasActions
             ]);
 
             $result = $action->callAfter() ?? $result;
-
-            $action->commitDatabaseTransaction();
         } catch (Halt $exception) {
             $exception->shouldRollbackDatabaseTransaction() ?
                 $action->rollBackDatabaseTransaction() :
@@ -141,6 +139,8 @@ trait HasActions
 
             throw $exception;
         }
+
+        $action->commitDatabaseTransaction();
 
         if (store($this)->has('redirect')) {
             return $result;

--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -84,8 +84,6 @@ trait HasBulkActions
             ]);
 
             $result = $action->callAfter() ?? $result;
-
-            $action->commitDatabaseTransaction();
         } catch (Halt $exception) {
             $exception->shouldRollbackDatabaseTransaction() ?
                 $action->rollBackDatabaseTransaction() :
@@ -112,6 +110,8 @@ trait HasBulkActions
 
             throw $exception;
         }
+
+        $action->commitDatabaseTransaction();
 
         if (store($this)->has('redirect')) {
             return $result;

--- a/tests/src/Panels/Fixtures/Resources/PostResource.php
+++ b/tests/src/Panels/Fixtures/Resources/PostResource.php
@@ -10,6 +10,9 @@ use Filament\Tables\Table;
 use Filament\Tests\Models\Post;
 use Filament\Tests\Panels\Fixtures\Resources\PostResource\Pages;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use RuntimeException;
 
 class PostResource extends Resource
 {
@@ -57,6 +60,16 @@ class PostResource extends Resource
             ->actions([
                 Tables\Actions\ViewAction::make(),
                 Tables\Actions\EditAction::make(),
+                Tables\Actions\Action::make('randomize_title')
+                    ->databaseTransaction()
+                    ->action(action: function (Post $record) {
+                        DB::afterCommit(function () {
+                            throw new RuntimeException('This exception, happening after the successfully commit of the current transaction, should not trigger a rollback by Filament.');
+                        });
+
+                        $record->title = Str::random(10);
+                        $record->save();
+                    }),
                 Tables\Actions\DeleteAction::make(),
             ])
             ->bulkActions([

--- a/tests/src/Panels/Fixtures/Resources/PostResource.php
+++ b/tests/src/Panels/Fixtures/Resources/PostResource.php
@@ -64,7 +64,7 @@ class PostResource extends Resource
                     ->databaseTransaction()
                     ->action(action: function (Post $record) {
                         DB::afterCommit(function () {
-                            throw new RuntimeException('This exception, happening after the successfully commit of the current transaction, should not trigger a rollback by Filament.');
+                            throw new RuntimeException('This exception, happening after the successful commit of the current transaction, should not trigger a rollback by Filament.');
                         });
 
                         $record->title = Str::random(10);

--- a/tests/src/Panels/Fixtures/Resources/PostResource/Pages/EditPost.php
+++ b/tests/src/Panels/Fixtures/Resources/PostResource/Pages/EditPost.php
@@ -4,7 +4,10 @@ namespace Filament\Tests\Panels\Fixtures\Resources\PostResource\Pages;
 
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
+use Filament\Tests\Models\Post;
 use Filament\Tests\Panels\Fixtures\Resources\PostResource;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
 
 class EditPost extends EditRecord
 {
@@ -17,6 +20,16 @@ class EditPost extends EditRecord
             Actions\ActionGroup::make([
                 Actions\DeleteAction::make(),
             ]),
+            Actions\Action::make('randomize_title')
+                ->databaseTransaction()
+                ->action(action: function (Post $record) {
+                    DB::afterCommit(function () {
+                        throw new RuntimeException('This exception, happening after the successfully commit of the current transaction, should not trigger a rollback by Filament.');
+                    });
+
+                    $record->title = 'Test';
+                    $record->save();
+                }),
         ];
     }
 

--- a/tests/src/Panels/Fixtures/Resources/PostResource/Pages/EditPost.php
+++ b/tests/src/Panels/Fixtures/Resources/PostResource/Pages/EditPost.php
@@ -24,7 +24,7 @@ class EditPost extends EditRecord
                 ->databaseTransaction()
                 ->action(action: function (Post $record) {
                     DB::afterCommit(function () {
-                        throw new RuntimeException('This exception, happening after the successfully commit of the current transaction, should not trigger a rollback by Filament.');
+                        throw new RuntimeException('This exception, happening after the successful commit of the current transaction, should not trigger a rollback by Filament.');
                     });
 
                     $record->title = 'Test';

--- a/tests/src/Panels/Resources/Pages/EditRecordTest.php
+++ b/tests/src/Panels/Resources/Pages/EditRecordTest.php
@@ -5,6 +5,7 @@ use Filament\Tests\Models\Post;
 use Filament\Tests\Panels\Fixtures\Resources\PostResource;
 use Filament\Tests\Panels\Fixtures\Resources\PostResource\Pages\EditPost;
 use Filament\Tests\Panels\Resources\TestCase;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 use function Filament\Tests\livewire;
@@ -108,4 +109,24 @@ it('can refresh data', function () {
     $page->assertFormSet([
         'title' => $newPostTitle,
     ]);
+});
+
+test('actions will not interfere with database transactions on an error', function () {
+    $post = Post::factory()->create();
+
+    $transactionLevel = DB::transactionLevel();
+
+    try {
+        livewire(PostResource\Pages\EditPost::class, [
+            'record' => $post->getKey(),
+        ])
+            ->callAction('randomize_title');
+    } catch (Exception $e) {
+        // This can be catched and handled somewhere else, code continues...
+    }
+
+    // Original transaction level should be unaffected...
+
+    expect(DB::transactionLevel())
+        ->toBe($transactionLevel);
 });

--- a/tests/src/Panels/Resources/Pages/ListRecordsTest.php
+++ b/tests/src/Panels/Resources/Pages/ListRecordsTest.php
@@ -117,7 +117,7 @@ it('can bulk delete posts', function () {
     }
 });
 
-it('actions will not interfere with database transactions on an error', function () {
+test('actions will not interfere with database transactions on an error', function () {
     $post = Post::factory()->create();
 
     $transactionLevel = DB::transactionLevel();
@@ -135,7 +135,7 @@ it('actions will not interfere with database transactions on an error', function
         ->toBe($transactionLevel);
 });
 
-it('table actions will not interfere with database transactions on an error', function () {
+test('table actions will not interfere with database transactions on an error', function () {
     $post = Post::factory()->create();
 
     $transactionLevel = DB::transactionLevel();

--- a/tests/src/Panels/Resources/Pages/ListRecordsTest.php
+++ b/tests/src/Panels/Resources/Pages/ListRecordsTest.php
@@ -143,7 +143,7 @@ test('table actions will not interfere with database transactions on an error', 
     $transactionLevel = DB::transactionLevel();
 
     try {
-        livewire(PostResource\Pages\ListPosts::class)
+        livewire(ListPosts::class)
             ->callTableAction('randomize_title', $post);
     } catch (Exception $e) {
         // This can be catched and handled somewhere else, code continues...

--- a/tests/src/Panels/Resources/Pages/ListRecordsTest.php
+++ b/tests/src/Panels/Resources/Pages/ListRecordsTest.php
@@ -131,6 +131,8 @@ test('actions will not interfere with database transactions on an error', functi
         // This can be catched and handled somewhere else, code continues...
     }
 
+    // Original transaction level should be unaffected...
+
     expect(DB::transactionLevel())
         ->toBe($transactionLevel);
 });
@@ -146,6 +148,8 @@ test('table actions will not interfere with database transactions on an error', 
     } catch (Exception $e) {
         // This can be catched and handled somewhere else, code continues...
     }
+
+    // Original transaction level should be unaffected...
 
     expect(DB::transactionLevel())
         ->toBe($transactionLevel);

--- a/tests/src/Panels/Resources/Pages/ListRecordsTest.php
+++ b/tests/src/Panels/Resources/Pages/ListRecordsTest.php
@@ -117,26 +117,6 @@ it('can bulk delete posts', function () {
     }
 });
 
-test('actions will not interfere with database transactions on an error', function () {
-    $post = Post::factory()->create();
-
-    $transactionLevel = DB::transactionLevel();
-
-    try {
-        livewire(PostResource\Pages\EditPost::class, [
-            'record' => $post->getKey(),
-        ])
-            ->callAction('randomize_title');
-    } catch (Exception $e) {
-        // This can be catched and handled somewhere else, code continues...
-    }
-
-    // Original transaction level should be unaffected...
-
-    expect(DB::transactionLevel())
-        ->toBe($transactionLevel);
-});
-
 test('table actions will not interfere with database transactions on an error', function () {
     $post = Post::factory()->create();
 

--- a/tests/src/Panels/Resources/Pages/ListRecordsTest.php
+++ b/tests/src/Panels/Resources/Pages/ListRecordsTest.php
@@ -123,7 +123,7 @@ test('table actions will not interfere with database transactions on an error', 
     $transactionLevel = DB::transactionLevel();
 
     try {
-        livewire(ListPosts::class)
+        livewire(PostResource\Pages\ListPosts::class)
             ->callTableAction('randomize_title', $post);
     } catch (Exception $e) {
         // This can be catched and handled somewhere else, code continues...

--- a/tests/src/Panels/Resources/Pages/ListRecordsTest.php
+++ b/tests/src/Panels/Resources/Pages/ListRecordsTest.php
@@ -7,6 +7,7 @@ use Filament\Tests\Panels\Fixtures\Resources\PostResource;
 use Filament\Tests\Panels\Fixtures\Resources\PostResource\Pages\ListPosts;
 use Filament\Tests\Panels\Fixtures\Resources\UserResource;
 use Filament\Tests\Panels\Resources\TestCase;
+use Illuminate\Support\Facades\DB;
 
 use function Filament\Tests\livewire;
 use function Pest\Laravel\assertSoftDeleted;
@@ -114,4 +115,38 @@ it('can bulk delete posts', function () {
     foreach ($posts as $post) {
         assertSoftDeleted($post);
     }
+});
+
+it('actions will not interfere with database transactions on an error', function () {
+    $post = Post::factory()->create();
+
+    $transactionLevel = DB::transactionLevel();
+
+    try {
+        livewire(PostResource\Pages\EditPost::class, [
+            'record' => $post->getKey(),
+        ])
+            ->callAction('randomize_title');
+    } catch (Exception $e) {
+        // This can be catched and handled somewhere else, code continues...
+    }
+
+    expect(DB::transactionLevel())
+        ->toBe($transactionLevel);
+});
+
+it('table actions will not interfere with database transactions on an error', function () {
+    $post = Post::factory()->create();
+
+    $transactionLevel = DB::transactionLevel();
+
+    try {
+        livewire(PostResource\Pages\ListPosts::class)
+            ->callTableAction('randomize_title', $post);
+    } catch (Exception $e) {
+        // This can be catched and handled somewhere else, code continues...
+    }
+
+    expect(DB::transactionLevel())
+        ->toBe($transactionLevel);
 });


### PR DESCRIPTION
This PR prevents Filament from catching any exceptions resulting in side-effects _after an already committed transaction_. Previously, these side-effects were still part of the `try/catch` blocks and therefore their exceptions could be catched, and triggering an extra rollback. That would cause the following flow to happen: `begin transaction` + `commit` + `rollback`.

I have also added a test in which you can observe the behavior. 