### PR TITLE
[4.x] Add dutch 2FA translation to profile page

### DIFF
--- a/packages/panels/resources/lang/nl/auth/pages/edit-profile.php
+++ b/packages/panels/resources/lang/nl/auth/pages/edit-profile.php
@@ -32,6 +32,10 @@ return [
 
     ],
 
+    'multi_factor_authentication' => [
+        'label' => 'Twee-factor-authenticatie (2FA)',
+    ],
+
     'notifications' => [
 
         'saved' => [


### PR DESCRIPTION
## Description

Translate the title of the 2FA settings on the profile page.

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
