### PR TITLE
$get honors $key property

### DIFF
--- a/packages/schemas/src/Components/Utilities/Get.php
+++ b/packages/schemas/src/Components/Utilities/Get.php
@@ -27,6 +27,6 @@ class Get
             );
         }
 
-        return $component->getState();
+        return data_get($component->getState(),  $key);
     }
 }


### PR DESCRIPTION
## Description

`Get $get` does not honour the `$key` property and returns the entire state instead.

Solves #16565

## Visual changes

none

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
