### PR TITLE
fix the namespaces in the packages/support/stubs

### DIFF
--- a/packages/support/stubs/DefaultPanelProvider.stub
+++ b/packages/support/stubs/DefaultPanelProvider.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Providers\Filament;
+namespace {{ namespace }}\Providers\Filament;
 
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;

--- a/packages/support/stubs/PanelProvider.stub
+++ b/packages/support/stubs/PanelProvider.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Providers\Filament;
+namespace {{ namespace }}\Providers\Filament;
 
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;


### PR DESCRIPTION
## Description

Fix Namespace Declarations in `packages/support/stubs`
This PR updates the namespace declarations in the stub files located in packages/support/stubs to ensure consistency and proper autoloading behavior.

Changes Made:
Corrected namespace definitions in all stub files
Aligned namespaces with PSR-4 standards and project structure
Removed any incorrect or outdated namespace references

These fixes prevent potential issues during stub-based code generation (e.g., incorrect class locations, autoload errors), and improve consistency across the package.

