### PR TITLE
Add missing SK & CZ translation

### DIFF
--- a/packages/forms/resources/lang/cs/components.php
+++ b/packages/forms/resources/lang/cs/components.php
@@ -482,6 +482,7 @@ return [
             'clear_formatting' => 'Vymazat formátování',
             'code_block' => 'Blok kódu',
             'custom_blocks' => 'Bloky',
+            'details' => 'Detaily',
             'h1' => 'Nadpis 1',
             'h2' => 'Nadpis 2',
             'h3' => 'Nadpis 3',

--- a/packages/forms/resources/lang/sk/components.php
+++ b/packages/forms/resources/lang/sk/components.php
@@ -482,6 +482,7 @@ return [
             'clear_formatting' => 'Vymazať formátovanie',
             'code_block' => 'Blok kódu',
             'custom_blocks' => 'Bloky',
+            'details' => 'Detaily',
             'h1' => 'Názov',
             'h2' => 'Nadpis',
             'h3' => 'Podnadpis',


### PR DESCRIPTION
## Description

Add missing SK & CZ translation.

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
