### PR TITLE
Fix: change color() in all actions to defaultColor() where required, so that it can be overidden

### DIFF
--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -255,7 +255,7 @@ trait CanExportRecords
             }
         });
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->modalWidth('xl');
 

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -383,7 +383,7 @@ trait CanImportRecords
                 }),
         ]);
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->modalWidth('xl');
 

--- a/packages/actions/src/DeleteAction.php
+++ b/packages/actions/src/DeleteAction.php
@@ -27,7 +27,7 @@ class DeleteAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::delete.single.notifications.deleted.title'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->groupedIcon(FilamentIcon::resolve('actions::delete-action.grouped') ?? 'heroicon-m-trash');
 

--- a/packages/actions/src/ForceDeleteAction.php
+++ b/packages/actions/src/ForceDeleteAction.php
@@ -25,7 +25,7 @@ class ForceDeleteAction extends Action
 
         $this->modalSubmitActionLabel(__('filament-actions::force-delete.single.modal.actions.delete.label'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->groupedIcon(FilamentIcon::resolve('actions::force-delete-action.grouped') ?? 'heroicon-m-trash');
 

--- a/packages/actions/src/RestoreAction.php
+++ b/packages/actions/src/RestoreAction.php
@@ -27,7 +27,7 @@ class RestoreAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::restore.single.notifications.restored.title'));
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->groupedIcon(FilamentIcon::resolve('actions::restore-action.grouped') ?? 'heroicon-m-arrow-uturn-left');
 

--- a/packages/actions/src/ViewAction.php
+++ b/packages/actions/src/ViewAction.php
@@ -27,7 +27,7 @@ class ViewAction extends Action
         $this->modalSubmitAction(false);
         $this->modalCancelAction(fn (StaticAction $action) => $action->label(__('filament-actions::view.single.modal.actions.close.label')));
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->groupedIcon(FilamentIcon::resolve('actions::view-action.grouped') ?? 'heroicon-m-eye');
 

--- a/packages/forms/src/Components/TextInput/Actions/HidePasswordAction.php
+++ b/packages/forms/src/Components/TextInput/Actions/HidePasswordAction.php
@@ -20,7 +20,7 @@ class HidePasswordAction extends Action
 
         $this->icon(FilamentIcon::resolve('forms::components.text-input.actions.hide-password') ?? 'heroicon-m-eye-slash');
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->extraAttributes([
             'x-cloak' => true,

--- a/packages/forms/src/Components/TextInput/Actions/ShowPasswordAction.php
+++ b/packages/forms/src/Components/TextInput/Actions/ShowPasswordAction.php
@@ -20,7 +20,7 @@ class ShowPasswordAction extends Action
 
         $this->icon(FilamentIcon::resolve('forms::components.text-input.actions.show-password') ?? 'heroicon-m-eye');
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->extraAttributes([
             'x-show' => '! isPasswordRevealed',

--- a/packages/tables/src/Actions/AssociateAction.php
+++ b/packages/tables/src/Actions/AssociateAction.php
@@ -66,7 +66,7 @@ class AssociateAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::associate.single.notifications.associated.title'));
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->form(fn (): array => [$this->getRecordSelect()]);
 

--- a/packages/tables/src/Actions/AttachAction.php
+++ b/packages/tables/src/Actions/AttachAction.php
@@ -66,7 +66,7 @@ class AttachAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::attach.single.notifications.attached.title'));
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->form(fn (): array => [$this->getRecordSelect()]);
 

--- a/packages/tables/src/Actions/BulkActionGroup.php
+++ b/packages/tables/src/Actions/BulkActionGroup.php
@@ -14,7 +14,7 @@ class BulkActionGroup extends ActionGroup
 
         $this->icon(FilamentIcon::resolve('tables::actions.open-bulk-actions') ?? 'heroicon-m-ellipsis-vertical');
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->button();
 

--- a/packages/tables/src/Actions/DeleteAction.php
+++ b/packages/tables/src/Actions/DeleteAction.php
@@ -27,7 +27,7 @@ class DeleteAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::delete.single.notifications.deleted.title'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::delete-action') ?? 'heroicon-m-trash');
 

--- a/packages/tables/src/Actions/DeleteBulkAction.php
+++ b/packages/tables/src/Actions/DeleteBulkAction.php
@@ -30,7 +30,7 @@ class DeleteBulkAction extends BulkAction
 
         $this->successNotificationTitle(__('filament-actions::delete.multiple.notifications.deleted.title'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::delete-action') ?? 'heroicon-m-trash');
 

--- a/packages/tables/src/Actions/DetachAction.php
+++ b/packages/tables/src/Actions/DetachAction.php
@@ -29,7 +29,7 @@ class DetachAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::detach.single.notifications.detached.title'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::detach-action') ?? 'heroicon-m-x-mark');
 

--- a/packages/tables/src/Actions/DetachBulkAction.php
+++ b/packages/tables/src/Actions/DetachBulkAction.php
@@ -30,7 +30,7 @@ class DetachBulkAction extends BulkAction
 
         $this->successNotificationTitle(__('filament-actions::detach.multiple.notifications.detached.title'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::detach-action') ?? 'heroicon-m-x-mark');
 

--- a/packages/tables/src/Actions/DissociateAction.php
+++ b/packages/tables/src/Actions/DissociateAction.php
@@ -29,7 +29,7 @@ class DissociateAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::dissociate.single.notifications.dissociated.title'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::dissociate-action') ?? 'heroicon-m-x-mark');
 

--- a/packages/tables/src/Actions/DissociateBulkAction.php
+++ b/packages/tables/src/Actions/DissociateBulkAction.php
@@ -30,7 +30,7 @@ class DissociateBulkAction extends BulkAction
 
         $this->successNotificationTitle(__('filament-actions::dissociate.multiple.notifications.dissociated.title'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::dissociate-action') ?? 'heroicon-m-x-mark');
 

--- a/packages/tables/src/Actions/ForceDeleteAction.php
+++ b/packages/tables/src/Actions/ForceDeleteAction.php
@@ -27,7 +27,7 @@ class ForceDeleteAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::force-delete.single.notifications.deleted.title'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::force-delete-action') ?? 'heroicon-m-trash');
 

--- a/packages/tables/src/Actions/ForceDeleteBulkAction.php
+++ b/packages/tables/src/Actions/ForceDeleteBulkAction.php
@@ -30,7 +30,7 @@ class ForceDeleteBulkAction extends BulkAction
 
         $this->successNotificationTitle(__('filament-actions::force-delete.multiple.notifications.deleted.title'));
 
-        $this->color('danger');
+        $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::force-delete-action') ?? 'heroicon-m-trash');
 

--- a/packages/tables/src/Actions/RestoreAction.php
+++ b/packages/tables/src/Actions/RestoreAction.php
@@ -27,7 +27,7 @@ class RestoreAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::restore.single.notifications.restored.title'));
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->icon(FilamentIcon::resolve('actions::restore-action') ?? 'heroicon-m-arrow-uturn-left');
 

--- a/packages/tables/src/Actions/RestoreBulkAction.php
+++ b/packages/tables/src/Actions/RestoreBulkAction.php
@@ -30,7 +30,7 @@ class RestoreBulkAction extends BulkAction
 
         $this->successNotificationTitle(__('filament-actions::restore.multiple.notifications.restored.title'));
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->icon(FilamentIcon::resolve('actions::restore-action') ?? 'heroicon-m-arrow-uturn-left');
 

--- a/packages/tables/src/Actions/ViewAction.php
+++ b/packages/tables/src/Actions/ViewAction.php
@@ -28,7 +28,7 @@ class ViewAction extends Action
         $this->modalSubmitAction(false);
         $this->modalCancelAction(fn (StaticAction $action) => $action->label(__('filament-actions::view.single.modal.actions.close.label')));
 
-        $this->color('gray');
+        $this->defaultColor('gray');
 
         $this->icon(FilamentIcon::resolve('actions::view-action') ?? 'heroicon-m-eye');
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Changed color() in ViewActions to defaultColor() so that it can be overidden if need be using configureUsing().

I wanted to change the color of my ViewActions globally but even when using ViewAction::configureUsing() I noticed that the color was not changing from the default "gray". I noticed that in all ViewActions, the color is strictly set to "gray". So the only way to override this was to specify ->color() on every single ViewAction in my project.

So, to be able to configure to color of the ViewActions globally, I've updated $this->color('gray') to $this->defaultColor('gray'). This way, it should not harm anything as people who have used ViewAction::color(xxx) should not be affected.

## Visual changes

### Before:
```
ViewAction::configureUsing( function(TableViewAction $action) {
     $action->color(Color::Lime);
});
```
![image](https://github.com/user-attachments/assets/19da41d9-f770-468b-885b-e0aa9da0b409)

### After:
(with ConfigureUsing override):
```
ViewAction::configureUsing( function(TableViewAction $action) {
     $action->color(Color::Lime);
});
```
![image](https://github.com/user-attachments/assets/caaaa9c7-d4a7-4408-9589-2234a72d1fe4)

(without ConfigureUsing override):
![image](https://github.com/user-attachments/assets/19da41d9-f770-468b-885b-e0aa9da0b409)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
