### PR TITLE
Fix TOTP code expiration time documentation

### DIFF
--- a/docs/07-users/02-multi-factor-authentication.md
+++ b/docs/07-users/02-multi-factor-authentication.md
@@ -275,7 +275,7 @@ public function panel(Panel $panel): Panel
 
 ### Changing the app code expiration time
 
-App codes are issued using a time-based one-time password (TOTP) algorithm, which means that they are only valid for a short period of time before and after the time they are generated. The time is defined in a "window" of time. By default, Filament uses an expiration window of `8`, which allows the code to be valid for 8 minutes after it is generated.
+App codes are issued using a time-based one-time password (TOTP) algorithm, which means that they are only valid for a short period of time before and after the time they are generated. The time is defined in a "window" of time. By default, Filament uses an expiration window of `8`, which creates a 4-minute validity period on either side of the generation time (8 minutes in total).
 
 To change the window, for example to only be valid for 2 minutes after it is generated, you can use the `codeWindow()` method on the `AppAuthentication` instance, set to `4`:
 

--- a/docs/07-users/02-multi-factor-authentication.md
+++ b/docs/07-users/02-multi-factor-authentication.md
@@ -275,7 +275,7 @@ public function panel(Panel $panel): Panel
 
 ### Changing the app code expiration time
 
-App codes are issued using a time-based one-time password (TOTP) algorithm, which means that they are only valid for a short period of time before and after the time they are generated. The time is defined in a "window" of time. By default, Filament uses an expiration window of `8`, which allows the code to be valid for 4 minutes after it is generated.
+App codes are issued using a time-based one-time password (TOTP) algorithm, which means that they are only valid for a short period of time before and after the time they are generated. The time is defined in a "window" of time. By default, Filament uses an expiration window of `8`, which allows the code to be valid for 8 minutes after it is generated.
 
 To change the window, for example to only be valid for 2 minutes after it is generated, you can use the `codeWindow()` method on the `AppAuthentication` instance, set to `4`:
 


### PR DESCRIPTION
## Description
This PR fixes an inconsistency in the multi-factor authentication documentation regarding TOTP code expiration timing.
Changes Made

Updated the documentation to correctly state that with a window of 8, TOTP codes are valid for 8 minutes after generation (not 4 minutes as previously stated)
This aligns with the standard TOTP algorithm where each window typically represents 30-second intervals, making a window of 8 equal to approximately 4 minutes in each direction (8 × 30 seconds = 240 seconds = 4 minutes), totaling 8 minutes of validity
## Visual changes

![Screenshot 2025-06-15 at 12 38 53 PM](https://github.com/user-attachments/assets/829994dd-ddbd-42ee-9b72-2461ec166adc)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

P.S. Loving the new beta features! Good Job Filament Team! 🚀 
