### PR TITLE
fix path when creating custom field/entry

### DIFF
--- a/packages/forms/src/Commands/MakeFieldCommand.php
+++ b/packages/forms/src/Commands/MakeFieldCommand.php
@@ -123,7 +123,7 @@ class MakeFieldCommand extends Command
             $path,
             $viewNamespace,
         ] = $this->askForComponentLocation(
-            path: 'Forms/Components',
+            path: 'Filament/Forms/Components',
             question: 'Where would you like to create the field?',
         );
 

--- a/packages/infolists/src/Commands/MakeEntryCommand.php
+++ b/packages/infolists/src/Commands/MakeEntryCommand.php
@@ -123,7 +123,7 @@ class MakeEntryCommand extends Command
             $path,
             $viewNamespace,
         ] = $this->askForComponentLocation(
-            path: 'Infolists/Components',
+            path: 'Filament/Infolists/Components',
             question: 'Where would you like to create the entry?',
         );
 


### PR DESCRIPTION
## Description

When using a command to create a custom field or entry the namespace is different from the file path, resulting in the component not being autoloaded/found.

Namespace: App\Filament\Infolist\Components
Path: App\Infolist\Components

![Imagem do WhatsApp de 2025-05-20 à(s) 12 07 35_8ab6e775](https://github.com/user-attachments/assets/791a3630-1a96-4be8-b5ad-5491971adb33)

This commit makes the path equal to the NS as App\Filament\Infolist\Components

## Visual changes

No changes

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
