### PR TITLE
Fix table group checkboxes being treated as record checkboxes 

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -876,7 +876,7 @@
                                                 wire:key="{{ $this->getId() }}.table.bulk_select_group.checkbox.{{ $page }}"
                                                 wire:loading.attr="disabled"
                                                 wire:target="{{ implode(',', \Filament\Tables\Table::LOADING_TARGETS) }}"
-                                                class="fi-ta-record-checkbox fi-ta-group-checkbox fi-checkbox-input"
+                                                class="fi-ta-group-checkbox fi-checkbox-input"
                                             />
                                         @endif
 
@@ -1541,7 +1541,7 @@
                                                                     wire:key="{{ $this->getId() }}.table.bulk_select_group.checkbox.{{ $page }}"
                                                                     wire:loading.attr="disabled"
                                                                     wire:target="{{ implode(',', \Filament\Tables\Table::LOADING_TARGETS) }}"
-                                                                    class="fi-ta-record-checkbox fi-ta-group-checkbox fi-checkbox-input"
+                                                                    class="fi-ta-group-checkbox fi-checkbox-input"
                                                                 />
                                                             @endif
                                                         </td>
@@ -1620,7 +1620,7 @@
                                                                     wire:key="{{ $this->getId() }}.table.bulk_select_group.checkbox.{{ $page }}"
                                                                     wire:loading.attr="disabled"
                                                                     wire:target="{{ implode(',', \Filament\Tables\Table::LOADING_TARGETS) }}"
-                                                                    class="fi-ta-record-checkbox fi-ta-group-checkbox fi-checkbox-input"
+                                                                    class="fi-ta-group-checkbox fi-checkbox-input"
                                                                 />
                                                             @endif
                                                         </td>


### PR DESCRIPTION
## Description
This PR removes the `fi-ta-record-checkbox` class from all group checkboxes in table. Having this class applied caused two issues.

When grouping was applied, the group checkboxes were treated as record checkboxes in `table.js` functions ( `getRecordsOnPage()` and `handleCheckboxClick()`) which caused them to be picked up by `this.$root?.getElementsByClassName` and their values to be injected into the `selectedRecords` property. This caused the selection indicator to display an incorrect amount of records (+1) as seen on the videos attached below. 

### Selecting records on page when grouping is applied
https://github.com/user-attachments/assets/d6d81889-8dcb-450b-ab34-b6f43c5cd936

### Selecting records using shift click when grouping is applied
https://github.com/user-attachments/assets/5043b073-3534-47c7-89e9-08afc0f73f00

On both videos the values of checkboxes are console logged. It shows multiple 'ons' for each group because it just logs the keys, not the `selectedRecords` set.

## Visual changes
The `fi-ta-record-checkbox` class also made the groups taller than in 3.x, basically having the same height as the record row. I'm actually not sure if this was a deliberate design choice. Regardless, removing the class made them look like in v3. If the change was actually intentional I would make changes.

### v3 (original and current look after PR)
![v3group](https://github.com/user-attachments/assets/165c7909-ab93-48c9-91db-96bd2535c383)
### v4 (before PR)
![v4group](https://github.com/user-attachments/assets/1faea440-90c4-4644-b76c-fe4532ae9690)

