### PR TITLE
add missing dependency

### DIFF
--- a/packages/forms/composer.json
+++ b/packages/forms/composer.json
@@ -19,6 +19,7 @@
         "illuminate/support": "^10.45|^11.0|^12.0",
         "illuminate/validation": "^10.45|^11.0|^12.0",
         "illuminate/view": "^10.45|^11.0|^12.0",
+        "staudenmeir/belongs-to-through": "^2.17",
         "spatie/laravel-package-tools": "^1.9"
     },
     "autoload": {


### PR DESCRIPTION
As mentioned [here](https://github.com/filamentphp/filament/discussions/16163), I think the staudenmeir/belongs-to-through dependency is missing. I am not sure if this is the correct way to update the forms-subtree, let me know if I have to create this PR somewhere else...