### PR TITLE
Fix Select relationship field generating empty Rule::in() when using JSON key in title (e.g., 'name->en')

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -948,7 +948,13 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
                 return $component->getOptionLabelFromRecord($record);
             }
 
-            return $record->getAttributeValue($component->getRelationshipTitleAttribute());
+            $relationshipTitleAttribute = $component->getRelationshipTitleAttribute();
+
+            if (str_contains($relationshipTitleAttribute, '->')) {
+                return Arr::get($record->toArray(), str_replace('->', '.', $relationshipTitleAttribute));
+            }
+
+            return $record->getAttributeValue($relationshipTitleAttribute);
         });
 
         $this->getSelectedRecordUsing(static function (Select $component, $state) use ($modifyQueryUsing): ?Model {

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -951,7 +951,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
             $relationshipTitleAttribute = $component->getRelationshipTitleAttribute();
 
             if (str_contains($relationshipTitleAttribute, '->')) {
-                return Arr::get($record->toArray(), str_replace('->', '.', $relationshipTitleAttribute));
+                return data_get($record->toArray(), str_replace('->', '.', $relationshipTitleAttribute));
             }
 
             return $record->getAttributeValue($relationshipTitleAttribute);

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -951,7 +951,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
             $relationshipTitleAttribute = $component->getRelationshipTitleAttribute();
 
             if (str_contains($relationshipTitleAttribute, '->')) {
-                return data_get($record->toArray(), str_replace('->', '.', $relationshipTitleAttribute));
+                return data_get($record, str_replace('->', '.', $relationshipTitleAttribute));
             }
 
             return $record->getAttributeValue($relationshipTitleAttribute);


### PR DESCRIPTION
## Description
When a relationship title attribute uses JSON path notation (e.g., `'name->en'`), Laravel's `getAttributeValue('name->en')` cannot resolve the value.
As a result, `getOptionLabel()` returns `null`, which leads to returning an empty array for `Rule::in()`. This breaks validation by allowing no valid values.

https://github.com/filamentphp/filament/blob/b302607a77d871330f56934168c202fe6dc64acc/packages/forms/src/Components/Select.php#L1385-L1398

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
