### PR TITLE
Update documentation Creating a custom theme steps

### DIFF
--- a/docs/08-styling/01-overview.md
+++ b/docs/08-styling/01-overview.md
@@ -1,6 +1,7 @@
 ---
 title: Overview
 ---
+import Aside from "@components/Aside.astro"
 
 ## Changing the colors
 
@@ -126,18 +127,21 @@ By default, this command will use NPM to install dependencies. If you want to us
 ```bash
 php artisan make:filament-theme --pm=bun
 ````
-This command generates a CSS file and a Tailwind configuration file in the `resources/css/filament` directory. To complete the setup, follow these steps:
 
-1. Add the theme's CSS file to the input array in `vite.config.js`:
-```
+This command generates a CSS file in the `resources/css/filament` directory.
+
+Add the theme's CSS file to the input array in `vite.config.js`:
+
+```js
 input: [
     // ...
     'resources/css/filament/admin/theme.css',
-],
+]
 ```
 
-2. Register the theme in the admin panel provider:
-```
+Now, register the Vite-compiled theme CSS file in the panel's provider:
+
+```php
 use Filament\Panel;
 
 public function panel(Panel $panel): Panel
@@ -148,11 +152,16 @@ public function panel(Panel $panel): Panel
 }
 ```
 
-3. Compile the theme:
-```
+Finally, compile the theme with Vite:
+
+```bash
 npm run build
 ```
-Note: Check the command output for the exact file path `(e.g., admin/theme.css)`, as it may vary depending on your panel configuration.
+
+<Aside variant="info">
+    Check the command output for the exact file path (e.g., `app/theme.css`), as it may vary depending on your panel's ID.
+</Aside>
+
 You can now customize the theme by editing the CSS and Tailwind configuration files in `resources/css/filament`.
 
 ## Using Tailwind CSS classes in your Blade views or PHP files

--- a/docs/08-styling/01-overview.md
+++ b/docs/08-styling/01-overview.md
@@ -126,16 +126,34 @@ By default, this command will use NPM to install dependencies. If you want to us
 ```bash
 php artisan make:filament-theme --pm=bun
 ````
+This command generates a CSS file and a Tailwind configuration file in the `resources/css/filament` directory. To complete the setup, follow these steps:
 
-The command will create a CSS file and Tailwind Configuration file in the `/resources/css/filament` directory. You can then customize the theme by editing these files. It will also give you instructions on how to compile the theme and register it in Filament. **Please follow the instructions in the command to complete the setup process:**
-
+1. Add the theme's CSS file to the input array in `vite.config.js`:
 ```
-⇂ First, add a new item to the `input` array of `vite.config.js`: `resources/css/filament/admin/theme.css`
-⇂ Next, register the theme in the admin panel provider using `->viteTheme('resources/css/filament/admin/theme.css')`
-⇂ Finally, run `npm run build` to compile the theme
+input: [
+    // ...
+    'resources/css/filament/admin/theme.css',
+],
 ```
 
-Please reference the command to see the exact file names that you need to register, they may not be `admin/theme.css`.
+2. Register the theme in the admin panel provider:
+```
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->viteTheme('resources/css/filament/admin/theme.css');
+}
+```
+
+3. Compile the theme:
+```
+npm run build
+```
+Note: Check the command output for the exact file path `(e.g., admin/theme.css)`, as it may vary depending on your panel configuration.
+You can now customize the theme by editing the CSS and Tailwind configuration files in `resources/css/filament`.
 
 ## Using Tailwind CSS classes in your Blade views or PHP files
 

--- a/docs/08-styling/01-overview.md
+++ b/docs/08-styling/01-overview.md
@@ -162,7 +162,7 @@ npm run build
     Check the command output for the exact file path (e.g., `app/theme.css`), as it may vary depending on your panel's ID.
 </Aside>
 
-You can now customize the theme by editing the CSS and Tailwind configuration files in `resources/css/filament`.
+You can now customize the theme by editing the CSS file in `resources/css/filament`.
 
 ## Using Tailwind CSS classes in your Blade views or PHP files
 


### PR DESCRIPTION
## Description

Updated the custom theme setup instructions in the documentation to improve readability and consistency with the rest of the Filament documentation. The revised instructions provide a clearer, step-by-step guide for creating and registering a custom theme. The changes address the previous less readable format of the theme setup steps, ensuring users can easily follow the process.

## Visual changes

No visual changes to the Filament UI itself, as this is a documentation update. Below are screenshots of the rendered Markdown before and after the changes:

- **Before**: 
<img width="1099" height="244" alt="Screenshot 2025-07-28 at 2 05 23 PM" src="https://github.com/user-attachments/assets/332696a1-0343-4c41-9ed9-8723a8cf6f93" />

- **After**: 
<img width="1099" height="662" alt="Screenshot 2025-07-28 at 2 07 39 PM" src="https://github.com/user-attachments/assets/656354c0-6d59-421b-81e6-867838946e62" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.