### PR TITLE
fix(spa): unsaved data changes alert

### DIFF
--- a/packages/panels/resources/views/components/page/unsaved-data-changes-alert.blade.php
+++ b/packages/panels/resources/views/components/page/unsaved-data-changes-alert.blade.php
@@ -6,23 +6,15 @@
     @if (FilamentView::hasSpaMode())
         @script
             <script>
-                let formSubmitted = false
-
-                document.addEventListener(
-                    'submit',
-                    () => (formSubmitted = true),
-                )
-
                 shouldPreventNavigation = () => {
-                    if (formSubmitted) {
+                    if ($wire?.__instance?.effects?.redirect) {
                         return
                     }
 
                     return (
                         window.jsMd5(
                             JSON.stringify($wire.data).replace(/\\/g, ''),
-                        ) !== $wire.savedDataHash ||
-                        $wire?.__instance?.effects?.redirect
+                        ) !== $wire.savedDataHash
                     )
                 }
 


### PR DESCRIPTION
## Description

This PR addresses an issue in SPA mode where the "unsaved changes" alert logic was based on whether any form had been submitted. This logic introduced two key issues:

1. **Editing and re-editing a form**: After submitting a form (e.g., updating a record), if a user made another change and attempted to navigate away, the unsaved changes alert would **not** appear — because `formSubmitted` was already `true` from the first submission.

2. **Additional forms on the same page**: If a user interacted with another form (e.g., a create action in a select field), submitting that would also set `formSubmitted = true`, which incorrectly prevented the alert from showing even if the main form had unsaved changes.

To fix this, the `formSubmitted` check was removed. However, this introduced another issue — the alert began appearing during programmatic redirects (e.g., after a create or delete action), which is likely why the `formSubmitted` check was originally added.

This PR resolves that by replacing the form submission check with a more targeted condition: it now checks if a redirect is happening programmatically using `$wire?.__instance?.effects?.redirect`. If so, the alert is not triggered. We've used this approach extensively in our own app and have not encountered any flaws with it.

Please let me know if there are edge cases we may have missed, or if there’s a better approach you’d recommend.

## Visual changes

Before:

![chrome-capture-2025-4-16 (1)](https://github.com/user-attachments/assets/197bdeb4-ac24-4916-87cc-5f1df848aafe)

After:

![chrome-capture-2025-4-16](https://github.com/user-attachments/assets/47b511db-d25d-41e4-b7e9-caed29c9f0de)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
