### PR TITLE
fix: Set default maxSize on SpatieMediaLibraryFileUpload based on media-library configuration

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -52,6 +52,8 @@ class SpatieMediaLibraryFileUpload extends FileUpload
     {
         parent::setUp();
 
+        $this->maxSize(round(config('media-library.max_file_size') / 1000));
+
         $this->loadStateFromRelationshipsUsing(static function (SpatieMediaLibraryFileUpload $component, HasMedia $record): void {
             /** @var Model&HasMedia $record */
             $media = $record->load('media')->getMedia($component->getCollection() ?? 'default')


### PR DESCRIPTION
## Description

This PR adds a default maxSize setting to the SpatieMediaLibraryFileUpload component that automatically uses the value from the media-library configuration. The maxSize is now set to `round(config('media-library.max_file_size') / 1000)` by default.
Currently, if developers forget to set maxSize manually, the media-library throws an exception when users try to upload files that exceed the size limit. By setting a default maxSize value that matches the media-library configuration, users will receive a validation error instead of an exception, which improves the user experience.


## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.