### PR TITLE
Optimize panel URL generation

### DIFF
--- a/packages/panels/src/Http/Controllers/RedirectToHomeController.php
+++ b/packages/panels/src/Http/Controllers/RedirectToHomeController.php
@@ -11,7 +11,7 @@ class RedirectToHomeController
     {
         $panel = Filament::getCurrentOrDefaultPanel();
 
-        $url = $panel->getUrl(Filament::getTenant());
+        $url = $panel->getRedirectUrl(Filament::getTenant());
 
         if (blank($url)) {
             abort(404);

--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -7,6 +7,7 @@ use Filament\Facades\Filament;
 use Filament\Navigation\NavigationManager;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Route;
 use Laravel\SerializableClosure\Serializers\Native;
 
 trait HasRoutes
@@ -166,6 +167,32 @@ trait HasRoutes
     }
 
     public function getUrl(?Model $tenant = null): ?string
+    {
+        $hasTenancy = $this->hasTenancy();
+
+        if ((! $tenant) && $hasTenancy && $this->auth()->hasUser()) {
+            $tenant = Filament::getUserDefaultTenant($this->auth()->user());
+        }
+
+        if (Route::has($homeRouteName = $this->generateRouteName('home'))) {
+            return route($homeRouteName, $tenant ? ['tenant' => $tenant] : []);
+        }
+
+        if ($tenant) {
+            $tenantSlugAttribute = $this->getTenantSlugAttribute();
+            $tenantRoutePrefix = $this->getTenantRoutePrefix() ?? '';
+
+            if (filled($tenantRoutePrefix)) {
+                $tenantRoutePrefix .= '/';
+            }
+
+            return url($this->getPath() . '/' . $tenantRoutePrefix . (filled($tenantSlugAttribute) ? $tenant->getAttributeValue($tenantSlugAttribute) : $tenant->getRouteKey()));
+        }
+
+        return url($this->getPath());
+    }
+
+    public function getRedirectUrl(?Model $tenant = null): ?string
     {
         if ((! $this->auth()->check()) && $this->hasLogin()) {
             return $this->getLoginUrl();


### PR DESCRIPTION
I am expecting that this might break some things so I am putting it in v4. It might need fixes if people report issues with it breaking certain tenancy setups.

This should optimize tenant URL generation to ensure that you don't need to list all navigation items to find the first one in order to link to a panel. This is especially useful in the tenant switcher.

Closes #13290
Closes #13928
Closes #14069