### PR TITLE
Add `refresh-page` event / listener

### DIFF
--- a/packages/panels/src/Pages/BasePage.php
+++ b/packages/panels/src/Pages/BasePage.php
@@ -14,6 +14,7 @@ use Filament\Support\Exceptions\Halt;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View;
 use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\On;
 use Livewire\Component;
 
 abstract class BasePage extends Component implements HasActions, HasRenderHookScopes, HasSchemas
@@ -45,6 +46,9 @@ abstract class BasePage extends Component implements HasActions, HasRenderHookSc
     public static bool $formActionsAreSticky = false;
 
     public static bool $hasInlineLabels = false;
+
+    #[On('refresh-page')]
+    public function refresh(): void {}
 
     public function render(): View
     {


### PR DESCRIPTION
Adds a `refresh-page` event/listener, similar to `refresh-sidebar` and `refresh-topbar`. 

Now that we have a `content()` method that accepts any combination of components, it's easy to end up with complex pages where `record->refresh()` or re-filling the form doesn't refresh everything that needs to be. This provides a simple way to nuke everything if you have to.

Not sure if this should be added to the docs or not. If it should be, let me know which section to put it in.