### PR TITLE
Add PHP8.4 to test workflows

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.3, 8.2]
+        php: [8.4, 8.3, 8.2]
         laravel: [12.*, 11.*]
         dependency-version: [prefer-stable]
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.3, 8.2]
+        php: [8.4, 8.3, 8.2]
         laravel: [12.*, 11.*]
         dependency-version: [prefer-stable]
         include:

--- a/packages/schemas/src/Components/Concerns/HasState.php
+++ b/packages/schemas/src/Components/Concerns/HasState.php
@@ -806,6 +806,7 @@ trait HasState
 
     protected function flushCachedAbsoluteStatePath(): void
     {
+        /** @phpstan-ignore unset.possiblyHookedProperty */
         unset($this->cachedAbsoluteStatePath);
     }
 

--- a/packages/schemas/src/Concerns/HasState.php
+++ b/packages/schemas/src/Concerns/HasState.php
@@ -469,6 +469,7 @@ trait HasState
 
     protected function flushCachedAbsoluteStatePath(): void
     {
+        /** @phpstan-ignore unset.possiblyHookedProperty */
         unset($this->cachedAbsoluteStatePath);
     }
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

With reference to [discussion 15388](https://github.com/filamentphp/filament/discussions/15388), this PR adds v8.4 to the php matrix for both the `tests` and `phpstan` GitHub workflows.

No code changes were needed for tests to pass. Two ignores were needed for phpstan.

I don't think the docs require updating unless support for PHP8.4 should be explicit rather than implied.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
