### PR TITLE
Fix broken XLSX exports

### DIFF
--- a/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
+++ b/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
@@ -25,7 +25,10 @@ class XlsxDownloader implements Downloader
 
         if ($disk->exists($filePath = $directory . DIRECTORY_SEPARATOR . $fileName)) {
             $response = $disk->download($filePath);
-            ob_end_clean();
+
+            if (ob_get_length() > 0) {
+                ob_end_clean();
+            }
 
             return $response;
         }


### PR DESCRIPTION
## Description

https://github.com/filamentphp/filament/pull/15792 added a `ob_end_clean()` call in [packages/actions/src/Exports/Downloaders/XlsxDownloader.php](https://github.com/filamentphp/filament/pull/15792/files/899ab4e3227c75de0b5f485318c55cc9398cc307#diff-7d8aad09ad3b6c26fe7592d9638f99a297cfee786f82b5e4b23b9a36e47c0fbc) based on a reported extra space being added to XSLX exports.

I have never encountered this and have been using Exports since their release, nor can I see a reported issue. It could be that the author of the PR had an extra space in their code as explained here (https://www.php.net/manual/en/function.ob-clean.php#110905):

> Don't use ob_clean() to clear white-space or other unwanted content "accidentally" generated by included files.
> Included files should not generate unwanted content in the first place.
> If they do, You are doing something wrong, like inserting white-space after "?>" (there should not be a "?>" at the end of PHP files: http://php.net/manual/en/language.basic-syntax.phptags.php ).

## Solution
To prevent an `ErrorException`: "ob_end_clean(): Failed to delete buffer. No buffer to delete", I've wrapped the call in a condition to first check that there is a buffer to clear.

Unless otherwise reported, I'd suggest the PR be reverted.

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
