### PR TITLE
feat(i18n): add custom-blocks pt/es translation & sync other keys in Rich Editor

### DIFF
--- a/packages/forms/resources/lang/es/components.php
+++ b/packages/forms/resources/lang/es/components.php
@@ -365,18 +365,83 @@ return [
 
     'rich_editor' => [
 
-        'dialogs' => [
+        'actions' => [
+
+            'attach_files' => [
+
+                'label' => 'Subir archivo',
+
+                'modal' => [
+
+                    'heading' => 'Subir archivo',
+
+                    'form' => [
+
+                        'file' => [
+
+                            'label' => [
+                                'new' => 'Archivo',
+                                'existing' => 'Reemplazar archivo',
+                            ],
+
+                        ],
+
+                        'alt' => [
+
+                            'label' => [
+                                'new' => 'Texto alternativo',
+                                'existing' => 'Cambiar texto alternativo',
+                            ],
+
+                        ],
+
+                    ],
+
+                ],
+
+            ],
+
+            'custom_block' => [
+
+                'modal' => [
+
+                    'actions' => [
+
+                        'insert' => [
+                            'label' => 'Insertar',
+                        ],
+
+                        'save' => [
+                            'label' => 'Guardar',
+                        ],
+
+                    ],
+
+                ],
+
+            ],
 
             'link' => [
 
-                'actions' => [
-                    'link' => 'Enlace',
-                    'unlink' => 'Quitar enlace',
+                'label' => 'Editar',
+
+                'modal' => [
+
+                    'heading' => 'Enlace',
+
+                    'form' => [
+
+                        'url' => [
+                            'label' => 'URL',
+                        ],
+
+                        'should_open_in_new_tab' => [
+                            'label' => 'Abrir en una nueva pestaña',
+                        ],
+
+                    ],
+
                 ],
-
-                'label' => 'URL',
-
-                'placeholder' => 'Teclee un enlace URL',
 
             ],
 
@@ -390,6 +455,7 @@ return [
             'bold' => 'Negrita',
             'bullet_list' => 'Viñetas',
             'code_block' => 'Bloque de código',
+            'custom_blocks' => 'Bloques',
             'h1' => 'Título',
             'h2' => 'Encabezado',
             'h3' => 'Subencabezado',
@@ -399,6 +465,8 @@ return [
             'ordered_list' => 'Lista numerada',
             'redo' => 'Rehacer',
             'strike' => 'Tachar',
+            'subscript' => 'Subíndice',
+            'superscript' => 'Superíndice',
             'underline' => 'Subrayar',
             'undo' => 'Deshacer',
         ],

--- a/packages/forms/resources/lang/pt/components.php
+++ b/packages/forms/resources/lang/pt/components.php
@@ -365,18 +365,83 @@ return [
 
     'rich_editor' => [
 
-        'dialogs' => [
+        'actions' => [
+
+            'attach_files' => [
+
+                'label' => 'Carregar ficheiro',
+
+                'modal' => [
+
+                    'heading' => 'Carregar ficheiro',
+
+                    'form' => [
+
+                        'file' => [
+
+                            'label' => [
+                                'new' => 'Ficheiro',
+                                'existing' => 'Substituir ficheiro',
+                            ],
+
+                        ],
+
+                        'alt' => [
+
+                            'label' => [
+                                'new' => 'Texto alternativo',
+                                'existing' => 'Alterar texto alternativo',
+                            ],
+
+                        ],
+
+                    ],
+
+                ],
+
+            ],
+
+            'custom_block' => [
+
+                'modal' => [
+
+                    'actions' => [
+
+                        'insert' => [
+                            'label' => 'Inserir',
+                        ],
+
+                        'save' => [
+                            'label' => 'Guardar',
+                        ],
+
+                    ],
+
+                ],
+
+            ],
 
             'link' => [
 
-                'actions' => [
-                    'link' => 'Ligação',
-                    'unlink' => 'Remover ligação',
+                'label' => 'Editar',
+
+                'modal' => [
+
+                    'heading' => 'Hiperligação',
+
+                    'form' => [
+
+                        'url' => [
+                            'label' => 'URL',
+                        ],
+
+                        'should_open_in_new_tab' => [
+                            'label' => 'Abrir numa nova aba',
+                        ],
+
+                    ],
+
                 ],
-
-                'label' => 'URL',
-
-                'placeholder' => 'Indique uma URL',
 
             ],
 
@@ -390,6 +455,7 @@ return [
             'bold' => 'Negrito',
             'bullet_list' => 'Lista',
             'code_block' => 'Bloco de código',
+            'custom_blocks' => 'Blocos',
             'h1' => 'Título',
             'h2' => 'Cabeçalho',
             'h3' => 'Subtítulo',
@@ -399,6 +465,8 @@ return [
             'ordered_list' => 'Lista numerada',
             'redo' => 'Refazer',
             'strike' => 'Rasurado',
+            'subscript' => 'Subscrito',
+            'superscript' => 'Sobrescrito',
             'underline' => 'Sublinhado',
             'undo' => 'Desfazer',
         ],

--- a/packages/forms/resources/lang/pt_BR/components.php
+++ b/packages/forms/resources/lang/pt_BR/components.php
@@ -365,18 +365,83 @@ return [
 
     'rich_editor' => [
 
-        'dialogs' => [
+        'actions' => [
+
+            'attach_files' => [
+
+                'label' => 'Carregar arquivo',
+
+                'modal' => [
+
+                    'heading' => 'Carregar arquivo',
+
+                    'form' => [
+
+                        'file' => [
+
+                            'label' => [
+                                'new' => 'Arquivo',
+                                'existing' => 'Substituir arquivo',
+                            ],
+
+                        ],
+
+                        'alt' => [
+
+                            'label' => [
+                                'new' => 'Texto alternativo',
+                                'existing' => 'Alterar texto alternativo',
+                            ],
+
+                        ],
+
+                    ],
+
+                ],
+
+            ],
+
+            'custom_block' => [
+
+                'modal' => [
+
+                    'actions' => [
+
+                        'insert' => [
+                            'label' => 'Inserir',
+                        ],
+
+                        'save' => [
+                            'label' => 'Salvar',
+                        ],
+
+                    ],
+
+                ],
+
+            ],
 
             'link' => [
 
-                'actions' => [
-                    'link' => 'Link',
-                    'unlink' => 'Remover link',
+                'label' => 'Editar',
+
+                'modal' => [
+
+                    'heading' => 'Link',
+
+                    'form' => [
+
+                        'url' => [
+                            'label' => 'URL',
+                        ],
+
+                        'should_open_in_new_tab' => [
+                            'label' => 'Abrir em uma nova aba',
+                        ],
+
+                    ],
+
                 ],
-
-                'label' => 'URL',
-
-                'placeholder' => 'Digite uma URL',
 
             ],
 
@@ -390,6 +455,7 @@ return [
             'bold' => 'Negrito',
             'bullet_list' => 'Lista com marcadores',
             'code_block' => 'Bloco de código',
+            'custom_blocks' => 'Blocos',
             'h1' => 'Título',
             'h2' => 'Cabeçalho',
             'h3' => 'Subtítulo',
@@ -399,6 +465,8 @@ return [
             'ordered_list' => 'Lista ordenada',
             'redo' => 'Refazer',
             'strike' => 'Tachado',
+            'subscript' => 'Subscrito',
+            'superscript' => 'Sobrescrito',
             'underline' => 'Sublinhado',
             'undo' => 'Desfazer',
         ],


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Add missing translations for custom-blocks in pt and es, removed unused keys, and synchronized rich_editor keys with the en reference.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
