### PR TITLE
refactor: extract Action context generation to method

### DIFF
--- a/packages/actions/src/Action.php
+++ b/packages/actions/src/Action.php
@@ -434,6 +434,22 @@ class Action extends ViewComponent implements Arrayable
             $argumentsParameter .= Js::from($arguments);
         }
 
+        $contextParameter = '';
+
+        if (count($context = $this->getContext())) {
+            $contextParameter .= ', ';
+            $contextParameter .= Js::from($context);
+
+            if ($argumentsParameter === '') {
+                $argumentsParameter = ', {}';
+            }
+        }
+
+        return "mountAction('{$this->getName()}'{$argumentsParameter}{$contextParameter})";
+    }
+
+    public function getContext(): array
+    {
         $context = [];
 
         if ($record = $this->getRecord()) {
@@ -454,18 +470,7 @@ class Action extends ViewComponent implements Arrayable
             $context['bulk'] = true;
         }
 
-        $contextParameter = '';
-
-        if (filled($context)) {
-            $contextParameter .= ', ';
-            $contextParameter .= Js::from($context);
-
-            if ($argumentsParameter === '') {
-                $argumentsParameter = ', {}';
-            }
-        }
-
-        return "mountAction('{$this->getName()}'{$argumentsParameter}{$contextParameter})";
+        return $context;
     }
 
     /**

--- a/packages/actions/src/Action.php
+++ b/packages/actions/src/Action.php
@@ -449,7 +449,7 @@ class Action extends ViewComponent implements Arrayable
     }
 
     /**
-     * @return array<string, string|true>
+     * @return array<string, mixed>
      */
     public function getContext(): array
     {

--- a/packages/actions/src/Action.php
+++ b/packages/actions/src/Action.php
@@ -449,7 +449,7 @@ class Action extends ViewComponent implements Arrayable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<string, string|true>
      */
     public function getContext(): array
     {

--- a/packages/actions/src/Action.php
+++ b/packages/actions/src/Action.php
@@ -448,6 +448,9 @@ class Action extends ViewComponent implements Arrayable
         return "mountAction('{$this->getName()}'{$argumentsParameter}{$contextParameter})";
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getContext(): array
     {
         $context = [];


### PR DESCRIPTION
I need to construct an action mount click handler via JavaScript (as one of the arguments is coming from JS). In V4, the click handler became more complex with the bunch of differing context keys that are available. This extracts the context generation into a specific action method, so that I can just still leave the context generation part on the action.

Thanks!