### PR TITLE
feat: ability to evaluate Closures in `viewData()`

### DIFF
--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -57,14 +57,6 @@ class Notification extends ViewComponent implements Arrayable
         return $static;
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function getViewData(): array
-    {
-        return $this->viewData;
-    }
-
     public function toArray(): array
     {
         return [

--- a/packages/support/src/Components/ViewComponent.php
+++ b/packages/support/src/Components/ViewComponent.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Arr;
 use Illuminate\View\ComponentAttributeBag;
 
 abstract class ViewComponent extends Component implements Htmlable
@@ -21,7 +22,7 @@ abstract class ViewComponent extends Component implements Htmlable
     protected string | Closure | null $defaultView = null;
 
     /**
-     * @var array<string, mixed>
+     * @var array<string|int, mixed>
      */
     protected array $viewData = [];
 
@@ -65,7 +66,7 @@ abstract class ViewComponent extends Component implements Htmlable
     }
 
     /**
-     * @param  array<string, mixed>  $data
+     * @param  array<string|int, mixed>  $data
      */
     public function viewData(array $data): static
     {
@@ -102,17 +103,15 @@ abstract class ViewComponent extends Component implements Htmlable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<string|int, mixed>
      */
     public function getViewData(): array
     {
-        return collect($this->viewData)
-            ->flatMap(function (mixed $value, string | int $key) {
-                return is_numeric($key)
-                    ? $this->evaluate($value)
-                    : [$key => $this->evaluate($value)];
-            })
-            ->all();
+        return Arr::mapWithKeys($this->viewData, function (mixed $value, string | int $key) {
+            return is_numeric($key)
+                ? $this->evaluate($value)
+                : [$key => $this->evaluate($value)];
+        });
     }
 
     public function toHtml(): string

--- a/packages/support/src/Components/ViewComponent.php
+++ b/packages/support/src/Components/ViewComponent.php
@@ -70,12 +70,7 @@ abstract class ViewComponent extends Component implements Htmlable
      */
     public function viewData(array | Closure $data): static
     {
-        if (
-            (is_array($data) && count($data))
-            || $data instanceof Closure
-        ) {
-            $this->viewData[] = $data;
-        }
+        $this->viewData[] = $data;
 
         return $this;
     }

--- a/packages/support/src/Components/ViewComponent.php
+++ b/packages/support/src/Components/ViewComponent.php
@@ -100,7 +100,7 @@ abstract class ViewComponent extends Component implements Htmlable
     }
 
     /**
-     * @return array<string|int, mixed>
+     * @return array<string, mixed>
      */
     public function getViewData(): array
     {

--- a/packages/support/src/Components/ViewComponent.php
+++ b/packages/support/src/Components/ViewComponent.php
@@ -22,7 +22,7 @@ abstract class ViewComponent extends Component implements Htmlable
     protected string | Closure | null $defaultView = null;
 
     /**
-     * @var array<string|int, mixed>
+     * @var array<array-key, array<string|int, mixed>|Closure>
      */
     protected array $viewData = [];
 
@@ -66,14 +66,11 @@ abstract class ViewComponent extends Component implements Htmlable
     }
 
     /**
-     * @param  array<string|int, mixed>  $data
+     * @param  array<string, mixed>|Closure  $data
      */
-    public function viewData(array $data): static
+    public function viewData(array | Closure $data): static
     {
-        $this->viewData = [
-            ...$this->viewData,
-            ...$data,
-        ];
+        $this->viewData[] = $data;
 
         return $this;
     }
@@ -107,10 +104,8 @@ abstract class ViewComponent extends Component implements Htmlable
      */
     public function getViewData(): array
     {
-        return Arr::mapWithKeys($this->viewData, function (mixed $value, string | int $key) {
-            return is_numeric($key)
-                ? $this->evaluate($value)
-                : [$key => $this->evaluate($value)];
+        return Arr::mapWithKeys($this->viewData, function (mixed $value) {
+            return $this->evaluate($value);
         });
     }
 

--- a/packages/support/src/Components/ViewComponent.php
+++ b/packages/support/src/Components/ViewComponent.php
@@ -101,6 +101,20 @@ abstract class ViewComponent extends Component implements Htmlable
         return $this->evaluate($this->defaultView);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
+    public function getViewData(): array
+    {
+        return collect($this->viewData)
+            ->flatMap(function (mixed $value, string | int $key) {
+                return is_numeric($key)
+                    ? $this->evaluate($value)
+                    : [$key => $this->evaluate($value)];
+            })
+            ->all();
+    }
+
     public function toHtml(): string
     {
         return $this->render()->render();
@@ -114,7 +128,7 @@ abstract class ViewComponent extends Component implements Htmlable
                 'attributes' => new ComponentAttributeBag,
                 ...$this->extractPublicMethods(),
                 ...(isset($this->viewIdentifier) ? [$this->viewIdentifier => $this] : []),
-                ...$this->viewData,
+                ...$this->getViewData(),
             ],
         );
     }

--- a/packages/support/src/Components/ViewComponent.php
+++ b/packages/support/src/Components/ViewComponent.php
@@ -70,7 +70,12 @@ abstract class ViewComponent extends Component implements Htmlable
      */
     public function viewData(array | Closure $data): static
     {
-        $this->viewData[] = $data;
+        if (
+            (is_array($data) && count($data))
+            || $data instanceof Closure
+        ) {
+            $this->viewData[] = $data;
+        }
 
         return $this;
     }

--- a/packages/support/src/Components/ViewComponent.php
+++ b/packages/support/src/Components/ViewComponent.php
@@ -22,7 +22,7 @@ abstract class ViewComponent extends Component implements Htmlable
     protected string | Closure | null $defaultView = null;
 
     /**
-     * @var array<array-key, array<string|int, mixed>|Closure>
+     * @var array<array<string, mixed> | Closure>
      */
     protected array $viewData = [];
 
@@ -66,7 +66,7 @@ abstract class ViewComponent extends Component implements Htmlable
     }
 
     /**
-     * @param  array<string, mixed>|Closure  $data
+     * @param  array<string, mixed> | Closure  $data
      */
     public function viewData(array | Closure $data): static
     {
@@ -104,9 +104,10 @@ abstract class ViewComponent extends Component implements Htmlable
      */
     public function getViewData(): array
     {
-        return Arr::mapWithKeys($this->viewData, function (mixed $value) {
-            return $this->evaluate($value);
-        });
+        return Arr::mapWithKeys(
+            $this->viewData,
+            fn (mixed $data): array => $this->evaluate($data) ?? [],
+        );
     }
 
     public function toHtml(): string

--- a/tests/src/Forms/Components/ViewTest.php
+++ b/tests/src/Forms/Components/ViewTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Filament\Forms\Components\View;
+use Filament\Tests\TestCase;
+
+uses(TestCase::class);
+
+it('can have view data', function () {
+    $view = View::make('test')->viewData([
+        'key_a' => 'Value A',
+        'key_b' => 'Value B',
+    ]);
+
+    expect($view)
+        ->getViewData()->toBe([
+            'key_a' => 'Value A',
+            'key_b' => 'Value B',
+        ]);
+});
+
+it('can have view data with closure on numeric keys', function () {
+    $view = View::make('test')->viewData([
+        'key_a' => 'Value A',
+        fn() => ['string_keyed_closure' => 'string_keyed_closure'],
+    ]);
+
+    expect($view)
+        ->getViewData()->toBe([
+            'key_a' => 'Value A',
+                'string_keyed_closure' => 'string_keyed_closure',
+        ]);
+});
+
+it('can have view data with closure on string keys', function () {
+    $view = View::make('test')->viewData([
+        'key_a' => 'Value A',
+        'key_b' => fn() => ['string_keyed_closure' => 'string_keyed_closure'],
+    ]);
+
+    expect($view)
+        ->getViewData()->toBe([
+            'key_a' => 'Value A',
+            'key_b' => [
+                'string_keyed_closure' => 'string_keyed_closure',
+            ]
+        ]);
+});

--- a/tests/src/Forms/Components/ViewTest.php
+++ b/tests/src/Forms/Components/ViewTest.php
@@ -19,31 +19,23 @@ it('can have view data', function () {
 });
 
 it('can have view data with closure on numeric keys', function () {
-    $view = View::make('test')->viewData([
-        'key_a' => 'Value A',
-        // Closure result will be merged with the top-level array...
-        fn () => ['string_keyed_closure' => 'string_keyed_closure'],
-    ]);
+    $view = View::make('test')
+        ->viewData([
+            'key_a' => 'Value A',
+        ])
+        ->viewData(function () {
+            // Closure result will be merged with the top-level array...
+            return ['string_keyed_closure' => 'string_keyed_closure'];
+        })
+        ->viewData(function () {
+            // Closure result will be merged with the top-level array...
+            return ['string_keyed_closure_b' => 'string_keyed_closure_b'];
+        });
 
     expect($view)
         ->getViewData()->toBe([
             'key_a' => 'Value A',
             'string_keyed_closure' => 'string_keyed_closure',
-        ]);
-});
-
-it('can have view data with closure on string keys', function () {
-    $view = View::make('test')->viewData([
-        'key_a' => 'Value A',
-        // Closure result will stay under the `key_b` key...
-        'key_b' => fn () => ['string_keyed_closure' => 'string_keyed_closure'],
-    ]);
-
-    expect($view)
-        ->getViewData()->toBe([
-            'key_a' => 'Value A',
-            'key_b' => [
-                'string_keyed_closure' => 'string_keyed_closure',
-            ],
+            'string_keyed_closure_b' => 'string_keyed_closure_b',
         ]);
 });

--- a/tests/src/Forms/Components/ViewTest.php
+++ b/tests/src/Forms/Components/ViewTest.php
@@ -6,38 +6,30 @@ use Filament\Tests\TestCase;
 uses(TestCase::class);
 
 it('can have view data', function () {
-    $view = View::make('test')
+    $component = View::make('test')
         ->viewData([
             'key_a' => 'Value A',
             'key_b' => 'Value B',
         ])
         ->viewData([]);
 
-    expect($view)
+    expect($component)
         ->getViewData()->toBe([
             'key_a' => 'Value A',
             'key_b' => 'Value B',
         ]);
 });
 
-it('can have view data with closure on numeric keys', function () {
-    $view = View::make('test')
-        ->viewData([
-            'key_a' => 'Value A',
-        ])
-        ->viewData(function () {
-            // Closure result will be merged with the top-level array...
-            return ['string_keyed_closure' => 'string_keyed_closure'];
-        })
-        ->viewData(function () {
-            // Closure result will be merged with the top-level array...
-            return ['string_keyed_closure_b' => 'string_keyed_closure_b'];
-        });
+it('can have view data inside closures', function () {
+    $component = View::make('test')
+        ->viewData(['key_a' => 'Value A'])
+        ->viewData(fn (): array => ['closure_key_a' => 'Closure Value A'])
+        ->viewData(fn (): array => ['closure_key_b' => 'Closure Value B']);
 
-    expect($view)
+    expect($component)
         ->getViewData()->toBe([
             'key_a' => 'Value A',
-            'string_keyed_closure' => 'string_keyed_closure',
-            'string_keyed_closure_b' => 'string_keyed_closure_b',
+            'closure_key_a' => 'Closure Value A',
+            'closure_key_b' => 'Closure Value B',
         ]);
 });

--- a/tests/src/Forms/Components/ViewTest.php
+++ b/tests/src/Forms/Components/ViewTest.php
@@ -21,20 +21,20 @@ it('can have view data', function () {
 it('can have view data with closure on numeric keys', function () {
     $view = View::make('test')->viewData([
         'key_a' => 'Value A',
-        fn() => ['string_keyed_closure' => 'string_keyed_closure'],
+        fn () => ['string_keyed_closure' => 'string_keyed_closure'],
     ]);
 
     expect($view)
         ->getViewData()->toBe([
             'key_a' => 'Value A',
-                'string_keyed_closure' => 'string_keyed_closure',
+            'string_keyed_closure' => 'string_keyed_closure',
         ]);
 });
 
 it('can have view data with closure on string keys', function () {
     $view = View::make('test')->viewData([
         'key_a' => 'Value A',
-        'key_b' => fn() => ['string_keyed_closure' => 'string_keyed_closure'],
+        'key_b' => fn () => ['string_keyed_closure' => 'string_keyed_closure'],
     ]);
 
     expect($view)
@@ -42,6 +42,6 @@ it('can have view data with closure on string keys', function () {
             'key_a' => 'Value A',
             'key_b' => [
                 'string_keyed_closure' => 'string_keyed_closure',
-            ]
+            ],
         ]);
 });

--- a/tests/src/Forms/Components/ViewTest.php
+++ b/tests/src/Forms/Components/ViewTest.php
@@ -6,10 +6,12 @@ use Filament\Tests\TestCase;
 uses(TestCase::class);
 
 it('can have view data', function () {
-    $view = View::make('test')->viewData([
-        'key_a' => 'Value A',
-        'key_b' => 'Value B',
-    ]);
+    $view = View::make('test')
+        ->viewData([
+            'key_a' => 'Value A',
+            'key_b' => 'Value B',
+        ])
+        ->viewData([]);
 
     expect($view)
         ->getViewData()->toBe([

--- a/tests/src/Forms/Components/ViewTest.php
+++ b/tests/src/Forms/Components/ViewTest.php
@@ -21,6 +21,7 @@ it('can have view data', function () {
 it('can have view data with closure on numeric keys', function () {
     $view = View::make('test')->viewData([
         'key_a' => 'Value A',
+        // Closure result will be merged with the top-level array...
         fn () => ['string_keyed_closure' => 'string_keyed_closure'],
     ]);
 
@@ -34,6 +35,7 @@ it('can have view data with closure on numeric keys', function () {
 it('can have view data with closure on string keys', function () {
     $view = View::make('test')->viewData([
         'key_a' => 'Value A',
+        // Closure result will stay under the `key_b` key...
         'key_b' => fn () => ['string_keyed_closure' => 'string_keyed_closure'],
     ]);
 


### PR DESCRIPTION
I wanted to insert a Blade view into a form and I noticed that surprisingly it was not possible to calculate the `viewData()` using a closure. As the `$viewData` property is an array that is merged on every call to the `viewData()` method, a convention should be found to support these closures.

I implemented this in the same way as e.g. the `->hintActions()` method, which accepts either an array of closures or an array of actions. In this case, the `viewData()` method will accept a regular array or an array with closures. If a closure is found on a numeric key, it is assumed the key means nothing and the end result is flat-merged to the top-level. If an closure is found with a string key, the closure is evaluated and set as the result of the original string key. See also the tests for examples of the three scenarios.

Thanks!