### PR TITLE
added id check to modal closed event

### DIFF
--- a/packages/actions/resources/views/components/modals.blade.php
+++ b/packages/actions/resources/views/components/modals.blade.php
@@ -27,7 +27,7 @@
             :wire:key="$action ? $this->getId() . '.actions.' . $action->getName() . '.modal' : null"
             x-on:closed-form-component-action-modal.window="if (($event.detail.id === '{{ $this->getId() }}') && $wire.mountedActions.length) open()"
             x-on:modal-closed.stop="
-                if ($event.detail.id !== '{{ $this->getId() }}-action') {
+                if (!$event.detail?.id?.startsWith('{{ $this->getId() }}')) {
                     return
                 }
 
@@ -93,7 +93,7 @@
             :wire:key="$action ? $this->getId() . '.table.actions.' . $action->getName() . '.modal' : null"
             x-on:closed-form-component-action-modal.window="if (($event.detail.id === '{{ $this->getId() }}') && $wire.mountedTableActions.length) open()"
             x-on:modal-closed.stop="
-                if ($event.detail.id !== '{{ $this->getId() }}-table-action') {
+                if (!$event.detail?.id?.startsWith('{{ $this->getId() }}')) {
                     return
                 }
 
@@ -153,7 +153,7 @@
             :wire:key="$action ? $this->getId() . '.table.bulk-actions.' . $action->getName() . '.modal' : null"
             x-on:closed-form-component-action-modal.window="if (($event.detail.id === '{{ $this->getId() }}') && $wire.mountedTableBulkAction) open()"
             x-on:modal-closed.stop="
-                if ($event.detail.id !== '{{ $this->getId() }}-table-bulk-action') {
+                if (!$event.detail?.id?.startsWith('{{ $this->getId() }}')) {
                     return
                 }
 
@@ -219,7 +219,7 @@
             :wire:key="$action ? $this->getId() . '.infolist.actions.' . $action->getName() . '.modal' : null"
             x-on:closed-form-component-action-modal.window="if (($event.detail.id === '{{ $this->getId() }}') && $wire.mountedInfolistActions.length) open()"
             x-on:modal-closed.stop="
-                if ($event.detail.id !== '{{ $this->getId() }}-infolist-action') {
+                if (!$event.detail?.id?.startsWith('{{ $this->getId() }}')) {
                     return
                 }
 
@@ -284,7 +284,7 @@
             :width="$action?->getModalWidth()"
             :wire:key="$action ? $this->getId() . '.' . $action->getComponent()->getStatePath() . '.actions.' . $action->getName() . '.modal' : null"
             x-on:modal-closed.stop="
-                if ($event.detail.id !== '{{ $this->getId() }}-form-component-action') {
+                if (!$event.detail?.id?.startsWith('{{ $this->getId() }}')) {
                     return
                 }
 

--- a/packages/actions/resources/views/components/modals.blade.php
+++ b/packages/actions/resources/views/components/modals.blade.php
@@ -27,6 +27,10 @@
             :wire:key="$action ? $this->getId() . '.actions.' . $action->getName() . '.modal' : null"
             x-on:closed-form-component-action-modal.window="if (($event.detail.id === '{{ $this->getId() }}') && $wire.mountedActions.length) open()"
             x-on:modal-closed.stop="
+                if ($event.detail.id !== '{{ $this->getId() }}-action') {
+                    return
+                }
+
                 const mountedActionShouldOpenModal = {{ \Illuminate\Support\Js::from($action && $this->mountedActionShouldOpenModal(mountedAction: $action)) }}
 
                 if (! mountedActionShouldOpenModal) {
@@ -89,6 +93,10 @@
             :wire:key="$action ? $this->getId() . '.table.actions.' . $action->getName() . '.modal' : null"
             x-on:closed-form-component-action-modal.window="if (($event.detail.id === '{{ $this->getId() }}') && $wire.mountedTableActions.length) open()"
             x-on:modal-closed.stop="
+                if ($event.detail.id !== '{{ $this->getId() }}-table-action') {
+                    return
+                }
+
                 const mountedTableActionShouldOpenModal = {{ \Illuminate\Support\Js::from($action && $this->mountedTableActionShouldOpenModal(mountedAction: $action)) }}
 
                 if (! mountedTableActionShouldOpenModal) {
@@ -145,6 +153,10 @@
             :wire:key="$action ? $this->getId() . '.table.bulk-actions.' . $action->getName() . '.modal' : null"
             x-on:closed-form-component-action-modal.window="if (($event.detail.id === '{{ $this->getId() }}') && $wire.mountedTableBulkAction) open()"
             x-on:modal-closed.stop="
+                if ($event.detail.id !== '{{ $this->getId() }}-table-bulk-action') {
+                    return
+                }
+
                 const mountedTableBulkActionShouldOpenModal = {{ \Illuminate\Support\Js::from($action && $this->mountedTableBulkActionShouldOpenModal(mountedBulkAction: $action)) }}
 
                 if (! mountedTableBulkActionShouldOpenModal) {
@@ -207,6 +219,10 @@
             :wire:key="$action ? $this->getId() . '.infolist.actions.' . $action->getName() . '.modal' : null"
             x-on:closed-form-component-action-modal.window="if (($event.detail.id === '{{ $this->getId() }}') && $wire.mountedInfolistActions.length) open()"
             x-on:modal-closed.stop="
+                if ($event.detail.id !== '{{ $this->getId() }}-infolist-action') {
+                    return
+                }
+
                 const mountedInfolistActionShouldOpenModal = {{ \Illuminate\Support\Js::from($action && $this->mountedInfolistActionShouldOpenModal(mountedAction: $action)) }}
 
                 if (! mountedInfolistActionShouldOpenModal) {
@@ -268,6 +284,10 @@
             :width="$action?->getModalWidth()"
             :wire:key="$action ? $this->getId() . '.' . $action->getComponent()->getStatePath() . '.actions.' . $action->getName() . '.modal' : null"
             x-on:modal-closed.stop="
+                if ($event.detail.id !== '{{ $this->getId() }}-form-component-action') {
+                    return
+                }
+
                 const mountedFormComponentActionShouldOpenModal = {{ \Illuminate\Support\Js::from($action && $this->mountedFormComponentActionShouldOpenModal()) }}
 
                 if (mountedFormComponentActionShouldOpenModal) {

--- a/packages/actions/resources/views/components/modals.blade.php
+++ b/packages/actions/resources/views/components/modals.blade.php
@@ -27,7 +27,7 @@
             :wire:key="$action ? $this->getId() . '.actions.' . $action->getName() . '.modal' : null"
             x-on:closed-form-component-action-modal.window="if (($event.detail.id === '{{ $this->getId() }}') && $wire.mountedActions.length) open()"
             x-on:modal-closed.stop="
-                if (!$event.detail?.id?.startsWith('{{ $this->getId() }}')) {
+                if (!$event.detail?.id?.startsWith('{{ $this->getId() }}-')) {
                     return
                 }
 
@@ -93,7 +93,7 @@
             :wire:key="$action ? $this->getId() . '.table.actions.' . $action->getName() . '.modal' : null"
             x-on:closed-form-component-action-modal.window="if (($event.detail.id === '{{ $this->getId() }}') && $wire.mountedTableActions.length) open()"
             x-on:modal-closed.stop="
-                if (!$event.detail?.id?.startsWith('{{ $this->getId() }}')) {
+                if (!$event.detail?.id?.startsWith('{{ $this->getId() }}-')) {
                     return
                 }
 
@@ -153,7 +153,7 @@
             :wire:key="$action ? $this->getId() . '.table.bulk-actions.' . $action->getName() . '.modal' : null"
             x-on:closed-form-component-action-modal.window="if (($event.detail.id === '{{ $this->getId() }}') && $wire.mountedTableBulkAction) open()"
             x-on:modal-closed.stop="
-                if (!$event.detail?.id?.startsWith('{{ $this->getId() }}')) {
+                if (!$event.detail?.id?.startsWith('{{ $this->getId() }}-')) {
                     return
                 }
 
@@ -219,7 +219,7 @@
             :wire:key="$action ? $this->getId() . '.infolist.actions.' . $action->getName() . '.modal' : null"
             x-on:closed-form-component-action-modal.window="if (($event.detail.id === '{{ $this->getId() }}') && $wire.mountedInfolistActions.length) open()"
             x-on:modal-closed.stop="
-                if (!$event.detail?.id?.startsWith('{{ $this->getId() }}')) {
+                if (!$event.detail?.id?.startsWith('{{ $this->getId() }}-')) {
                     return
                 }
 
@@ -284,7 +284,7 @@
             :width="$action?->getModalWidth()"
             :wire:key="$action ? $this->getId() . '.' . $action->getComponent()->getStatePath() . '.actions.' . $action->getName() . '.modal' : null"
             x-on:modal-closed.stop="
-                if (!$event.detail?.id?.startsWith('{{ $this->getId() }}')) {
+                if (!$event.detail?.id?.startsWith('{{ $this->getId() }}-')) {
                     return
                 }
 

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -72,7 +72,7 @@
             this.isOpen = false
 
             this.$refs.modalContainer.dispatchEvent(
-                new CustomEvent('modal-closed', { id: '{{ $id }}' }),
+                new CustomEvent('modal-closed', { detail: { id: '{{ $id }}' } }),
             )
         },
 
@@ -85,7 +85,7 @@
                 @endif
 
                 this.$refs.modalContainer.dispatchEvent(
-                    new CustomEvent('modal-opened', { id: '{{ $id }}' }),
+                    new CustomEvent('modal-opened', { detail: { id: '{{ $id }}' } }),
                 )
             })
         },


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When we open another modal in an action modal and click the close button in the top right corner to close the child modal, it also closes the parent action modal and keeps the black overlay. 

Related plugin issue: https://github.com/alperenersoy/filament-export/issues/146

## Visual changes

Before:

[Screencast From 2025-05-01 21-29-34.webm](https://github.com/user-attachments/assets/b695bc92-5a39-499b-a3b3-d8b6cede2fe3)

After:

[Screencast From 2025-05-01 21-51-07.webm](https://github.com/user-attachments/assets/992d6190-7a64-4d26-9032-898def2509fa)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
