### PR TITLE
:recycle:  require confirmation before setting label in actions

### DIFF
--- a/packages/actions/src/DeleteAction.php
+++ b/packages/actions/src/DeleteAction.php
@@ -19,6 +19,8 @@ class DeleteAction extends Action
     {
         parent::setUp();
 
+        $this->requiresConfirmation();
+
         $this->label(__('filament-actions::delete.single.label'));
 
         $this->modalHeading(fn (): string => __('filament-actions::delete.single.modal.heading', ['label' => $this->getRecordTitle()]));
@@ -30,8 +32,6 @@ class DeleteAction extends Action
         $this->defaultColor('danger');
 
         $this->groupedIcon(FilamentIcon::resolve('actions::delete-action.grouped') ?? 'heroicon-m-trash');
-
-        $this->requiresConfirmation();
 
         $this->modalIcon(FilamentIcon::resolve('actions::delete-action.modal') ?? 'heroicon-o-trash');
 

--- a/packages/actions/src/ForceDeleteAction.php
+++ b/packages/actions/src/ForceDeleteAction.php
@@ -19,6 +19,8 @@ class ForceDeleteAction extends Action
     {
         parent::setUp();
 
+        $this->requiresConfirmation();
+
         $this->label(__('filament-actions::force-delete.single.label'));
 
         $this->modalHeading(fn (): string => __('filament-actions::force-delete.single.modal.heading', ['label' => $this->getRecordTitle()]));
@@ -28,8 +30,6 @@ class ForceDeleteAction extends Action
         $this->defaultColor('danger');
 
         $this->groupedIcon(FilamentIcon::resolve('actions::force-delete-action.grouped') ?? 'heroicon-m-trash');
-
-        $this->requiresConfirmation();
 
         $this->modalIcon(FilamentIcon::resolve('actions::force-delete-action.modal') ?? 'heroicon-o-trash');
 

--- a/packages/actions/src/RestoreAction.php
+++ b/packages/actions/src/RestoreAction.php
@@ -19,6 +19,8 @@ class RestoreAction extends Action
     {
         parent::setUp();
 
+        $this->requiresConfirmation();
+
         $this->label(__('filament-actions::restore.single.label'));
 
         $this->modalHeading(fn (): string => __('filament-actions::restore.single.modal.heading', ['label' => $this->getRecordTitle()]));
@@ -30,8 +32,6 @@ class RestoreAction extends Action
         $this->defaultColor('gray');
 
         $this->groupedIcon(FilamentIcon::resolve('actions::restore-action.grouped') ?? 'heroicon-m-arrow-uturn-left');
-
-        $this->requiresConfirmation();
 
         $this->modalIcon(FilamentIcon::resolve('actions::restore-action.modal') ?? 'heroicon-o-arrow-uturn-left');
 

--- a/packages/tables/src/Actions/DeleteAction.php
+++ b/packages/tables/src/Actions/DeleteAction.php
@@ -19,6 +19,8 @@ class DeleteAction extends Action
     {
         parent::setUp();
 
+        $this->requiresConfirmation();
+
         $this->label(__('filament-actions::delete.single.label'));
 
         $this->modalHeading(fn (): string => __('filament-actions::delete.single.modal.heading', ['label' => $this->getRecordTitle()]));
@@ -30,8 +32,6 @@ class DeleteAction extends Action
         $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::delete-action') ?? 'heroicon-m-trash');
-
-        $this->requiresConfirmation();
 
         $this->modalIcon(FilamentIcon::resolve('actions::delete-action.modal') ?? 'heroicon-o-trash');
 

--- a/packages/tables/src/Actions/DeleteBulkAction.php
+++ b/packages/tables/src/Actions/DeleteBulkAction.php
@@ -22,6 +22,8 @@ class DeleteBulkAction extends BulkAction
     {
         parent::setUp();
 
+        $this->requiresConfirmation();
+
         $this->label(__('filament-actions::delete.multiple.label'));
 
         $this->modalHeading(fn (): string => __('filament-actions::delete.multiple.modal.heading', ['label' => $this->getPluralModelLabel()]));
@@ -33,8 +35,6 @@ class DeleteBulkAction extends BulkAction
         $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::delete-action') ?? 'heroicon-m-trash');
-
-        $this->requiresConfirmation();
 
         $this->modalIcon(FilamentIcon::resolve('actions::delete-action.modal') ?? 'heroicon-o-trash');
 

--- a/packages/tables/src/Actions/DetachAction.php
+++ b/packages/tables/src/Actions/DetachAction.php
@@ -21,6 +21,8 @@ class DetachAction extends Action
     {
         parent::setUp();
 
+        $this->requiresConfirmation();
+
         $this->label(__('filament-actions::detach.single.label'));
 
         $this->modalHeading(fn (): string => __('filament-actions::detach.single.modal.heading', ['label' => $this->getRecordTitle()]));
@@ -32,8 +34,6 @@ class DetachAction extends Action
         $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::detach-action') ?? 'heroicon-m-x-mark');
-
-        $this->requiresConfirmation();
 
         $this->modalIcon(FilamentIcon::resolve('actions::detach-action.modal') ?? 'heroicon-o-x-mark');
 

--- a/packages/tables/src/Actions/DetachBulkAction.php
+++ b/packages/tables/src/Actions/DetachBulkAction.php
@@ -22,6 +22,8 @@ class DetachBulkAction extends BulkAction
     {
         parent::setUp();
 
+        $this->requiresConfirmation();
+
         $this->label(__('filament-actions::detach.multiple.label'));
 
         $this->modalHeading(fn (): string => __('filament-actions::detach.multiple.modal.heading', ['label' => $this->getPluralModelLabel()]));
@@ -33,8 +35,6 @@ class DetachBulkAction extends BulkAction
         $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::detach-action') ?? 'heroicon-m-x-mark');
-
-        $this->requiresConfirmation();
 
         $this->modalIcon(FilamentIcon::resolve('actions::detach-action.modal') ?? 'heroicon-o-x-mark');
 

--- a/packages/tables/src/Actions/DissociateAction.php
+++ b/packages/tables/src/Actions/DissociateAction.php
@@ -21,6 +21,8 @@ class DissociateAction extends Action
     {
         parent::setUp();
 
+        $this->requiresConfirmation();
+
         $this->label(__('filament-actions::dissociate.single.label'));
 
         $this->modalHeading(fn (): string => __('filament-actions::dissociate.single.modal.heading', ['label' => $this->getRecordTitle()]));
@@ -32,8 +34,6 @@ class DissociateAction extends Action
         $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::dissociate-action') ?? 'heroicon-m-x-mark');
-
-        $this->requiresConfirmation();
 
         $this->modalIcon(FilamentIcon::resolve('actions::dissociate-action.modal') ?? 'heroicon-o-x-mark');
 

--- a/packages/tables/src/Actions/DissociateBulkAction.php
+++ b/packages/tables/src/Actions/DissociateBulkAction.php
@@ -22,6 +22,8 @@ class DissociateBulkAction extends BulkAction
     {
         parent::setUp();
 
+        $this->requiresConfirmation();
+
         $this->label(__('filament-actions::dissociate.multiple.label'));
 
         $this->modalHeading(fn (): string => __('filament-actions::dissociate.multiple.modal.heading', ['label' => $this->getPluralModelLabel()]));
@@ -33,8 +35,6 @@ class DissociateBulkAction extends BulkAction
         $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::dissociate-action') ?? 'heroicon-m-x-mark');
-
-        $this->requiresConfirmation();
 
         $this->modalIcon(FilamentIcon::resolve('actions::dissociate-action.modal') ?? 'heroicon-o-x-mark');
 

--- a/packages/tables/src/Actions/ForceDeleteAction.php
+++ b/packages/tables/src/Actions/ForceDeleteAction.php
@@ -19,6 +19,8 @@ class ForceDeleteAction extends Action
     {
         parent::setUp();
 
+        $this->requiresConfirmation();
+
         $this->label(__('filament-actions::force-delete.single.label'));
 
         $this->modalHeading(fn (): string => __('filament-actions::force-delete.single.modal.heading', ['label' => $this->getRecordTitle()]));
@@ -30,8 +32,6 @@ class ForceDeleteAction extends Action
         $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::force-delete-action') ?? 'heroicon-m-trash');
-
-        $this->requiresConfirmation();
 
         $this->modalIcon(FilamentIcon::resolve('actions::force-delete-action.modal') ?? 'heroicon-o-trash');
 

--- a/packages/tables/src/Actions/ForceDeleteBulkAction.php
+++ b/packages/tables/src/Actions/ForceDeleteBulkAction.php
@@ -22,6 +22,8 @@ class ForceDeleteBulkAction extends BulkAction
     {
         parent::setUp();
 
+        $this->requiresConfirmation();
+
         $this->label(__('filament-actions::force-delete.multiple.label'));
 
         $this->modalHeading(fn (): string => __('filament-actions::force-delete.multiple.modal.heading', ['label' => $this->getPluralModelLabel()]));
@@ -33,8 +35,6 @@ class ForceDeleteBulkAction extends BulkAction
         $this->defaultColor('danger');
 
         $this->icon(FilamentIcon::resolve('actions::force-delete-action') ?? 'heroicon-m-trash');
-
-        $this->requiresConfirmation();
 
         $this->modalIcon(FilamentIcon::resolve('actions::force-delete-action.modal') ?? 'heroicon-o-trash');
 

--- a/packages/tables/src/Actions/RestoreAction.php
+++ b/packages/tables/src/Actions/RestoreAction.php
@@ -19,6 +19,8 @@ class RestoreAction extends Action
     {
         parent::setUp();
 
+        $this->requiresConfirmation();
+
         $this->label(__('filament-actions::restore.single.label'));
 
         $this->modalHeading(fn (): string => __('filament-actions::restore.single.modal.heading', ['label' => $this->getRecordTitle()]));
@@ -30,8 +32,6 @@ class RestoreAction extends Action
         $this->defaultColor('gray');
 
         $this->icon(FilamentIcon::resolve('actions::restore-action') ?? 'heroicon-m-arrow-uturn-left');
-
-        $this->requiresConfirmation();
 
         $this->modalIcon(FilamentIcon::resolve('actions::restore-action.modal') ?? 'heroicon-o-arrow-uturn-left');
 

--- a/packages/tables/src/Actions/RestoreBulkAction.php
+++ b/packages/tables/src/Actions/RestoreBulkAction.php
@@ -22,6 +22,8 @@ class RestoreBulkAction extends BulkAction
     {
         parent::setUp();
 
+        $this->requiresConfirmation();
+
         $this->label(__('filament-actions::restore.multiple.label'));
 
         $this->modalHeading(fn (): string => __('filament-actions::restore.multiple.modal.heading', ['label' => $this->getPluralModelLabel()]));
@@ -33,8 +35,6 @@ class RestoreBulkAction extends BulkAction
         $this->defaultColor('gray');
 
         $this->icon(FilamentIcon::resolve('actions::restore-action') ?? 'heroicon-m-arrow-uturn-left');
-
-        $this->requiresConfirmation();
 
         $this->modalIcon(FilamentIcon::resolve('actions::restore-action.modal') ?? 'heroicon-o-arrow-uturn-left');
 


### PR DESCRIPTION
Resolves #16859 

## Description

This PR ensures that the `requiresConfirmation()` method is always called before `label()` in all relevant action classes.  
Previously, calling `requiresConfirmation()` after `label()` could result in the confirmation logic overwriting a custom label set by the user.  
By moving `requiresConfirmation()` before `label()`, we prevent this unintended label overwrite and ensure that custom labels are preserved.

## Visual changes

N/A – This is an internal code order/style fix and does not affect the UI.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.