### PR TITLE
feat(panels): add new content render hooks before and after main content

### DIFF
--- a/docs/09-advanced/01-render-hooks.md
+++ b/docs/09-advanced/01-render-hooks.md
@@ -52,6 +52,8 @@ use Filament\View\PanelsRenderHook;
 - `PanelsRenderHook::AUTH_REGISTER_FORM_BEFORE` - Before register form
 - `PanelsRenderHook::BODY_END` - Before `</body>`
 - `PanelsRenderHook::BODY_START` - After `<body>`
+- `PanelsRenderHook::CONTENT_AFTER` - After page content
+- `PanelsRenderHook::CONTENT_BEFORE` - Before page content
 - `PanelsRenderHook::CONTENT_END` - After page content, inside `<main>`
 - `PanelsRenderHook::CONTENT_START` - Before page content, inside `<main>`
 - `PanelsRenderHook::FOOTER` - Footer of the page

--- a/packages/panels/resources/views/components/layout/index.blade.php
+++ b/packages/panels/resources/views/components/layout/index.blade.php
@@ -71,6 +71,8 @@
             @endif
             class="fi-main-ctn"
         >
+            {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::CONTENT_BEFORE, scopes: $renderHookScopes) }}
+
             <main
                 @class([
                     'fi-main',
@@ -83,6 +85,8 @@
 
                 {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::CONTENT_END, scopes: $renderHookScopes) }}
             </main>
+
+            {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::CONTENT_AFTER, scopes: $renderHookScopes) }}
 
             {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::FOOTER, scopes: $renderHookScopes) }}
         </div>

--- a/packages/panels/src/View/PanelsRenderHook.php
+++ b/packages/panels/src/View/PanelsRenderHook.php
@@ -24,6 +24,10 @@ class PanelsRenderHook
 
     const BODY_START = 'panels::body.start';
 
+    const CONTENT_AFTER = 'panels::content.after';
+
+    const CONTENT_BEFORE = 'panels::content.before';
+
     const CONTENT_END = 'panels::content.end';
 
     const CONTENT_START = 'panels::content.start';


### PR DESCRIPTION
Introduce `CONTENT_BEFORE` and `CONTENT_AFTER` hooks to improve customization around the main content area.