### PR TITLE
Fix typo in documentation

### DIFF
--- a/packages/forms/docs/07-advanced.md
+++ b/packages/forms/docs/07-advanced.md
@@ -560,7 +560,7 @@ Group::make()
 
 Please note that if you are saving the data to a `BelongsTo` relationship, then the foreign key column in your database must be `nullable()`. This is because Filament saves the form first, before saving the relationship. Since the form is saved first, the foreign ID does not exist yet, so it must be nullable. Immediately after the form is saved, Filament saves the relationship, which will then fill in the foreign ID and save it again.
 
-It is worth noting that if you have an observer on your form model, then you may need to adapt it to ensure that it does not depend on the relationship existing when it it created. For example, if you have an observer that sends an email to a related record when a form is created, you may need to switch to using a different hook that runs after the relationship is attached, like `updated()`.
+It is worth noting that if you have an observer on your form model, then you may need to adapt it to ensure that it does not depend on the relationship existing when it is created. For example, if you have an observer that sends an email to a related record when a form is created, you may need to switch to using a different hook that runs after the relationship is attached, like `updated()`.
 
 ### Conditionally saving data to a relationship
 


### PR DESCRIPTION


<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Corrected a typo in the documentation section explaining how Filament handles saving data to a BelongsTo relationship. The word "it it created" was changed to "it is created" for clarity. This ensures that readers understand the timing of observer hooks in relation to when relationships are attached. No changes were made to the technical content, only the wording was improved for accuracy and readability.

## Visual changes

### Before
![Cursor_and_Advanced_forms_-_Forms_-_Filament](https://github.com/user-attachments/assets/3211178f-5175-4130-8215-489965e95022)

### After
![Cursor_and_Advanced_forms_-_Forms_-_Filament-2](https://github.com/user-attachments/assets/4437127f-d3af-45d2-9582-cab50294f3e4)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
