### PR TITLE
[4.x] chore: bump tiptap-php to v2

### DIFF
--- a/packages/forms/composer.json
+++ b/packages/forms/composer.json
@@ -13,7 +13,7 @@
         "filament/actions": "self.version",
         "filament/schemas": "self.version",
         "filament/support": "self.version",
-        "ueberdosis/tiptap-php": "^1.4"
+        "ueberdosis/tiptap-php": "^2.0"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
## Description

This patch bumps the `ueberdosis/tiptap-php` to v2.

The [v2 release](https://github.com/ueberdosis/tiptap-php/releases/tag/2.0.0) includes some breaking changes, but they do not appear to affect the current implementation.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
