### PR TITLE
feat: Change create another label easily

### DIFF
--- a/docs/03-resources/03-creating-records.md
+++ b/docs/03-resources/03-creating-records.md
@@ -113,7 +113,7 @@ protected function getCreatedNotification(): ?Notification
 
 ## Creating another record
 
-### Modify create another action
+### Modifying the create another action
 
 If you'd like to modify the "create another" action, you can use the `createAnotherAction()` method:
 

--- a/docs/03-resources/03-creating-records.md
+++ b/docs/03-resources/03-creating-records.md
@@ -113,6 +113,17 @@ protected function getCreatedNotification(): ?Notification
 
 ## Creating another record
 
+### Change create another label
+
+If you'd like to change the "create another" label, you can use the `createAnotherLabel()` method:
+
+```php
+use Filament\Actions\CreateAction;
+
+CreateAction::make()
+    ->createAnotherLabel('Custom create another label')
+```
+
 ### Disabling create another
 
 To disable the "create and create another" feature, define the `$canCreateAnother` property as `false` on the Create page class:

--- a/docs/03-resources/03-creating-records.md
+++ b/docs/03-resources/03-creating-records.md
@@ -113,15 +113,15 @@ protected function getCreatedNotification(): ?Notification
 
 ## Creating another record
 
-### Change create another label
+### Modify create another action
 
-If you'd like to change the "create another" label, you can use the `createAnotherLabel()` method:
+If you'd like to modify the "create another" action, you can use the `createAnotherAction()` method:
 
 ```php
 use Filament\Actions\CreateAction;
 
 CreateAction::make()
-    ->createAnotherLabel('Custom create another label')
+    ->createAnotherAction(fn (Action $action): Action => $aciton->label('Custom create another label'))
 ```
 
 ### Disabling create another

--- a/docs/03-resources/03-creating-records.md
+++ b/docs/03-resources/03-creating-records.md
@@ -113,17 +113,6 @@ protected function getCreatedNotification(): ?Notification
 
 ## Creating another record
 
-### Modifying the create another action
-
-If you'd like to modify the "create another" action, you can use the `createAnotherAction()` method:
-
-```php
-use Filament\Actions\CreateAction;
-
-CreateAction::make()
-    ->createAnotherAction(fn (Action $action): Action => $aciton->label('Custom create another label'))
-```
-
 ### Disabling create another
 
 To disable the "create and create another" feature, define the `$canCreateAnother` property as `false` on the Create page class:

--- a/packages/actions/docs/04-create.md
+++ b/packages/actions/docs/04-create.md
@@ -246,15 +246,15 @@ CreateAction::make()
 
 ## Creating another record
 
-### Change create another label
+### Modify create another action
 
-If you'd like to change the "create another" label, you can use the `createAnotherLabel()` method:
+If you'd like to modify the "create another" action, you can use the `createAnotherAction()` method:
 
 ```php
 use Filament\Actions\CreateAction;
 
 CreateAction::make()
-    ->createAnotherLabel('Custom create another label')
+    ->createAnotherAction(fn (Action $action): Action => $aciton->label('Custom create another label'))
 ```
 
 ### Disabling create another

--- a/packages/actions/docs/04-create.md
+++ b/packages/actions/docs/04-create.md
@@ -248,7 +248,7 @@ CreateAction::make()
 
 ### Modify create another action
 
-If you'd like to modify the "create another" action, you can use the `createAnotherAction()` method:
+If you'd like to modify the "create another" action, you may use the `createAnotherAction()` method, passing a closure that returns an action. All methods that are available to [customize action trigger buttons](overview) can be used:
 
 ```php
 use Filament\Actions\CreateAction;

--- a/packages/actions/docs/04-create.md
+++ b/packages/actions/docs/04-create.md
@@ -246,7 +246,7 @@ CreateAction::make()
 
 ## Creating another record
 
-### Modify create another action
+### Modifying the create another action
 
 If you'd like to modify the "create another" action, you may use the `createAnotherAction()` method, passing a closure that returns an action. All methods that are available to [customize action trigger buttons](overview) can be used:
 

--- a/packages/actions/docs/04-create.md
+++ b/packages/actions/docs/04-create.md
@@ -246,6 +246,17 @@ CreateAction::make()
 
 ## Creating another record
 
+### Change create another label
+
+If you'd like to change the "create another" label, you can use the `createAnotherLabel()` method:
+
+```php
+use Filament\Actions\CreateAction;
+
+CreateAction::make()
+    ->createAnotherLabel('Custom create another label')
+```
+
 ### Disabling create another
 
 If you'd like to remove the "create another" button from the modal, you can use the `createAnother(false)` method:

--- a/packages/actions/docs/04-create.md
+++ b/packages/actions/docs/04-create.md
@@ -248,7 +248,7 @@ CreateAction::make()
 
 ### Modifying the create another action
 
-If you'd like to modify the "create another" action, you may use the `createAnotherAction()` method, passing a closure that returns an action. All methods that are available to [customize action trigger buttons](overview) can be used:
+If you'd like to modify the "create another" action, you may use the `createAnotherAction()` method, passing a function that returns an action. All methods that are available to [customize action trigger buttons](overview) can be used:
 
 ```php
 use Filament\Actions\CreateAction;

--- a/packages/actions/src/CreateAction.php
+++ b/packages/actions/src/CreateAction.php
@@ -171,9 +171,9 @@ class CreateAction extends Action
         return (bool) $this->evaluate($this->canCreateAnother);
     }
 
-    public function createAnotherAction(Closure $createAnotherUsing): static
+    public function createAnotherAction(Closure $callback): static
     {
-        $this->modifyCreateAnotherActionUsing = $createAnotherUsing;
+        $this->modifyCreateAnotherActionUsing = $callback;
 
         return $this;
     }

--- a/packages/actions/src/CreateAction.php
+++ b/packages/actions/src/CreateAction.php
@@ -9,6 +9,7 @@ use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use Filament\Support\Facades\FilamentIcon;
 use Filament\Support\Icons\Heroicon;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -21,6 +22,8 @@ class CreateAction extends Action
     use CanCustomizeProcess;
 
     protected bool | Closure $canCreateAnother = true;
+
+    protected string | Htmlable | Closure | null $createAnotherLabel = null;
 
     protected ?Closure $preserveFormDataWhenCreatingAnotherUsing = null;
 
@@ -44,7 +47,7 @@ class CreateAction extends Action
         $this->extraModalFooterActions(function (): array {
             return $this->canCreateAnother() ? [
                 $this->makeModalSubmitAction('createAnother', arguments: ['another' => true])
-                    ->label(__('filament-actions::create.single.modal.actions.create_another.label')),
+                    ->label($this->getCreateAnotherLabel()),
             ] : [];
         });
 
@@ -170,6 +173,18 @@ class CreateAction extends Action
     public function canCreateAnother(): bool
     {
         return (bool) $this->evaluate($this->canCreateAnother);
+    }
+
+    public function createAnotherLabel(string | Htmlable | Closure | null $label): static
+    {
+        $this->createAnotherLabel = $label;
+
+        return $this;
+    }
+
+    public function getCreateAnotherLabel(): string
+    {
+        return $this->evaluate($this->createAnotherLabel) ?? __('filament-actions::create.single.modal.actions.create_another.label');
     }
 
     public function shouldClearRecordAfter(): bool


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

Previously, customizing the "Create Another" button label required redeclaring the entire `extraModalFooterActions`
```php
->headerActions([
    $createAction = CreateAction::make()
        ->extraModalFooterActions(function () use (&$createAction) {
            return [
                $createAction->makeModalSubmitAction('createAnother', ['another' => true])
                    ->label('Custom create another label'),
            ];
        })
])
```

This PR introduces a more concise and expressive approach to achieve the same result:
```php
->headerActions([
    CreateAction::make()
        ->createAnotherLabel('Custom create another label')
])
```

## Visual changes

None

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
