### PR TITLE
fix: scroll to active sidebar item logic

### DIFF
--- a/packages/panels/resources/views/components/layout/index.blade.php
+++ b/packages/panels/resources/views/components/layout/index.blade.php
@@ -48,6 +48,46 @@
             ></div>
 
             @livewire(\Filament\Livewire\Sidebar::class)
+            
+            <script>
+                document.addEventListener('DOMContentLoaded', () => {
+                    setTimeout(() => {
+                        let activeSidebarItem = document.querySelector(
+                                '.fi-main-sidebar .fi-sidebar-item.fi-active',
+                        )
+                        
+                        if (
+                                !activeSidebarItem ||
+                                activeSidebarItem.offsetParent === null
+                        ) {
+                            activeSidebarItem = document.querySelector(
+                                    '.fi-main-sidebar .fi-sidebar-group.fi-active',
+                            )
+                        }
+                        
+                        if (
+                                !activeSidebarItem ||
+                                activeSidebarItem.offsetParent === null
+                        ) {
+                            return
+                        }
+                        
+                        const sidebarWrapper = document.querySelector(
+                                '.fi-main-sidebar .fi-sidebar-nav',
+                        )
+                        
+                        if (!sidebarWrapper) {
+                            return
+                        }
+                        
+                        sidebarWrapper.scrollTo(
+                                0,
+                                activeSidebarItem.offsetTop -
+                                window.innerHeight / 2,
+                        )
+                    }, 10)
+                })
+            </script>
         @endif
 
         <div

--- a/packages/panels/resources/views/components/layout/index.blade.php
+++ b/packages/panels/resources/views/components/layout/index.blade.php
@@ -48,41 +48,41 @@
             ></div>
 
             @livewire(\Filament\Livewire\Sidebar::class)
-            
+
             <script>
                 document.addEventListener('DOMContentLoaded', () => {
                     setTimeout(() => {
                         let activeSidebarItem = document.querySelector(
-                                '.fi-main-sidebar .fi-sidebar-item.fi-active',
+                            '.fi-main-sidebar .fi-sidebar-item.fi-active',
                         )
-                        
+
                         if (
-                                !activeSidebarItem ||
-                                activeSidebarItem.offsetParent === null
+                            !activeSidebarItem ||
+                            activeSidebarItem.offsetParent === null
                         ) {
                             activeSidebarItem = document.querySelector(
-                                    '.fi-main-sidebar .fi-sidebar-group.fi-active',
+                                '.fi-main-sidebar .fi-sidebar-group.fi-active',
                             )
                         }
-                        
+
                         if (
-                                !activeSidebarItem ||
-                                activeSidebarItem.offsetParent === null
+                            !activeSidebarItem ||
+                            activeSidebarItem.offsetParent === null
                         ) {
                             return
                         }
-                        
+
                         const sidebarWrapper = document.querySelector(
-                                '.fi-main-sidebar .fi-sidebar-nav',
+                            '.fi-main-sidebar .fi-sidebar-nav',
                         )
-                        
+
                         if (!sidebarWrapper) {
                             return
                         }
-                        
+
                         sidebarWrapper.scrollTo(
-                                0,
-                                activeSidebarItem.offsetTop -
+                            0,
+                            activeSidebarItem.offsetTop -
                                 window.innerHeight / 2,
                         )
                     }, 10)


### PR DESCRIPTION
This PR adds the scroll to sidebar item logic to scroll to the current active sidebar item.