### PR TITLE
remove redundant method call in EditRecord page

### DIFF
--- a/packages/panels/src/Pages/Auth/EditProfile.php
+++ b/packages/panels/src/Pages/Auth/EditProfile.php
@@ -210,7 +210,7 @@ class EditProfile extends Page
 
         return Notification::make()
             ->success()
-            ->title($this->getSavedNotificationTitle());
+            ->title($title);
     }
 
     protected function getSavedNotificationTitle(): ?string

--- a/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
+++ b/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
@@ -166,7 +166,7 @@ abstract class EditTenantProfile extends Page
 
         return Notification::make()
             ->success()
-            ->title($this->getSavedNotificationTitle());
+            ->title($title);
     }
 
     protected function getSavedNotificationTitle(): ?string

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -229,7 +229,7 @@ class EditRecord extends Page
 
         return Notification::make()
             ->success()
-            ->title($this->getSavedNotificationTitle());
+            ->title($title);
     }
 
     protected function getSavedNotificationTitle(): ?string


### PR DESCRIPTION
removed unnecessary method call, no real reason to call it twice since it gets stored in a variable before