### PR TITLE
Missing italian translations

### DIFF
--- a/packages/actions/resources/lang/it/import.php
+++ b/packages/actions/resources/lang/it/import.php
@@ -13,6 +13,10 @@ return [
             'file' => [
                 'label' => 'File',
                 'placeholder' => 'Carica un file CSV',
+                
+                'rules' => [
+                    'duplicate_columns' => '{0} Il file non deve contenere più di un\'intestazione di colonna vuota.|{1,*} Il file non deve contenere intestazioni di colonna duplicate: :columns.',
+                ],
             ],
 
             'columns' => [
@@ -72,6 +76,7 @@ return [
         'file_name' => 'import-:import_id-:csv_name-failed-rows',
         'error_header' => 'errore',
         'system_error' => 'Errore di sistema, per favore contatta il supporto.',
+        'column_mapping_required_for_new_record' => 'La colonna :attribute non è stata mappata ad una colonna nel file, ma è richiesta per la creazione di nuovi record.',
     ],
 
 ];

--- a/packages/actions/resources/lang/it/import.php
+++ b/packages/actions/resources/lang/it/import.php
@@ -13,7 +13,7 @@ return [
             'file' => [
                 'label' => 'File',
                 'placeholder' => 'Carica un file CSV',
-                
+
                 'rules' => [
                     'duplicate_columns' => '{0} Il file non deve contenere più di un\'intestazione di colonna vuota.|{1,*} Il file non deve contenere intestazioni di colonna duplicate: :columns.',
                 ],

--- a/packages/forms/resources/lang/it/components.php
+++ b/packages/forms/resources/lang/it/components.php
@@ -12,14 +12,62 @@ return [
 
             'add' => [
                 'label' => 'Aggiungi a :label',
+                
+                'modal' => [
+
+                    'heading' => 'Aggiungi a :label',
+
+                    'actions' => [
+
+                        'add' => [
+                            'label' => 'Aggiungi',
+                        ],
+
+                    ],
+
+                ],
             ],
 
             'add_between' => [
                 'label' => 'Inserisci tra i blocchi',
+                
+                'modal' => [
+
+                    'heading' => 'Aggiungi a :label',
+
+                    'actions' => [
+
+                        'add' => [
+                            'label' => 'Aggiungi',
+                        ],
+
+                    ],
+
+                ],
             ],
 
             'delete' => [
                 'label' => 'Elimina',
+            ],
+            
+            'edit' => [
+
+                'label' => 'Modifica',
+
+                'modal' => [
+
+                    'heading' => 'Modifica blocco',
+
+                    'actions' => [
+
+                        'save' => [
+                            'label' => 'Salva modifiche',
+                        ],
+
+                    ],
+
+                ],
+
             ],
 
             'reorder' => [
@@ -357,6 +405,8 @@ return [
 
             'create_option' => [
 
+                'label' => 'Crea',
+
                 'modal' => [
 
                     'heading' => 'Crea',
@@ -378,6 +428,8 @@ return [
             ],
 
             'edit_option' => [
+
+                'label' => 'Modifica',
 
                 'modal' => [
 
@@ -418,6 +470,31 @@ return [
 
     'tags_input' => [
         'placeholder' => 'Nuovo tag',
+    ],
+
+    'text_input' => [
+
+        'actions' => [
+
+            'hide_password' => [
+                'label' => 'Nascondi password',
+            ],
+
+            'show_password' => [
+                'label' => 'Mostra password',
+            ],
+
+        ],
+
+    ],
+
+    'toggle_buttons' => [
+
+        'boolean' => [
+            'true' => 'Si',
+            'false' => 'No',
+        ],
+
     ],
 
     'wizard' => [

--- a/packages/forms/resources/lang/it/components.php
+++ b/packages/forms/resources/lang/it/components.php
@@ -12,7 +12,7 @@ return [
 
             'add' => [
                 'label' => 'Aggiungi a :label',
-                
+
                 'modal' => [
 
                     'heading' => 'Aggiungi a :label',
@@ -30,7 +30,7 @@ return [
 
             'add_between' => [
                 'label' => 'Inserisci tra i blocchi',
-                
+
                 'modal' => [
 
                     'heading' => 'Aggiungi a :label',
@@ -49,7 +49,7 @@ return [
             'delete' => [
                 'label' => 'Elimina',
             ],
-            
+
             'edit' => [
 
                 'label' => 'Modifica',

--- a/packages/panels/resources/lang/it/layout.php
+++ b/packages/panels/resources/lang/it/layout.php
@@ -52,4 +52,12 @@ return [
 
     ],
 
+    'avatar' => [
+        'alt' => 'Avatar di :name',
+    ],
+
+    'logo' => [
+        'alt' => 'Logo di :name',
+    ],
+
 ];

--- a/packages/support/resources/lang/it/components/pagination.php
+++ b/packages/support/resources/lang/it/components/pagination.php
@@ -4,7 +4,7 @@ return [
 
     'label' => 'Navigazione paginazione',
 
-    'overview' => 'Mostrati da :first a :last di :total risultati',
+    'overview' => '{1} Mostrato 1 risultato|[2,*] Mostrati da :first a :last di :total risultati',
 
     'fields' => [
 
@@ -22,8 +22,16 @@ return [
 
     'actions' => [
 
+        'first' => [
+            'label' => 'Prima',
+        ],
+
         'go_to_page' => [
             'label' => 'Vai a pagina :page',
+        ],
+
+        'last' => [
+            'label' => 'Ultima',
         ],
 
         'next' => [

--- a/packages/tables/resources/lang/it/table.php
+++ b/packages/tables/resources/lang/it/table.php
@@ -10,6 +10,10 @@ return [
 
     'columns' => [
 
+        'actions' => [
+            'label' => 'Azione|Azioni',
+        ],
+
         'text' => [
 
             'actions' => [
@@ -111,6 +115,10 @@ return [
     'filters' => [
 
         'actions' => [
+
+            'apply' => [
+                'label' => 'Applica filtri',
+            ],
 
             'remove' => [
                 'label' => 'Rimuovi filtro',


### PR DESCRIPTION
## Description

This pull request includes various updates to the Italian language files for different components, adding new translations and improving existing ones. The most important changes are grouped by the files they affect:

Updates to `import.php`:

* Added rules for duplicate columns in the file upload section.
* Added a new error message for column mapping required for new records.

Updates to `components.php`:

* Added modal headings and actions for the 'add', 'add_between', 'edit', 'create_option', and 'edit_option' labels.
* Added translations for text input actions to show/hide the password and toggle buttons for boolean values.

Updates to `layout.php`:

* Added alt text for avatar and logo images.

Updates to `pagination.php`:

* Improved the overview message for pagination and added labels for 'first' and 'last' actions. 

Updates to `table.php`:

* Added labels for actions and apply/remove filters in the table columns. 

## Visual changes
We now have IT translations in some new places.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
