### PR TITLE
 feat(i18n): add empty option label to pt and es

### DIFF
--- a/packages/tables/resources/lang/es/table.php
+++ b/packages/tables/resources/lang/es/table.php
@@ -145,7 +145,13 @@ return [
         ],
 
         'select' => [
+
             'placeholder' => 'Todos',
+
+            'relationship' => [
+                'empty_option_label' => 'Ninguno',
+            ],
+
         ],
 
         'trashed' => [

--- a/packages/tables/resources/lang/pt/table.php
+++ b/packages/tables/resources/lang/pt/table.php
@@ -145,7 +145,13 @@ return [
         ],
 
         'select' => [
+
             'placeholder' => 'Todos',
+
+            'relationship' => [
+                'empty_option_label' => 'Nenhum',
+            ],
+
         ],
 
         'trashed' => [

--- a/packages/tables/resources/lang/pt_BR/table.php
+++ b/packages/tables/resources/lang/pt_BR/table.php
@@ -144,7 +144,13 @@ return [
         ],
 
         'select' => [
+
             'placeholder' => 'Todos',
+
+            'relationship' => [
+                'empty_option_label' => 'Nenhum',
+            ],
+
         ],
 
         'trashed' => [


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Add Spanish and Portuguese select empty label

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
