### PR TITLE
fix: $defaultImageUrl not loading when getImageUrl() is null

### DIFF
--- a/packages/infolists/resources/views/components/image-entry.blade.php
+++ b/packages/infolists/resources/views/components/image-entry.blade.php
@@ -98,7 +98,7 @@
             >
                 @foreach ($limitedState as $stateItem)
                     <img
-                        src="{{ filled($stateItem) ? $getImageUrl($stateItem) : $defaultImageUrl }}"
+                        src="{{ filled($stateItem) ? ($getImageUrl($stateItem) ?? $defaultImageUrl) : $defaultImageUrl }}"
                         {{
                             $getExtraImgAttributeBag()
                                 ->class([

--- a/packages/tables/resources/views/columns/image-column.blade.php
+++ b/packages/tables/resources/views/columns/image-column.blade.php
@@ -84,7 +84,7 @@
             >
                 @foreach ($limitedState as $stateItem)
                     <img
-                        src="{{ filled($stateItem) ? $getImageUrl($stateItem) : $defaultImageUrl }}"
+                        src="{{ filled($stateItem) ? ($getImageUrl($stateItem) ?? $defaultImageUrl) : $defaultImageUrl }}"
                         {{
                             $getExtraImgAttributeBag()
                                 ->class([


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
ImageEntry and ImageColumn documentation states that defaultImageUrl() is a method for displaying a placeholder image if one doesn't exist yet.

But If $stateItem is a filled string that points to a location that does not exist in storage then getImageUrl() will return null due to the file not existing and by doing so no image is loaded into the browser even though we set a default placeholder.

So by using the ?? operator in the branch where string is filled we make sure the browser loads an image whether it's the placeholder or the storage one.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Sources
- https://filamentphp.com/docs/3.x/tables/columns/image#adding-a-default-image-url
- https://filamentphp.com/docs/3.x/infolists/entries/image#adding-a-default-image-url

## Visual changes
### \Filament\Tables\Columns\ImageColumn;

| Before | After |
|----------|----------|
| ![before-column](https://github.com/user-attachments/assets/8b304705-1c7c-46e9-b383-d4c64b5e9d57)    | ![after-column](https://github.com/user-attachments/assets/2b0f9816-3c74-4850-bee6-ba150e962a25) |

### \Filament\Infolists\Components\ImageEntry

| Before | After |
|----------|----------|
| ![before-infolist](https://github.com/user-attachments/assets/fd3bb9bf-73c1-4b42-9879-4569570330c2) | ![after-infolist](https://github.com/user-attachments/assets/f4dae766-71b8-495a-86cc-ef78814987ac) |

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [✔] Code style has been fixed by running the `composer cs` command.
- [✔] Changes have been tested to not break existing functionality.
- [✔] Documentation is up-to-date.
