### PR TITLE
Fix: ensure getType() always returns valid string

### DIFF
--- a/packages/forms/src/Components/TextInput.php
+++ b/packages/forms/src/Components/TextInput.php
@@ -213,7 +213,9 @@ class TextInput extends Field implements CanHaveNumericState, Contracts\CanBeLen
 
     public function getType(): string
     {
-        if ($type = $this->evaluate($this->type)) {
+        $type = $this->evaluate($this->type);
+        
+        if (is_string($type) && $type !== '') {
             return $type;
         } elseif ($this->isEmail()) {
             return 'email';


### PR DESCRIPTION
## Description

The `getType()` method can currently return invalid values (e.g., `null`, array, or other non-string values) when `$this->type` is evaluated as a closure or dynamic value. This violates the expected return type of `string` and may lead to unexpected behavior in form components.

This PR ensures that `getType()` always returns a valid string by:

* Checking if the evaluated `$type` is a non-empty string before returning it.

---

## Visual changes

N/A – No visual changes introduced. This is a backend logic improvement.

---

## Functional changes

* [x] Code style has been fixed by running the `composer cs` command.
* [x] Changes have been tested to not break existing functionality.
* [x] Documentation is up-to-date (not applicable to this logic-only change).
