### PR TITLE
Lets the chart() function take a Collection

### DIFF
--- a/packages/widgets/src/StatsOverviewWidget/Stat.php
+++ b/packages/widgets/src/StatsOverviewWidget/Stat.php
@@ -10,8 +10,8 @@ use Filament\Schemas\Components\Concerns\HasDescription;
 use Filament\Schemas\Components\Concerns\HasLabel;
 use Filament\Support\Concerns\HasColor;
 use Filament\Support\Enums\IconPosition;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Support\Collection;
 
 class Stat extends Component
 {
@@ -101,15 +101,15 @@ class Stat extends Component
     }
 
     /**
-     * @param  array<float> | null  $chart
+     * @param  array<float> | Arrayable | null  $chart
      */
-    public function chart(null|array|Collection $chart): static
+    public function chart(array | Arrayable | null $chart): static
     {
         if (is_null($chart)) {
             return $this;
         }
 
-        if (is_a($chart, Collection::class)) {
+        if ($chart instanceof Arrayable) {
             $chart = $chart->toArray();
         }
 

--- a/packages/widgets/src/StatsOverviewWidget/Stat.php
+++ b/packages/widgets/src/StatsOverviewWidget/Stat.php
@@ -11,6 +11,7 @@ use Filament\Schemas\Components\Concerns\HasLabel;
 use Filament\Support\Concerns\HasColor;
 use Filament\Support\Enums\IconPosition;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Collection;
 
 class Stat extends Component
 {
@@ -102,8 +103,16 @@ class Stat extends Component
     /**
      * @param  array<float> | null  $chart
      */
-    public function chart(?array $chart): static
+    public function chart(null|array|Collection $chart): static
     {
+        if (is_null($chart)) {
+            return $this;
+        }
+
+        if (is_a($chart, Collection::class)) {
+            $chart = $chart->toArray();
+        }
+
         $this->chart = $chart;
 
         return $this;


### PR DESCRIPTION
## Description

If the chart() function takes a Collection, then it is converted to an array. Backward compatible change.

## Visual changes

This is a minor change and does not cause visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date. (No changes needed in the docs, this is a minor change only)
