### PR TITLE
Widget command livewire path solution(adjustment)

### DIFF
--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -163,7 +163,11 @@ class MakeWidgetCommand extends Command
 
         $path = (string) str($widget)
             ->prepend('/')
-            ->prepend($resource === null ? $path : "{$resourcePath}\\{$resource}\\Widgets\\")
+            ->prepend(
+                ! $panel 
+                    ? app_path('Livewire/')  // Always use Livewire path when no panel is selected
+                    : ($resource === null ? $path : "{$resourcePath}\\{$resource}\\Widgets\\")
+            )
             ->replace('\\', '/')
             ->replace('//', '/')
             ->append('.php');

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -164,7 +164,7 @@ class MakeWidgetCommand extends Command
         $path = (string) str($widget)
             ->prepend('/')
             ->prepend(
-                ! $panel 
+                ! $panel
                     ? app_path('Livewire/')  // Always use Livewire path when no panel is selected
                     : ($resource === null ? $path : "{$resourcePath}\\{$resource}\\Widgets\\")
             )

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -203,10 +203,10 @@ class MakeWidgetCommand extends Command
 
             $this->copyStubToApp('ChartWidget', $path, [
                 'class' => $widgetClass,
-                'namespace' => ! $panel 
+                'namespace' => ! $panel
                     ? $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')
-                    : (filled($resource) 
-                        ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') 
+                    : (filled($resource)
+                        ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')
                         : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')),
                 'type' => match ($chartType) {
                     'Bar chart' => 'bar',
@@ -222,28 +222,28 @@ class MakeWidgetCommand extends Command
         } elseif ($type === 'Stats overview') {
             $this->copyStubToApp('StatsOverviewWidget', $path, [
                 'class' => $widgetClass,
-                'namespace' => ! $panel 
+                'namespace' => ! $panel
                     ? $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')
-                    : (filled($resource) 
-                        ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') 
+                    : (filled($resource)
+                        ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')
                         : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')),
             ]);
         } elseif ($type === 'Table') {
             $this->copyStubToApp('TableWidget', $path, [
                 'class' => $widgetClass,
-                'namespace' => ! $panel 
+                'namespace' => ! $panel
                     ? $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')
-                    : (filled($resource) 
-                        ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') 
+                    : (filled($resource)
+                        ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')
                         : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')),
             ]);
         } else {
             $this->copyStubToApp('Widget', $path, [
                 'class' => $widgetClass,
-                'namespace' => ! $panel 
+                'namespace' => ! $panel
                     ? $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')
-                    : (filled($resource) 
-                        ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') 
+                    : (filled($resource)
+                        ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')
                         : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')),
                 'view' => $view,
             ]);

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -203,7 +203,11 @@ class MakeWidgetCommand extends Command
 
             $this->copyStubToApp('ChartWidget', $path, [
                 'class' => $widgetClass,
-                'namespace' => filled($resource) ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : ''),
+                'namespace' => ! $panel 
+                    ? $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')
+                    : (filled($resource) 
+                        ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') 
+                        : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')),
                 'type' => match ($chartType) {
                     'Bar chart' => 'bar',
                     'Bubble chart' => 'bubble',
@@ -218,17 +222,29 @@ class MakeWidgetCommand extends Command
         } elseif ($type === 'Stats overview') {
             $this->copyStubToApp('StatsOverviewWidget', $path, [
                 'class' => $widgetClass,
-                'namespace' => filled($resource) ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : ''),
+                'namespace' => ! $panel 
+                    ? $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')
+                    : (filled($resource) 
+                        ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') 
+                        : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')),
             ]);
         } elseif ($type === 'Table') {
             $this->copyStubToApp('TableWidget', $path, [
                 'class' => $widgetClass,
-                'namespace' => filled($resource) ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : ''),
+                'namespace' => ! $panel 
+                    ? $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')
+                    : (filled($resource) 
+                        ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') 
+                        : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')),
             ]);
         } else {
             $this->copyStubToApp('Widget', $path, [
                 'class' => $widgetClass,
-                'namespace' => filled($resource) ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : ''),
+                'namespace' => ! $panel 
+                    ? $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')
+                    : (filled($resource) 
+                        ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') 
+                        : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '')),
                 'view' => $view,
             ]);
 

--- a/tests/src/Commands/WidgetCommandLivewireTest.php
+++ b/tests/src/Commands/WidgetCommandLivewireTest.php
@@ -7,22 +7,25 @@ use Illuminate\Support\Facades\File;
 
 use function Pest\Laravel\artisan;
 
-uses(TestCase::class)
-    ->group('integration')
-    ->beforeEach(function () {
-        File::deleteDirectory($this->app->basePath('app/Livewire'));
-    });
+uses(TestCase::class);
 
-it('can create a table widget in livewire directory', function () {
+test('can create a table widget in livewire directory', function () {
+    $widgetPath = $this->app->basePath('app/Livewire/TestWidget.php');
+    
+    if (file_exists($widgetPath)) {
+        unlink($widgetPath);
+    }
+
+    expect(file_exists($widgetPath))->toBeFalse();
+
     artisan('make:filament-widget', [
         'name' => 'TestWidget',
         '--force' => true,
-        '--resource' => 'InvoiceResource',
     ])
         ->expectsQuestion('What type of widget do you want to create?', 'Table')
+        ->expectsQuestion('What is the resource you would like to create this in?', '')
         ->expectsQuestion('Where would you like to create this?', 'App\\Livewire alongside other Livewire components')
         ->assertSuccessful();
 
-    $widgetPath = $this->app->basePath('app/Livewire/TestWidget.php');
     expect(file_exists($widgetPath))->toBeTrue();
 });

--- a/tests/src/Commands/WidgetCommandLivewireTest.php
+++ b/tests/src/Commands/WidgetCommandLivewireTest.php
@@ -3,8 +3,9 @@
 namespace Filament\Tests\Commands;
 
 use Filament\Tests\TestCase;
-use function Pest\Laravel\artisan;
 use Illuminate\Support\Facades\File;
+
+use function Pest\Laravel\artisan;
 
 uses(TestCase::class)
     ->group('integration')

--- a/tests/src/Commands/WidgetCommandLivewireTest.php
+++ b/tests/src/Commands/WidgetCommandLivewireTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Filament\Tests\Commands;
+
+use Filament\Tests\TestCase;
+use function Pest\Laravel\artisan;
+use Illuminate\Support\Facades\File;
+
+uses(TestCase::class)
+    ->group('integration')
+    ->beforeEach(function () {
+        File::deleteDirectory($this->app->basePath('app/Livewire'));
+    });
+
+it('can create a table widget in livewire directory', function () {
+    artisan('make:filament-widget', [
+        'name' => 'TestWidget',
+        '--force' => true,
+        '--resource' => 'InvoiceResource',
+    ])
+        ->expectsQuestion('What type of widget do you want to create?', 'Table')
+        ->expectsQuestion('Where would you like to create this?', 'App\\Livewire alongside other Livewire components')
+        ->assertSuccessful();
+
+    $widgetPath = $this->app->basePath('app/Livewire/TestWidget.php');
+    expect(file_exists($widgetPath))->toBeTrue();
+});

--- a/tests/src/Commands/WidgetCommandLivewireTest.php
+++ b/tests/src/Commands/WidgetCommandLivewireTest.php
@@ -3,7 +3,6 @@
 namespace Filament\Tests\Commands;
 
 use Filament\Tests\TestCase;
-use Illuminate\Support\Facades\File;
 
 use function Pest\Laravel\artisan;
 
@@ -11,7 +10,7 @@ uses(TestCase::class);
 
 test('can create a table widget in livewire directory', function () {
     $widgetPath = $this->app->basePath('app/Livewire/TestWidget.php');
-    
+
     if (file_exists($widgetPath)) {
         unlink($widgetPath);
     }

--- a/tests/src/Panels/Resources/Pages/EditRecordTest.php
+++ b/tests/src/Panels/Resources/Pages/EditRecordTest.php
@@ -117,7 +117,7 @@ test('actions will not interfere with database transactions on an error', functi
     $transactionLevel = DB::transactionLevel();
 
     try {
-        livewire(PostResource\Pages\EditPost::class, [
+        livewire(EditPost::class, [
             'record' => $post->getKey(),
         ])
             ->callAction('randomize_title');

--- a/tests/src/Panels/Resources/Pages/ListRecordsTest.php
+++ b/tests/src/Panels/Resources/Pages/ListRecordsTest.php
@@ -123,7 +123,7 @@ test('table actions will not interfere with database transactions on an error', 
     $transactionLevel = DB::transactionLevel();
 
     try {
-        livewire(PostResource\Pages\ListPosts::class)
+        livewire(ListPosts::class)
             ->callTableAction('randomize_title', $post);
     } catch (Exception $e) {
         // This can be catched and handled somewhere else, code continues...


### PR DESCRIPTION
Hello.

This is a modification/adjustment to my PR Solution [https://github.com/filamentphp/filament/pull/15871](url) to the issue [https://github.com/filamentphp/filament/issues/14637](url)

### **Description**

When the `make:filament-widget` command is run to create a new widget and the resource is provided and when the user selects `[App\Livewire] alongside other Livewire components` after selecting `Table` from the first prompt, a file permission error was thrown and the directory was not being created. The solution now creates a new file `TestWidget.php` within the `app/Livewire` directory when it's prompted by the user. I've fixed the problems in the initial solution by modifying the `MakeWidgetCommand.php` and also the test `WidgetCommandLivewireTest.php` according to the `v4` coding style.

### **Visual Changes:**

**Before the Solution:**

<img width="855" alt="filament-widget-livewire-path-issue" src="https://github.com/user-attachments/assets/5b35ea0f-7816-4ae0-a192-8dc51f159ea6" />

### **After the Solution:**

<img width="728" alt="filament-widget-livewire-path-solution" src="https://github.com/user-attachments/assets/97abc9c0-22e3-4f37-ad32-fff05c1f1ad5" />

### **Functional Changes:**

I've fixed the style with the composer cs command, the file changes have been tested.
