### PR TITLE
feat(i18n): add merge tags translations for pt and es

### DIFF
--- a/packages/forms/resources/lang/es/components.php
+++ b/packages/forms/resources/lang/es/components.php
@@ -382,6 +382,8 @@ return [
 
         ],
 
+        'no_merge_tag_search_results_message' => 'No se encontraron etiquetas dinámicas.',
+
         'tools' => [
             'attach_files' => 'Adjuntar archivos',
             'blockquote' => 'Cita',
@@ -393,6 +395,7 @@ return [
             'h3' => 'Subencabezado',
             'italic' => 'Cursiva',
             'link' => 'Enlace',
+            'merge_tags' => 'Etiquetas dinámicas',
             'ordered_list' => 'Lista numerada',
             'redo' => 'Rehacer',
             'strike' => 'Tachar',

--- a/packages/forms/resources/lang/pt/components.php
+++ b/packages/forms/resources/lang/pt/components.php
@@ -382,6 +382,8 @@ return [
 
         ],
 
+        'no_merge_tag_search_results_message' => 'Nenhuma tag encontrada.',
+
         'tools' => [
             'attach_files' => 'Anexar ficheiros',
             'blockquote' => 'Bloco de citação',
@@ -393,6 +395,7 @@ return [
             'h3' => 'Subtítulo',
             'italic' => 'Itálico',
             'link' => 'Hiperligação',
+            'merge_tags' => 'Tags dinâmicas',
             'ordered_list' => 'Lista numerada',
             'redo' => 'Refazer',
             'strike' => 'Rasurado',

--- a/packages/forms/resources/lang/pt/components.php
+++ b/packages/forms/resources/lang/pt/components.php
@@ -382,7 +382,7 @@ return [
 
         ],
 
-        'no_merge_tag_search_results_message' => 'Nenhuma tag encontrada.',
+        'no_merge_tag_search_results_message' => 'Nenhuma tag dinâmica encontrada.',
 
         'tools' => [
             'attach_files' => 'Anexar ficheiros',

--- a/packages/forms/resources/lang/pt_BR/components.php
+++ b/packages/forms/resources/lang/pt_BR/components.php
@@ -382,7 +382,7 @@ return [
 
         ],
 
-        'no_merge_tag_search_results_message' => 'Nenhuma tag encontrada.',
+        'no_merge_tag_search_results_message' => 'Nenhuma tag dinâmica encontrada.',
 
         'tools' => [
             'attach_files' => 'Anexar arquivos',

--- a/packages/forms/resources/lang/pt_BR/components.php
+++ b/packages/forms/resources/lang/pt_BR/components.php
@@ -382,6 +382,8 @@ return [
 
         ],
 
+        'no_merge_tag_search_results_message' => 'Nenhuma tag encontrada.',
+
         'tools' => [
             'attach_files' => 'Anexar arquivos',
             'blockquote' => 'Bloco de citação',
@@ -393,6 +395,7 @@ return [
             'h3' => 'Subtítulo',
             'italic' => 'Itálico',
             'link' => 'Link',
+            'merge_tags' => 'Tags dinâmicas',
             'ordered_list' => 'Lista ordenada',
             'redo' => 'Refazer',
             'strike' => 'Tachado',


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Add translations for merge tags in Portuguese and Spanish

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
