### PR TITLE
Fix: total rows calculation for group by in CanExportRecords trait

### DIFF
--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -130,7 +130,7 @@ trait CanExportRecords
 
             $records = $action instanceof ExportTableBulkAction ? $action->getRecords() : null;
 
-            $totalRows = $records ? $records->count() : $query->count();
+            $totalRows = $records ? $records->count() : $query->toBase()->getCountForPagination();
             $maxRows = $action->getMaxRows() ?? $totalRows;
 
             if ($maxRows < $totalRows) {


### PR DESCRIPTION
**Fix: Correct total row count for grouped queries in exports**

When exporting data, using `$query->count()` on queries that include a `groupBy()` clause produces incorrect results. This is because `count()` ignores the grouping and returns the total number of underlying rows instead of the number of grouped records.

### Problem

Given a query like:

```php
$query = User::select('role', DB::raw('count(*) as total'))
    ->groupBy('role');
```

Suppose you have 100 users across 3 roles. You expect to get **3** grouped rows, but `$query->count()` will return **100**, because it performs the count without considering the `groupBy()`.

### Solution

We replace:

```php
$totalRows = $query->count();
```

with:

```php
$totalRows = $query->toBase()->getCountForPagination();
```

The `getCountForPagination()` method respects the `groupBy()` clause and returns the correct count — in this case, **3**.

### Benefits

* Accurate total row count for grouped data
* Correct pagination and summary in exported results
* No impact on non-grouped queries

This ensures the export behaves as expected when working with grouped datasets.

Note: In my case, the total record is supposed to be 100 after grouping. the `$query->count()` always returns 1, so I always get only the first record exported. 
