### PR TITLE
Adds default collapse for grouped rows

### DIFF
--- a/packages/tables/docs/08-grouping.md
+++ b/packages/tables/docs/08-grouping.md
@@ -202,6 +202,25 @@ public function table(Table $table): Table
 }
 ```
 
+### Collapsing groups by default
+
+By default, the groups will be expanded to show each individual item within the group.  To default a specific group to showing only the headers use the `collapsed()` method:
+
+```php
+use Filament\Tables\Grouping\Group;
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->groups([
+            Group::make('author.name')
+                ->collapsible()
+                ->collapsed(),
+        ]);
+}
+```
+
 ## Summarising groups
 
 You can use [summaries](summaries) with groups to display a summary of the records inside a group. This works automatically if you choose to add a summariser to a column in a grouped table.

--- a/packages/tables/resources/views/components/group/header.blade.php
+++ b/packages/tables/resources/views/components/group/header.blade.php
@@ -1,5 +1,6 @@
 @props([
     'collapsible' => false,
+    'collapsed' => false,
     'description' => null,
     'label' => null,
     'start' => null,
@@ -9,6 +10,9 @@
 <div
     @if ($collapsible)
         x-on:click="toggleCollapseGroup(@js($title))"
+        @if ($collapsed)
+            x-init="collapsedGroups.push(@js($title))"
+        @endif
     @endif
     {{
         $attributes->class([
@@ -43,7 +47,10 @@
             :label="filled($label) ? ($label . ': ' . $title) : $title"
             size="sm"
             :x-bind:aria-expanded="'! isGroupCollapsed(' . \Illuminate\Support\Js::from($title) . ')'"
-            :x-bind:class="'isGroupCollapsed(' . \Illuminate\Support\Js::from($title) . ') && \'-rotate-180\''"
+            :x-bind:class="'{\'-rotate-180\' : isGroupCollapsed(' . \Illuminate\Support\Js::from($title) . ')}'"
+            @class([
+                '-rotate-180' => $collapsed,
+            ])
         />
     @endif
 </div>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -459,6 +459,7 @@
 
                                 <x-filament-tables::group.header
                                     :collapsible="$group->isCollapsible()"
+                                    :collapsed="$group->isCollapsed()"
                                     :description="$group->getDescription($record, $recordGroupTitle)"
                                     :label="$group->isTitlePrefixedWithLabel() ? $group->getLabel() : null"
                                     :title="$recordGroupTitle"
@@ -1042,6 +1043,7 @@
                                         >
                                             <x-filament-tables::group.header
                                                 :collapsible="$group->isCollapsible()"
+                                                :collapsed="$group->isCollapsed()"
                                                 :description="$group->getDescription($record, $recordGroupTitle)"
                                                 :label="$group->isTitlePrefixedWithLabel() ? $group->getLabel() : null"
                                                 :title="$recordGroupTitle"
@@ -1077,6 +1079,7 @@
                                     :x-sortable-item="$isReordering ? $recordKey : null"
                                     @class([
                                         'group cursor-move' => $isReordering,
+                                        'hidden' => $group?->isCollapsed(),
                                         ...$getRecordClasses($record),
                                     ])
                                 >

--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -41,7 +41,7 @@ class Group extends Component
 
     protected bool $isCollapsible = false;
 
-    protected bool | Closure $isCollapsed = true;
+    protected bool | Closure $isCollapsed = false;
 
     protected bool $isTitlePrefixedWithLabel = true;
 

--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -62,7 +62,6 @@ class Group extends Component
         return $static;
     }
 
-
     public function collapsible(bool $condition = true): static
     {
         $this->isCollapsible = $condition;

--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -41,6 +41,8 @@ class Group extends Component
 
     protected bool $isCollapsible = false;
 
+    protected bool | Closure $isCollapsed = true;
+
     protected bool $isTitlePrefixedWithLabel = true;
 
     protected bool $isDate = false;
@@ -60,11 +62,25 @@ class Group extends Component
         return $static;
     }
 
+
     public function collapsible(bool $condition = true): static
     {
         $this->isCollapsible = $condition;
 
         return $this;
+    }
+
+    public function collapsed(bool | Closure $condition = true): static
+    {
+        $this->collapsible();
+        $this->isCollapsed = $condition;
+
+        return $this;
+    }
+
+    public function isCollapsed(): bool
+    {
+        return (bool) $this->evaluate($this->isCollapsed);
     }
 
     public function column(?string $column): static


### PR DESCRIPTION
## Description

This adds support for collapsing grouped rows by default:

```
$table->groups([
    Group::make('name')
        ->collapsible()
        ->collapsed()
]);
```

cf. https://github.com/filamentphp/filament/discussions/10717

I'm also happy to open a v4 PR if needed in addition to this one.

## Visual changes

There are no changes to the UI, but here are some screenshot with the changes:

### Without Summaries:

Standard behavior (not collapsed):

![image](https://github.com/user-attachments/assets/18c0affa-932c-4df8-81a3-bbf19d337b68)

With `->collapsed()`:

![Screenshot 2025-04-09 at 2 49 34 PM](https://github.com/user-attachments/assets/e1f39dc6-a3a1-4b80-9759-cc8c39098a9d)


### With Summaries:

Standard behavior (not collapsed):

![Screenshot 2025-04-09 at 2 35 14 PM](https://github.com/user-attachments/assets/fda6622d-e8bd-40bf-885e-1b43edb1fb00)

With `->collapsed()`:

![Screenshot 2025-04-09 at 2 34 45 PM](https://github.com/user-attachments/assets/8f8e24af-3de8-43ae-a84f-5e1cf1769e58)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
