### PR TITLE
Add Table Toolbar Actions

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -2,6 +2,7 @@
     use Filament\Support\Enums\Alignment;
     use Filament\Support\Enums\VerticalAlignment;
     use Filament\Support\Facades\FilamentView;
+    use Filament\Tables\Actions\ToolbarActionsPosition;
     use Filament\Tables\Columns\Column;
     use Filament\Tables\Columns\ColumnGroup;
     use Filament\Tables\Enums\ActionsPosition;
@@ -31,6 +32,11 @@
         fn (\Filament\Tables\Actions\Action | \Filament\Tables\Actions\BulkAction | \Filament\Tables\Actions\ActionGroup $action): bool => $action->isVisible(),
     );
     $headerActionsPosition = $getHeaderActionsPosition();
+    $toolbarActions = array_filter(
+        $getToolbarActions(),
+        fn (\Filament\Tables\Actions\Action | \Filament\Tables\Actions\BulkAction | \Filament\Tables\Actions\ActionGroup $action): bool => $action->isVisible(),
+    );
+    $toolbarActionsPosition = $getToolbarActionsPosition();
     $heading = $getHeading();
     $group = $getGrouping();
     $bulkActions = array_filter(
@@ -182,6 +188,13 @@
             >
                 {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\Tables\View\TablesRenderHook::TOOLBAR_START, scopes: static::class) }}
 
+                @if ($toolbarActions && $toolbarActionsPosition === ToolbarActionsPosition::Start)
+                    <x-filament-tables::actions
+                        :actions="$toolbarActions"
+                        wrap
+                    />
+                @endif
+
                 <div class="flex shrink-0 items-center gap-x-4">
                     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\Tables\View\TablesRenderHook::TOOLBAR_REORDER_TRIGGER_BEFORE, scopes: static::class) }}
 
@@ -256,6 +269,13 @@
                             {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\Tables\View\TablesRenderHook::TOOLBAR_TOGGLE_COLUMN_TRIGGER_AFTER, scopes: static::class) }}
                         @endif
                     </div>
+                @endif
+
+                @if ($toolbarActions && $toolbarActionsPosition === ToolbarActionsPosition::End)
+                    <x-filament-tables::actions
+                        :actions="$toolbarActions"
+                        wrap
+                    />
                 @endif
 
                 {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\Tables\View\TablesRenderHook::TOOLBAR_END) }}

--- a/packages/tables/src/Actions/ToolbarActionsPosition.php
+++ b/packages/tables/src/Actions/ToolbarActionsPosition.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Filament\Tables\Actions;
+
+enum ToolbarActionsPosition
+{
+    case Start;
+    case End;
+}

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -27,6 +27,7 @@ class Table extends ViewComponent
     use Table\Concerns\HasFilters;
     use Table\Concerns\HasHeader;
     use Table\Concerns\HasHeaderActions;
+    use Table\Concerns\HasToolbarActions;
     use Table\Concerns\HasQuery;
     use Table\Concerns\HasQueryStringIdentifier;
     use Table\Concerns\HasRecordAction;

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -27,13 +27,13 @@ class Table extends ViewComponent
     use Table\Concerns\HasFilters;
     use Table\Concerns\HasHeader;
     use Table\Concerns\HasHeaderActions;
-    use Table\Concerns\HasToolbarActions;
     use Table\Concerns\HasQuery;
     use Table\Concerns\HasQueryStringIdentifier;
     use Table\Concerns\HasRecordAction;
     use Table\Concerns\HasRecordClasses;
     use Table\Concerns\HasRecords;
     use Table\Concerns\HasRecordUrl;
+    use Table\Concerns\HasToolbarActions;
 
     /**
      * @var view-string

--- a/packages/tables/src/Table/Concerns/HasToolbarActions.php
+++ b/packages/tables/src/Table/Concerns/HasToolbarActions.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Filament\Tables\Table\Concerns;
+
+use Closure;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\ActionGroup;
+use Filament\Tables\Actions\BulkAction;
+use Filament\Tables\Actions\ToolbarActionsPosition;
+use Illuminate\Support\Arr;
+use InvalidArgumentException;
+
+trait HasToolbarActions
+{
+    /**
+     * @var array<string, Action | BulkAction | ActionGroup>
+     */
+    protected array $toolbarActions = [];
+
+    protected ToolbarActionsPosition | Closure | null $toolbarActionsPosition = null;
+
+    public function toolbarActionsPosition(ToolbarActionsPosition | Closure | null $position = null): static
+    {
+        $this->toolbarActionsPosition = $position;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<Action | BulkAction | ActionGroup> | ActionGroup  $actions
+     */
+    public function toolbarActions(array | ActionGroup $actions, ToolbarActionsPosition | Closure | null $position = null): static
+    {
+        $this->toolbarActions = [];
+        $this->pushToolbarActions($actions);
+
+        if ($position) {
+            $this->toolbarActionsPosition($position);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param  array<Action | BulkAction | ActionGroup> | ActionGroup  $actions
+     */
+    public function pushToolbarActions(array | ActionGroup $actions): static
+    {
+        foreach (Arr::wrap($actions) as $action) {
+            $action->table($this);
+
+            if ($action instanceof ActionGroup) {
+                foreach ($action->getFlatActions() as $flatAction) {
+                    if ($flatAction instanceof BulkAction) {
+                        $this->cacheBulkAction($flatAction);
+                    } elseif ($flatAction instanceof Action) {
+                        $this->cacheAction($flatAction);
+                    }
+                }
+            } elseif ($action instanceof Action) {
+                $this->cacheAction($action);
+            } elseif ($action instanceof BulkAction) {
+                $this->cacheBulkAction($action);
+            } else {
+                throw new InvalidArgumentException('Table header actions must be an instance of ' . Action::class . ', ' . BulkAction::class . ' or ' . ActionGroup::class . '.');
+            }
+
+            $this->toolbarActions[] = $action;
+        }
+
+        return $this;
+    }
+
+    public function getToolbarActionsPosition(): ToolbarActionsPosition
+    {
+        $position = $this->evaluate($this->toolbarActionsPosition);
+
+        if (filled($position)) {
+            return $position;
+        }
+
+        return ToolbarActionsPosition::End;
+    }
+
+    /**
+     * @return array<string, Action | BulkAction | ActionGroup>
+     */
+    public function getToolbarActions(): array
+    {
+        return $this->toolbarActions;
+    }
+}


### PR DESCRIPTION
## Description

This introduces a new way to add actions to Tables, i called toolbarActions. Which by default goes to the end (first screenshot), but optionally you can place at start (second screenshot).

Adding a way to make more compact tables, or place it differently.

## Visual changes

![image](https://github.com/user-attachments/assets/48b67a56-91c7-44e5-999e-96d60b029ba6)
![image](https://github.com/user-attachments/assets/128089ef-c3fa-4db9-a84c-cb19dcf36983)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.

I didn't change the documentation as i wanted to confirm if this is something you guys want to add.
