### PR TITLE
[4.x] Add missing tableAction/tableActionRecord initializer

### DIFF
--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -57,6 +57,24 @@ trait InteractsWithActions
     public $defaultActionContext = null;
 
     /**
+     * @var mixed
+     */
+    #[Url(as: 'tableAction')]
+    public $defaultTableAction = null;
+
+    /**
+     * @var mixed
+     */
+    #[Url(as: 'tableActionRecord')]
+    public $defaultTableActionRecord = null;
+
+    /**
+     * @var mixed
+     */
+    #[Url(as: 'tableActionArguments')]
+    public $defaultTableActionArguments = null;
+
+    /**
      * @var array<string, Action>
      */
     protected array $cachedActions = [];

--- a/packages/panels/resources/views/components/page/index.blade.php
+++ b/packages/panels/resources/views/components/page/index.blade.php
@@ -128,6 +128,10 @@
         <div
             wire:init="mountAction(@js($this->defaultAction) @if (filled($this->defaultActionArguments) || filled($this->defaultActionContext)) , @if (filled($this->defaultActionArguments)) @js($this->defaultActionArguments) @else {} @endif @endif @if (filled($this->defaultActionContext)) @js($this->defaultActionContext) @endif)"
         ></div>
+    @elseif ($this instanceof \Filament\Tables\Contracts\HasTable && filled($this->defaultTableAction) && filled($this->defaultTableActionRecord))
+        <div
+            wire:init="mountTableAction(@js($this->defaultTableAction), @js($this->defaultTableActionRecord) @if(filled($this->tableActionArguments)), @js($this->tableActionArguments) @endif)"
+        ></div>
     @endif
 
     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_END, scopes: $this->getRenderHookScopes()) }}

--- a/packages/panels/resources/views/components/page/index.blade.php
+++ b/packages/panels/resources/views/components/page/index.blade.php
@@ -122,15 +122,15 @@
 
     @if (! ($this instanceof \Filament\Tables\Contracts\HasTable))
         <x-filament-actions::modals />
+    @elseif ($this->isTableLoaded() && filled($this->defaultTableAction))
+        <div
+            wire:init="mountAction(@js($this->defaultTableAction) , @if (filled($this->defaultTableActionArguments)) @js($this->defaultTableActionArguments) @else {} @endif , @js(['table' => true, 'recordKey' => $this->defaultTableActionRecord]))"
+        ></div>
     @endif
 
     @if (filled($this->defaultAction))
         <div
-            wire:init="mountAction(@js($this->defaultAction) @if (filled($this->defaultActionArguments) || filled($this->defaultActionContext)) , @if (filled($this->defaultActionArguments)) @js($this->defaultActionArguments) @else {} @endif @endif @if (filled($this->defaultActionContext)) @js($this->defaultActionContext) @endif)"
-        ></div>
-    @elseif ($this instanceof \Filament\Tables\Contracts\HasTable && filled($this->defaultTableAction) && filled($this->defaultTableActionRecord))
-        <div
-            wire:init="mountTableAction(@js($this->defaultTableAction), @js($this->defaultTableActionRecord) @if(filled($this->tableActionArguments)) , @js($this->tableActionArguments) @endif)"
+            wire:init="mountAction(@js($this->defaultAction) @if (filled($this->defaultActionArguments) || filled($this->defaultActionContext)) , @if (filled($this->defaultActionArguments)) @js($this->defaultActionArguments) @else {} @endif @endif @if (filled($this->defaultActionContext)) , @js($this->defaultActionContext) @endif)"
         ></div>
     @endif
 

--- a/packages/panels/resources/views/components/page/index.blade.php
+++ b/packages/panels/resources/views/components/page/index.blade.php
@@ -130,7 +130,7 @@
         ></div>
     @elseif ($this instanceof \Filament\Tables\Contracts\HasTable && filled($this->defaultTableAction) && filled($this->defaultTableActionRecord))
         <div
-            wire:init="mountTableAction(@js($this->defaultTableAction), @js($this->defaultTableActionRecord) @if(filled($this->tableActionArguments)), @js($this->tableActionArguments) @endif)"
+            wire:init="mountTableAction(@js($this->defaultTableAction), @js($this->defaultTableActionRecord) @if(filled($this->tableActionArguments)) , @js($this->tableActionArguments) @endif)"
         ></div>
     @endif
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

It was documented at http://filamentphp.com/docs/4.x/resources/overview#generating-urls-to-resource-modals that you can use `tableAction` and `tableActionRecord` to link to table actions like edit/view/delete on a page (which is useful for simple resources). Still, I tried using it, and it wasn't working, so I browsed the source code to find out that it wasn't implemented anywhere.

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
