### PR TITLE
Allow closure for default avatar provider

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasAvatars.php
+++ b/packages/panels/src/Panel/Concerns/HasAvatars.php
@@ -2,13 +2,14 @@
 
 namespace Filament\Panel\Concerns;
 
+use Closure;
 use Filament\AvatarProviders\UiAvatarsProvider;
 
 trait HasAvatars
 {
-    protected string $defaultAvatarProvider = UiAvatarsProvider::class;
+    protected string | Closure $defaultAvatarProvider = UiAvatarsProvider::class;
 
-    public function defaultAvatarProvider(string $provider): static
+    public function defaultAvatarProvider(string | Closure $provider): static
     {
         $this->defaultAvatarProvider = $provider;
 
@@ -17,6 +18,6 @@ trait HasAvatars
 
     public function getDefaultAvatarProvider(): string
     {
-        return $this->defaultAvatarProvider;
+        return $this->evaluate($this->defaultAvatarProvider);
     }
 }


### PR DESCRIPTION
## Description

Simple PR to allow using Closure for `defaultAvatarProvider` instead of only strings.

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
