### PR TITLE
Xlsx style cell column

### DIFF
--- a/packages/actions/docs/12-export.md
+++ b/packages/actions/docs/12-export.md
@@ -602,6 +602,8 @@ You can only specify a single character, otherwise an exception will be thrown.
 
 ## Customizing XLSX files
 
+### Styling all cells
+
 If you want to style the cells of the XLSX file, you may override the `getXlsxCellStyle()` method on the exporter class, returning an [OpenSpout `Style` object](https://github.com/openspout/openspout/blob/4.x/docs/documentation.md#styling):
 
 ```php
@@ -614,6 +616,8 @@ public function getXlsxCellStyle(): ?Style
         ->setFontName('Consolas');
 }
 ```
+
+### Styling all header cells
 
 If you want to use a different style for the header cells of the XLSX file only, you may override the `getXlsxHeaderCellStyle()` method on the exporter class, returning an [OpenSpout `Style` object](https://github.com/openspout/openspout/blob/4.x/docs/documentation.md#styling):
 
@@ -637,6 +641,8 @@ public function getXlsxHeaderCellStyle(): ?Style
 }
 ```
 
+### Writer options (creating)
+
 Alternatively, if you want to pass "options" to the [OpenSpout XLSX `Writer`](https://github.com/openspout/openspout/blob/4.x/docs/documentation.md#column-widths), you can return an `OpenSpout\Writer\XLSX\Options` instance from the `getXlsxWriterOptions()` method of the exporter class:
 
 ```php
@@ -651,6 +657,8 @@ public function getXlsxWriterOptions(): ?Options
     return $options;
 }
 ```
+
+### Writer before close
 
 If you want to customize the XLSX writer before it is closed, you can override the `configureXlsxWriterBeforeClosing()` method on the exporter class. This method receives the `Writer` instance as a parameter, and you can modify it before it is closed:
 
@@ -671,6 +679,63 @@ public function configureXlsxWriterBeforeClose(Writer $writer): Writer
     return $writer;
 }
 ```
+
+### Styling an entire column
+
+To apply a consistent style to all cells in a column, use the `xlsxCellColumnStyleUsing()` method:
+
+```php
+use Filament\Actions\Exports\ExportColumn;
+use OpenSpout\Common\Entity\Style\Style;
+
+ExportColumn::make('price')
+    ->xlsxCellColumnStyleUsing(fn (): Style => (new Style())
+        ->setFontBold()
+        ->setFontSize(12)
+        ->setFontColor(Color::rgb(255, 0, 0)) // Red
+    )
+```
+
+### Styling a cell based on its value
+
+To dynamically style cells based on their values, use the `xlsxCellColumnStyleFromStateUsing()` method:
+
+```php
+use Filament\Actions\Exports\ExportColumn;
+use OpenSpout\Common\Entity\Style\Style;
+
+ExportColumn::make('status')
+    ->xlsxCellColumnStyleFromStateUsing(fn (string $state): ?Style => match ($state) {
+        'active' => (new Style())->setFontColor(Color::rgb(0, 255, 0)), // Green
+        'inactive' => (new Style())->setFontColor(Color::rgb(255, 0, 0)), // Red
+        default => null,
+    })
+```
+
+### Combining styles
+
+If you define both a general column style and a value-based style, the styles will be merged automatically. In cases where the same styles are defined with different values, the value-based style takes precedence over the general column style.
+
+```php
+use Filament\Actions\Exports\ExportColumn;
+use OpenSpout\Common\Entity\Style\Style;
+
+ExportColumn::make('quantity')
+    ->xlsxCellColumnStyleUsing(fn (): Style => (new Style())->setFontBold()->setFontColor(Color::rgb(0, 0, 255))) // Blue
+    ->xlsxCellColumnStyleFromStateUsing(fn ($state): ?Style => match (true) {
+            $state > 30 => (new Style())->setFontColor(Color::rgb(0, 255, 0)), // Green
+            $state > 20 => (new Style())->setFontColor(Color::rgb(255, 0, 0)), // Red
+            default => null,
+        }
+    )
+```
+
+|id|name|quantity|
+|--|----|--------|
+|1 |Product A|**<span style="color:red">25</span>**|
+|2 |Product B|**<span style="color:green">35</span>**|
+|3 |Product C|**<span style="color:blue">15</span>**|
+
 
 ## Customizing the export job
 

--- a/packages/actions/docs/12-export.md
+++ b/packages/actions/docs/12-export.md
@@ -660,7 +660,7 @@ public function getXlsxWriterOptions(): ?Options
 
 ### Writer before close
 
-If you want to customize the XLSX writer before it is closed, you can override the `configureXlsxWriterBeforeClosing()` method on the exporter class. This method receives the `Writer` instance as a parameter, and you can modify it before it is closed:
+If you want to customize the XLSX writer before it is closed, you can override the `configureXlsxWriterBeforeClose()` method on the exporter class. This method receives the `Writer` instance as a parameter, and you can modify it before it is closed:
 
 ```php
 use OpenSpout\Writer\XLSX\Entity\SheetView;

--- a/packages/actions/src/Exports/Concerns/CanStyleXlsxCellColumn.php
+++ b/packages/actions/src/Exports/Concerns/CanStyleXlsxCellColumn.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Filament\Actions\Exports\Concerns;
+
+use Closure;
+use OpenSpout\Common\Entity\Style\Style;
+use OpenSpout\Writer\Common\Manager\Style\StyleMerger;
+
+trait CanStyleXlsxCellColumn
+{
+    /** @var array<Closure | Style> */
+    protected array $xlsxCellColumnStylesUsing = [];
+
+    protected Closure | Style | null $xlsxCellColumnStyleFromStateUsing = null;
+
+    protected ?Style $cachedXlsxCellColumnStyle;
+
+    public function xlsxCellColumnStyleUsing(Closure $callback): static
+    {
+        $this->xlsxCellColumnStylesUsing[] = $callback;
+
+        return $this;
+    }
+
+    public function xlsxCellColumnStyleFromStateUsing(Closure | Style $xlsxCellColumnStyleFromStateUsing): static
+    {
+        $this->xlsxCellColumnStyleFromStateUsing = $xlsxCellColumnStyleFromStateUsing;
+
+        return $this;
+    }
+
+    public function getXlsxCellColumnStyle(mixed $state = null): ?Style
+    {
+        $stateStyle = $this->evaluate($this->xlsxCellColumnStyleFromStateUsing, [
+            'state' => $state,
+        ]);
+
+        if (empty($this->xlsxCellColumnStylesUsing)) {
+            return $stateStyle;
+        }
+
+        $styleMerger = new StyleMerger;
+
+        if (! isset($this->cachedXlsxCellColumnStyle)) {
+            $cellColumnStyle = new Style;
+
+            foreach ($this->xlsxCellColumnStylesUsing as $callbackOrStyle) {
+                $style = $this->evaluate($callbackOrStyle);
+                if ($style && $style instanceof Style) {
+                    $cellColumnStyle = $styleMerger->merge(
+                        $style,
+                        $cellColumnStyle,
+                    );
+                }
+            }
+
+            $this->cachedXlsxCellColumnStyle = $cellColumnStyle;
+        }
+
+        if ($stateStyle === null) {
+            return $this->cachedXlsxCellColumnStyle;
+        }
+
+        return $styleMerger->merge(
+            $stateStyle,
+            $this->cachedXlsxCellColumnStyle
+        );
+    }
+}

--- a/packages/actions/src/Exports/ExportColumn.php
+++ b/packages/actions/src/Exports/ExportColumn.php
@@ -15,6 +15,7 @@ class ExportColumn extends Component
 {
     use CanAggregateRelatedModels;
     use Concerns\CanFormatState;
+    use Concerns\CanStyleXlsxCellColumn;
     use HasCellState;
 
     protected string $name;

--- a/packages/actions/src/Exports/Jobs/CreateXlsxFile.php
+++ b/packages/actions/src/Exports/Jobs/CreateXlsxFile.php
@@ -11,6 +11,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Http\File;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Arr;
 use League\Csv\Reader as CsvReader;
 use League\Csv\Statement;
 use OpenSpout\Common\Entity\Row;
@@ -52,13 +53,23 @@ class CreateXlsxFile implements ShouldQueue
 
         $csvDelimiter = $this->exporter::getCsvDelimiter();
 
-        $writeRowsFromFile = function (string $file, ?Style $style = null) use ($csvDelimiter, $disk, $writer): void {
+        $exportColumnsByIndex = array_values($this->exporter->getCachedColumns());
+
+        $writeRowsFromFile = function (string $file, bool $isHeader, ?Style $style = null) use ($csvDelimiter, $disk, $writer, $exportColumnsByIndex): void {
             $csvReader = CsvReader::createFromStream($disk->readStream($file));
             $csvReader->setDelimiter($csvDelimiter);
             $csvResults = (new Statement)->process($csvReader);
 
             foreach ($csvResults->getRecords() as $row) {
-                $writer->addRow(Row::fromValues($row, $style));
+                if ($isHeader) {
+                    $writer->addRow(Row::fromValues($row, $style));
+                } else {
+                    $columnsFormats = Arr::map(
+                        $row,
+                        fn (string $value, $index) => $exportColumnsByIndex[$index]->getXlsxCellColumnStyle($value)
+                    );
+                    $writer->addRow(Row::fromValuesWithStyles($row, $style, $columnsFormats));
+                }
             }
         };
 
@@ -66,6 +77,7 @@ class CreateXlsxFile implements ShouldQueue
 
         $writeRowsFromFile(
             $this->export->getFileDirectory() . DIRECTORY_SEPARATOR . 'headers.csv',
+            true,
             $this->exporter->getXlsxHeaderCellStyle() ?? $cellStyle,
         );
 
@@ -78,7 +90,7 @@ class CreateXlsxFile implements ShouldQueue
                 continue;
             }
 
-            $writeRowsFromFile($file, $cellStyle);
+            $writeRowsFromFile($file, false, $cellStyle);
         }
 
         $this->exporter->configureXlsxWriterBeforeClose($writer);


### PR DESCRIPTION
## Description

Currently, you can style the header and the rest of the cells (separately). This PR allows you to format each of the exported columns (value cells only; header row cells are not included).
When you style a column, you can call the function multiple times, and each style (or callback) is saved in an array. When obtaining the column style, all styles are calculated and merged. This is designed to allow styling, for example, in the make/setup function for potential new column classes that extend the `ExportColumn` class.
Styles (or callbacks) can be fixed, meaning they do not depend on the cell value. They will be cached to improve performance and avoid merging each row of data in the export file. Additionally, you can assign a style based on the cell value, which will be executed on each row of data (OpenSpout does not support Excel conditional formatting).

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
