### PR TITLE
fix: add missing `$defaultActionContext` property

### DIFF
--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -51,6 +51,12 @@ trait InteractsWithActions
     public $defaultActionArguments = null;
 
     /**
+     * @var mixed
+     */
+    #[Url(as: 'actionContext')]
+    public $defaultActionContext = null;
+
+    /**
      * @var array<string, Action>
      */
     protected array $cachedActions = [];
@@ -681,6 +687,7 @@ trait InteractsWithActions
             // actually set to `'null'` strings and remain in the URL.
             $this->defaultAction = [];
             $this->defaultActionArguments = [];
+            $this->defaultActionContext = [];
 
             return;
         }


### PR DESCRIPTION
The Blade file already references this property but it was not yet added. Not sure if the `Url` property should be added? Perhaps it might be a little sensitive and only having the action name and arguments might be enough. On the other hand if removing it people might not be able to open actions by default from certain contexts.