### PR TITLE
Add 'resource-namespace' option to MakeResourceCommand for customizab…

### DIFF
--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -146,6 +146,12 @@ class MakePageCommand extends Command
                 description: 'The resource to create the page in',
             ),
             new InputOption(
+                name: 'resource-namespace',
+                shortcut: null,
+                mode: InputOption::VALUE_NONE,
+                description: 'The namespace of the resource class, such as [App\\Filament\\Resources]',
+            ),
+            new InputOption(
                 name: 'type',
                 shortcut: 'T',
                 mode: InputOption::VALUE_REQUIRED,

--- a/packages/panels/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/panels/src/Commands/MakeRelationManagerCommand.php
@@ -202,6 +202,12 @@ class MakeRelationManagerCommand extends Command
                 description: 'The fully-qualified class name of the related resource',
             ),
             new InputOption(
+                name: 'resource-namespace',
+                shortcut: null,
+                mode: InputOption::VALUE_NONE,
+                description: 'The namespace of the resource class, such as [App\\Filament\\Resources]',
+            ),
+            new InputOption(
                 name: 'soft-deletes',
                 shortcut: null,
                 mode: InputOption::VALUE_NONE,

--- a/packages/panels/src/Commands/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/MakeResourceCommand.php
@@ -179,6 +179,13 @@ class MakeResourceCommand extends Command
                 description: 'The namespace of the model class, [App\\Models] by default',
             ),
             new InputOption(
+                name: 'resource-namespace',
+                shortcut: null,
+                mode: InputOption::VALUE_NONE,
+                description: 'The namespace of the resource class, [App\\Filament\\Resources] by default',
+            ),
+
+            new InputOption(
                 name: 'nested',
                 shortcut: 'N',
                 mode: InputOption::VALUE_OPTIONAL,

--- a/packages/panels/src/Commands/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/MakeResourceCommand.php
@@ -179,13 +179,6 @@ class MakeResourceCommand extends Command
                 description: 'The namespace of the model class, [App\\Models] by default',
             ),
             new InputOption(
-                name: 'resource-namespace',
-                shortcut: null,
-                mode: InputOption::VALUE_NONE,
-                description: 'The namespace of the resource class, [App\\Filament\\Resources] by default',
-            ),
-
-            new InputOption(
                 name: 'nested',
                 shortcut: 'N',
                 mode: InputOption::VALUE_OPTIONAL,
@@ -203,6 +196,12 @@ class MakeResourceCommand extends Command
                 shortcut: null,
                 mode: InputOption::VALUE_REQUIRED,
                 description: 'The panel to create the resource in',
+            ),
+            new InputOption(
+                name: 'resource-namespace',
+                shortcut: null,
+                mode: InputOption::VALUE_NONE,
+                description: 'The namespace of the resource class, such as [App\\Filament\\Resources]',
             ),
             new InputOption(
                 name: 'simple',

--- a/packages/support/src/Commands/Concerns/HasResourcesLocation.php
+++ b/packages/support/src/Commands/Concerns/HasResourcesLocation.php
@@ -48,8 +48,8 @@ trait HasResourcesLocation
                 (Arr::first($directories) ?? app_path('Filament/Resources/')),
             ];
         }
-        if ($this->option('resource-namespace')){
-            return[
+        if ($this->option('resource-namespace')) {
+            return [
                 $this->option('resource-namespace'),
                 $directories[array_search($this->option('resource-namespace'), $namespaces)],
             ];

--- a/packages/support/src/Commands/Concerns/HasResourcesLocation.php
+++ b/packages/support/src/Commands/Concerns/HasResourcesLocation.php
@@ -48,6 +48,12 @@ trait HasResourcesLocation
                 (Arr::first($directories) ?? app_path('Filament/Resources/')),
             ];
         }
+        if ($this->option('resource-namespace')){
+            return[
+                $this->option('resource-namespace'),
+                $directories[array_search($this->option('resource-namespace'), $namespaces)],
+            ];
+        }
 
         $keyedNamespaces = array_combine(
             $namespaces,

--- a/packages/support/src/Commands/Concerns/HasResourcesLocation.php
+++ b/packages/support/src/Commands/Concerns/HasResourcesLocation.php
@@ -48,6 +48,7 @@ trait HasResourcesLocation
                 (Arr::first($directories) ?? app_path('Filament/Resources/')),
             ];
         }
+
         if ($this->option('resource-namespace')) {
             return [
                 $this->option('resource-namespace'),

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -136,6 +136,12 @@ class MakeWidgetCommand extends Command
                 description: 'The resource to create the widget in',
             ),
             new InputOption(
+                name: 'resource-namespace',
+                shortcut: null,
+                mode: InputOption::VALUE_NONE,
+                description: 'The namespace of the resource class, such as [App\\Filament\\Resources]',
+            ),
+            new InputOption(
                 name: 'stats-overview',
                 shortcut: 'S',
                 mode: InputOption::VALUE_NONE,


### PR DESCRIPTION
**Description**
This pull request addresses an issue with the `make:filament-resource` command where, during resource generation, the system prompts the user to select a namespace if multiple namespaces are available. This interactive behavior hinders full automation, especially when generating new modules automatically based on the database structure.
To solve this, an optional `--resource-namespace` flag has been added to the command. This option allows specifying the desired namespace programmatically, eliminating the need for user interaction and enabling seamless automation of resource generation.
**Visual changes**
No visual changes introduced.
**Functional changes**
	•	Added `--resource-namespace` option to `make:filament-resource` command to allow non-interactive namespace specification.
	•	No the interactive namespace prompt when the option is provided.
	•	This change enables full automation of resource creation workflows without manual intervention.
	•	Code style has been checked and updated accordingly.
	•	Functionality tested to ensure no existing features are broken.
