### PR TITLE
fix: replace blank() with null check on ReflectionClass

### DIFF
--- a/packages/support/src/Concerns/EvaluatesClosures.php
+++ b/packages/support/src/Concerns/EvaluatesClosures.php
@@ -130,7 +130,7 @@ trait EvaluatesClosures
 
         $class = $parameter->getDeclaringClass();
 
-        if (blank($class)) {
+        if (is_null($class)) {
             return $name;
         }
 


### PR DESCRIPTION
### 🐛 Calling `blank()` on `ReflectionClass` causes error in `EvaluatesClosures`

#### Summary

In `Filament\Support\Concerns\EvaluatesClosures::getTypedReflectionParameterClassName()`, the method uses `blank()` to check whether `$parameter->getDeclaringClass()` is falsy:

```php
$class = $parameter->getDeclaringClass();

if (blank($class)) {
    return $name;
}
```

However, `getDeclaringClass()` returns either a `ReflectionClass` instance or `null`. When it returns a `ReflectionClass`, calling `blank()` throws an exception:

<img width="2670" height="952" alt="image" src="https://github.com/user-attachments/assets/3912e177-0973-4b09-80a7-c7ea08d0570c" />

This happens because `blank()` internally checks `instanceof Stringable` and then attempts to cast the object to a string (via `(string) $value`), which is invalid for `ReflectionClass` and results in a fatal error.

---

#### Real-world case

This issue occurs when evaluating closures that have parameters typed with classes used in Filament forms. For example, if a closure parameter references a form field class, `getDeclaringClass()` may return a `ReflectionClass` instance.

Since Laravel's `blank()` calls `(string) $value` after `isStringable()`, this results in:

- fatal error in `isStringable()`,
- followed by failure in `blank()`.

`vendor/laravel/framework/src/Illuminate/Support/helpers.php:67`
<img width="793" height="262" alt="image" src="https://github.com/user-attachments/assets/957f68bf-2832-41a1-9862-7c6c6b32733c" />
<img width="1897" height="941" alt="image" src="https://github.com/user-attachments/assets/cb11b269-2b46-4744-82d9-0ca3218ce847" />

---

#### Proposed fix

Replace:

```php
if (blank($class)) {
```

with:

```php
if (is_null($class)) {
```

This avoids calling `blank()` on non-stringable objects and correctly handles the null check.
