### PR TITLE
Check if policy is an object or string

### DIFF
--- a/packages/panels/src/helpers.php
+++ b/packages/panels/src/helpers.php
@@ -42,7 +42,7 @@ if (! function_exists('Filament\get_authorization_response')) {
         if (Filament::isAuthorizationStrict()) {
             $policyClass = match (true) {
                 is_string($policy) => $policy,
-                is_object($policy) => get_class($policy),
+                is_object($policy) => $policy::class,
                 default => null,
             };
 

--- a/packages/panels/src/helpers.php
+++ b/packages/panels/src/helpers.php
@@ -40,9 +40,15 @@ if (! function_exists('Filament\get_authorization_response')) {
         }
 
         if (Filament::isAuthorizationStrict()) {
-            throw new Exception(blank($policy)
+            $policyClass = match (true) {
+                is_string($policy) => $policy,
+                is_object($policy) => get_class($policy),
+                default => null,
+            };
+
+            throw new Exception(blank($policyClass)
                 ? "Strict authorization mode is enabled, but no policy was found for [{$model}]."
-                : "Strict authorization mode is enabled, but no [{$action}()] method was found on [{$policy}].");
+                : "Strict authorization mode is enabled, but no [{$action}()] method was found on [{$policyClass}].");
         }
 
         /** @var bool | Response | null $response */

--- a/tests/src/Support/helpersTest.php
+++ b/tests/src/Support/helpersTest.php
@@ -1,8 +1,13 @@
 <?php
 
+use Filament\Facades\Filament;
+use Filament\Tests\TestCase;
 use Illuminate\View\ComponentAttributeBag;
 
+use function Filament\get_authorization_response;
 use function Filament\Support\prepare_inherited_attributes;
+
+uses(TestCase::class);
 
 it('will prepare attributes', function (): void {
     $bag = new ComponentAttributeBag([
@@ -39,3 +44,10 @@ it('will prepare data attributes', function (): void {
         'data-foo' => 'bar',
     ]);
 });
+
+
+it('can handle policy being an object when method does not exist', function (): void {
+    Filament::getCurrentOrDefaultPanel()->strictAuthorization();
+
+    get_authorization_response('view-asdf', \Filament\Tests\Fixtures\Models\Ticket::class);
+})->throws(Exception::class, 'Strict authorization mode is enabled, but no [view-asdf()] method was found on [Filament\Tests\Fixtures\Policies\TicketPolicy].');

--- a/tests/src/Support/helpersTest.php
+++ b/tests/src/Support/helpersTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Filament\Facades\Filament;
+use Filament\Tests\Fixtures\Models\Ticket;
 use Filament\Tests\TestCase;
 use Illuminate\View\ComponentAttributeBag;
 
@@ -49,5 +50,5 @@ it('will prepare data attributes', function (): void {
 it('can handle policy being an object when method does not exist', function (): void {
     Filament::getCurrentOrDefaultPanel()->strictAuthorization();
 
-    get_authorization_response('view-asdf', \Filament\Tests\Fixtures\Models\Ticket::class);
-})->throws(Exception::class, 'Strict authorization mode is enabled, but no [view-asdf()] method was found on [Filament\Tests\Fixtures\Policies\TicketPolicy].');
+    get_authorization_response('edit', Ticket::class);
+})->throws(Exception::class, 'Strict authorization mode is enabled, but no [edit()] method was found on [Filament\Tests\Fixtures\Policies\TicketPolicy].');


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Currently the exception does not throw, and instead a typeerror throws instead.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
