### PR TITLE
Fix: Exporting excel files not working in Laravel Vapor environments

### DIFF
--- a/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
+++ b/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
@@ -24,13 +24,13 @@ class XlsxDownloader implements Downloader
         $fileName = $export->file_name . '.xlsx';
 
         if ($disk->exists($filePath = $directory . DIRECTORY_SEPARATOR . $fileName)) {
-            $response = $disk->download($filePath);
-
-            if (ob_get_length() > 0) {
-                ob_end_clean();
-            }
-
-            return $response;
+            return response()->streamDownload(function () use ($disk, $filePath) {
+                if (ob_get_level()) ob_end_clean();
+                echo $disk->get($filePath);
+                flush();
+            }, $fileName, [
+                'Content-Type' => 'application/vnd.ms-excel',
+            ]);
         }
 
         $writer = app(Writer::class);

--- a/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
+++ b/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
@@ -25,7 +25,9 @@ class XlsxDownloader implements Downloader
 
         if ($disk->exists($filePath = $directory . DIRECTORY_SEPARATOR . $fileName)) {
             return response()->streamDownload(function () use ($disk, $filePath) {
-                if (ob_get_level()) ob_end_clean();
+                if (ob_get_level()) {
+                    ob_end_clean();
+                }
                 echo $disk->get($filePath);
                 flush();
             }, $fileName, [

--- a/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
+++ b/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
@@ -24,17 +24,15 @@ class XlsxDownloader implements Downloader
         $fileName = $export->file_name . '.xlsx';
 
         if ($disk->exists($filePath = $directory . DIRECTORY_SEPARATOR . $fileName)) {
-            return response()->streamDownload(function () use ($disk, $filePath) {
-                if (ob_get_level()) {
-                    ob_end_clean();
-                }
+            $response = $disk->download($filePath);
 
-                echo $disk->get($filePath);
+            if (ob_get_length() > 0) {
+                ob_end_clean();
+            }
 
-                flush();
-            }, $fileName, [
-                'Content-Type' => 'application/vnd.ms-excel',
-            ]);
+            $response->headers->set('X-Vapor-Base64-Encode', 'True');
+
+            return $response;
         }
 
         $writer = app(Writer::class);

--- a/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
+++ b/packages/actions/src/Exports/Downloaders/XlsxDownloader.php
@@ -28,7 +28,9 @@ class XlsxDownloader implements Downloader
                 if (ob_get_level()) {
                     ob_end_clean();
                 }
+
                 echo $disk->get($filePath);
+
                 flush();
             }, $fileName, [
                 'Content-Type' => 'application/vnd.ms-excel',


### PR DESCRIPTION
## Description

CSV exports work correctly but we had an issue where the exports for excel didn't work in our production server, but they did locally. After some debugging I found this error:

`Fatal error: Uncaught Exception: Error encoding runtime JSON response: Malformed UTF-8 characters, possibly incorrectly encoded in /var/task/vendor/laravel/vapor-core/src/Runtime/NotifiesLambda.php:49`

The error came from this part in XlsxDownloader:

```
        if ($disk->exists($filePath = $directory . DIRECTORY_SEPARATOR . $fileName)) {
            $response = $disk->download($filePath);

            if (ob_get_length() > 0) {
                ob_end_clean();
            }

            return $response;
        }
```

I modified it to stream the download the same way csv exports are streamed and now it works fine in my production and staging server, so it should work the same on other environments but it also works on vapor environments now:

```
        if ($disk->exists($filePath = $directory . DIRECTORY_SEPARATOR . $fileName)) {
            return response()->streamDownload(function () use ($disk, $filePath) {
                if (ob_get_level()) {
                    ob_end_clean();
                }

                echo $disk->get($filePath);

                flush();
            }, $fileName, [
                'Content-Type' => 'application/vnd.ms-excel',
            ]);
        }
```

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
