### PR TITLE
cast recordKey to string

### DIFF
--- a/packages/support/src/Concerns/HasCellState.php
+++ b/packages/support/src/Concerns/HasCellState.php
@@ -83,6 +83,7 @@ trait HasCellState
         }
 
         $recordKey = (string) $record->getKey();
+
         if (array_key_exists($recordKey, $this->cachedState)) {
             return $this->cachedState[$recordKey];
         }

--- a/packages/support/src/Concerns/HasCellState.php
+++ b/packages/support/src/Concerns/HasCellState.php
@@ -82,8 +82,9 @@ trait HasCellState
             return null;
         }
 
-        if (array_key_exists($record->getKey(), $this->cachedState)) {
-            return $this->cachedState[$record->getKey()];
+        $recordKey = (string) $record->getKey();
+        if (array_key_exists($recordKey, $this->cachedState)) {
+            return $this->cachedState[$recordKey];
         }
 
         $state = ($this->getStateUsing !== null) ?
@@ -101,7 +102,7 @@ trait HasCellState
             $state = $this->getDefaultState();
         }
 
-        return $this->cachedState[$record->getKey()] = $state;
+        return $this->cachedState[$recordKey] = $state;
     }
 
     public function getStateFromRecord(): mixed


### PR DESCRIPTION
Without casting the key to a string I get the error `array_key_exists(): Argument #1 ($key) must be a valid array offset type` because my key is a uuid-object
