### PR TITLE
docs: Fix empty make method for user menu example

### DIFF
--- a/docs/06-navigation/03-user-menu.md
+++ b/docs/06-navigation/03-user-menu.md
@@ -20,7 +20,6 @@ public function panel(Panel $panel): Panel
         // ...
         ->userMenuItems([
             Action::make('settings')
-                ->label('Settings')
                 ->url(fn (): string => Settings::getUrl())
                 ->icon('heroicon-o-cog-6-tooth'),
             // ...

--- a/docs/06-navigation/03-user-menu.md
+++ b/docs/06-navigation/03-user-menu.md
@@ -19,7 +19,7 @@ public function panel(Panel $panel): Panel
     return $panel
         // ...
         ->userMenuItems([
-            Action::make()
+            Action::make('navigateToSettings')
                 ->label('Settings')
                 ->url(fn (): string => Settings::getUrl())
                 ->icon('heroicon-o-cog-6-tooth'),

--- a/docs/06-navigation/03-user-menu.md
+++ b/docs/06-navigation/03-user-menu.md
@@ -19,7 +19,7 @@ public function panel(Panel $panel): Panel
     return $panel
         // ...
         ->userMenuItems([
-            Action::make('navigateToSettings')
+            Action::make('settings')
                 ->label('Settings')
                 ->url(fn (): string => Settings::getUrl())
                 ->icon('heroicon-o-cog-6-tooth'),
@@ -91,8 +91,7 @@ You can send a `POST` HTTP request from a user menu item by passing a URL to the
 ```php
 use Filament\Actions\Action;
 
-Action::make()
-    ->label('Lock session')
+Action::make('lockSession')
     ->url(fn (): string => route('lock-session'))
     ->postToUrl()
 ```


### PR DESCRIPTION
A name needs to be passed to `Action::make()`. Updated user menu example to include this.