### PR TITLE
Prevent 2FA setup modal from being closed accidentally

### DIFF
--- a/packages/panels/src/Auth/MultiFactor/GoogleTwoFactor/Actions/SetUpGoogleTwoFactorAuthenticationAction.php
+++ b/packages/panels/src/Auth/MultiFactor/GoogleTwoFactor/Actions/SetUpGoogleTwoFactorAuthenticationAction.php
@@ -54,7 +54,6 @@ class SetUpGoogleTwoFactorAuthenticationAction
             ->modalWidth(Width::Large)
             ->closeModalByClickingAway(false)
             ->closeModalByEscaping(false)
-            ->modalCloseButton(false)
             ->modalIcon(Heroicon::OutlinedLockClosed)
             ->modalIconColor('primary')
             ->modalHeading(__('filament-panels::auth/multi-factor/google-two-factor/actions/set-up.modal.heading'))

--- a/packages/panels/src/Auth/MultiFactor/GoogleTwoFactor/Actions/SetUpGoogleTwoFactorAuthenticationAction.php
+++ b/packages/panels/src/Auth/MultiFactor/GoogleTwoFactor/Actions/SetUpGoogleTwoFactorAuthenticationAction.php
@@ -52,6 +52,9 @@ class SetUpGoogleTwoFactorAuthenticationAction
                 ]);
             })
             ->modalWidth(Width::Large)
+            ->closeModalByClickingAway(false)
+            ->closeModalByEscaping(false)
+            ->modalCloseButton(false)
             ->modalIcon(Heroicon::OutlinedLockClosed)
             ->modalIconColor('primary')
             ->modalHeading(__('filament-panels::auth/multi-factor/google-two-factor/actions/set-up.modal.heading'))


### PR DESCRIPTION
Prevents accidentally breaking the 2FA setup flow or closing before recovery codes are copied.