### PR TITLE
fix(rector): method rename

### DIFF
--- a/packages/upgrade/src/Rector/SimpleMethodChangesRector.php
+++ b/packages/upgrade/src/Rector/SimpleMethodChangesRector.php
@@ -84,7 +84,7 @@ class SimpleMethodChangesRector extends AbstractRector
                     'getRelativeRouteName' => $prependPanelParamModifier,
                     'getSlug' => $prependNullablePanelParamModifier,
                     'prependClusterSlug' => $prependPanelParamModifier,
-                    'prependClusterBaseName' => $prependPanelParamModifier,
+                    'prependClusterRouteBaseName' => $prependPanelParamModifier,
                 ],
             ],
             [


### PR DESCRIPTION
Fixes one last method name in #16355 that was incorrect for some reason.