### PR TITLE
Introduce `uniqueForTenant()` to scope unique rule per tenant

### DIFF
--- a/packages/forms/docs/23-validation.md
+++ b/packages/forms/docs/23-validation.md
@@ -517,6 +517,7 @@ In multi-tenant applications, you may want a field to be unique only within the 
 ```php
 Field::make('email')->uniqueForTenant()
 ```
+This method accepts the same parameters as `Field::unique()`, such as `table`, `column`, `ignoreRecord`, `ignorable`, and `modifyRuleUsing`.
 
 ### ULID
 

--- a/packages/forms/docs/23-validation.md
+++ b/packages/forms/docs/23-validation.md
@@ -510,6 +510,13 @@ Field::make('email')
     })
 ```
 
+### Unique for Tenant
+
+In multi-tenant applications, you may want a field to be unique only within the current tenant's scope.
+
+```php
+Field::make('email')->uniqueForTenant()
+```
 
 ### ULID
 

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -3,6 +3,7 @@
 namespace Filament\Forms\Components\Concerns;
 
 use Closure;
+use Filament\Facades\Filament;
 use Filament\Forms\Components\Contracts\CanBeLengthConstrained;
 use Filament\Forms\Components\Contracts\HasNestedRecursiveValidationRules;
 use Filament\Forms\Components\Field;
@@ -536,6 +537,21 @@ trait CanBeValidated
 
             return $rule;
         }, fn (Field $component, ?string $model): bool => (bool) ($component->evaluate($table) ?? $model));
+
+        return $this;
+    }
+
+    public function uniqueForTenant(string | Closure | null $table = null, string | Closure | null $column = null, Model | Closure | null $ignorable = null, ?bool $ignoreRecord = null): static
+    {
+        $modifyRuleUsing = Filament::hasTenancy() ?
+            function (Field $component, Unique $rule) {
+                $tenantOwnershipRelationship = $component->getLivewire()::getResource()::getTenantOwnershipRelationship($component->getModelInstance());
+
+                return $rule->where($tenantOwnershipRelationship->getForeignKeyName(), Filament::getTenant()->getKey());
+            } :
+            null;
+
+        $this->unique($table, $column, $ignorable, $ignoreRecord, $modifyRuleUsing);
 
         return $this;
     }

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -572,20 +572,6 @@ trait CanBeValidated
         return $this;
     }
 
-    public static function getTenantOwnershipRelationship(Model $record): Relation
-    {
-        $relationshipName = static::getTenantOwnershipRelationshipName();
-
-        if (! $record->isRelation($relationshipName)) {
-            $resourceClass = static::class;
-            $recordClass = $record::class;
-
-            throw new Exception("The model [{$recordClass}] does not have a relationship named [{$relationshipName}]. You can change the relationship being used by passing it to the [ownershipRelationship] argument of the [tenant()] method in configuration. You can change the relationship being used per-resource by setting it as the [\$tenantOwnershipRelationshipName] static property on the [{$resourceClass}] resource class.");
-        }
-
-        return $record->{$relationshipName}();
-    }
-
     public function uniqueValidationIgnoresRecordByDefault(bool | Closure $condition = true): static
     {
         $this->shouldUniqueValidationIgnoreRecordByDefault = $condition;

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -3,6 +3,7 @@
 namespace Filament\Forms\Components\Concerns;
 
 use Closure;
+use Exception;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Contracts\CanBeLengthConstrained;
 use Filament\Forms\Components\Contracts\HasNestedRecursiveValidationRules;
@@ -550,7 +551,16 @@ trait CanBeValidated
 
                     $tenantOwnershipRelationship = $resource::getTenantOwnershipRelationship($component->getModelInstance());
                 } else {
-                    $tenantOwnershipRelationship = Filament::getTenantOwnershipRelationship($component->getModelInstance());
+                    $relationshipName = Filament::getTenantOwnershipRelationshipName();
+                    $model = $component->getModelInstance();
+
+                    if (! $model->isRelation($relationshipName)) {
+                        $recordClass = $model::class;
+
+                        throw new Exception("The model [{$recordClass}] does not have a relationship named [{$relationshipName}]. You can change the relationship being used by passing it to the [ownershipRelationship] argument of the [tenant()] method in configuration.");
+                    }
+
+                    $tenantOwnershipRelationship = $model->{$relationshipName}();
                 }
 
                 return $rule->where($tenantOwnershipRelationship->getForeignKeyName(), Filament::getTenant()->getKey());
@@ -560,6 +570,20 @@ trait CanBeValidated
         $this->unique($table, $column, $ignorable, $ignoreRecord, $modifyRuleUsing);
 
         return $this;
+    }
+
+    public static function getTenantOwnershipRelationship(Model $record): Relation
+    {
+        $relationshipName = static::getTenantOwnershipRelationshipName();
+
+        if (! $record->isRelation($relationshipName)) {
+            $resourceClass = static::class;
+            $recordClass = $record::class;
+
+            throw new Exception("The model [{$recordClass}] does not have a relationship named [{$relationshipName}]. You can change the relationship being used by passing it to the [ownershipRelationship] argument of the [tenant()] method in configuration. You can change the relationship being used per-resource by setting it as the [\$tenantOwnershipRelationshipName] static property on the [{$resourceClass}] resource class.");
+        }
+
+        return $record->{$relationshipName}();
     }
 
     public function uniqueValidationIgnoresRecordByDefault(bool | Closure $condition = true): static

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -545,7 +545,13 @@ trait CanBeValidated
     {
         $modifyRuleUsing = Filament::hasTenancy() ?
             function (Field $component, Unique $rule) {
-                $tenantOwnershipRelationship = $component->getLivewire()::getResource()::getTenantOwnershipRelationship($component->getModelInstance());
+                if (method_exists($component->getLivewire(), 'getResource')) {
+                    $resource = $component->getLivewire()::getResource();
+
+                    $tenantOwnershipRelationship = $resource::getTenantOwnershipRelationship($component->getModelInstance());
+                } else {
+                    $tenantOwnershipRelationship = Filament::getTenantOwnershipRelationship($component->getModelInstance());
+                }
 
                 return $rule->where($tenantOwnershipRelationship->getForeignKeyName(), Filament::getTenant()->getKey());
             } :

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -542,10 +542,10 @@ trait CanBeValidated
         return $this;
     }
 
-    public function uniqueForTenant(string | Closure | null $table = null, string | Closure | null $column = null, Model | Closure | null $ignorable = null, ?bool $ignoreRecord = null): static
+    public function uniqueForTenant(string | Closure | null $table = null, string | Closure | null $column = null, Model | Closure | null $ignorable = null, ?bool $ignoreRecord = null, ?Closure $modifyRuleUsing = null): static
     {
         $modifyRuleUsing = Filament::hasTenancy() ?
-            function (Field $component, Unique $rule) {
+            function (Field $component, Unique $rule) use ($modifyRuleUsing) {
                 if (method_exists($component->getLivewire(), 'getResource')) {
                     $resource = $component->getLivewire()::getResource();
 
@@ -563,9 +563,17 @@ trait CanBeValidated
                     $tenantOwnershipRelationship = $model->{$relationshipName}();
                 }
 
-                return $rule->where($tenantOwnershipRelationship->getForeignKeyName(), Filament::getTenant()->getKey());
+                $rule = $rule->where($tenantOwnershipRelationship->getForeignKeyName(), Filament::getTenant()->getKey());
+
+                if ($modifyRuleUsing) {
+                    $rule = $component->evaluate($modifyRuleUsing, [
+                        'rule' => $rule,
+                    ]) ?? $rule;
+                }
+
+                return $rule;
             } :
-            null;
+            $modifyRuleUsing;
 
         $this->unique($table, $column, $ignorable, $ignoreRecord, $modifyRuleUsing);
 

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -547,7 +547,7 @@ trait CanBeValidated
         $modifyRuleUsing = Filament::hasTenancy() ?
             function (Field $component, Unique $rule) use ($modifyRuleUsing) {
                 if (method_exists($component->getLivewire(), 'getResource')) {
-                    $resource = $component->getLivewire()::getResource();
+                    $resource = $component->getLivewire()->getResource();
 
                     $tenantOwnershipRelationship = $resource::getTenantOwnershipRelationship($component->getModelInstance());
                 } else {


### PR DESCRIPTION
## Description

This PR introduces a new method `uniqueForTenant()` to form fields, allowing to easily apply tenant-scoped unique validation when using multitenancy features.

---

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
