### PR TITLE
fix for html labels on table columns

### DIFF
--- a/packages/tables/src/Concerns/HasColumnManager.php
+++ b/packages/tables/src/Concerns/HasColumnManager.php
@@ -186,8 +186,8 @@ trait HasColumnManager
     {
         return [
             'type' => self::TABLE_COLUMN_MANAGER_GROUP_TYPE,
-            'name' => $group->getLabel(),
-            'label' => $group->getLabel(),
+            'name' => (string) $group->getLabel(),
+            'label' => (string) $group->getLabel(),
             'isToggled' => true,
             'isToggleable' => true,
             'columns' => collect($group->getColumns())
@@ -205,7 +205,7 @@ trait HasColumnManager
         return [
             'type' => self::TABLE_COLUMN_MANAGER_COLUMN_TYPE,
             'name' => $column->getName(),
-            'label' => $column->getLabel(),
+            'label' => (string) $column->getLabel(),
             'isToggled' => ! $column->isToggleable() || ! $column->isToggledHiddenByDefault(),
             'isToggleable' => $column->isToggleable(),
         ];


### PR DESCRIPTION
## Description

When you want to use a html label .. you get an error from livewire because the property can't be synced.

Property type not supported in Livewire for property: [{}]

To solve this I added a string cast.

Simple example:

```php
TextColumn::make('id')
    ->label(new HtmlString('ID'))
```

## Visual changes

![image](https://github.com/user-attachments/assets/c364d7dc-9f85-4ff3-a907-3e6d7061d97e)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
