### PR TITLE
fix: read only label date time picker

### DIFF
--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -23,6 +23,7 @@
     :component="$getFieldWrapperView()"
     :field="$field"
     :inline-label-vertical-alignment="\Filament\Support\Enums\VerticalAlignment::Center"
+    :isReadOnly="$isReadOnly()"
 >
     <x-filament::input.wrapper
         :disabled="$isDisabled"

--- a/packages/forms/resources/views/components/field-wrapper/index.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/index.blade.php
@@ -15,6 +15,7 @@
     'id' => null,
     'inlineLabelVerticalAlignment' => VerticalAlignment::Start,
     'isDisabled' => null,
+    'isReadOnly' => null,
     'label' => null,
     'labelPrefix' => null,
     'labelSrOnly' => null,
@@ -35,6 +36,7 @@
         $hintIconTooltip ??= $field->getHintIconTooltip();
         $id ??= $field->getId();
         $isDisabled ??= $field->isDisabled();
+        $isReadOnly ??= false;
         $label ??= $field->getLabel();
         $labelSrOnly ??= $field->isLabelHidden();
         $required ??= $field->isMarkedAsRequired();
@@ -88,6 +90,7 @@
                         :for="$id"
                         :disabled="$isDisabled"
                         :prefix="$labelPrefix"
+                        :readOnly="$isReadOnly"
                         :required="$required"
                         :suffix="$labelSuffix"
                     >

--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -1,9 +1,16 @@
 @props([
     'disabled' => false,
     'prefix' => null,
+    'readOnly' => false,
     'required' => false,
     'suffix' => null,
 ])
+
+@php
+    if ($readOnly) {
+        $attributes = $attributes->exceptProps(['for']);
+    }
+@endphp
 
 <label
     {{ $attributes->class(['fi-fo-field-wrp-label inline-flex items-center gap-x-3']) }}


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
Date Time Picker has been set to readOnly, if you click on the Label, it still opens the Date Time Picker dialog.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->
What is currently happening.

https://github.com/user-attachments/assets/79bce719-29b2-4ae2-848f-df3ee584f24a

After repair

https://github.com/user-attachments/assets/c145a1df-1394-441d-a486-40c4a3750141



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
