### PR TITLE
Fix: change data column to json in notifications table

### DIFF
--- a/docs-assets/app/database/migrations/2023_07_02_122748_create_notifications_table.php
+++ b/docs-assets/app/database/migrations/2023_07_02_122748_create_notifications_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->uuid('id')->primary();
             $table->string('type');
             $table->morphs('notifiable');
-            $table->text('data');
+            $table->json('data');
             $table->timestamp('read_at')->nullable();
             $table->timestamps();
         });


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

[Migration](https://github.com/filamentphp/filament/blob/c92463fd58be397598b68c1fc6e0c9de5bfd3bd4/docs-assets/app/database/migrations/2023_07_02_122748_create_notifications_table.php#L14) defines `$table->text('data');` but method `getNotificationsQuery` uses `->` operator in where clause:

```php
public function getNotificationsQuery(): Builder | Relation
    {
        /** @phpstan-ignore-next-line */
        return $this->getUser()->notifications()->where('data->format', 'filament');
    }
```

In PostgreSQL, JSON operators are not allowed when column is not JSON type, causing error:
```
SQLSTATE[42883]: Undefined function: 7 ERROR: operator does not exist: text ->> unknown LINE 1: ...ifications"."notifiable_id" is not null and "data"->>'format... ^ HINT: No operator matches the given name and argument types. You might need to add explicit type casts.
```

## Visual changes

No visual changes

## Functional changes

- [x] Code style has been fixed by running the composer cs command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.