### PR TITLE
Fixes: Typed property Filament\Support\Assets\Asset::$package must not be accessed before initialization

### DIFF
--- a/packages/support/src/Assets/Asset.php
+++ b/packages/support/src/Assets/Asset.php
@@ -48,7 +48,7 @@ abstract class Asset
 
     public function getPackage(): string
     {
-        return $this->package;
+        return $this->package ?? '';
     }
 
     public function getPath(): ?string


### PR DESCRIPTION
# Description

Fixes the error: Typed property Filament\Support\Assets\Asset::$package must not be accessed before initialization

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
