### PR TITLE
Fix ModalTableSelect issue in Repeater context

### DIFF
--- a/packages/forms/src/Components/ModalTableSelect.php
+++ b/packages/forms/src/Components/ModalTableSelect.php
@@ -75,7 +75,7 @@ class ModalTableSelect extends Field
         });
 
         $this->registerActions([
-            fn (ModalTableSelect $component): Action => $this->getSelectAction(),
+            fn (ModalTableSelect $component): Action => $component->getSelectAction(),
         ]);
     }
 


### PR DESCRIPTION
## Description

This PR fixes an issue with ModalTableSelect when used inside a Repeater or Builder.

When multiple entries are added (e.g., two repeater items), and a selection is made using the ModalTableSelect in the first item, the selected value would incorrectly be applied to the last item in the list instead.

This fix ensures that the selected value is correctly assigned to the intended repeater or builder entry, rather than being overwritten in the last item.

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
