### PR TITLE
Docs V4 - Tabs

### DIFF
--- a/docs-assets/app/app/Livewire/Schemas/LayoutDemo.php
+++ b/docs-assets/app/app/Livewire/Schemas/LayoutDemo.php
@@ -175,6 +175,31 @@ class LayoutDemo extends Component implements HasActions, HasSchemas
                             ]),
                     ]),
                 Group::make()
+                    ->id('tabsBadgesColor')
+                    ->extraAttributes([
+                        'class' => 'p-16 max-w-2xl',
+                    ])
+                    ->schema([
+                        Tabs::make('Tabs')
+                            ->statePath('tabsBadgesColor')
+                            ->schema([
+                                Tab::make('Notifications')
+                                    ->badge(5)
+                                    ->badgeColor('info')
+                                    ->schema([
+                                        Checkbox::make('enabled')
+                                            ->default(true),
+                                        Select::make('frequency')
+                                            ->default('hourly')
+                                            ->options([
+                                                'hourly' => 'Hourly',
+                                            ]),
+                                    ]),
+                                Tab::make('Security'),
+                                Tab::make('Meta'),
+                            ]),
+                    ]),
+                Group::make()
                     ->id('wizard')
                     ->extraAttributes([
                         'class' => 'p-16 max-w-5xl',

--- a/docs-assets/screenshots/schema.js
+++ b/docs-assets/screenshots/schema.js
@@ -1240,6 +1240,15 @@ export default {
             deviceScaleFactor: 3,
         },
     },
+    'schemas/layout/tabs/badges-color': {
+        url: 'schemas/layout',
+        selector: '#tabsBadgesColor',
+        viewport: {
+            width: 1920,
+            height: 640,
+            deviceScaleFactor: 3,
+        },
+    },
     'schemas/layout/wizard/simple': {
         url: 'schemas/layout',
         selector: '#wizard',

--- a/packages/schemas/docs/04-tabs.md
+++ b/packages/schemas/docs/04-tabs.md
@@ -144,7 +144,7 @@ Tabs::make('Tabs')
     ->tabs([
         Tab::make('Notifications')
             ->badge(5)
-            ->badgeColor('success')
+            ->badgeColor('info')
             ->schema([
                 // ...
             ]),
@@ -153,6 +153,8 @@ Tabs::make('Tabs')
 ```
 
 <UtilityInjection set="schemaComponents" version="4.x">As well as allowing a static value, the `badgeColor()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+
+<AutoScreenshot name="schemas/layout/tabs/badges-color" alt="Tabs with badges with color" version="4.x" />
 
 ## Using grid columns within a tab
 
@@ -259,7 +261,7 @@ Tabs::make('Tabs')
     ->persistTabInQueryString()
 ```
 
-By default, the current tab is persisted in the URL's query string using the `tab` key. You can change this key by passing it to the `persistTabInQueryString()` method:
+When enabled, the current tab is persisted in the URL's query string using the `tab` key. You can change this key by passing it to the `persistTabInQueryString()` method:
 
 ```php
 use Filament\Schemas\Components\Tabs;


### PR DESCRIPTION
Added a badge color screenshot to be consistent with other places like icons-after. I also changed the badge color to info instead of success. For people like me that some degree of colorblindness the difference between amber and green isn't large enough to make it immediately perceptible that there was a change. Going to blue should make the color change more obvious. 