### PR TITLE
[4.x] Avoid infinite loop from JS update from Laravel framework 56159

### DIFF
--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -344,7 +344,7 @@ class Notification extends ViewComponent implements Arrayable, HasEmbeddedView
         ob_start(); ?>
 
         <div
-            x-data="notificationComponent({ notification: <?= Js::from($this) ?> })"
+            x-data="notificationComponent({ notification: <?= Js::from($this->toArray()) ?> })"
             x-transition:enter-start="fi-transition-enter-start"
             x-transition:leave-end="fi-transition-leave-end"
             <?= $attributes ?>


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This new pull request from Laravel framework https://github.com/laravel/framework/pull/56159 make the render of notification into an infinite loop

Use `Js::from($this->toArray())` instead to serialize only the clean data array.


## Visual changes


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
