### PR TITLE
[v4] Fix: Width enum throwing warnings on tryFrom if width is null

### DIFF
--- a/packages/actions/src/Concerns/HasDropdown.php
+++ b/packages/actions/src/Concerns/HasDropdown.php
@@ -71,8 +71,8 @@ trait HasDropdown
     {
         $width = $this->evaluate($this->dropdownWidth);
 
-        if (! ($width instanceof Width)) {
-            $width = filled($width) ? (Width::tryFrom($width) ?? $width) : null;
+        if (is_string($width)) {
+            $width = Width::tryFrom($width) ?? $width;
         }
 
         return $width;

--- a/packages/actions/src/Concerns/HasDropdown.php
+++ b/packages/actions/src/Concerns/HasDropdown.php
@@ -72,7 +72,7 @@ trait HasDropdown
         $width = $this->evaluate($this->dropdownWidth);
 
         if (! ($width instanceof Width)) {
-            $width = Width::tryFrom($width) ?? $width;
+            $width = filled($width) ? (Width::tryFrom($width) ?? $width) : null;
         }
 
         return $width;

--- a/packages/panels/resources/views/components/layout/index.blade.php
+++ b/packages/panels/resources/views/components/layout/index.blade.php
@@ -11,7 +11,7 @@
     $renderHookScopes = $livewire?->getRenderHookScopes();
     $maxContentWidth ??= (filament()->getMaxContentWidth() ?? Width::SevenExtraLarge);
 
-    if (is_string($maxContentWidth) && ! $maxContentWidth instanceof Width) {
+    if (is_string($maxContentWidth)) {
         $maxContentWidth = Width::tryFrom($maxContentWidth) ?? $maxContentWidth;
     }
 @endphp

--- a/packages/panels/resources/views/components/layout/index.blade.php
+++ b/packages/panels/resources/views/components/layout/index.blade.php
@@ -11,7 +11,7 @@
     $renderHookScopes = $livewire?->getRenderHookScopes();
     $maxContentWidth ??= (filament()->getMaxContentWidth() ?? Width::SevenExtraLarge);
 
-    if (! $maxContentWidth instanceof Width) {
+    if (is_string($maxContentWidth) && ! $maxContentWidth instanceof Width) {
         $maxContentWidth = Width::tryFrom($maxContentWidth) ?? $maxContentWidth;
     }
 @endphp

--- a/packages/panels/resources/views/components/layout/simple.blade.php
+++ b/packages/panels/resources/views/components/layout/simple.blade.php
@@ -6,7 +6,7 @@
     $renderHookScopes = $livewire?->getRenderHookScopes();
     $maxContentWidth ??= (filament()->getSimplePageMaxContentWidth() ?? Width::Large);
 
-    if (! $maxContentWidth instanceof Width) {
+    if (is_string($maxContentWidth) && ! $maxContentWidth instanceof Width) {
         $maxContentWidth = Width::tryFrom($maxContentWidth) ?? $maxContentWidth;
     }
 @endphp

--- a/packages/panels/resources/views/components/layout/simple.blade.php
+++ b/packages/panels/resources/views/components/layout/simple.blade.php
@@ -6,7 +6,7 @@
     $renderHookScopes = $livewire?->getRenderHookScopes();
     $maxContentWidth ??= (filament()->getSimplePageMaxContentWidth() ?? Width::Large);
 
-    if (is_string($maxContentWidth) && ! $maxContentWidth instanceof Width) {
+    if (is_string($maxContentWidth)) {
         $maxContentWidth = Width::tryFrom($maxContentWidth) ?? $maxContentWidth;
     }
 @endphp

--- a/packages/support/resources/views/components/dropdown/index.blade.php
+++ b/packages/support/resources/views/components/dropdown/index.blade.php
@@ -22,7 +22,7 @@
         'padding' => $sizePadding,
     ])->filter()->toJson();
 
-    if (is_string($width) && ! ($width instanceof Width)) {
+    if (is_string($width)) {
         $width = Width::tryFrom($width) ?? $width;
     }
 @endphp

--- a/packages/support/resources/views/components/dropdown/index.blade.php
+++ b/packages/support/resources/views/components/dropdown/index.blade.php
@@ -22,7 +22,7 @@
         'padding' => $sizePadding,
     ])->filter()->toJson();
 
-    if (! ($width instanceof Width)) {
+    if (is_string($width) && ! ($width instanceof Width)) {
         $width = Width::tryFrom($width) ?? $width;
     }
 @endphp

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -50,8 +50,8 @@
         $footerActionsAlignment = filled($footerActionsAlignment) ? (Alignment::tryFrom($footerActionsAlignment) ?? $footerActionsAlignment) : null;
     }
 
-    if (! $width instanceof Width) {
-        $width = filled($width) ? (Width::tryFrom($width) ?? $width) : null;
+    if (is_string($width)) {
+        $width = Width::tryFrom($width) ?? $width;
     }
 
     $closeEventHandler = filled($id) ? '$dispatch(' . \Illuminate\Support\Js::from($closeEventName) . ', { id: ' . \Illuminate\Support\Js::from($id) . ' })' : 'close()';


### PR DESCRIPTION
## Description

Fixes warnings in PHP when `Filament\Support\Enums\Width::tryFrom($value)` is passed a `null` value.

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
