### PR TITLE
Update HtmlString to Htmlable contract in rich editor state cast

### DIFF
--- a/packages/forms/src/Components/RichEditor/StateCasts/RichEditorStateCast.php
+++ b/packages/forms/src/Components/RichEditor/StateCasts/RichEditorStateCast.php
@@ -4,7 +4,7 @@ namespace Filament\Forms\Components\RichEditor\StateCasts;
 
 use Filament\Forms\Components\RichEditor;
 use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
-use Illuminate\Support\HtmlString;
+use Illuminate\Contracts\Support\Htmlable;
 
 class RichEditorStateCast implements StateCast
 {
@@ -60,7 +60,7 @@ class RichEditorStateCast implements StateCast
      */
     public function set(mixed $state): array
     {
-        if ($state instanceof HtmlString) {
+        if ($state instanceof Htmlable) {
             $state = $state->toHtml();
         }
 


### PR DESCRIPTION
## Description
Adds Htmlable contact instead of HtmlString as requested in #16989 

## Visual changes
None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
