### PR TITLE
Add extra attributes to builder block's

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -1,7 +1,6 @@
 @php
     use Filament\Actions\Action;
     use Filament\Support\Enums\Alignment;
-    use Illuminate\View\ComponentAttributeBag;
 
     $fieldWrapperView = $getFieldWrapperView();
     $items = $getItems();
@@ -121,9 +120,7 @@
                         x-on:expand="isCollapsed = false"
                         x-sortable-item="{{ $itemKey }}"
                         {{
-                            \Filament\Support\prepare_inherited_attributes(
-                                new ComponentAttributeBag($item->getParentComponent()->getExtraAttributes())
-                            )
+                            $item->getParentComponent()->getExtraAttributes()
                                 ->class(['fi-fo-builder-item'])
                         }}
                         x-bind:class="{ 'fi-collapsed': isCollapsed }"

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -1,6 +1,7 @@
 @php
     use Filament\Actions\Action;
     use Filament\Support\Enums\Alignment;
+    use Illuminate\View\ComponentAttributeBag;
 
     $fieldWrapperView = $getFieldWrapperView();
     $items = $getItems();
@@ -119,7 +120,12 @@
                         x-on:builder-collapse.window="$event.detail === '{{ $statePath }}' && (isCollapsed = true)"
                         x-on:expand="isCollapsed = false"
                         x-sortable-item="{{ $itemKey }}"
-                        class="fi-fo-builder-item"
+                        {{
+                            \Filament\Support\prepare_inherited_attributes(
+                                new ComponentAttributeBag($item->getParentComponent()->getExtraAttributes())
+                            )
+                                ->class(['fi-fo-builder-item'])
+                        }}
                         x-bind:class="{ 'fi-collapsed': isCollapsed }"
                     >
                         @if ($reorderActionIsVisible || $moveUpActionIsVisible || $moveDownActionIsVisible || $hasBlockIcons || $hasBlockLabels || $editActionIsVisible || $cloneActionIsVisible || $deleteActionIsVisible || $isCollapsible || $visibleExtraItemActions)


### PR DESCRIPTION
## Description

Add the ability to use extra attributes in builder blocks. 

```php
Forms\Components\Builder\Block::make('one')
      ->extraAttributes(['class' => 'compact-builder'])
      ->schema([
          Forms\Components\RichEditor::make('one')
              ->hiddenLabel(),
      ]),
```

## Reason for change

Needed a way of customising individual blocks (too many borders when embeded inside repeater).  
<img width="1050" alt="Screenshot 2025-07-02 at 18 04 06" src="https://github.com/user-attachments/assets/076c475f-9382-4a1e-bc50-1a9ed9315c45" />

<img width="1050" alt="Screenshot 2025-07-02 at 18 04 26" src="https://github.com/user-attachments/assets/20fde506-260d-4802-819f-5d7e48d716a4" />


```css
.fi-fo-builder-item.compact-builder {
    .fi-fo-builder-item-content {
        padding: 0;
    }

    .fi-input-wrp {
        border: none;
        box-shadow: none;
        border-radius: 0 0 0.75rem 0.75rem;
    }
}
```

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
