### PR TITLE
Update wizard.js

### DIFF
--- a/packages/schemas/resources/js/components/wizard.js
+++ b/packages/schemas/resources/js/components/wizard.js
@@ -50,7 +50,7 @@ export default function wizardSchemaComponent({
 
         scroll() {
             this.$nextTick(() => {
-                this.$refs.header.children[
+                this.$refs.header?.children[
                     this.getStepIndex(this.step)
                 ].scrollIntoView({ behavior: 'smooth', block: 'start' })
             })


### PR DESCRIPTION
this.$refs.header can be undefined at the time the scroll() method runs. This causes the following runtime error: Uncaught TypeError: Cannot read properties of undefined (reading 'children')

Added a null check using optional chaining (?.) before accessing this.$refs.header.children.

```js
scroll() {
    this.$nextTick(() => {
        this.$refs.header?.children[
            this.getStepIndex(this.step)
        ].scrollIntoView({ behavior: 'smooth', block: 'start' })
    })
}
```
