### PR TITLE
Adding ability to specify the columns number in the field set of the export action.

### DIFF
--- a/packages/actions/docs/12-export.md
+++ b/packages/actions/docs/12-export.md
@@ -78,25 +78,6 @@ public function table(Table $table): Table
 
 The ["exporter" class needs to be created](#creating-an-exporter) to tell Filament how to export each row.
 
-## Customizing the column selection form layout
-
-When the column mapping feature is enabled (which is the default), users will see a form that allows them to select which columns to export and customize their labels. You can control the layout of this form using the `columns()` method.
-
-### Setting the number of columns
-
-By default, the column selection form displays in a single column layout. You can change this using the `columns()` method:
-
-```php
-use App\Filament\Exports\ProductExporter;
-use Filament\Actions\ExportAction;
-
-ExportAction::make()
-    ->exporter(ProductExporter::class)
-    ->columns(3)
-```
-
-This will display the column selection checkboxes and label inputs in a 2-column layout, making better use of available space when you have many exportable columns.
-
 ## Creating an exporter
 
 To create an exporter class for a model, you may use the `make:filament-exporter` command, passing the name of a model:
@@ -154,6 +135,21 @@ use Filament\Actions\Exports\ExportColumn;
 ExportColumn::make('description')
     ->enabledByDefault(false)
 ```
+
+### Configuring the column selection form layout
+
+By default, the column selection form uses a single column layout. You can change this using the `columnMappingColumns()` method, passing the number of columns you would like to use for the layout on large screens:
+
+```php
+use App\Filament\Exports\ProductExporter;
+use Filament\Actions\ExportAction;
+
+ExportAction::make()
+    ->exporter(ProductExporter::class)
+    ->columnMappingColumns(3)
+```
+
+This will display the column selection checkboxes and label inputs in a 3-column layout, making better use of available space when you have many exportable columns. Note that while there will be three columns in the layout on large screens, the layout will still be responsive and there will be fewer columns displayed on smaller screens.
 
 ### Disabling column selection
 

--- a/packages/actions/docs/12-export.md
+++ b/packages/actions/docs/12-export.md
@@ -80,7 +80,7 @@ The ["exporter" class needs to be created](#creating-an-exporter) to tell Filame
 
 ## Customizing the column selection form layout
 
-When the column mapping feature is enabled (which is the default), users will see a form that allows them to select which columns to export and customize their labels. You can control the layout of this form using the `columns()` and `inlineLabel()` methods.
+When the column mapping feature is enabled (which is the default), users will see a form that allows them to select which columns to export and customize their labels. You can control the layout of this form using the `columns()` method.
 
 ### Setting the number of columns
 
@@ -92,25 +92,10 @@ use Filament\Actions\ExportAction;
 
 ExportAction::make()
     ->exporter(ProductExporter::class)
-    ->columns(2)
+    ->columns(3)
 ```
 
 This will display the column selection checkboxes and label inputs in a 2-column layout, making better use of available space when you have many exportable columns.
-
-### Controlling inline labels
-
-By default, the column selection form displays labels inline with the form controls. You can disable this behavior using the `inlineLabel()` method:
-
-```php
-use App\Filament\Exports\ProductExporter;
-use Filament\Actions\ExportAction;
-
-ExportAction::make()
-    ->exporter(ProductExporter::class)
-    ->inlineLabel(false)
-```
-
-When inline labels are disabled, the labels will be displayed above the form controls instead of next to them.
 
 ## Creating an exporter
 

--- a/packages/actions/docs/12-export.md
+++ b/packages/actions/docs/12-export.md
@@ -78,6 +78,40 @@ public function table(Table $table): Table
 
 The ["exporter" class needs to be created](#creating-an-exporter) to tell Filament how to export each row.
 
+## Customizing the column selection form layout
+
+When the column mapping feature is enabled (which is the default), users will see a form that allows them to select which columns to export and customize their labels. You can control the layout of this form using the `columns()` and `inlineLabel()` methods.
+
+### Setting the number of columns
+
+By default, the column selection form displays in a single column layout. You can change this using the `columns()` method:
+
+```php
+use App\Filament\Exports\ProductExporter;
+use Filament\Actions\ExportAction;
+
+ExportAction::make()
+    ->exporter(ProductExporter::class)
+    ->columns(2)
+```
+
+This will display the column selection checkboxes and label inputs in a 2-column layout, making better use of available space when you have many exportable columns.
+
+### Controlling inline labels
+
+By default, the column selection form displays labels inline with the form controls. You can disable this behavior using the `inlineLabel()` method:
+
+```php
+use App\Filament\Exports\ProductExporter;
+use Filament\Actions\ExportAction;
+
+ExportAction::make()
+    ->exporter(ProductExporter::class)
+    ->inlineLabel(false)
+```
+
+When inline labels are disabled, the labels will be displayed above the form controls instead of next to them.
+
 ## Creating an exporter
 
 To create an exporter class for a model, you may use the `make:filament-exporter` command, passing the name of a model:

--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -82,9 +82,24 @@ trait CanExportRecords
 
         $this->groupedIcon(FilamentIcon::resolve('actions::export-action.grouped') ?? Heroicon::ArrowDownTray);
 
-        $this->form(fn (ExportAction | ExportBulkAction $action): array => [
+        $this->schema(fn (ExportAction | ExportBulkAction $action): array => [
             ...($action->hasColumnMapping() ? [Fieldset::make(__('filament-actions::export.modal.form.columns.label'))
-                ->columns($this->getColumns())
+                ->columns(match ($columns = $action->getColumns()) {
+                    1 => 1,
+                    2 => [
+                        'sm' => 2,
+                        'lg' => 2,
+                    ],
+                    3 => [
+                        'sm' => 2,
+                        'lg' => 3,
+                    ],
+                    default => [
+                        'sm' => 2,
+                        'md' => 3,
+                        'lg' => $columns,
+                    ],
+                })
                 ->schema(function () use ($action): array {
                     return array_map(
                         fn (ExportColumn $column): Flex => Flex::make([
@@ -269,11 +284,11 @@ trait CanExportRecords
 
         $this->defaultColor('gray');
 
-        $this->modalWidth(fn () => match ($this->getColumns()) {
-            2 => Width::TwoExtraLarge->value,
-            3 => Width::ThreeExtraLarge->value,
-            4 => Width::FourExtraLarge->value,
-            default => Width::ExtraLarge,
+        $this->modalWidth(static fn (ExportAction | ExportBulkAction $action): Width => match ($action->getColumns()) {
+            1 => Width::Medium,
+            2 => Width::ThreeExtraLarge,
+            3 => Width::FiveExtraLarge,
+            default => Width::SevenExtraLarge,
         });
 
         $this->successNotificationTitle(__('filament-actions::export.notifications.started.title'));

--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -44,7 +44,7 @@ trait CanExportRecords
 
     protected int | Closure $chunkSize = 100;
 
-    protected int | Closure $columns = 1;
+    protected int | Closure $columnMappingColumns = 1;
 
     protected int | Closure | null $maxRows = null;
 
@@ -84,7 +84,7 @@ trait CanExportRecords
 
         $this->schema(fn (ExportAction | ExportBulkAction $action): array => [
             ...($action->hasColumnMapping() ? [Fieldset::make(__('filament-actions::export.modal.form.columns.label'))
-                ->columns(match ($columns = $action->getColumns()) {
+                ->columns(match ($columns = $action->getColumnMappingColumns()) {
                     1 => 1,
                     2 => [
                         'sm' => 2,
@@ -284,7 +284,7 @@ trait CanExportRecords
 
         $this->defaultColor('gray');
 
-        $this->modalWidth(static fn (ExportAction | ExportBulkAction $action): Width => match ($action->getColumns()) {
+        $this->modalWidth(static fn (ExportAction | ExportBulkAction $action): Width => match ($action->getColumnMappingColumns()) {
             1 => Width::Medium,
             2 => Width::ThreeExtraLarge,
             3 => Width::FiveExtraLarge,
@@ -303,16 +303,16 @@ trait CanExportRecords
         return 'export';
     }
 
-    public function columns(int | Closure $columns): static
+    public function columnMappingColumns(int | Closure $columns): static
     {
-        $this->columns = $columns;
+        $this->columnMappingColumns = $columns;
 
         return $this;
     }
 
-    public function getColumns(): int
+    public function getColumnMappingColumns(): int
     {
-        return $this->evaluate($this->columns);
+        return $this->evaluate($this->columnMappingColumns);
     }
 
     /**

--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -20,6 +20,7 @@ use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Flex;
 use Filament\Schemas\Components\Utilities\Get;
+use Filament\Support\Enums\Width;
 use Filament\Support\Facades\FilamentIcon;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Contracts\HasTable;
@@ -271,7 +272,12 @@ trait CanExportRecords
 
         $this->defaultColor('gray');
 
-        $this->modalWidth('xl');
+        $this->modalWidth(fn () => match ($this->getColumns()) {
+            2 => Width::TwoExtraLarge->value,
+            3 => Width::ThreeExtraLarge->value,
+            4 => Width::FourExtraLarge->value,
+            default => Width::ExtraLarge,
+        });
 
         $this->successNotificationTitle(__('filament-actions::export.notifications.started.title'));
 
@@ -306,6 +312,10 @@ trait CanExportRecords
 
     public function getInlineLabel(): bool
     {
+        if ($this->getColumns() > 1) {
+            return false;
+        }
+
         return $this->evaluate($this->inlineLabel);
     }
 

--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -43,6 +43,10 @@ trait CanExportRecords
 
     protected int | Closure $chunkSize = 100;
 
+    protected int | Closure $columns = 1;
+
+    protected bool | Closure $inlineLabel = true;
+
     protected int | Closure | null $maxRows = null;
 
     protected string | Closure | null $csvDelimiter = null;
@@ -81,8 +85,8 @@ trait CanExportRecords
 
         $this->form(fn (ExportAction | ExportBulkAction $action): array => [
             ...($action->hasColumnMapping() ? [Fieldset::make(__('filament-actions::export.modal.form.columns.label'))
-                ->columns(1)
-                ->inlineLabel()
+                ->columns($this->getColumns())
+                ->inlineLabel($this->getInlineLabel())
                 ->schema(function () use ($action): array {
                     return array_map(
                         fn (ExportColumn $column): Flex => Flex::make([
@@ -279,6 +283,30 @@ trait CanExportRecords
     public static function getDefaultName(): ?string
     {
         return 'export';
+    }
+
+    public function columns(int | Closure $columns): static
+    {
+        $this->columns = $columns;
+
+        return $this;
+    }
+
+    public function getColumns(): int
+    {
+        return $this->evaluate($this->columns);
+    }
+
+    public function inlineLabel(bool | Closure $condition = true): static
+    {
+        $this->inlineLabel = $condition;
+
+        return $this;
+    }
+
+    public function getInlineLabel(): bool
+    {
+        return $this->evaluate($this->inlineLabel);
     }
 
     /**

--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -46,8 +46,6 @@ trait CanExportRecords
 
     protected int | Closure $columns = 1;
 
-    protected bool | Closure $inlineLabel = true;
-
     protected int | Closure | null $maxRows = null;
 
     protected string | Closure | null $csvDelimiter = null;
@@ -87,7 +85,6 @@ trait CanExportRecords
         $this->form(fn (ExportAction | ExportBulkAction $action): array => [
             ...($action->hasColumnMapping() ? [Fieldset::make(__('filament-actions::export.modal.form.columns.label'))
                 ->columns($this->getColumns())
-                ->inlineLabel($this->getInlineLabel())
                 ->schema(function () use ($action): array {
                     return array_map(
                         fn (ExportColumn $column): Flex => Flex::make([
@@ -301,22 +298,6 @@ trait CanExportRecords
     public function getColumns(): int
     {
         return $this->evaluate($this->columns);
-    }
-
-    public function inlineLabel(bool | Closure $condition = true): static
-    {
-        $this->inlineLabel = $condition;
-
-        return $this;
-    }
-
-    public function getInlineLabel(): bool
-    {
-        if ($this->getColumns() > 1) {
-            return false;
-        }
-
-        return $this->evaluate($this->inlineLabel);
     }
 
     /**


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This feature will add an ability to specify the columns of the field set in the export action as well specify wither it should be inline labeled or not.

## Visual changes

Before:
<img width="537" alt="Screenshot 2025-06-24 at 8 07 46 AM" src="https://github.com/user-attachments/assets/a6c808b0-0fba-4e2e-a382-ed36d4dcb657" />

After:
<img width="939" alt="Screenshot 2025-06-24 at 8 08 29 AM" src="https://github.com/user-attachments/assets/438a9a8b-9e4a-4311-bdd2-0c147956c7e3" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
