### PR TITLE
Add Illuminate\Support\HtmlString support as state to RichEditor component

### DIFF
--- a/packages/forms/src/Components/RichEditor/StateCasts/RichEditorStateCast.php
+++ b/packages/forms/src/Components/RichEditor/StateCasts/RichEditorStateCast.php
@@ -4,6 +4,7 @@ namespace Filament\Forms\Components\RichEditor\StateCasts;
 
 use Filament\Forms\Components\RichEditor;
 use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
+use Illuminate\Support\HtmlString;
 
 class RichEditorStateCast implements StateCast
 {
@@ -59,6 +60,10 @@ class RichEditorStateCast implements StateCast
      */
     public function set(mixed $state): array
     {
+        if ($state instanceof HtmlString) {
+            $state = $state->toHtml();
+        }
+
         $editor = $this->richEditor->getTipTapEditor()
             ->setContent($state ?? [
                 'type' => 'doc',


### PR DESCRIPTION
## Description
Fixes #16988

## Visual changes
none.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
