### PR TITLE
feat: support Redirector type in Logout response

### DIFF
--- a/packages/panels/src/Http/Responses/Auth/LogoutResponse.php
+++ b/packages/panels/src/Http/Responses/Auth/LogoutResponse.php
@@ -5,10 +5,11 @@ namespace Filament\Http\Responses\Auth;
 use Filament\Facades\Filament;
 use Filament\Http\Responses\Auth\Contracts\LogoutResponse as Responsable;
 use Illuminate\Http\RedirectResponse;
+use Livewire\Features\SupportRedirects\Redirector;
 
 class LogoutResponse implements Responsable
 {
-    public function toResponse($request): RedirectResponse
+    public function toResponse($request): RedirectResponse | Redirector
     {
         return redirect()->to(
             Filament::hasLogin() ? Filament::getLoginUrl() : Filament::getUrl(),


### PR DESCRIPTION
This _shouldn't_ break any existing applications since the docs does not tell users to `extend` the base class, but instead `implement` the contract.