### PR TITLE
[v4] return null when record is array

### DIFF
--- a/packages/support/src/Concerns/HasCellState.php
+++ b/packages/support/src/Concerns/HasCellState.php
@@ -118,6 +118,10 @@ trait HasCellState
             return $state;
         }
 
+        if (is_array($record)) {
+            return null;
+        }
+
         if (! $this->hasRelationship($record)) {
             return null;
         }

--- a/packages/support/src/Concerns/HasCellState.php
+++ b/packages/support/src/Concerns/HasCellState.php
@@ -118,7 +118,7 @@ trait HasCellState
             return $state;
         }
 
-        if (is_array($record)) {
+        if ($this instanceof Column && is_array($record)) {
             return null;
         }
 

--- a/packages/support/src/Concerns/HasCellState.php
+++ b/packages/support/src/Concerns/HasCellState.php
@@ -118,7 +118,7 @@ trait HasCellState
             return $state;
         }
 
-        if (($this instanceof Column) && is_array($record)) {
+        if (($this instanceof Column) && is_array($record)) { /** @phpstan-ignore function.impossibleType */
             return null;
         }
 

--- a/packages/support/src/Concerns/HasCellState.php
+++ b/packages/support/src/Concerns/HasCellState.php
@@ -118,7 +118,7 @@ trait HasCellState
             return $state;
         }
 
-        if ($this instanceof Column && is_array($record)) {
+        if (($this instanceof Column) && is_array($record)) {
             return null;
         }
 

--- a/packages/support/src/Concerns/HasCellState.php
+++ b/packages/support/src/Concerns/HasCellState.php
@@ -118,7 +118,7 @@ trait HasCellState
             return $state;
         }
 
-        if (($this instanceof Column) && is_array($record)) { /** @phpstan-ignore function.impossibleType */
+        if (($this instanceof Column) && is_array($record)) { /** @phpstan-ignore function.impossibleType, booleanAnd.alwaysFalse */
             return null;
         }
 


### PR DESCRIPTION
## Description

When using custom data records, an `array` is retrieved from `getRecord` method. When the state is `null`, the record is passed to all relationship methods that only accept `Model` instances. Therefore, we need to early return `null` when record is an array.

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
