### PR TITLE
Disable step button if previous action is disabled

### DIFF
--- a/packages/forms/resources/views/components/wizard.blade.php
+++ b/packages/forms/resources/views/components/wizard.blade.php
@@ -151,7 +151,7 @@
                     type="button"
                     x-bind:aria-current="getStepIndex(step) === {{ $loop->index }} ? 'step' : null"
                     x-on:click="step = @js($step->getId())"
-                    x-bind:disabled="! isStepAccessible(@js($step->getId()))"
+                    x-bind:disabled="! isStepAccessible(@js($step->getId())) || @js($previousAction->isDisabled())"
                     role="step"
                     class="fi-fo-wizard-header-step-button flex h-full items-center gap-x-4 px-6 py-4 text-start"
                 >


### PR DESCRIPTION
## Description

This pull request fixes a bug in the wizard component (`wizard.blade.php`) where the step selector allowed selection even when the `previousAction` was disabled.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
