### PR TITLE
Fix getColumns return type

### DIFF
--- a/packages/widgets/docs/01-overview.md
+++ b/packages/widgets/docs/01-overview.md
@@ -120,7 +120,7 @@ public function getColumns(): int | string | array
 You may wish to change the number of widget grid columns based on the responsive [breakpoint](https://tailwindcss.com/docs/responsive-design#overview) of the browser. You can do this using an array that contains the number of columns that should be used at each breakpoint:
 
 ```php
-public function getColumns(): int | string | array
+public function getColumns(): int | array
 {
     return [
         'md' => 4,


### PR DESCRIPTION
Fix mismatch return type.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

The getColumns only support int and array type

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
