### PR TITLE
Fix static data table action exception

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -1280,9 +1280,9 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
     }
 
     /**
-     * @return Model|class-string<Model>|null
+     * @return Model|class-string<Model>|array|null
      */
-    public function getActionSchemaModel(): Model | string | null
+    public function getActionSchemaModel(): Model | string | array | null
     {
         if ($this->hasRelationship()) {
             return $this->getRelationship()->getModel()::class;

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -1280,7 +1280,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
     }
 
     /**
-     * @return Model|class-string<Model>|array|null
+     * @return Model|class-string<Model>|array<string, mixed>|null
      */
     public function getActionSchemaModel(): Model | string | array | null
     {

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -1280,9 +1280,9 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
     }
 
     /**
-     * @return Model|class-string<Model>|array<string, mixed>|null
+     * @return Model | array<string, mixed> | class-string<Model> | null
      */
-    public function getActionSchemaModel(): Model | string | array | null
+    public function getActionSchemaModel(): Model | array | string | null
     {
         if ($this->hasRelationship()) {
             return $this->getRelationship()->getModel()::class;

--- a/packages/schemas/src/Components/Concerns/HasActions.php
+++ b/packages/schemas/src/Components/Concerns/HasActions.php
@@ -146,9 +146,9 @@ trait HasActions
     }
 
     /**
-     * @return Model|class-string<Model>|null
+     * @return Model|class-string<Model>|array|null
      */
-    public function getActionSchemaModel(): Model | string | null
+    public function getActionSchemaModel(): Model | string | array | null
     {
         return $this->actionSchemaModel ?? $this->getRecord() ?? $this->getModel();
     }

--- a/packages/schemas/src/Components/Concerns/HasActions.php
+++ b/packages/schemas/src/Components/Concerns/HasActions.php
@@ -146,7 +146,7 @@ trait HasActions
     }
 
     /**
-     * @return Model|class-string<Model>|array|null
+     * @return Model|class-string<Model>|array<string, mixed>|null
      */
     public function getActionSchemaModel(): Model | string | array | null
     {

--- a/packages/schemas/src/Components/Concerns/HasActions.php
+++ b/packages/schemas/src/Components/Concerns/HasActions.php
@@ -146,9 +146,9 @@ trait HasActions
     }
 
     /**
-     * @return Model|class-string<Model>|array<string, mixed>|null
+     * @return Model | array<string, mixed> | class-string<Model> | null
      */
-    public function getActionSchemaModel(): Model | string | array | null
+    public function getActionSchemaModel(): Model | array | string | null
     {
         return $this->actionSchemaModel ?? $this->getRecord() ?? $this->getModel();
     }


### PR DESCRIPTION
When using tables with static data, actions sometimes cause the following exception:

`Filament\Schemas\Components\Component::getActionSchemaModel(): Return value must be of type Illuminate\Database\Eloquent\Model|string|null, array returned`

I'm using a table with static data for my MFA settings. This exception is occurring when I click "Use a recovery code" inside my `DisableTotpAuthentication` table action.

```PHP
        return Action::make('disableTotpAuthentication')
            .........
            ->schema([
                OneTimeCodeInput::make('code')
                    ->label('Use a recovery code')
                    ->belowContent(fn (Get $get): Action => Action::make('useRecoveryCode')
                        ->action(fn (Set $set) => $set('useRecoveryCode', true))
                        ->visible(fn (): bool => $isRecoverable && (! $get('useRecoveryCode'))))
......
```

Adding `array` as a return type fixes the problem.