### PR TITLE
Add missing SK & CZ components translation

### DIFF
--- a/packages/forms/resources/lang/cs/components.php
+++ b/packages/forms/resources/lang/cs/components.php
@@ -289,6 +289,7 @@ return [
             'blockquote' => 'Bloková citace',
             'bold' => 'Tučně',
             'bullet_list' => 'Seznam s odrážkami',
+            'code' => 'Kód',
             'code_block' => 'Blok kódu',
             'heading' => 'Nadpis',
             'italic' => 'Kurzíva',
@@ -386,6 +387,7 @@ return [
     ],
 
     'rich_editor' => [
+
         'actions' => [
 
             'attach_files' => [
@@ -480,6 +482,7 @@ return [
             'bold' => 'Tučně',
             'bullet_list' => 'Seznam s odrážkami',
             'clear_formatting' => 'Vymazat formátování',
+            'code' => 'Kód',
             'code_block' => 'Blok kódu',
             'custom_blocks' => 'Bloky',
             'details' => 'Detaily',

--- a/packages/forms/resources/lang/sk/components.php
+++ b/packages/forms/resources/lang/sk/components.php
@@ -289,6 +289,7 @@ return [
             'blockquote' => 'Citát',
             'bold' => 'Tučné písmo',
             'bullet_list' => 'Odrážkový zoznam',
+            'code' => 'Kód',
             'code_block' => 'Blok kódu',
             'heading' => 'Nadpis',
             'italic' => 'Kurzíva',
@@ -386,6 +387,7 @@ return [
     ],
 
     'rich_editor' => [
+
         'actions' => [
 
             'attach_files' => [
@@ -480,6 +482,7 @@ return [
             'bold' => 'Tučné písmo',
             'bullet_list' => 'Odrážkový zoznam',
             'clear_formatting' => 'Vymazať formátovanie',
+            'code' => 'Kód',
             'code_block' => 'Blok kódu',
             'custom_blocks' => 'Bloky',
             'details' => 'Detaily',

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -4,6 +4,7 @@ namespace Filament\Forms\Components;
 
 use Closure;
 use Exception;
+use Filament\Forms\View\FormsIconAlias;
 use Filament\Support\Concerns\HasAlignment;
 use Filament\Support\Concerns\HasExtraAlpineAttributes;
 use Filament\Support\Icons\Heroicon;
@@ -529,7 +530,7 @@ class FileUpload extends BaseFileUpload
                     'label' => __('filament-forms::components.file_upload.editor.actions.drag_move.label'),
                     'iconHtml' => generate_icon_html(
                         'fi-o-arrows-move',
-                        alias: \Filament\Forms\View\FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_DRAG_MOVE,
+                        alias: FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_DRAG_MOVE,
                     ),
                     'alpineClickHandler' => "editor.setDragMode('move')",
                 ],
@@ -537,7 +538,7 @@ class FileUpload extends BaseFileUpload
                     'label' => __('filament-forms::components.file_upload.editor.actions.drag_crop.label'),
                     'iconHtml' => generate_icon_html(
                         'fi-o-crop',
-                        alias: \Filament\Forms\View\FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_DRAG_CROP,
+                        alias: FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_DRAG_CROP,
                     ),
                     'alpineClickHandler' => "editor.setDragMode('crop')",
                 ],
@@ -545,7 +546,7 @@ class FileUpload extends BaseFileUpload
                     'label' => __('filament-forms::components.file_upload.editor.actions.zoom_in.label'),
                     'iconHtml' => generate_icon_html(
                         Heroicon::MagnifyingGlassPlus,
-                        alias: \Filament\Forms\View\FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_ZOOM_IN,
+                        alias: FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_ZOOM_IN,
                     ),
                     'alpineClickHandler' => 'editor.zoom(0.1)',
                 ],
@@ -553,7 +554,7 @@ class FileUpload extends BaseFileUpload
                     'label' => __('filament-forms::components.file_upload.editor.actions.zoom_out.label'),
                     'iconHtml' => generate_icon_html(
                         Heroicon::MagnifyingGlassMinus,
-                        alias: \Filament\Forms\View\FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_ZOOM_OUT,
+                        alias: FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_ZOOM_OUT,
                     ),
                     'alpineClickHandler' => 'editor.zoom(-0.1)',
                 ],
@@ -561,7 +562,7 @@ class FileUpload extends BaseFileUpload
                     'label' => __('filament-forms::components.file_upload.editor.actions.zoom_100.label'),
                     'iconHtml' => generate_icon_html(
                         Heroicon::ArrowsPointingOut,
-                        alias: \Filament\Forms\View\FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_ZOOM_100,
+                        alias: FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_ZOOM_100,
                     ),
                     'alpineClickHandler' => 'editor.zoomTo(1)',
                 ],
@@ -571,7 +572,7 @@ class FileUpload extends BaseFileUpload
                     'label' => __('filament-forms::components.file_upload.editor.actions.move_left.label'),
                     'iconHtml' => generate_icon_html(
                         Heroicon::ArrowLeftCircle,
-                        alias: \Filament\Forms\View\FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_MOVE_LEFT,
+                        alias: FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_MOVE_LEFT,
                     ),
                     'alpineClickHandler' => 'editor.move(-10, 0)',
                 ],
@@ -579,7 +580,7 @@ class FileUpload extends BaseFileUpload
                     'label' => __('filament-forms::components.file_upload.editor.actions.move_right.label'),
                     'iconHtml' => generate_icon_html(
                         Heroicon::ArrowRightCircle,
-                        alias: \Filament\Forms\View\FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_MOVE_RIGHT,
+                        alias: FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_MOVE_RIGHT,
                     ),
                     'alpineClickHandler' => 'editor.move(10, 0)',
                 ],
@@ -587,7 +588,7 @@ class FileUpload extends BaseFileUpload
                     'label' => __('filament-forms::components.file_upload.editor.actions.move_up.label'),
                     'iconHtml' => generate_icon_html(
                         Heroicon::ArrowUpCircle,
-                        alias: \Filament\Forms\View\FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_MOVE_UP,
+                        alias: FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_MOVE_UP,
                     ),
                     'alpineClickHandler' => 'editor.move(0, -10)',
                 ],
@@ -595,7 +596,7 @@ class FileUpload extends BaseFileUpload
                     'label' => __('filament-forms::components.file_upload.editor.actions.move_down.label'),
                     'iconHtml' => generate_icon_html(
                         Heroicon::ArrowDownCircle,
-                        alias: \Filament\Forms\View\FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_MOVE_DOWN,
+                        alias: FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_MOVE_DOWN,
                     ),
                     'alpineClickHandler' => 'editor.move(0, 10)',
                 ],
@@ -605,7 +606,7 @@ class FileUpload extends BaseFileUpload
                     'label' => __('filament-forms::components.file_upload.editor.actions.rotate_left.label'),
                     'iconHtml' => generate_icon_html(
                         Heroicon::ArrowUturnLeft,
-                        alias: \Filament\Forms\View\FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_ROTATE_LEFT,
+                        alias: FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_ROTATE_LEFT,
                     ),
                     'alpineClickHandler' => 'editor.rotate(-90)',
                 ],
@@ -613,7 +614,7 @@ class FileUpload extends BaseFileUpload
                     'label' => __('filament-forms::components.file_upload.editor.actions.rotate_right.label'),
                     'iconHtml' => generate_icon_html(
                         Heroicon::ArrowUturnRight,
-                        alias: \Filament\Forms\View\FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_ROTATE_RIGHT,
+                        alias: FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_ROTATE_RIGHT,
                     ),
                     'alpineClickHandler' => 'editor.rotate(90)',
                 ],
@@ -621,7 +622,7 @@ class FileUpload extends BaseFileUpload
                     'label' => __('filament-forms::components.file_upload.editor.actions.flip_horizontal.label'),
                     'iconHtml' => generate_icon_html(
                         'fi-o-flip-horizontal',
-                        alias: \Filament\Forms\View\FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_FLIP_HORIZONTAL,
+                        alias: FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_FLIP_HORIZONTAL,
                     ),
                     'alpineClickHandler' => 'editor.scaleX(-editor.getData().scaleX || -1)',
                 ],
@@ -629,7 +630,7 @@ class FileUpload extends BaseFileUpload
                     'label' => __('filament-forms::components.file_upload.editor.actions.flip_vertical.label'),
                     'iconHtml' => generate_icon_html(
                         'fi-o-flip-vertical',
-                        alias: \Filament\Forms\View\FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_FLIP_VERTICAL,
+                        alias: FormsIconAlias::COMPONENTS_FILE_UPLOAD_EDITOR_ACTIONS_FLIP_VERTICAL,
                     ),
                     'alpineClickHandler' => 'editor.scaleY(-editor.getData().scaleY || -1)',
                 ],

--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -9,6 +9,7 @@ use Filament\Notifications\Events\DatabaseNotificationsSent;
 use Filament\Notifications\Livewire\Notifications;
 use Filament\Notifications\View\Components\NotificationComponent;
 use Filament\Notifications\View\Components\NotificationComponent\IconComponent;
+use Filament\Notifications\View\NotificationsIconAlias;
 use Filament\Support\Components\Contracts\HasEmbeddedView;
 use Filament\Support\Components\ViewComponent;
 use Filament\Support\Concerns\HasColor;
@@ -392,7 +393,7 @@ class Notification extends ViewComponent implements Arrayable, HasEmbeddedView
                 x-on:click="close"
                 class="fi-icon-btn fi-no-notification-close-btn"
             >
-                <?= generate_icon_html(Heroicon::XMark, alias: \Filament\Notifications\View\NotificationsIconAlias::NOTIFICATION_CLOSE_BUTTON)->toHtml() ?>
+                <?= generate_icon_html(Heroicon::XMark, alias: NotificationsIconAlias::NOTIFICATION_CLOSE_BUTTON)->toHtml() ?>
             </button>
         </div>
 


### PR DESCRIPTION
## Description

Add missing SK & CZ components translation.

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
