### PR TITLE
fix: Error handling for dropdown without menu items

### DIFF
--- a/packages/support/resources/views/components/dropdown/index.blade.php
+++ b/packages/support/resources/views/components/dropdown/index.blade.php
@@ -30,11 +30,11 @@
         },
 
         open: function (event) {
-            $refs.panel.open(event)
+            $refs.panel?.open(event)
         },
 
         close: function (event) {
-            $refs.panel.close(event)
+            $refs.panel?.close(event)
         },
     }"
     {{ $attributes->class(['fi-dropdown']) }}

--- a/packages/support/resources/views/components/dropdown/index.blade.php
+++ b/packages/support/resources/views/components/dropdown/index.blade.php
@@ -26,7 +26,7 @@
 <div
     x-data="{
         toggle: function (event) {
-            $refs.panel.toggle(event)
+            $refs.panel?.toggle(event)
         },
 
         open: function (event) {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
Adds error handling for a bug introduced in https://github.com/filamentphp/filament/pull/13241.

Currently a JavaScript error occurs when clicking on a dropdown that has no menu items. The error is caused by the absence of the `<div x-ref="panel">` element.

![image](https://github.com/user-attachments/assets/d931d2b4-f9c3-4dcc-89e2-ef4e8327beca)


## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
