### PR TITLE
fix: prevent error when calling non-existent getTagClassName method

### DIFF
--- a/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
+++ b/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
@@ -100,7 +100,9 @@ class SpatieTagsInput extends TagsInput
         }
 
         $model = $this->getModel();
-        $tagClass = $model ? $model::getTagClassName() : config('tags.tag_model', Tag::class);
+        $tagClass = $model && method_exists($model, 'getTagClassName')
+            ? $model::getTagClassName()
+            : config('tags.tag_model', Tag::class);
         $type = $this->getType();
         $query = $tagClass::query();
 

--- a/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
+++ b/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
@@ -100,7 +100,7 @@ class SpatieTagsInput extends TagsInput
         }
 
         $model = $this->getModel();
-        $tagClass = $model && method_exists($model, 'getTagClassName')
+        $tagClass = ($model && method_exists($model, 'getTagClassName'))
             ? $model::getTagClassName()
             : config('tags.tag_model', Tag::class);
         $type = $this->getType();


### PR DESCRIPTION
## Description

[spatie-laravel-tags-plugin] This pull request makes a minor improvement to the `getSuggestions` method in the `SpatieTagsInput` component. It enhances the logic for determining the tag class by checking if the model has a `getTagClassName` method before calling it.

## Visual changes

* [`packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php`](diffhunk://#diff-46c7a9b19f5ebf5c0b4be4b0ebba1dcde4240f3e40547c97330efea31489a93aL103-R105): Updated the `$tagClass` assignment to include a `method_exists` check, ensuring that the `getTagClassName` method is only called if it exists on the model.
## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
