### PR TITLE
[v4] Add missing evaluate to `isMultiFactorAuthenticationRequired()`

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasAuth.php
+++ b/packages/panels/src/Panel/Concerns/HasAuth.php
@@ -312,7 +312,7 @@ trait HasAuth
 
     public function isMultiFactorAuthenticationRequired(): bool
     {
-        return $this->isMultiFactorAuthenticationRequired;
+        return $this->evaluate($this->isMultiFactorAuthenticationRequired);
     }
 
     public function hasProfile(): bool

--- a/packages/panels/src/Panel/Concerns/HasAuth.php
+++ b/packages/panels/src/Panel/Concerns/HasAuth.php
@@ -312,7 +312,7 @@ trait HasAuth
 
     public function isMultiFactorAuthenticationRequired(): bool
     {
-        return $this->evaluate($this->isMultiFactorAuthenticationRequired);
+        return (bool) $this->evaluate($this->isMultiFactorAuthenticationRequired);
     }
 
     public function hasProfile(): bool


### PR DESCRIPTION
## Description

The field can also be a closure so we need to use `evaluate`.

https://github.com/filamentphp/filament/blob/09a2eb4dcac2ba144fb616a1b072b5555a5deaae/packages/panels/src/Panel/Concerns/HasAuth.php#L58

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
