### PR TITLE
feat(i18n): add error-notifications translations for pt and es

### DIFF
--- a/packages/panels/resources/lang/es/error-notifications.php
+++ b/packages/panels/resources/lang/es/error-notifications.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+
+    'title' => 'Error al cargar la página',
+
+    'body' => 'Ocurrió un error al intentar cargar esta página. Por favor, inténtelo de nuevo más tarde.',
+
+];

--- a/packages/panels/resources/lang/pt/error-notifications.php
+++ b/packages/panels/resources/lang/pt/error-notifications.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+
+    'title' => 'Erro ao carregar a página',
+
+    'body' => 'Ocorreu um erro ao tentar carregar esta página. Por favor, tente novamente mais tarde.',
+
+];

--- a/packages/panels/resources/lang/pt_BR/error-notifications.php
+++ b/packages/panels/resources/lang/pt_BR/error-notifications.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+
+    'title' => 'Erro ao carregar a página',
+
+    'body' => 'Ocorreu um erro ao tentar carregar esta página. Por favor, tente novamente mais tarde.',
+
+];


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR adds the translations of the texts related to error-notifications into Portuguese (pt) and Spanish (es).

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
