### PR TITLE
Placeholder Form Component Can Be Copied

### DIFF
--- a/packages/forms/docs/04-layout/08-placeholder.md
+++ b/packages/forms/docs/04-layout/08-placeholder.md
@@ -44,3 +44,42 @@ Placeholder::make('total')
         return '€' . number_format($get('cost') * $get('quantity'), 2);
     })
 ```
+
+## Allowing the content to be copied to the clipboard
+
+You may make the content copyable, such that clicking on content the value to the clipboard, and optionally specify a custom confirmation message and duration in milliseconds. This feature only works when SSL is enabled for the app.
+
+```php
+use Filament\Forms\Components\Placeholder;
+
+Placeholder::make('placeholder')
+    ->content('My content')
+    ->copyable()
+    ->copyMessage('Content copied')
+    ->copyMessageDuration(1500)
+```
+
+### Customizing the text that is copied to the clipboard
+
+You can customize the text that gets copied to the clipboard using the `copyableState()` method:
+
+```php
+use Filament\Forms\Components\Placeholder;
+
+Placeholder::make('placeholder')
+    ->content('My content')
+    ->copyable()
+    ->copyableState(fn (string $state): string => "Placeholder: {$state}")
+```
+
+In this function, you can access the whole table row with `$record`:
+
+```php
+use App\Models\Post;
+use Filament\Forms\Components\Placeholder;
+
+Placeholder::make('placeholder')
+    ->content('My content')
+    ->copyable()
+    ->copyableState(fn (Post $record): string => "Record: {$record->name}")
+```

--- a/packages/forms/resources/views/components/placeholder.blade.php
+++ b/packages/forms/resources/views/components/placeholder.blade.php
@@ -12,12 +12,31 @@
     :hint-icon-tooltip="$getHintIconTooltip()"
     :state-path="$getStatePath()"
 >
+    @php
+        $copyableState = $getContent();
+        $copyMessage = $getCopyMessage($state);
+        $copyMessageDuration = $getCopyMessageDuration($state);
+        $itemIsCopyable = $isCopyable($state);
+    @endphp
     <div
         {{
             $attributes
                 ->merge($getExtraAttributes(), escape: false)
-                ->class(['fi-fo-placeholder text-sm leading-6'])
+                ->class([
+                    'fi-fo-placeholder text-sm leading-6',
+                    'cursor-pointer' => $itemIsCopyable,
+                ])
         }}
+
+        @if ($itemIsCopyable)
+            x-on:click="
+                window.navigator.clipboard.writeText(@js($copyableState))
+                $tooltip(@js($copyMessage), {
+                    theme: $store.theme,
+                    timeout: @js($copyMessageDuration),
+                })
+            "
+        @endif
     >
         {{ $getContent() }}
     </div>

--- a/packages/forms/src/Components/Placeholder.php
+++ b/packages/forms/src/Components/Placeholder.php
@@ -7,6 +7,7 @@ class Placeholder extends Component implements Contracts\HasHintActions
     use Concerns\HasHelperText;
     use Concerns\HasHint;
     use Concerns\HasName;
+    use Concerns\CanBeCopied;
 
     /**
      * @var view-string

--- a/packages/forms/src/Components/Placeholder.php
+++ b/packages/forms/src/Components/Placeholder.php
@@ -2,12 +2,14 @@
 
 namespace Filament\Forms\Components;
 
+use Filament\Support\Concerns\CanBeCopied;
+
 class Placeholder extends Component implements Contracts\HasHintActions
 {
     use Concerns\HasHelperText;
     use Concerns\HasHint;
     use Concerns\HasName;
-    use Concerns\CanBeCopied;
+    use CanBeCopied;
 
     /**
      * @var view-string


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Allows the contents of form Placeholder components to be copyable to the clipboard.

## Visual changes

There are no visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
