### PR TITLE
Add the `PasswordResetLinkSent` event dispatch to the  request password reset page

### DIFF
--- a/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
+++ b/packages/panels/src/Pages/Auth/PasswordReset/RequestPasswordReset.php
@@ -17,6 +17,7 @@ use Filament\Notifications\Notification;
 use Filament\Pages\Concerns\InteractsWithFormActions;
 use Filament\Pages\SimplePage;
 use Filament\Support\Facades\FilamentIcon;
+use Illuminate\Auth\Events\PasswordResetLinkSent;
 use Illuminate\Contracts\Auth\CanResetPassword;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Facades\Password;
@@ -80,6 +81,10 @@ class RequestPasswordReset extends SimplePage
                 $notification->url = Filament::getResetPasswordUrl($token, $user);
 
                 $user->notify($notification);
+
+                if (class_exists(PasswordResetLinkSent::class)) {
+                    event(new PasswordResetLinkSent($user));
+                }
             },
         );
 

--- a/tests/src/Panels/Auth/PasswordReset/RequestPasswordResetTest.php
+++ b/tests/src/Panels/Auth/PasswordReset/RequestPasswordResetTest.php
@@ -51,10 +51,9 @@ it('can request password reset', function () {
         );
 
     Notification::assertSentTo($userToResetPassword, ResetPassword::class);
+
     if (class_exists(PasswordResetLinkSent::class)) {
-        Event::assertDispatched(PasswordResetLinkSent::class, fn (PasswordResetLinkSent $event) => $event->user->is($userToResetPassword));
-    } else {
-        Event::assertNotDispatched(PasswordResetLinkSent::class);
+        Event::assertDispatched(PasswordResetLinkSent::class, fn (PasswordResetLinkSent $event): bool => $event->user->is($userToResetPassword));
     }
 });
 

--- a/tests/src/Panels/Auth/PasswordReset/RequestPasswordResetTest.php
+++ b/tests/src/Panels/Auth/PasswordReset/RequestPasswordResetTest.php
@@ -51,7 +51,11 @@ it('can request password reset', function () {
         );
 
     Notification::assertSentTo($userToResetPassword, ResetPassword::class);
-    Event::assertDispatched(PasswordResetLinkSent::class, fn (PasswordResetLinkSent $event) => $event->user->is($userToResetPassword));
+    if (class_exists(PasswordResetLinkSent::class)) {
+        Event::assertDispatched(PasswordResetLinkSent::class, fn (PasswordResetLinkSent $event) => $event->user->is($userToResetPassword));
+    } else {
+        Event::assertNotDispatched(PasswordResetLinkSent::class);
+    }
 });
 
 it('cannot request password reset without panel access', function () {

--- a/tests/src/Panels/Auth/PasswordReset/RequestPasswordResetTest.php
+++ b/tests/src/Panels/Auth/PasswordReset/RequestPasswordResetTest.php
@@ -6,6 +6,8 @@ use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Pages\Auth\PasswordReset\RequestPasswordReset;
 use Filament\Tests\Models\User;
 use Filament\Tests\TestCase;
+use Illuminate\Auth\Events\PasswordResetLinkSent;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
 
 use function Filament\Tests\livewire;
@@ -30,6 +32,7 @@ it('can render page with a custom slug', function () {
 
 it('can request password reset', function () {
     Notification::fake();
+    Event::fake();
 
     $this->assertGuest();
 
@@ -48,6 +51,7 @@ it('can request password reset', function () {
         );
 
     Notification::assertSentTo($userToResetPassword, ResetPassword::class);
+    Event::assertDispatched(PasswordResetLinkSent::class, fn (PasswordResetLinkSent $event) => $event->user->is($userToResetPassword));
 });
 
 it('cannot request password reset without panel access', function () {


### PR DESCRIPTION
The request password reset page doesn't dispatch the [`PasswordResetLinkSent`](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Auth/Events/PasswordResetLinkSent.php) event, so I added it.

Also included it with a `class_exists` check to make sure it's compatible with older versions of Laravel.