### PR TITLE
Fix Render hooks links in docs

### DIFF
--- a/docs/05-panel-configuration.md
+++ b/docs/05-panel-configuration.md
@@ -65,7 +65,7 @@ Make sure your `routes/web.php` file doesn't already define the `''` or `'/'` ro
 
 ## Render hooks
 
-[Render hooks](../advanced/render-hooks) allow you to render Blade content at various points in the framework views. You can [register global render hooks](../support/render-hooks#registering-render-hooks) in a service provider or middleware, but it also allows you to register render hooks that are specific to a panel. To do that, you can use the `renderHook()` method on the panel configuration object. Here's an example, integrating [`wire-elements/modal`](https://github.com/wire-elements/modal) with Filament:
+[Render hooks](advanced/render-hooks) allow you to render Blade content at various points in the framework views. You can [register global render hooks](advanced/render-hooks#registering-render-hooks) in a service provider or middleware, but it also allows you to register render hooks that are specific to a panel. To do that, you can use the `renderHook()` method on the panel configuration object. Here's an example, integrating [`wire-elements/modal`](https://github.com/wire-elements/modal) with Filament:
 
 ```php
 use Filament\Panel;
@@ -83,7 +83,7 @@ public function panel(Panel $panel): Panel
 }
 ```
 
-A full list of available render hooks can be found [here](../advanced/render-hooks#available-render-hooks).
+A full list of available render hooks can be found [here](advanced/render-hooks#available-render-hooks).
 
 ## Setting a domain
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Fix the three render hooks links in the V4 docs. Currently they are not working which results in a redirect to the V3 docs.

## Visual changes
No visual changes

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
