### PR TITLE
chore: update documentation link

### DIFF
--- a/packages/forms/docs/03-fields/08-date-time-picker.md
+++ b/packages/forms/docs/03-fields/08-date-time-picker.md
@@ -239,7 +239,7 @@ Please note that this setting is only enforced on native date pickers. If you're
 
 There are a few differences, compared to [`disabled()`](getting-started#disabling-a-field):
 
-- When using `readOnly()`, the field will still be sent to the server when the form is submitted. It can be mutated with the browser console, or via JavaScript. You can use [`dehydrated(false)`](advanced#preventing-a-field-from-being-dehydrated) to prevent this.
+- When using `readOnly()`, the field will still be sent to the server when the form is submitted. It can be mutated with the browser console, or via JavaScript. You can use [`dehydrated(false)`](../advanced#preventing-a-field-from-being-dehydrated) to prevent this.
 - There are no styling changes, such as less opacity, when using `readOnly()`.
 - The field is still focusable when using `readOnly()`.
 


### PR DESCRIPTION
## Description
When clicking the link, it doesn't take to the correct documentation but instead to the initial installation page. It turns out the problem was that the "advanced" path was outside of the "fields".