### PR TITLE
Gate password reset process with canAccessPanel logic

### DIFF
--- a/packages/panels/resources/lang/en/pages/auth/password-reset/request-password-reset.php
+++ b/packages/panels/resources/lang/en/pages/auth/password-reset/request-password-reset.php
@@ -37,6 +37,8 @@ return [
             'body' => 'Please try again in :seconds seconds.',
         ],
 
+        'sent' => 'If that email address is valid in our records, we will send you an email to reset your password.',
+
     ],
 
 ];

--- a/packages/panels/resources/lang/en/pages/auth/password-reset/request-password-reset.php
+++ b/packages/panels/resources/lang/en/pages/auth/password-reset/request-password-reset.php
@@ -32,12 +32,14 @@ return [
 
     'notifications' => [
 
+        'sent' => [
+            'body' => 'If your account doesn\'t exist, you will not receive the email.',
+        ],
+
         'throttled' => [
             'title' => 'Too many requests',
             'body' => 'Please try again in :seconds seconds.',
         ],
-
-        'sent' => 'If that email address is valid in our records, we will send you an email to reset your password.',
 
     ],
 

--- a/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
+++ b/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
@@ -69,7 +69,7 @@ class RequestPasswordReset extends SimplePage
                     throw new Exception("Model [{$userClass}] does not have a [notify()] method.");
                 }
 
-                if (!($user instanceof FilamentUser) || !$user->canAccessPanel(Filament::getCurrentPanel())) {
+                if (! ($user instanceof FilamentUser) || ! $user->canAccessPanel(Filament::getCurrentPanel())) {
                     return;
                 }
 

--- a/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
+++ b/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
@@ -11,6 +11,7 @@ use Filament\Facades\Filament;
 use Filament\Forms\Components\Component;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
+use Filament\Models\Contracts\FilamentUser;
 use Filament\Notifications\Auth\ResetPassword as ResetPasswordNotification;
 use Filament\Notifications\Notification;
 use Filament\Pages\Concerns\InteractsWithFormActions;
@@ -68,6 +69,10 @@ class RequestPasswordReset extends SimplePage
                     throw new Exception("Model [{$userClass}] does not have a [notify()] method.");
                 }
 
+                if (!($user instanceof FilamentUser) || !$user->canAccessPanel(Filament::getCurrentPanel())) {
+                    return;
+                }
+
                 $notification = app(ResetPasswordNotification::class, ['token' => $token]);
                 $notification->url = Filament::getResetPasswordUrl($token, $user);
 
@@ -81,7 +86,7 @@ class RequestPasswordReset extends SimplePage
             return;
         }
 
-        $this->getSentNotification($status)?->send();
+        $this->getSentNotification('filament-panels::pages/auth/password-reset/request-password-reset.notifications.sent')?->send();
 
         $this->form->fill();
     }

--- a/packages/panels/src/Pages/Auth/PasswordReset/ResetPassword.php
+++ b/packages/panels/src/Pages/Auth/PasswordReset/ResetPassword.php
@@ -83,8 +83,9 @@ class ResetPassword extends SimplePage
             $this->getCredentialsFromFormData($data),
             function (CanResetPassword | Model | Authenticatable $user) use ($data, &$hasPanelAccess) {
 
-                if (!($user instanceof FilamentUser) || !$user->canAccessPanel(Filament::getCurrentPanel())) {
+                if (! ($user instanceof FilamentUser) || ! $user->canAccessPanel(Filament::getCurrentPanel())) {
                     $hasPanelAccess = false;
+
                     return;
                 }
 

--- a/packages/panels/src/Pages/Auth/PasswordReset/ResetPassword.php
+++ b/packages/panels/src/Pages/Auth/PasswordReset/ResetPassword.php
@@ -82,8 +82,10 @@ class ResetPassword extends SimplePage
         $status = Password::broker(Filament::getAuthPasswordBroker())->reset(
             $this->getCredentialsFromFormData($data),
             function (CanResetPassword | Model | Authenticatable $user) use ($data, &$hasPanelAccess) {
-
-                if (! ($user instanceof FilamentUser) || ! $user->canAccessPanel(Filament::getCurrentPanel())) {
+                if (
+                    ($user instanceof FilamentUser) &&
+                    (! $user->canAccessPanel(Filament::getCurrentPanel()))
+                ) {
                     $hasPanelAccess = false;
 
                     return;

--- a/packages/panels/src/Pages/Auth/PasswordReset/ResetPassword.php
+++ b/packages/panels/src/Pages/Auth/PasswordReset/ResetPassword.php
@@ -11,6 +11,7 @@ use Filament\Forms\Components\Component;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Http\Responses\Auth\Contracts\PasswordResetResponse;
+use Filament\Models\Contracts\FilamentUser;
 use Filament\Notifications\Notification;
 use Filament\Pages\Concerns\InteractsWithFormActions;
 use Filament\Pages\SimplePage;
@@ -76,17 +77,29 @@ class ResetPassword extends SimplePage
         $data['email'] = $this->email;
         $data['token'] = $this->token;
 
+        $hasPanelAccess = true;
+
         $status = Password::broker(Filament::getAuthPasswordBroker())->reset(
             $this->getCredentialsFromFormData($data),
-            function (CanResetPassword | Model | Authenticatable $user) use ($data) {
+            function (CanResetPassword | Model | Authenticatable $user) use ($data, &$hasPanelAccess) {
+
+                if (!($user instanceof FilamentUser) || !$user->canAccessPanel(Filament::getCurrentPanel())) {
+                    $hasPanelAccess = false;
+                    return;
+                }
+
                 $user->forceFill([
                     'password' => Hash::make($data['password']),
                     'remember_token' => Str::random(60),
                 ])->save();
 
                 event(new PasswordReset($user));
-            },
+            }
         );
+
+        if ($hasPanelAccess === false) {
+            $status = Password::INVALID_USER;
+        }
 
         if ($status === Password::PASSWORD_RESET) {
             Notification::make()

--- a/tests/src/Panels/Auth/PasswordReset/RequestPasswordResetTest.php
+++ b/tests/src/Panels/Auth/PasswordReset/RequestPasswordResetTest.php
@@ -2,12 +2,12 @@
 
 use Filament\Facades\Filament;
 use Filament\Notifications\Auth\ResetPassword;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Pages\Auth\PasswordReset\RequestPasswordReset;
 use Filament\Panel;
 use Filament\Tests\Models\User;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Facades\Notification;
-use Filament\Notifications\Notification as FilamentNotification;
 
 use function Filament\Tests\livewire;
 

--- a/tests/src/Panels/Auth/PasswordReset/RequestPasswordResetTest.php
+++ b/tests/src/Panels/Auth/PasswordReset/RequestPasswordResetTest.php
@@ -4,7 +4,6 @@ use Filament\Facades\Filament;
 use Filament\Notifications\Auth\ResetPassword;
 use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Pages\Auth\PasswordReset\RequestPasswordReset;
-use Filament\Panel;
 use Filament\Tests\Models\User;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Facades\Notification;
@@ -44,23 +43,21 @@ it('can request password reset', function () {
         ->assertNotified(
             FilamentNotification::make()
                 ->success()
-                ->title(__('filament-panels::pages/auth/password-reset/request-password-reset.notifications.sent'))
+                ->title(__('passwords.sent'))
+                ->body(__('filament-panels::pages/auth/password-reset/request-password-reset.notifications.sent.body'))
         );
 
     Notification::assertSentTo($userToResetPassword, ResetPassword::class);
 });
 
-it('can gate password resets based on panel access', function () {
+it('cannot request password reset without panel access', function () {
     Notification::fake();
 
     $this->assertGuest();
 
     $userToResetPassword = User::factory()->create();
 
-    $testPanel = Panel::make();
-    $testPanel->id('test');
-
-    Filament::setCurrentPanel($testPanel);
+    Filament::setCurrentPanel(Filament::getPanel('custom'));
 
     livewire(RequestPasswordReset::class)
         ->fillForm([
@@ -70,7 +67,8 @@ it('can gate password resets based on panel access', function () {
         ->assertNotified(
             FilamentNotification::make()
                 ->success()
-                ->title(__('filament-panels::pages/auth/password-reset/request-password-reset.notifications.sent'))
+                ->title(__('passwords.sent'))
+                ->body(__('filament-panels::pages/auth/password-reset/request-password-reset.notifications.sent.body'))
         );
 
     Notification::assertNotSentTo($userToResetPassword, ResetPassword::class);

--- a/tests/src/Panels/Auth/PasswordReset/RequestPasswordResetTest.php
+++ b/tests/src/Panels/Auth/PasswordReset/RequestPasswordResetTest.php
@@ -3,9 +3,11 @@
 use Filament\Facades\Filament;
 use Filament\Notifications\Auth\ResetPassword;
 use Filament\Pages\Auth\PasswordReset\RequestPasswordReset;
+use Filament\Panel;
 use Filament\Tests\Models\User;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Facades\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
 
 use function Filament\Tests\livewire;
 
@@ -39,9 +41,39 @@ it('can request password reset', function () {
             'email' => $userToResetPassword->email,
         ])
         ->call('request')
-        ->assertNotified();
+        ->assertNotified(
+            FilamentNotification::make()
+                ->success()
+                ->title(__('filament-panels::pages/auth/password-reset/request-password-reset.notifications.sent'))
+        );
 
     Notification::assertSentTo($userToResetPassword, ResetPassword::class);
+});
+
+it('can gate password resets based on panel access', function () {
+    Notification::fake();
+
+    $this->assertGuest();
+
+    $userToResetPassword = User::factory()->create();
+
+    $testPanel = Panel::make();
+    $testPanel->id('test');
+
+    Filament::setCurrentPanel($testPanel);
+
+    livewire(RequestPasswordReset::class)
+        ->fillForm([
+            'email' => $userToResetPassword->email,
+        ])
+        ->call('request')
+        ->assertNotified(
+            FilamentNotification::make()
+                ->success()
+                ->title(__('filament-panels::pages/auth/password-reset/request-password-reset.notifications.sent'))
+        );
+
+    Notification::assertNotSentTo($userToResetPassword, ResetPassword::class);
 });
 
 it('can throttle requests', function () {

--- a/tests/src/Panels/Auth/PasswordReset/ResetPasswordTest.php
+++ b/tests/src/Panels/Auth/PasswordReset/ResetPasswordTest.php
@@ -3,7 +3,6 @@
 use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Filament\Pages\Auth\PasswordReset\ResetPassword;
-use Filament\Panel;
 use Filament\Tests\Models\User;
 use Filament\Tests\TestCase;
 use Illuminate\Auth\Events\PasswordReset;
@@ -75,7 +74,7 @@ it('can reset password', function () {
     ]);
 });
 
-it('can gate reset password based on panel access', function () {
+it('cannot reset password without panel access', function () {
     Event::fake();
 
     $this->assertGuest();
@@ -83,10 +82,7 @@ it('can gate reset password based on panel access', function () {
     $userToResetPassword = User::factory()->create();
     $token = Password::createToken($userToResetPassword);
 
-    $testPanel = Panel::make();
-    $testPanel->id('test');
-
-    Filament::setCurrentPanel($testPanel);
+    Filament::setCurrentPanel(Filament::getPanel('custom'));
 
     livewire(ResetPassword::class, [
         'email' => $userToResetPassword->email,

--- a/tests/src/Panels/Auth/PasswordReset/ResetPasswordTest.php
+++ b/tests/src/Panels/Auth/PasswordReset/ResetPasswordTest.php
@@ -1,15 +1,15 @@
 <?php
 
 use Filament\Facades\Filament;
+use Filament\Notifications\Notification;
 use Filament\Pages\Auth\PasswordReset\ResetPassword;
+use Filament\Panel;
 use Filament\Tests\Models\User;
 use Filament\Tests\TestCase;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
-use Filament\Panel;
-use Filament\Notifications\Notification;
 
 use function Filament\Tests\livewire;
 


### PR DESCRIPTION
## Description

Currently, the password reset and password reset request process don't check the the `canAccessPanel()` method on the FilamentUser contract, which leads to a few possible issues:

- User experience inconsistency: A user can successfully reset their password, only to be told their credentials are invalid when attempting to log in.
- Unintended interactions with notifications / events: Where custom notifications or events are in use in a multi-panel configuration, actions may be taken against users who should not be eligible to receive those notifications / events.

## Visual changes

 Existing password reset request process - user requesting a reset on a panel they shouldn't have access to.

https://github.com/user-attachments/assets/d8706521-5f0d-4ff5-9af4-c3abe5f81795

Existing password reset process - user completing reset on a pabel they shouldn't have access to, along with subsequent login attempt following reset.

https://github.com/user-attachments/assets/f43015c4-2226-4efd-8cb6-d6cf1dcbc530


New password reset request process - user requesting a reset, now receives an ambiguous notification so as to not bleed information about whether a notification has been sent or not.


https://github.com/user-attachments/assets/b3247ce8-8a44-4891-ba19-1d81b616bf61

New password reset process - when a user attempts to reset a password on a panel they do not have access to, for example where access has been removed _after_ the reset request was raised, the user is notified that the user account is invalid for the request.


https://github.com/user-attachments/assets/1a911082-b9f8-4e4e-888e-e18f7b7f65a2


## Functional changes

The process has been updated with the following changes:

- Password reset request:
  -  This process checks that a user is a valid instance of a FilamentUser contract, and checks that the user has access to the current panel via the `canAccessPanel` method.  A password reset request is only dispatched where a user as valid access to the panel.
  - Unless requests are throttled, a standard notification is used to advise that an email will have been sent if the email is valid in the system, to avoid leaking user access information.
  - Tests updated to reflect these changes.
- Password reset:
  - This process checks that a user is a valid instance of a FilamentUser contract, and checks that the user has access to the current panel via the `canAccessPanel` method. 
  - Where a user has valid access to the panel, the password is updated as normal.
  - Where a user does not have valid access to the panel, e.g. where access was revoked after a reset request was generated, the user is notified that the user is invalid.
  - Tests updated to reflect these changes.

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
