### PR TITLE
Update 02-getting-started.md

### DIFF
--- a/docs/02-getting-started.md
+++ b/docs/02-getting-started.md
@@ -42,4 +42,4 @@ Custom pages are a blank canvas for you to build whatever you want in a panel. T
 
 Each custom page has a PHP class and a Blade view. The PHP class is technically a [full-page Livewire component](https://livewire.laravel.com/docs/components) (in fact, every page class in a Filament panel is a Livewire component). As such, every page has access to the full power of Livewire to build an interactive server-rendered UI.
 
-To start your journey by creating a custom page, visit the [Custom pages documentation](advanced/custom-pages).
+To start your journey by creating a custom page, visit the [Custom pages documentation](navigation/custom-pages).


### PR DESCRIPTION
Changed the target for Custom Page link, from /advanced section to /navigation section as the former is not available. 

## Description

Small change needed as it may cause confusion especially for beginners.

## Visual changes

No significant change on the docs except for the target href.

## Functional changes

N/A
