### PR TITLE
Fix passing action arguments link

### DIFF
--- a/docs/06-navigation/02-custom-pages.md
+++ b/docs/06-navigation/02-custom-pages.md
@@ -33,7 +33,7 @@ public static function canAccess(): bool
 
 Actions are buttons that can perform tasks on the page, or visit a URL. You can read more about their capabilities [here](../actions).
 
-Since all pages are Livewire components, you can [add actions](../actions/adding-an-action-to-a-livewire-component#adding-the-action) anywhere. Pages already have the `InteractsWithActions` trait, `HasActions` interface, and `<x-filament-actions::modals />` Blade component all set up for you.
+Since all pages are Livewire components, you can [add actions](../components/action#adding-the-action) anywhere. Pages already have the `InteractsWithActions` trait, `HasActions` interface, and `<x-filament-actions::modals />` Blade component all set up for you.
 
 ### Header actions
 

--- a/packages/actions/docs/01-overview.md
+++ b/packages/actions/docs/01-overview.md
@@ -540,7 +540,7 @@ function (Model $record) {
 
 ### Injecting the current arguments
 
-If you wish to access the [current arguments](adding-an-action-to-a-livewire-component#passing-action-arguments) that have been passed to the action, define an `$arguments` parameter:
+If you wish to access the [current arguments](../components/action#passing-action-arguments) that have been passed to the action, define an `$arguments` parameter:
 
 ```php
 function (array $arguments) {

--- a/packages/forms/docs/06-checkbox-list.md
+++ b/packages/forms/docs/06-checkbox-list.md
@@ -251,7 +251,7 @@ CheckboxList::make('technology')
 
 ## Integrating with an Eloquent relationship
 
-> If you're building a form inside your Livewire component, make sure you have set up the [form's model](../adding-a-form-to-a-livewire-component#setting-a-form-model). Otherwise, Filament doesn't know which model to use to retrieve the relationship from.
+> If you're building a form inside your Livewire component, make sure you have set up the [form's model](../components/form#setting-a-form-model). Otherwise, Filament doesn't know which model to use to retrieve the relationship from.
 
 You may employ the `relationship()` method of the `CheckboxList` to point to a `BelongsToMany` relationship. Filament will load the options from the relationship, and save them back to the relationship's pivot table when the form is submitted. The `titleAttribute` is the name of a column that will be used to generate a label for each option:
 

--- a/packages/forms/docs/23-validation.md
+++ b/packages/forms/docs/23-validation.md
@@ -175,7 +175,7 @@ The field value must exist in the database. [See the Laravel documentation.](htt
 Field::make('invitation')->exists()
 ```
 
-By default, the form's model will be searched, [if it is registered](adding-a-form-to-a-livewire-component#setting-a-form-model). You may specify a custom table name or model to search:
+By default, the form's model will be searched, [if it is registered](../components/form#setting-a-form-model). You may specify a custom table name or model to search:
 
 ```php
 use App\Models\Invitation;


### PR DESCRIPTION
## Description

Fix for incorrect link in https://filamentphp.com/docs/4.x/actions/overview#injecting-the-current-arguments passage.

## Visual changes

N/A

## Functional changes

- [ ] Link has been updated to `../components/action#passing-action-arguments`
