### PR TITLE
fix: ensure $format defaults to null in isoDate(Time) methods

### DIFF
--- a/packages/infolists/src/Components/Concerns/CanFormatState.php
+++ b/packages/infolists/src/Components/Concerns/CanFormatState.php
@@ -83,9 +83,11 @@ trait CanFormatState
         return $this;
     }
 
-    public function isoDate(string | Closure | null $format, string | Closure | null $timezone = null): static
+    public function isoDate(string | Closure | null $format = null, string | Closure | null $timezone = null): static
     {
         $this->isDate = true;
+
+        $format ??= fn (TextEntry $component): string => $component->getContainer()->getDefaultIsoDateDisplayFormat();
 
         $this->formatStateUsing(static function (TextEntry $component, $state) use ($format, $timezone): ?string {
             if (blank($state)) {
@@ -100,7 +102,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function isoDateTime(string | Closure | null $format, string | Closure | null $timezone = null): static
+    public function isoDateTime(string | Closure | null $format = null, string | Closure | null $timezone = null): static
     {
         $this->isDateTime = true;
 

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -83,9 +83,11 @@ trait CanFormatState
         return $this;
     }
 
-    public function isoDate(string | Closure | null $format, string | Closure | null $timezone = null): static
+    public function isoDate(string | Closure | null $format = null, string | Closure | null $timezone = null): static
     {
         $this->isDate = true;
+
+        $format ??= fn (TextColumn $column): string => $column->getTable()->getDefaultIsoDateDisplayFormat();
 
         $this->formatStateUsing(static function (TextColumn $column, $state) use ($format, $timezone): ?string {
             if (blank($state)) {
@@ -100,7 +102,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function isoDateTime(string | Closure | null $format, string | Closure | null $timezone = null): static
+    public function isoDateTime(string | Closure | null $format = null, string | Closure | null $timezone = null): static
     {
         $this->isDateTime = true;
 


### PR DESCRIPTION
## Description

This pull request addresses a missing default value for the $format parameter in the following methods:

- isoDate
- isoDateTime

These methods are designed to use a fallback format when no $format is provided (i.e., when $format is null). However, until now, the $format parameter did not have a default value, which meant that calling these methods without explicitly passing a format would result in an ArgumentCountError.

This PR sets the default value of $format to null to align the implementation with the intended behavior.

The same issue recently occurred in the iso*Tooltip methods. See: #16771 

## Visual changes

There are no visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
