### PR TITLE
Fix: Mount actions on preview blocks

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -248,7 +248,7 @@
                                     <div
                                         class="fi-fo-builder-item-preview-edit-overlay"
                                         role="button"
-                                        x-on:click.stop="{{ '$wire.mountFormComponentAction(\'' . $statePath . '\', \'edit\', { item: \'' . $itemKey . '\' })' }}"
+                                        x-on:click.stop="{{ '$wire.mountAction(\'edit\', { item: \'' . $itemKey . '\' }, { schemaComponent: \'' . $key . '\' })' }}"
                                     ></div>
                                 @endif
                             @else


### PR DESCRIPTION
## Description

When using Builder block previews without interactive blocks, when clicking a preview the load would fail due to the missing method "mountFormComponentAction". Fixed by replacing with mountAction method.

## Visual changes

No visual changes.

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
