### PR TITLE
Update casts syntax in docs

### DIFF
--- a/docs-assets/app/app/Models/Post.php
+++ b/docs-assets/app/app/Models/Post.php
@@ -10,9 +10,12 @@ class Post extends Model
 {
     use HasFactory;
 
-    protected $casts = [
-        'is_featured' => 'boolean',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'is_featured' => 'boolean',
+        ];
+    }
 
     public function author(): BelongsTo
     {

--- a/docs-assets/app/app/Models/Post.php
+++ b/docs-assets/app/app/Models/Post.php
@@ -10,6 +10,9 @@ class Post extends Model
 {
     use HasFactory;
 
+    /**
+     * @return array<string, string>
+     */
     protected function casts(): array
     {
         return [

--- a/docs-assets/app/app/Models/User.php
+++ b/docs-assets/app/app/Models/User.php
@@ -36,15 +36,13 @@ class User extends Authenticatable implements FilamentUser
         'remember_token',
     ];
 
-    /**
-     * The attributes that should be cast.
-     *
-     * @var array<string, string>
-     */
-    protected $casts = [
-        'colleagues' => 'array',
-        'email_verified_at' => 'datetime',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'colleagues' => 'array',
+            'email_verified_at' => 'datetime',
+        ];
+    }
 
     public function canAccessPanel(Panel $panel): bool
     {

--- a/docs-assets/app/app/Models/User.php
+++ b/docs-assets/app/app/Models/User.php
@@ -36,6 +36,9 @@ class User extends Authenticatable implements FilamentUser
         'remember_token',
     ];
 
+    /**
+     * @return array<string, string>
+     */
     protected function casts(): array
     {
         return [

--- a/docs/07-users/02-multi-factor-authentication.md
+++ b/docs/07-users/02-multi-factor-authentication.md
@@ -64,8 +64,8 @@ class User extends Authenticatable implements FilamentUser, MustVerifyEmail
      */
     protected function casts(): array
     {
-        // ...
         return [
+            // ...
             'app_authentication_secret' => 'encrypted',
         ];
     }
@@ -172,8 +172,8 @@ class User extends Authenticatable implements FilamentUser, HasAppAuthentication
      */
     protected function casts(): array
     {
-        // ...
         return [
+            // ...
             'app_authentication_recovery_codes' => 'encrypted:array',
         ];
     }
@@ -348,8 +348,8 @@ class User extends Authenticatable implements FilamentUser, MustVerifyEmail
      */
     protected function casts(): array
     {
-        // ...
         return [
+            // ...
             'has_email_authentication' => 'boolean',
         ];
     }

--- a/docs/07-users/02-multi-factor-authentication.md
+++ b/docs/07-users/02-multi-factor-authentication.md
@@ -60,12 +60,15 @@ class User extends Authenticatable implements FilamentUser, MustVerifyEmail
     ];
 
     /**
-     * @var array<string, string>
+     * @return array<string, string>
      */
-    protected $casts = [
+    protected function casts(): array
+    {
         // ...
-        'app_authentication_secret' => 'encrypted',
-    ];
+        return [
+            'app_authentication_secret' => 'encrypted',
+        ];
+    }
     
     // ...
 }
@@ -165,12 +168,15 @@ class User extends Authenticatable implements FilamentUser, HasAppAuthentication
     ];
 
     /**
-     * @var array<string, string>
+     * @return array<string, string>
      */
-    protected $casts = [
+    protected function casts(): array
+    {
         // ...
-        'app_authentication_recovery_codes' => 'encrypted:array',
-    ];
+        return [
+            'app_authentication_recovery_codes' => 'encrypted:array',
+        ];
+    }
     
     // ...
 }
@@ -337,14 +343,16 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 
 class User extends Authenticatable implements FilamentUser, MustVerifyEmail
 {
-    // ...
     /**
-     * @var array<string, string>
+     * @return array<string, string>
      */
-    protected $casts = [
+    protected function casts(): array
+    {
         // ...
-        'has_email_authentication' => 'boolean',
-    ];
+        return [
+            'has_email_authentication' => 'boolean',
+        ];
+    }
     
     // ...
 }

--- a/packages/actions/src/Exports/Models/Export.php
+++ b/packages/actions/src/Exports/Models/Export.php
@@ -27,7 +27,7 @@ class Export extends Model
 {
     use Prunable;
 
-   protected function casts(): array
+    protected function casts(): array
     {
         return [
             'completed_at' => 'timestamp',

--- a/packages/actions/src/Exports/Models/Export.php
+++ b/packages/actions/src/Exports/Models/Export.php
@@ -27,12 +27,15 @@ class Export extends Model
 {
     use Prunable;
 
-    protected $casts = [
-        'completed_at' => 'timestamp',
-        'processed_rows' => 'integer',
-        'total_rows' => 'integer',
-        'successful_rows' => 'integer',
-    ];
+   protected function casts(): array
+    {
+        return [
+            'completed_at' => 'timestamp',
+            'processed_rows' => 'integer',
+            'total_rows' => 'integer',
+            'successful_rows' => 'integer',
+        ];
+    }
 
     protected $guarded = [];
 

--- a/packages/actions/src/Exports/Models/Export.php
+++ b/packages/actions/src/Exports/Models/Export.php
@@ -27,6 +27,9 @@ class Export extends Model
 {
     use Prunable;
 
+    /**
+     * @return array<string, string>
+     */
     protected function casts(): array
     {
         return [

--- a/packages/actions/src/Imports/Models/FailedImportRow.php
+++ b/packages/actions/src/Imports/Models/FailedImportRow.php
@@ -16,6 +16,9 @@ class FailedImportRow extends Model
 {
     use Prunable;
 
+    /**
+     * @return array<string, string>
+     */
     protected function casts(): array
     {
         return [

--- a/packages/actions/src/Imports/Models/FailedImportRow.php
+++ b/packages/actions/src/Imports/Models/FailedImportRow.php
@@ -16,9 +16,12 @@ class FailedImportRow extends Model
 {
     use Prunable;
 
-    protected $casts = [
-        'data' => 'array',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'data' => 'array',
+        ];
+    }
 
     protected $guarded = [];
 

--- a/packages/actions/src/Imports/Models/Import.php
+++ b/packages/actions/src/Imports/Models/Import.php
@@ -28,12 +28,15 @@ class Import extends Model
 {
     use Prunable;
 
-    protected $casts = [
-        'completed_at' => 'timestamp',
-        'processed_rows' => 'integer',
-        'total_rows' => 'integer',
-        'successful_rows' => 'integer',
-    ];
+   protected function casts(): array
+    {
+        return [
+            'completed_at' => 'timestamp',
+            'processed_rows' => 'integer',
+            'total_rows' => 'integer',
+            'successful_rows' => 'integer',
+        ];
+    }
 
     protected $guarded = [];
 

--- a/packages/actions/src/Imports/Models/Import.php
+++ b/packages/actions/src/Imports/Models/Import.php
@@ -28,7 +28,7 @@ class Import extends Model
 {
     use Prunable;
 
-   protected function casts(): array
+    protected function casts(): array
     {
         return [
             'completed_at' => 'timestamp',

--- a/packages/actions/src/Imports/Models/Import.php
+++ b/packages/actions/src/Imports/Models/Import.php
@@ -28,6 +28,9 @@ class Import extends Model
 {
     use Prunable;
 
+    /**
+     * @return array<string, string>
+     */
     protected function casts(): array
     {
         return [

--- a/packages/forms/docs/03-select.md
+++ b/packages/forms/docs/03-select.md
@@ -219,6 +219,9 @@ use Illuminate\Database\Eloquent\Model;
 
 class App extends Model
 {
+    /**
+     * @return array<string, string>
+     */
     protected function casts(): array
     {
         return [

--- a/packages/forms/docs/03-select.md
+++ b/packages/forms/docs/03-select.md
@@ -219,9 +219,12 @@ use Illuminate\Database\Eloquent\Model;
 
 class App extends Model
 {
-    protected $casts = [
-        'technologies' => 'array',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'technologies' => 'array',
+        ];
+    }
 
     // ...
 }

--- a/packages/forms/docs/04-checkbox.md
+++ b/packages/forms/docs/04-checkbox.md
@@ -23,6 +23,9 @@ use Illuminate\Database\Eloquent\Model;
 
 class User extends Model
 {
+    /**
+     * @return array<string, string>
+     */
     protected function casts(): array
     {
         return [

--- a/packages/forms/docs/04-checkbox.md
+++ b/packages/forms/docs/04-checkbox.md
@@ -23,9 +23,12 @@ use Illuminate\Database\Eloquent\Model;
 
 class User extends Model
 {
-    protected $casts = [
-        'is_admin' => 'boolean',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'is_admin' => 'boolean',
+        ];
+    }
 
     // ...
 }

--- a/packages/forms/docs/05-toggle.md
+++ b/packages/forms/docs/05-toggle.md
@@ -23,6 +23,9 @@ use Illuminate\Database\Eloquent\Model;
 
 class User extends Model
 {
+    /**
+     * @return array<string, string>
+     */
     protected function casts(): array
     {
         return [

--- a/packages/forms/docs/05-toggle.md
+++ b/packages/forms/docs/05-toggle.md
@@ -23,9 +23,12 @@ use Illuminate\Database\Eloquent\Model;
 
 class User extends Model
 {
-    protected $casts = [
-        'is_admin' => 'boolean',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'is_admin' => 'boolean',
+        ];
+    }
 
     // ...
 }

--- a/packages/forms/docs/06-checkbox-list.md
+++ b/packages/forms/docs/06-checkbox-list.md
@@ -32,11 +32,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class App extends Model
 {
-   protected function casts(): array
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
     {
         return [
             'technologies' => 'array',
         ];
+    }
 
     // ...
 }

--- a/packages/forms/docs/06-checkbox-list.md
+++ b/packages/forms/docs/06-checkbox-list.md
@@ -32,9 +32,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class App extends Model
 {
-    protected $casts = [
-        'technologies' => 'array',
-    ];
+   protected function casts(): array
+    {
+        return [
+            'technologies' => 'array',
+        ];
 
     // ...
 }

--- a/packages/forms/docs/09-file-upload.md
+++ b/packages/forms/docs/09-file-upload.md
@@ -75,11 +75,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class Message extends Model
 {
-   protected function casts(): array
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
     { 
         return [
             'attachments' => 'array',
         ];
+    }
 
     // ...
 }

--- a/packages/forms/docs/09-file-upload.md
+++ b/packages/forms/docs/09-file-upload.md
@@ -75,9 +75,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class Message extends Model
 {
-    protected $casts = [
-        'attachments' => 'array',
-    ];
+   protected function casts(): array
+    { 
+        return [
+            'attachments' => 'array',
+        ];
 
     // ...
 }

--- a/packages/forms/docs/10-rich-editor.md
+++ b/packages/forms/docs/10-rich-editor.md
@@ -37,9 +37,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
-    protected $casts = [
-        'content' => 'array',
-    ];
+   protected function casts(): array
+    {
+        return [
+            'content' => 'array',
+        ];
 
     // ...
 }

--- a/packages/forms/docs/10-rich-editor.md
+++ b/packages/forms/docs/10-rich-editor.md
@@ -37,11 +37,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
-   protected function casts(): array
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
     {
         return [
             'content' => 'array',
         ];
+    }
 
     // ...
 }

--- a/packages/forms/docs/14-tags-input.md
+++ b/packages/forms/docs/14-tags-input.md
@@ -26,11 +26,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
-   protected function casts(): array
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
     {
         return [
             'tags' => 'array',
         ];
+    }
 
     // ...
 }

--- a/packages/forms/docs/14-tags-input.md
+++ b/packages/forms/docs/14-tags-input.md
@@ -26,9 +26,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
-    protected $casts = [
-        'tags' => 'array',
-    ];
+   protected function casts(): array
+    {
+        return [
+            'tags' => 'array',
+        ];
 
     // ...
 }

--- a/packages/forms/docs/16-key-value.md
+++ b/packages/forms/docs/16-key-value.md
@@ -23,9 +23,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
-    protected $casts = [
-        'meta' => 'array',
-    ];
+    protected function casts(): array
+    { 
+        return [
+            'meta' => 'array',
+        ];
 
     // ...
 }

--- a/packages/forms/docs/16-key-value.md
+++ b/packages/forms/docs/16-key-value.md
@@ -23,11 +23,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
+    /**
+     * @return array<string, string>
+     */
     protected function casts(): array
     { 
         return [
             'meta' => 'array',
         ];
+    }
 
     // ...
 }

--- a/packages/forms/docs/18-toggle-buttons.md
+++ b/packages/forms/docs/18-toggle-buttons.md
@@ -196,11 +196,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class App extends Model
 {
+    /**
+     * @return array<string, string>
+     */
     protected function casts(): array
     { 
         return [
             'technologies' => 'array',
         ];
+    }
 
     // ...
 }

--- a/packages/forms/docs/18-toggle-buttons.md
+++ b/packages/forms/docs/18-toggle-buttons.md
@@ -196,9 +196,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class App extends Model
 {
-    protected $casts = [
-        'technologies' => 'array',
-    ];
+    protected function casts(): array
+    { 
+        return [
+            'technologies' => 'array',
+        ];
 
     // ...
 }

--- a/packages/forms/docs/19-slider.md
+++ b/packages/forms/docs/19-slider.md
@@ -147,7 +147,7 @@ class Post extends Model
     protected function casts(): array
     {
         return [
-            'slider' => array,
+            'slider' => 'array',
         ];
     }
 

--- a/packages/forms/docs/19-slider.md
+++ b/packages/forms/docs/19-slider.md
@@ -139,11 +139,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
-    //Laravel 10
-    protected $casts = [
-        'slider' => 'array',
-    ];
-    //Laravel 11 or later
+    
     protected function casts(): array
     {
         return [

--- a/packages/forms/docs/19-slider.md
+++ b/packages/forms/docs/19-slider.md
@@ -139,9 +139,17 @@ use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
+    //Laravel 10
     protected $casts = [
         'slider' => 'array',
     ];
+    //Laravel 11 or later
+    protected function casts(): array
+    {
+        return [
+            'slider' => array,
+        ];
+    }
 
     // ...
 }

--- a/packages/forms/docs/19-slider.md
+++ b/packages/forms/docs/19-slider.md
@@ -139,7 +139,9 @@ use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
-    
+    /**
+     * @return array<string, string>
+     */
     protected function casts(): array
     {
         return [

--- a/packages/infolists/docs/07-key-value-entry.md
+++ b/packages/infolists/docs/07-key-value-entry.md
@@ -33,11 +33,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
-   protected function casts(): array
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
     { 
         return [
             'meta' => 'array',
         ];
+    }
 
     // ...
 }

--- a/packages/infolists/docs/07-key-value-entry.md
+++ b/packages/infolists/docs/07-key-value-entry.md
@@ -33,9 +33,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
-    protected $casts = [
-        'meta' => 'array',
-    ];
+   protected function casts(): array
+    { 
+        return [
+            'meta' => 'array',
+        ];
 
     // ...
 }

--- a/tests/src/Fixtures/Models/Post.php
+++ b/tests/src/Fixtures/Models/Post.php
@@ -14,13 +14,16 @@ class Post extends Model
     use HasFactory;
     use SoftDeletes;
 
-    protected $casts = [
-        'string_backed_enum' => StringBackedEnum::class,
-        'is_published' => 'boolean',
-        'tags' => 'array',
-        'json' => 'array',
-        'json_array_of_objects' => 'array',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'string_backed_enum' => StringBackedEnum::class,
+            'is_published' => 'boolean',
+            'tags' => 'array',
+            'json' => 'array',
+            'json_array_of_objects' => 'array',
+        ];
+    }
 
     protected $guarded = [];
 

--- a/tests/src/Fixtures/Models/Post.php
+++ b/tests/src/Fixtures/Models/Post.php
@@ -14,6 +14,9 @@ class Post extends Model
     use HasFactory;
     use SoftDeletes;
 
+    /**
+     * @return array<string, string>
+     */
     protected function casts(): array
     {
         return [

--- a/tests/src/Fixtures/Models/User.php
+++ b/tests/src/Fixtures/Models/User.php
@@ -32,16 +32,16 @@ class User extends Authenticatable implements FilamentUser, HasAppAuthentication
         'app_authentication_recovery_codes',
     ];
 
-    /**
-     * @var array<string, string>
-     */
-    protected $casts = [
-        'json' => 'array',
-        'email_verified_at' => 'datetime',
-        'app_authentication_secret' => 'encrypted',
-        'app_authentication_recovery_codes' => 'encrypted:array',
-        'has_email_authentication' => 'boolean',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'json' => 'array',
+            'email_verified_at' => 'datetime',
+            'app_authentication_secret' => 'encrypted',
+            'app_authentication_recovery_codes' => 'encrypted:array',
+            'has_email_authentication' => 'boolean',
+        ];
+    }
 
     public function canAccessPanel(Panel $panel): bool
     {

--- a/tests/src/Fixtures/Models/User.php
+++ b/tests/src/Fixtures/Models/User.php
@@ -32,6 +32,9 @@ class User extends Authenticatable implements FilamentUser, HasAppAuthentication
         'app_authentication_recovery_codes',
     ];
 
+    /**
+     * @return array<string, string>
+     */
     protected function casts(): array
     {
         return [


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Laravel 11 and later will be remove the attribute overiding, instead use function like in
 https://laravel.com/docs/eloquent-mutators#attribute-casting

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
