### PR TITLE
fix: `ToggleColumn` disabled state

### DIFF
--- a/packages/tables/src/Columns/ToggleColumn.php
+++ b/packages/tables/src/Columns/ToggleColumn.php
@@ -46,12 +46,17 @@ class ToggleColumn extends Column implements Editable, HasEmbeddedView
             ->merge([
                 'x-load' => true,
                 'x-load-src' => FilamentAsset::getAlpineComponentSrc('columns/toggle', 'filament/tables'),
-                'disabled' => $this->isDisabled(),
                 'x-data' => 'toggleTableColumn({
                     name: ' . Js::from($this->getName()) . ',
                     recordKey: ' . Js::from($this->getRecordKey()) . ',
                     state: ' . Js::from($state) . ',
                 })',
+                'x-tooltip' => filled($tooltip = $this->getTooltip($state))
+                    ? '{
+                        content: ' . Js::from($tooltip) . ',
+                        theme: $store.theme,
+                    }'
+                    : null,
             ], escape: false)
             ->class([
                 'fi-ta-toggle',
@@ -64,12 +69,6 @@ class ToggleColumn extends Column implements Editable, HasEmbeddedView
                 'disabled' => $this->isDisabled(),
                 'wire:loading.attr' => 'disabled',
                 'wire:target' => implode(',', Table::LOADING_TARGETS),
-                'x-tooltip' => filled($tooltip = $this->getTooltip($state))
-                    ? '{
-                        content: ' . Js::from($tooltip) . ',
-                        theme: $store.theme,
-                    }'
-                    : null,
             ], escape: false)
             ->class(['fi-toggle']);
 

--- a/packages/tables/src/Columns/ToggleColumn.php
+++ b/packages/tables/src/Columns/ToggleColumn.php
@@ -81,7 +81,7 @@ class ToggleColumn extends Column implements Editable, HasEmbeddedView
         >
             <input type="hidden" value="<?= $state ? 1 : 0 ?>" x-ref="serverState" />
 
-            <div
+            <button
                 x-bind:aria-checked="state?.toString()"
                 x-on:click="if (! $el.hasAttribute('disabled')) state = ! state"
                 x-bind:class="state ? '<?= Arr::toCssClasses([
@@ -112,7 +112,7 @@ class ToggleColumn extends Column implements Editable, HasEmbeddedView
                         <?= generate_icon_html($onIcon, size: IconSize::ExtraSmall)?->toHtml() ?>
                     </div>
                 </div>
-            </div>
+            </button>
 
             <?php if ($state) { ?>
                 <div


### PR DESCRIPTION
This PR fixes two issues with the `ToggleColumn` in disabled state:
- The toggle would not have the disabled styling (fixed by changing to element type `<button>` instead of `<div>`, same as the re-usable toggle component).
- The tooltip has been moved from the ~$buttonAttributes~ to the container attributes, and the `disabled` attribute has been removed on the container as it is already present on the `$buttonAttributes`. This structure mimics the V3 structure.