### PR TITLE
Update CanFormatState.php

### DIFF
--- a/packages/infolists/docs/03-entries/02-text.md
+++ b/packages/infolists/docs/03-entries/02-text.md
@@ -113,6 +113,14 @@ use Filament\Infolists\Components\TextEntry;
 TextEntry::make('price')
     ->money('EUR')
 ```
+There is also a `precision` argument for `money()` that allows you to dispaly the original value in Integer format. This could be useful if you stores the price with integer, for example:
+
+```php
+use Filament\Infolists\Components\TextEntry;
+
+TextEntry::make('price')
+    ->money('EUR', precision: 2)
+```
 
 There is also a `divideBy` argument for `money()` that allows you to divide the original value by a number before formatting it. This could be useful if your database stores the price in cents, for example:
 

--- a/packages/infolists/src/Components/Concerns/CanFormatState.php
+++ b/packages/infolists/src/Components/Concerns/CanFormatState.php
@@ -149,11 +149,11 @@ trait CanFormatState
         return $this;
     }
 
-    public function money(string | Closure | null $currency = null, int $divideBy = 0, string | Closure | null $locale = null): static
+    public function money(string | Closure | null $currency = null, int $divideBy = 0, string | Closure | null $locale = null, ?int $precision = null): static
     {
         $this->isMoney = true;
 
-        $this->formatStateUsing(static function (TextEntry $component, $state) use ($currency, $divideBy, $locale): ?string {
+        $this->formatStateUsing(static function (TextEntry $component, $state) use ($currency, $divideBy, $locale, $precision): ?string {
             if (blank($state)) {
                 return null;
             }
@@ -169,7 +169,7 @@ trait CanFormatState
                 $state /= $divideBy;
             }
 
-            return Number::currency($state, $currency, $locale);
+            return Number::currency($state, $currency, $locale, $precision);
         });
 
         return $this;

--- a/packages/tables/docs/03-columns/02-text.md
+++ b/packages/tables/docs/03-columns/02-text.md
@@ -149,6 +149,15 @@ TextColumn::make('price')
     ->money('EUR', divideBy: 100)
 ```
 
+There is also a `precision` argument for `money()` that allows you to dispaly the original value in Integer format. This could be useful if you stores the price with integer, for example:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('price')
+    ->money('EUR', precision: 2)
+```
+
 By default, your app's locale will be used to format the money suitably. If you would like to customize the locale used, you can pass it to the `locale` argument:
 
 ```php

--- a/packages/tables/docs/07-summaries.md
+++ b/packages/tables/docs/07-summaries.md
@@ -275,6 +275,16 @@ TextColumn::make('price')
     ->summarize(Sum::make()->money('EUR'))
 ```
 
+There is also a `precision` argument for `money()` that allows you to dispaly the original value in Integer format. This could be useful if you stores the price with integer, for example:
+
+```php
+use Filament\Tables\Columns\Summarizers\Sum;
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('price')
+    ->summarize(Sum::make()->money('EUR', precision: 2))
+```
+
 There is also a `divideBy` argument for `money()` that allows you to divide the original value by a number before formatting it. This could be useful if your database stores the price in cents, for example:
 
 ```php

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -149,11 +149,11 @@ trait CanFormatState
         return $this;
     }
 
-    public function money(string | Closure | null $currency = null, int $divideBy = 0, string | Closure | null $locale = null): static
+    public function money(string | Closure | null $currency = null, int $divideBy = 0, string | Closure | null $locale = null, ?int $precision = null): static
     {
         $this->isMoney = true;
 
-        $this->formatStateUsing(static function (TextColumn $column, $state) use ($currency, $divideBy, $locale): ?string {
+        $this->formatStateUsing(static function (TextColumn $column, $state) use ($currency, $divideBy, $locale, $precision): ?string {
             if (blank($state)) {
                 return null;
             }
@@ -169,7 +169,7 @@ trait CanFormatState
                 $state /= $divideBy;
             }
 
-            return Number::currency($state, $currency, $locale);
+            return Number::currency($state, $currency, $locale, $precision);
         });
 
         return $this;

--- a/packages/tables/src/Columns/Summarizers/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Summarizers/Concerns/CanFormatState.php
@@ -45,9 +45,9 @@ trait CanFormatState
         return $this;
     }
 
-    public function money(string | Closure | null $currency = null, int $divideBy = 0, string | Closure | null $locale = null): static
+    public function money(string | Closure | null $currency = null, int $divideBy = 0, string | Closure | null $locale = null, ?int $precision = null): static
     {
-        $this->formatStateUsing(static function ($state, Summarizer $summarizer) use ($currency, $divideBy, $locale): ?string {
+        $this->formatStateUsing(static function ($state, Summarizer $summarizer) use ($currency, $divideBy, $locale, $precision): ?string {
             if (blank($state)) {
                 return null;
             }
@@ -63,7 +63,7 @@ trait CanFormatState
                 $state /= $divideBy;
             }
 
-            return Number::currency($state, $currency, $locale);
+            return Number::currency($state, $currency, $locale, $precision);
         });
 
         return $this;


### PR DESCRIPTION
## Description
In laravel Number::currency helper have optimal $precision parameter, in this change only add, that option default value = null waht is mean xx,00 in this change add option for xx EUR USD HUF etc..

## Update functionality
 Update functionality add exist but can't usable yet number formater helper
https://laravel.com/docs/12.x/helpers#method-number-currency
## Visual changes

https://laravel.com/docs/12.x/helpers#method-number-currency

That image decribe everything

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
