### PR TITLE
Doc: Fix typo in method name

### DIFF
--- a/docs/06-navigation/02-custom-pages.md
+++ b/docs/06-navigation/02-custom-pages.md
@@ -155,7 +155,7 @@ This pairs well with [responsive widget widths](dashboard#responsive-widget-widt
 
 #### Passing data to widgets from the page
 
-You may pass data to widgets from the page using the `getWidgetsData()` method:
+You may pass data to widgets from the page using the `getWidgetData()` method:
 
 ```php
 public function getWidgetData(): array


### PR DESCRIPTION
The method name should be getWidgetData() instead of getWidgetsData().

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
