### PR TITLE
fix(section): ensure action motion with non-English modal headings

### DIFF
--- a/packages/forms/src/Components/Section.php
+++ b/packages/forms/src/Components/Section.php
@@ -83,7 +83,9 @@ class Section extends Component implements Contracts\CanConcealComponents, Contr
         }
 
         $id = Str::slug($heading);
-
+        if (empty($id)) {
+            $id = substr(md5($heading), 0, 8);
+        }
         if ($statePath = $this->getStatePath()) {
             $id = "{$statePath}.{$id}";
         }


### PR DESCRIPTION
Previously, non-English characters in Section Action's ModalHeading caused motion effects failure due to invalid ID generation. This Commit Solve the proplem.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Resolves invalid ID generation in Section Action components when using non-English ModalHeadings, which caused motion effects failure.


## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
