### PR TITLE
fix(docs): typo in language of code block

### DIFF
--- a/docs/14-upgrade-guide.md
+++ b/docs/14-upgrade-guide.md
@@ -207,7 +207,7 @@ In v4, the default disk for Filament is set to `local`, and the visibility of fi
 
 Previously, custom theme CSS files contained this:
 
-```cs
+```css
 @import '../../../../vendor/filament/filament/resources/css/theme.css';
 
 @config 'tailwind.config.js';


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The code block with the css for custom theme CSS files at https://filamentphp.com/docs/4.x/upgrade-guide#high-impact-changes has a typo in the language hint. It currently is `cs`, but should be `css` (as in the next code block).

## Visual changes

When merged, this PR fixes the syntax highlighting and makes it similar to the next code block, such that the `@`-statements are properly and consistently highlighted (currently, the first code block (with the wrong language hint) has a different highlighting compared to the second code block (with the correct language hint)).
![image](https://github.com/user-attachments/assets/346f44a2-f2ac-4865-8040-1ef0e50ff90d)

## Functional changes
None

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
