### PR TITLE
Add support for page-specific relation managers with policy enforcement

### DIFF
--- a/packages/panels/docs/03-resources/05-viewing-records.md
+++ b/packages/panels/docs/03-resources/05-viewing-records.md
@@ -1,7 +1,6 @@
 ---
 title: Viewing records
 ---
-
 import LaracastsBanner from "@components/LaracastsBanner.astro"
 
 ## Creating a resource with a View page
@@ -15,15 +14,13 @@ php artisan make:filament-resource User --view
 ## Using an infolist instead of a disabled form
 
 <LaracastsBanner
-title="Infolists"
-description="Watch the Rapid Laravel Development with Filament series on Laracasts - it will teach you the basics of
-adding infolists to Filament resources."
-url="https://laracasts.com/series/rapid-laravel-development-with-filament/episodes/12"
-series="rapid-laravel-development"
+    title="Infolists"
+    description="Watch the Rapid Laravel Development with Filament series on Laracasts - it will teach you the basics of adding infolists to Filament resources."
+    url="https://laracasts.com/series/rapid-laravel-development-with-filament/episodes/12"
+    series="rapid-laravel-development"
 />
 
-By default, the View page will display a disabled form with the record's data. If you preferred to display the record's
-data in an "infolist", you can define an `infolist()` method on the resource class:
+By default, the View page will display a disabled form with the record's data. If you preferred to display the record's data in an "infolist", you can define an `infolist()` method on the resource class:
 
 ```php
 use Filament\Infolists;
@@ -41,10 +38,7 @@ public static function infolist(Infolist $infolist): Infolist
 }
 ```
 
-The `schema()` method is used to define the structure of your infolist. It is an array
-of [entries](../../infolists/entries/getting-started#available-entries)
-and [layout components](../../infolists/layout/getting-started#available-layout-components), in the order they should
-appear in your infolist.
+The `schema()` method is used to define the structure of your infolist. It is an array of [entries](../../infolists/entries/getting-started#available-entries) and [layout components](../../infolists/layout/getting-started#available-layout-components), in the order they should appear in your infolist.
 
 Check out the Infolists docs for a [guide](../../infolists/getting-started) on how to build infolists with Filament.
 
@@ -72,8 +66,7 @@ public static function getPages(): array
 
 ## Viewing records in modals
 
-If your resource is simple, you may wish to view records in modals rather than on the [View page](viewing-records). If
-this is the case, you can just [delete the view page](getting-started#deleting-resource-pages).
+If your resource is simple, you may wish to view records in modals rather than on the [View page](viewing-records). If this is the case, you can just [delete the view page](getting-started#deleting-resource-pages).
 
 If your resource doesn't contain a `ViewAction`, you can add one to the `$table->actions()` array:
 
@@ -96,9 +89,7 @@ public static function table(Table $table): Table
 
 ## Customizing data before filling the form
 
-You may wish to modify the data from a record before it is filled into the form. To do this, you may define a
-`mutateFormDataBeforeFill()` method on the View page class to modify the `$data` array, and return the modified version
-before it is filled into the form:
+You may wish to modify the data from a record before it is filled into the form. To do this, you may define a `mutateFormDataBeforeFill()` method on the View page class to modify the `$data` array, and return the modified version before it is filled into the form:
 
 ```php
 protected function mutateFormDataBeforeFill(array $data): array
@@ -109,13 +100,11 @@ protected function mutateFormDataBeforeFill(array $data): array
 }
 ```
 
-Alternatively, if you're viewing records in a modal action, check out
-the [Actions documentation](../../actions/prebuilt-actions/view#customizing-data-before-filling-the-form).
+Alternatively, if you're viewing records in a modal action, check out the [Actions documentation](../../actions/prebuilt-actions/view#customizing-data-before-filling-the-form).
 
 ## Lifecycle hooks
 
-Hooks may be used to execute code at various points within a page's lifecycle, like before a form is filled. To set up a
-hook, create a protected method on the View page class with the name of the hook:
+Hooks may be used to execute code at various points within a page's lifecycle, like before a form is filled. To set up a hook, create a protected method on the View page class with the name of the hook:
 
 ```php
 use Filament\Resources\Pages\ViewRecord;
@@ -138,17 +127,13 @@ class ViewUser extends ViewRecord
 
 ## Authorization
 
-For authorization, Filament will observe any [model policies](https://laravel.com/docs/authorization#creating-policies)
-that are registered in your app.
+For authorization, Filament will observe any [model policies](https://laravel.com/docs/authorization#creating-policies) that are registered in your app.
 
 Users may access the View page if the `view()` method of the model policy returns `true`.
 
 ## Creating another View page
 
-One View page may not be enough space to allow users to navigate a lot of information. You can create as many View pages
-for a resource as you want. This is especially useful if you are
-using [resource sub-navigation](getting-started#resource-sub-navigation), as you are then easily able to switch between
-the different View pages.
+One View page may not be enough space to allow users to navigate a lot of information. You can create as many View pages for a resource as you want. This is especially useful if you are using [resource sub-navigation](getting-started#resource-sub-navigation), as you are then easily able to switch between the different View pages.
 
 To create a View page, you should use the `make:filament-page` command:
 
@@ -171,8 +156,7 @@ public static function getPages(): array
 }
 ```
 
-Now, you can define the `infolist()` or `form()` for this page, which can contain other components that are not present
-on the main View page:
+Now, you can define the `infolist()` or `form()` for this page, which can contain other components that are not present on the main View page:
 
 ```php
 use Filament\Infolists\Infolist;
@@ -186,49 +170,9 @@ public function infolist(Infolist $infolist): Infolist
 }
 ```
 
-## Customizing relation managers for a specific view page
-
-You can specify which relation managers should appear on a view page by defining a `getRelations()` method:
-
-```php
-protected function getRelations(): array
-{
-    return [
-        CustomerAddressesRelationManager::class,
-        CustomerContactsRelationManager::class,
-    ];
-}
-```
-
-This is useful when you have [multiple view pages](#creating-another-view-page) and need different relation managers on
-each page:
-
-```php
-// ViewCustomer.php
-protected function getRelations(): array
-{
-    return [
-        RelationManagers\OrdersRelationManager::class,
-        RelationManagers\SubscriptionsRelationManager::class,
-    ];
-}
-
-// ViewCustomerContact.php 
-protected function getRelations(): array
-{
-    return [
-        RelationManagers\ContactsRelationManager::class,
-        RelationManagers\AddressesRelationManager::class,
-    ];
-}
-```
-
-If `getRelations()` isn't defined or returns an empty array, any relation managers defined in the resource will be used.
-
 ## Adding view pages to resource sub-navigation
 
-If you're using [resource sub-navigation](getting-started#resource-sub-navigation), you can register this page as normal
-in `getRecordSubNavigation()` of the resource:
+If you're using [resource sub-navigation](getting-started#resource-sub-navigation), you can register this page as normal in `getRecordSubNavigation()` of the resource:
 
 ```php
 use App\Filament\Resources\CustomerResource\Pages;
@@ -245,8 +189,7 @@ public static function getRecordSubNavigation(Page $page): array
 
 ## Custom view
 
-For further customization opportunities, you can override the static `$view` property on the page class to a custom view
-in your app:
+For further customization opportunities, you can override the static `$view` property on the page class to a custom view in your app:
 
 ```php
 protected static string $view = 'filament.resources.users.pages.view-user';
@@ -275,5 +218,4 @@ Here's a basic example of what that view might contain:
 </x-filament-panels::page>
 ```
 
-To see everything that the default view contains, you can check the
-`vendor/filament/filament/resources/views/resources/pages/view-record.blade.php` file in your project.
+To see everything that the default view contains, you can check the `vendor/filament/filament/resources/views/resources/pages/view-record.blade.php` file in your project.

--- a/packages/panels/docs/03-resources/05-viewing-records.md
+++ b/packages/panels/docs/03-resources/05-viewing-records.md
@@ -172,10 +172,10 @@ public function infolist(Infolist $infolist): Infolist
 
 ## Customizing relation managers for a specific view page
 
-You can specify which relation managers should appear on a view page by defining a `getRelations()` method:
+You can specify which relation managers should appear on a view page by defining a `getAllRelationManagers()` method:
 
 ```php
-protected function getRelations(): array
+protected function getAllRelationManagers(): array
 {
     return [
         CustomerAddressesRelationManager::class,
@@ -189,7 +189,7 @@ each page:
 
 ```php
 // ViewCustomer.php
-protected function getRelations(): array
+protected function getAllRelationManagers(): array
 {
     return [
         RelationManagers\OrdersRelationManager::class,
@@ -198,7 +198,7 @@ protected function getRelations(): array
 }
 
 // ViewCustomerContact.php 
-protected function getRelations(): array
+protected function getAllRelationManagers(): array
 {
     return [
         RelationManagers\ContactsRelationManager::class,
@@ -207,7 +207,7 @@ protected function getRelations(): array
 }
 ```
 
-If `getRelations()` isn't defined or returns an empty array, any relation managers defined in the resource will be used.
+If `getAllRelationManagers` isn't defined or returns an empty array, any relation managers defined in the resource will be used.
 
 ## Adding view pages to resource sub-navigation
 

--- a/packages/panels/docs/03-resources/05-viewing-records.md
+++ b/packages/panels/docs/03-resources/05-viewing-records.md
@@ -1,6 +1,7 @@
 ---
 title: Viewing records
 ---
+
 import LaracastsBanner from "@components/LaracastsBanner.astro"
 
 ## Creating a resource with a View page
@@ -14,13 +15,15 @@ php artisan make:filament-resource User --view
 ## Using an infolist instead of a disabled form
 
 <LaracastsBanner
-    title="Infolists"
-    description="Watch the Rapid Laravel Development with Filament series on Laracasts - it will teach you the basics of adding infolists to Filament resources."
-    url="https://laracasts.com/series/rapid-laravel-development-with-filament/episodes/12"
-    series="rapid-laravel-development"
+title="Infolists"
+description="Watch the Rapid Laravel Development with Filament series on Laracasts - it will teach you the basics of
+adding infolists to Filament resources."
+url="https://laracasts.com/series/rapid-laravel-development-with-filament/episodes/12"
+series="rapid-laravel-development"
 />
 
-By default, the View page will display a disabled form with the record's data. If you preferred to display the record's data in an "infolist", you can define an `infolist()` method on the resource class:
+By default, the View page will display a disabled form with the record's data. If you preferred to display the record's
+data in an "infolist", you can define an `infolist()` method on the resource class:
 
 ```php
 use Filament\Infolists;
@@ -38,7 +41,10 @@ public static function infolist(Infolist $infolist): Infolist
 }
 ```
 
-The `schema()` method is used to define the structure of your infolist. It is an array of [entries](../../infolists/entries/getting-started#available-entries) and [layout components](../../infolists/layout/getting-started#available-layout-components), in the order they should appear in your infolist.
+The `schema()` method is used to define the structure of your infolist. It is an array
+of [entries](../../infolists/entries/getting-started#available-entries)
+and [layout components](../../infolists/layout/getting-started#available-layout-components), in the order they should
+appear in your infolist.
 
 Check out the Infolists docs for a [guide](../../infolists/getting-started) on how to build infolists with Filament.
 
@@ -66,7 +72,8 @@ public static function getPages(): array
 
 ## Viewing records in modals
 
-If your resource is simple, you may wish to view records in modals rather than on the [View page](viewing-records). If this is the case, you can just [delete the view page](getting-started#deleting-resource-pages).
+If your resource is simple, you may wish to view records in modals rather than on the [View page](viewing-records). If
+this is the case, you can just [delete the view page](getting-started#deleting-resource-pages).
 
 If your resource doesn't contain a `ViewAction`, you can add one to the `$table->actions()` array:
 
@@ -89,7 +96,9 @@ public static function table(Table $table): Table
 
 ## Customizing data before filling the form
 
-You may wish to modify the data from a record before it is filled into the form. To do this, you may define a `mutateFormDataBeforeFill()` method on the View page class to modify the `$data` array, and return the modified version before it is filled into the form:
+You may wish to modify the data from a record before it is filled into the form. To do this, you may define a
+`mutateFormDataBeforeFill()` method on the View page class to modify the `$data` array, and return the modified version
+before it is filled into the form:
 
 ```php
 protected function mutateFormDataBeforeFill(array $data): array
@@ -100,11 +109,13 @@ protected function mutateFormDataBeforeFill(array $data): array
 }
 ```
 
-Alternatively, if you're viewing records in a modal action, check out the [Actions documentation](../../actions/prebuilt-actions/view#customizing-data-before-filling-the-form).
+Alternatively, if you're viewing records in a modal action, check out
+the [Actions documentation](../../actions/prebuilt-actions/view#customizing-data-before-filling-the-form).
 
 ## Lifecycle hooks
 
-Hooks may be used to execute code at various points within a page's lifecycle, like before a form is filled. To set up a hook, create a protected method on the View page class with the name of the hook:
+Hooks may be used to execute code at various points within a page's lifecycle, like before a form is filled. To set up a
+hook, create a protected method on the View page class with the name of the hook:
 
 ```php
 use Filament\Resources\Pages\ViewRecord;
@@ -127,13 +138,17 @@ class ViewUser extends ViewRecord
 
 ## Authorization
 
-For authorization, Filament will observe any [model policies](https://laravel.com/docs/authorization#creating-policies) that are registered in your app.
+For authorization, Filament will observe any [model policies](https://laravel.com/docs/authorization#creating-policies)
+that are registered in your app.
 
 Users may access the View page if the `view()` method of the model policy returns `true`.
 
 ## Creating another View page
 
-One View page may not be enough space to allow users to navigate a lot of information. You can create as many View pages for a resource as you want. This is especially useful if you are using [resource sub-navigation](getting-started#resource-sub-navigation), as you are then easily able to switch between the different View pages.
+One View page may not be enough space to allow users to navigate a lot of information. You can create as many View pages
+for a resource as you want. This is especially useful if you are
+using [resource sub-navigation](getting-started#resource-sub-navigation), as you are then easily able to switch between
+the different View pages.
 
 To create a View page, you should use the `make:filament-page` command:
 
@@ -156,7 +171,8 @@ public static function getPages(): array
 }
 ```
 
-Now, you can define the `infolist()` or `form()` for this page, which can contain other components that are not present on the main View page:
+Now, you can define the `infolist()` or `form()` for this page, which can contain other components that are not present
+on the main View page:
 
 ```php
 use Filament\Infolists\Infolist;
@@ -170,9 +186,49 @@ public function infolist(Infolist $infolist): Infolist
 }
 ```
 
+## Customizing relation managers for a specific view page
+
+You can specify which relation managers should appear on a view page by defining a `getRelations()` method:
+
+```php
+protected function getRelations(): array
+{
+    return [
+        CustomerAddressesRelationManager::class,
+        CustomerContactsRelationManager::class,
+    ];
+}
+```
+
+This is useful when you have [multiple view pages](#creating-another-view-page) and need different relation managers on
+each page:
+
+```php
+// ViewCustomer.php
+protected function getRelations(): array
+{
+    return [
+        RelationManagers\OrdersRelationManager::class,
+        RelationManagers\SubscriptionsRelationManager::class,
+    ];
+}
+
+// ViewCustomerContact.php 
+protected function getRelations(): array
+{
+    return [
+        RelationManagers\ContactsRelationManager::class,
+        RelationManagers\AddressesRelationManager::class,
+    ];
+}
+```
+
+If `getRelations()` isn't defined or returns an empty array, any relation managers defined in the resource will be used.
+
 ## Adding view pages to resource sub-navigation
 
-If you're using [resource sub-navigation](getting-started#resource-sub-navigation), you can register this page as normal in `getRecordSubNavigation()` of the resource:
+If you're using [resource sub-navigation](getting-started#resource-sub-navigation), you can register this page as normal
+in `getRecordSubNavigation()` of the resource:
 
 ```php
 use App\Filament\Resources\CustomerResource\Pages;
@@ -189,7 +245,8 @@ public static function getRecordSubNavigation(Page $page): array
 
 ## Custom view
 
-For further customization opportunities, you can override the static `$view` property on the page class to a custom view in your app:
+For further customization opportunities, you can override the static `$view` property on the page class to a custom view
+in your app:
 
 ```php
 protected static string $view = 'filament.resources.users.pages.view-user';
@@ -218,4 +275,5 @@ Here's a basic example of what that view might contain:
 </x-filament-panels::page>
 ```
 
-To see everything that the default view contains, you can check the `vendor/filament/filament/resources/views/resources/pages/view-record.blade.php` file in your project.
+To see everything that the default view contains, you can check the
+`vendor/filament/filament/resources/views/resources/pages/view-record.blade.php` file in your project.

--- a/packages/panels/docs/03-resources/05-viewing-records.md
+++ b/packages/panels/docs/03-resources/05-viewing-records.md
@@ -170,6 +170,45 @@ public function infolist(Infolist $infolist): Infolist
 }
 ```
 
+## Customizing relation managers for a specific view page
+
+You can specify which relation managers should appear on a view page by defining a `getRelations()` method:
+
+```php
+protected function getRelations(): array
+{
+    return [
+        CustomerAddressesRelationManager::class,
+        CustomerContactsRelationManager::class,
+    ];
+}
+```
+
+This is useful when you have [multiple view pages](#creating-another-view-page) and need different relation managers on
+each page:
+
+```php
+// ViewCustomer.php
+protected function getRelations(): array
+{
+    return [
+        RelationManagers\OrdersRelationManager::class,
+        RelationManagers\SubscriptionsRelationManager::class,
+    ];
+}
+
+// ViewCustomerContact.php 
+protected function getRelations(): array
+{
+    return [
+        RelationManagers\ContactsRelationManager::class,
+        RelationManagers\AddressesRelationManager::class,
+    ];
+}
+```
+
+If `getRelations()` isn't defined or returns an empty array, any relation managers defined in the resource will be used.
+
 ## Adding view pages to resource sub-navigation
 
 If you're using [resource sub-navigation](getting-started#resource-sub-navigation), you can register this page as normal in `getRecordSubNavigation()` of the resource:

--- a/packages/panels/docs/03-resources/05-viewing-records.md
+++ b/packages/panels/docs/03-resources/05-viewing-records.md
@@ -207,7 +207,7 @@ protected function getAllRelationManagers(): array
 }
 ```
 
-If `getAllRelationManagers` isn't defined or returns an empty array, any relation managers defined in the resource will be used.
+If `getAllRelationManagers()` isn't defined, any relation managers defined in the resource will be used.
 
 ## Adding view pages to resource sub-navigation
 

--- a/packages/panels/src/Resources/Pages/Concerns/HasRelationManagers.php
+++ b/packages/panels/src/Resources/Pages/Concerns/HasRelationManagers.php
@@ -16,9 +16,9 @@ trait HasRelationManagers
     /**
      * @return array<class-string<RelationManager> | RelationGroup | RelationManagerConfiguration>
      */
-    protected function getRelations(): array
+    protected function getAllRelationManagers(): array
     {
-        return [];
+        return $this->getResource()::getRelations();
     }
 
     /**
@@ -26,9 +26,7 @@ trait HasRelationManagers
      */
     public function getRelationManagers(): array
     {
-        $managers = filled($relations = $this->getRelations())
-            ? $relations
-            : $this->getResource()::getRelations();
+        $managers = $this->getAllRelationManagers();
 
         return array_filter(
             $managers,

--- a/packages/panels/src/Resources/Pages/Concerns/HasRelationManagers.php
+++ b/packages/panels/src/Resources/Pages/Concerns/HasRelationManagers.php
@@ -16,19 +16,9 @@ trait HasRelationManagers
     /**
      * @return array<class-string<RelationManager> | RelationGroup | RelationManagerConfiguration>
      */
-    protected function getRelations(): array
-    {
-        return [];
-    }
-
-    /**
-     * @return array<class-string<RelationManager> | RelationGroup | RelationManagerConfiguration>
-     */
     public function getRelationManagers(): array
     {
-        $managers = filled($relations = $this->getRelations())
-            ? $relations
-            : $this->getResource()::getRelations();
+        $managers = $this->getResource()::getRelations();
 
         return array_filter(
             $managers,

--- a/packages/panels/src/Resources/Pages/Concerns/HasRelationManagers.php
+++ b/packages/panels/src/Resources/Pages/Concerns/HasRelationManagers.php
@@ -16,9 +16,19 @@ trait HasRelationManagers
     /**
      * @return array<class-string<RelationManager> | RelationGroup | RelationManagerConfiguration>
      */
+    protected function getRelations(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<class-string<RelationManager> | RelationGroup | RelationManagerConfiguration>
+     */
     public function getRelationManagers(): array
     {
-        $managers = $this->getResource()::getRelations();
+        $managers = filled($relations = $this->getRelations())
+            ? $relations
+            : $this->getResource()::getRelations();
 
         return array_filter(
             $managers,


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
This PR introduces a new `getRelations()` method for ViewRecord or EditRecord pages that allows developers to specify page-specific relation managers while maintaining proper policy enforcement.

## Current Situation
Currently, developers who want to customize relation managers for specific ViewRecord pages often override the `getRelationManagers()` method directly. While this works functionally, it inadvertently bypasses the policy checks from `canViewForRecord()` that would normally be applied.

## Enhancement
This PR adds:
- A new protected `getRelations()` method
- Updated logic in `getRelationManagers()` to use relation managers from `getRelations()` when available, while still applying proper policy filters

## Benefits
- Provides a documented, official way to customize relation managers per view page
- Ensures all relation managers respect visibility policies
- Maintains backward compatibility
- Improves security by preventing accidental policy bypasses

## Usage Example
```php
class ViewProject extends ViewRecord
{
    protected function getRelations(): array
    {
        return [
            ProjectUsersRelationManager::class,
            ProjectTasksRelationManager::class,
        ];
    }
}
```

## Migration for existing code
Developers who were previously overriding `getRelationManagers()` directly should update their code to use `getRelations()` instead to benefit from proper policy enforcement.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
