### PR TITLE
Feature: Personal pivot data

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,5 @@
         "trix": "^2.1",
         "uuid-browser": "^3.1.0",
         "vanilla-colorful": "^0.7.2"
-    },
-    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -63,5 +63,6 @@
         "trix": "^2.1",
         "uuid-browser": "^3.1.0",
         "vanilla-colorful": "^0.7.2"
-    }
+    },
+    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/forms/docs/03-fields/03-select.md
+++ b/packages/forms/docs/03-fields/03-select.md
@@ -281,6 +281,25 @@ Select::make('primaryTechnologies')
     ])
 ```
 
+Or you can specify personalized pivot data values
+
+```php
+use Filament\Forms\Components\Select;
+
+Select::make('technologies')
+    ->relationship(name: 'technologies', titleAttribute: 'name')
+    ->multiple()
+    ->pivotData(
+        fn (array $state): array => collect($state)
+            ->mapWithKeys(fn ($technology, $index) => [
+                $technology => [
+                    'is_primary' => $index === 0, // set `is_primary` only for first technology
+                ],
+            ])
+            ->toArray()
+    )
+```
+
 ### Creating a new option in a modal
 
 You may define a custom form that can be used to create a new record and attach it to the `BelongsTo` relationship:

--- a/packages/forms/docs/03-fields/06-checkbox-list.md
+++ b/packages/forms/docs/03-fields/06-checkbox-list.md
@@ -274,6 +274,24 @@ CheckboxList::make('primaryTechnologies')
     ])
 ```
 
+Or you can specify personalized pivot data values
+
+```php
+use Filament\Forms\Components\Select;
+
+CheckboxList::make('technologies')
+    ->relationship(name: 'technologies', titleAttribute: 'name')
+    ->pivotData(
+        fn (array $state): array => collect($state)
+            ->mapWithKeys(fn ($technology, $index) => [
+                $technology => [
+                    'is_primary' => $index === 0, // set `is_primary` only for first technology
+                ],
+            ])
+            ->toArray()
+    )
+```
+
 ## Setting a custom no search results message
 
 When you're using a searchable checkbox list, you may want to display a custom message when no search results are found. You can do this using the `noSearchResultsMessage()` method:

--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -225,6 +225,13 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
                 return;
             }
 
+            // For multiple state with personal pivotData
+            if (static::isPersonalPivotData($pivotData, $state ?? [])) {
+                $relationship->sync($pivotData, detaching: false);
+
+                return;
+            }
+
             $relationship->syncWithPivotValues($state ?? [], $pivotData, detaching: false);
         });
 

--- a/packages/forms/src/Components/Concerns/HasPivotData.php
+++ b/packages/forms/src/Components/Concerns/HasPivotData.php
@@ -3,6 +3,7 @@
 namespace Filament\Forms\Components\Concerns;
 
 use Closure;
+use Illuminate\Support\Arr;
 
 trait HasPivotData
 {
@@ -27,5 +28,14 @@ trait HasPivotData
     public function getPivotData(): array
     {
         return $this->evaluate($this->pivotData) ?? [];
+    }
+
+    protected static function isPersonalPivotData(array $data, array $state): bool
+    {
+        if (count($data) !== count($state)) return false;
+        if (collect($state)->some(fn($key) => !array_key_exists($key, $data))) return false;
+        if (collect($data)->some(fn($value) => !is_array($value) || !Arr::isAssoc($value))) return false;
+
+        return true;
     }
 }

--- a/packages/forms/src/Components/Concerns/HasPivotData.php
+++ b/packages/forms/src/Components/Concerns/HasPivotData.php
@@ -32,9 +32,15 @@ trait HasPivotData
 
     protected static function isPersonalPivotData(array $data, array $state): bool
     {
-        if (count($data) !== count($state)) return false;
-        if (collect($state)->some(fn($key) => !array_key_exists($key, $data))) return false;
-        if (collect($data)->some(fn($value) => !is_array($value) || !Arr::isAssoc($value))) return false;
+        if (count($data) !== count($state)) {
+            return false;
+        }
+        if (collect($state)->some(fn ($key) => ! array_key_exists($key, $data))) {
+            return false;
+        }
+        if (collect($data)->some(fn ($value) => ! is_array($value) || ! Arr::isAssoc($value))) {
+            return false;
+        }
 
         return true;
     }

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -1045,6 +1045,13 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
                 return;
             }
 
+            // For multiple state with personal pivotData
+            if (static::isPersonalPivotData($pivotData, $state)) {
+                $relationship->sync($pivotData, detaching: false);
+
+                return;
+            }
+
             $relationship->syncWithPivotValues($state, $pivotData, detaching: false);
         });
 

--- a/tests/src/Forms/Components/PersonalPivotForMultipleTest.php
+++ b/tests/src/Forms/Components/PersonalPivotForMultipleTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use Filament\Tests\Models\Team;
+use Filament\Tests\Models\User;
+use Filament\Tests\Panels\Fixtures\Resources\UserResource\Pages\CreateUser;
+use Filament\Tests\Panels\Fixtures\Resources\UserResource\Pages\CreateUserWithPersonalPivotData;
+use Filament\Tests\TestCase;
+
+use function Filament\Tests\livewire;
+
+uses(TestCase::class);
+
+it('can use personal pivot data for multiple select', function () {
+    $teams = Team::factory()->count(5)->create();
+    $newUser = User::factory()->definition();
+
+    livewire(CreateUserWithPersonalPivotData::class)
+        ->fillForm([
+            'name' => $newUser['name'],
+            'email' => $newUser['email'],
+            'password' => $newUser['password'],
+            'role' => 'admin',
+            'team_id' => [
+                $teams->get(0)->id,
+                $teams->get(2)->id,
+                $teams->get(4)->id,
+            ],
+        ])
+        ->call('create');
+
+    $user = User::where('email', $newUser['email'])->first();
+
+    expect($user)->not->toBeNull();
+
+    expect(DB::table('team_user')->where([
+        'user_id' => $user->id,
+        'team_id' => $teams[0]->id,
+        'role' => 'owner',
+    ])->exists())->toBeTrue();
+
+    expect(DB::table('team_user')->where([
+        'user_id' => $user->id,
+        'role' => 'admin',
+    ])->pluck('team_id')->toArray())->toBe([3, 5]);
+});
+
+it('can use old pivot data for multiple select', function () {
+    $teams = Team::factory()->count(5)->create();
+    $newUser = User::factory()->definition();
+
+    livewire(CreateUser::class)
+        ->fillForm([
+            'name' => $newUser['name'],
+            'email' => $newUser['email'],
+            'password' => $newUser['password'],
+            'role' => 'admin',
+            'team_id' => [
+                $teams->get(0)->id,
+                $teams->get(2)->id,
+                $teams->get(4)->id,
+            ],
+        ])
+        ->call('create');
+
+    $user = User::where('email', $newUser['email'])->first();
+
+    expect($user)->not->toBeNull();
+
+    expect(DB::table('team_user')->where([
+        'user_id' => $user->id,
+        'role' => 'owner',
+    ])->count())->toBe(0);
+
+    expect(DB::table('team_user')->where([
+        'user_id' => $user->id,
+        'role' => 'admin',
+    ])->pluck('team_id')->toArray())->toBe([1, 3, 5]);
+});

--- a/tests/src/Panels/Fixtures/Resources/UserResource.php
+++ b/tests/src/Panels/Fixtures/Resources/UserResource.php
@@ -26,6 +26,44 @@ class UserResource extends Resource
             ->schema([
                 Forms\Components\TextInput::make('name')->required(),
                 Forms\Components\TextInput::make('email')->required(),
+                Forms\Components\TextInput::make('password')->required()->hiddenOn(Pages\EditUser::class),
+
+                Forms\Components\Section::make('Teams')
+                    ->hiddenOn(Pages\EditUser::class)
+                    ->schema([
+                        Forms\Components\Select::make('team_id')
+                            ->multiple()
+                            ->hiddenOn(Pages\CreateUser::class)
+                            ->relationship(
+                                name          : 'teams',
+                                titleAttribute: 'name',
+                            )
+                            ->pivotData(
+                                fn (Forms\Get $get, array $state): array => collect($state)
+                                    ->mapWithKeys(fn ($team, $index) => [
+                                        $team => [
+                                            'role' => $get('role') === 'admin' && $index === 0 ? 'owner' : $get('role'),
+                                            'created_at' => now(),
+                                        ],
+                                    ])
+                                    ->toArray()
+                            ),
+
+                        Forms\Components\Select::make('team_id')
+                            ->multiple()
+                            ->hiddenOn(Pages\CreateUserWithPersonalPivotData::class)
+                            ->relationship(
+                                name          : 'teams',
+                                titleAttribute: 'name',
+                            )
+                            ->pivotData([
+                                'role' => 'admin',
+                            ]),
+
+                        Forms\Components\Select::make('role')
+                            ->options(['admin', 'user'])
+                            ->dehydrated(false),
+                    ]),
             ]);
     }
 

--- a/tests/src/Panels/Fixtures/Resources/UserResource/Pages/CreateUserWithPersonalPivotData.php
+++ b/tests/src/Panels/Fixtures/Resources/UserResource/Pages/CreateUserWithPersonalPivotData.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Filament\Tests\Panels\Fixtures\Resources\UserResource\Pages;
+
+use Filament\Resources\Pages\CreateRecord;
+use Filament\Tests\Panels\Fixtures\Resources\UserResource;
+
+class CreateUserWithPersonalPivotData extends CreateRecord
+{
+    protected static string $resource = UserResource::class;
+}


### PR DESCRIPTION
## Description

In the case of `relationship` + `multiple` Selects and CheckboxLists, it is possible to bind `pivotData` 
```php
Select::make('primaryTechnologies')
    ->relationship(name: 'technologies', titleAttribute: 'name')
    ->multiple()
    ->pivotData([
        'is_primary' => true,
    ])
```
https://filamentphp.com/docs/3.x/forms/fields/select#saving-pivot-data-to-the-relationship
But there is no way to pass specific `pivotData`. 
For example, I want to make `is_primary=true` for the first relationship only, such as this:
```php
Select::make('technologies')
    ->relationship(name: 'technologies', titleAttribute: 'name')
    ->multiple()
    ->pivotData(
        fn (array $state): array => collect($state)
            ->mapWithKeys(fn ($technology, $index) => [
                $technology => [
                    'is_primary' => $index === 0, // set `is_primary` only for first technology
                ],
            ])
            ->toArray()
    )
```
Also a classic example: when creating a team and adding admins to it, I want to create the first one as `owner` and not just `admin`.
Taking into account that `pivotData` accepts Closure into which `Forms\Get`, state etc. are binded, it turns out to be quite convenient and flexible. 

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
