### PR TITLE
fix: support enums as Select options with disableOptionsWhenSelectedI…

### DIFF
--- a/packages/forms/src/Components/Concerns/CanDisableOptionsWhenSelectedInSiblingRepeaterItems.php
+++ b/packages/forms/src/Components/Concerns/CanDisableOptionsWhenSelectedInSiblingRepeaterItems.php
@@ -27,7 +27,13 @@ trait CanDisableOptionsWhenSelectedInSiblingRepeaterItems
                         ->after('.'),
                 )
                 ->flatten()
-                ->diff(Arr::wrap($state))
+                ->map(function ($siblingItemState) {
+                    if ($siblingItemState instanceof \UnitEnum) {
+                        return property_exists($siblingItemState, 'value') ? $siblingItemState->value : $siblingItemState->name;
+                    }
+                    return $siblingItemState;
+                })
+                ->diff(Arr::wrap($state instanceof \UnitEnum ? (property_exists($state, 'value') ? $state->value : $state->name) : $state))
                 ->filter(fn (mixed $siblingItemState): bool => filled($siblingItemState))
                 ->contains($value);
         });

--- a/packages/forms/src/Components/Concerns/CanDisableOptionsWhenSelectedInSiblingRepeaterItems.php
+++ b/packages/forms/src/Components/Concerns/CanDisableOptionsWhenSelectedInSiblingRepeaterItems.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Forms\Components\Concerns;
 
+use BackedEnum;
 use Filament\Forms\Components\Component;
 use Filament\Forms\Components\Contracts\CanDisableOptions;
 use Illuminate\Support\Arr;
@@ -27,13 +28,14 @@ trait CanDisableOptionsWhenSelectedInSiblingRepeaterItems
                         ->after('.'),
                 )
                 ->flatten()
-                ->map(function ($siblingItemState) {
-                    if ($siblingItemState instanceof \UnitEnum) {
-                        return property_exists($siblingItemState, 'value') ? $siblingItemState->value : $siblingItemState->name;
+                ->map(function (mixed $siblingItemState): mixed {
+                    if ($siblingItemState instanceof BackedEnum) {
+                        return $siblingItemState->value;
                     }
+
                     return $siblingItemState;
                 })
-                ->diff(Arr::wrap($state instanceof \UnitEnum ? (property_exists($state, 'value') ? $state->value : $state->name) : $state))
+                ->diff(Arr::wrap(($state instanceof BackedEnum) ? $state->value : $state))
                 ->filter(fn (mixed $siblingItemState): bool => filled($siblingItemState))
                 ->contains($value);
         });

--- a/tests/src/Forms/Components/RepeaterTest.php
+++ b/tests/src/Forms/Components/RepeaterTest.php
@@ -8,6 +8,7 @@ use Filament\Tests\TestCase;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Filament\Forms\Components\Select;
 
 use function Filament\Tests\livewire;
 
@@ -140,6 +141,26 @@ it('can remove items from a repeater', function () {
     $undoRepeaterFake();
 });
 
+it('can use enum as select options with disableOptionsWhenSelectedInSiblingRepeaterItems', function () {
+    $undoRepeaterFake = Repeater::fake();
+
+    livewire(TestComponentWithEnumSelectRepeater::class)
+        ->fillForm([
+            'alternatives' => [
+                ['letter' => TestLetterEnum::A],
+                ['letter' => TestLetterEnum::B],
+            ],
+        ])
+        ->assertFormSet([
+            'alternatives' => [
+                ['letter' => TestLetterEnum::A],
+                ['letter' => TestLetterEnum::B],
+            ],
+        ]);
+
+    $undoRepeaterFake();
+});
+
 class TestComponentWithRepeater extends Livewire
 {
     public function form(Form $form): Form
@@ -177,4 +198,33 @@ class TestComponentWithRepeater extends Livewire
     {
         return view('forms.fixtures.form');
     }
+}
+
+class TestComponentWithEnumSelectRepeater extends Livewire
+{
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Repeater::make('alternatives')
+                    ->schema([
+                        Select::make('letter')
+                            ->options(TestLetterEnum::class)
+                            ->disableOptionsWhenSelectedInSiblingRepeaterItems(),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function render(): View
+    {
+        return view('forms.fixtures.form');
+    }
+}
+
+enum TestLetterEnum: string
+{
+    case A = 'A';
+    case B = 'B';
+    case C = 'C';
 }

--- a/tests/src/Forms/Components/RepeaterTest.php
+++ b/tests/src/Forms/Components/RepeaterTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Tests\Forms\Fixtures\Livewire;
@@ -8,7 +9,6 @@ use Filament\Tests\TestCase;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Filament\Forms\Components\Select;
 
 use function Filament\Tests\livewire;
 
@@ -141,7 +141,7 @@ it('can remove items from a repeater', function () {
     $undoRepeaterFake();
 });
 
-it('can use enum as select options with disableOptionsWhenSelectedInSiblingRepeaterItems', function () {
+it('can use select options from an enum with `disableOptionsWhenSelectedInSiblingRepeaterItems()`', function () {
     $undoRepeaterFake = Repeater::fake();
 
     livewire(TestComponentWithEnumSelectRepeater::class)


### PR DESCRIPTION
…nSiblingRepeaterItems

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR fixes an issue where the `disableOptionsWhenSelectedInSiblingRepeaterItems()` method did not work correctly when a PHP enum was used as options for a `Select` field inside a `Repeater`.  
Previously, this resulted in the error:  
> Object of class App\Enums\AlternativeLetter could not be converted to string.

Enum values are now normalized to their scalar values before comparison, ensuring that option selection and disabling works as expected with enums.  
An automated test was added to cover this scenario.  
To keep the test self-contained and avoid polluting the fixtures directory, the test enum (`TestLetterEnum`) is declared at the end of the test file.

## Visual changes

<!-- No visual changes. This is a backend/logic fix only. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.