### PR TITLE
Update InteractsWithToolbarButtons.php

### DIFF
--- a/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
+++ b/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
@@ -92,8 +92,6 @@ trait InteractsWithToolbarButtons
 
             if (! is_array($buttonGroup)) {
                 $newButtonGroup[] = $buttonGroup;
-
-                continue;
             }
 
             if (filled($newButtonGroup)) {

--- a/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
+++ b/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
@@ -92,6 +92,8 @@ trait InteractsWithToolbarButtons
 
             if (! is_array($buttonGroup)) {
                 $newButtonGroup[] = $buttonGroup;
+
+                continue;
             }
 
             if (filled($newButtonGroup)) {
@@ -103,6 +105,10 @@ trait InteractsWithToolbarButtons
             }
 
             $toolbar[] = $buttonGroup;
+        }
+
+        if (filled($newButtonGroup)) {
+            $toolbar[] = $newButtonGroup;
         }
 
         return $toolbar;


### PR DESCRIPTION
Show buttons as one group if no group is defined. Fixes #16868.

Fixes breaking change in RichEditor toolbarButtons();

## Description


## Visual changes


```php
// v3 style
RichEditor::make('description')
    ->toolbarButtons([
        'attachFiles',
        'blockquote',
        'bold',
    ]),
```
![afbeelding](https://github.com/user-attachments/assets/f4a67a2f-5527-4d6a-a90d-2ea9b98e8879)

```php
// v4 style
RichEditor::make('description')
    ->toolbarButtons([
        [
            'attachFiles',
            'blockquote',
            'bold',
        ]
    ]),
```
![afbeelding](https://github.com/user-attachments/assets/902054d8-2b5e-4243-b468-817accab1910)

```php
// v4 documentation
RichEditor::make('description')
    ->toolbarButtons([
        ['bold', 'italic', 'underline', 'strike', 'subscript', 'superscript', 'link'],
        ['h2', 'h3', 'alignStart', 'alignCenter', 'alignEnd'],
        ['blockquote', 'codeBlock', 'bulletList', 'orderedList'],
        ['table', 'attachFiles'], // The `customBlocks` and `mergeTags` tools are also added here if those features are used.
        ['undo', 'redo'],
    ]),
```
![afbeelding](https://github.com/user-attachments/assets/179cda88-22fd-495c-9253-a33d58484108)


## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
