### PR TITLE
[4.x] Fix default sort

### DIFF
--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -101,7 +101,7 @@ trait CanSortRecords
         }
 
         if ($defaultSort instanceof Builder) {
-            $query = $defaultSort;
+            return $defaultSort;
         }
 
         $qualifiedKeyName = $query->getModel()->getQualifiedKeyName();


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
I noticed unexpected sorting behavior during the Filament v4 operational check.
The defaultSort() method is being used, but the model's primary key is still being sorted as well.
![スクリーンショット 2025-06-14 065738](https://github.com/user-attachments/assets/9629866b-7e59-4521-b4a3-6c5a8373e07e)


<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
