### PR TITLE
Hidden fields incorrectly dehydrated in Section with state path

### DIFF
--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -186,14 +186,10 @@ trait HasState
             return;
         }
 
-        if ($this->getStatePath(isAbsolute: false)) {
+        if ($this->hasStatePath()) {
             foreach ($this->getStateToDehydrate() as $key => $value) {
                 Arr::set($state, $key, $value);
             }
-        }
-
-        if ($this->isHiddenAndNotDehydrated()) {
-            return;
         }
 
         foreach ($this->getChildComponentContainers(withHidden: true) as $container) {
@@ -438,7 +434,11 @@ trait HasState
 
     public function isDehydrated(): bool
     {
-        return (bool) $this->evaluate($this->isDehydrated);
+        if (! $this->evaluate($this->isDehydrated)) {
+            return false;
+        }
+
+        return ! $this->isHiddenAndNotDehydrated();
     }
 
     public function isDehydratedWhenHidden(): bool

--- a/packages/forms/src/Concerns/HasState.php
+++ b/packages/forms/src/Concerns/HasState.php
@@ -72,10 +72,6 @@ trait HasState
     public function dehydrateState(array &$state = [], bool $isDehydrated = true): array
     {
         foreach ($this->getComponents(withHidden: true) as $component) {
-            if ($component->isHiddenAndNotDehydrated()) {
-                continue;
-            }
-
             $component->dehydrateState($state, $isDehydrated);
         }
 
@@ -89,10 +85,6 @@ trait HasState
     public function mutateDehydratedState(array &$state = []): array
     {
         foreach ($this->getComponents(withHidden: true) as $component) {
-            if ($component->isHiddenAndNotDehydrated()) {
-                continue;
-            }
-
             if (! $component->isDehydrated()) {
                 continue;
             }

--- a/tests/src/Forms/StateTest.php
+++ b/tests/src/Forms/StateTest.php
@@ -7,6 +7,9 @@ use Filament\Forms\Get;
 use Filament\Tests\Forms\Fixtures\Livewire;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Str;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Radio;
+use Filament\Forms\Components\TextInput;
 
 uses(TestCase::class);
 
@@ -706,3 +709,46 @@ test('parent sibling state can be retrieved absolutely from another component', 
     expect($placeholder)
         ->getContent()->toBe($state);
 });
+
+test(
+    'conditionally hidden and non-dehydrated field within a section (with state path) is incorrectly dehydrated when hidden',
+    function () {
+        $container = ComponentContainer::make(Livewire::make())
+            ->components([
+                Section::make("User Information")
+                    ->statePath('data')
+                    ->schema([
+                        Radio::make('show_input')
+                            ->label('Control Input Visibility')
+                            ->options([
+                                'show' => 'Show',
+                                'hide' => 'Hide',
+                            ])
+                            ->live(),
+
+                        TextInput::make('name')
+                            ->label('Conditional Name')
+                            ->hidden(fn (Get $get): bool => $get('show_input') === 'hide' || $get('show_input') === null)
+                            ->dehydrated(fn (Get $get): bool => $get('show_input') === 'show'),
+                    ]),
+            ])
+            ->fill([
+                'data' => [
+                    'show_input' => 'hide',
+                    'name' => 'lorem ipsum',
+                ]
+            ]);
+
+        $dehydratedState = $container->dehydrateState();
+
+        // Assert: Expect 'name' field NOT to be present in dehydrated state when 'show_input' is 'hide'
+        // This assertion is designed to FAIL due to the bug, thus documenting it.
+        expect($dehydratedState)
+            ->toBe([
+                'data' => [
+                    'show_input' => 'hide',
+                    // 'name' field with 'lorem ipsum' should NOT be here if the bug was fixed.
+                ],
+            ]);
+    }
+);

--- a/tests/src/Forms/StateTest.php
+++ b/tests/src/Forms/StateTest.php
@@ -3,13 +3,13 @@
 use Filament\Forms\ComponentContainer;
 use Filament\Forms\Components\Component;
 use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Components\Radio;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\TextInput;
 use Filament\Forms\Get;
 use Filament\Tests\Forms\Fixtures\Livewire;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Str;
-use Filament\Forms\Components\Section;
-use Filament\Forms\Components\Radio;
-use Filament\Forms\Components\TextInput;
 
 uses(TestCase::class);
 
@@ -715,7 +715,7 @@ test(
     function () {
         $container = ComponentContainer::make(Livewire::make())
             ->components([
-                Section::make("User Information")
+                Section::make('User Information')
                     ->statePath('data')
                     ->schema([
                         Radio::make('show_input')
@@ -736,7 +736,7 @@ test(
                 'data' => [
                     'show_input' => 'hide',
                     'name' => 'lorem ipsum',
-                ]
+                ],
             ]);
 
         $dehydratedState = $container->dehydrateState();


### PR DESCRIPTION
## Description

This PR addresses a bug where conditionally hidden fields within a Section component (with state path) are incorrectly dehydrated. Currently, when a field is both:
- Hidden based on a condition
- Inside a Section with a state path
- Marked as non-dehydrated

The field's value is still being dehydrated when it should not be.

Example scenario:
```php
Section::make("User Information")
    ->statePath('data')
    ->schema([
        Radio::make('show_input')
            ->label('Control Input Visibility')
            ->options([
                 'show' => 'Show',
                  'hide' => 'Hide',
             ])
              ->live(),,
        TextInput::make('name')
            ->hidden(fn (Get $get): bool => $get('show_input') === 'hide')
            ->dehydrated(fn (Get $get): bool => $get('show_input') === 'show')
    ])
```

When `show_input` is 'hide', the 'name' field is still being dehydrated despite being hidden and explicitly configured not to dehydrate.

I couldn't fix the bug further, but I created a test to demonstrate this issue

## Functional changes
- [x] Added test case demonstrating the bug
- [x] Code style has been fixed by running the `composer cs` command. 