### PR TITLE
Docs: v4 Installation on Windows

### DIFF
--- a/docs/01-introduction/02-installation.md
+++ b/docs/01-introduction/02-installation.md
@@ -38,7 +38,13 @@ Installation comes in two flavors, depending on whether you want to build an app
 
 ## Installing the panel builder
 
-Since Filament v4 is in beta, you will need to set the `minimum-stability` in your `composer.json` file to be `beta` before installing any packages:
+Since Filament v4 is in beta, you will need to set the `minimum-stability` in your `composer.json` file to be `beta` before installing any packages. Either adjust it manually or via CLI:
+
+```bash
+composer config minimum-stability beta
+```
+
+Your `composer.json` should look like this:
 
 ```json
 {
@@ -49,7 +55,7 @@ Since Filament v4 is in beta, you will need to set the `minimum-stability` in yo
 Install the Filament Panel Builder by running the following commands in your Laravel project directory:
 
 ```bash
-composer require filament/filament:"^4.0"
+composer require filament/filament:~4.0
 
 php artisan filament:install --panels
 ```

--- a/docs/01-introduction/02-installation.md
+++ b/docs/01-introduction/02-installation.md
@@ -55,10 +55,20 @@ Your `composer.json` should look like this:
 Install the Filament Panel Builder by running the following commands in your Laravel project directory:
 
 ```bash
-composer require filament/filament:~4.0
+composer require filament/filament:"^4.0"
 
 php artisan filament:install --panels
 ```
+
+<Aside variant="warning">
+    When using Windows PowerShell to install Filament, you may need to run the command below, since it ignores `^` characters in version constraints:
+
+    ```bash
+    composer require '"filament/filament:^4.0"'
+
+    php artisan filament:install --panels
+    ```
+</Aside>
 
 This will create and register a new [Laravel service provider](https://laravel.com/docs/providers) called `app/Providers/Filament/AdminPanelProvider.php`.
 
@@ -84,7 +94,13 @@ Open `/admin` in your web browser, sign in, and [start building your app](../get
 
 ## Installing the individual components
 
-Since Filament v4 is in beta, you will need to set the `minimum-stability` in your `composer.json` file to be `beta` before installing any packages:
+Since Filament v4 is in beta, you will need to set the `minimum-stability` in your `composer.json` file to be `beta` before installing any packages. Either adjust it manually or via CLI:
+
+```bash
+composer config minimum-stability beta
+```
+
+Your `composer.json` should look like this:
 
 ```json
 {
@@ -106,6 +122,21 @@ composer require
 ```
 
 You can install additional packages later in your project without having to repeat these installation steps.
+
+<Aside variant="warning">
+    When using Windows PowerShell to install Filament, you may need to run the command below, since it ignores `^` characters in version constraints:
+
+    ```bash
+    composer require
+        '"filament/tables:^4.0"'
+        '"filament/schemas:^4.0"'
+        '"filament/forms:^4.0"'
+        '"filament/infolists:^4.0"'
+        '"filament/actions:^4.0"'
+        '"filament/notifications:^4.0"'
+        '"filament/widgets:^4.0"'
+    ```
+</Aside>
 
 If you only want to use the set of [Blade UI components](../components), you'll need to require `filament/support` at this stage.
 

--- a/docs/14-upgrade-guide.md
+++ b/docs/14-upgrade-guide.md
@@ -23,7 +23,13 @@ import Disclosure from "@components/Disclosure.astro"
     The upgrade script is not a replacement for the upgrade guide. It handles many small changes that are not mentioned in the upgrade guide, but it does not handle all breaking changes. You should still read the [manual upgrade steps](#breaking-changes-that-must-be-handled-manually) to see what changes you need to make to your code.
 </Aside>
 
-The first step to upgrade your Filament app is to run the automated upgrade script. Since Filament v4 is in beta, you will need to set the `minimum-stability` in your `composer.json` file to be `beta` before installing any packages:
+The first step to upgrade your Filament app is to run the automated upgrade script. Since Filament v4 is in beta, you will need to set the `minimum-stability` in your `composer.json` file to be `beta` before installing any packages. Either adjust it manually or via CLI:
+
+```bash
+composer config minimum-stability beta
+```
+
+Your `composer.json` should look like this:
 
 ```json
 {
@@ -38,6 +44,16 @@ composer require filament/upgrade:"^4.0" -W --dev
 
 vendor/bin/filament-v4
 ```
+
+<Aside variant="warning">
+    When using Windows PowerShell to install Filament, you may need to run the command below, since it ignores `^` characters in version constraints:
+
+    ```bash
+    composer require '"filament/upgrade:^4.0"' -W --dev
+
+    vendor/bin/filament-v4
+    ```
+</Aside>
 
 <Aside variant="warning">
     If installing the upgrade script fails, make sure that your PHPStan version is at least v2, or your Larastan version is at least v3. The script uses Rector v2, which requires PHPStan v2 or higher.

--- a/packages/upgrade/bin/filament-v4
+++ b/packages/upgrade/bin/filament-v4
@@ -91,7 +91,13 @@ foreach (json_decode(file_get_contents('composer.json'), true)['require'] as $pa
         continue;
     }
 
-    $requireCommands[] = "composer require {$package}:\"^4.0\" -W --no-update";
+    $isWindowsPowershell = str_starts_with(php_uname(), 'Windows');
+
+    if (! $isWindowsPowershell) {
+        $requireCommands[] = "composer require {$package}:\"^4.0\" -W --no-update";
+    } else {
+        $requireCommands[] = "composer require '\"{$package}:^4.0\"' -W --no-update";
+    }
 }
 
 $requireCommands = implode("</strong><br /><strong>", $requireCommands);


### PR DESCRIPTION
The caret ^ is used as an escape character in Powershell. No quoting helps. The tilde works though and is almost similar in semantics. `~4.0` will allow updated until `5.0`.

