### PR TITLE
Update missing spanish translation - rich editor tools details

### DIFF
--- a/packages/forms/resources/lang/en/components.php
+++ b/packages/forms/resources/lang/en/components.php
@@ -297,7 +297,6 @@ return [
             'redo' => 'Redo',
             'strike' => 'Strikethrough',
             'table' => 'Table',
-
             'undo' => 'Undo',
         ],
 

--- a/packages/forms/resources/lang/es/components.php
+++ b/packages/forms/resources/lang/es/components.php
@@ -483,6 +483,7 @@ return [
             'clear_formatting' => 'Limpiar formato',
             'code_block' => 'Bloque de código',
             'custom_blocks' => 'Bloques',
+            'details' => 'Detalles',
             'h1' => 'Título',
             'h2' => 'Encabezado',
             'h3' => 'Subencabezado',


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Update missing spanish translation -`forms.components`: `rich_editor.tools.details`

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
