### PR TITLE
Documented persistsFiltersInSession() function

### DIFF
--- a/packages/panels/docs/05-dashboard.md
+++ b/packages/panels/docs/05-dashboard.md
@@ -215,6 +215,17 @@ class Dashboard extends BaseDashboard
 
 Handling data from the filter action is the same as handling data from the filters header form, except that the data is validated before being passed to the widget. The `InteractsWithPageFilters` trait still applies.
 
+### Persisting Filter State In Session
+
+By default the filters applied will persist in the session on page reload. To change this add the the `persistsFiltersInSession()` method to your Dashboard.php file:
+
+```php
+public function persistsFiltersInSession(): bool
+{
+    return false;
+}
+```
+
 ## Disabling the default widgets
 
 By default, two widgets are displayed on the dashboard. These widgets can be disabled by updating the `widgets()` array of the [configuration](configuration):

--- a/packages/panels/docs/05-dashboard.md
+++ b/packages/panels/docs/05-dashboard.md
@@ -215,14 +215,36 @@ class Dashboard extends BaseDashboard
 
 Handling data from the filter action is the same as handling data from the filters header form, except that the data is validated before being passed to the widget. The `InteractsWithPageFilters` trait still applies.
 
-### Persisting Filter State In Session
+### Persisting widget filters in the user's session
 
-By default the filters applied will persist in the session on page reload. To change this add the the `persistsFiltersInSession()` method to your Dashboard.php file:
+By default, the dashboard filters applied will persist in the user's session between page loads. To disable this, override the `$persistsFiltersInSession` property in the dashboard page class:
 
 ```php
-public function persistsFiltersInSession(): bool
+use Filament\Pages\Dashboard as BaseDashboard;
+use Filament\Pages\Dashboard\Concerns\HasFiltersForm;
+
+class Dashboard extends BaseDashboard
 {
-    return false;
+    use HasFiltersForm;
+
+    protected bool $persistsFiltersInSession = false;
+}
+```
+
+Alternatively, override the `persistsFiltersInSession()` method in the dashboard page class:
+
+```php
+use Filament\Pages\Dashboard as BaseDashboard;
+use Filament\Pages\Dashboard\Concerns\HasFiltersForm;
+
+class Dashboard extends BaseDashboard
+{
+    use HasFiltersForm;
+
+    public function persistsFiltersInSession(): bool
+    {
+        return false;
+    }
 }
 ```
 


### PR DESCRIPTION
It wasn't clear that filters persist in session by default unlike tables. The persistsFiltersInSession() chain method is also not available on dashboard. So added section on how you can overwrite this method if you don't want filters persisted.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
