### PR TITLE
Table repeater not counting Hidden as actual column

### DIFF
--- a/packages/forms/resources/views/components/repeater/table.blade.php
+++ b/packages/forms/resources/views/components/repeater/table.blade.php
@@ -137,6 +137,10 @@
                                     </td>
                                 @endif
 
+                                @php
+                                    $counter = 0
+                                @endphp
+
                                 @foreach ($item->getComponents(withHidden: true) as $component)
                                     @php
                                         throw_unless(
@@ -145,13 +149,21 @@
                                         );
                                     @endphp
 
-                                    @if (count($tableColumns) > $loop->index)
-                                        @if ($component->isVisible())
-                                            <td>
-                                                {{ $component }}
-                                            </td>
+                                    @if (count($tableColumns) > $counter)
+                                        @if ($component instanceof \Filament\Forms\Components\Hidden)
+                                            {{ $component }}
                                         @else
-                                            <td class="fi-hidden"></td>
+                                            @php
+                                                $counter++
+                                            @endphp
+
+                                            @if ($component->isVisible())
+                                                <td>
+                                                    {{ $component }}
+                                                </td>
+                                            @else
+                                                <td class="fi-hidden"></td>
+                                            @endif
                                         @endif
                                     @endif
                                 @endforeach


### PR DESCRIPTION
## Description

This fixes #16480. The `Filament\Forms\Components\Hidden` are not counted as actual columns.

## Visual changes
Before:
![image](https://github.com/user-attachments/assets/422dfdbb-b03e-475e-ad39-bd7770d3ebc5)

After:
![image](https://github.com/user-attachments/assets/b3d74919-d344-44ef-925e-0a8d37b503a2)

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
