### PR TITLE
fix(dependencies): match `composer.lock` laravel version with `composer.json`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1448,7 +1448,7 @@
             "require": {
                 "blade-ui-kit/blade-heroicons": "^2.5",
                 "danharrin/livewire-rate-limiting": "^2.0",
-                "illuminate/contracts": "^11.15|^12.0",
+                "illuminate/contracts": "^11.28|^12.0",
                 "kirschbaum-development/eloquent-power-joins": "^4.0",
                 "league/uri-components": "^7.0",
                 "livewire/livewire": "^3.5",

--- a/docs-assets/app/composer.lock
+++ b/docs-assets/app/composer.lock
@@ -1266,7 +1266,7 @@
                 "blade-ui-kit/blade-heroicons": "^2.5",
                 "danharrin/livewire-rate-limiting": "^2.0",
                 "ext-intl": "*",
-                "illuminate/contracts": "^11.15|^12.0",
+                "illuminate/contracts": "^11.28|^12.0",
                 "kirschbaum-development/eloquent-power-joins": "^4.0",
                 "league/uri-components": "^7.0",
                 "livewire/livewire": "^3.5",


### PR DESCRIPTION
## Description

That was fast merge @danharrin  for #16207, here is a follow up for the same fix.
Matching `composer.lock` files with same minimum laravel version as `composer.json`.

## Visual changes

None

## Functional changes

None

- [x] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
