### PR TITLE
Add alias for `FilamentManager::class` from abstract `filament`

### DIFF
--- a/packages/panels/src/FilamentServiceProvider.php
+++ b/packages/panels/src/FilamentServiceProvider.php
@@ -48,6 +48,8 @@ class FilamentServiceProvider extends PackageServiceProvider
             return new FilamentManager;
         });
 
+        $this->app->alias('filament', FilamentManager::class);
+
         $this->app->singleton(PanelRegistry::class, function (): PanelRegistry {
             return new PanelRegistry;
         });


### PR DESCRIPTION
## Description
An extension to a [discussion I opened](https://github.com/filamentphp/filament/discussions/16339), then immediately realised can be solved with a non-breaking one-liner.

This PR uses the alias functionality for service container bindings to allow Dependency Injection (DI) for `FilamentManager::class`.

An example is provided in the discussion, but I'll bring it here.

```php
use Filament\FilamentManager;
use Illuminate\Contracts\Auth\Guard;

class GetFilamentAuth
{
    public function __construct(private FilamentManager $filament) {}

    public function __invoke(): Guard
    {
        $this->filament->auth()
    }
}
```

This should be a non-breaking change, as the original functionality of using `app('filament')` should be fully preserved. This just emulates [Laravel's own functionality](https://laravel.com/docs/12.x/facades#facade-class-reference) for allowing the use of Facades, DI, and app bindings to pull out its services.

I've made a small change in a local (currently private, it's a package I'm developing) repository that checks that the container resolves when using `app(FilamentManager::class)`. This had passed:

```php
beforeEach(function () {
    $this->getAuditable = new GetAuditable(app(FilamentManager::class));

    $this->articleTitle = 'Example post title!';

    $this->article = Article::factory()->create([
        'title' => $this->articleTitle,
    ]);

    $this->audit = $this->article->audits()->first();

});

it('can get auditable of Audit', function () {
    expect(($this->getAuditable)($this->audit))
        ->toBeInstanceOf(Article::class)
        ->title->toBe($this->articleTitle);
});
```