### PR TITLE
Fix: Add thousands separators to table selection indicators

### DIFF
--- a/packages/tables/resources/views/components/selection/indicator.blade.php
+++ b/packages/tables/resources/views/components/selection/indicator.blade.php
@@ -53,7 +53,7 @@
                 {{-- Make sure the Alpine attributes get re-evaluated after a Livewire request: --}}
                 :wire:key="$this->getId() . 'table.selection.indicator.actions.select-all.' . $allSelectableRecordsCount . '.' . $page"
             >
-                {{ trans_choice('filament-tables::table.selection_indicator.actions.select_all.label', $allSelectableRecordsCount, ['count' => \Illuminate\Support\Number::format($allSelectableRecordsCount)]) }}
+                {{ trans_choice('filament-tables::table.selection_indicator.actions.select_all.label', $allSelectableRecordsCount, ['count' => \Illuminate\Support\Number::format($allSelectableRecordsCount, locale: $locale)]) }}
             </x-filament::link>
 
             <x-filament::link

--- a/packages/tables/resources/views/components/selection/indicator.blade.php
+++ b/packages/tables/resources/views/components/selection/indicator.blade.php
@@ -1,3 +1,7 @@
+@php
+    $locale = app()->getLocale();
+@endphp
+
 @props([
     'allSelectableRecordsCount',
     'deselectAllRecordsAction' => 'deselectAllRecords',
@@ -30,7 +34,7 @@
         <span
             x-text="
                 window.pluralize(@js(__('filament-tables::table.selection_indicator.selected_count')), {{ $selectedRecordsPropertyName }}.length, {
-                    count: {{ $selectedRecordsPropertyName }}.length,
+                    count: new Intl.NumberFormat(@js($locale)).format({{ $selectedRecordsPropertyName }}.length),
                 })
             "
             class="text-sm font-medium leading-6 text-gray-700 dark:text-gray-200"


### PR DESCRIPTION
## Description

Some time ago I noticed that the "select all x" records right button on tables didn't have the thousands separator (https://github.com/filamentphp/filament/pull/14838). But I saw it also happens on the left table selected records indicator as well. So I added the thousands separators too.

It also respects the app locale. I've tested it in English & in Catalan with 10,000 records & with 999 records. It appears to be okay in both languages (haven't tested it using other locales):
| English | Catalan |
|--|--|
| 10,000 | 10.000 |


## Visual changes

#### English:

| Before | After |
|--|--|
| ✅ ![image1](https://github.com/user-attachments/assets/46719705-cdc2-43be-935a-9d528e509b64) | ✅ ![image2](https://github.com/user-attachments/assets/93f421f9-5fde-4655-b8cf-1d6efb0d1d92) |
| ❌ ![image3](https://github.com/user-attachments/assets/9fe40f07-63c3-4314-b276-6ef3b0d5a8b4) | ✅ ![image4](https://github.com/user-attachments/assets/6a15324a-b01c-4176-beb7-45b9510729e3) |

#### Catalan:

| Before | After |
|--|--|
| ❌ ![image5](https://github.com/user-attachments/assets/16652a45-b182-4c43-a9dc-1dde91a0c21e) | ✅ ![image6](https://github.com/user-attachments/assets/7c158fde-70bf-4ce3-8fce-15220239d3bc) |
| ❌ ![image7](https://github.com/user-attachments/assets/95c2b344-06f2-463d-8f3b-55d40ef0e646) | ✅ ![image8](https://github.com/user-attachments/assets/8a2331ab-dd65-44f2-996c-c848842632bc) |


## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
