### PR TITLE
[v4] Removing self-start so it can depend on parent style. 

### DIFF
--- a/packages/support/resources/css/components/section.css
+++ b/packages/support/resources/css/components/section.css
@@ -149,7 +149,7 @@
         @apply flex items-center gap-3;
 
         & > .fi-icon {
-            @apply self-start text-gray-400 dark:text-gray-500;
+            @apply text-gray-400 dark:text-gray-500;
 
             &.fi-color {
                 @apply text-color-500 dark:text-color-400;


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Solve this bug #16505 

## Visual changes

before
![image](https://github.com/user-attachments/assets/8c7d064c-6f04-4b64-bb5e-4ef0876bfca4)

after
<img width="1226" alt="Screenshot 2025-06-14 at 12 37 44 PM" src="https://github.com/user-attachments/assets/c7f64201-2ff9-48fe-9c51-e633babd62b5" />

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
