### PR TITLE
[v4] Fix toogle column alignment

### DIFF
--- a/packages/tables/resources/css/columns/checkbox.css
+++ b/packages/tables/resources/css/columns/checkbox.css
@@ -1,7 +1,16 @@
 .fi-ta-checkbox {
-    @apply flex items-center;
+    @apply w-full;
 
     &:not(.fi-inline) {
         @apply px-3 py-4;
+    }
+
+    &.fi-align-center {
+        @apply text-center;
+    }
+
+    &.fi-align-end,
+    &.fi-align-right {
+        @apply text-end;
     }
 }

--- a/packages/tables/resources/css/columns/toggle.css
+++ b/packages/tables/resources/css/columns/toggle.css
@@ -1,5 +1,16 @@
 .fi-ta-toggle {
+    @apply w-full;
+
     &:not(.fi-inline) {
         @apply px-3 py-4;
+    }
+
+    &.fi-align-center {
+        @apply text-center;
+    }
+
+    &.fi-align-end,
+    &.fi-align-right {
+        @apply text-end;
     }
 }

--- a/packages/tables/src/Columns/CheckboxColumn.php
+++ b/packages/tables/src/Columns/CheckboxColumn.php
@@ -4,6 +4,7 @@ namespace Filament\Tables\Columns;
 
 use Filament\Forms\Components\Concerns\HasExtraInputAttributes;
 use Filament\Support\Components\Contracts\HasEmbeddedView;
+use Filament\Support\Enums\Alignment;
 use Filament\Support\Facades\FilamentAsset;
 use Filament\Support\Facades\FilamentView;
 use Filament\Tables\Columns\Contracts\Editable;
@@ -44,6 +45,7 @@ class CheckboxColumn extends Column implements Editable, HasEmbeddedView
             ], escape: false)
             ->class([
                 'fi-ta-checkbox',
+                ((($alignment = $this->getAlignment()) instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : '')),
                 'fi-inline' => $this->isInline(),
             ]);
 

--- a/packages/tables/src/Columns/ToggleColumn.php
+++ b/packages/tables/src/Columns/ToggleColumn.php
@@ -5,6 +5,7 @@ namespace Filament\Tables\Columns;
 use Filament\Forms\Components\Concerns\HasToggleColors;
 use Filament\Forms\Components\Concerns\HasToggleIcons;
 use Filament\Support\Components\Contracts\HasEmbeddedView;
+use Filament\Support\Enums\Alignment;
 use Filament\Support\Enums\IconSize;
 use Filament\Support\Facades\FilamentAsset;
 use Filament\Support\Facades\FilamentView;
@@ -57,6 +58,7 @@ class ToggleColumn extends Column implements Editable, HasEmbeddedView
             ], escape: false)
             ->class([
                 'fi-ta-toggle',
+                ((($alignment = $this->getAlignment()) instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : '')),
                 'fi-inline' => $this->isInline(),
             ]);
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Toogle Column alignment not working as intended.

Laravel 12 - Filament v4 alpha 8

## Visual changes

Before:

https://github.com/user-attachments/assets/c9a3e869-e9ba-4c6d-8e76-ff511bc4aeb1

After:

https://github.com/user-attachments/assets/b5845551-db3e-4c78-8102-806183272b0d

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
