### PR TITLE
feat(panels): add render hooks for CONTENT_BEFORE and CONTENT_AFTER

### DIFF
--- a/packages/panels/resources/views/components/layout/index.blade.php
+++ b/packages/panels/resources/views/components/layout/index.blade.php
@@ -42,6 +42,8 @@
                 {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::TOPBAR_AFTER, scopes: $livewire?->getRenderHookScopes()) }}
             @endif
 
+            {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::CONTENT_BEFORE, scopes: $livewire?->getRenderHookScopes()) }}
+
             <main
                 @class([
                     'fi-main mx-auto h-full w-full px-4 md:px-6 lg:px-8',
@@ -77,6 +79,8 @@
 
                 {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::CONTENT_END, scopes: $livewire?->getRenderHookScopes()) }}
             </main>
+
+            {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::CONTENT_AFTER, scopes: $livewire?->getRenderHookScopes()) }}
 
             {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::FOOTER, scopes: $livewire?->getRenderHookScopes()) }}
         </div>

--- a/packages/panels/src/View/PanelsRenderHook.php
+++ b/packages/panels/src/View/PanelsRenderHook.php
@@ -24,6 +24,10 @@ class PanelsRenderHook
 
     const BODY_START = 'panels::body.start';
 
+    const CONTENT_AFTER = 'panels::content.after';
+
+    const CONTENT_BEFORE = 'panels::content.before';
+
     const CONTENT_END = 'panels::content.end';
 
     const CONTENT_START = 'panels::content.start';

--- a/packages/support/docs/06-render-hooks.md
+++ b/packages/support/docs/06-render-hooks.md
@@ -52,6 +52,8 @@ FilamentView::registerRenderHook(
 - `PanelsRenderHook::AUTH_REGISTER_FORM_BEFORE` - Before register form
 - `PanelsRenderHook::BODY_END` - Before `</body>`
 - `PanelsRenderHook::BODY_START` - After `<body>`
+- `PanelsRenderHook::CONTENT_AFTER` - After page content
+- `PanelsRenderHook::CONTENT_BEFORE` - Before page content
 - `PanelsRenderHook::CONTENT_END` - After page content, inside `<main>`
 - `PanelsRenderHook::CONTENT_START` - Before page content, inside `<main>`
 - `PanelsRenderHook::FOOTER` - Footer of the page


### PR DESCRIPTION
Introduce `CONTENT_BEFORE` and `CONTENT_AFTER` render hooks in `PanelsRenderHook` to allow customization before and after the main content. Updated relevant documentation and Blade template to integrate the new hooks.