### PR TITLE
Adds the ability to define extra HTML attributes for record URLs in tables

### DIFF
--- a/packages/tables/docs/10-advanced.md
+++ b/packages/tables/docs/10-advanced.md
@@ -140,6 +140,21 @@ public function table(Table $table): Table
 }
 ```
 
+You may adding extra attributes to the record URL
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->recordUrlExtraAttributes([
+            'class' => 'underline',
+            'wire:navigate.hover' => true,
+        ]);
+}
+```
+
 If you'd like to [override the URL](columns/getting-started#opening-urls) for a specific column, or instead [run an action](columns/getting-started#running-actions) when a column is clicked, see the [columns documentation](columns/getting-started#opening-urls).
 
 ## Reordering records

--- a/packages/tables/resources/views/components/columns/column.blade.php
+++ b/packages/tables/resources/views/components/columns/column.blade.php
@@ -9,33 +9,33 @@
 ])
 
 @php
-    use Filament\Support\Enums\Alignment;
+use Filament\Support\Enums\Alignment;
 
-    $action = $column->getAction();
-    $alignment = $column->getAlignment() ?? Alignment::Start;
-    $name = $column->getName();
-    $shouldOpenUrlInNewTab = $column->shouldOpenUrlInNewTab();
-    $tooltip = $column->getTooltip();
-    $url = $column->getUrl();
+$action = $column->getAction();
+$alignment = $column->getAlignment() ?? Alignment::Start;
+$name = $column->getName();
+$shouldOpenUrlInNewTab = $column->shouldOpenUrlInNewTab();
+$tooltip = $column->getTooltip();
+$url = $column->getUrl();
 
-    if (! $alignment instanceof Alignment) {
-        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
-    }
+if (!$alignment instanceof Alignment) {
+    $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
+}
 
-    $columnClasses = \Illuminate\Support\Arr::toCssClasses([
-        'flex w-full disabled:pointer-events-none',
-        match ($alignment) {
-            Alignment::Start => 'justify-start text-start',
-            Alignment::Center => 'justify-center text-center',
-            Alignment::End => 'justify-end text-end',
-            Alignment::Left => 'justify-start text-left',
-            Alignment::Right => 'justify-end text-right',
-            Alignment::Justify, Alignment::Between => 'justify-between text-justify',
-            default => $alignment,
-        },
-    ]);
+$columnClasses = \Illuminate\Support\Arr::toCssClasses([
+    'flex w-full disabled:pointer-events-none',
+    match ($alignment) {
+        Alignment::Start => 'justify-start text-start',
+        Alignment::Center => 'justify-center text-center',
+        Alignment::End => 'justify-end text-end',
+        Alignment::Left => 'justify-start text-left',
+        Alignment::Right => 'justify-end text-right',
+        Alignment::Justify, Alignment::Between => 'justify-between text-justify',
+        default => $alignment,
+    },
+]);
 
-    $slot = $column->viewData(['recordKey' => $recordKey]);
+$slot = $column->viewData(['recordKey' => $recordKey]);
 @endphp
 
 <div
@@ -48,26 +48,28 @@
     @endif
     {{ $attributes->class(['fi-ta-col-wrp']) }}
 >
-    @if (($url || ($recordUrl && $action === null)) && (! $isClickDisabled))
-        <a
-            {{ \Filament\Support\generate_href_html($url ?: $recordUrl, $url ? $shouldOpenUrlInNewTab : $shouldOpenRecordUrlInNewTab) }}
-            class="{{ $columnClasses }}"
-        >
-            {{ $slot }}
-        </a>
-    @elseif (($action || $recordAction) && (! $isClickDisabled))
+    @if (($url || ($recordUrl && $action === null)) && (!$isClickDisabled))
+
+            <a
+                {{ \Filament\Support\generate_href_html($url ?: $recordUrl, $url ? $shouldOpenUrlInNewTab : $shouldOpenRecordUrlInNewTab) }}
+
+                {{$attributes->merge($column->getTable()->getRecordUrlExtraAttributes(), escape: false)->class($columnClasses)}}  
+            >
+                {{ $slot }}
+            </a>
+    @elseif (($action || $recordAction) && (!$isClickDisabled))
         @php
-            if ($action instanceof \Filament\Tables\Actions\Action) {
-                $wireClickAction = "mountTableAction('{$action->getName()}', '{$recordKey}')";
-            } elseif ($action) {
-                $wireClickAction = "callTableColumnAction('{$name}', '{$recordKey}')";
-            } else {
-                if ($this->getTable()->getAction($recordAction)) {
-                    $wireClickAction = "mountTableAction('{$recordAction}', '{$recordKey}')";
-                } else {
-                    $wireClickAction = "{$recordAction}('{$recordKey}')";
-                }
-            }
+    if ($action instanceof \Filament\Tables\Actions\Action) {
+        $wireClickAction = "mountTableAction('{$action->getName()}', '{$recordKey}')";
+    } elseif ($action) {
+        $wireClickAction = "callTableColumnAction('{$name}', '{$recordKey}')";
+    } else {
+        if ($this->getTable()->getAction($recordAction)) {
+            $wireClickAction = "mountTableAction('{$recordAction}', '{$recordKey}')";
+        } else {
+            $wireClickAction = "{$recordAction}('{$recordKey}')";
+        }
+    }
         @endphp
 
         <button

--- a/packages/tables/src/Table/Concerns/HasRecordUrl.php
+++ b/packages/tables/src/Table/Concerns/HasRecordUrl.php
@@ -4,21 +4,23 @@ namespace Filament\Tables\Table\Concerns;
 
 use Closure;
 use Illuminate\Database\Eloquent\Model;
-
+use Illuminate\View\ComponentAttributeBag;
 trait HasRecordUrl
 {
-    protected bool | Closure $shouldOpenRecordUrlInNewTab = false;
+    protected bool|Closure $shouldOpenRecordUrlInNewTab = false;
 
-    protected string | Closure | null $recordUrl = null;
+    protected string|Closure|null $recordUrl = null;
 
-    public function openRecordUrlInNewTab(bool | Closure $condition = true): static
+    protected array $recordUrlExtraAttributes = [];
+
+    public function openRecordUrlInNewTab(bool|Closure $condition = true): static
     {
         $this->shouldOpenRecordUrlInNewTab = $condition;
 
         return $this;
     }
 
-    public function recordUrl(string | Closure | null $url, bool | Closure $shouldOpenInNewTab = false): static
+    public function recordUrl(string|Closure|null $url, bool|Closure $shouldOpenInNewTab = false): static
     {
         $this->openRecordUrlInNewTab($shouldOpenInNewTab);
         $this->recordUrl = $url;
@@ -35,7 +37,7 @@ trait HasRecordUrl
             ],
             typedInjections: [
                 Model::class => $record,
-                $record::class => $record,
+                    $record::class => $record,
             ],
         );
     }
@@ -49,8 +51,36 @@ trait HasRecordUrl
             ],
             typedInjections: [
                 Model::class => $record,
-                $record::class => $record,
+                    $record::class => $record,
             ],
         );
+    }
+
+    public function recordUrlextraAttributes(array|Closure $attributes, bool $merge = false): static
+    {
+        if ($merge) {
+            $this->recordUrlextraAttributes[] = $attributes;
+        } else {
+            $this->recordUrlextraAttributes = [$attributes];
+        }
+
+        return $this;
+    }
+
+
+    public function getRecordUrlExtraAttributes(): array
+    {
+        $temporaryAttributeBag = new ComponentAttributeBag;
+
+        foreach ($this->recordUrlextraAttributes as $recordUrlextraAttributes) {
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($recordUrlextraAttributes));
+        }
+
+        return $temporaryAttributeBag->getAttributes();
+    }
+
+    public function getExtraAttributeBag(): ComponentAttributeBag
+    {
+        return new ComponentAttributeBag($this->getExtraAttributes());
     }
 }


### PR DESCRIPTION
## Description

Adds the ability to define extra HTML attributes for record URLs in tables, via a new `$table->recordUrlExtraAttributes()` method.  
This allows better control over the generated links, such as adding classes, targets, ARIA labels, wire:navigated.hover etc. 

## Visual changes

No visual changes.

## Functional changes

- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.