### PR TITLE
Fix the column bug that uses formatStateUsing which returns an HtmlString

### DIFF
--- a/packages/infolists/src/Components/Concerns/CanFormatState.php
+++ b/packages/infolists/src/Components/Concerns/CanFormatState.php
@@ -373,12 +373,14 @@ trait CanFormatState
             $state = $state->getLabel();
         }
 
-        if ($characterLimit = $this->getCharacterLimit()) {
-            $state = Str::limit($state, $characterLimit, $this->getCharacterLimitEnd());
-        }
+        if (! $isHtml) {
+            if ($characterLimit = $this->getCharacterLimit()) {
+                $state = Str::limit($state, $characterLimit, $this->getCharacterLimitEnd());
+            }
 
-        if ($wordLimit = $this->getWordLimit()) {
-            $state = Str::words($state, $wordLimit, $this->getWordLimitEnd());
+            if ($wordLimit = $this->getWordLimit()) {
+                $state = Str::words($state, $wordLimit, $this->getWordLimitEnd());
+            }
         }
 
         $prefix = $this->getPrefix();

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -377,12 +377,14 @@ trait CanFormatState
             $state = $state->getLabel();
         }
 
-        if ($characterLimit = $this->getCharacterLimit()) {
-            $state = Str::limit($state, $characterLimit, $this->getCharacterLimitEnd());
-        }
+        if (! $isHtml) {
+            if ($characterLimit = $this->getCharacterLimit()) {
+                $state = Str::limit($state, $characterLimit, $this->getCharacterLimitEnd());
+            }
 
-        if ($wordLimit = $this->getWordLimit()) {
-            $state = Str::words($state, $wordLimit, $this->getWordLimitEnd());
+            if ($wordLimit = $this->getWordLimit()) {
+                $state = Str::words($state, $wordLimit, $this->getWordLimitEnd());
+            }
         }
 
         $prefix = $this->getPrefix();


### PR DESCRIPTION
When formatStateUsing returns an instance of Htmlable.

This was limiting the HTML text and causing it to break.

A check was added to Str::limit and Str::words to verify whether the state is an instance of Htmlable.

Bug demonstration with the image below.

<img width="567" height="247" alt="Captura de tela 2025-07-13 184301" src="https://github.com/user-attachments/assets/564d02be-4c35-483b-b80d-f8d74ab28474" />

Using ysfkaya/phone-input PhoneColumn has a formatStateUsing which returns an HtmlString.

https://github.com/ysfkaya/filament-phone-input/blob/main/src/Tables/PhoneColumn.php#L52

Then I identified the problem with the check before doing Str::limit and Str::words on a state that is an HTML.

<img width="624" height="286" alt="image" src="https://github.com/user-attachments/assets/cc643b9c-4b1f-414e-b941-66603c97ef6c" />