### PR TITLE
Minor bugfix: Fixes NavigationItem's url parameter to not reset the shouldOpenUrlInNewTab flag

### DIFF
--- a/packages/panels/src/Navigation/NavigationItem.php
+++ b/packages/panels/src/Navigation/NavigationItem.php
@@ -147,7 +147,7 @@ class NavigationItem extends Component
 
     public function url(string | Closure | null $url, bool | Closure $shouldOpenInNewTab = false): static
     {
-        $this->openUrlInNewTab($shouldOpenInNewTab);
+        $this->openUrlInNewTab($this->shouldOpenUrlInNewTab() || $shouldOpenInNewTab);
         $this->url = $url;
 
         return $this;

--- a/packages/panels/src/Navigation/NavigationItem.php
+++ b/packages/panels/src/Navigation/NavigationItem.php
@@ -147,10 +147,11 @@ class NavigationItem extends Component
 
     public function url(string | Closure | null $url, bool | Closure | null $shouldOpenInNewTab = null): static
     {
+        $this->url = $url;
+
         if ($shouldOpenInNewTab !== null) {
             $this->openUrlInNewTab($shouldOpenInNewTab);
         }
-        $this->url = $url;
 
         return $this;
     }

--- a/packages/panels/src/Navigation/NavigationItem.php
+++ b/packages/panels/src/Navigation/NavigationItem.php
@@ -148,7 +148,7 @@ class NavigationItem extends Component
     public function url(string | Closure | null $url, bool | Closure | null $shouldOpenInNewTab = null): static
     {
         if ($shouldOpenInNewTab !== null) {
-            $this->openUrlInNewTab($this->shouldOpenUrlInNewTab() || $shouldOpenInNewTab);
+            $this->openUrlInNewTab($shouldOpenInNewTab);
         }
         $this->url = $url;
 

--- a/packages/panels/src/Navigation/NavigationItem.php
+++ b/packages/panels/src/Navigation/NavigationItem.php
@@ -145,9 +145,11 @@ class NavigationItem extends Component
         return $this;
     }
 
-    public function url(string | Closure | null $url, bool | Closure $shouldOpenInNewTab = false): static
+    public function url(string | Closure | null $url, bool | Closure | null $shouldOpenInNewTab = null): static
     {
-        $this->openUrlInNewTab($shouldOpenInNewTab);
+        if ($shouldOpenInNewTab !== null) {
+            $this->openUrlInNewTab($this->shouldOpenUrlInNewTab() || $shouldOpenInNewTab);
+        }
         $this->url = $url;
 
         return $this;


### PR DESCRIPTION
## Description

Updates the url() method in NavigationItem, so that if in the builder pattern the url() parameter is called (omitting the optional $shouldOpenInNewTab parameter) after calling openUrlInNewTab, the shouldOpenUrlInNewTab property's state will not reset and the link will open in a new tab as expected.

### Fixed use case:

In the provided example below, before the fix, the link opened in the same page, and not a new tab.

```php

...
class AdminPanelProvider extends PanelProvider
{
    public function panel(Panel $panel): Panel
    {
        return $panel
        /// ...
            ->navigationItems([
                NavigationItem::make('Documentation')
                    ->icon(Heroicon::QuestionMarkCircle)
                    ->openUrlInNewTab()
                    ->url('https://...')
                    ->group('Help'),
            ])
       /// ...
 

```

## Visual changes

No visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date. // No changes
