### PR TITLE
[3.x] add missing type variables for eloquent-builder

### DIFF
--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -190,6 +190,12 @@ abstract class Exporter
         return null;
     }
 
+    /**
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>  $query
+     * @return Builder<TModel>
+     */
     public static function modifyQuery(Builder $query): Builder
     {
         return $query;

--- a/packages/panels/src/Resources/Components/Tab.php
+++ b/packages/panels/src/Resources/Components/Tab.php
@@ -8,6 +8,7 @@ use Filament\Support\Concerns\HasBadge;
 use Filament\Support\Concerns\HasExtraAttributes;
 use Filament\Support\Concerns\HasIcon;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
 class Tab extends Component
 {
@@ -58,6 +59,12 @@ class Tab extends Component
         return $this->evaluate($this->label);
     }
 
+    /**
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>  $query
+     * @return Builder<TModel>
+     */
     public function modifyQuery(Builder $query): Builder
     {
         return $this->evaluate($this->modifyQueryUsing, [

--- a/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
@@ -162,6 +162,12 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
         return array_unique($state);
     }
 
+    /**
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>|Relation  $query
+     * @return Builder<TModel>|Relation
+     */
     public function applyEagerLoading(Builder | Relation $query): Builder | Relation
     {
         if ($this->isHidden()) {

--- a/packages/spatie-laravel-tags-plugin/src/Tables/Columns/SpatieTagsColumn.php
+++ b/packages/spatie-laravel-tags-plugin/src/Tables/Columns/SpatieTagsColumn.php
@@ -84,6 +84,12 @@ class SpatieTagsColumn extends TextColumn
         return $this->getType() instanceof AllTagTypes;
     }
 
+    /**
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>|Relation  $query
+     * @return Builder<TModel>|Relation
+     */
     public function applyEagerLoading(Builder | Relation $query): Builder | Relation
     {
         if ($this->isHidden()) {

--- a/packages/support/src/Contracts/TranslatableContentDriver.php
+++ b/packages/support/src/Contracts/TranslatableContentDriver.php
@@ -28,5 +28,11 @@ interface TranslatableContentDriver
      */
     public function updateRecord(Model $record, array $data): Model;
 
+    /**
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>  $query
+     * @return Builder<TModel>
+     */
     public function applySearchConstraintToQuery(Builder $query, string $column, string $search, string $whereClause, ?bool $isCaseInsensitivityForced = null): Builder;
 }

--- a/packages/tables/src/Filters/QueryBuilder.php
+++ b/packages/tables/src/Filters/QueryBuilder.php
@@ -10,6 +10,7 @@ use Filament\Forms\Components\Repeater;
 use Filament\Tables\Filters\QueryBuilder\Concerns\HasConstraints;
 use Filament\Tables\Filters\QueryBuilder\Forms\Components\RuleBuilder;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\ValidationException;
 
 class QueryBuilder extends BaseFilter
@@ -93,7 +94,11 @@ class QueryBuilder extends BaseFilter
     }
 
     /**
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>  $query
      * @param  array<string, mixed>  $rules
+     * @return Builder<TModel>
      */
     public function applyRulesToQuery(Builder $query, array $rules, RuleBuilder $ruleBuilder): Builder
     {
@@ -131,7 +136,11 @@ class QueryBuilder extends BaseFilter
     }
 
     /**
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>  $query
      * @param  array<string, mixed>  $rules
+     * @return Builder<TModel>
      */
     public function applyRulesToBaseQuery(Builder $query, array $rules, RuleBuilder $ruleBuilder): Builder
     {

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/BooleanConstraint/Operators/IsTrueOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/BooleanConstraint/Operators/IsTrueOperator.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Filters\QueryBuilder\Constraints\BooleanConstraint\Ope
 
 use Filament\Tables\Filters\QueryBuilder\Constraints\Operators\Operator;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
 class IsTrueOperator extends Operator
 {
@@ -31,6 +32,12 @@ class IsTrueOperator extends Operator
         );
     }
 
+    /**
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>  $query
+     * @return Builder<TModel>
+     */
     public function apply(Builder $query, string $qualifiedColumn): Builder
     {
         return $query->where($qualifiedColumn, ! $this->isInverse());

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -5,6 +5,7 @@ namespace Filament\Tables\Filters;
 use Closure;
 use Filament\Forms\Components\Select;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Znck\Eloquent\Relations\BelongsToThrough;
 
@@ -131,7 +132,11 @@ class SelectFilter extends BaseFilter
     }
 
     /**
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>  $query
      * @param  array<string, mixed>  $data
+     * @return Builder<TModel>
      */
     public function apply(Builder $query, array $data = []): Builder
     {


### PR DESCRIPTION
## Description

Add missing type variables for eloquent-builder for more type-safety (like https://github.com/filamentphp/filament/pull/16317 but for the 3.x-branch)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
