### PR TITLE
Add page content render hooks

### DIFF
--- a/docs/09-advanced/01-render-hooks.md
+++ b/docs/09-advanced/01-render-hooks.md
@@ -68,10 +68,14 @@ use Filament\View\PanelsRenderHook;
 - `PanelsRenderHook::PAGE_END` - End of the page content container, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_FOOTER_WIDGETS_AFTER` - After the page footer widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_FOOTER_WIDGETS_BEFORE` - Before the page footer widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
+- `PanelsRenderHook::PAGE_FOOTER_WIDGETS_END` - End of the page footer widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
+- `PanelsRenderHook::PAGE_FOOTER_WIDGETS_START` - Start of the page footer widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_HEADER_ACTIONS_AFTER` - After the page header actions, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_HEADER_ACTIONS_BEFORE` - Before the page header actions, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_HEADER_WIDGETS_AFTER` - After the page header widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_HEADER_WIDGETS_BEFORE` - Before the page header widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
+- `PanelsRenderHook::PAGE_HEADER_WIDGETS_END` - End of the page header widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
+- `PanelsRenderHook::PAGE_HEADER_WIDGETS_START` - Start of the page header widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_START` - Start of the page content container, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_SUB_NAVIGATION_END_AFTER` - After the page sub navigation "end" sidebar position, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_SUB_NAVIGATION_END_BEFORE` - Before the page sub navigation "end" sidebar position, also [can be scoped](#scoping-render-hooks) to the page or resource class

--- a/packages/panels/resources/views/components/page/index.blade.php
+++ b/packages/panels/resources/views/components/page/index.blade.php
@@ -89,11 +89,19 @@
             @endif
 
             <div class="fi-page-content">
+                {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_CONTENT_START, scopes: $this->getRenderHookScopes()) }}
+
                 {{ $this->headerWidgets }}
+
+                {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_CONTENT_BEFORE, scopes: $this->getRenderHookScopes()) }}
 
                 {{ $slot }}
 
+                {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_CONTENT_AFTER, scopes: $this->getRenderHookScopes()) }}
+
                 {{ $this->footerWidgets }}
+
+                {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_CONTENT_END, scopes: $this->getRenderHookScopes()) }}
             </div>
 
             @if ($subNavigation && $subNavigationPosition === SubNavigationPosition::End)

--- a/packages/panels/resources/views/components/page/index.blade.php
+++ b/packages/panels/resources/views/components/page/index.blade.php
@@ -89,19 +89,19 @@
             @endif
 
             <div class="fi-page-content">
-                {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_CONTENT_START, scopes: $this->getRenderHookScopes()) }}
+                {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_HEADER_WIDGETS_BEFORE, scopes: $this->getRenderHookScopes()) }}
 
                 {{ $this->headerWidgets }}
 
-                {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_CONTENT_BEFORE, scopes: $this->getRenderHookScopes()) }}
+                {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_HEADER_WIDGETS_AFTER, scopes: $this->getRenderHookScopes()) }}
 
                 {{ $slot }}
 
-                {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_CONTENT_AFTER, scopes: $this->getRenderHookScopes()) }}
+                {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_FOOTER_WIDGETS_BEFORE, scopes: $this->getRenderHookScopes()) }}
 
                 {{ $this->footerWidgets }}
 
-                {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_CONTENT_END, scopes: $this->getRenderHookScopes()) }}
+                {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_FOOTER_WIDGETS_AFTER, scopes: $this->getRenderHookScopes()) }}
             </div>
 
             @if ($subNavigation && $subNavigationPosition === SubNavigationPosition::End)

--- a/packages/panels/src/Pages/Page.php
+++ b/packages/panels/src/Pages/Page.php
@@ -382,10 +382,10 @@ abstract class Page extends BasePage
     {
         return $schema
             ->components([
-                RenderHook::make(PanelsRenderHook::PAGE_HEADER_WIDGETS_BEFORE),
+                RenderHook::make(PanelsRenderHook::PAGE_HEADER_WIDGETS_START),
                 Grid::make($this->getHeaderWidgetsColumns())
                     ->schema($widgets = $this->getWidgetsSchemaComponents($this->getHeaderWidgets())),
-                RenderHook::make(PanelsRenderHook::PAGE_HEADER_WIDGETS_AFTER),
+                RenderHook::make(PanelsRenderHook::PAGE_HEADER_WIDGETS_END),
             ])
             ->hidden(empty($widgets));
     }
@@ -394,10 +394,10 @@ abstract class Page extends BasePage
     {
         return $schema
             ->components([
-                RenderHook::make(PanelsRenderHook::PAGE_FOOTER_WIDGETS_BEFORE),
+                RenderHook::make(PanelsRenderHook::PAGE_FOOTER_WIDGETS_START),
                 Grid::make($this->getFooterWidgetsColumns())
                     ->schema($widgets = $this->getWidgetsSchemaComponents($this->getFooterWidgets())),
-                RenderHook::make(PanelsRenderHook::PAGE_FOOTER_WIDGETS_AFTER),
+                RenderHook::make(PanelsRenderHook::PAGE_FOOTER_WIDGETS_END),
             ])
             ->hidden(empty($widgets));
     }

--- a/packages/panels/src/View/PanelsRenderHook.php
+++ b/packages/panels/src/View/PanelsRenderHook.php
@@ -50,6 +50,14 @@ class PanelsRenderHook
 
     const LAYOUT_START = 'panels::layout.start';
 
+    const PAGE_CONTENT_AFTER = 'panels::page.content.after';
+
+    const PAGE_CONTENT_BEFORE = 'panels::page.content.before';
+
+    const PAGE_CONTENT_END = 'panels::page.content.end';
+
+    const PAGE_CONTENT_START = 'panels::page.content.start';
+
     const PAGE_END = 'panels::page.end';
 
     const PAGE_FOOTER_WIDGETS_AFTER = 'panels::page.footer-widgets.after';

--- a/packages/panels/src/View/PanelsRenderHook.php
+++ b/packages/panels/src/View/PanelsRenderHook.php
@@ -50,19 +50,15 @@ class PanelsRenderHook
 
     const LAYOUT_START = 'panels::layout.start';
 
-    const PAGE_CONTENT_AFTER = 'panels::page.content.after';
-
-    const PAGE_CONTENT_BEFORE = 'panels::page.content.before';
-
-    const PAGE_CONTENT_END = 'panels::page.content.end';
-
-    const PAGE_CONTENT_START = 'panels::page.content.start';
-
     const PAGE_END = 'panels::page.end';
 
     const PAGE_FOOTER_WIDGETS_AFTER = 'panels::page.footer-widgets.after';
 
     const PAGE_FOOTER_WIDGETS_BEFORE = 'panels::page.footer-widgets.before';
+
+    const PAGE_FOOTER_WIDGETS_END = 'panels::page.footer-widgets.end';
+
+    const PAGE_FOOTER_WIDGETS_START = 'panels::page.footer-widgets.start';
 
     const PAGE_HEADER_ACTIONS_AFTER = 'panels::page.header.actions.after';
 
@@ -71,6 +67,10 @@ class PanelsRenderHook
     const PAGE_HEADER_WIDGETS_AFTER = 'panels::page.header-widgets.after';
 
     const PAGE_HEADER_WIDGETS_BEFORE = 'panels::page.header-widgets.before';
+
+    const PAGE_HEADER_WIDGETS_END = 'panels::page.header-widgets.end';
+
+    const PAGE_HEADER_WIDGETS_START = 'panels::page.header-widgets.start';
 
     const PAGE_START = 'panels::page.start';
 


### PR DESCRIPTION
## Description

In filament v3 PAGE_HEADER_WIDGETS render hooks were displayed even if no widgets were displayed. That changed in filament v4 and we lost ability to hook around main page content on every page. This PR adds new PAGE_CONTENT_START, PAGE_CONTENT_BEFORE, PAGE_CONTENT_AFTER and PAGE_CONTENT_END render hooks.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
