### PR TITLE
Fix loading indicator appearing in table after group deselection

### DIFF
--- a/packages/tables/resources/js/components/table.js
+++ b/packages/tables/resources/js/components/table.js
@@ -84,13 +84,11 @@ export default ({
             this.deselectRecords(
                 await $wire.getGroupedSelectableTableRecordKeys(group),
             )
-
-            return
+        } else {
+            this.selectRecords(
+                await $wire.getGroupedSelectableTableRecordKeys(group),
+            )
         }
-
-        this.selectRecords(
-            await $wire.getGroupedSelectableTableRecordKeys(group),
-        )
 
         this.isLoading = false
     },


### PR DESCRIPTION
## Description
This PR fixes a small UI bug that occurs when there are selected records after deselecting a group in a table.

## Visual changes

### Before
https://github.com/user-attachments/assets/2c34f245-2dcb-4fde-ad8e-7a280cf7c3c0

### After
https://github.com/user-attachments/assets/f172dc82-ac98-4075-a294-de05263586aa

