### PR TITLE
Cache cell state to prevent multiple execution of the closure in `state()/getStateUsing()`

### DIFF
--- a/packages/support/src/Concerns/HasCellState.php
+++ b/packages/support/src/Concerns/HasCellState.php
@@ -24,12 +24,10 @@ trait HasCellState
 
     protected ?string $inverseRelationshipName = null;
 
-    protected array $cachedStatePerRecordId = [];
-
-    protected function getRecordId(): mixed
-    {
-        return $this->getRecord()?->getKey();
-    }
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $cachedState = [];
 
     public function inverseRelationship(?string $name): static
     {
@@ -78,12 +76,14 @@ trait HasCellState
 
     public function getState(): mixed
     {
-        if (! $this->getRecord()) {
+        $record = $this->getRecord();
+
+        if (! $record) {
             return null;
         }
 
-        if (array_key_exists($this->getRecordId(), $this->cachedStatePerRecordId)) {
-            return $this->cachedStatePerRecordId[$this->getRecordId()];
+        if (array_key_exists($record->getKey(), $this->cachedState)) {
+            return $this->cachedState[$record->getKey()];
         }
 
         $state = ($this->getStateUsing !== null) ?
@@ -101,9 +101,7 @@ trait HasCellState
             $state = $this->getDefaultState();
         }
 
-        $this->cachedStatePerRecordId[$this->getRecordId()] = $state;
-
-        return $state;
+        return $this->cachedState[$record->getKey()] = $state;
     }
 
     public function getStateFromRecord(): mixed

--- a/packages/support/src/Concerns/HasCellState.php
+++ b/packages/support/src/Concerns/HasCellState.php
@@ -24,6 +24,13 @@ trait HasCellState
 
     protected ?string $inverseRelationshipName = null;
 
+    protected array $cachedStatePerRecordId = [];
+
+    protected function getRecordId(): mixed
+    {
+        return $this->getRecord()?->getKey();
+    }
+
     public function inverseRelationship(?string $name): static
     {
         $this->inverseRelationshipName = $name;
@@ -75,6 +82,10 @@ trait HasCellState
             return null;
         }
 
+        if (array_key_exists($this->getRecordId(), $this->cachedStatePerRecordId)) {
+            return $this->cachedStatePerRecordId[$this->getRecordId()];
+        }
+
         $state = ($this->getStateUsing !== null) ?
             $this->evaluate($this->getStateUsing) :
             $this->getStateFromRecord();
@@ -89,6 +100,8 @@ trait HasCellState
         if (blank($state)) {
             $state = $this->getDefaultState();
         }
+
+        $this->cachedStatePerRecordId[$this->getRecordId()] = $state;
 
         return $state;
     }


### PR DESCRIPTION
## Description

In the table view of a panel, closures in `->state(...)` or `->getStateUsing(...)` get called three times per row, instead of one. This can severely impact performance if the closure is a query that takes time to execute - especially if multiple columns are using this.

The issue was reported here: #14852

Here is a reproduction repository of the issue: https://github.com/robinmoisson/filament-state-bug (relevant code [is here](https://github.com/robinmoisson/filament-state-bug/blob/main/app/Filament/Resources/UserResource.php#L22-L31))

See [this comment](https://github.com/filamentphp/filament/issues/14852#issuecomment-2661140603): the problem is that the state is computed in the `text-column.blade.php` blade template to display the value (which is expected), but it is also computed in the `isClickDisabled` method, which is called twice (it would be called once if not for a blade quirk). This leads to the state closure being called 3 times.

My proposal to fix this is to cache the state upon first computation, as I don't see any easy way of passing the computed state to `isClickDisabled`.

Also I saw after making the change the contributing guide saying I should tag @danharrin to the conversation before implementing the change - apologies! I've been using this fix locally but I'm not familiar with all the filament codebase, let me know if this wouldn't be a good solution.

## Visual changes

From the repro rep, before:
![Screenshot from 2025-03-23 09-40-52](https://github.com/user-attachments/assets/7a10f84a-ad91-4d8c-858e-65a9157013c2)

After:
![Screenshot from 2025-03-23 09-40-49](https://github.com/user-attachments/assets/3b3d00c1-ac10-4319-a3b1-7beaedd677b4)


## Functional changes

The state of each column state is now cached by record key upon first computation.

(For "Changes have been tested to not break existing functionality." below, I ran the tests with `composer test:pest` and there wasn't any issue, let me know if I should test it in a different way)

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
