### PR TITLE
Fix: Better detection of encoding for .csv files

### DIFF
--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -440,7 +440,18 @@ trait CanImportRecords
     protected function detectCsvEncoding(mixed $resource): ?string
     {
         rewind($resource);
-        $contentSample = fread($resource, 8192);
+
+        $lineCount = 0;
+        $contentSample = '';
+
+        while (!feof($resource) && $lineCount < 20) {
+            $line = fgets($resource);
+            if ($line === false) {
+                break;
+            }
+            $contentSample .= $line;
+            $lineCount++;
+        }
 
         // The encoding of a subset should be declared before the encoding of its superset.
         $encodings = [

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -444,11 +444,13 @@ trait CanImportRecords
         $lineCount = 0;
         $contentSample = '';
 
-        while (!feof($resource) && $lineCount < 20) {
+        while ((! feof($resource)) && ($lineCount < 20)) {
             $line = fgets($resource);
+
             if ($line === false) {
                 break;
             }
+
             $contentSample .= $line;
             $lineCount++;
         }

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -439,7 +439,8 @@ trait CanImportRecords
 
     protected function detectCsvEncoding(mixed $resource): ?string
     {
-        $fileHeader = fgets($resource);
+        rewind($resource);
+        $contentSample = fread($resource, 8192);
 
         // The encoding of a subset should be declared before the encoding of its superset.
         $encodings = [
@@ -454,7 +455,7 @@ trait CanImportRecords
         ];
 
         foreach ($encodings as $encoding) {
-            if (! mb_check_encoding($fileHeader, $encoding)) {
+            if (! mb_check_encoding($contentSample, $encoding)) {
                 continue;
             }
 


### PR DESCRIPTION
## Description

When importing a .csv file into Filament, incorrect file encoding can sometimes be detected. This issue occurs because only the header of the file is used to determine the encoding. If the header is short or lacks distinctive characters, the detection can produce false positives — multiple encodings might appear valid.

To improve accuracy, I modified the code to scan the first 8 KB of the file instead of just the header. This change still ensures fast performance but significantly improves detection accuracy and reduces false positives. Especially for older formats like 

## Visual changes

There are no visual changes by this update. 

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
