### PR TITLE
Add `extraAttributes` to tables

### DIFF
--- a/packages/support/src/View/Concerns/CanGenerateButtonHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateButtonHtml.php
@@ -211,9 +211,9 @@ trait CanGenerateButtonHtml
             <?php if (filled($badge)) { ?>
                 <div class="fi-btn-badge-ctn">
                     <span <?= (new ComponentAttributeBag)->color(BadgeComponent::class, $badgeColor)->class([
-                            'fi-badge',
-                            ($badgeSize instanceof Size) ? "fi-size-{$badgeSize->value}" : $badgeSize,
-                        ])->toHtml() ?>>
+                        'fi-badge',
+                        ($badgeSize instanceof Size) ? "fi-size-{$badgeSize->value}" : $badgeSize,
+                    ])->toHtml() ?>>
                         <?= e($badge) ?>
                     </span>
                 </div>

--- a/packages/support/src/View/Concerns/CanGenerateButtonHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateButtonHtml.php
@@ -211,9 +211,9 @@ trait CanGenerateButtonHtml
             <?php if (filled($badge)) { ?>
                 <div class="fi-btn-badge-ctn">
                     <span <?= (new ComponentAttributeBag)->color(BadgeComponent::class, $badgeColor)->class([
-                        'fi-badge',
-                        ($badgeSize instanceof Size) ? "fi-size-{$badgeSize->value}" : $badgeSize,
-                    ])->toHtml() ?>>
+                            'fi-badge',
+                            ($badgeSize instanceof Size) ? "fi-size-{$badgeSize->value}" : $badgeSize,
+                        ])->toHtml() ?>>
                         <?= e($badge) ?>
                     </span>
                 </div>

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -115,10 +115,10 @@
                 currentSelectionLivewireProperty: @js($getCurrentSelectionLivewireProperty()),
                 $wire,
             })"
-    @class([
+    {{ $attributes->merge($getExtraAttributes())->class([
         'fi-ta',
         'fi-loading' => $records === null,
-    ])
+    ]) }}
 >
     <input
         type="hidden"

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -115,10 +115,12 @@
                 currentSelectionLivewireProperty: @js($getCurrentSelectionLivewireProperty()),
                 $wire,
             })"
-    {{ $attributes->merge($getExtraAttributes())->class([
-        'fi-ta',
-        'fi-loading' => $records === null,
-    ]) }}
+    {{
+        $attributes->merge($getExtraAttributes())->class([
+            'fi-ta',
+            'fi-loading' => $records === null,
+        ])
+    }}
 >
     <input
         type="hidden"

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -116,7 +116,7 @@
                 $wire,
             })"
     {{
-        $attributes->merge($getExtraAttributes())->class([
+        $getExtraAttributeBag()->class([
             'fi-ta',
             'fi-loading' => $records === null,
         ])

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -4,11 +4,13 @@ namespace Filament\Tables;
 
 use Filament\Support\Components\ViewComponent;
 use Filament\Support\Concerns\HasDefaultDataFormattingSettings;
+use Filament\Support\Concerns\HasExtraAttributes;
 use Filament\Tables\Contracts\HasTable;
 
 class Table extends ViewComponent
 {
     use HasDefaultDataFormattingSettings;
+    use HasExtraAttributes;
     use Table\Concerns\BelongsToLivewire;
     use Table\Concerns\CanBeStriped;
     use Table\Concerns\CanDeferLoading;


### PR DESCRIPTION
I need to apply a bunch of styling to specific tables. Sometimes these are in pages with more than one table. Having `extraAttributes` on tables lets me add a class I can use as selector in my theme.