### PR TITLE
[4.x] feat(table): allow to collapsing all groups by default

### DIFF
--- a/packages/tables/docs/07-grouping.md
+++ b/packages/tables/docs/07-grouping.md
@@ -202,6 +202,28 @@ public function table(Table $table): Table
 }
 ```
 
+## Collapsing all groups by default
+
+You can set all groups to be collapsed by default when the page loads using the `allGroupsCollapsed()` method:
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->groups([
+            Group::make('author.name')
+                ->collapsible(),
+            Group::make('status')
+                ->collapsible(),
+        ])
+        ->allGroupsCollapsed();
+}
+```
+
+This will automatically collapse all groups when the table is first loaded, and when users change the grouping selection.
+
 ## Summarising groups
 
 You can use [summaries](summaries) with groups to display a summary of the records inside a group. This works automatically if you choose to add a summariser to a column in a grouped table.

--- a/packages/tables/resources/js/components/table.js
+++ b/packages/tables/resources/js/components/table.js
@@ -2,11 +2,12 @@ export default ({
     canSelectMultipleRecords,
     canTrackDeselectedRecords,
     currentSelectionLivewireProperty,
+    areAllGroupsCollapsed = false,
     $wire,
 }) => ({
     checkboxClickController: null,
 
-    collapsedGroups: [],
+    collapsedGroups: areAllGroupsCollapsed ? [] : [],
 
     isLoading: false,
 
@@ -44,7 +45,13 @@ export default ({
             }
         }
 
-        this.$nextTick(() => this.watchForCheckboxClicks())
+        this.$nextTick(() => {
+            this.watchForCheckboxClicks()
+            
+            if (areAllGroupsCollapsed) {
+                this.collapsedGroups = this.getAllGroupTitles()
+            }
+        })
 
         Livewire.hook('element.init', ({ component }) => {
             if (component.id === this.livewireId) {
@@ -247,7 +254,24 @@ export default ({
     },
 
     resetCollapsedGroups() {
-        this.collapsedGroups = []
+        if (areAllGroupsCollapsed) {
+            this.collapsedGroups = this.getAllGroupTitles()
+        } else {
+            this.collapsedGroups = []
+        }
+    },
+
+    getAllGroupTitles() {
+        const groupTitles = []
+        
+        for (let groupHeader of this.$root?.getElementsByClassName('fi-ta-group-heading') ?? []) {
+            const title = groupHeader.textContent?.trim()
+            if (title) {
+                groupTitles.push(title)
+            }
+        }
+        
+        return groupTitles
     },
 
     watchForCheckboxClicks() {

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -113,6 +113,7 @@
                 canSelectMultipleRecords: @js($canSelectMultipleRecords),
                 canTrackDeselectedRecords: @js($canTrackDeselectedRecords()),
                 currentSelectionLivewireProperty: @js($getCurrentSelectionLivewireProperty()),
+                areAllGroupsCollapsed: @js($areAllGroupsCollapsed()),
                 $wire,
             })"
     @class([

--- a/packages/tables/src/Table/Concerns/CanGroupRecords.php
+++ b/packages/tables/src/Table/Concerns/CanGroupRecords.php
@@ -31,6 +31,8 @@ trait CanGroupRecords
 
     protected bool | Closure $isGroupingDirectionSettingHidden = false;
 
+    protected bool | Closure $areAllGroupsCollapsed = false;
+
     protected ?Closure $modifyGroupRecordsTriggerActionUsing = null;
 
     public function groupRecordsTriggerAction(?Closure $callback): static
@@ -67,6 +69,17 @@ trait CanGroupRecords
     public function groupingDirectionSettingHidden(bool | Closure $condition = true): static
     {
         $this->isGroupingDirectionSettingHidden = $condition;
+
+        return $this;
+    }
+
+    public function allGroupsCollapsed(bool | Closure $condition = true): static
+    {
+        $this->areAllGroupsCollapsed = $condition;
+
+        if ($condition) {
+            array_map(fn (Group $group) => $group->collapsible(), $this->getGroups());
+        }
 
         return $this;
     }
@@ -142,6 +155,11 @@ trait CanGroupRecords
     public function isGroupingDirectionSettingHidden(): bool
     {
         return (bool) $this->evaluate($this->isGroupingDirectionSettingHidden);
+    }
+
+    public function areAllGroupsCollapsed(): bool
+    {
+        return (bool) $this->evaluate($this->areAllGroupsCollapsed);
     }
 
     public function getDefaultGroup(): ?Group

--- a/tests/src/Fixtures/Livewire/PostsTable.php
+++ b/tests/src/Fixtures/Livewire/PostsTable.php
@@ -40,8 +40,10 @@ class PostsTable extends Component implements HasActions, HasSchemas, Tables\Con
             ->query(Post::query())
             ->groups(fn () => [
                 Tables\Grouping\Group::make('author.name')
-                    ->label(fn (Table $table, self $livewire) => 'Dynamic label'),
+                    ->label(fn (Table $table, self $livewire) => 'Dynamic label')
+                    ->collapsible(),
             ])
+            ->allGroupsCollapsed()
             ->columns([
                 Tables\Columns\TextColumn::make('title')
                     ->sortable()

--- a/tests/src/Tables/GroupingTest.php
+++ b/tests/src/Tables/GroupingTest.php
@@ -41,3 +41,30 @@ it('can group a table', function (): void {
                 ->getLabel()->toBe('Dynamic label');
         });
 });
+
+it('can collapse all groups by default', function (): void {
+    $posts = Post::factory()->count(20)->create();
+
+    livewire(PostsTable::class)
+        ->tap(function (Testable $testable): void {
+            /** @var PostsTable $livewire */
+            $livewire = $testable->instance();
+
+            $table = $livewire->getTable();
+
+            expect($table)
+                ->areAllGroupsCollapsed()->toBeTrue();
+        })
+        ->set('tableGrouping', 'author.name')
+        ->tap(function (Testable $testable): void {
+            /** @var PostsTable $livewire */
+            $livewire = $testable->instance();
+
+            $table = $livewire->getTable();
+
+            expect($table)
+                ->getGrouping()->toBeInstanceOf(Tables\Grouping\Group::class)
+                ->and($table->getGrouping())
+                ->isCollapsible()->toBeTrue();
+        });
+});


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Allow table to collapsing all groups by default

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
