### PR TITLE
Add option to get file url

### DIFF
--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -70,6 +70,8 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
 
     protected ?Closure $getUploadedFileUsing = null;
 
+    protected ?Closure $getFileUrlUsing = null;
+
     protected ?Closure $reorderUploadedFilesUsing = null;
 
     protected ?Closure $saveUploadedFileUsing = null;
@@ -157,7 +159,16 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
 
             $url = null;
 
-            if ($component->getVisibility() === 'private') {
+            $getFileUrlUsing = $this->getFileUrlUsing;
+
+            if ($getFileUrlUsing) {
+                $url = $this->evaluate($getFileUrlUsing, [
+                    'disk' => $component->getDiskName(),
+                    'file' => $file,
+                ]);
+            }
+
+            if (! $url && $component->getVisibility() === 'private') {
                 try {
                     $url = $storage->temporaryUrl(
                         $file,
@@ -457,6 +468,13 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
     public function getUploadedFileUsing(?Closure $callback): static
     {
         $this->getUploadedFileUsing = $callback;
+
+        return $this;
+    }
+
+    public function getFileUrlUsing(?Closure $callback): static
+    {
+        $this->getFileUrlUsing = $callback;
 
         return $this;
     }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

I am facing an issue when using public S3 object, the handler to get the public url is not right, in my case it should be using `publicUrl` instead of `url`. So, I implemented a custom closure to override the url handler.

But, I think the method I am using to solve the problem is not suitable for most of the people that using FileUpload, and within this PR I am attaching an optional approach to handle the FileUpload's url generation. See https://github.com/aldesrahim/filament-file-upload/commit/b6c662bde2c937f53f2e6a9efe20e5cd9d6f8b76

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
