### PR TITLE
Fix: sortable error on builder component

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -81,7 +81,7 @@
             <ul
                 x-sortable
                 data-sortable-animation-duration="{{ $getReorderAnimationDuration() }}"
-                wire:end.stop="mountAction('reorder', { items: $event.target.sortable.toArray() }, { schemaComponent: '{{ $key }}' })'"
+                wire:end.stop="mountAction('reorder', { items: $event.target.sortable.toArray() }, { schemaComponent: '{{ $key }}' })"
                 class="fi-fo-builder-items"
             >
                 @php


### PR DESCRIPTION
## Description

Typo on builder.blade.php made the sortable feature fail.

<img width="1063" alt="Captura de ecrã 2025-06-22, às 17 55 21" src="https://github.com/user-attachments/assets/bd33be70-5762-4b3d-8f2d-0659db572d1e" />


## Visual changes

None.

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
