### PR TITLE
[v4] update incorrect deprecated use method

### DIFF
--- a/packages/tables/src/Filters/Concerns/HasSchema.php
+++ b/packages/tables/src/Filters/Concerns/HasSchema.php
@@ -80,7 +80,7 @@ trait HasSchema
     }
 
     /**
-     * @deprecated Use `getSchema()` instead.
+     * @deprecated Use `getSchemaComponents()` instead.
      *
      * @return array<Component | Action | ActionGroup>
      */


### PR DESCRIPTION
This took me down a rabbit hole for longer than I want to admit trying to debug why `->getSchema()` wasn't returning what I expected it to return! haha