### PR TITLE
Handle Postgres nested JSON searches

### DIFF
--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -167,27 +167,24 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
             'pgsql' => (
                 str($column)->contains('->')
                     ? (
-                        // Handle table.field part with double quotes
+                        // Handle `table.field` part with double quotes
                         str($column)
                             ->before('->')
                             ->explode('.')
-                            ->map(fn (string $part) => str($part)->wrap('"'))
+                            ->map(fn (string $part): string => (string) str($part)->wrap('"'))
                             ->implode('.')
-                    ) .
-                    // Handle JSON path parts
-                    collect(str($column)->after('->')->explode('->'))
-                        ->map(function ($segment, $index) use ($column) {
+                    ) . collect(str($column)->after('->')->explode('->')) // Handle JSON path parts
+                        ->map(function ($segment, $index) use ($column): string {
                             $totalParts = substr_count($column, '->');
 
-                            return ($index === $totalParts - 1)
-                                ? "->>'$segment'"
-                                : "->'$segment'";
+                            return ($index === ($totalParts - 1))
+                                ? "->>'{$segment}'"
+                                : "->'{$segment}'";
                         })
                         ->implode('')
-
                     : str($column)
                         ->explode('.')
-                        ->map(fn (string $part) => str($part)->wrap('"'))
+                        ->map(fn (string $part): string => (string) str($part)->wrap('"'))
                         ->implode('.')
             ) . '::text',
             default => $column,

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -183,7 +183,6 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
                                 ? "->>'$segment'"
                                 : "->'$segment'";
                         })
-                        ->prepend('')
                         ->implode('')
 
                     : str($column)

--- a/tests/src/Support/helpersTest.php
+++ b/tests/src/Support/helpersTest.php
@@ -44,7 +44,7 @@ it('will prepare data attributes', function () {
     ]);
 });
 
-it('will generate json search column expression for mysql', function () {
+it('will generate a JSON search column expression for MySQL', function () {
     $column = 'data->name';
     $isSearchForcedCaseInsensitive = true;
 
@@ -62,7 +62,7 @@ it('will generate json search column expression for mysql', function () {
         ->toBe("lower(json_extract(`data`, '$.\"name\"'))");
 });
 
-it('will generate json search column expression for pgsql', function () {
+it('will generate a JSON search column expression for Postgres', function () {
     $column = 'data->name';
     $isSearchForcedCaseInsensitive = true;
 
@@ -78,7 +78,7 @@ it('will generate json search column expression for pgsql', function () {
         ->toBe("lower(\"data\"->>'name'::text)");
 });
 
-it('will generate nested json search column expression for pgsql', function () {
+it('will generate a nested JSON search column expression for Postgres', function () {
     $column = 'data->name->value->en';
     $isSearchForcedCaseInsensitive = true;
 
@@ -94,7 +94,7 @@ it('will generate nested json search column expression for pgsql', function () {
         ->toBe("lower(\"data\"->'name'->'value'->>'en'::text)");
 });
 
-it('will generate column expression for pgsql with colons in the name', function (string $column, string $text) {
+it('will generate a column expression for Postgres with colons in the table name', function (string $column, string $expectedExpression) {
     $isSearchForcedCaseInsensitive = true;
 
     $databaseConnection = Mockery::mock(Connection::class);
@@ -103,10 +103,10 @@ it('will generate column expression for pgsql with colons in the name', function
 
     $grammar = new PostgresGrammar($databaseConnection);
 
-    $expression = generate_search_column_expression($column, $isSearchForcedCaseInsensitive, $databaseConnection);
+    $actualExpression = generate_search_column_expression($column, $isSearchForcedCaseInsensitive, $databaseConnection);
 
-    expect($expression->getValue($grammar))
-        ->toBe($text);
+    expect($actualExpression->getValue($grammar))
+        ->toBe($expectedExpression);
 })
     ->with([
         ['blog:posts.title', 'lower("blog:posts"."title"::text)'],

--- a/tests/src/Support/helpersTest.php
+++ b/tests/src/Support/helpersTest.php
@@ -78,6 +78,22 @@ it('will generate json search column expression for pgsql', function () {
         ->toBe("lower(\"data\"->>'name'::text)");
 });
 
+it('will generate nested json search column expression for pgsql', function () {
+    $column = 'data->name->value->en';
+    $isSearchForcedCaseInsensitive = true;
+
+    $databaseConnection = Mockery::mock(Connection::class);
+    $databaseConnection->shouldReceive('getDriverName')->andReturn('pgsql');
+    $databaseConnection->shouldReceive('getConfig')->with('search_collation')->andReturn(null);
+
+    $grammar = new PostgresGrammar($databaseConnection);
+
+    $expression = generate_search_column_expression($column, $isSearchForcedCaseInsensitive, $databaseConnection);
+
+    expect($expression->getValue($grammar))
+        ->toBe("lower(\"data\"->'name'->'value'->>'en'::text)");
+});
+
 it('will generate column expression for pgsql with colons in the name', function (string $column, string $text) {
     $isSearchForcedCaseInsensitive = true;
 


### PR DESCRIPTION
## Description

Continuing from yesterday's PR, this looks to enhance the search to support nested JSON field searches in PostgreSQL.

With this update the search will now support searches like `table.field->one->two->three`.

Currently, this would error due to the wrapping `"` logic.

## Tests

I've added a test to show that the PostgreSQL nested search formats correctly. MySQL is not affected.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
