### PR TITLE
remove hasRelationship check

### DIFF
--- a/packages/schemas/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
+++ b/packages/schemas/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
@@ -63,8 +63,7 @@ trait EntanglesStateWithSingularRelationship
 
                     if (
                         ($childComponent instanceof CanEntangleWithSingularRelationships) &&
-                        ($childComponent->getRelationshipName() === $component->getRelationshipName()) &&
-                        ($childComponent->hasRelationship())
+                        ($childComponent->getRelationshipName() === $component->getRelationshipName())
                     ) {
                         $componentsWithThisRelationship[] = $childComponent;
 


### PR DESCRIPTION
## Description

When hasRelationship() returned false in line 67 the component was not added to $componentsWithThisRelationship. So the condition for the deletion of a record never matched.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x ] Changes have been tested to not break existing functionality.
- [x ] Documentation is up-to-date.
