### PR TITLE
fix(docs): missing semicolon in code block

### DIFF
--- a/docs/06-navigation/03-user-menu.md
+++ b/docs/06-navigation/03-user-menu.md
@@ -75,7 +75,7 @@ You can also conditionally hide a user menu item by using the `visible()` or `hi
 
 ```php
 use App\Models\Payment;
-use Filament\Actions\Action
+use Filament\Actions\Action;
 
 Action::make('payments')
     ->visible(fn (): bool => auth()->user()->can('viewAny', Payment::class))


### PR DESCRIPTION
## Description

A semicolon is missing in the second import statement in the code block of https://filamentphp.com/docs/4.x/navigation/user-menu#conditionally-hiding-user-menu-items, causing the highlighting to be a bit off.

## Visual changes
The code highlighting should be correct again when this is fixed.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
