### PR TITLE
Hidden fields in Section incorrectly dehydrated in Section with state path

### DIFF
--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -4,6 +4,7 @@ namespace Filament\Forms\Components\Concerns;
 
 use Closure;
 use Filament\Forms\Components\Component;
+use Filament\Forms\Components\Section;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
 use Illuminate\Contracts\Support\Arrayable;
@@ -189,7 +190,7 @@ trait HasState
             // we need to dehydrate the child component containers while
             // informing them that they are not dehydrated, so that their
             // child components get removed from the state.
-            foreach ($this->getChildComponentContainers() as $container) {
+            foreach ($this->getChildComponentContainers(withHidden: true) as $container) {
                 $container->dehydrateState($state, isDehydrated: false);
             }
 

--- a/packages/forms/src/Components/Concerns/HasState.php
+++ b/packages/forms/src/Components/Concerns/HasState.php
@@ -4,7 +4,6 @@ namespace Filament\Forms\Components\Concerns;
 
 use Closure;
 use Filament\Forms\Components\Component;
-use Filament\Forms\Components\Section;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
 use Illuminate\Contracts\Support\Arrayable;

--- a/tests/src/Forms/StateTest.php
+++ b/tests/src/Forms/StateTest.php
@@ -618,7 +618,7 @@ test('components in a hidden parent component with a grandparent component with 
         ->fill();
 
     expect($container)
-        ->dehydrateState()->toBe(['data' => []]);
+        ->dehydrateState()->toBe(['data' => ['data' => []]]);
 });
 
 test('disabled components are excluded from state dehydration', function () {

--- a/tests/src/Forms/StateTest.php
+++ b/tests/src/Forms/StateTest.php
@@ -602,6 +602,28 @@ test('hidden components are not excluded from state dehydration if there is anot
         ->dehydrateState()->data->not()->toBe([]);
 });
 
+test('components in a hidden parent component with a grandparent component with a state path are excluded from state dehydration', function () {
+    $container = ComponentContainer::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            (new Component)
+                ->statePath(Str::random())
+                ->schema([
+                    (new Component)
+                        ->schema([
+                            (new Component)
+                                ->statePath(Str::random())
+                                ->default(Str::random()),
+                        ])
+                        ->hidden(),
+                ]),
+        ])
+        ->fill();
+
+    expect($container)
+        ->dehydrateState()->toBe([]);
+});
+
 test('disabled components are excluded from state dehydration', function () {
     $container = ComponentContainer::make(Livewire::make())
         ->statePath('data')
@@ -800,49 +822,3 @@ test('parent sibling state can be retrieved absolutely from another component', 
     expect($placeholder)
         ->getContent()->toBe($state);
 });
-
-test(
-    'fields in hidden section should not be included in dehydrated state',
-    function () {
-        $container = ComponentContainer::make(Livewire::make())
-            ->components([
-                Section::make("User Information")
-                    ->statePath('data')
-                    ->schema([
-                        Radio::make('show_input')
-                            ->label('Control Input Visibility')
-                            ->options([
-                                'show' => 'Show',
-                                'hide' => 'Hide',
-                            ])
-                            ->live(),
-
-                        Section::make("Name")
-                            ->schema([
-                                TextInput::make('name')
-                                    ->label('Conditional Name')
-                            ])
-                            ->hidden(fn (Get $get): bool => $get('show_input') === 'hide' || $get('show_input') === null)
-                            ->dehydrated(fn (Get $get): bool => $get('show_input') === 'show'),
-                    ]),
-            ])
-            ->fill([
-                'data' => [
-                    'show_input' => 'hide',
-                    'name' => 'lorem ipsum',
-                ]
-            ]);
-
-        $dehydratedState = $container->dehydrateState();
-
-        // Assert: Expect 'name' field NOT to be present in dehydrated state when 'show_input' is 'hide'
-        // This assertion is designed to FAIL due to the bug, thus documenting it.
-        expect($dehydratedState)
-            ->toBe([
-                'data' => [
-                    'show_input' => 'hide',
-                    // 'name' field with 'lorem ipsum' should NOT be here if the bug was fixed.
-                ],
-            ]);
-    }
-);

--- a/tests/src/Forms/StateTest.php
+++ b/tests/src/Forms/StateTest.php
@@ -604,7 +604,7 @@ test('components in a hidden parent component with a grandparent component with 
         ->statePath('data')
         ->components([
             (new Component)
-                ->statePath(Str::random())
+                ->statePath('data')
                 ->schema([
                     (new Component)
                         ->schema([
@@ -618,7 +618,7 @@ test('components in a hidden parent component with a grandparent component with 
         ->fill();
 
     expect($container)
-        ->dehydrateState()->toBe([]);
+        ->dehydrateState()->toBe(['data' => []]);
 });
 
 test('disabled components are excluded from state dehydration', function () {

--- a/tests/src/Forms/StateTest.php
+++ b/tests/src/Forms/StateTest.php
@@ -1,15 +1,12 @@
 <?php
 
-use Filament\Forms\Get;
-use Illuminate\Support\Str;
-use Filament\Tests\TestCase;
-use Filament\Forms\Components\Radio;
 use Filament\Forms\ComponentContainer;
-use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Component;
-use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Get;
 use Filament\Tests\Forms\Fixtures\Livewire;
+use Filament\Tests\TestCase;
+use Illuminate\Support\Str;
 
 uses(TestCase::class);
 


### PR DESCRIPTION
This PR addresses a bug where fields inside a hidden Section component (with a state path) are incorrectly included in the dehydrated state. Currently, when a field is:

- Placed inside a Section inside with a state path inside a section
- The Section is hidden based on a condition
- The field is marked as dehydrated only when visible

The field's value is still being dehydrated even though the Section (and thus the field) is hidden, and the dehydration condition should prevent this.

**Example scenario:**
```php
Section::make('User Information')
    ->statePath('data')
    ->schema([
        Radio::make('show_input')
            ->label('Control Input Visibility')
            ->options([
                'show' => 'Show',
                'hide' => 'Hide',
            ])
            ->live(),
        Section::make('Name')
            ->schema([
                TextInput::make('name')
                    ->label('Conditional Name'),
            ])
            ->hidden(fn (Get $get): bool => $get('show_input') === 'hide' || $get('show_input') === null)
            ->dehydrated(fn (Get $get): bool => $get('show_input') === 'show'),
    ])
```
When `show_input` is `'hide'`, the `'name'` field is still present in the dehydrated state, even though the Section is hidden and the dehydration condition should prevent this.

**What this PR does:**
- Adds a test case demonstrating the bug where fields inside a hidden Section are incorrectly dehydrated.
- Documents the expected behavior: hidden fields inside hidden Sections should not be present in the dehydrated state.

P.S. Similar to another pr I have created before https://github.com/filamentphp/filament/pull/16295