### PR TITLE
Added isPasteable option to File Upload 

### DIFF
--- a/packages/forms/docs/03-fields/09-file-upload.md
+++ b/packages/forms/docs/03-fields/09-file-upload.md
@@ -412,6 +412,17 @@ FileUpload::make('attachment')
     ->deletable(false)
 ```
 
+## Allow submission of file from Clipboard paste
+
+You can accept submission via the clipboard paste by using `pasteable(true)`:
+
+```php
+use Filament\Forms\Components\FileUpload;
+
+FileUpload::make('attachment')
+    ->pasteable(true)
+```
+
 ## Prevent file information fetching
 
 While the form is loaded, it will automatically detect whether the files exist, what size they are, and what type of files they are. This is all done on the backend. When using remote storage with many files, this can be time-consuming. You can use the `fetchFileInformation(false)` method to disable this feature:

--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -30,6 +30,7 @@ export default function fileUploadFormComponent({
     imageEditorViewportHeight,
     imageEditorViewportWidth,
     deleteUploadedFileUsing,
+    isPasteable,
     isDeletable,
     isDisabled,
     getUploadedFilesUsing,
@@ -103,7 +104,7 @@ export default function fileUploadFormComponent({
             this.pond = FilePond.create(this.$refs.input, {
                 acceptedFileTypes,
                 allowImageExifOrientation: shouldOrientImageFromExif,
-                allowPaste: false,
+                allowPaste: isPasteable,
                 allowRemove: isDeletable,
                 allowReorder: isReorderable,
                 allowImagePreview: isPreviewable,

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -55,6 +55,7 @@
                     imageResizeTargetWidth: @js($imageResizeTargetWidth),
                     imageResizeUpscale: @js($getImageResizeUpscale()),
                     isAvatar: @js($isAvatar),
+                    isPasteable: @js($isPasteable()),
                     isDeletable: @js($isDeletable()),
                     isDisabled: @js($isDisabled),
                     isDownloadable: @js($isDownloadable()),

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -26,6 +26,8 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
      */
     protected array | Arrayable | Closure | null $acceptedFileTypes = null;
 
+    protected bool | Closure $isPasteable = false;
+
     protected bool | Closure $isDeletable = true;
 
     protected bool | Closure $isDownloadable = false;
@@ -238,6 +240,13 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
 
             return "mimetypes:{$types}";
         });
+
+        return $this;
+    }
+
+    public function pasteable(bool | Closure $condition = false): static
+    {
+        $this->isPasteable = $condition;
 
         return $this;
     }
@@ -473,6 +482,11 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
         $this->saveUploadedFileUsing = $callback;
 
         return $this;
+    }
+
+    public function isPasteable(): bool
+    {
+        return (bool) $this->evaluate($this->isPasteable);
     }
 
     public function isDeletable(): bool

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -244,7 +244,7 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
         return $this;
     }
 
-    public function pasteable(bool | Closure $condition = false): static
+    public function pasteable(bool | Closure $condition = true): static
     {
         $this->isPasteable = $condition;
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Added an isPasteable parameter to match isDeletable

## Functional changes

This should allow people to specify ->isPasteable on the Filepond plugin

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
