### PR TITLE
Fix "isLimited is not defined" error in TextColumn expandableLimitedList functionlity.

### DIFF
--- a/packages/support/resources/views/components/link.blade.php
+++ b/packages/support/resources/views/components/link.blade.php
@@ -301,4 +301,53 @@
         @endif
     </button>
     @trim
+@elseif ($tag === 'div')
+    <div
+        role="button"
+        @if ($keyBindings || $hasTooltip)
+            x-data="{}"
+        @endif
+        @if ($keyBindings)
+            x-bind:id="$id('key-bindings')"
+            x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id).click()"
+        @endif
+        @if ($hasTooltip)
+            x-tooltip="{
+                content: @js($tooltip),
+                theme: $store.theme,
+            }"
+        @endif
+        {{ $attributes->class([$linkClasses]) }}
+    >
+        @if ($icon && $iconPosition === IconPosition::Before)
+            <x-filament::icon
+                :alias="$iconAlias"
+                :icon="$icon"
+                :class="$iconClasses"
+                :style="$iconStyles"
+            />
+        @endif
+
+        <span class="{{ $labelClasses }}" style="{{ $labelStyles }}">
+            {{ $slot }}
+        </span>
+
+        @if ($icon && $iconPosition === IconPosition::After)
+            <x-filament::icon
+                :alias="$iconAlias"
+                :icon="$icon"
+                :class="$iconClasses"
+                :style="$iconStyles"
+            />
+        @endif
+
+        @if (filled($badge))
+            <div class="{{ $badgeContainerClasses }}">
+                <x-filament::badge :color="$badgeColor" :size="$badgeSize">
+                    {{ $badge }}
+                </x-filament::badge>
+            </div>
+        @endif
+    </div>
+    @trim
 @endif

--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -281,8 +281,8 @@
                     @if ($isLimitedListExpandable)
                         <x-filament::link
                             color="gray"
-                            tag="button"
-                            x-on:click.prevent="isLimited = false"
+                            role="button"
+                            x-on:click.prevent.stop="isLimited = false"
                             x-show="isLimited"
                         >
                             {{ trans_choice('filament-tables::table.columns.text.actions.expand_list', $limitedArrayStateCount) }}
@@ -290,9 +290,9 @@
 
                         <x-filament::link
                             color="gray"
-                            tag="button"
+                            role="button"
                             x-cloak
-                            x-on:click.prevent="isLimited = true"
+                            x-on:click.prevent.stop="isLimited = true"
                             x-show="! isLimited"
                         >
                             {{ trans_choice('filament-tables::table.columns.text.actions.collapse_list', $limitedArrayStateCount) }}

--- a/packages/tables/resources/views/columns/text-column.blade.php
+++ b/packages/tables/resources/views/columns/text-column.blade.php
@@ -281,7 +281,7 @@
                     @if ($isLimitedListExpandable)
                         <x-filament::link
                             color="gray"
-                            role="button"
+                            tag="div"
                             x-on:click.prevent.stop="isLimited = false"
                             x-show="isLimited"
                         >
@@ -290,7 +290,7 @@
 
                         <x-filament::link
                             color="gray"
-                            role="button"
+                            tag="div"
                             x-cloak
                             x-on:click.prevent.stop="isLimited = true"
                             x-show="! isLimited"


### PR DESCRIPTION
Fix expandableLimitedList "isLimited is not defined" error by updating x-filament::link attributes 

## Description

This pull request fixes the "isLimited is not defined" error that occurs when the `expandableLimitedList()` functionality is activated. The issue was caused by the use of the `tag="button"` attribute in the `<x-filament::link>` component.

This fix removes the `tag="button"` attribute and replaces it with `tag="div"`, which has been added to the global Link component’s tag options. It also ensures that `role="button"` is retained to maintain accessibility.

Additionally, the `.stop` modifier was added to the `x-on:click.prevent` directive to prevent event propagation. (Modal or page navigation when the cell is clicked).

## Visual changes
No visual changes were introduced. The component retains its default styling and behavior as an `<a>` tag.

Before:

https://github.com/user-attachments/assets/47402d13-6343-4f08-9e99-9216ac026190

After:

https://github.com/user-attachments/assets/912a00d6-34c2-49fd-bdca-b4a5bcb6f05b

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
