### PR TITLE
fix: defer evaluating edit option form data

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -277,7 +277,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
 
         $action = Action::make($this->getCreateOptionActionName())
             ->label(__('filament-forms::components.select.actions.create_option.label'))
-            ->form(function (Select $component, Form $form): array | Form | null {
+            ->form(static function (Select $component, Form $form): array | Form | null {
                 return $component->getCreateOptionActionForm($form->model(
                     $component->getRelationship() ? $component->getRelationship()->getModel()::class : null,
                 ));

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -433,7 +433,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
                     $form->model($component->getSelectedRecord()),
                 );
             })
-            ->fillForm($this->getEditOptionActionFormData())
+            ->fillForm(fn () => $this->getEditOptionActionFormData())
             ->action(static function (Action $action, array $arguments, Select $component, array $data, ComponentContainer $form) {
                 if (! $component->getUpdateOptionUsing()) {
                     throw new Exception("Select field [{$component->getStatePath()}] must have a [updateOptionUsing()] closure set.");

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -428,12 +428,12 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
 
         $action = Action::make($this->getEditOptionActionName())
             ->label(__('filament-forms::components.select.actions.edit_option.label'))
-            ->form(function (Select $component, Form $form): array | Form | null {
+            ->form(static function (Select $component, Form $form): array | Form | null {
                 return $component->getEditOptionActionForm(
                     $form->model($component->getSelectedRecord()),
                 );
             })
-            ->fillForm(fn () => $this->getEditOptionActionFormData())
+            ->fillForm(static fn (Select $component) => $component->getEditOptionActionFormData())
             ->action(static function (Action $action, array $arguments, Select $component, array $data, ComponentContainer $form) {
                 if (! $component->getUpdateOptionUsing()) {
                     throw new Exception("Select field [{$component->getStatePath()}] must have a [updateOptionUsing()] closure set.");


### PR DESCRIPTION
#16953 caused issue for people having code snippets like this:

```php
->fillEditOptionActionFormUsing(function (Leg $record, string | int $state) {
    if (! is_numeric($state)) {
        return [];
    }

    return $record->departureAirport->serviceProviders()->find($state)->attributesToArray();
})
```

Where the `$state` is assumed to be always filled in, as the edit-action is only shown when the state is filled in. After the change in #16953, this code would fail as the closure would execute with potentially nullable state. This PR fixes the issue by defering the executing of this closure to the moment when the edit action is only actually mounted.