### PR TITLE
Fix handling of single vs multiple file uploads in SpatieMediaLibrary…

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -32,7 +32,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
      * @var array<string, mixed> | Closure | null
      */
     protected array | Closure | null $customHeaders = null;
-
+    
     /**
      * @var array<string, mixed> | Closure | null
      */
@@ -42,7 +42,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
      * @var array<string, array<string, string>> | Closure | null
      */
     protected array | Closure | null $manipulations = null;
-
+    
     /**
      * @var array<string, mixed> | Closure | null
      */
@@ -54,26 +54,32 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
         $this->loadStateFromRelationshipsUsing(static function (SpatieMediaLibraryFileUpload $component, HasMedia $record): void {
             /** @var Model&HasMedia $record */
-            $media = $record->load('media')->getMedia($component->getCollection() ?? 'default')
+            $mediaItems = $record->load('media')->getMedia($component->getCollection() ?? 'default')
                 ->when(
                     $component->hasMediaFilter(),
                     fn (Collection $media) => $component->filterMedia($media)
-                )
-                ->when(
-                    ! $component->isMultiple(),
-                    fn (Collection $media): Collection => $media->take(1),
-                )
-                ->mapWithKeys(function (Media $media): array {
-                    $uuid = $media->getAttributeValue('uuid');
+                );
 
-                    return [$uuid => $uuid];
-                })
+            if (! $component->isMultiple()) {
+                $mediaItems = $mediaItems->take(1);
+            }
+
+            $uuids = $mediaItems
+                ->mapWithKeys(fn (Media $media) => [$media->uuid => $media->uuid])
                 ->toArray();
 
-            $component->state($media);
+            $component->state($uuids);
         });
 
-        $this->afterStateHydrated(null);
+        $this->afterStateHydrated(static function (SpatieMediaLibraryFileUpload $component, string|array|null $state): void {
+            if (is_array($state)) return;
+
+            if (is_string($state)) {
+                $component->state([$state => $state]);
+            } else {
+                $component->state([]);
+            }
+        });
 
         $this->beforeStateDehydrated(null);
 
@@ -86,27 +92,28 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
             /** @var ?Media $media */
             $media = $component->getRecord()->getRelationValue('media')->firstWhere('uuid', $file);
+            if (! $media) return null;
 
             $url = null;
 
             if ($component->getVisibility() === 'private') {
-                $conversion = $component->getConversion();
-
                 try {
-                    $url = $media?->getTemporaryUrl(
+                    $url = $media->getTemporaryUrl(
                         now()->addMinutes(30)->endOfHour(),
-                        (filled($conversion) && $media->hasGeneratedConversion($conversion)) ? $conversion : '',
+                        $component->getConversion() && $media->hasGeneratedConversion($component->getConversion())
+                            ? $component->getConversion()
+                            : ''
                     );
                 } catch (Throwable $exception) {
                     // This driver does not support creating temporary URLs.
                 }
             }
 
-            if ($component->getConversion() && $media?->hasGeneratedConversion($component->getConversion())) {
-                $url ??= $media->getUrl($component->getConversion());
+            if (! $url && $component->getConversion() && $media->hasGeneratedConversion($component->getConversion())) {
+                $url = $media->getUrl($component->getConversion());
             }
 
-            $url ??= $media?->getUrl();
+            $url ??= $media->getUrl();
 
             return [
                 'name' => $media?->getAttributeValue('name') ?? $media?->getAttributeValue('file_name'),
@@ -150,7 +157,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
                 ->withProperties($component->getProperties())
                 ->toMediaCollection($component->getCollection() ?? 'default', $component->getDiskName());
 
-            return $media->getAttributeValue('uuid');
+                return $media->getAttributeValue('uuid');
         });
 
         $this->reorderUploadedFilesUsing(static function (SpatieMediaLibraryFileUpload $component, ?Model $record, array $state): array {
@@ -190,7 +197,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
         return $this;
     }
-
+    
     /**
      * @param  array<string, mixed> | Closure | null  $headers
      */
@@ -217,7 +224,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
     public function manipulations(array | Closure | null $manipulations): static
     {
         $this->manipulations = $manipulations;
-
+       
         return $this;
     }
 
@@ -227,14 +234,14 @@ class SpatieMediaLibraryFileUpload extends FileUpload
     public function properties(array | Closure | null $properties): static
     {
         $this->properties = $properties;
-
+       
         return $this;
     }
 
     public function responsiveImages(bool | Closure $condition = true): static
     {
         $this->hasResponsiveImages = $condition;
-
+       
         return $this;
     }
 
@@ -242,11 +249,13 @@ class SpatieMediaLibraryFileUpload extends FileUpload
     {
         /** @var Model&HasMedia $record */
         $record = $this->getRecord();
+        $state = $this->getState();
+        $uuids = is_array($state) ? array_keys($state) : [];
 
         $record
             ->getMedia($this->getCollection() ?? 'default')
-            ->whereNotIn('uuid', array_keys($this->getRawState() ?? []))
-            ->when($this->hasMediaFilter(), fn (Collection $media): Collection => $this->filterMedia($media))
+            ->whereNotIn('uuid', $uuids)
+            ->when($this->hasMediaFilter(), fn (Collection $media) => $this->filterMedia($media))
             ->each(fn (Media $media) => $media->delete());
     }
 
@@ -258,17 +267,13 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
         /** @var Model&HasMedia $model */
         $model = $this->getModelInstance();
-
+        
         $collection = $this->getCollection() ?? 'default';
 
-        /** @phpstan-ignore-next-line */
-        $diskNameFromRegisteredConversions = $model
+        return $model
             ->getRegisteredMediaCollections()
-            ->filter(fn (MediaCollection $mediaCollection): bool => $mediaCollection->name === $collection)
-            ->first()
-            ?->diskName;
-
-        return $diskNameFromRegisteredConversions ?? config('filament.default_filesystem_disk');
+            ->firstWhere('name', $collection)
+            ?->diskName ?? config('filament.default_filesystem_disk');
     }
 
     public function getCollection(): ?string
@@ -326,7 +331,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
     public function mediaName(string | Closure | null $name): static
     {
         $this->mediaName = $name;
-
+       
         return $this;
     }
 

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -18,35 +18,42 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 {
     use HasMediaFilter;
 
-    protected string | Closure | null $collection = null;
+    protected string|Closure|null $collection = null;
 
-    protected string | Closure | null $conversion = null;
+    protected string|Closure|null $conversion = null;
 
-    protected string | Closure | null $conversionsDisk = null;
+    protected string|Closure|null $conversionsDisk = null;
 
-    protected bool | Closure $hasResponsiveImages = false;
+    protected bool|Closure $hasResponsiveImages = false;
 
-    protected string | Closure | null $mediaName = null;
-
-    /**
-     * @var array<string, mixed> | Closure | null
-     */
-    protected array | Closure | null $customHeaders = null;
-    
-    /**
-     * @var array<string, mixed> | Closure | null
-     */
-    protected array | Closure | null $customProperties = null;
+    protected bool $originalStateLoaded = false;
 
     /**
-     * @var array<string, array<string, string>> | Closure | null
+     * @var array<string, string> The UUIDs of media items initially loaded
      */
-    protected array | Closure | null $manipulations = null;
-    
+    protected array $originalState = [];
+
+    protected string|Closure|null $mediaName = null;
+
     /**
-     * @var array<string, mixed> | Closure | null
+     * @var array<string, mixed>|Closure|null
      */
-    protected array | Closure | null $properties = null;
+    protected array|Closure|null $customHeaders = null;
+
+    /**
+     * @var array<string, mixed>|Closure|null
+     */
+    protected array|Closure|null $customProperties = null;
+
+    /**
+     * @var array<string, array<string, string>>|Closure|null
+     */
+    protected array|Closure|null $manipulations = null;
+
+    /**
+     * @var array<string, mixed>|Closure|null
+     */
+    protected array|Closure|null $properties = null;
 
     protected function setUp(): void
     {
@@ -69,12 +76,32 @@ class SpatieMediaLibraryFileUpload extends FileUpload
                 ->toArray();
 
             $component->state($uuids);
+            $component->originalState = $uuids;
+            $component->originalStateLoaded = true;
         });
 
         $this->afterStateHydrated(static function (SpatieMediaLibraryFileUpload $component, string|array|null $state): void {
-            if (is_array($state)) return;
+            if (is_array($state) && ! empty($state)) {
+                return;
+            }
 
-            if (is_string($state)) {
+            if ($record = $component->getRecord()) {
+                $mediaItems = $record->getMedia($component->getCollection() ?? 'default')
+                    ->when(
+                        $component->hasMediaFilter(),
+                        fn (Collection $media) => $component->filterMedia($media)
+                    );
+
+                if (! $component->isMultiple()) {
+                    $mediaItems = $mediaItems->take(1);
+                }
+
+                $uuids = $mediaItems
+                    ->mapWithKeys(fn (Media $media) => [$media->uuid => $media->uuid])
+                    ->toArray();
+
+                $component->state($uuids);
+            } elseif (is_string($state)) {
                 $component->state([$state => $state]);
             } else {
                 $component->state([]);
@@ -92,7 +119,9 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
             /** @var ?Media $media */
             $media = $component->getRecord()->getRelationValue('media')->firstWhere('uuid', $file);
-            if (! $media) return null;
+            if (! $media) {
+                return null;
+            }
 
             $url = null;
 
@@ -104,7 +133,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
                             ? $component->getConversion()
                             : ''
                     );
-                } catch (Throwable $exception) {
+                } catch (Throwable) {
                     // This driver does not support creating temporary URLs.
                 }
             }
@@ -116,28 +145,44 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             $url ??= $media->getUrl();
 
             return [
-                'name' => $media?->getAttributeValue('name') ?? $media?->getAttributeValue('file_name'),
-                'size' => $media?->getAttributeValue('size'),
-                'type' => $media?->getAttributeValue('mime_type'),
+                'name' => $media->getAttributeValue('name') ?? $media->getAttributeValue('file_name'),
+                'size' => $media->getAttributeValue('size'),
+                'type' => $media->getAttributeValue('mime_type'),
                 'url' => $url,
             ];
         });
 
         $this->saveRelationshipsUsing(static function (SpatieMediaLibraryFileUpload $component): void {
-            $component->deleteAbandonedFiles();
+            /** @var Model&HasMedia $record */
+            $record = $component->getRecord();
+            $state = $component->getState();
+            $stateUuids = is_array($state) ? array_keys($state) : [];
+
+            $existingMediaUuids = $record
+                ->getMedia($component->getCollection() ?? 'default')
+                ->when($component->hasMediaFilter(), fn (Collection $media) => $component->filterMedia($media))
+                ->pluck('uuid')
+                ->toArray();
+
+            $hasChanges = array_diff($existingMediaUuids, $stateUuids) || array_diff($stateUuids, $existingMediaUuids);
+
+            if ($hasChanges) {
+                $component->deleteAbandonedFiles();
+            }
+
             $component->saveUploadedFiles();
         });
 
         $this->saveUploadedFileUsing(static function (SpatieMediaLibraryFileUpload $component, TemporaryUploadedFile $file, ?Model $record): ?string {
             if (! method_exists($record, 'addMediaFromString')) {
-                return $file;
+                return null;
             }
 
             try {
                 if (! $file->exists()) {
                     return null;
                 }
-            } catch (UnableToCheckFileExistence $exception) {
+            } catch (UnableToCheckFileExistence) {
                 return null;
             }
 
@@ -157,7 +202,17 @@ class SpatieMediaLibraryFileUpload extends FileUpload
                 ->withProperties($component->getProperties())
                 ->toMediaCollection($component->getCollection() ?? 'default', $component->getDiskName());
 
-                return $media->getAttributeValue('uuid');
+            $uuid = $media->uuid;
+
+            // Explicitly patch state to ensure it's updated properly
+            if ($component->isMultiple()) {
+                $current = $component->getState() ?? [];
+                $component->state([...$current, $uuid => $uuid]);
+            } else {
+                $component->state([$uuid => $uuid]);
+            }
+
+            return $uuid;
         });
 
         $this->reorderUploadedFilesUsing(static function (SpatieMediaLibraryFileUpload $component, ?Model $record, array $state): array {
@@ -177,31 +232,72 @@ class SpatieMediaLibraryFileUpload extends FileUpload
         });
     }
 
-    public function collection(string | Closure | null $collection): static
+    /**
+     * Determine if the component state has changes compared to the originally loaded state.
+     */
+    public function hasStateChanges(): bool
+    {
+        if (! $this->originalStateLoaded) {
+            return false;
+        }
+
+        $currentState = $this->getState();
+
+        return $this->originalState !== ($currentState ?? []);
+    }
+
+    /**
+     * Delete files that are no longer present in the current state.
+     */
+    public function deleteAbandonedFiles(): void
+    {
+        /** @var Model&HasMedia $record */
+        $record = $this->getRecord();
+        $state = $this->getState();
+
+        $existingMedia = $record->getMedia($this->getCollection() ?? 'default');
+
+        if ($this->hasMediaFilter()) {
+            $existingMedia = $this->filterMedia($existingMedia);
+        }
+
+        if (is_string($state)) {
+            $uuids = [$state];
+        } elseif (is_array($state)) {
+            $uuids = array_values($state);
+        } else {
+            $uuids = [];
+        }
+
+        $mediaToDelete = $existingMedia->whereNotIn('uuid', $uuids);
+        $mediaToDelete->each(fn (Media $media) => $media->delete());
+    }
+
+    public function collection(string|Closure|null $collection): static
     {
         $this->collection = $collection;
 
         return $this;
     }
 
-    public function conversion(string | Closure | null $conversion): static
+    public function conversion(string|Closure|null $conversion): static
     {
         $this->conversion = $conversion;
 
         return $this;
     }
 
-    public function conversionsDisk(string | Closure | null $disk): static
+    public function conversionsDisk(string|Closure|null $disk): static
     {
         $this->conversionsDisk = $disk;
 
         return $this;
     }
-    
+
     /**
-     * @param  array<string, mixed> | Closure | null  $headers
+     * @param  array<string, mixed>|Closure|null  $headers
      */
-    public function customHeaders(array | Closure | null $headers): static
+    public function customHeaders(array|Closure|null $headers): static
     {
         $this->customHeaders = $headers;
 
@@ -209,9 +305,9 @@ class SpatieMediaLibraryFileUpload extends FileUpload
     }
 
     /**
-     * @param  array<string, mixed> | Closure | null  $properties
+     * @param  array<string, mixed>|Closure|null  $properties
      */
-    public function customProperties(array | Closure | null $properties): static
+    public function customProperties(array|Closure|null $properties): static
     {
         $this->customProperties = $properties;
 
@@ -219,44 +315,44 @@ class SpatieMediaLibraryFileUpload extends FileUpload
     }
 
     /**
-     * @param  array<string, array<string, string>> | Closure | null  $manipulations
+     * @param  array<string, array<string, string>>|Closure|null  $manipulations
      */
-    public function manipulations(array | Closure | null $manipulations): static
+    public function manipulations(array|Closure|null $manipulations): static
     {
         $this->manipulations = $manipulations;
-       
+
         return $this;
     }
 
     /**
-     * @param  array<string, mixed> | Closure | null  $properties
+     * @param  array<string, mixed>|Closure|null  $properties
      */
-    public function properties(array | Closure | null $properties): static
+    public function properties(array|Closure|null $properties): static
     {
         $this->properties = $properties;
-       
+
         return $this;
     }
 
-    public function responsiveImages(bool | Closure $condition = true): static
+    public function responsiveImages(bool|Closure $condition = true): static
     {
         $this->hasResponsiveImages = $condition;
-       
+
         return $this;
     }
 
-    public function deleteAbandonedFiles(): void
+    public function mediaName(string|Closure|null $name): static
     {
-        /** @var Model&HasMedia $record */
-        $record = $this->getRecord();
-        $state = $this->getState();
-        $uuids = is_array($state) ? array_keys($state) : [];
+        $this->mediaName = $name;
 
-        $record
-            ->getMedia($this->getCollection() ?? 'default')
-            ->whereNotIn('uuid', $uuids)
-            ->when($this->hasMediaFilter(), fn (Collection $media) => $this->filterMedia($media))
-            ->each(fn (Media $media) => $media->delete());
+        return $this;
+    }
+
+    public function getMediaName(TemporaryUploadedFile $file): ?string
+    {
+        return $this->evaluate($this->mediaName, [
+            'file' => $file,
+        ]);
     }
 
     public function getDiskName(): string
@@ -267,11 +363,9 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
         /** @var Model&HasMedia $model */
         $model = $this->getModelInstance();
-        
         $collection = $this->getCollection() ?? 'default';
 
-        return $model
-            ->getRegisteredMediaCollections()
+        return $model->getRegisteredMediaCollections()
             ->firstWhere('name', $collection)
             ?->diskName ?? config('filament.default_filesystem_disk');
     }
@@ -326,19 +420,5 @@ class SpatieMediaLibraryFileUpload extends FileUpload
     public function hasResponsiveImages(): bool
     {
         return (bool) $this->evaluate($this->hasResponsiveImages);
-    }
-
-    public function mediaName(string | Closure | null $name): static
-    {
-        $this->mediaName = $name;
-       
-        return $this;
-    }
-
-    public function getMediaName(TemporaryUploadedFile $file): ?string
-    {
-        return $this->evaluate($this->mediaName, [
-            'file' => $file,
-        ]);
     }
 }


### PR DESCRIPTION
## ✅ Description

This PR fixes two critical issues in `SpatieMediaLibraryFileUpload` when used in **single file mode** (`->multiple(false)` or omitted) on **Filament v4.0.0-beta11**.

---

### 🐛 Issues Fixed

**1. Fatal type error during submission in single mode**  
Previously, the component attempted to apply `array_keys()` on a `TemporaryUploadedFile` or a string UUID, causing a fatal type error:

`array_keys(): Argument #1 ($array) must be of type array, Livewire\Features\SupportFileUploads\TemporaryUploadedFile given`

**2. Media deletion logic deleting files incorrectly or failing to delete**  
- When no changes were made to the upload field, existing media were still being deleted.
- When all files were removed in **single mode**, the `state` was a string or `null`, causing the deletion logic to early return.
- As a result, uploaded media either persisted incorrectly or were prematurely removed.

---

### 🔍 Issue Discovered During Usage

While using the patched component in a production application, it became clear that media files were being deleted even when no interaction occurred with the upload field.

✅ **The fix introduced in the second commit:**
- Added a `hasStateChanges()` method to detect actual state changes.
- Ensured `deleteAbandonedFiles()` only runs when a change is detected.
- Normalized the `state` value to handle both string and array formats reliably in both single and multiple modes.

---

### ✅ What this PR does

- ✅ Normalizes the component’s state to an array, even in single mode  
- ✅ Prevents `array_keys()` type errors  
- ✅ Prevents media deletion unless the state and DB media UUIDs differ  
- ✅ Ensures files are deleted properly when removed from the UI  
- ✅ Fully supports both single and multiple file uploads  
- ✅ Maintains backwards compatibility with current plugin usage  

Closes: #16775

---

## 🖼️ Visual Changes

There are no visual design changes, but:

- ✅ Files now render correctly in single file mode on edit pages  
- ✅ No error is thrown during form submit  
- ✅ Uploading and deletion works for both single and multiple configurations  

---

## ⚙️ Functional Changes

- [x] Fixes `array_keys()` type error in single file mode  
- [x] Normalizes state for consistent behavior in both modes  
- [x] Prevents incorrect media deletion when form is unchanged  
- [x] Ensures correct deletion when all files are removed  
- [x] Tested with standard `HasMedia` model and resource setup  

---

## 📦 Code Quality

- [ ] Code style has been fixed by running the `composer cs` command.  
- [x] Changes have been tested to not break existing functionality.  
- [ ] Documentation is up-to-date.  
