### PR TITLE
Add loading indicator when table defers first load

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -1244,7 +1244,11 @@
                     @endif
                 </x-filament-tables::table>
             @elseif ($records === null)
-                <div class="h-32"></div>
+                <div class="h-32 flex items-center justify-center">
+                    <div wire:loading wire:target="loadTable" class="w-full">
+                        <x-filament::loading-indicator class="h-16 w-16 opacity-50 mx-auto" />
+                    </div>
+                </div>
             @elseif ($emptyState = $getEmptyState())
                 {{ $emptyState }}
             @else

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -1245,9 +1245,7 @@
                 </x-filament-tables::table>
             @elseif ($records === null)
                 <div class="h-32 flex items-center justify-center">
-                    <div wire:loading wire:target="loadTable" class="w-full">
-                        <x-filament::loading-indicator class="h-16 w-16 opacity-50 mx-auto" />
-                    </div>
+                    <x-filament::loading-indicator class="h-8 w-8" />
                 </div>
             @elseif ($emptyState = $getEmptyState())
                 {{ $emptyState }}


### PR DESCRIPTION
## Description

This PR adds a loading indicator to the Filament table when the table loading is deferred. Currently, when `$table->deferLoading()` is used, the table appears empty for a brief moment, before loading the table data. This feels a bit "unfinished" and jumpy from a user perspective.  
With the changes in this PR, a visual loading indicator is shown while the data is loading. Making for a better user experience.

## Visual changes

Before:  

https://github.com/user-attachments/assets/cd6c9289-be58-4a1f-adff-29d29db7669f
  
After:  

https://github.com/user-attachments/assets/50dfb6ce-907d-4f74-bb64-0062ac65e917


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
