### PR TITLE
[4.x] Feat: Configurable default view and size for record actions

### DIFF
--- a/packages/tables/src/Table/Concerns/HasRecordActions.php
+++ b/packages/tables/src/Table/Concerns/HasRecordActions.php
@@ -24,20 +24,28 @@ trait HasRecordActions
 
     protected RecordActionsPosition | Closure | null $recordActionsPosition = null;
 
-    protected Size | Closure | null $recordActionsDefaultSize = Size::Small;
+    protected Size | string | Closure | null $recordActionsDefaultSize = Size::Small;
 
     protected string | Closure | null $recordActionsDefaultView = Action::LINK_VIEW;
 
     /**
      * @param  array<Action | ActionGroup> | ActionGroup  $actions
      */
-    public function recordActions(array | ActionGroup $actions, RecordActionsPosition | string | Closure | null $position = null): static
+    public function recordActions(array | ActionGroup $actions, RecordActionsPosition | string | Closure | null $position = null, string | Closure | null $defaultView = null, Size | string | Closure | null $defaultSize = null): static
     {
         $this->recordActions = [];
         $this->pushRecordActions($actions);
 
         if ($position) {
             $this->recordActionsPosition($position);
+        }
+
+        if ($defaultView) {
+            $this->recordActionsDefaultView($defaultView);
+        }
+
+        if ($defaultSize) {
+            $this->recordActionsDefaultSize($defaultSize);
         }
 
         return $this;
@@ -103,7 +111,7 @@ trait HasRecordActions
         return $this;
     }
 
-    public function recordActionsDefaultSize(Size | Closure | null $size = null): static
+    public function recordActionsDefaultSize(Size | string | Closure | null $size = null): static
     {
         $this->recordActionsDefaultSize = $size;
 
@@ -138,14 +146,14 @@ trait HasRecordActions
         return $this->evaluate($this->recordActionsAlignment);
     }
 
-    public function getRecordActionsDefaultSize(): ?Size
+    public function getRecordActionsDefaultSize(): Size | string | Closure | null
     {
-        return $this->evaluate($this->recordActionsDefaultSize);
+        return $this->recordActionsDefaultSize;
     }
 
-    public function getRecordActionsDefaultView(): ?string
+    public function getRecordActionsDefaultView(): string | Closure | null
     {
-        return $this->evaluate($this->recordActionsDefaultView);
+        return $this->recordActionsDefaultView;
     }
 
     public function getRecordActionsColumnLabel(): string | Htmlable | null

--- a/packages/tables/src/Table/Concerns/HasRecordActions.php
+++ b/packages/tables/src/Table/Concerns/HasRecordActions.php
@@ -61,8 +61,8 @@ trait HasRecordActions
 
                 $this->mergeCachedFlatActions($flatActions);
             } elseif ($action instanceof Action) {
-                $action->defaultSize($this->getRecordActionsSize());
-                $action->defaultView($this->getRecordActionsView());
+                $action->defaultSize($this->getRecordActionsDefaultSize());
+                $action->defaultView($this->getRecordActionsDefaultView());
 
                 $this->cacheAction($action);
             } else {

--- a/packages/tables/src/Table/Concerns/HasRecordActions.php
+++ b/packages/tables/src/Table/Concerns/HasRecordActions.php
@@ -24,9 +24,9 @@ trait HasRecordActions
 
     protected RecordActionsPosition | Closure | null $recordActionsPosition = null;
 
-    protected Size | Closure | null $recordActionsSize = Size::Small;
+    protected Size | Closure | null $recordActionsDefaultSize = Size::Small;
 
-    protected string | Closure | null $recordActionsView = Action::LINK_VIEW;
+    protected string | Closure | null $recordActionsDefaultView = Action::LINK_VIEW;
 
     /**
      * @param  array<Action | ActionGroup> | ActionGroup  $actions
@@ -96,16 +96,16 @@ trait HasRecordActions
         return $this;
     }
 
-    public function recordActionsView(string | Closure | null $view = null): static
+    public function recordActionsDefaultView(string | Closure | null $view = null): static
     {
-        $this->recordActionsView = $view;
+        $this->recordActionsDefaultView = $view;
 
         return $this;
     }
 
-    public function recordActionsSize(Size | Closure | null $size = null): static
+    public function recordActionsDefaultSize(Size | Closure | null $size = null): static
     {
-        $this->recordActionsSize = $size;
+        $this->recordActionsDefaultSize = $size;
 
         return $this;
     }
@@ -138,14 +138,14 @@ trait HasRecordActions
         return $this->evaluate($this->recordActionsAlignment);
     }
 
-    public function getRecordActionsSize(): ?Size
+    public function getRecordActionsDefaultSize(): ?Size
     {
-        return $this->evaluate($this->recordActionsSize);
+        return $this->evaluate($this->recordActionsDefaultSize);
     }
 
-    public function getRecordActionsView(): ?string
+    public function getRecordActionsDefaultView(): ?string
     {
-        return $this->evaluate($this->recordActionsView);
+        return $this->evaluate($this->recordActionsDefaultView);
     }
 
     public function getRecordActionsColumnLabel(): string | Htmlable | null

--- a/packages/tables/src/Table/Concerns/HasRecordActions.php
+++ b/packages/tables/src/Table/Concerns/HasRecordActions.php
@@ -24,6 +24,10 @@ trait HasRecordActions
 
     protected RecordActionsPosition | Closure | null $recordActionsPosition = null;
 
+    protected Size | Closure | null $recordActionsSize = Size::Small;
+
+    protected string | Closure | null $recordActionsView = Action::LINK_VIEW;
+
     /**
      * @param  array<Action | ActionGroup> | ActionGroup  $actions
      */
@@ -57,8 +61,8 @@ trait HasRecordActions
 
                 $this->mergeCachedFlatActions($flatActions);
             } elseif ($action instanceof Action) {
-                $action->defaultSize(Size::Small);
-                $action->defaultView($action::LINK_VIEW);
+                $action->defaultSize($this->getRecordActionsSize());
+                $action->defaultView($this->getRecordActionsView());
 
                 $this->cacheAction($action);
             } else {
@@ -92,6 +96,20 @@ trait HasRecordActions
         return $this;
     }
 
+    public function recordActionsView(string | Closure | null $view = null): static
+    {
+        $this->recordActionsView = $view;
+
+        return $this;
+    }
+
+    public function recordActionsSize(Size | Closure | null $size = null): static
+    {
+        $this->recordActionsSize = $size;
+
+        return $this;
+    }
+
     /**
      * @return array<Action | ActionGroup>
      */
@@ -118,6 +136,16 @@ trait HasRecordActions
     public function getRecordActionsAlignment(): ?string
     {
         return $this->evaluate($this->recordActionsAlignment);
+    }
+
+    public function getRecordActionsSize(): ?Size
+    {
+        return $this->evaluate($this->recordActionsSize);
+    }
+
+    public function getRecordActionsView(): ?string
+    {
+        return $this->evaluate($this->recordActionsView);
     }
 
     public function getRecordActionsColumnLabel(): string | Htmlable | null


### PR DESCRIPTION
## Description

Currently, the default action view and size are fixed for record actions. I would like them to be configurable so that by using `Table::configureUsing()`, all record actions can be set to another view and/or size by default (in my case I want them to be icon buttons). 

## Visual changes

N.A.

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
