### PR TITLE
fire only one notificationsSent event per request

### DIFF
--- a/packages/notifications/src/NotificationsServiceProvider.php
+++ b/packages/notifications/src/NotificationsServiceProvider.php
@@ -49,6 +49,13 @@ class NotificationsServiceProvider extends PackageServiceProvider
                 return;
             }
 
+            // Prevent multiple dispatches in the same request
+            $requestKey = 'filament.notifications.dispatched.' . request()->fingerprint();
+            if (app()->has($requestKey)) {
+                return;
+            }
+
+            app()->instance($requestKey, true);
             $component->dispatch('notificationsSent');
         });
 

--- a/packages/notifications/src/NotificationsServiceProvider.php
+++ b/packages/notifications/src/NotificationsServiceProvider.php
@@ -55,7 +55,7 @@ class NotificationsServiceProvider extends PackageServiceProvider
                 return;
             }
 
-            app()->instance($requestKey, true);
+            app()->scoped($requestKey, fn () => true);
             $component->dispatch('notificationsSent');
         });
 


### PR DESCRIPTION
## Description

Fixes #16662 .

Adds a check, using the request fingerprint, to return out of the `NotificationsServiceProvider` component dehydration logic if the set of notifications has already been dispatched by another component.

## Visual changes

Notifications no longer render more than once under the conditions demonstrated in #16662

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
