### PR TITLE
bug fix for HasOne,HasMany select in a repeater created in pull https…

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -988,7 +988,8 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
         $this->saveRelationshipsUsing(static function (Select $component, Model $record, $state) use ($modifyQueryUsing) {
             $relationship = $component->getRelationship();
 
-            if (($relationship instanceof HasOne) || ($relationship instanceof HasMany)) {
+            if (str($component->getStatePath())->substrCount('.') <= 1
+                && ($relationship instanceof HasOne) || ($relationship instanceof HasMany)) {
                 $query = $relationship->getQuery();
 
                 if ($modifyQueryUsing) {


### PR DESCRIPTION
## Description

Since version 3.3.4 https://github.com/filamentphp/filament/releases/tag/v3.3.4 the update broke selects in a repeater on a form. I locked to v3.3.3 till I had time to look at it and looks like the pull request that was merged https://github.com/filamentphp/filament/pull/15650 created a problem with HasOne, HasMany in a select in a repeater on a form as is trying to make an update main model instead of the relationship handling the update. 

I have added check that the if the data path is less than 1 deep then it runs the new code otherwise it ignores it if it is deeper in the case of it being in a repeater, if there is a better way to check for this let me know and I will amend. 

## Visual changes

Error on save trying to set id of the record to null on update

![image](https://github.com/user-attachments/assets/269e53c3-47ba-429d-9824-a8932e1165f6)

## Functional changes

- [ x ] Code style has been fixed by running the `composer cs` command.
- [ x ] Changes have been tested to not break existing functionality.
- [ x ] Documentation is up-to-date.
