### PR TITLE
Updated the Create Action to no longer enable double clicking during creation and therefore creating duplicate records

### DIFF
--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOneOrManyThrough;
 use Illuminate\Support\Js;
+use Livewire\Attributes\Locked;
 use Throwable;
 
 /**
@@ -44,6 +45,7 @@ class CreateRecord extends Page
 
     protected static bool $canCreateAnother = true;
 
+    #[Locked]
     public bool $isCreating = false;
 
     public function getBreadcrumb(): string
@@ -76,7 +78,9 @@ class CreateRecord extends Page
 
     public function create(bool $another = false): void
     {
-        if ($this->isCreating) return;
+        if ($this->isCreating) {
+            return;
+        }
 
         $this->isCreating = true;
 

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -44,6 +44,8 @@ class CreateRecord extends Page
 
     protected static bool $canCreateAnother = true;
 
+    public bool $isCreating = false;
+
     public function getBreadcrumb(): string
     {
         return static::$breadcrumb ?? __('filament-panels::resources/pages/create-record.breadcrumb');
@@ -74,6 +76,10 @@ class CreateRecord extends Page
 
     public function create(bool $another = false): void
     {
+        if ($this->isCreating) return;
+
+        $this->isCreating = true;
+
         $this->authorizeAccess();
 
         try {
@@ -99,9 +105,13 @@ class CreateRecord extends Page
                 $this->rollBackDatabaseTransaction() :
                 $this->commitDatabaseTransaction();
 
+            $this->isCreating = false;
+
             return;
         } catch (Throwable $exception) {
             $this->rollBackDatabaseTransaction();
+
+            $this->isCreating = false;
 
             throw $exception;
         }
@@ -118,6 +128,8 @@ class CreateRecord extends Page
             $this->record = null;
 
             $this->fillForm();
+
+            $this->isCreating = false;
 
             return;
         }


### PR DESCRIPTION
## Description

When using the default CreateAction, slower network conditions can cause the submit button to be re-enabled before the redirect completes. This brief window allows users to click the button again, potentially resulting in duplicate record creation.

This fix introduces a new isCreating boolean flag to prevent multiple submissions. The flag is set when creation begins and immediately halts any subsequent attempts while the process is in progress. It is reset if an exception occurs to ensure normal functionality resumes.

## Visual changes

https://github.com/user-attachments/assets/ed4005c0-7e86-48ed-9ced-bf9a470d321e

## Functional changes

- [✔️ ] Code style has been fixed by running the `composer cs` command.
- [✔️] Changes have been tested to not break existing functionality.
- [✔️] Documentation is up-to-date.
