### PR TITLE
fix(table-columns): sort table columns when a new column is added

### DIFF
--- a/packages/tables/src/Concerns/HasColumnManager.php
+++ b/packages/tables/src/Concerns/HasColumnManager.php
@@ -6,6 +6,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Components\Component;
 use Filament\Tables\Columns\Column;
 use Filament\Tables\Columns\ColumnGroup;
+use Illuminate\Support\Collection;
 
 /**
  * @property-read Schema $toggleTableColumnForm
@@ -214,12 +215,18 @@ trait HasColumnManager
     protected function syncTableColumnManagerWithDefaultState(): void
     {
         $defaultState = $this->getDefaultTableColumnManagerState();
+        $newTableColumnManagerItems = $this->getNewTableColumnManagerItems($defaultState);
 
         $this->tableColumns = collect($this->tableColumns)
             ->map(fn (array $item) => $this->syncTableColumnManagerItemWithDefaultState($item, $defaultState))
             ->filter()
             ->values()
-            ->merge($this->getNewTableColumnManagerItems($defaultState))
+            ->when(
+                count($newTableColumnManagerItems),
+                fn (Collection $items) => $items
+                    ->merge($newTableColumnManagerItems)
+                    ->sortBy(fn (array $item): int => (int) array_search($item['name'], array_column($defaultState, 'name')))
+            )
             ->all();
     }
 

--- a/packages/tables/src/Concerns/HasColumnManager.php
+++ b/packages/tables/src/Concerns/HasColumnManager.php
@@ -6,7 +6,6 @@ use Filament\Schemas\Schema;
 use Filament\Support\Components\Component;
 use Filament\Tables\Columns\Column;
 use Filament\Tables\Columns\ColumnGroup;
-use Illuminate\Support\Collection;
 
 /**
  * @property-read Schema $toggleTableColumnForm
@@ -215,18 +214,13 @@ trait HasColumnManager
     protected function syncTableColumnManagerWithDefaultState(): void
     {
         $defaultState = $this->getDefaultTableColumnManagerState();
-        $newTableColumnManagerItems = $this->getNewTableColumnManagerItems($defaultState);
 
         $this->tableColumns = collect($this->tableColumns)
             ->map(fn (array $item) => $this->syncTableColumnManagerItemWithDefaultState($item, $defaultState))
             ->filter()
             ->values()
-            ->when(
-                count($newTableColumnManagerItems),
-                fn (Collection $items) => $items
-                    ->merge($newTableColumnManagerItems)
-                    ->sortBy(fn (array $item): int => (int) array_search($item['name'], array_column($defaultState, 'name')))
-            )
+            ->merge($this->getNewTableColumnManagerItems($defaultState))
+            ->sortBy(fn (array $item): int => (int) array_search($item['name'], array_column($defaultState, 'name')))
             ->all();
     }
 


### PR DESCRIPTION
## Description

When a new column is added to a table .. especially during development .. the new column is always added to the end of the table as long as the session persists.

To solve this I added a sort by the names of the default state.

## Visual changes

-

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
