### PR TITLE
Resolve Resource namespace  not accept value error on terminal

### DIFF
--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -148,7 +148,7 @@ class MakePageCommand extends Command
             new InputOption(
                 name: 'resource-namespace',
                 shortcut: null,
-                mode: InputOption::VALUE_NONE,
+                mode: InputOption::VALUE_OPTIONAL,
                 description: 'The namespace of the resource class, such as [App\\Filament\\Resources]',
             ),
             new InputOption(

--- a/packages/panels/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/panels/src/Commands/MakeRelationManagerCommand.php
@@ -204,7 +204,7 @@ class MakeRelationManagerCommand extends Command
             new InputOption(
                 name: 'resource-namespace',
                 shortcut: null,
-                mode: InputOption::VALUE_NONE,
+                mode: InputOption::VALUE_OPTIONAL,
                 description: 'The namespace of the resource class, such as [App\\Filament\\Resources]',
             ),
             new InputOption(

--- a/packages/panels/src/Commands/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/MakeResourceCommand.php
@@ -200,7 +200,7 @@ class MakeResourceCommand extends Command
             new InputOption(
                 name: 'resource-namespace',
                 shortcut: null,
-                mode: InputOption::VALUE_NONE,
+                mode: InputOption::VALUE_OPTIONAL,
                 description: 'The namespace of the resource class, such as [App\\Filament\\Resources]',
             ),
             new InputOption(

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -138,7 +138,7 @@ class MakeWidgetCommand extends Command
             new InputOption(
                 name: 'resource-namespace',
                 shortcut: null,
-                mode: InputOption::VALUE_NONE,
+                mode: InputOption::VALUE_OPTIONAL,
                 description: 'The namespace of the resource class, such as [App\\Filament\\Resources]',
             ),
             new InputOption(


### PR DESCRIPTION
### Description
Fixed an issue where the `--resource-namespace` option did not accept any value when creating resources, pages, and other components via the command line in Filament. This caused an error preventing the proper use of the `--resource-namespace` option. The fix involved minor adjustments in the signature or handling of the option within the command classes to accept values correctly.
### Visual changes
No visual changes. This fix is internal and affects command-line behavior only.
### Functional changes
•	Code style has been fixed by running the `composer cs` command.
•	Changes have been tested to not break existing functionality.
