### PR TITLE
Add EmbeddedWidget

### DIFF
--- a/packages/schemas/src/Components/EmbeddedWidget.php
+++ b/packages/schemas/src/Components/EmbeddedWidget.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Filament\Schemas\Components;
+
+use Closure;
+use Exception;
+use Filament\Widgets\Widget;
+use Illuminate\Contracts\View\View;
+
+class EmbeddedWidget extends Component
+{
+    /**
+     * @param  array<string, mixed> | Closure  $livewireComponentData
+     */
+    public static function make(string | Closure | null $livewireComponent = null, array | Closure $livewireComponentData = []): static | Livewire
+    {
+        if (filled($livewireComponent)) {
+            return Livewire::make($livewireComponent, $livewireComponentData);
+        }
+
+        $static = app(static::class);
+        $static->configure();
+
+        return $static;
+    }
+
+    public function render(): View
+    {
+        $livewire = $this->getLivewire();
+
+        if (! ($livewire instanceof Widget)) {
+            throw new Exception('The [' . $livewire::class . '] component must be a widget.');
+        }
+
+        return $livewire->render();
+    }
+}

--- a/packages/schemas/src/Components/EmbeddedWidget.php
+++ b/packages/schemas/src/Components/EmbeddedWidget.php
@@ -14,14 +14,7 @@ class EmbeddedWidget extends Component
      */
     public static function make(string | Closure $livewireComponent, array | Closure $livewireComponentData = []): static | Livewire
     {
-        if (filled($livewireComponent)) {
-            return Livewire::make($livewireComponent, $livewireComponentData);
-        }
-
-        $static = app(static::class);
-        $static->configure();
-
-        return $static;
+        return Livewire::make($livewireComponent, $livewireComponentData);
     }
 
     public function render(): View

--- a/packages/schemas/src/Components/EmbeddedWidget.php
+++ b/packages/schemas/src/Components/EmbeddedWidget.php
@@ -12,7 +12,7 @@ class EmbeddedWidget extends Component
     /**
      * @param  array<string, mixed> | Closure  $livewireComponentData
      */
-    public static function make(string | Closure | null $livewireComponent = null, array | Closure $livewireComponentData = []): static | Livewire
+    public static function make(string | Closure $livewireComponent, array | Closure $livewireComponentData = []): static | Livewire
     {
         if (filled($livewireComponent)) {
             return Livewire::make($livewireComponent, $livewireComponentData);

--- a/packages/schemas/src/Components/EmbeddedWidget.php
+++ b/packages/schemas/src/Components/EmbeddedWidget.php
@@ -12,7 +12,7 @@ class EmbeddedWidget extends Component
     /**
      * @param  array<string, mixed> | Closure  $livewireComponentData
      */
-    public static function make(string | Closure $livewireComponent, array | Closure $livewireComponentData = []): static | Livewire
+    public static function make(string | Closure $livewireComponent, array | Closure $livewireComponentData = []):Livewire
     {
         return Livewire::make($livewireComponent, $livewireComponentData);
     }

--- a/packages/schemas/src/Components/EmbeddedWidget.php
+++ b/packages/schemas/src/Components/EmbeddedWidget.php
@@ -12,7 +12,7 @@ class EmbeddedWidget extends Component
     /**
      * @param  array<string, mixed> | Closure  $livewireComponentData
      */
-    public static function make(string | Closure $livewireComponent, array | Closure $livewireComponentData = []):Livewire
+    public static function make(string | Closure $livewireComponent, array | Closure $livewireComponentData = []): Livewire
     {
         return Livewire::make($livewireComponent, $livewireComponentData);
     }


### PR DESCRIPTION
Provides a consistent API for adding widgets to page content:

```PHP
    public function content(Schema $schema): Schema
    {
        return $schema
            ->components([
                $this->getFormContentComponent(),
                EmbeddedWidget::make(SummaryWidget::class, [
                    'total' => $total,
                ]),
                EmbeddedTable::make()
            ]);
    }
```