### PR TITLE
Add Optional Truncate-Table Support to ImportAction

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/08-import.md
+++ b/packages/actions/docs/07-prebuilt-actions/08-import.md
@@ -601,6 +601,16 @@ ImportAction::make()
 
 If you are encountering memory or timeout issues when importing large CSV files, you may wish to reduce the chunk size.
 
+## Deleting all existing data before an import
+
+To remove all existing records before running an import, enable the `truncateBeforeImport()` option on the import action:
+
+```php
+ImportAction::make()
+    ->importer(ProductImporter::class)
+    ->truncateBeforeImport(true)
+```
+
 ## Changing the CSV delimiter
 
 The default delimiter for CSVs is the comma (`,`). If your import uses a different delimiter, you may call the `csvDelimiter()` method on the action, passing a new one:

--- a/packages/actions/src/Concerns/CanImportRecords.php
+++ b/packages/actions/src/Concerns/CanImportRecords.php
@@ -70,6 +70,11 @@ trait CanImportRecords
      */
     protected array $fileValidationRules = [];
 
+    /**
+     * @var bool | Closure
+     */
+    protected bool | Closure $truncateBeforeImport = false;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -210,6 +215,12 @@ trait CanImportRecords
                     ->send();
 
                 return;
+            }
+
+            // Check if truncateBeforeImport is set and truncate the model
+            if ($this->truncateBeforeImport) {
+                $model = $action->getImporter()::getModel();
+                $model::truncate();
             }
 
             $user = auth()->user();
@@ -499,6 +510,13 @@ trait CanImportRecords
     public function job(?string $job): static
     {
         $this->job = $job;
+
+        return $this;
+    }
+
+    public function truncateBeforeImport(bool | Closure $truncate): static
+    {
+        $this->truncateBeforeImport = $truncate;
 
         return $this;
     }


### PR DESCRIPTION
## Description
This update introduces an optional feature to truncate the target database table before executing an import. This is particularly useful when Filament is not the source of truth, and external systems are providing the authoritative data set. In such cases, ensuring the database only contains the latest imported records is critical to avoid data inconsistencies.

You can now use the new ->truncateBeforeImport(true) method on the ImportAction to enable this behavior:
 
```
ImportAction::make()
    ->importer(ProductImporter::class)
    ->truncateBeforeImport(true)
```

This gives developers fine-grained control over the import behavior when syncing external data.

## Visual changes
there are no visual changes. 

## Functional changes
- [x] Added truncateBeforeImport(bool $shouldTruncate) method to ImportAction.
- [x] Automatically truncates the relevant table when the flag is set to true.
- [x] Documentation has been updated accordingly.