### PR TITLE
[4.x] fix: show all password strength validation errors instead of just one

### DIFF
--- a/packages/forms/src/Components/RichEditor/StateCasts/RichEditorStateCast.php
+++ b/packages/forms/src/Components/RichEditor/StateCasts/RichEditorStateCast.php
@@ -59,6 +59,9 @@ class RichEditorStateCast implements StateCast
      */
     public function set(mixed $state): array
     {
+        if (is_array($state) && array_is_list($state)) {
+            $state = reset($state);
+        }
         $editor = $this->richEditor->getTipTapEditor()
             ->setContent($state ?? [
                 'type' => 'doc',

--- a/packages/panels/src/Auth/Pages/Register.php
+++ b/packages/panels/src/Auth/Pages/Register.php
@@ -10,6 +10,7 @@ use Filament\Actions\ActionGroup;
 use Filament\Auth\Events\Registered;
 use Filament\Auth\Http\Responses\Contracts\RegistrationResponse;
 use Filament\Auth\Notifications\VerifyEmail;
+use Filament\Auth\Rules\PasswordStrength;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
@@ -191,7 +192,13 @@ class Register extends SimplePage
             ->password()
             ->revealable(filament()->arePasswordsRevealable())
             ->required()
-            ->rule(Password::default())
+            ->rule(PasswordStrength::make()
+                ->min(8)
+                ->letters()
+                ->numbers()
+                ->symbols()
+                ->mixedCase()
+            )
             ->dehydrateStateUsing(fn ($state) => Hash::make($state))
             ->same('passwordConfirmation')
             ->validationAttribute(__('filament-panels::auth/pages/register.form.password.validation_attribute'));

--- a/packages/panels/src/Auth/Rules/PasswordStrength.php
+++ b/packages/panels/src/Auth/Rules/PasswordStrength.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Filament\Auth\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class PasswordStrength implements ValidationRule
+{
+    protected array $failedRules = [];
+    protected int $min;
+    protected bool $letters;
+    protected bool $numbers;
+    protected bool $symbols;
+    protected bool $mixedCase;
+
+    protected function __construct() { }
+
+    public static function make(): static
+    {
+        $instance = new static();
+
+        $instance->min = 8;
+        $instance->letters = true;
+        $instance->numbers = true;
+        $instance->symbols = true;
+        $instance->mixedCase = true;
+
+        return $instance;
+    }
+
+    public function min(int $length): static
+    {
+        $this->min = $length;
+        return $this;
+    }
+
+    public function letters(bool $enable = true): static
+    {
+        $this->letters = $enable;
+        return $this;
+    }
+
+    public function numbers(bool $enable = true): static
+    {
+        $this->numbers = $enable;
+        return $this;
+    }
+
+    public function symbols(bool $enable = true): static
+    {
+        $this->symbols = $enable;
+        return $this;
+    }
+
+    public function mixedCase(bool $enable = true): static
+    {
+        $this->mixedCase = $enable;
+        return $this;
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $this->failedRules = [];
+
+        if (!is_string($value)) {
+            $fail(__('The :attribute must be a string.', ['attribute' => $attribute]));
+            return;
+        }
+
+        if (strlen($value) < $this->min) {
+            $this->failedRules[] = 'min_length';
+        }
+
+        if ($this->letters && !preg_match('/\pL/u', $value)) {
+            $this->failedRules[] = 'letters';
+        }
+
+        if ($this->numbers && !preg_match('/\pN/u', $value)) {
+            $this->failedRules[] = 'numbers';
+        }
+
+        if ($this->symbols && !preg_match('/\p{S}|\p{P}|\p{Z}/u', $value)) {
+            $this->failedRules[] = 'symbols';
+        }
+
+        if ($this->mixedCase && !preg_match('/[a-z]/', $value) || !preg_match('/[A-Z]/', $value)) {
+            $this->failedRules[] = 'mixed_case';
+        }
+
+        if (!empty($this->failedRules)) {
+            $fail($this->constructMessage());
+        }
+    }
+
+    protected function constructMessage(): string
+    {
+        $parts = [];
+
+        foreach ($this->failedRules as $rule) {
+            $parts[] = match ($rule) {
+                'min_length' => __('at least :min characters', ['min' => $this->min]),
+                'letters' => __('at least one letter'),
+                'numbers' => __('at least one number'),
+                'symbols' => __('at least one symbol'),
+                'mixed_case' => __('at least one uppercase and one lowercase letter'),
+                default => null,
+            };
+        }
+
+        if (count($parts) === 1) {
+            return __('The password must contain :requirement.', ['requirement' => $parts[0]]);
+        }
+
+        $last = array_pop($parts);
+        return __('The password must contain :requirements, and :last.', [
+            'requirements' => implode(', ', $parts),
+            'last' => $last
+        ]);
+    }
+}

--- a/tests/src/Panels/Auth/RegisterTest.php
+++ b/tests/src/Panels/Auth/RegisterTest.php
@@ -44,8 +44,8 @@ it('can register', function (): void {
         ->fillForm([
             'name' => $userToRegister->name,
             'email' => $userToRegister->email,
-            'password' => 'password',
-            'passwordConfirmation' => 'password',
+            'password' => 'Str0ng!Pass123',
+            'passwordConfirmation' => 'Str0ng!Pass123',
         ])
         ->call('register')
         ->assertRedirect(Filament::getUrl());
@@ -57,7 +57,7 @@ it('can register', function (): void {
 
     $this->assertCredentials([
         'email' => $userToRegister->email,
-        'password' => 'password',
+        'password' => 'Str0ng!Pass123',
     ]);
 });
 
@@ -75,8 +75,8 @@ it('can register and redirect user to their intended URL', function (): void {
         ->fillForm([
             'name' => $userToRegister->name,
             'email' => $userToRegister->email,
-            'password' => 'password',
-            'passwordConfirmation' => 'password',
+            'password' => 'Str0ng!Pass123',
+            'passwordConfirmation' => 'Str0ng!Pass123',
         ])
         ->call('register')
         ->assertRedirect($intendedUrl);
@@ -95,8 +95,8 @@ it('can throttle registration attempts', function (): void {
             ->fillForm([
                 'name' => $userToRegister->name,
                 'email' => $userToRegister->email,
-                'password' => 'password',
-                'passwordConfirmation' => 'password',
+                'password' => 'Str0ng!Pass123',
+                'passwordConfirmation' => 'Str0ng!Pass123',
             ])
             ->call('register')
             ->assertRedirect(Filament::getUrl());
@@ -131,6 +131,18 @@ it('can validate `name` is required', function (): void {
         ->fillForm(['name' => ''])
         ->call('register')
         ->assertHasFormErrors(['name' => ['required']]);
+});
+
+it('can validate weak password fails with multiple messages', function (): void {
+    livewire(Register::class)
+        ->fillForm([
+            'name' => 'Test User',
+            'email' => 'weak@example.com',
+            'password' => 'weak',  
+            'passwordConfirmation' => 'weak',
+        ])
+        ->call('register')
+        ->assertHasFormErrors(['password']);
 });
 
 it('can validate `name` is max 255 characters', function (): void {


### PR DESCRIPTION
## Description

Fixed https://github.com/filamentphp/filament/issues/16243

## Visual changes

![Screenshot 2025-06-28 at 11 32 04 AM](https://github.com/user-attachments/assets/d3a8f882-1af0-4a70-804b-fa56b5d87e86)


