### PR TITLE
Change hasRoute to hasRoutes in ActionsServiceProvider

### DIFF
--- a/packages/actions/src/ActionsServiceProvider.php
+++ b/packages/actions/src/ActionsServiceProvider.php
@@ -25,7 +25,7 @@ class ActionsServiceProvider extends PackageServiceProvider
                 'create_exports_table',
                 'create_failed_import_rows_table',
             ])
-            ->hasRoute('web')
+            ->hasRoutes('web')
             ->hasTranslations()
             ->hasViews();
     }


### PR DESCRIPTION
Follow the same pattern configured in the [filament/panels](https://github.com/filamentphp/filament/blob/4.x/packages/panels/src/FilamentServiceProvider.php#L55) package, which uses ->hasRoutes('web').

Since it's just a single file, it would be a good idea to use ->hasRoutes('web') instead of the other method ->hasRoute('web').

Or, if you prefer, change the filament/panels package to follow a standard configuration for the project's packages.

#17070 