### PR TITLE
Fix typo configuration

### DIFF
--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -296,7 +296,7 @@ class Notification extends ViewComponent implements Arrayable
             Assert::assertNotSame(
                 collect($expectedNotification)->except(['id'])->toArray(),
                 collect($notification->toArray())->except(['id'])->toArray(),
-                'The notification with the given configration was sent'
+                'The notification with the given configuration was sent'
             );
 
             return;


### PR DESCRIPTION
## Description
Fixes a typo, from "configration" to "configuration"

## Visual changes

Not applicable

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
