### PR TITLE
[4.x] Feat: make RichContentRenderer Macroable

### DIFF
--- a/packages/forms/src/Components/RichEditor/RichContentRenderer.php
+++ b/packages/forms/src/Components/RichEditor/RichContentRenderer.php
@@ -17,6 +17,7 @@ use Filament\Forms\Components\RichEditor\TipTapExtensions\SmallExtension;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
 use League\Flysystem\UnableToCheckFileExistence;
 use Throwable;
 use Tiptap\Core\Extension;
@@ -49,6 +50,8 @@ use Tiptap\Nodes\Text;
 
 class RichContentRenderer implements Htmlable
 {
+    use Macroable;
+
     /**
      * @var string | array<string, mixed>
      */


### PR DESCRIPTION
## Description

Adds `Macroable` trait to the `RichContentRenderer` to allow for customization from external code, i.e. plugins.

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
