### PR TITLE
[v4] Aligned `headerEnd` Slot in `chart-widget.blade.php` with `section`'s blade slot naming 

### DIFF
--- a/packages/widgets/resources/views/chart-widget.blade.php
+++ b/packages/widgets/resources/views/chart-widget.blade.php
@@ -17,7 +17,7 @@
         :collapsible="$isCollapsible"
     >
         @if ($filters || method_exists($this, 'getFiltersSchema'))
-            <x-slot name="headerEnd">
+            <x-slot name="afterHeader">
                 @if ($filters)
                     <x-filament::input.wrapper
                         inline-prefix


### PR DESCRIPTION
## Description

This PR ensures that the `headerEnd` slot in the file matches the naming conventions used by the `section` Blade component. Specifically: `chart-widget.blade.php`

- The `headerEnd` slot was renamed to align with the predefined slot name in the `section` component `afterHeader`.

## Visual changes

N/A - This is an internal naming consistency update and has no direct visual impact.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
