### PR TITLE
Update slider.blade.php

### DIFF
--- a/packages/forms/resources/views/components/slider.blade.php
+++ b/packages/forms/resources/views/components/slider.blade.php
@@ -3,6 +3,7 @@
     $isVertical = $isVertical();
     $pipsMode = $getPipsMode();
     $livewireKey = $getLivewireKey();
+    $isDisabled = $isDisabled();
 @endphp
 
 <x-dynamic-component :component="$fieldWrapperView" :field="$field">
@@ -14,7 +15,7 @@
                     behavior: @js($getBehaviorForJs()),
                     decimalPlaces: @js($getDecimalPlaces()),
                     fillTrack: @js($getFillTrack()),
-                    isDisabled: @js($isDisabled()),
+                    isDisabled: @js($isDisabled),
                     isRtl: @js($isRtl()),
                     isVertical: @js($isVertical),
                     maxDifference: @js($getMaxDifference()),


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fix isDisabled issue in Slider Blade View

```Serialization of 'Closure' is not allowed```

Triggered in

```php
        wire:key="{{ $livewireKey }}.{{
            substr(md5(serialize([
                $isDisabled,
            ])), 0, 64)
        }}"
```

Using 

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
