### PR TITLE
Update missing translations in forms/resources/lang/fr/components.php

### DIFF
--- a/packages/forms/resources/lang/fr/components.php
+++ b/packages/forms/resources/lang/fr/components.php
@@ -384,7 +384,7 @@ return [
         'actions' => [
 
             'create_option' => [
-
+                'label' => 'Créer',
                 'modal' => [
 
                     'heading' => 'Créer',
@@ -406,7 +406,7 @@ return [
             ],
 
             'edit_option' => [
-
+                'label' => 'Modifier',
                 'modal' => [
 
                     'heading' => 'Modifier',


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

i ran the `php artisan filament:check-translations fr` command and i saw 2 missing translations.
select.actions.edit_option.label and select.actions.create_option.label

## Visual changes

Before
![image](https://github.com/user-attachments/assets/d2969501-00f4-4558-a920-91cee1cc0520)
After
![image](https://github.com/user-attachments/assets/4dd92689-f141-40bc-a089-c4914ff4c454)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
