### PR TITLE
Fix support for schema-qualified column names in TextConstraint ContainsOperator (PostgreSQL)

### DIFF
--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/ContainsOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/ContainsOperator.php
@@ -69,7 +69,7 @@ class ContainsOperator extends Operator
             if (count($parts) === 3) {
                 [$schema, $table, $column] = $parts;
                 $table = "{$schema}.{$table}";
-            } elseif (count($parts) === 2) {
+            } else {
                 [$table, $column] = $parts;
             }
 

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/ContainsOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/ContainsOperator.php
@@ -75,7 +75,7 @@ class ContainsOperator extends Operator
 
             if (Str::lower($table) !== $table) {
                 $table = collect(explode('.', $table))
-                    ->map(fn ($segment) => "\"{$segment}\"")
+                    ->map(fn (string $segment): string => "\"{$segment}\"")
                     ->implode('.');
             }
 

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/ContainsOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/ContainsOperator.php
@@ -64,14 +64,23 @@ class ContainsOperator extends Operator
         $isPostgres = $databaseConnection->getDriverName() === 'pgsql';
 
         if ($isPostgres) {
-            [$table, $column] = explode('.', $qualifiedColumn);
+            $parts = explode('.', $qualifiedColumn);
+
+            if (count($parts) === 3) {
+                [$schema, $table, $column] = $parts;
+                $table = "{$schema}.{$table}";
+            } elseif (count($parts) === 2) {
+                [$table, $column] = $parts;
+            }
 
             if (Str::lower($table) !== $table) {
-                $table = (string) str($table)->wrap('"');
+                $table = collect(explode('.', $table))
+                    ->map(fn ($segment) => "\"{$segment}\"")
+                    ->implode('.');
             }
 
             if (Str::lower($column) !== $column) {
-                $column = (string) str($column)->wrap('"');
+                $column = "\"{$column}\"";
             }
 
             $qualifiedColumn = new Expression("lower({$table}.{$column}::text)");

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EndsWithOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EndsWithOperator.php
@@ -75,7 +75,7 @@ class EndsWithOperator extends Operator
 
             if (Str::lower($table) !== $table) {
                 $table = collect(explode('.', $table))
-                    ->map(fn ($segment) => "\"{$segment}\"")
+                    ->map(fn (string $segment): string => "\"{$segment}\"")
                     ->implode('.');
             }
 

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EndsWithOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EndsWithOperator.php
@@ -69,7 +69,7 @@ class EndsWithOperator extends Operator
             if (count($parts) === 3) {
                 [$schema, $table, $column] = $parts;
                 $table = "{$schema}.{$table}";
-            } elseif (count($parts) === 2) {
+            } else {
                 [$table, $column] = $parts;
             }
 

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EndsWithOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EndsWithOperator.php
@@ -64,14 +64,23 @@ class EndsWithOperator extends Operator
         $isPostgres = $databaseConnection->getDriverName() === 'pgsql';
 
         if ($isPostgres) {
-            [$table, $column] = explode('.', $qualifiedColumn);
+            $parts = explode('.', $qualifiedColumn);
+
+            if (count($parts) === 3) {
+                [$schema, $table, $column] = $parts;
+                $table = "{$schema}.{$table}";
+            } elseif (count($parts) === 2) {
+                [$table, $column] = $parts;
+            }
 
             if (Str::lower($table) !== $table) {
-                $table = (string) str($table)->wrap('"');
+                $table = collect(explode('.', $table))
+                    ->map(fn ($segment) => "\"{$segment}\"")
+                    ->implode('.');
             }
 
             if (Str::lower($column) !== $column) {
-                $column = (string) str($column)->wrap('"');
+                $column = "\"{$column}\"";
             }
 
             $qualifiedColumn = new Expression("lower({$table}.{$column}::text)");

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EqualsOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EqualsOperator.php
@@ -75,7 +75,7 @@ class EqualsOperator extends Operator
 
             if (Str::lower($table) !== $table) {
                 $table = collect(explode('.', $table))
-                    ->map(fn ($segment) => "\"{$segment}\"")
+                    ->map(fn (string $segment): string => "\"{$segment}\"")
                     ->implode('.');
             }
 

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EqualsOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EqualsOperator.php
@@ -69,7 +69,7 @@ class EqualsOperator extends Operator
             if (count($parts) === 3) {
                 [$schema, $table, $column] = $parts;
                 $table = "{$schema}.{$table}";
-            } elseif (count($parts) === 2) {
+            } else {
                 [$table, $column] = $parts;
             }
 

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EqualsOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/EqualsOperator.php
@@ -64,14 +64,23 @@ class EqualsOperator extends Operator
         $isPostgres = $databaseConnection->getDriverName() === 'pgsql';
 
         if ($isPostgres) {
-            [$table, $column] = explode('.', $qualifiedColumn);
+            $parts = explode('.', $qualifiedColumn);
+
+            if (count($parts) === 3) {
+                [$schema, $table, $column] = $parts;
+                $table = "{$schema}.{$table}";
+            } elseif (count($parts) === 2) {
+                [$table, $column] = $parts;
+            }
 
             if (Str::lower($table) !== $table) {
-                $table = (string) str($table)->wrap('"');
+                $table = collect(explode('.', $table))
+                    ->map(fn ($segment) => "\"{$segment}\"")
+                    ->implode('.');
             }
 
             if (Str::lower($column) !== $column) {
-                $column = (string) str($column)->wrap('"');
+                $column = "\"{$column}\"";
             }
 
             $qualifiedColumn = new Expression("lower({$table}.{$column}::text)");

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/StartsWithOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/StartsWithOperator.php
@@ -64,14 +64,23 @@ class StartsWithOperator extends Operator
         $isPostgres = $databaseConnection->getDriverName() === 'pgsql';
 
         if ($isPostgres) {
-            [$table, $column] = explode('.', $qualifiedColumn);
+            $parts = explode('.', $qualifiedColumn);
+
+            if (count($parts) === 3) {
+                [$schema, $table, $column] = $parts;
+                $table = "{$schema}.{$table}";
+            } elseif (count($parts) === 2) {
+                [$table, $column] = $parts;
+            }
 
             if (Str::lower($table) !== $table) {
-                $table = (string) str($table)->wrap('"');
+                $table = collect(explode('.', $table))
+                    ->map(fn ($segment) => "\"{$segment}\"")
+                    ->implode('.');
             }
 
             if (Str::lower($column) !== $column) {
-                $column = (string) str($column)->wrap('"');
+                $column = "\"{$column}\"";
             }
 
             $qualifiedColumn = new Expression("lower({$table}.{$column}::text)");

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/StartsWithOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/StartsWithOperator.php
@@ -69,7 +69,7 @@ class StartsWithOperator extends Operator
             if (count($parts) === 3) {
                 [$schema, $table, $column] = $parts;
                 $table = "{$schema}.{$table}";
-            } elseif (count($parts) === 2) {
+            } else {
                 [$table, $column] = $parts;
             }
 

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/StartsWithOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/TextConstraint/Operators/StartsWithOperator.php
@@ -75,7 +75,7 @@ class StartsWithOperator extends Operator
 
             if (Str::lower($table) !== $table) {
                 $table = collect(explode('.', $table))
-                    ->map(fn ($segment) => "\"{$segment}\"")
+                    ->map(fn (string $segment): string => "\"{$segment}\"")
                     ->implode('.');
             }
 


### PR DESCRIPTION
## Description

This PR fixes an issue in Filament\Tables\Filters\QueryBuilder\Constraints\TextConstraint\Operators\ContainsOperator where schema-qualified columns (e.g., demo_schema.items.title) are incorrectly parsed when building PostgreSQL filters.

The code currently uses:

```php
[$table, $column] = explode('.', $qualifiedColumn);
```

This breaks when the column name is schema-qualified (schema.table.column) because explode() only supports two parts. It results in incorrect SQL and errors like:

```
SQLSTATE[42P01]: Undefined table: 7 ERROR: missing FROM-clause entry for table "demo_schema"
```