### PR TITLE
fix: afterStateUpdatedJS live when onBlur:true

### DIFF
--- a/packages/schemas/src/Schema.php
+++ b/packages/schemas/src/Schema.php
@@ -244,7 +244,7 @@ class Schema extends ViewComponent implements HasEmbeddedView
                             x-data="filamentSchemaComponent({
                                 path: <?= Js::from($schemaComponentStatePath) ?>,
                                 containerPath: <?= Js::from($statePath) ?>,
-                                isLive: <?= Js::from($schemaComponent->isLive()) ?>,
+                                isLive: <?= Js::from($schemaComponent->isLive() && !$schemaComponent->isLiveOnBlur()) ?>,
                                 $wire,
                             })"
                             <?php if ($afterStateUpdatedJs = $schemaComponent->getAfterStateUpdatedJs()) { ?>


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

On this code, dd() shouldn't be triggered each time the input changes, only on blur. This PR aims to fix it.

```php
TextInput::make('title')
    ->afterStateUpdatedJs(<<<'JS'
        console.log($state)
    JS)
    ->live(onBlur: true)
    ->afterStateUpdated(function (?string $state) {
        dd($state);
    })
```

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
