### PR TITLE
Fix filepond invisible blocking div

### DIFF
--- a/packages/forms/resources/css/components/file-upload.css
+++ b/packages/forms/resources/css/components/file-upload.css
@@ -41,6 +41,16 @@
         @apply rounded-full;
     }
 
+    & .filepond--root[data-style-panel-layout~='compact'],
+    & .filepond--root[data-style-panel-layout~='integrated'] {
+        & .filepond--list-scroller {
+            overflow: unset;
+            height: unset;
+            margin-top: 0;
+            margin-bottom: 0;
+        }
+    }
+
     & .filepond--panel-root {
         @apply bg-transparent;
     }

--- a/packages/forms/resources/css/components/file-upload.css
+++ b/packages/forms/resources/css/components/file-upload.css
@@ -30,7 +30,7 @@
     }
 
     & .filepond--root {
-        @apply mb-0 rounded-lg bg-white font-sans shadow-sm ring-1 ring-gray-950/10 dark:bg-white/5 dark:ring-white/20;
+        @apply mb-0 rounded-lg bg-white font-sans shadow-sm ring-1 ring-gray-950/10 dark:bg-white/5 dark:ring-white/20 overflow-hidden;
     }
 
     & .filepond--root[data-disabled='disabled'] {
@@ -39,16 +39,6 @@
 
     & .filepond--root[data-style-panel-layout='compact circle'] {
         @apply rounded-full;
-    }
-
-    & .filepond--root[data-style-panel-layout~='compact'],
-    & .filepond--root[data-style-panel-layout~='integrated'] {
-        & .filepond--list-scroller {
-            overflow: unset;
-            height: unset;
-            margin-top: 0;
-            margin-bottom: 0;
-        }
     }
 
     & .filepond--panel-root {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fixes issue: https://github.com/filamentphp/filament/issues/16841

Overwrite the css classes because the filepond project seems to be not updated anymore.

Tested it for SpatieMediaLibraryFileUpload and FileUpload. With and without multiple().

## Visual changes
Before
![Screenshot 2025-07-06 at 12 43 16](https://github.com/user-attachments/assets/47d3a9f8-2331-442d-92eb-18b30649136a)

After
![Screenshot 2025-07-09 at 22 55 05](https://github.com/user-attachments/assets/d0768049-c44f-43b2-a73c-102eb5ffc461)

Working like expected
https://github.com/user-attachments/assets/d1fe9644-2925-4cb1-91f0-0397cbb04cc8

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
