### PR TITLE
Add orderBy qualified keyname for stable pagination sort

### DIFF
--- a/packages/tables/src/Concerns/CanPaginateRecords.php
+++ b/packages/tables/src/Concerns/CanPaginateRecords.php
@@ -30,6 +30,9 @@ trait CanPaginateRecords
     {
         $perPage = $this->getTableRecordsPerPage();
 
+        // Add orderBy key to ensure stable order results
+        $query->orderBy($query->getModel()->getQualifiedKeyName());
+        
         if (version_compare(App::version(), '11.0', '>=')) {
             $total = $query->toBase()->getCountForPagination();
 


### PR DESCRIPTION
Makes sure to add a unique key to the orderBy to prevent missing/duplicate items when pagination because of unstable sorting, when keys are the same.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This adds a default sort to pagination on the keyname, so that a unique key is always available when sorting, in the case of keys with the same value. Fixes https://github.com/filamentphp/filament/issues/15865

## Visual changes
Sorting on provider type (which is AWS for multiple). See that 25 and 26 are on page 1 and 3. There are some values missing entirely when paginating.

Before
![Screenshot 2025-06-16 at 11 27 31](https://github.com/user-attachments/assets/73e2bbc6-aa1b-4a74-a35e-dba77c51a22a)
After
![Screenshot 2025-06-16 at 11 28 55](https://github.com/user-attachments/assets/9785a393-958d-4c95-aa54-1d5c54437409)

## Functional changes

The query changes to add a secondary orderBy. This could result to duplicate orderBy but I don't think this has any effect?

```
select * from `servers` where `servers`.`deleted_at` is null order by `provider` asc, `servers`.`id` asc limit 10 offset 20
select * from `servers` where `servers`.`deleted_at` is null order by `servers`.`id` asc, `servers`.`id` asc limit 10 offset 20
```

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
