### PR TITLE
docs: update ColorPicker hex-regex to allow capital letters

### DIFF
--- a/packages/forms/docs/03-fields/17-color-picker.md
+++ b/packages/forms/docs/03-fields/17-color-picker.md
@@ -42,7 +42,7 @@ You may use Laravel's validation rules to validate the values of the color picke
 use Filament\Forms\Components\ColorPicker;
 
 ColorPicker::make('hex_color')
-    ->regex('/^#([a-f0-9]{6}|[a-f0-9]{3})\b$/')
+    ->regex('/^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})\b$/')
 
 ColorPicker::make('hsl_color')
     ->hsl()


### PR DESCRIPTION
The previous regex doesn't allow capital letters which is quite unhandy when copy-pasting from one source that might format in capitals by default to another. The suggested regex is now changed to allow capital letters.