### PR TITLE
[4.x] fix: ensure $format defaults to null in iso*Tooltip methods

### DIFF
--- a/packages/infolists/src/Components/Concerns/CanFormatState.php
+++ b/packages/infolists/src/Components/Concerns/CanFormatState.php
@@ -176,8 +176,10 @@ trait CanFormatState
         return $this;
     }
 
-    public function isoDateTooltip(string | Closure | null $format, string | Closure | null $timezone = null): static
+    public function isoDateTooltip(string | Closure | null $format = null, string | Closure | null $timezone = null): static
     {
+        $format ??= fn (TextEntry $component): string => $component->getContainer()->getDefaultIsoDateDisplayFormat();
+
         $this->tooltip(static function (TextEntry $component, mixed $state) use ($format, $timezone): ?string {
             if (blank($state)) {
                 return null;
@@ -191,7 +193,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function isoDateTimeTooltip(string | Closure | null $format, string | Closure | null $timezone = null): static
+    public function isoDateTimeTooltip(string | Closure | null $format = null, string | Closure | null $timezone = null): static
     {
         $format ??= fn (TextEntry $component): string => $component->getContainer()->getDefaultIsoDateTimeDisplayFormat();
 
@@ -200,7 +202,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function isoTimeTooltip(string | Closure | null $format, string | Closure | null $timezone = null): static
+    public function isoTimeTooltip(string | Closure | null $format = null, string | Closure | null $timezone = null): static
     {
         $format ??= fn (TextEntry $component): string => $component->getContainer()->getDefaultIsoTimeDisplayFormat();
 

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -176,8 +176,10 @@ trait CanFormatState
         return $this;
     }
 
-    public function isoDateTooltip(string | Closure | null $format, string | Closure | null $timezone = null): static
+    public function isoDateTooltip(string | Closure | null $format = null, string | Closure | null $timezone = null): static
     {
+        $format ??= fn (TextColumn $column): string => $column->getTable()->getDefaultIsoDateDisplayFormat();
+
         $this->tooltip(static function (TextColumn $column, mixed $state) use ($format, $timezone): ?string {
             if (blank($state)) {
                 return null;
@@ -191,7 +193,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function isoDateTimeTooltip(string | Closure | null $format, string | Closure | null $timezone = null): static
+    public function isoDateTimeTooltip(string | Closure | null $format = null, string | Closure | null $timezone = null): static
     {
         $format ??= fn (TextColumn $column): string => $column->getTable()->getDefaultIsoDateTimeDisplayFormat();
 
@@ -200,7 +202,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function isoTimeTooltip(string | Closure | null $format, string | Closure | null $timezone = null): static
+    public function isoTimeTooltip(string | Closure | null $format = null, string | Closure | null $timezone = null): static
     {
         $format ??= fn (TextColumn $column): string => $column->getTable()->getDefaultIsoTimeDisplayFormat();
 


### PR DESCRIPTION
## Description

This pull request addresses a missing default value for the $format parameter in the following methods:

- isoDateTooltip
- isoDateTimeTooltip
- isoTimeTooltip

These methods are designed to use a fallback format when no $format is provided (i.e., when $format is null). However, until now, the $format parameter did not have a default value, which meant that calling these methods without explicitly passing a format would result in an ArgumentCountError.

This PR sets the default value of $format to null to align the implementation with the intended behavior.

## Visual changes

There are no visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
