### PR TITLE
Allow direct editing per type in morphtoselect

### DIFF
--- a/packages/forms/docs/03-fields/03-select.md
+++ b/packages/forms/docs/03-fields/03-select.md
@@ -401,6 +401,36 @@ MorphToSelect::make('commentable')
 
 > Many of the same options in the select field are available for `MorphToSelect`, including `searchable()`, `preload()`, `native()`, `allowHtml()`, and `optionsLimit()`.
 
+#### Customizing the select component for each morphed type
+
+You may further customize any of the aspects of the select component using the `modifySelect()` method:
+
+```php
+use Filament\Forms\Components\MorphToSelect;
+use Illuminate\Database\Eloquent\Builder;
+
+MorphToSelect::make('commentable')
+    ->searchable()
+    ->types([
+        MorphToSelect\Type::make(Product::class)
+            ->titleAttribute('name')
+            ->modifySelect(function($select) {
+                return $select->preload()
+                    ->createOptionForm([
+                        TextInput::make('title')
+                            ->required(),
+                    ])
+                    ->createoptionusing(function (array $data) {
+                        return Product::create($data)->getKey();
+                    });
+            }),
+        MorphToSelect\Type::make(Post::class)
+            ->titleAttribute('title'),
+    ])
+```
+
+> This can be useful, if for example you want to allow all the options to appear by default for only one type or you want to allow users to add a new option for only one type.
+
 ## Allowing HTML in the option labels
 
 By default, Filament will escape any HTML in the option labels. If you'd like to allow HTML, you can use the `allowHtml()` method:

--- a/packages/forms/docs/03-fields/03-select.md
+++ b/packages/forms/docs/03-fields/03-select.md
@@ -401,35 +401,63 @@ MorphToSelect::make('commentable')
 
 > Many of the same options in the select field are available for `MorphToSelect`, including `searchable()`, `preload()`, `native()`, `allowHtml()`, and `optionsLimit()`.
 
-#### Customizing the select component for each morphed type
+#### Customizing the morph select fields
 
-You may further customize any of the aspects of the select component using the `modifySelect()` method:
+You may further customize the "key" select field for a specific morph type using the `modifyKeySelectUsing()` method:
 
 ```php
 use Filament\Forms\Components\MorphToSelect;
-use Illuminate\Database\Eloquent\Builder;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
 
 MorphToSelect::make('commentable')
-    ->searchable()
     ->types([
         MorphToSelect\Type::make(Product::class)
             ->titleAttribute('name')
-            ->modifySelect(function($select) {
-                return $select->preload()
-                    ->createOptionForm([
-                        TextInput::make('title')
-                            ->required(),
-                    ])
-                    ->createoptionusing(function (array $data) {
-                        return Product::create($data)->getKey();
-                    });
-            }),
+            ->modifyKeySelectUsing(fn (Select $select): Select => $select
+                ->createOptionForm([
+                    TextInput::make('title')
+                        ->required(),
+                ])
+                ->createOptionUsing(function (array $data): int {
+                    return Product::create($data)->getKey();
+                })),
         MorphToSelect\Type::make(Post::class)
             ->titleAttribute('title'),
     ])
 ```
 
-> This can be useful, if for example you want to allow all the options to appear by default for only one type or you want to allow users to add a new option for only one type.
+This is useful if you want to customize the "key" select field for each morphed type individually. If you want to customize the key select for all types, you can use the `modifyKeySelectUsing()` method on the `MorphToSelect` component itself:
+
+```php
+use Filament\Forms\Components\MorphToSelect;
+use Filament\Forms\Components\Select;
+
+MorphToSelect::make('commentable')
+    ->types([
+        MorphToSelect\Type::make(Product::class)
+            ->titleAttribute('name'),
+        MorphToSelect\Type::make(Post::class)
+            ->titleAttribute('title'),
+    ])
+    ->modifyKeySelectUsing(fn (Select $select): Select => $select->native())
+```
+
+You can also modify the "type" select field using the `modifyTypeSelectUsing()` method:
+
+```php
+use Filament\Forms\Components\MorphToSelect;
+use Filament\Forms\Components\Select;
+
+MorphToSelect::make('commentable')
+    ->types([
+        MorphToSelect\Type::make(Product::class)
+            ->titleAttribute('name'),
+        MorphToSelect\Type::make(Post::class)
+            ->titleAttribute('title'),
+    ])
+    ->modifyTypeSelectUsing(fn (Select $select): Select => $select->native())
+```
 
 ## Allowing HTML in the option labels
 

--- a/packages/forms/src/Components/MorphToSelect.php
+++ b/packages/forms/src/Components/MorphToSelect.php
@@ -118,6 +118,12 @@ class MorphToSelect extends Component
             ]) ?? $keySelect;
         }
 
+        if ($selectedType?->modifySelect) {
+            $keySelect = $this->evaluate($selectedType->modifySelect, [
+                'select' => $keySelect,
+            ]) ?? $keySelect;
+        }
+
         return [$typeSelect, $keySelect];
     }
 

--- a/packages/forms/src/Components/MorphToSelect.php
+++ b/packages/forms/src/Components/MorphToSelect.php
@@ -118,8 +118,8 @@ class MorphToSelect extends Component
             ]) ?? $keySelect;
         }
 
-        if ($selectedType?->modifySelect) {
-            $keySelect = $this->evaluate($selectedType->modifySelect, [
+        if ($selectedType?->modifyKeySelectUsing) {
+            $keySelect = $this->evaluate($selectedType->modifyKeySelectUsing, [
                 'select' => $keySelect,
             ]) ?? $keySelect;
         }

--- a/packages/forms/src/Components/MorphToSelect/Type.php
+++ b/packages/forms/src/Components/MorphToSelect/Type.php
@@ -24,7 +24,7 @@ class Type
 
     public Closure $getOptionsUsing;
 
-    public ?Closure $modifySelect = null;
+    public ?Closure $modifyKeySelectUsing = null;
 
     protected ?Closure $modifyOptionsQueryUsing = null;
 
@@ -222,9 +222,9 @@ class Type
         return $this;
     }
 
-    public function modifySelect(?Closure $callback): static
+    public function modifyKeySelectUsing(?Closure $callback): static
     {
-        $this->modifySelect = $callback;
+        $this->modifyKeySelectUsing = $callback;
 
         return $this;
     }

--- a/packages/forms/src/Components/MorphToSelect/Type.php
+++ b/packages/forms/src/Components/MorphToSelect/Type.php
@@ -24,6 +24,8 @@ class Type
 
     public Closure $getOptionsUsing;
 
+    public ?Closure $modifySelect = null;
+
     protected ?Closure $modifyOptionsQueryUsing = null;
 
     /**
@@ -216,6 +218,13 @@ class Type
     public function searchColumns(?array $columns): static
     {
         $this->searchColumns = $columns;
+
+        return $this;
+    }
+
+    public function modifySelect(?Closure $callback): static
+    {
+        $this->modifySelect = $callback;
 
         return $this;
     }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Currently there is no way to modify the select for morphToSelect Types directly. Instead, you can hack `modifyKeySelectUsing` and then have an if-else statement to check the label: `if ($select->getLabel() == 'label X)`. This allows you to edit the select inline directly

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
