### PR TITLE
fix(repeater): bubble afterStateUpdated to parents

### DIFF
--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -89,7 +89,7 @@ trait HasState
         return $this;
     }
 
-    public function callAfterStateUpdated(bool $shouldBubbleToParents = true, bool $isBubbling = false): static
+    public function callAfterStateUpdated(bool $shouldBubbleToParents = true): static
     {
         foreach ($this->afterStateUpdated as $callback) {
             $runId = spl_object_id($callback) . md5(json_encode($this->getState()));
@@ -103,8 +103,8 @@ trait HasState
             store($this)->push('executedAfterStateUpdatedCallbacks', value: $runId, iKey: $runId);
         }
 
-        if ($shouldBubbleToParents && ($isBubbling || $this->isLive())) {
-            $this->getContainer()->getParentComponent()?->callAfterStateUpdated(isBubbling: true);
+        if ($shouldBubbleToParents) {
+            $this->getContainer()->getParentComponent()?->callAfterStateUpdated();
         }
 
         return $this;

--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -89,7 +89,7 @@ trait HasState
         return $this;
     }
 
-    public function callAfterStateUpdated(): static
+    public function callAfterStateUpdated(bool $shouldBubbleToParents = true, bool $isBubbling = false): static
     {
         foreach ($this->afterStateUpdated as $callback) {
             $runId = spl_object_id($callback) . md5(json_encode($this->getState()));
@@ -101,6 +101,10 @@ trait HasState
             $this->callAfterStateUpdatedHook($callback);
 
             store($this)->push('executedAfterStateUpdatedCallbacks', value: $runId, iKey: $runId);
+        }
+
+        if ($shouldBubbleToParents && ($isBubbling || $this->isLive())) {
+            $this->getContainer()->getParentComponent()?->callAfterStateUpdated(isBubbling: true);
         }
 
         return $this;

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -162,21 +162,6 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
         });
     }
 
-    protected function callAfterStateUpdatedOnParents(Component $component, bool $isLive = false): void
-    {
-        if (! $isLive && ! $component->isLive()) {
-            return;
-        }
-
-        $parent = $component->getContainer()->getParentComponent();
-
-        if ($parent) {
-            $parent->callAfterStateUpdated();
-
-            $this->callAfterStateUpdatedOnParents($parent, true);
-        }
-    }
-
     public function getAddAction(): Action
     {
         $action = Action::make($this->getAddActionName())
@@ -200,8 +185,6 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
                 $component->collapsed(false, shouldMakeComponentCollapsible: false);
 
                 $component->callAfterStateUpdated();
-
-                $this->callAfterStateUpdatedOnParents($component);
             })
             ->button()
             ->size(ActionSize::Small)
@@ -277,8 +260,6 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
                 $component->collapsed(false, shouldMakeComponentCollapsible: false);
 
                 $component->callAfterStateUpdated();
-
-                $this->callAfterStateUpdatedOnParents($component);
             })
             ->button()
             ->size(ActionSize::Small)
@@ -339,8 +320,6 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
                 $component->collapsed(false, shouldMakeComponentCollapsible: false);
 
                 $component->callAfterStateUpdated();
-
-                $this->callAfterStateUpdatedOnParents($component);
             })
             ->iconButton()
             ->size(ActionSize::Small)
@@ -380,8 +359,6 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
                 $component->state($items);
 
                 $component->callAfterStateUpdated();
-
-                $this->callAfterStateUpdatedOnParents($component);
             })
             ->iconButton()
             ->size(ActionSize::Small)
@@ -420,8 +397,6 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
                 $component->state($items);
 
                 $component->callAfterStateUpdated();
-
-                $this->callAfterStateUpdatedOnParents($component);
             })
             ->iconButton()
             ->size(ActionSize::Small)
@@ -460,8 +435,6 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
                 $component->state($items);
 
                 $component->callAfterStateUpdated();
-
-                $this->callAfterStateUpdatedOnParents($component);
             })
             ->iconButton()
             ->size(ActionSize::Small)
@@ -503,8 +476,6 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
                 $component->state($items);
 
                 $component->callAfterStateUpdated();
-
-                $this->callAfterStateUpdatedOnParents($component);
             })
             ->livewireClickHandlerEnabled(false)
             ->iconButton()

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -162,6 +162,21 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
         });
     }
 
+    protected function callAfterStateUpdatedOnParents(Component $component, bool $isLive = false): void
+    {
+        if (! $isLive && ! $component->isLive()) {
+            return;
+        }
+
+        $parent = $component->getContainer()->getParentComponent();
+
+        if ($parent) {
+            $parent->callAfterStateUpdated();
+
+            $this->callAfterStateUpdatedOnParents($parent, true);
+        }
+    }
+
     public function getAddAction(): Action
     {
         $action = Action::make($this->getAddActionName())
@@ -185,6 +200,8 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
                 $component->collapsed(false, shouldMakeComponentCollapsible: false);
 
                 $component->callAfterStateUpdated();
+
+                $this->callAfterStateUpdatedOnParents($component);
             })
             ->button()
             ->size(ActionSize::Small)
@@ -260,6 +277,8 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
                 $component->collapsed(false, shouldMakeComponentCollapsible: false);
 
                 $component->callAfterStateUpdated();
+
+                $this->callAfterStateUpdatedOnParents($component);
             })
             ->button()
             ->size(ActionSize::Small)
@@ -320,6 +339,8 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
                 $component->collapsed(false, shouldMakeComponentCollapsible: false);
 
                 $component->callAfterStateUpdated();
+
+                $this->callAfterStateUpdatedOnParents($component);
             })
             ->iconButton()
             ->size(ActionSize::Small)
@@ -359,6 +380,8 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
                 $component->state($items);
 
                 $component->callAfterStateUpdated();
+
+                $this->callAfterStateUpdatedOnParents($component);
             })
             ->iconButton()
             ->size(ActionSize::Small)
@@ -397,6 +420,8 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
                 $component->state($items);
 
                 $component->callAfterStateUpdated();
+
+                $this->callAfterStateUpdatedOnParents($component);
             })
             ->iconButton()
             ->size(ActionSize::Small)
@@ -435,6 +460,8 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
                 $component->state($items);
 
                 $component->callAfterStateUpdated();
+
+                $this->callAfterStateUpdatedOnParents($component);
             })
             ->iconButton()
             ->size(ActionSize::Small)
@@ -476,6 +503,8 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
                 $component->state($items);
 
                 $component->callAfterStateUpdated();
+
+                $this->callAfterStateUpdatedOnParents($component);
             })
             ->livewireClickHandlerEnabled(false)
             ->iconButton()

--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -27,13 +27,13 @@ trait HasState
     {
         foreach ($this->getComponents(withHidden: true) as $component) {
             if ($component->getStatePath() === $path) {
-                $component->callAfterStateUpdated();
+                $component->callAfterStateUpdated(shouldBubbleToParents: false);
 
                 return true;
             }
 
             if (str($path)->startsWith("{$component->getStatePath()}.")) {
-                $component->callAfterStateUpdated();
+                $component->callAfterStateUpdated(shouldBubbleToParents: false);
             }
 
             foreach ($component->getChildComponentContainers() as $container) {


### PR DESCRIPTION
## Description

This PR addresses an issue where `afterStateUpdated` callbacks on parent components were not being triggered after running repeater-related actions such as **add**, **delete**, **reorder**, etc.

In these cases, the component would call `afterStateUpdated` on itself at the end of the action, but unlike normal state updates, the update did **not bubble up** to its parent components. This meant any logic relying on `afterStateUpdated` at the parent level would silently fail to run.

To fix this, a new helper was introduced that first checks if the component is live, and then recursively walks up the component tree, calling `afterStateUpdated` on each parent. This mirrors the behavior of actual state updates, ensuring that all necessary callbacks are triggered.

This approach has worked well in our testing and reflects the expected behavior of how state updates should propagate. Let me know if there’s a more appropriate way to handle this logic, or if there are any edge cases we might’ve missed.

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.