### PR TITLE
[V4] fixed: center align section header icon

### DIFF
--- a/packages/support/resources/views/components/section/index.blade.php
+++ b/packages/support/resources/views/components/section/index.blade.php
@@ -92,7 +92,7 @@
                     <x-filament::icon
                         :icon="$icon"
                         @class([
-                            'fi-section-header-icon self-start',
+                            'fi-section-header-icon self-center',
                             match ($iconColor) {
                                 'gray' => 'text-gray-400 dark:text-gray-500',
                                 default => 'fi-color-custom text-custom-500 dark:text-custom-400',


### PR DESCRIPTION
This pull request includes a minor change for this bug [#16505](https://github.com/filamentphp/filament/issues/16505) to the alignment of the section header icon in `packages/support/resources/views/components/section/index.blade.php`. The alignment was updated from `self-start` to `self-center` to improve visual consistency.
