### PR TITLE
[4.x] Fix/recursive component performances

### DIFF
--- a/packages/schemas/src/Concerns/HasComponents.php
+++ b/packages/schemas/src/Concerns/HasComponents.php
@@ -12,6 +12,7 @@ use Filament\Schemas\Components\Text;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 trait HasComponents
 {
@@ -151,11 +152,16 @@ trait HasComponents
 
             $targetRelativeKey = $findComponentUsing;
             if ($isAbsoluteKey) {
-                $targetRelativeKey = str($findComponentUsing)->replaceStart($this->getKey(true) . '.', '');
+                $targetRelativeKey = Str::replaceStart($this->getKey(true) . '.', '', $findComponentUsing);
             }
 
-            $targetLocalKey = str($targetRelativeKey)->before('.');
-            $targetNestedKey = str($targetRelativeKey)->after('.');
+            if (Str::contains($targetRelativeKey, '.')) {
+                $targetLocalKey = Str::before($targetRelativeKey, '.');
+                $targetNestedKey = Str::after($targetRelativeKey, '.');
+            } else {
+                $targetLocalKey = $targetRelativeKey;
+                $targetNestedKey = null;
+            }
 
             foreach ($this->getComponents($withActions, $withHidden) as $component) {
                 if (! ($component instanceof Component)) {

--- a/packages/schemas/src/Concerns/HasComponents.php
+++ b/packages/schemas/src/Concerns/HasComponents.php
@@ -128,14 +128,9 @@ trait HasComponents
 
     public function getComponent(string | Closure $findComponentUsing, bool $withActions = true, bool $withHidden = false, bool $isAbsoluteKey = false, ?Component $skipComponentChildContainersWhileSearching = null): Component | Action | ActionGroup | null
     {
-        if (is_string($findComponentUsing) && (! $isAbsoluteKey) && filled($key = $this->getKey())) {
-            $findComponentUsing = "{$key}.$findComponentUsing";
-            $isAbsoluteKey = true;
-        }
-
         if ($skipComponentChildContainersWhileSearching) {
-            foreach ($this->getComponents($withActions, $withHidden) as $component) {
-                if ($findComponentUsing instanceof Closure) {
+            if ($findComponentUsing instanceof Closure) {
+                foreach ($this->getComponents($withActions, $withHidden) as $component) {
                     if ($findComponentUsing($component)) {
                         return $component;
                     }
@@ -149,34 +144,55 @@ trait HasComponents
                             return $foundComponent;
                         }
                     }
-
-                    continue;
                 }
 
+                return null;
+            }
+
+            $targetRelativeKey = $findComponentUsing;
+            if ($isAbsoluteKey) {
+                $targetRelativeKey = str($findComponentUsing)->replaceStart($this->getKey(true) . '.', '');
+            }
+
+            $targetLocalKey = str($targetRelativeKey)->before('.');
+            $targetNestedKey = str($targetRelativeKey)->after('.');
+
+            foreach ($this->getComponents($withActions, $withHidden) as $component) {
                 if (! ($component instanceof Component)) {
                     continue;
                 }
-
-                $componentKey = $component->getKey();
-
-                if (filled($componentKey) && ($componentKey === $findComponentUsing)) {
-                    return $component;
-                }
-
                 if ($component === $skipComponentChildContainersWhileSearching) {
                     continue;
                 }
 
-                if (blank($componentKey) || str_starts_with($findComponentUsing, "{$componentKey}.")) {
-                    foreach ($component->getChildSchemas($withHidden) as $childSchema) {
-                        if ($foundComponent = $childSchema->getComponent($findComponentUsing, $withActions, $withHidden, $isAbsoluteKey, $skipComponentChildContainersWhileSearching)) {
-                            return $foundComponent;
-                        }
+                $componentLocalKey = $component->getKey(isAbsolute: false);
+                if (filled($componentLocalKey)) {
+                    if ($componentLocalKey !== $targetLocalKey) {
+                        continue;
+                    }
+
+                    if (empty($targetNestedKey)) {
+                        return $component;
                     }
                 }
+
+                $nestedRelativeKey = filled($componentLocalKey) ? $targetNestedKey : $targetRelativeKey;
+
+                foreach ($component->getChildSchemas($withHidden) as $childSchema) {
+                    if ($foundComponent = $childSchema->getComponent($nestedRelativeKey, $withActions, $withHidden, false, $skipComponentChildContainersWhileSearching)) {
+                        return $foundComponent;
+                    }
+                }
+
+                break;
             }
 
             return null;
+        }
+
+        if (is_string($findComponentUsing) && (! $isAbsoluteKey) && filled($key = $this->getKey())) {
+            $findComponentUsing = "{$key}.$findComponentUsing";
+            $isAbsoluteKey = true;
         }
 
         if (! is_string($findComponentUsing)) {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR aims to rewrite getComponent to handle the recursive traversal of components much more efficiently and significantly faster.

A detailed explanation can be found in the corresponding issue: #16974 

With a large number of nested components, such as when using the Builder, there no longer appears to be any noticeable performance impact — it now performs similarly to a smaller schema.


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.  **(Based on my experience, I haven't observed any problems in any of my cases; however, other situations may indeed exist.)**
- [ ] Documentation is up-to-date.
