### PR TITLE
Fix PostgreSQL JSON searching

### DIFF
--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -171,19 +171,14 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
         }
 
         $column = match ($driverName) {
-            'pgsql' => str($column)->contains('->')
-                ? str($column)
-                    ->beforeLast('->')
-                    ->append('->>')
-                    ->append("'")
-                    ->append(str($column)->afterLast('->'))
-                    ->append("'")
-                : $column,
-            default => $column,
-        };
-
-        $column = match ($driverName) {
-            'pgsql' => "{$column}::text",
+            'pgsql' => (str($column)->contains('->')
+                    ? str($column)
+                        ->beforeLast('->')
+                        ->append('->>')
+                        ->append("'")
+                        ->append(str($column)->afterLast('->'))
+                        ->append("'")
+                    : $column) . '::text',
             default => $column,
         };
 

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -171,6 +171,20 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
         }
 
         $column = match ($driverName) {
+            'pgsql' => str($column)->contains('->')
+                ? str($column)
+                    ->beforeLast('->')
+                    ->append('->>')
+                    ->append("'")
+                    ->append(str($column)->afterLast('->'))
+                    ->append("'")
+                : $column,
+            default => $column,
+        };
+
+        echo $column;
+
+        $column = match ($driverName) {
             'pgsql' => "{$column}::text",
             default => $column,
         };

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -182,8 +182,6 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
             default => $column,
         };
 
-        echo $column;
-
         $column = match ($driverName) {
             'pgsql' => "{$column}::text",
             default => $column,

--- a/tests/src/Support/helpersTest.php
+++ b/tests/src/Support/helpersTest.php
@@ -1,7 +1,12 @@
 <?php
 
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Grammars\MySqlGrammar;
+use Illuminate\Database\Query\Grammars\PostgresGrammar;
 use Illuminate\View\ComponentAttributeBag;
 
+use function Filament\Support\generate_search_column_expression;
 use function Filament\Support\prepare_inherited_attributes;
 
 it('will prepare attributes', function () {
@@ -38,4 +43,38 @@ it('will prepare data attributes', function () {
     expect($attributes->getAttributes())->toBe([
         'data-foo' => 'bar',
     ]);
+});
+
+it('will generate json search column expression for mysql', function () {
+    $column = 'data->name';
+    $isSearchForcedCaseInsensitive = true;
+
+    $databaseConnection = Mockery::mock(Connection::class);
+    $databaseConnection->shouldReceive('getDriverName')->andReturn('mysql');
+    $databaseConnection->shouldReceive('getConfig')->with('search_collation')->andReturn(null);
+
+    $grammar = new MySqlGrammar($databaseConnection);
+
+    $databaseConnection->shouldReceive('getQueryGrammar')->andReturn($grammar);
+
+    $expression = generate_search_column_expression($column, $isSearchForcedCaseInsensitive, $databaseConnection);
+
+    expect($expression->getValue($grammar))
+        ->toBe("lower(json_extract(`data`, '$.\"name\"'))");
+});
+
+it('will generate json search column expression for pgsql', function () {
+    $column = 'data->name';
+    $isSearchForcedCaseInsensitive = true;
+
+    $databaseConnection = Mockery::mock(Connection::class);
+    $databaseConnection->shouldReceive('getDriverName')->andReturn('pgsql');
+    $databaseConnection->shouldReceive('getConfig')->with('search_collation')->andReturn(null);
+
+    $grammar = new PostgresGrammar($databaseConnection);
+
+    $expression = generate_search_column_expression($column, $isSearchForcedCaseInsensitive, $databaseConnection);
+
+    expect($expression->getValue($grammar))
+        ->toBe("lower(data->>'name'::text)");
 });

--- a/tests/src/Support/helpersTest.php
+++ b/tests/src/Support/helpersTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Grammars\MySqlGrammar;
 use Illuminate\Database\Query\Grammars\PostgresGrammar;


### PR DESCRIPTION
## Description

When searching JSON fields in pgsql it would error with 

```
SQLSTATE[42703]: Undefined column: 7 ERROR: column "name" does not exist LINE 1: ...."deleted_at" is null) and (lower(attribute_data->name::text... ^
```

This was because the column search expression was 

```
lower(attribute_data -> name::text)::text LIKE '%chuck%'
```

rather than the correct

```
lower(attribute_data ->> 'name'::text)::text LIKE '%chuck%'
```


You will see there's two changes: 

1. `->` changes to `->>`
2. we are wrapping `name` in single inverted commas

## Tests

I have added two tests to show that the MySQL version remains as it was, and the PostgreSQL returns as expected.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
