### PR TITLE
fix/accessibility fix for complex elements 3.x

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -34,7 +34,11 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" labelTag="div">
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
+    labelTag="div"
+>
     <div
         x-data="{}"
         {{

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -34,7 +34,11 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" label-tag="div">
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
+    label-tag="div"
+>
     <div
         x-data="{}"
         {{

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -34,7 +34,7 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
+<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" labelTag="div">
     <div
         x-data="{}"
         {{

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -34,11 +34,16 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" labelTag="div">
+<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" label-tag="div">
     <div
         x-data="{}"
         {{
             $attributes
+                ->merge([
+                    'aria-labelledby' => "{$getId()}-label",
+                    'id' => $getId(),
+                    'role' => 'group',
+                ], escape: false)
                 ->merge($getExtraAttributes(), escape: false)
                 ->class(['fi-fo-builder grid grid-cols-1 gap-y-4'])
         }}

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -1,5 +1,6 @@
 @php
     $gridDirection = $getGridDirection() ?? 'column';
+    $id = $getId();
     $isBulkToggleable = $isBulkToggleable();
     $isDisabled = $isDisabled();
     $isSearchable = $isSearchable();
@@ -15,8 +16,8 @@
         {{
             $attributes
                 ->merge([
-                    'aria-labelledby' => "{$getId()}-label",
-                    'id' => $getId(),
+                    'aria-labelledby' => "{$id}-label",
+                    'id' => $id,
                     'role' => 'group',
                 ], escape: false)
         }}
@@ -174,6 +175,10 @@
             "
         >
             @forelse ($getOptions() as $value => $label)
+                @php
+                    $inputId = "{$id}-{$value}";
+                @endphp
+
                 <div
                     wire:key="{{ $this->getId() }}.{{ $statePath }}.{{ $field::class }}.options.{{ $value }}"
                     @if ($isSearchable)
@@ -194,6 +199,7 @@
                 >
                     <label
                         class="fi-fo-checkbox-list-option-label flex gap-x-3"
+                        for="{{ $inputId }}"
                     >
                         <x-filament::input.checkbox
                             :valid="! $errors->has($statePath)"
@@ -201,6 +207,7 @@
                                 \Filament\Support\prepare_inherited_attributes($getExtraInputAttributeBag())
                                     ->merge([
                                         'disabled' => $isDisabled || $isOptionDisabled($value, $label),
+                                        'id' => $inputId,
                                         'value' => $value,
                                         'wire:loading.attr' => 'disabled',
                                         $applyStateBindingModifiers('wire:model') => $statePath,

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -6,7 +6,7 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
+<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" labelTag="div">
     <div
         x-data="{
             areAllCheckboxesChecked: false,

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -6,7 +6,11 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" label-tag="div">
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
+    label-tag="div"
+>
     <div
         {{
             $attributes

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -6,7 +6,11 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" labelTag="div">
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
+    labelTag="div"
+>
     <div
         x-data="{
             areAllCheckboxesChecked: false,

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -6,8 +6,16 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" labelTag="div">
+<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" label-tag="div">
     <div
+        {{
+            $attributes
+                ->merge([
+                    'aria-labelledby' => "{$getId()}-label",
+                    'id' => $getId(),
+                    'role' => 'group',
+                ], escape: false)
+        }}
         x-data="{
             areAllCheckboxesChecked: false,
 

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -139,7 +139,7 @@
                         placeholder="{{ $getPlaceholder() }}"
                         wire:key="{{ $this->getId() }}.{{ $statePath }}.{{ $field::class }}.display-text"
                         x-model="displayText"
-                        @if ($id = $getId()) id="{{ $id }}" @endif
+                        id="{{ $id }}"
                         @class([
                             'fi-fo-date-time-picker-display-text-input w-full border-none bg-transparent px-3 py-1.5 text-base text-gray-950 outline-none transition duration-75 placeholder:text-gray-400 focus:ring-0 disabled:text-gray-500 disabled:[-webkit-text-fill-color:theme(colors.gray.500)] dark:text-white dark:placeholder:text-gray-500 dark:disabled:text-gray-400 dark:disabled:[-webkit-text-fill-color:theme(colors.gray.400)] sm:text-sm sm:leading-6',
                         ])
@@ -161,6 +161,7 @@
                             <div class="flex items-center justify-between">
                                 <select
                                     x-model="focusedMonth"
+                                    id="{{ $id }}-month"
                                     class="grow cursor-pointer border-none bg-transparent p-0 text-sm font-medium text-gray-950 focus:ring-0 dark:bg-gray-900 dark:text-white"
                                 >
                                     <template
@@ -177,6 +178,7 @@
                                     type="number"
                                     inputmode="numeric"
                                     x-model.debounce="focusedYear"
+                                    id="{{ $id }}-year"
                                     class="w-16 border-none bg-transparent p-0 text-right text-sm text-gray-950 focus:ring-0 dark:text-white"
                                 />
                             </div>
@@ -248,6 +250,7 @@
                                     type="number"
                                     inputmode="numeric"
                                     x-model.debounce="hour"
+                                    id="{{ $id }}-hour"
                                     class="me-1 w-10 border-none bg-transparent p-0 text-center text-sm text-gray-950 focus:ring-0 dark:text-white"
                                 />
 
@@ -264,6 +267,7 @@
                                     type="number"
                                     inputmode="numeric"
                                     x-model.debounce="minute"
+                                    id="{{ $id }}-minute"
                                     class="me-1 w-10 border-none bg-transparent p-0 text-center text-sm text-gray-950 focus:ring-0 dark:text-white"
                                 />
 
@@ -281,6 +285,7 @@
                                         type="number"
                                         inputmode="numeric"
                                         x-model.debounce="second"
+                                        id="{{ $id }}-second"
                                         class="me-1 w-10 border-none bg-transparent p-0 text-center text-sm text-gray-950 focus:ring-0 dark:text-white"
                                     />
                                 @endif

--- a/packages/forms/resources/views/components/key-value.blade.php
+++ b/packages/forms/resources/views/components/key-value.blade.php
@@ -14,6 +14,7 @@
     :component="$getFieldWrapperView()"
     :field="$field"
     :has-inline-label="$hasInlineLabel"
+    labelTag="div"
 >
     <x-slot
         name="label"

--- a/packages/forms/resources/views/components/key-value.blade.php
+++ b/packages/forms/resources/views/components/key-value.blade.php
@@ -8,6 +8,7 @@
     $isDisabled = $isDisabled();
     $isReorderable = $isReorderable();
     $statePath = $getStatePath();
+    $id = $getId();
 @endphp
 
 <x-dynamic-component
@@ -47,8 +48,8 @@
             {{
                 $attributes
                     ->merge([
-                        'aria-labelledby' => "{$getId()}-label",
-                        'id' => $getId(),
+                        'aria-labelledby' => "{$id}-label",
+                        'id' => $id,
                         'role' => 'group',
                     ], escape: false)
                     ->merge($getExtraAlpineAttributes(), escape: false)
@@ -124,6 +125,7 @@
                                     :placeholder="filled($placeholder = $getKeyPlaceholder()) ? $placeholder : null"
                                     type="text"
                                     x-model="row.key"
+                                    x-bind:id="'{{ $id }}-key-' + index"
                                     :attributes="
                                         \Filament\Support\prepare_inherited_attributes(
                                             new \Illuminate\View\ComponentAttributeBag([
@@ -141,6 +143,7 @@
                                     :placeholder="filled($placeholder = $getValuePlaceholder()) ? $placeholder : null"
                                     type="text"
                                     x-model="row.value"
+                                    x-bind:id="'{{ $id }}-value-' + index"
                                     :attributes="
                                         \Filament\Support\prepare_inherited_attributes(
                                             new \Illuminate\View\ComponentAttributeBag([

--- a/packages/forms/resources/views/components/key-value.blade.php
+++ b/packages/forms/resources/views/components/key-value.blade.php
@@ -71,6 +71,7 @@
 
                         <th
                             scope="col"
+                            id="{{ $id }}-key-header"
                             class="px-3 py-2 text-start text-sm font-medium text-gray-700 dark:text-gray-200"
                         >
                             {{ $getKeyLabel() }}
@@ -78,6 +79,7 @@
 
                         <th
                             scope="col"
+                            id="{{ $id }}-value-header"
                             class="px-3 py-2 text-start text-sm font-medium text-gray-700 dark:text-gray-200"
                         >
                             {{ $getValueLabel() }}
@@ -126,6 +128,8 @@
                                     type="text"
                                     x-model="row.key"
                                     x-bind:id="'{{ $id }}-key-' + index"
+                                    x-bind:aria-label="'{{ $getKeyLabel() }} ' + index"
+                                    aria-describedby="{{ $id }}-key-header"
                                     :attributes="
                                         \Filament\Support\prepare_inherited_attributes(
                                             new \Illuminate\View\ComponentAttributeBag([
@@ -144,6 +148,8 @@
                                     type="text"
                                     x-model="row.value"
                                     x-bind:id="'{{ $id }}-value-' + index"
+                                    x-bind:aria-label="'{{ $getValueLabel() }} ' + index"
+                                    aria-describedby="{{ $id }}-value-header"
                                     :attributes="
                                         \Filament\Support\prepare_inherited_attributes(
                                             new \Illuminate\View\ComponentAttributeBag([

--- a/packages/forms/resources/views/components/key-value.blade.php
+++ b/packages/forms/resources/views/components/key-value.blade.php
@@ -14,7 +14,7 @@
     :component="$getFieldWrapperView()"
     :field="$field"
     :has-inline-label="$hasInlineLabel"
-    labelTag="div"
+    label-tag="div"
 >
     <x-slot
         name="label"
@@ -46,6 +46,11 @@
                     })"
             {{
                 $attributes
+                    ->merge([
+                        'aria-labelledby' => "{$getId()}-label",
+                        'id' => $getId(),
+                        'role' => 'group',
+                    ], escape: false)
                     ->merge($getExtraAlpineAttributes(), escape: false)
                     ->class(['divide-y divide-gray-200 dark:divide-white/10'])
             }}

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -6,7 +6,7 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
+<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" labelTag="div">
     <x-filament::grid
         :default="$getColumns('default')"
         :sm="$getColumns('sm')"

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -6,7 +6,11 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" labelTag="div">
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
+    labelTag="div"
+>
     <x-filament::grid
         :default="$getColumns('default')"
         :sm="$getColumns('sm')"

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -6,7 +6,7 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" labelTag="div">
+<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" label-tag="div">
     <x-filament::grid
         :default="$getColumns('default')"
         :sm="$getColumns('sm')"
@@ -18,6 +18,11 @@
         :direction="$gridDirection"
         :attributes="
             \Filament\Support\prepare_inherited_attributes($attributes)
+                ->merge([
+                    'aria-labelledby' => '{$getId()}-label',
+                    'id' => $getId(),
+                    'role' => 'radiogroup',
+                ], escape: false)
                 ->merge($getExtraAttributes(), escape: false)
                 ->class([
                     'fi-fo-radio gap-4',

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -6,7 +6,11 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" label-tag="div">
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
+    label-tag="div"
+>
     <x-filament::grid
         :default="$getColumns('default')"
         :sm="$getColumns('sm')"

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -5,7 +5,7 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" labelTag="div">
+<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" label-tag="div">
     @if ($isDisabled())
         <div
             x-data="{
@@ -32,6 +32,14 @@
                 x-data="richEditorFormComponent({
                             state: $wire.{{ $applyStateBindingModifiers("\$entangle('{$statePath}')", isOptimisticallyLive: false) }},
                         })"
+                {{
+                    $getExtraAlpineAttributeBag()
+                        ->merge([
+                            'aria-labelledby' => "{$getId()}-label",
+                            'id' => $getId(),
+                            'role' => 'group',
+                        ], escape: false)
+                }}
                 x-on:trix-attachment-add="
                     if (! $event.attachment.file) return
 

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -5,7 +5,11 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" label-tag="div">
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
+    label-tag="div"
+>
     @if ($isDisabled())
         <div
             x-data="{

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -5,7 +5,11 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" labelTag="div">
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
+    labelTag="div"
+>
     @if ($isDisabled())
         <div
             x-data="{

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -5,7 +5,7 @@
     $statePath = $getStatePath();
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
+<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" labelTag="div">
     @if ($isDisabled())
         <div
             x-data="{


### PR DESCRIPTION
# Filament Accessibility Fixes Progress

## Components for Both 3.x and 4.x

-   [x] Builder
-   [x] Checkbox list
-   [x] Key-value
-   [x] Radio
-   [x] Rich editor
-   [x] Date time picker (non-native only) (see notes)
-   [ ] Select (non-native only) (see notes)
-   [ ] Toggle (needs ID) (see notes)

## Components for 4.x Only

-   [ ] Code editor
-   [ ] Color picker
-   [ ] Livewire field
-   [ ] Modal table select
-   [ ] Repeater, simple repeater, table repeater
-   [ ] Slider
-   [ ] Table select
-   [ ] Tags input
-   [ ] One time code input (needs ID for label mapping)

## Notes
- All listed components are on the test results for the screenshot.
- **Date time picker** (non-native) label is already pointing to a readonly input that's inside a button. Chrome and Light House do not show an error. Added id's for sub components.
- **Select** (non-native) label is pointing to a hidden select but the element is Choices.js. No Chrome errors found to fix.
- **Toggle** already has an id. 

## Visual changes
Before:
<img width="1074" height="243" alt="image" src="https://github.com/user-attachments/assets/b5068ac2-702d-43b3-af56-a6d306efdab2" />

After:
<img width="1094" height="380" alt="image" src="https://github.com/user-attachments/assets/b5f0aee5-da57-48d3-83fc-f3c70bb15fca" />


## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
