### PR TITLE
Correct discover_app_classes for Windows paths

### DIFF
--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -301,7 +301,7 @@ if (! function_exists('Filament\Support\discover_app_classes')) {
 
         return collect($classLoader->getClassMap())
             ->filter(function (string $file, string $class) use ($parentClass): bool {
-                if (! str($file)->startsWith(base_path('vendor/composer/../../'))) {
+                if (! str($file)->startsWith(base_path('vendor' . DIRECTORY_SEPARATOR . 'composer/../../'))) {
                     return false;
                 }
 


### PR DESCRIPTION
## Description

When attempting to create a new resource it is currently failing to detect class names when running the command on a Windows machine due to the use of forward slashes when filtering out classes from the composer autoload.

**Output of `base_path('vendor/composer/../../')`:**
```
D:\Sites\filamentv4\vendor/composer/../..
```
**Path returned by composer autoload class map:**
```
D:\Sites\filamentv4\vendor\composer/../../app/Models/User.php
```

Using the built-in PHP constant for "DIRECTORY_SEPARATOR" in the path fixes it, not sure why composer only uses backslashes on windows until just before moving up a directory...

**Output of `base_path('vendor' . DIRECTORY_SEPARATOR . 'composer/../../')`:**
```
D:\Sites\filamentv4\vendor\composer/../..
```


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
