### PR TITLE
Replace button with span for sortable column headers

### DIFF
--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -26,7 +26,11 @@
     <span
         @if ($sortable)
             aria-label="{{ trim(strip_tags($slot)) }}"
+            role="button"
+            tabindex="0"
             wire:click="sortTable('{{ $name }}')"
+            @keydown.enter="$wire.sortTable('{{ $name }}')"
+            @keydown.space.prevent="$wire.sortTable('{{ $name }}')"
         @endif
         @class([
             'group flex w-full items-center gap-x-1',

--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -29,8 +29,8 @@
             role="button"
             tabindex="0"
             wire:click="sortTable('{{ $name }}')"
-            @keydown.enter="$wire.sortTable('{{ $name }}')"
-            @keydown.space.prevent="$wire.sortTable('{{ $name }}')"
+            x-on:keydown.enter="$wire.sortTable('{{ $name }}')"
+            x-on:keydown.space.prevent="$wire.sortTable('{{ $name }}')"
         @endif
         @class([
             'group flex w-full items-center gap-x-1',

--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -29,8 +29,8 @@
             role="button"
             tabindex="0"
             wire:click="sortTable('{{ $name }}')"
-            x-on:keydown.enter="$wire.sortTable('{{ $name }}')"
-            x-on:keydown.space.prevent="$wire.sortTable('{{ $name }}')"
+            x-on:keydown.enter.prevent.stop="$wire.sortTable('{{ $name }}')"
+            x-on:keydown.space.prevent.stop="$wire.sortTable('{{ $name }}')"
         @endif
         @class([
             'group flex w-full items-center gap-x-1',

--- a/packages/tables/resources/views/components/header-cell.blade.php
+++ b/packages/tables/resources/views/components/header-cell.blade.php
@@ -23,14 +23,14 @@
     @endif
     {{ $attributes->class(['fi-ta-header-cell px-3 py-3.5 sm:first-of-type:ps-6 sm:last-of-type:pe-6']) }}
 >
-    <{{ $sortable ? 'button' : 'span' }}
+    <span
         @if ($sortable)
             aria-label="{{ trim(strip_tags($slot)) }}"
-            type="button"
             wire:click="sortTable('{{ $name }}')"
         @endif
         @class([
             'group flex w-full items-center gap-x-1',
+            'cursor-pointer' => $sortable,
             'whitespace-nowrap' => ! $wrap,
             'whitespace-normal' => $wrap,
             match ($alignment) {
@@ -67,5 +67,5 @@
                 ])
             />
         @endif
-    </{{ $sortable ? 'button' : 'span' }}>
+    </span>
 </th>


### PR DESCRIPTION
## Description
Improve table header semantics: Replace button with span for sortable columns
What & Why:
- Replaces `<button>` wrapper with `<span>` + `cursor-pointer` for sortable table headers
- Maintains identical visual behavior and functionality
- Opens possibilities for richer header experiences (allows adding custom livewire components, and actions to the label without breaking)
#### will gladly make any adjustments that this may need, or for breaking changes this made and I have missed

## Visual changes
![image](https://github.com/user-attachments/assets/5f459166-d331-43cd-bbe7-a2989d854c36)
![image](https://github.com/user-attachments/assets/4208b1e4-a5d7-4fc2-b213-0071dd81635e)
![image](https://github.com/user-attachments/assets/89b32c6d-f653-4336-b426-b4e437f55d06)



## Functional changes
- [x] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
