### PR TITLE
Prevent duplicate entries when using same Repeater ID across Wizard steps

### DIFF
--- a/tests/src/Forms/StateTest.php
+++ b/tests/src/Forms/StateTest.php
@@ -1,12 +1,16 @@
 <?php
 
-use Filament\Forms\ComponentContainer;
-use Filament\Forms\Components\Component;
-use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Get;
-use Filament\Tests\Forms\Fixtures\Livewire;
-use Filament\Tests\TestCase;
 use Illuminate\Support\Str;
+use Filament\Tests\TestCase;
+use Filament\Forms\Components\Wizard;
+use Filament\Forms\ComponentContainer;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Component;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Components\Wizard\Step;
+use Filament\Tests\Forms\Fixtures\Livewire;
 
 uses(TestCase::class);
 
@@ -818,4 +822,43 @@ test('parent sibling state can be retrieved absolutely from another component', 
 
     expect($placeholder)
         ->getContent()->toBe($state);
+});
+
+test('when repeaters share the same id across wizard steps data is filled only once', function () {
+    $container = ComponentContainer::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            Wizard::make()
+                ->steps([
+                    Step::make('step1')
+                        ->schema([
+                            Repeater::make('repeater')
+                                ->schema([
+                                    TextInput::make('name'),
+                                ]),
+                        ]),
+                    Step::make('step2')
+                        ->schema([
+                            Repeater::make('repeater')
+                                ->schema([
+                                    TextInput::make('name2'),
+                                ]),
+                        ]),
+                ]),
+        ])
+        ->fill([
+            'repeater' => [
+                'name' => 'lorem ipsum',
+                'name2' => 'lorem ipsum',
+            ],
+        ]);
+
+    $dehydratedState = $container->dehydrateState();
+
+    expect($dehydratedState['data']['repeater'])
+        ->toHaveCount(1)
+        ->each(fn($item) => $item->toBe([
+            'name' => 'lorem ipsum',
+            'name2' => 'lorem ipsum',
+        ]));
 });


### PR DESCRIPTION
## Description

I discovered the following bug in my production application:

I have a Wizard with a Repeater that I use across two steps with the same ID. When I save the record and later return to edit it, I sometimes see that a nulled second entry is created (data: []), which is incorrect behavior.

I have created a dedicated test that tries to more or less reproduce this behavior. I fill the form with information for the repeater, but two arrays are automatically created instead of just one.

Expected Behavior:
When using a Repeater with the same ID across multiple Wizard steps, filling the form should create only one repeater item containing all the merged field data

```php
test('when repeaters share the same id across wizard steps data is filled only once', function () {
    $container = ComponentContainer::make(Livewire::make())
        ->statePath('data')
        ->components([
            Wizard::make()
                ->steps([
                    Step::make('step1')
                        ->schema([
                            Repeater::make('repeater')
                                ->schema([
                                    TextInput::make('name'),
                                ]),
                        ]),
                    Step::make('step2')
                        ->schema([
                            Repeater::make('repeater')
                                ->schema([
                                    TextInput::make('name2'),
                                ]),
                        ]),
                ]),
        ])
        ->fill([
            'repeater' => [
                'name' => 'lorem ipsum',
                'name2' => 'lorem ipsum',
            ],
        ]);

    $dehydratedState = $container->dehydrateState();

    expect($dehydratedState['data']['repeater'])
        ->toHaveCount(1) // <- fails, fill creates 2 items
        ->each(fn($item) => $item->toBe([
            'name' => 'lorem ipsum',
            'name2' => 'lorem ipsum',
        ]));
});
```