### PR TITLE
Fix missing static in RichEditor docs

### DIFF
--- a/packages/forms/docs/10-rich-editor.md
+++ b/packages/forms/docs/10-rich-editor.md
@@ -296,7 +296,7 @@ class HeroBlock extends RichContentCustomBlock
      * @param  array<string, mixed>  $config
      * @param  array<string, mixed>  $data
      */
-    public function toHtml(array $config, array $data): string
+    public static function toHtml(array $config, array $data): string
     {
         return view('blocks.hero', [
             'heading' => $config['heading'],


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
The method should be static, like its parent.
<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
