### PR TITLE
Fix SQL syntax error during global search when using : in table names #16864

### DIFF
--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -163,15 +163,11 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
     {
         $driverName = $databaseConnection->getDriverName();
 
-        if (Str::lower($column) !== $column) {
-            $column = match ($driverName) {
-                'pgsql' => (string) str($column)->wrap('"'),
-                default => $column,
-            };
-        }
-
         $column = match ($driverName) {
-            'pgsql' => "{$column}::text",
+            'pgsql' => (string) str($column)
+                ->explode('.')
+                ->map(fn (string $part) => str($part)->wrap('"'))
+                ->implode('.') . '::text',
             default => $column,
         };
 

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -166,8 +166,13 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
         $column = match ($driverName) {
             'pgsql' => (
                 str($column)->contains('->')
-                    ? str($column)
-                        ->beforeLast('->')
+                    ? str(
+                        str($column)
+                            ->beforeLast('->')
+                            ->explode('.')
+                            ->map(fn (string $part) => str($part)->wrap('"'))
+                            ->implode('.')
+                    )
                         ->append('->>')
                         ->append("'")
                         ->append(str($column)->afterLast('->'))

--- a/tests/src/Support/helpersTest.php
+++ b/tests/src/Support/helpersTest.php
@@ -75,5 +75,24 @@ it('will generate json search column expression for pgsql', function () {
     $expression = generate_search_column_expression($column, $isSearchForcedCaseInsensitive, $databaseConnection);
 
     expect($expression->getValue($grammar))
-        ->toBe("lower(data->>'name'::text)");
+        ->toBe("lower(\"data\"->>'name'::text)");
 });
+
+it('will generate column expression for pgsql with colons in the name', function (string $column, string $text) {
+    $isSearchForcedCaseInsensitive = true;
+
+    $databaseConnection = Mockery::mock(Connection::class);
+    $databaseConnection->shouldReceive('getDriverName')->andReturn('pgsql');
+    $databaseConnection->shouldReceive('getConfig')->with('search_collation')->andReturn(null);
+
+    $grammar = new PostgresGrammar($databaseConnection);
+
+    $expression = generate_search_column_expression($column, $isSearchForcedCaseInsensitive, $databaseConnection);
+
+    expect($expression->getValue($grammar))
+        ->toBe($text);
+})
+    ->with([
+        ['blog:posts.title', 'lower("blog:posts"."title"::text)'],
+        ['blog:posts:comments.author.name', 'lower("blog:posts:comments"."author"."name"::text)'],
+    ]);


### PR DESCRIPTION
## Description

I've experienced a bug with PGSQL and global search when using `:` in table names.

I've documented the issue in detail in #16864.

This PR applies the suggested fix in the issue, adding the quoting logic.

## Visual changes

There are no visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
