### PR TITLE
Check enable Reorderable Columns

### DIFF
--- a/packages/tables/src/Concerns/HasColumnManager.php
+++ b/packages/tables/src/Concerns/HasColumnManager.php
@@ -63,6 +63,10 @@ trait HasColumnManager
      */
     public function applyTableColumnManager(?array $state = null): void
     {
+        if (!$this->getTable()->hasReorderableColumns()) {
+            return;
+        }
+        
         if (filled($state)) {
             $this->tableColumns = $state;
         }

--- a/packages/tables/src/Concerns/HasColumnManager.php
+++ b/packages/tables/src/Concerns/HasColumnManager.php
@@ -63,10 +63,10 @@ trait HasColumnManager
      */
     public function applyTableColumnManager(?array $state = null): void
     {
-        if (!$this->getTable()->hasReorderableColumns()) {
+        if (! $this->getTable()->hasReorderableColumns()) {
             return;
         }
-        
+
         if (filled($state)) {
             $this->tableColumns = $state;
         }


### PR DESCRIPTION
Even though column reordering was not activated, there was a problem with not maintaining the order defined in the columns of the resource table.

Columns definition:

![image](https://github.com/user-attachments/assets/ef774e85-a8bc-494f-a66c-84486e3b85f6)

Bug reported in issue #16720 that changed the order of columns, even though column reordering was not enabled in the table.

![image](https://github.com/user-attachments/assets/1a92f439-2bb4-4be0-b181-9d1a080b1a12)

Locally test the default behavior of columns in the correct order:

![image](https://github.com/user-attachments/assets/15afc242-dff2-4993-b879-ed6ec1ab9a08)

Debugging where to change the position of the columns I realized that the applyTableColumnManager from Concerns/HasColumnManager.php is called and the position of the columns was changed.
