### PR TITLE
Ability to check if macro exists

### DIFF
--- a/packages/support/src/Concerns/Macroable.php
+++ b/packages/support/src/Concerns/Macroable.php
@@ -41,7 +41,7 @@ trait Macroable
 
     public static function hasMacro(string $name): bool
     {
-        return isset(static::$macros[$name]);
+        return (bool) static::getMacro($name);
     }
 
     /**

--- a/packages/support/src/Concerns/Macroable.php
+++ b/packages/support/src/Concerns/Macroable.php
@@ -39,6 +39,11 @@ trait Macroable
         static::$macros = [];
     }
 
+    public static function hasMacro(string $name): bool
+    {
+        return isset(static::$macros[$name]);
+    }
+
     /**
      * @param  array<array-key>  $parameters
      */

--- a/tests/src/Support/MacroableTest.php
+++ b/tests/src/Support/MacroableTest.php
@@ -21,7 +21,7 @@ test('component is macroable', function () {
         ->toBeTrue();
 
     expect(Form::hasMacro('someMacro'))
-        ->toBeTrue(); // Decendant of `Component`...
+        ->toBeTrue(); // Descendant of `Component`...
 
     expect(Field::hasMacro('someMacro'))
         ->toBeFalse();

--- a/tests/src/Support/MacroableTest.php
+++ b/tests/src/Support/MacroableTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Filament\Forms\ComponentContainer;
+use Filament\Support\Colors\Color;
+use Filament\Support\Components\Component;
+use Filament\Tests\Forms\Fixtures\Livewire;
+use Filament\Tests\TestCase;
+use Illuminate\Support\Str;
+
+uses(TestCase::class);
+
+it('can macro a component', function () {
+   expect(Component::hasMacro('someMacro'))
+       ->toBeFalse();
+
+   expect(Component::hasMacro('someMacro'))
+       ->toBeFalse();
+
+    Component::macro('someMacro', fn () => 'Hello');
+
+    expect(Component::hasMacro('someMacro'))
+        ->toBeTrue();
+});

--- a/tests/src/Support/MacroableTest.php
+++ b/tests/src/Support/MacroableTest.php
@@ -1,19 +1,28 @@
 <?php
 
+use Filament\Forms\ComponentContainer;
+use Filament\Forms\Components\Field;
+use Filament\Forms\Form;
 use Filament\Support\Components\Component;
 use Filament\Tests\TestCase;
 
 uses(TestCase::class);
 
 test('component is macroable', function () {
-    expect(Component::hasMacro('someMacro'))
+    expect(ComponentContainer::hasMacro('someMacro'))
         ->toBeFalse();
 
-    expect(Component::hasMacro('someMacro'))
+    expect(ComponentContainer::hasMacro('someMacro'))
         ->toBeFalse();
 
-    Component::macro('someMacro', fn () => 'Hello');
+    ComponentContainer::macro('someMacro', fn () => 'Hello');
 
-    expect(Component::hasMacro('someMacro'))
+    expect(ComponentContainer::hasMacro('someMacro'))
         ->toBeTrue();
+
+    expect(Form::hasMacro('someMacro'))
+        ->toBeTrue(); // Decendant of `Component`...
+
+    expect(Field::hasMacro('someMacro'))
+        ->toBeFalse();
 });

--- a/tests/src/Support/MacroableTest.php
+++ b/tests/src/Support/MacroableTest.php
@@ -5,7 +5,7 @@ use Filament\Tests\TestCase;
 
 uses(TestCase::class);
 
-it('can macro a component', function () {
+test('component is macroable', function () {
     expect(Component::hasMacro('someMacro'))
         ->toBeFalse();
 

--- a/tests/src/Support/MacroableTest.php
+++ b/tests/src/Support/MacroableTest.php
@@ -1,20 +1,16 @@
 <?php
 
-use Filament\Forms\ComponentContainer;
-use Filament\Support\Colors\Color;
 use Filament\Support\Components\Component;
-use Filament\Tests\Forms\Fixtures\Livewire;
 use Filament\Tests\TestCase;
-use Illuminate\Support\Str;
 
 uses(TestCase::class);
 
 it('can macro a component', function () {
-   expect(Component::hasMacro('someMacro'))
-       ->toBeFalse();
+    expect(Component::hasMacro('someMacro'))
+        ->toBeFalse();
 
-   expect(Component::hasMacro('someMacro'))
-       ->toBeFalse();
+    expect(Component::hasMacro('someMacro'))
+        ->toBeFalse();
 
     Component::macro('someMacro', fn () => 'Hello');
 


### PR DESCRIPTION
This PR allows to check if a macro is registered using a `Component:hasMacro()` method, similar to Laravel's `hasMacro()` method.

Thanks!