### PR TITLE
Revert cached state

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
@@ -128,40 +128,38 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
      */
     public function getState(): array
     {
-        return $this->cacheState(function (): array {
-            $record = $this->getRecord();
+        $record = $this->getRecord();
 
-            if ($this->hasRelationship($record)) {
-                $record = $this->getRelationshipResults($record);
-            }
+        if ($this->hasRelationship($record)) {
+            $record = $this->getRelationshipResults($record);
+        }
 
-            $records = Arr::wrap($record);
+        $records = Arr::wrap($record);
 
-            $state = [];
+        $state = [];
 
-            $collection = $this->getCollection() ?? 'default';
+        $collection = $this->getCollection() ?? 'default';
 
-            foreach ($records as $record) {
-                /** @var Model $record */
-                $state = [
-                    ...$state,
-                    ...$record->getRelationValue('media')
-                        ->when(
-                            ! $collection instanceof AllMediaCollections,
-                            fn (MediaCollection $mediaCollection) => $mediaCollection->filter(fn (Media $media): bool => $media->getAttributeValue('collection_name') === $collection),
-                        )
-                        ->when(
-                            $this->hasMediaFilter(),
-                            fn (Collection $media) => $this->filterMedia($media)
-                        )
-                        ->sortBy('order_column')
-                        ->pluck('uuid')
-                        ->all(),
-                ];
-            }
+        foreach ($records as $record) {
+            /** @var Model $record */
+            $state = [
+                ...$state,
+                ...$record->getRelationValue('media')
+                    ->when(
+                        ! $collection instanceof AllMediaCollections,
+                        fn (MediaCollection $mediaCollection) => $mediaCollection->filter(fn (Media $media): bool => $media->getAttributeValue('collection_name') === $collection),
+                    )
+                    ->when(
+                        $this->hasMediaFilter(),
+                        fn (Collection $media) => $this->filterMedia($media)
+                    )
+                    ->sortBy('order_column')
+                    ->pluck('uuid')
+                    ->all(),
+            ];
+        }
 
-            return array_unique($state);
-        });
+        return array_unique($state);
     }
 
     public function applyEagerLoading(Builder | Relation $query): Builder | Relation

--- a/packages/support/src/Concerns/HasCellState.php
+++ b/packages/support/src/Concerns/HasCellState.php
@@ -4,7 +4,6 @@ namespace Filament\Support\Concerns;
 
 use Closure;
 use Exception;
-use Filament\Tables\Columns\Column;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;

--- a/packages/support/src/Concerns/HasCellState.php
+++ b/packages/support/src/Concerns/HasCellState.php
@@ -25,11 +25,6 @@ trait HasCellState
 
     protected ?string $inverseRelationshipName = null;
 
-    /**
-     * @var array<string, mixed>
-     */
-    protected array $cachedState = [];
-
     public function inverseRelationship(?string $name): static
     {
         $this->inverseRelationshipName = $name;
@@ -77,24 +72,22 @@ trait HasCellState
 
     public function getState(): mixed
     {
-        return $this->cacheState(function (): mixed {
-            $state = ($this->getStateUsing !== null) ?
-                $this->evaluate($this->getStateUsing) :
-                $this->getStateFromRecord();
+        $state = ($this->getStateUsing !== null) ?
+            $this->evaluate($this->getStateUsing) :
+            $this->getStateFromRecord();
 
-            if (is_string($state) && ($separator = $this->getSeparator())) {
-                $state = explode($separator, $state);
-                $state = (count($state) === 1 && blank($state[0])) ?
-                    [] :
-                    $state;
-            }
+        if (is_string($state) && ($separator = $this->getSeparator())) {
+            $state = explode($separator, $state);
+            $state = (count($state) === 1 && blank($state[0])) ?
+                [] :
+                $state;
+        }
 
-            if (blank($state)) {
-                $state = $this->getDefaultState();
-            }
+        if (blank($state)) {
+            $state = $this->getDefaultState();
+        }
 
-            return $state;
-        });
+        return $state;
     }
 
     public function getStateFromRecord(): mixed
@@ -131,11 +124,6 @@ trait HasCellState
         }
 
         return $state->all();
-    }
-
-    public function clearCachedState(): void
-    {
-        $this->cachedState = [];
     }
 
     public function separator(string | Closure | null $separator = ','): static
@@ -299,30 +287,5 @@ trait HasCellState
         }
 
         return (string) str($name)->beforeLast('.');
-    }
-
-    protected function cacheState(Closure $state): mixed
-    {
-        $record = $this->getRecord();
-
-        if (! $record) {
-            return null;
-        }
-
-        if ($this instanceof Column) {
-            $recordKey = $this->getLivewire()->getTableRecordKey($record);
-        } else {
-            $recordKey = (string) $record->getKey();
-        }
-
-        if (blank($recordKey)) {
-            return $state();
-        }
-
-        if (array_key_exists($recordKey, $this->cachedState)) {
-            return $this->cachedState[$recordKey];
-        }
-
-        return $this->cachedState[$recordKey] = $state();
     }
 }

--- a/packages/tables/src/Columns/Summarizers/Count.php
+++ b/packages/tables/src/Columns/Summarizers/Count.php
@@ -39,9 +39,7 @@ class Count extends Summarizer
 
         foreach ($query->clone()->distinct()->pluck($attribute) as $value) {
             $column->record($this->getQuery()->getModel()->setKeyName($attribute)->setAttribute($attribute, $value));
-            $column->clearCachedState();
             $columnState = $column->getState();
-            $column->clearCachedState();
             $color = json_encode($column->getColor($columnState));
             $icon = $column->getIcon($columnState);
 

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -180,8 +180,6 @@ class TestsColumns
 
             $livewireClass = $this->instance()::class;
 
-            $column->clearCachedState();
-
             $state = $column->getState();
 
             if (is_array($state)) {
@@ -217,8 +215,6 @@ class TestsColumns
             $column->record($record);
 
             $livewireClass = $this->instance()::class;
-
-            $column->clearCachedState();
 
             $state = $column->getState();
 
@@ -256,8 +252,6 @@ class TestsColumns
 
             $livewireClass = $this->instance()::class;
 
-            $column->clearCachedState();
-
             Assert::assertEquals(
                 $value,
                 $column->formatState($column->getState()),
@@ -284,8 +278,6 @@ class TestsColumns
             $column->record($record);
 
             $livewireClass = $this->instance()::class;
-
-            $column->clearCachedState();
 
             Assert::assertFalse(
                 $column->formatState($column->getState()) == $value,


### PR DESCRIPTION
This feature has caused many problems for users since it was introduced. They are all user error (table rows don't have properly unique keys), but a breaking change nonetheless so I am reverting it. It will be enabled in v4.

One such breakage: #16165

Original PR: #15924