### PR TITLE
Honor actions alignment for table actions with content grid

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -640,7 +640,7 @@
                                         @if ($recordHasActions)
                                             <x-filament-tables::actions
                                                 :actions="$actions"
-                                                :alignment="(! $contentGrid) ? 'start md:end' : Alignment::Start"
+                                                :alignment="(! $contentGrid) ? 'start md:end' : $actionsAlignment ?? Alignment::Start"
                                                 :record="$record"
                                                 wrap="-sm"
                                                 :class="$recordActionsClasses"


### PR DESCRIPTION
## Description

I'm using a content grid for a table + some actions. The default alignment for the actions doesn't look right so I used `actionsAlignment` to change the alignment. However, that value isn't actually used in the view, it's always `Alignment::Start`.
This PR fixes that.

## Visual changes

Example:
```php
$table
    ->columns([
        Stack::make([
            ...,
        ]),
    ])
    ->actions(...)
    ->actionsAlignment('center')
    ->contentGrid(['default' => 2])
```

Before:
![grafik](https://github.com/user-attachments/assets/8183f6ec-145d-42bd-b746-d71bf280fee9)

After:
![grafik](https://github.com/user-attachments/assets/06b52953-16f0-4fbb-91e7-02269c80e1bd)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
