### PR TITLE
Add missing CZ and SK translation

### DIFF
--- a/packages/tables/resources/lang/cs/table.php
+++ b/packages/tables/resources/lang/cs/table.php
@@ -12,6 +12,10 @@ return [
                 'label' => 'Použít sloupce',
             ],
 
+            'reset' => [
+                'label' => 'Resetovat sloupce',
+            ],
+
         ],
 
     ],

--- a/packages/tables/resources/lang/sk/table.php
+++ b/packages/tables/resources/lang/sk/table.php
@@ -12,6 +12,10 @@ return [
                 'label' => 'Použiť stĺpce',
             ],
 
+            'reset' => [
+                'label' => 'Resetovať stĺpce',
+            ],
+
         ],
 
     ],
@@ -139,7 +143,7 @@ return [
             ],
 
             'reset' => [
-                'label' => 'Resetovať',
+                'label' => 'Resetovať filtre',
             ],
 
         ],


### PR DESCRIPTION
## Description

Add missing CZ and SK translation

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
