### PR TITLE
Change hasRoutes to hasRoute

### DIFF
--- a/packages/panels/src/FilamentServiceProvider.php
+++ b/packages/panels/src/FilamentServiceProvider.php
@@ -52,7 +52,7 @@ class FilamentServiceProvider extends PackageServiceProvider
                 Commands\MakeThemeCommand::class,
                 Commands\MakeUserCommand::class,
             ])
-            ->hasRoutes('web')
+            ->hasRoute('web')
             ->hasTranslations()
             ->hasViews();
     }


### PR DESCRIPTION
Follow the same pattern configured in the [filament/actions](https://github.com/filamentphp/filament/blob/4.x/packages/actions/src/ActionsServiceProvider.php#L28) package, which uses ->hasRoute('web').

Since it's just a single file, it would be a good idea to use ->hasRoute('web') instead of the other ->hasRoutes('web') method.

Or, if you prefer, change the filament/actions package to follow a standard configuration for the project's packages.