### PR TITLE
[4.x] Support HTML output for option labels in ModalTableSelect

### DIFF
--- a/packages/forms/src/Components/ModalTableSelect.php
+++ b/packages/forms/src/Components/ModalTableSelect.php
@@ -173,7 +173,7 @@ class ModalTableSelect extends Field
         return $this;
     }
 
-    public function getOptionLabel(bool $withDefault = true): ?string
+    public function getOptionLabel(bool $withDefault = true): string | Htmlable | null
     {
         $state = null;
 

--- a/packages/forms/src/Components/ModalTableSelect.php
+++ b/packages/forms/src/Components/ModalTableSelect.php
@@ -191,7 +191,7 @@ class ModalTableSelect extends Field
     }
 
     /**
-     * @return array<string>
+     * @return array<string | Htmlable>
      */
     public function getOptionLabels(bool $withDefaults = true): array
     {


### PR DESCRIPTION
## Description

This update enhances the ModalTableSelect component by allowing the getOptionLabelUsing() method to return a Htmlable instance.

The goal is to make the rendering of option labels more flexible. By supporting Htmlable return values (e.g. via HtmlString), developers can now output structured or styled HTML content – such as icons, formatting, or rich label structures.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
