### PR TITLE
add missing generics for eloquent-builder

### DIFF
--- a/packages/actions/src/Concerns/InteractsWithSelectedRecords.php
+++ b/packages/actions/src/Concerns/InteractsWithSelectedRecords.php
@@ -7,6 +7,7 @@ use Exception;
 use Filament\Support\Authorization\DenyResponse;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 
@@ -58,6 +59,9 @@ trait InteractsWithSelectedRecords
         return $records;
     }
 
+    /**
+     * @return Builder<Model>
+     */
     public function getSelectedRecordsQuery(): Builder
     {
         if (! $this->canAccessSelectedRecords()) {

--- a/packages/actions/src/CreateAction.php
+++ b/packages/actions/src/CreateAction.php
@@ -177,6 +177,9 @@ class CreateAction extends Action
         return true;
     }
 
+    /**
+     * @return Relation|Builder<Model>|null
+     */
     public function getRelationship(): Relation | Builder | null
     {
         return $this->evaluate($this->getRelationshipUsing) ?? $this->getTable()?->getRelationship() ?? $this->getHasActionsLivewire()?->getDefaultActionRelationship($this);

--- a/packages/actions/src/Exports/ExportColumn.php
+++ b/packages/actions/src/Exports/ExportColumn.php
@@ -111,6 +111,10 @@ class ExportColumn extends Component
             ->ucfirst();
     }
 
+    /**
+     * @param  EloquentBuilder<Model>  $query
+     * @return EloquentBuilder<Model>
+     */
     public function applyRelationshipAggregates(EloquentBuilder $query): EloquentBuilder
     {
         return $query->when(
@@ -134,6 +138,10 @@ class ExportColumn extends Component
         );
     }
 
+    /**
+     * @param  EloquentBuilder<Model>  $query
+     * @return EloquentBuilder<Model>
+     */
     public function applyEagerLoading(EloquentBuilder $query): EloquentBuilder
     {
         if (! $this->hasRelationship($query->getModel())) {

--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -215,6 +215,10 @@ abstract class Exporter
         return $writer;
     }
 
+    /**
+     * @param  Builder<Model>  $query
+     * @return Builder<Model>
+     */
     public static function modifyQuery(Builder $query): Builder
     {
         return $query;

--- a/packages/actions/src/Imports/Models/FailedImportRow.php
+++ b/packages/actions/src/Imports/Models/FailedImportRow.php
@@ -27,6 +27,9 @@ class FailedImportRow extends Model
         return $this->belongsTo(app(Import::class)::class);
     }
 
+    /**
+     * @return Builder<FailedImportRow>
+     */
     public function prunable(): Builder
     {
         return static::where(

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -1130,6 +1130,10 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
         return $this;
     }
 
+    /**
+     * @param  Builder<Model>  $query
+     * @return Builder<Model>
+     */
     protected function applySearchConstraint(Builder $query, string $search): Builder
     {
         /** @var Connection $databaseConnection */

--- a/packages/notifications/src/Livewire/DatabaseNotifications.php
+++ b/packages/notifications/src/Livewire/DatabaseNotifications.php
@@ -87,12 +87,18 @@ class DatabaseNotifications extends Component implements HasActions, HasSchemas
         return static::$isPaginated;
     }
 
+    /**
+     * @return Builder<Model>|Relation
+     */
     public function getNotificationsQuery(): Builder | Relation
     {
         /** @phpstan-ignore-next-line */
         return $this->getUser()->notifications()->where('data->format', 'filament');
     }
 
+    /**
+     * @return Builder<Model>|Relation
+     */
     public function getUnreadNotificationsQuery(): Builder | Relation
     {
         /** @phpstan-ignore-next-line */

--- a/packages/panels/src/Resources/Concerns/HasTabs.php
+++ b/packages/panels/src/Resources/Concerns/HasTabs.php
@@ -6,6 +6,7 @@ use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Tabs;
 use Filament\Schemas\Components\Tabs\Tab;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
 trait HasTabs
 {
@@ -60,6 +61,10 @@ trait HasTabs
             ->ucfirst();
     }
 
+    /**
+     * @param  Builder<Model>  $query
+     * @return Builder<Model>
+     */
     protected function modifyQueryWithActiveTab(Builder $query): Builder
     {
         if (blank(filled($this->activeTab))) {

--- a/packages/panels/src/Resources/Concerns/InteractsWithRelationshipTable.php
+++ b/packages/panels/src/Resources/Concerns/InteractsWithRelationshipTable.php
@@ -53,6 +53,9 @@ trait InteractsWithRelationshipTable
         return static::$shouldSkipAuthorization;
     }
 
+    /**
+     * @return Relation|Builder<Model>
+     */
     public function getRelationship(): Relation | Builder
     {
         return $this->getOwnerRecord()->{static::getRelationshipName()}();

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -64,6 +64,9 @@ abstract class Resource
         static::table($table); /** @phpstan-ignore staticMethod.resultUnused */
     }
 
+    /**
+     * @return Builder<Model>
+     */
     public static function getEloquentQuery(): Builder
     {
         return static::getModel()::query();

--- a/packages/panels/src/Resources/Resource/Concerns/BelongsToParent.php
+++ b/packages/panels/src/Resources/Resource/Concerns/BelongsToParent.php
@@ -36,6 +36,10 @@ trait BelongsToParent
         return $parentResource;
     }
 
+    /**
+     * @param  Builder<Model>  $query
+     * @return Builder<Model>
+     */
     public static function scopeEloquentQueryToParent(Builder $query, Model $parentRecord): Builder
     {
         $parentResourceRegistration = static::getParentResourceRegistration();

--- a/packages/panels/src/Resources/Resource/Concerns/BelongsToTenant.php
+++ b/packages/panels/src/Resources/Resource/Concerns/BelongsToTenant.php
@@ -19,6 +19,10 @@ trait BelongsToTenant
 
     protected static ?string $tenantRelationshipName = null;
 
+    /**
+     * @param  Builder<Model>  $query
+     * @return Builder<Model>
+     */
     public static function scopeEloquentQueryToTenant(Builder $query, ?Model $tenant): Builder
     {
         $tenant ??= Filament::getTenant();

--- a/packages/panels/src/Resources/Resource/Concerns/HasGlobalSearch.php
+++ b/packages/panels/src/Resources/Resource/Concerns/HasGlobalSearch.php
@@ -100,6 +100,9 @@ trait HasGlobalSearch
         return static::$globalSearchResultsLimit;
     }
 
+    /**
+     * @param  Builder<Model>  $query
+     */
     public static function modifyGlobalSearchQuery(Builder $query, string $search): void {}
 
     public static function getGlobalSearchResults(string $search): Collection
@@ -140,6 +143,9 @@ trait HasGlobalSearch
         return static::$shouldSplitGlobalSearchTerms ?? true;
     }
 
+    /**
+     * @param  Builder<Model>  $query
+     */
     protected static function applyGlobalSearchAttributeConstraints(Builder $query, string $search): void
     {
         /** @var Connection $databaseConnection */
@@ -184,7 +190,9 @@ trait HasGlobalSearch
     }
 
     /**
+     * @param  Builder<Model>  $query
      * @param  array<string>  $searchAttributes
+     * @return Builder<Model>
      */
     protected static function applyGlobalSearchAttributeConstraint(Builder $query, string $search, array $searchAttributes, bool &$isFirst): Builder
     {
@@ -221,6 +229,9 @@ trait HasGlobalSearch
         return $query;
     }
 
+    /**
+     * @return Builder<Model>
+     */
     public static function getGlobalSearchEloquentQuery(): Builder
     {
         return static::getEloquentQuery();

--- a/packages/panels/src/Widgets/Concerns/InteractsWithPageTable.php
+++ b/packages/panels/src/Widgets/Concerns/InteractsWithPageTable.php
@@ -99,6 +99,9 @@ trait InteractsWithPageTable /** @phpstan-ignore trait.unused */
         return $this->tablePage = $page;
     }
 
+    /**
+     * @return Builder<Model>
+     */
     protected function getPageTableQuery(): Builder
     {
         return $this->getTablePageInstance()->getFilteredSortedTableQuery();

--- a/packages/schemas/src/Components/Tabs/Tab.php
+++ b/packages/schemas/src/Components/Tabs/Tab.php
@@ -14,6 +14,7 @@ use Filament\Support\Concerns\HasIconPosition;
 use Filament\Support\Enums\IconPosition;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
 class Tab extends Component implements CanConcealComponents
@@ -82,6 +83,10 @@ class Tab extends Component implements CanConcealComponents
         return $this;
     }
 
+    /**
+     * @param  Builder<Model>  $query
+     * @return Builder<Model>
+     */
     public function modifyQuery(Builder $query): Builder
     {
         return $this->evaluate($this->modifyQueryUsing, [

--- a/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
@@ -164,6 +164,10 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
         });
     }
 
+    /**
+     * @param  Builder<Model>|Relation  $query
+     * @return Builder<Model>|Relation
+     */
     public function applyEagerLoading(Builder | Relation $query): Builder | Relation
     {
         if ($this->isHidden()) {

--- a/packages/spatie-laravel-tags-plugin/src/Tables/Columns/SpatieTagsColumn.php
+++ b/packages/spatie-laravel-tags-plugin/src/Tables/Columns/SpatieTagsColumn.php
@@ -86,6 +86,10 @@ class SpatieTagsColumn extends TextColumn
         return $this->getType() instanceof AllTagTypes;
     }
 
+    /**
+     * @param  Builder<Model>|Relation  $query
+     * @return Builder<Model>|Relation
+     */
     public function applyEagerLoading(Builder | Relation $query): Builder | Relation
     {
         if ($this->isHidden()) {

--- a/packages/support/src/Contracts/TranslatableContentDriver.php
+++ b/packages/support/src/Contracts/TranslatableContentDriver.php
@@ -32,5 +32,9 @@ interface TranslatableContentDriver
      */
     public function updateRecord(Model $record, array $data): Model;
 
+    /**
+     * @param  Builder<Model>  $query
+     * @return Builder<Model>
+     */
     public function applySearchConstraintToQuery(Builder $query, string $column, string $search, string $whereClause, ?bool $isSearchForcedCaseInsensitive = null): Builder;
 }

--- a/packages/support/src/Services/RelationshipJoiner.php
+++ b/packages/support/src/Services/RelationshipJoiner.php
@@ -3,6 +3,7 @@
 namespace Filament\Support\Services;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Expression;
@@ -13,6 +14,10 @@ use Kirschbaum\PowerJoins\JoinsHelper;
 
 class RelationshipJoiner
 {
+    /**
+     * @param  Builder<Model>  $query
+     * @return Builder<Model>
+     */
     public function leftJoinRelationship(Builder $query, string $relationship): Builder
     {
         if (str($relationship)->contains('.')) {
@@ -37,6 +42,7 @@ class RelationshipJoiner
     }
 
     /**
+     * @param  Builder<Model>  $query
      * @return array<JoinClause>
      */
     public function getLeftJoinsForRelationship(Builder $query, string $relationship): array
@@ -47,6 +53,9 @@ class RelationshipJoiner
         return $query->toBase()->joins;
     }
 
+    /**
+     * @return Builder<Model>
+     */
     public function prepareQueryForNoConstraints(Relation $relationship): Builder
     {
         $relationshipQuery = $relationship->getQuery();

--- a/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Columns\Concerns;
 
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Arr;
@@ -13,6 +14,10 @@ use function Filament\Support\generate_search_term_expression;
 
 trait InteractsWithTableQuery
 {
+    /**
+     * @param  EloquentBuilder<Model>|Relation  $query
+     * @return EloquentBuilder<Model>|Relation
+     */
     public function applyRelationshipAggregates(EloquentBuilder | Relation $query): EloquentBuilder | Relation
     {
         return $query->when(
@@ -36,6 +41,10 @@ trait InteractsWithTableQuery
         );
     }
 
+    /**
+     * @param  EloquentBuilder<Model>|Relation  $query
+     * @return EloquentBuilder<Model>|Relation
+     */
     public function applyEagerLoading(EloquentBuilder | Relation $query): EloquentBuilder | Relation
     {
         if (! $this->hasRelationship($query->getModel())) {
@@ -51,6 +60,10 @@ trait InteractsWithTableQuery
         return $query->with([$relationshipName]);
     }
 
+    /**
+     * @param  EloquentBuilder<Model>  $query
+     * @return EloquentBuilder<Model>
+     */
     public function applySearchConstraint(EloquentBuilder $query, string $search, bool &$isFirst): EloquentBuilder
     {
         if ($this->searchQuery) {
@@ -108,6 +121,10 @@ trait InteractsWithTableQuery
         return $query;
     }
 
+    /**
+     * @param  EloquentBuilder<Model>  $query
+     * @return EloquentBuilder<Model>
+     */
     public function applySort(EloquentBuilder $query, string $direction = 'asc'): EloquentBuilder
     {
         if ($this->sortQuery) {
@@ -127,6 +144,7 @@ trait InteractsWithTableQuery
     }
 
     /**
+     * @param  EloquentBuilder<Model>  $query
      * @param  array<string> | null  $relationships
      */
     protected function getSortColumnForQuery(EloquentBuilder $query, string $sortColumn, ?array $relationships = null): string | Builder

--- a/packages/tables/src/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Concerns/CanGroupRecords.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Concerns;
 
 use Filament\Tables\Grouping\Group;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
 trait CanGroupRecords
 {
@@ -45,6 +46,10 @@ trait CanGroupRecords
         };
     }
 
+    /**
+     * @param  Builder<Model>  $query
+     * @return Builder<Model>
+     */
     protected function applyGroupingToTableQuery(Builder $query): Builder
     {
         $group = $this->getTableGrouping();

--- a/packages/tables/src/Concerns/CanPaginateRecords.php
+++ b/packages/tables/src/Concerns/CanPaginateRecords.php
@@ -6,6 +6,7 @@ use Filament\Tables\Enums\PaginationMode;
 use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Pagination\LengthAwarePaginator;
 
 trait CanPaginateRecords
@@ -26,6 +27,9 @@ trait CanPaginateRecords
         $this->resetPage();
     }
 
+    /**
+     * @param  Builder<Model>  $query
+     */
     protected function paginateTableQuery(Builder $query): Paginator | CursorPaginator
     {
         $perPage = $this->getTableRecordsPerPage();

--- a/packages/tables/src/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Concerns/CanSearchRecords.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Concerns;
 
 use Filament\Tables\Filters\Indicator;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
@@ -59,6 +60,10 @@ trait CanSearchRecords
         $this->resetPage();
     }
 
+    /**
+     * @param  Builder<Model>  $query
+     * @return Builder<Model>
+     */
     protected function applySearchToTableQuery(Builder $query): Builder
     {
         $this->applyColumnSearchesToTableQuery($query);
@@ -67,6 +72,10 @@ trait CanSearchRecords
         return $query;
     }
 
+    /**
+     * @param  Builder<Model>  $query
+     * @return Builder<Model>
+     */
     protected function applyColumnSearchesToTableQuery(Builder $query): Builder
     {
         $table = $this->getTable();
@@ -130,6 +139,10 @@ trait CanSearchRecords
         );
     }
 
+    /**
+     * @param  Builder<Model>  $query
+     * @return Builder<Model>
+     */
     protected function applyGlobalSearchToTableQuery(Builder $query): Builder
     {
         $search = $this->getTableSearch();

--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -3,6 +3,7 @@
 namespace Filament\Tables\Concerns;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
 trait CanSortRecords
 {
@@ -68,6 +69,10 @@ trait CanSortRecords
         $this->resetPage();
     }
 
+    /**
+     * @param  Builder<Model>  $query
+     * @return Builder<Model>
+     */
     protected function applySortingToTableQuery(Builder $query): Builder
     {
         if ($this->getTable()->isGroupsOnly()) {
@@ -95,6 +100,10 @@ trait CanSortRecords
         return $query;
     }
 
+    /**
+     * @param  Builder<Model>  $query
+     * @return Builder<Model>
+     */
     protected function applyDefaultSortingToTableQuery(Builder $query): Builder
     {
         $sortDirection = ($this->getTable()->getDefaultSortDirection() ?? $this->tableSortDirection) === 'desc' ? 'desc' : 'asc';

--- a/packages/tables/src/Concerns/CanSummarizeRecords.php
+++ b/packages/tables/src/Concerns/CanSummarizeRecords.php
@@ -6,17 +6,24 @@ use Closure;
 use Filament\Support\Services\RelationshipJoiner;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Str;
 use stdClass;
 
 trait CanSummarizeRecords
 {
+    /**
+     * @return Builder<Model>
+     */
     public function getAllTableSummaryQuery(): Builder
     {
         return $this->getFilteredTableQuery();
     }
 
+    /**
+     * @return Builder<Model>
+     */
     public function getPageTableSummaryQuery(): Builder
     {
         return $this->getFilteredSortedTableQuery()->forPage(
@@ -26,6 +33,7 @@ trait CanSummarizeRecords
     }
 
     /**
+     * @param  Builder<Model>  $query
      * @return array<string, mixed>
      */
     public function getTableSummarySelectedState(Builder $query, ?Closure $modifyQueryUsing = null): array

--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -242,6 +242,9 @@ trait HasBulkActions
         return $this->cachedSelectedTableRecords = $query->get();
     }
 
+    /**
+     * @return Builder<Model>
+     */
     public function getSelectedTableRecordsQuery(bool $shouldFetchSelectedRecords = true, ?int $chunkSize = null): Builder
     {
         $table = $this->getTable();

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -5,6 +5,7 @@ namespace Filament\Tables\Concerns;
 use Filament\Schemas\Schema;
 use Filament\Tables\Filters\BaseFilter;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 
 /**
@@ -148,6 +149,10 @@ trait HasFilters
         $this->handleTableFilterUpdates();
     }
 
+    /**
+     * @param  Builder<Model>  $query
+     * @return Builder<Model>
+     */
     protected function applyFiltersToTableQuery(Builder $query): Builder
     {
         foreach ($this->getTable()->getFilters() as $filter) {

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -24,6 +24,9 @@ trait HasRecords
 
     protected Collection | Paginator | CursorPaginator | null $cachedTableRecords = null;
 
+    /**
+     * @return ?Builder<Model>
+     */
     public function getFilteredTableQuery(): ?Builder
     {
         $query = $this->getTable()->getQuery();
@@ -35,6 +38,10 @@ trait HasRecords
         return $this->filterTableQuery($query);
     }
 
+    /**
+     * @param  Builder<Model>  $query
+     * @return Builder<Model>
+     */
     public function filterTableQuery(Builder $query): Builder
     {
         $this->applyFiltersToTableQuery($query);
@@ -58,6 +65,9 @@ trait HasRecords
         return $query;
     }
 
+    /**
+     * @return ?Builder<Model>
+     */
     public function getFilteredSortedTableQuery(): ?Builder
     {
         $query = $this->getFilteredTableQuery();
@@ -73,6 +83,9 @@ trait HasRecords
         return $query;
     }
 
+    /**
+     * @return Builder<Model>
+     */
     public function getTableQueryForExport(): Builder
     {
         $query = $this->getTable()->getQuery();

--- a/packages/tables/src/Contracts/HasTable.php
+++ b/packages/tables/src/Contracts/HasTable.php
@@ -40,6 +40,9 @@ interface HasTable
 
     public function getSelectedTableRecords(bool $shouldFetchSelectedRecords = true, ?int $chunkSize = null): EloquentCollection | Collection | LazyCollection;
 
+    /**
+     * @return Builder<Model>
+     */
     public function getSelectedTableRecordsQuery(bool $shouldFetchSelectedRecords = true, ?int $chunkSize = null): Builder;
 
     public function parseTableFilterName(string $name): string;
@@ -70,8 +73,14 @@ interface HasTable
 
     public function getTableSortDirection(): ?string;
 
+    /**
+     * @return Builder<Model>
+     */
     public function getAllTableSummaryQuery(): Builder;
 
+    /**
+     * @return Builder<Model>
+     */
     public function getPageTableSummaryQuery(): Builder;
 
     public function isTableColumnToggledHidden(string $name): bool;
@@ -107,10 +116,19 @@ interface HasTable
      */
     public function getTableColumnSearchIndicators(): array;
 
+    /**
+     * @return ?Builder<Model>
+     */
     public function getFilteredTableQuery(): ?Builder;
 
+    /**
+     * @return ?Builder<Model>
+     */
     public function getFilteredSortedTableQuery(): ?Builder;
 
+    /**
+     * @return Builder<Model>
+     */
     public function getTableQueryForExport(): Builder;
 
     public function makeFilamentTranslatableContentDriver(): ?TranslatableContentDriver;

--- a/packages/tables/src/Filters/Concerns/HasRelationship.php
+++ b/packages/tables/src/Filters/Concerns/HasRelationship.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception;
 use Filament\Support\Services\RelationshipJoiner;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasOneOrManyThrough;
@@ -48,6 +49,9 @@ trait HasRelationship
         return filled($this->getRelationshipName());
     }
 
+    /**
+     * @return Relation|Builder<Model>
+     */
     public function getRelationship(): Relation | Builder
     {
         $model = $this->getTable()->getModel();
@@ -91,6 +95,9 @@ trait HasRelationship
         return $this->modifyRelationshipQueryUsing;
     }
 
+    /**
+     * @return ?Builder<Model>
+     */
     public function getRelationshipQuery(): ?Builder
     {
         $relationship = Relation::noConstraints(fn () => $this->getRelationship());
@@ -110,6 +117,9 @@ trait HasRelationship
         return $relationshipQuery;
     }
 
+    /**
+     * @param  ?Builder<Model>  $query
+     */
     public function getRelationshipKey(?Builder $query = null): ?string
     {
         $relationship = $this->getRelationship();

--- a/packages/tables/src/Filters/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Filters/Concerns/InteractsWithTableQuery.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Filters\Concerns;
 
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
 trait InteractsWithTableQuery
 {
@@ -12,7 +13,9 @@ trait InteractsWithTableQuery
     protected ?Closure $modifyBaseQueryUsing = null;
 
     /**
+     * @param  Builder<Model>  $query
      * @param  array<string, mixed>  $data
+     * @return Builder<Model>
      */
     public function apply(Builder $query, array $data = []): Builder
     {
@@ -38,7 +41,9 @@ trait InteractsWithTableQuery
     }
 
     /**
+     * @param  Builder<Model>  $query
      * @param  array<string, mixed>  $data
+     * @return Builder<Model>
      */
     public function applyToBaseQuery(Builder $query, array $data = []): Builder
     {

--- a/packages/tables/src/Filters/QueryBuilder.php
+++ b/packages/tables/src/Filters/QueryBuilder.php
@@ -10,6 +10,7 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Filters\QueryBuilder\Concerns\HasConstraints;
 use Filament\Tables\Filters\QueryBuilder\Forms\Components\RuleBuilder;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\ValidationException;
 
 class QueryBuilder extends BaseFilter
@@ -93,7 +94,9 @@ class QueryBuilder extends BaseFilter
     }
 
     /**
+     * @param  Builder<Model>  $query
      * @param  array<string, mixed>  $rules
+     * @return Builder<Model>
      */
     public function applyRulesToQuery(Builder $query, array $rules, RuleBuilder $ruleBuilder): Builder
     {
@@ -131,7 +134,9 @@ class QueryBuilder extends BaseFilter
     }
 
     /**
+     * @param  Builder<Model>  $query
      * @param  array<string, mixed>  $rules
+     * @return Builder<Model>
      */
     public function applyRulesToBaseQuery(Builder $query, array $rules, RuleBuilder $ruleBuilder): Builder
     {

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/BooleanConstraint/Operators/IsTrueOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/BooleanConstraint/Operators/IsTrueOperator.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Filters\QueryBuilder\Constraints\BooleanConstraint\Ope
 
 use Filament\Tables\Filters\QueryBuilder\Constraints\Operators\Operator;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
 class IsTrueOperator extends Operator
 {
@@ -31,6 +32,10 @@ class IsTrueOperator extends Operator
         );
     }
 
+    /**
+     * @param  Builder<Model>  $query
+     * @return Builder<Model>
+     */
     public function apply(Builder $query, string $qualifiedColumn): Builder
     {
         return $query->where($qualifiedColumn, ! $this->isInverse());

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -5,6 +5,7 @@ namespace Filament\Tables\Filters;
 use Closure;
 use Filament\Forms\Components\Select;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Znck\Eloquent\Relations\BelongsToThrough;
 
@@ -131,7 +132,9 @@ class SelectFilter extends BaseFilter
     }
 
     /**
+     * @param  Builder<Model>  $query
      * @param  array<string, mixed>  $data
+     * @return Builder<Model>
      */
     public function apply(Builder $query, array $data = []): Builder
     {


### PR DESCRIPTION
## Description

add missing generics for eloquent-builder

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
