### PR TITLE
feat: add shouldVerifyErrors property field-wrapper

### DIFF
--- a/packages/forms/resources/views/components/field-wrapper.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper.blade.php
@@ -4,6 +4,7 @@
 
 @props([
     'field' => null,
+    'hasErrors' => true,
     'hasInlineLabel' => null,
     'hasNestedRecursiveValidationRules' => null,
     'id' => null,
@@ -15,7 +16,6 @@
     'labelSuffix' => null,
     'required' => null,
     'statePath' => null,
-    'shouldVerifyErrors' => true,
 ])
 
 @php
@@ -41,7 +41,7 @@
     $aboveErrorMessageSchema = $field?->getChildSchema($field::ABOVE_ERROR_MESSAGE_SCHEMA_KEY)?->toHtmlString();
     $belowErrorMessageSchema = $field?->getChildSchema($field::BELOW_ERROR_MESSAGE_SCHEMA_KEY)?->toHtmlString();
 
-    $hasError = $shouldVerifyErrors && filled($statePath) && ($errors->has($statePath) || ($hasNestedRecursiveValidationRules && $errors->has("{$statePath}.*")));
+    $hasError = $hasErrors && filled($statePath) && ($errors->has($statePath) || ($hasNestedRecursiveValidationRules && $errors->has("{$statePath}.*")));
 @endphp
 
 <div

--- a/packages/forms/resources/views/components/field-wrapper.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper.blade.php
@@ -15,6 +15,7 @@
     'labelSuffix' => null,
     'required' => null,
     'statePath' => null,
+    'shouldVerifyErrors' => true,
 ])
 
 @php
@@ -40,7 +41,7 @@
     $aboveErrorMessageSchema = $field?->getChildSchema($field::ABOVE_ERROR_MESSAGE_SCHEMA_KEY)?->toHtmlString();
     $belowErrorMessageSchema = $field?->getChildSchema($field::BELOW_ERROR_MESSAGE_SCHEMA_KEY)?->toHtmlString();
 
-    $hasError = filled($statePath) && ($errors->has($statePath) || ($hasNestedRecursiveValidationRules && $errors->has("{$statePath}.*")));
+    $hasError = $shouldVerifyErrors && filled($statePath) && ($errors->has($statePath) || ($hasNestedRecursiveValidationRules && $errors->has("{$statePath}.*")));
 @endphp
 
 <div


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

I'm making custom form components and they will have custom error messages, so it's important that the filament wrapper has a way to disable its error checking.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
