### PR TITLE
chore: improved docs a bit

### DIFF
--- a/packages/forms/docs/08-adding-a-form-to-a-livewire-component.md
+++ b/packages/forms/docs/08-adding-a-form-to-a-livewire-component.md
@@ -124,7 +124,7 @@ use App\Models\Post;
 
 public function mount(Post $post): void
 {
-    $this->form->fill($post->toArray());
+    $this->form->fill($post->attributesToArray());
 }
 ```
 


### PR DESCRIPTION
This pull request includes a small change to the docs. The change updates the method used to populate a form with a `Post` model's data, replacing `toArray()` with `attributesToArray()` to ensure only the model's attributes are included. 

If relations are loading automatically, for example, with the `$with` property, it can end in error and take some time to debug as well. so if the docs suggest using `attributesToArray()`, the development can be smooth. Yes, it's a rare case, though.