### PR TITLE
[4.x] Do not call `getPageTableSummaryQuery` when using custom data tables

### DIFF
--- a/packages/tables/resources/views/components/summary/index.blade.php
+++ b/packages/tables/resources/views/components/summary/index.blade.php
@@ -26,7 +26,7 @@
 
     $hasPageSummary = (! $groupsOnly) && $records instanceof \Illuminate\Contracts\Pagination\Paginator && $records->hasPages();
 
-    $pageTableSummaryQuery = $hasPageSummary ? $this->getPageTableSummaryQuery() : null;
+    $pageTableSummaryQuery = $this->hasQuery() && $hasPageSummary ? $this->getPageTableSummaryQuery() : null;
     $allTableSummaryQuery = $this->getAllTableSummaryQuery();
 @endphp
 

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -37,7 +37,7 @@
     $filtersFormWidth = $getFiltersFormWidth();
     $hasColumnGroups = $hasColumnGroups();
     $hasColumnsLayout = $hasColumnsLayout();
-    $hasSummary = $hasSummary($this->getAllTableSummaryQuery());
+    $hasSummary = $hasQuery() ? $hasSummary($this->getAllTableSummaryQuery()) : false;
     $header = $getHeader();
     $headerActions = array_filter(
         $getHeaderActions(),

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -24,6 +24,11 @@ trait HasRecords
 
     protected Collection | Paginator | CursorPaginator | null $cachedTableRecords = null;
 
+    public function hasQuery(): bool
+    {
+        return $this->getTable()->hasQuery();
+    }
+
     public function getFilteredTableQuery(): ?Builder
     {
         $query = $this->getTable()->getQuery();


### PR DESCRIPTION
## Description

Fixes the two following comment on pull request: https://github.com/filamentphp/filament/pull/16651

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
