### PR TITLE
[4.x] Feat: Global configuration of ungrouped record actions

### DIFF
--- a/packages/tables/docs/04-actions.md
+++ b/packages/tables/docs/04-actions.md
@@ -82,9 +82,9 @@ public function table(Table $table): Table
 }
 ```
 
-### Global settings
+### Global record action settings
 
-To customize the default configuration used for ungrouped record actions, you can call the function `configureUngroupedRecordActionsUsing()` inside the static `configureUsing()` method of `Filament\Tables\Table` from the `boot()` method of a service provider.
+To customize the default configuration used for ungrouped record actions, you can use `configureUngroupedRecordActionsUsing()` from a [`Table::configureUsing()` function](overview#global-settings) in the `boot()` method of a service provider:
 
 ```php
 use Filament\Actions\Action;

--- a/packages/tables/docs/04-actions.md
+++ b/packages/tables/docs/04-actions.md
@@ -82,6 +82,20 @@ public function table(Table $table): Table
 }
 ```
 
+### Global settings
+
+To customize the default configuration used for ungrouped record actions, you can call the function `configureUngroupedRecordActionsUsing()` inside the static `configureUsing()` method of `Filament\Tables\Table` from the `boot()` method of a service provider.
+
+```php
+use Filament\Actions\Action;
+use Filament\Tables\Table;
+
+Table::configureUsing(function (Table $table): void {
+    $table
+        ->configureUngroupedRecordActionsUsing(fn (Action $action) => $action->iconButton());
+});
+```
+
 <AutoScreenshot name="tables/actions/before-cells" alt="Table with actions before cells" version="4.x" />
 
 ### Accessing the selected table rows

--- a/packages/tables/docs/04-actions.md
+++ b/packages/tables/docs/04-actions.md
@@ -84,7 +84,7 @@ public function table(Table $table): Table
 
 ### Global record action settings
 
-To customize the default configuration used for ungrouped record actions, you can use `configureUngroupedRecordActionsUsing()` from a [`Table::configureUsing()` function](overview#global-settings) in the `boot()` method of a service provider:
+To customize the default configuration used for ungrouped record actions, you can use `modifyUngroupedRecordActionsUsing()` from a [`Table::configureUsing()` function](overview#global-settings) in the `boot()` method of a service provider:
 
 ```php
 use Filament\Actions\Action;
@@ -92,7 +92,7 @@ use Filament\Tables\Table;
 
 Table::configureUsing(function (Table $table): void {
     $table
-        ->configureUngroupedRecordActionsUsing(fn (Action $action) => $action->iconButton());
+        ->modifyUngroupedRecordActionsUsing(fn (Action $action) => $action->iconButton());
 });
 ```
 

--- a/packages/tables/src/Table/Concerns/HasRecordActions.php
+++ b/packages/tables/src/Table/Concerns/HasRecordActions.php
@@ -237,9 +237,9 @@ trait HasRecordActions
         return $flatActions;
     }
 
-    public function configureUngroupedRecordActionsUsing(Closure $closure): static
+    public function configureUngroupedRecordActionsUsing(?Closure $callback = null): static
     {
-        $this->configureUngroupedRecordActionsUsing = $closure;
+        $this->configureUngroupedRecordActionsUsing = $callback;
 
         return $this;
     }

--- a/packages/tables/src/Table/Concerns/HasRecordActions.php
+++ b/packages/tables/src/Table/Concerns/HasRecordActions.php
@@ -24,7 +24,7 @@ trait HasRecordActions
 
     protected RecordActionsPosition | Closure | null $recordActionsPosition = null;
 
-    protected ?Closure $configureUngroupedRecordActionsUsing = null;
+    protected ?Closure $modifyUngroupedRecordActionsUsing = null;
 
     /**
      * @param  array<Action | ActionGroup> | ActionGroup  $actions
@@ -62,8 +62,8 @@ trait HasRecordActions
                 $action->defaultSize(Size::Small);
                 $action->defaultView($action::LINK_VIEW);
 
-                if ($this->configureUngroupedRecordActionsUsing) {
-                    $this->evaluate($this->configureUngroupedRecordActionsUsing, ['action' => $action]);
+                if ($this->modifyUngroupedRecordActionsUsing) {
+                    $this->evaluate($this->modifyUngroupedRecordActionsUsing, ['action' => $action]);
                 }
 
                 $this->cacheAction($action);
@@ -237,9 +237,9 @@ trait HasRecordActions
         return $flatActions;
     }
 
-    public function configureUngroupedRecordActionsUsing(?Closure $callback = null): static
+    public function modifyUngroupedRecordActionsUsing(?Closure $callback = null): static
     {
-        $this->configureUngroupedRecordActionsUsing = $callback;
+        $this->modifyUngroupedRecordActionsUsing = $callback;
 
         return $this;
     }

--- a/packages/tables/src/Table/Concerns/HasRecordActions.php
+++ b/packages/tables/src/Table/Concerns/HasRecordActions.php
@@ -24,6 +24,8 @@ trait HasRecordActions
 
     protected RecordActionsPosition | Closure | null $recordActionsPosition = null;
 
+    protected ?Closure $configureUngroupedRecordActionsUsing = null;
+
     /**
      * @param  array<Action | ActionGroup> | ActionGroup  $actions
      */
@@ -59,6 +61,10 @@ trait HasRecordActions
             } elseif ($action instanceof Action) {
                 $action->defaultSize(Size::Small);
                 $action->defaultView($action::LINK_VIEW);
+
+                if ($this->configureUngroupedRecordActionsUsing) {
+                    $this->evaluate($this->configureUngroupedRecordActionsUsing, ['action' => $action]);
+                }
 
                 $this->cacheAction($action);
             } else {
@@ -229,5 +235,12 @@ trait HasRecordActions
         }
 
         return $flatActions;
+    }
+
+    public function configureUngroupedRecordActionsUsing(Closure $closure): static
+    {
+        $this->configureUngroupedRecordActionsUsing = $closure;
+
+        return $this;
     }
 }


### PR DESCRIPTION
## Description

This PR adds the function `configureUngroupedRecordActionsUsing()` as suggested in #16693.
I am not sure whether this functionality should be mentioned in the docs, feel free to adapt it or leave it out.

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
