### PR TITLE
fix: untranslated Vietnamese strings in 4.x

### DIFF
--- a/packages/actions/resources/lang/vi/import.php
+++ b/packages/actions/resources/lang/vi/import.php
@@ -52,7 +52,7 @@ return [
             'actions' => [
 
                 'download_failed_rows_csv' => [
-                    'label' => 'Download information about the failed row|Download information about the failed rows',
+                    'label' => 'Tải xuống thông tin về hàng bị lỗi|Tải xuống thông tin về những hàng bị lỗi',
                 ],
 
             ],

--- a/packages/tables/resources/lang/vi/table.php
+++ b/packages/tables/resources/lang/vi/table.php
@@ -204,7 +204,7 @@ return [
 
     'selection_indicator' => [
 
-        'selected_count' => 'Đã chọn 1 bản ghi đã chọn|Đã chọn :count bản ghi',
+        'selected_count' => 'Đã chọn 1 bản ghi|Đã chọn :count bản ghi',
 
         'actions' => [
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This is a hotfix. This addresses two issues that was present in a previous (merged) pull request: https://github.com/filamentphp/filament/pull/16836

- Remove a duplicated word
- Translate a string that wasn't translated

## Visual changes

This PR doesn't contain any visual change other than updated text.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
