### PR TITLE
Add missing pt_BR translation in request-password-reset.

### DIFF
--- a/packages/panels/resources/lang/pt_BR/pages/auth/password-reset/request-password-reset.php
+++ b/packages/panels/resources/lang/pt_BR/pages/auth/password-reset/request-password-reset.php
@@ -32,6 +32,10 @@ return [
 
     'notifications' => [
 
+        'sent' => [
+            'body' => 'Se sua conta não existir, você não receberá o e-mail.',
+        ],
+
         'throttled' => [
             'title' => 'Muitas solicitações',
             'body' => 'Por favor tente novamente em :seconds segundos.',


### PR DESCRIPTION
This pull request includes a minor change to the `request-password-reset.php` file for missing pt_BR translation.