### PR TITLE
Fix select component this outside of object

### DIFF
--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -25,6 +25,7 @@
     $statePath = $getStatePath();
     $state = $getState();
     $livewireKey = $getLivewireKey();
+    $livewireId = $getLivewire()->getId();
 @endphp
 
 <x-dynamic-component
@@ -159,7 +160,7 @@
                             isDisabled: @js($isDisabled),
                             isMultiple: @js($isMultiple),
                             isSearchable: @js($isSearchable),
-                            livewireId: @js($id),
+                            livewireId: @js($livewireId),
                             hasDynamicOptions: @js($hasDynamicOptions()),
                             hasDynamicSearchResults: @js($hasDynamicSearchResults()),
                             loadingMessage: @js($getLoadingMessage()),

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -159,7 +159,7 @@
                             isDisabled: @js($isDisabled),
                             isMultiple: @js($isMultiple),
                             isSearchable: @js($isSearchable),
-                            livewireId: @js($this->getId()),
+                            livewireId: @js($id),
                             hasDynamicOptions: @js($hasDynamicOptions()),
                             hasDynamicSearchResults: @js($hasDynamicSearchResults()),
                             loadingMessage: @js($getLoadingMessage()),


### PR DESCRIPTION
## Description
Fixes #16916. Sorry about the previous pull request #16917 with the incorrect ID 🙏
This is returning the same ID as `$this->getId()`.

The only thing I'm not sure about is if `$getLivewire` variable/closure will always be available here?
I tested it in filters and an edit form, and it seems to be good.

## Visual changes
None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
