### PR TITLE
In a wizard, prevent users from pressing the 'Next' button rapidly and skipping steps while the live form is still loading

### DIFF
--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -293,6 +293,7 @@
                 "
             @endif
             x-bind:class="{ 'hidden': isLastStep(), 'block': ! isLastStep() }"
+            wire:loading.class="opacity-50 pointer-events-none"
         >
             {{ $nextAction }}
         </span>

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -293,7 +293,7 @@
                 "
             @endif
             x-bind:class="{ 'hidden': isLastStep(), 'block': ! isLastStep() }"
-            wire:loading.class="pointer-events-none"
+            wire:loading.class="pointer-events-none opacity-70"
         >
             {{ $nextAction }}
         </span>

--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -293,7 +293,7 @@
                 "
             @endif
             x-bind:class="{ 'hidden': isLastStep(), 'block': ! isLastStep() }"
-            wire:loading.class="opacity-50 pointer-events-none"
+            wire:loading.class="pointer-events-none"
         >
             {{ $nextAction }}
         </span>

--- a/tests/src/Panels/Resources/Pages/EditRecordTest.php
+++ b/tests/src/Panels/Resources/Pages/EditRecordTest.php
@@ -117,7 +117,7 @@ test('actions will not interfere with database transactions on an error', functi
     $transactionLevel = DB::transactionLevel();
 
     try {
-        livewire(PostResource\Pages\EditPost::class, [
+        livewire(EditPost::class, [
             'record' => $post->getKey(),
         ])
             ->callAction('randomize_title');

--- a/tests/src/Panels/Resources/Pages/ListRecordsTest.php
+++ b/tests/src/Panels/Resources/Pages/ListRecordsTest.php
@@ -123,7 +123,7 @@ test('table actions will not interfere with database transactions on an error', 
     $transactionLevel = DB::transactionLevel();
 
     try {
-        livewire(PostResource\Pages\ListPosts::class)
+        livewire(ListPosts::class)
             ->callTableAction('randomize_title', $post);
     } catch (Exception $e) {
         // This can be catched and handled somewhere else, code continues...


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

In a Wizard page preventing to press Next button rapidly and skipping steps when in form there is live() form.
Without this user can click next button rapidly and skip mandatory steps without validation.

## Visual changes

Disabling Next button when live() is working

## Functional changes

No change

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
