### PR TITLE
V4 fix hiding columns in column manager when hidden

### DIFF
--- a/packages/panels/src/Resources/Concerns/HasTabs.php
+++ b/packages/panels/src/Resources/Concerns/HasTabs.php
@@ -51,6 +51,10 @@ trait HasTabs
     public function updatedActiveTab(): void
     {
         $this->resetPage();
+
+        $this->cachedDefaultTableColumnState = null;
+
+        $this->applyTableColumnManager();
     }
 
     public function generateTabLabel(string $key): string

--- a/packages/tables/src/Concerns/HasColumnManager.php
+++ b/packages/tables/src/Concerns/HasColumnManager.php
@@ -192,28 +192,39 @@ trait HasColumnManager
     }
 
     /**
-     * @return array{type: string, name: string, label: string, isToggled: bool, isToggleable: bool, columns: array<int, array{type: string, name: string, label: string, isToggled: bool, isToggleable: bool}>}
+     * @return ?array{type: string, name: string, label: string, isToggled: bool, isToggleable: bool, columns: array<int, array{type: string, name: string, label: string, isToggled: bool, isToggleable: bool}>}
      */
-    protected function mapTableColumnGroupToArray(ColumnGroup $group): array
+    protected function mapTableColumnGroupToArray(ColumnGroup $group): ?array
     {
+        $columns = collect($group->getColumns())
+            ->map(fn (Column $column): ?array => $this->mapTableColumnToArray($column))
+            ->filter()
+            ->values()
+            ->all();
+
+        if (empty($columns)) {
+            return null;
+        }
+
         return [
             'type' => self::TABLE_COLUMN_MANAGER_GROUP_TYPE,
             'name' => (string) $group->getLabel(),
             'label' => (string) $group->getLabel(),
             'isToggled' => true,
             'isToggleable' => true,
-            'columns' => collect($group->getColumns())
-                ->map(fn (Column $column): array => $this->mapTableColumnToArray($column))
-                ->values()
-                ->all(),
+            'columns' => $columns,
         ];
     }
 
     /**
-     * @return array{type: string, name: string, label: string, isToggled: bool, isToggleable: bool}
+     * @return ?array{type: string, name: string, label: string, isToggled: bool, isToggleable: bool}
      */
-    protected function mapTableColumnToArray(Column $column): array
+    protected function mapTableColumnToArray(Column $column): ?array
     {
+        if ($column->isHidden()) {
+            return null;
+        }
+
         return [
             'type' => self::TABLE_COLUMN_MANAGER_COLUMN_TYPE,
             'name' => $column->getName(),


### PR DESCRIPTION
Fixes #16880 

Dan, as we talked about separately, this PR _for the most part_ fixes the issue where table columns that use the `->hidden()`method were showing up in the column manager.

However, the one area where this is not working is when a dev is hiding a column based on the `activeTab` AND the table columns have been reordered. When those two conditions are met, then when switching to another tab that has different (or no) logic for hiding columns based on the active tab, neither the columns, nor the manager update on the first click. 

I actually now know what the issue is and how to fix it, but I will do that in a separate PR later on as that scenario is more of an edge case compared to the wider issue this PR is fixing.

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
