### PR TITLE
[v4] docs: Use lowercase L in `Infolist`

### DIFF
--- a/docs/03-resources/13-code-quality-tips.md
+++ b/docs/03-resources/13-code-quality-tips.md
@@ -56,12 +56,12 @@ public static function table(Table $table): Table
 Or the `infolist()`:
 
 ```php
-use App\Filament\Resources\Customers\Schemas\CustomerInfoList;
+use App\Filament\Resources\Customers\Schemas\CustomerInfolist;
 use Filament\Schemas\Schema;
 
 public static function infolist(Schema $schema): Schema
 {
-    return CustomerInfoList::configure($schema);
+    return CustomerInfolist::configure($schema);
 }
 ```
 


### PR DESCRIPTION
## Description

The methods are called `infolist()`, and not `infoList()`, so I think the class name should use a lowercase **L** as well for consistency. 
