### PR TITLE
Add missing infolist IT translations

### DIFF
--- a/packages/infolists/resources/lang/it/components.php
+++ b/packages/infolists/resources/lang/it/components.php
@@ -1,0 +1,38 @@
+<?php
+
+return [
+
+    'entries' => [
+
+        'text' => [
+
+            'actions' => [
+                'collapse_list' => 'Mostra :count in meno',
+                'expand_list' => 'Mostra altri :count',
+            ],
+
+            'more_list_items' => 'e altri :count',
+
+        ],
+
+        'key_value' => [
+
+            'columns' => [
+
+                'key' => [
+                    'label' => 'Chiave',
+                ],
+
+                'value' => [
+                    'label' => 'Valore',
+                ],
+
+            ],
+
+            'placeholder' => 'Nessun elemento',
+
+        ],
+
+    ],
+
+];


### PR DESCRIPTION
## Description
This pull request includes the addition of Italian language support for the `infolists` package. The changes involve adding translations for various components in the `components.php` file.

Localization:

* [`packages/infolists/resources/lang/it/components.php`]: Added Italian translations for actions such as 'collapse_list' and 'expand_list', as well as labels for 'key' and 'value'.


<!-- Describe the addressed issue or the need for the new or updated functionality. -->


## Visual changes
We now have IT translations in infolist package.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
