### PR TITLE
implemented getLengthValidationRules on rich editor

### DIFF
--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -22,6 +22,7 @@ use Filament\Support\Icons\Heroicon;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Tiptap\Editor;
 
@@ -819,5 +820,69 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
     public function getFloatingToolbars(): array
     {
         return $this->evaluate($this->floatingToolbars) ?? $this->getDefaultFloatingToolbars();
+    }
+
+    public function getLengthValidationRules(): array
+    {
+        $rules = [];
+
+        if (filled($maxLength = $this->getMaxLength())) {
+            $rules[] = function (string $attribute, mixed $value, Closure $fail) use ($maxLength): void {
+                if (blank($value)) {
+                    return;
+                }
+
+                $textLength = Str::length($this->getTipTapEditor()
+                    ->setContent($value)
+                    ->getText());
+
+                if ($textLength > $maxLength) {
+                    $fail(__('validation.max.string', [
+                        'attribute' => str_replace('data.', '', $attribute),
+                        'max' => $maxLength,
+                    ]));
+                }
+            };
+        }
+
+        if (filled($minLength = $this->getMinLength())) {
+            $rules[] = function (string $attribute, mixed $value, Closure $fail) use ($minLength): void {
+                if (blank($value)) {
+                    return;
+                }
+
+                $textLength = Str::length($this->getTipTapEditor()
+                    ->setContent($value)
+                    ->getText());
+
+                if ($textLength < $minLength) {
+                    $fail(__('validation.min.string', [
+                        'attribute' => str_replace('data.', '', $attribute),
+                        'min' => $minLength,
+                    ]));
+                }
+            };
+        }
+
+        if (filled($length = $this->getLength())) {
+            $rules[] = function (string $attribute, mixed $value, Closure $fail) use ($length): void {
+                if (blank($value)) {
+                    return;
+                }
+
+                $textLength = Str::length($this->getTipTapEditor()
+                    ->setContent($value)
+                    ->getText());
+
+                if ($textLength !== $length) {
+                    $fail(__('validation.size.string', [
+                        'attribute' => str_replace('data.', '', $attribute),
+                        'size' => $length,
+                    ]));
+                }
+            };
+        }
+
+        return $rules;
     }
 }

--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -827,7 +827,7 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
         $rules = [];
 
         if (filled($maxLength = $this->getMaxLength())) {
-            $rules[] = function (string $attribute, mixed $value, Closure $fail) use ($maxLength): void {
+            $rules[] = function (string $_attribute, mixed $value, Closure $fail) use ($maxLength): void {
                 if (blank($value)) {
                     return;
                 }
@@ -837,16 +837,15 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
                     ->getText());
 
                 if ($textLength > $maxLength) {
-                    $fail(__('validation.max.string', [
-                        'attribute' => str_replace('data.', '', $attribute),
+                    $fail('validation.max.string')->translate([
                         'max' => $maxLength,
-                    ]));
+                    ]);
                 }
             };
         }
 
         if (filled($minLength = $this->getMinLength())) {
-            $rules[] = function (string $attribute, mixed $value, Closure $fail) use ($minLength): void {
+            $rules[] = function (string $_attribute, mixed $value, Closure $fail) use ($minLength): void {
                 if (blank($value)) {
                     return;
                 }
@@ -856,16 +855,15 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
                     ->getText());
 
                 if ($textLength < $minLength) {
-                    $fail(__('validation.min.string', [
-                        'attribute' => str_replace('data.', '', $attribute),
+                    $fail('validation.min.string')->translate([
                         'min' => $minLength,
-                    ]));
+                    ]);
                 }
             };
         }
 
         if (filled($length = $this->getLength())) {
-            $rules[] = function (string $attribute, mixed $value, Closure $fail) use ($length): void {
+            $rules[] = function (string $_attribute, mixed $value, Closure $fail) use ($length): void {
                 if (blank($value)) {
                     return;
                 }
@@ -875,10 +873,9 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
                     ->getText());
 
                 if ($textLength !== $length) {
-                    $fail(__('validation.size.string', [
-                        'attribute' => str_replace('data.', '', $attribute),
+                    $fail('validation.size.string')->translate([
                         'size' => $length,
-                    ]));
+                    ]);
                 }
             };
         }


### PR DESCRIPTION
## Description
Fixes #17028 

## Visual changes
#### Before
https://github.com/user-attachments/assets/7d1f03c4-992d-45d3-8d9a-62ad2492d661

#### After
https://github.com/user-attachments/assets/e316de84-7be4-4d72-82cd-28969c24f405

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
