### PR TITLE
[v3] Add support for disabled checkboxes when bulkToggleable

### DIFF
--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -23,7 +23,7 @@
                 this.areAllCheckboxesChecked =
                     this.visibleCheckboxListOptions.length ===
                     this.visibleCheckboxListOptions.filter((checkboxLabel) =>
-                        checkboxLabel.querySelector('input[type=checkbox]:checked'),
+                        checkboxLabel.querySelector('input[type=checkbox]:checked, input[type=checkbox]:disabled'),
                     ).length
             },
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When a checkboxlist has all values checked on mount, except the disabled ones. The bulk toggle button has the wrong state.

## Visual changes
Before:
<img width="385" height="244" alt="image" src="https://github.com/user-attachments/assets/5e3f8e1a-589a-4854-8eb9-88f7c31eeb1c" />

After:
<img width="424" height="239" alt="image" src="https://github.com/user-attachments/assets/8e69d441-f6e6-4271-bd05-fbed163f1640" />

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
