### PR TITLE
Updated `getColumns` method to accept an `array $options` parameter

### DIFF
--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -98,7 +98,7 @@ trait CanExportRecords
                         ])
                             ->verticallyAlignCenter()
                             ->statePath($column->getName()),
-                        $action->getExporter()::getColumns(),
+                        $action->getExporter()::getColumns($this->getOptions()),
                     );
                 })
                 ->statePath('columnMap')] : []),
@@ -157,7 +157,7 @@ trait CanExportRecords
                     ->mapWithKeys(fn (array $column, string $columnName): array => [$columnName => $column['label']])
                     ->all();
             } else {
-                $columnMap = collect($exporter::getColumns())
+                $columnMap = collect($exporter::getColumns($options))
                     ->mapWithKeys(fn (ExportColumn $column): array => [$column->getName() => $column->getLabel()])
                     ->all();
             }

--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -49,10 +49,6 @@ abstract class Exporter
         return $data;
     }
 
-    /**
-     * @param array $options
-     * @return array
-     */
     abstract public static function getColumns(array $options = []): array;
 
     /**

--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -50,9 +50,10 @@ abstract class Exporter
     }
 
     /**
-     * @return array<ExportColumn>
+     * @param array $options
+     * @return array
      */
-    abstract public static function getColumns(): array;
+    abstract public static function getColumns(array $options = []): array;
 
     /**
      * @return array<Component>
@@ -122,7 +123,7 @@ abstract class Exporter
      */
     public function getCachedColumns(): array
     {
-        return $this->cachedColumns ??= array_reduce(static::getColumns(), function (array $carry, ExportColumn $column): array {
+        return $this->cachedColumns ??= array_reduce(static::getColumns($this->getOptions()), function (array $carry, ExportColumn $column): array {
             $carry[$column->getName()] = $column->exporter($this);
 
             return $carry;

--- a/packages/actions/stubs/Exporter.stub
+++ b/packages/actions/stubs/Exporter.stub
@@ -11,7 +11,7 @@ class {{ exporterClass }} extends Exporter
 {
     protected static ?string $model = {{ modelClass }}::class;
 
-    public static function getColumns(): array
+    public static function getColumns(array $options = []): array
     {
         return [
 {{ columns }}


### PR DESCRIPTION
Updated `getColumns` method to accept an `array $options` parameter, enabling more flexible column configuration. Adjusted relevant calls and logic to pass options where necessary. This improves customizability of the export functionality.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This pull request solves the problem of passing the action options to the getColumns method of the export class, this allows generating export with dynamic columns based on the passed options.

## Visual changes

There were no visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
