### PR TITLE
Fix: update translation key

### DIFF
--- a/packages/panels/src/Auth/Pages/PasswordReset/RequestPasswordReset.php
+++ b/packages/panels/src/Auth/Pages/PasswordReset/RequestPasswordReset.php
@@ -130,7 +130,7 @@ class RequestPasswordReset extends SimplePage
     {
         return Notification::make()
             ->title(__($status))
-            ->body(($status === Password::RESET_LINK_SENT) ? __('filament-panels::pages/auth/password-reset/request-password-reset.notifications.sent.body') : null)
+            ->body(($status === Password::RESET_LINK_SENT) ? __('filament-panels::auth/pages/password-reset/request-password-reset.notifications.sent.body') : null)
             ->success();
     }
 

--- a/tests/src/Panels/Auth/PasswordReset/RequestPasswordResetTest.php
+++ b/tests/src/Panels/Auth/PasswordReset/RequestPasswordResetTest.php
@@ -47,7 +47,7 @@ it('can request password reset', function (): void {
             FilamentNotification::make()
                 ->success()
                 ->title(__('passwords.sent'))
-                ->body(__('filament-panels::pages/auth/password-reset/request-password-reset.notifications.sent.body'))
+                ->body(__('filament-panels::auth/pages/password-reset/request-password-reset.notifications.sent.body'))
         );
 
     Notification::assertSentTo($userToResetPassword, ResetPassword::class);
@@ -105,7 +105,7 @@ it('cannot request password reset without panel access', function (): void {
             FilamentNotification::make()
                 ->success()
                 ->title(__('passwords.sent'))
-                ->body(__('filament-panels::pages/auth/password-reset/request-password-reset.notifications.sent.body'))
+                ->body(__('filament-panels::auth/pages/password-reset/request-password-reset.notifications.sent.body'))
         );
 
     Notification::assertNotSentTo($userToResetPassword, ResetPassword::class);


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Update translation key for request reset password notification.

Seems like this one was missed.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

Before:

![image](https://github.com/user-attachments/assets/83ece9cd-f25e-460e-a572-460b5ce21e15)

After:

![image](https://github.com/user-attachments/assets/61fcf778-8f9d-434c-acbf-db4612e67747)

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
