### PR TITLE
fix: URL not working on image entry component

### DIFF
--- a/packages/infolists/src/Components/ImageEntry.php
+++ b/packages/infolists/src/Components/ImageEntry.php
@@ -536,7 +536,7 @@ class ImageEntry extends Entry implements HasEmbeddedView
                     "width: {$width}" => $width,
                 ])
                 ->toHtml() ?>>
-                    <?= '+' . $stateOverLimitCount ?>
+                    +<?= $stateOverLimitCount ?>
                 </div>
             <?php } ?>
         </div>

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -528,7 +528,7 @@ class ImageColumn extends Column implements HasEmbeddedView
                     "width: {$width}" => $width,
                 ])
                 ->toHtml() ?>>
-                    <?= '+' . $stateOverLimitCount ?>
+                    +<?= $stateOverLimitCount ?>
                 </div>
             <?php } ?>
         </div>

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -17,6 +17,8 @@ use Illuminate\View\ComponentAttributeBag;
 use League\Flysystem\UnableToCheckFileExistence;
 use Throwable;
 
+use function Filament\Support\generate_href_html;
+
 class ImageColumn extends Column implements HasEmbeddedView
 {
     use CanWrap;
@@ -481,31 +483,36 @@ class ImageColumn extends Column implements HasEmbeddedView
                 ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : ''),
             ]);
 
-        ob_start(); ?>
+        $shouldOpenUrlInNewTab = $this->shouldOpenUrlInNewTab();
 
-        <div <?= $attributes->toHtml() ?>>
-            <?php foreach ($state as $stateItem) { ?>
-                <img
-                    <?= $this->getExtraImgAttributeBag()
-                        ->merge([
-                            'src' => filled($stateItem) ? ($this->getImageUrl($stateItem) ?? $defaultImageUrl) : $defaultImageUrl,
-                            'x-tooltip' => filled($tooltip = $this->getTooltip($stateItem))
-                                ? '{
-                                    content: ' . Js::from($tooltip) . ',
-                                    theme: $store.theme,
-                                }'
-                                : null,
-                        ], escape: false)
-                        ->style([
-                            "height: {$height}" => $height,
-                            "width: {$width}" => $width,
-                        ])
-                        ->toHtml() ?>
-                />
-            <?php } ?>
+        $formatState = function (mixed $stateItem) use ($defaultImageUrl, $width, $height, $shouldOpenUrlInNewTab): string {
 
-            <?php if ($hasLimitedRemainingText) { ?>
-                <div <?= (new ComponentAttributeBag)
+            $item = '<img ' . $this->getExtraImgAttributeBag()
+                ->merge([
+                    'src' => filled($stateItem) ? ($this->getImageUrl($stateItem) ?? $defaultImageUrl) : $defaultImageUrl,
+                    'x-tooltip' => filled($tooltip = $this->getTooltip($stateItem))
+                        ? '{
+                                content: ' . Js::from($tooltip) . ',
+                                theme: $store.theme,
+                            }'
+                        : null,
+                ], escape: false)
+                ->style([
+                    "height: {$height}" => $height,
+                    "width: {$width}" => $width,
+                ])
+                ->toHtml()
+                . ' />';
+
+            if (filled($url = $this->getUrl($stateItem))) {
+                $item = '<a ' . generate_href_html($url, $shouldOpenUrlInNewTab)->toHtml() . '>' . $item . '</a>';
+            }
+
+            return $item;
+        };
+
+        $getLimitedRemainingTextHtml = function () use ($stateOverLimitCount, $limitedRemainingTextSize, $height, $width): string {
+            return '<div ' . (new ComponentAttributeBag)
                 ->class([
                     'fi-ta-image-limited-remaining-text',
                     (($limitedRemainingTextSize instanceof TextSize) ? "fi-size-{$limitedRemainingTextSize->value}" : $limitedRemainingTextSize) => $limitedRemainingTextSize,
@@ -514,12 +521,17 @@ class ImageColumn extends Column implements HasEmbeddedView
                     "height: {$height}" => $height,
                     "width: {$width}" => $width,
                 ])
-                ->toHtml() ?>>
-                    +<?= $stateOverLimitCount ?>
-                </div>
-            <?php } ?>
-        </div>
+                ->toHtml() . '> +' . $stateOverLimitCount . '</div>';
+        };
 
-        <?php return ob_get_clean();
+        $html = implode('', array_map($formatState, $state));
+
+        if ($hasLimitedRemainingText) {
+            $html .= $getLimitedRemainingTextHtml();
+        }
+
+        $html = '<div ' . $attributes->toHtml() . '>' . $html . '</div>';
+
+        return $html;
     }
 }

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -486,7 +486,6 @@ class ImageColumn extends Column implements HasEmbeddedView
         $shouldOpenUrlInNewTab = $this->shouldOpenUrlInNewTab();
 
         $formatState = function (mixed $stateItem) use ($defaultImageUrl, $width, $height, $shouldOpenUrlInNewTab): string {
-
             $item = '<img ' . $this->getExtraImgAttributeBag()
                 ->merge([
                     'src' => filled($stateItem) ? ($this->getImageUrl($stateItem) ?? $defaultImageUrl) : $defaultImageUrl,
@@ -511,8 +510,15 @@ class ImageColumn extends Column implements HasEmbeddedView
             return $item;
         };
 
-        $getLimitedRemainingTextHtml = function () use ($stateOverLimitCount, $limitedRemainingTextSize, $height, $width): string {
-            return '<div ' . (new ComponentAttributeBag)
+        ob_start(); ?>
+
+        <div <?= $attributes->toHtml() ?>>
+            <?php foreach ($state as $stateItem) { ?>
+                <?= $formatState($stateItem) ?>
+            <?php } ?>
+
+            <?php if ($hasLimitedRemainingText) { ?>
+                <div <?= (new ComponentAttributeBag)
                 ->class([
                     'fi-ta-image-limited-remaining-text',
                     (($limitedRemainingTextSize instanceof TextSize) ? "fi-size-{$limitedRemainingTextSize->value}" : $limitedRemainingTextSize) => $limitedRemainingTextSize,
@@ -521,17 +527,12 @@ class ImageColumn extends Column implements HasEmbeddedView
                     "height: {$height}" => $height,
                     "width: {$width}" => $width,
                 ])
-                ->toHtml() . '> +' . $stateOverLimitCount . '</div>';
-        };
+                ->toHtml() ?>>
+                    <?= '+' . $stateOverLimitCount ?>
+                </div>
+            <?php } ?>
+        </div>
 
-        $html = implode('', array_map($formatState, $state));
-
-        if ($hasLimitedRemainingText) {
-            $html .= $getLimitedRemainingTextHtml();
-        }
-
-        $html = '<div ' . $attributes->toHtml() . '>' . $html . '</div>';
-
-        return $html;
+        <?php return ob_get_clean();
     }
 }


### PR DESCRIPTION
## Description
Fixes #16899. It seems that the logic that adds the `<a>` to the `<img>` elements was missing.

I took inspiration from the `packages/infolists/src/Components/TextEntry.php` component for consistency.

Tested on:

- Single image ✅
- Multiple images ✅
- Multiple images with a limit (and limit exceeded text) ✅
- Works with state-based URLs ✅
    - Such as `->url(fn(string $state): ?string => $state)` 

In regards to documentation, the TextEntry component doesn't mention it, and I assume this is because it's [covered in the Overview](https://filamentphp.com/docs/4.x/infolists/overview#opening-a-url-when-an-entry-is-clicked) so I'm not sure if we need to go into more detail than that.

## Visual changes
None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
