### PR TITLE
Feature: XLSX Configure Writer

### DIFF
--- a/packages/actions/docs/12-export.md
+++ b/packages/actions/docs/12-export.md
@@ -652,25 +652,21 @@ public function getXlsxWriterOptions(): ?Options
 }
 ```
 
-If you want to customize the XLSX writer before it is closed, you can override the `configureXlsxWriterBeforeClose()` method on the exporter class. This method receives the `OpenSpout\Writer\XLSX\Writer` instance as a parameter, and you can modify it before it is closed:
+If you want to customize the XLSX writer before it is closed, you can override the `configureXlsxWriterBeforeClosing()` method on the exporter class. This method receives the `Writer` instance as a parameter, and you can modify it before it is closed:
 
 ```php
-use OpenSpout\Writer\XLSX\Options;
+use OpenSpout\Writer\XLSX\Entity\SheetView;
+use OpenSpout\Writer\XLSX\Writer;
 
-public function configureXlsxWriterBeforeClose(Writer &$writer): Writer
+public function configureXlsxWriterBeforeClose(Writer $writer): Writer
 {
-    $sheetView = new SheetView;
+    $sheetView = new SheetView();
     $sheetView->setFreezeRow(2);
     $sheetView->setFreezeColumn('B');
+    
     $sheet = $writer->getCurrentSheet();
     $sheet->setSheetView($sheetView);
-
     $sheet->setName('export');
-
-    $countColumns = count(value: $this->getCachedColumns());
-    $countRows = $sheet->getWrittenRowCount();
-    $autoFilter = new AutoFilter(0, 1, $countColumns - 1, $countRows); // Note that columns are 0-indexed, while rows are 1-indexed
-    $sheet->setAutoFilter($autoFilter);
     
     return $writer;
 }

--- a/packages/actions/docs/12-export.md
+++ b/packages/actions/docs/12-export.md
@@ -652,6 +652,30 @@ public function getXlsxWriterOptions(): ?Options
 }
 ```
 
+If you want to customize the XLSX writer before it is closed, you can override the `configureXlsxWriterBeforeClose()` method on the exporter class. This method receives the `OpenSpout\Writer\XLSX\Writer` instance as a parameter, and you can modify it before it is closed:
+
+```php
+use OpenSpout\Writer\XLSX\Options;
+
+public function configureXlsxWriterBeforeClose(Writer &$writer): Writer
+{
+    $sheetView = new SheetView;
+    $sheetView->setFreezeRow(2);
+    $sheetView->setFreezeColumn('B');
+    $sheet = $writer->getCurrentSheet();
+    $sheet->setSheetView($sheetView);
+
+    $sheet->setName('export');
+
+    $countColumns = count(value: $this->getCachedColumns());
+    $countRows = $sheet->getWrittenRowCount();
+    $autoFilter = new AutoFilter(0, 1, $countColumns - 1, $countRows); // Note that columns are 0-indexed, while rows are 1-indexed
+    $sheet->setAutoFilter($autoFilter);
+    
+    return $writer;
+}
+```
+
 ## Customizing the export job
 
 The default job for processing exports is `Filament\Actions\Exports\Jobs\PrepareCsvExport`. If you want to extend this class and override any of its methods, you may replace the original class in the `register()` method of a service provider:

--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
 use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Writer\XLSX\Options;
+use OpenSpout\Writer\XLSX\Writer;
 
 abstract class Exporter
 {
@@ -207,6 +208,11 @@ abstract class Exporter
     public function getXlsxWriterOptions(): ?Options
     {
         return null;
+    }
+
+    public function configureXlsxWriterBeforeClose(Writer &$writer): Writer
+    {
+        return $writer;
     }
 
     public static function modifyQuery(Builder $query): Builder

--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -210,7 +210,7 @@ abstract class Exporter
         return null;
     }
 
-    public function configureXlsxWriterBeforeClose(Writer &$writer): Writer
+    public function configureXlsxWriterBeforeClose(Writer $writer): Writer
     {
         return $writer;
     }

--- a/packages/actions/src/Exports/Jobs/CreateXlsxFile.php
+++ b/packages/actions/src/Exports/Jobs/CreateXlsxFile.php
@@ -81,6 +81,8 @@ class CreateXlsxFile implements ShouldQueue
             $writeRowsFromFile($file, $cellStyle);
         }
 
+        $this->exporter->configureXlsxWriterBeforeClose($writer);
+
         $writer->close();
 
         $disk->putFileAs(

--- a/tests/src/Fixtures/Resources/PostCategories/PostCategoryResource.php
+++ b/tests/src/Fixtures/Resources/PostCategories/PostCategoryResource.php
@@ -6,12 +6,13 @@ use BackedEnum;
 use Filament\Resources\Resource;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Fixtures\Models\PostCategory;
+use UnitEnum;
 
 class PostCategoryResource extends Resource
 {
     protected static ?string $model = PostCategory::class;
 
-    protected static string | \UnitEnum | null $navigationGroup = 'Blog';
+    protected static string | UnitEnum | null $navigationGroup = 'Blog';
 
     protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedRectangleStack;
 

--- a/tests/src/Fixtures/Resources/Posts/PostResource.php
+++ b/tests/src/Fixtures/Resources/Posts/PostResource.php
@@ -19,12 +19,13 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use RuntimeException;
+use UnitEnum;
 
 class PostResource extends Resource
 {
     protected static ?string $model = Post::class;
 
-    protected static string | \UnitEnum | null $navigationGroup = 'Blog';
+    protected static string | UnitEnum | null $navigationGroup = 'Blog';
 
     protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedDocumentText;
 

--- a/tests/src/Fixtures/Resources/Shop/Products/ProductResource.php
+++ b/tests/src/Fixtures/Resources/Shop/Products/ProductResource.php
@@ -6,12 +6,13 @@ use BackedEnum;
 use Filament\Resources\Resource;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Fixtures\Models\Product;
+use UnitEnum;
 
 class ProductResource extends Resource
 {
     protected static ?string $model = Product::class;
 
-    protected static string | \UnitEnum | null $navigationGroup = 'Shop';
+    protected static string | UnitEnum | null $navigationGroup = 'Shop';
 
     protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedShoppingBag;
 


### PR DESCRIPTION
## Description

In PR https://github.com/filamentphp/filament/pull/14411, options were added for the new Writer, but some features cannot be enabled through Options, for example https://github.com/openspout/openspout/blob/4.x/docs/documentation.md#autofilter-xlsx-writer and https://github.com/openspout/openspout/blob/4.x/docs/documentation.md#sheet-view-xlsx-writer.

This method is called before closing the Writer, but after all records have been written, because it is useful to have `$writer->getCurrentSheet()->getWrittenRowCount()` to know how many rows have been written.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
