### PR TITLE
fix: Support HasEmbeddedView components for partialRendering

### DIFF
--- a/packages/schemas/src/Components/Concerns/CanPartiallyRender.php
+++ b/packages/schemas/src/Components/Concerns/CanPartiallyRender.php
@@ -69,12 +69,8 @@ trait CanPartiallyRender
                 throw new Exception('A [key()] or [statePath()] is required to partially render a component.');
             }
 
-            $render = $this instanceof HasEmbeddedView
-                ? $this->toEmbeddedHtml(...)
-                : $this->render(...);
-
             return [
-                "schema-component::{$key}" => $render(),
+                "schema-component::{$key}" => $this->toHtml(),
             ];
         });
     }

--- a/packages/schemas/src/Components/Concerns/CanPartiallyRender.php
+++ b/packages/schemas/src/Components/Concerns/CanPartiallyRender.php
@@ -4,7 +4,6 @@ namespace Filament\Schemas\Components\Concerns;
 
 use Closure;
 use Exception;
-use Filament\Support\Components\Contracts\HasEmbeddedView;
 use Filament\Support\Livewire\Partials\PartialsComponentHook;
 
 trait CanPartiallyRender
@@ -70,7 +69,7 @@ trait CanPartiallyRender
             }
 
             return [
-                "schema-component::{$key}" => $this->toHtml(),
+                "schema-component::{$key}" => $this->hasView() ? $this->render() : $this->toHtml(),
             ];
         });
     }

--- a/packages/schemas/src/Components/Concerns/CanPartiallyRender.php
+++ b/packages/schemas/src/Components/Concerns/CanPartiallyRender.php
@@ -4,6 +4,7 @@ namespace Filament\Schemas\Components\Concerns;
 
 use Closure;
 use Exception;
+use Filament\Support\Components\Contracts\HasEmbeddedView;
 use Filament\Support\Livewire\Partials\PartialsComponentHook;
 
 trait CanPartiallyRender
@@ -68,8 +69,12 @@ trait CanPartiallyRender
                 throw new Exception('A [key()] or [statePath()] is required to partially render a component.');
             }
 
+            $render = $this instanceof HasEmbeddedView
+                ? $this->toEmbeddedHtml(...)
+                : $this->render(...);
+
             return [
-                "schema-component::{$key}" => $this->render(),
+                "schema-component::{$key}" => $render(),
             ];
         });
     }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Partial rendering broke because it tries to call `->render()` on the component which does not exist on `HasEmbeddedView` components.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
