### PR TITLE
feat: allow custom credential extraction and notification customization for password reset

### DIFF
--- a/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
+++ b/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
@@ -76,18 +76,12 @@ class RequestPasswordReset extends SimplePage
         );
 
         if ($status !== Password::RESET_LINK_SENT) {
-            Notification::make()
-                ->title(__($status))
-                ->danger()
-                ->send();
+            $this->getFailureNotification($status)?->send();
 
             return;
         }
 
-        Notification::make()
-            ->title(__($status))
-            ->success()
-            ->send();
+        $this->getSentNotification($status)?->send();
 
         $this->form->fill();
     }
@@ -104,6 +98,20 @@ class RequestPasswordReset extends SimplePage
                 'minutes' => $exception->minutesUntilAvailable,
             ]) : null)
             ->danger();
+    }
+
+    protected function getFailureNotification(string $status): ?Notification
+    {
+        return Notification::make()
+            ->title(__($status))
+            ->danger();
+    }
+
+    protected function getSentNotification(string $status): ?Notification
+    {
+        return Notification::make()
+            ->title(__($status))
+            ->success();
     }
 
     public function form(Form $form): Form

--- a/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
+++ b/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
@@ -60,7 +60,7 @@ class RequestPasswordReset extends SimplePage
         $data = $this->form->getState();
 
         $status = Password::broker(Filament::getAuthPasswordBroker())->sendResetLink(
-            $data,
+            $this->getCredentialsFromFormData($data),
             function (CanResetPassword $user, string $token): void {
                 if (! method_exists($user, 'notify')) {
                     $userClass = $user::class;
@@ -179,5 +179,16 @@ class RequestPasswordReset extends SimplePage
     protected function hasFullWidthFormActions(): bool
     {
         return true;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function getCredentialsFromFormData(array $data): array
+    {
+        return [
+            'email' => $data['email'],
+        ];
     }
 }

--- a/packages/panels/src/Pages/Auth/PasswordReset/ResetPassword.php
+++ b/packages/panels/src/Pages/Auth/PasswordReset/ResetPassword.php
@@ -77,7 +77,7 @@ class ResetPassword extends SimplePage
         $data['token'] = $this->token;
 
         $status = Password::broker(Filament::getAuthPasswordBroker())->reset(
-            $data,
+            $this->getCredentialsFromFormData($data),
             function (CanResetPassword | Model | Authenticatable $user) use ($data) {
                 $user->forceFill([
                     'password' => Hash::make($data['password']),
@@ -189,5 +189,14 @@ class ResetPassword extends SimplePage
     protected function hasFullWidthFormActions(): bool
     {
         return true;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function getCredentialsFromFormData(array $data): array
+    {
+        return $data;
     }
 }


### PR DESCRIPTION
## 1. Added `getCredentialsFromFormData` in `RequestPasswordReset`

This is useful when you want to use a different identifier for password resets (e.g., Brazilian CPF) or modify the submitted data (e.g., removing masks).

Example from my app:
```php
protected function getCredentialsFromFormData(array $data): array
    {
        return [
            'cpf' => preg_replace('/[^0-9]/', '', $data['cpf']),
        ];
    }
```

This method follows the same implementation found in `Filament\Pages\Auth\Login`.

## 2. Added `getFailureNotification` and `getSentNotification` in `RequestPasswordReset`

These methods allow for customization of the messages/notifications shown specifically on the password reset page.

Example from my app:
```php
protected function getSentNotification(string $status): ?Notification
    {
        return parent::getSentNotification($status)
            ->title(__('We have sent a password reset link to the email and WhatsApp associated with your account.'))
            ->persistent();
    }
```

## 3. Added `getCredentialsFromFormData` in `ResetPassword`

This is useful when you want to use a different identifier for password resets (e.g., Brazilian CPF) or modify the submitted data (e.g., removing masks).

Example from my app:
```php
protected function getCredentialsFromFormData(array $data): array
    {
        return [
            'cpf' => $data['email'], // CPF is used as email in the form
            'token' => $data['token'],
            'password' => $data['password'],
        ];
    }
```

This method follows the same implementation found in `Filament\Pages\Auth\Login`.