### PR TITLE
Add missing FR translation for request password reset notification

### DIFF
--- a/packages/panels/resources/lang/fr/pages/auth/password-reset/request-password-reset.php
+++ b/packages/panels/resources/lang/fr/pages/auth/password-reset/request-password-reset.php
@@ -32,6 +32,10 @@ return [
 
     'notifications' => [
 
+        'sent' => [
+            'body' => 'Vous ne recevrez aucun email si aucun compte n’est associé à cette adresse.',
+        ],
+
         'throttled' => [
             'title' => 'Trop de requêtes',
             'body' => 'Merci de réessayer dans :seconds secondes.',


### PR DESCRIPTION
## Description

- pages/auth/password-reset/request-password-reset.notifications.sent.body

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
