### PR TITLE
fix: convert `defaultFocusedDate()` to correct timezone

### DIFF
--- a/packages/forms/src/Components/DateTimePicker.php
+++ b/packages/forms/src/Components/DateTimePicker.php
@@ -433,7 +433,7 @@ class DateTimePicker extends Field implements Contracts\HasAffixActions
     {
         $defaultFocusedDate = $this->evaluate($this->defaultFocusedDate);
 
-        if ($timezone = $this->getTimezone()) {
+        if (filled($defaultFocusedDate) && ($timezone = $this->getTimezone())) {
             $defaultFocusedDate->timezone($timezone);
         }
 

--- a/packages/forms/src/Components/DateTimePicker.php
+++ b/packages/forms/src/Components/DateTimePicker.php
@@ -431,7 +431,13 @@ class DateTimePicker extends Field implements Contracts\HasAffixActions
 
     public function getDefaultFocusedDate(): ?string
     {
-        return $this->evaluate($this->defaultFocusedDate);
+        $defaultFocusedDate = $this->evaluate($this->defaultFocusedDate);
+
+        if ($timezone = $this->getTimezone()) {
+            $defaultFocusedDate->timezone($timezone);
+        }
+
+        return $defaultFocusedDate;
     }
 
     /**

--- a/packages/forms/src/Components/DateTimePicker.php
+++ b/packages/forms/src/Components/DateTimePicker.php
@@ -433,8 +433,8 @@ class DateTimePicker extends Field implements Contracts\HasAffixActions
     {
         $defaultFocusedDate = $this->evaluate($this->defaultFocusedDate);
 
-        if (filled($defaultFocusedDate) && ($timezone = $this->getTimezone())) {
-            $defaultFocusedDate->setTimezone($timezone);
+        if (filled($defaultFocusedDate)) {
+            $defaultFocusedDate->setTimezone($this->getTimezone());
         }
 
         return $defaultFocusedDate;

--- a/packages/forms/src/Components/DateTimePicker.php
+++ b/packages/forms/src/Components/DateTimePicker.php
@@ -434,6 +434,18 @@ class DateTimePicker extends Field implements Contracts\HasAffixActions
         $defaultFocusedDate = $this->evaluate($this->defaultFocusedDate);
 
         if (filled($defaultFocusedDate)) {
+            if (! $defaultFocusedDate instanceof CarbonInterface) {
+                try {
+                    $defaultFocusedDate = Carbon::createFromFormat($this->getFormat(), (string) $defaultFocusedDate, config('app.timezone'));
+                } catch (InvalidFormatException $exception) {
+                    try {
+                        $defaultFocusedDate = Carbon::parse($defaultFocusedDate, config('app.timezone'));
+                    } catch (InvalidFormatException $exception) {
+                        return null;
+                    }
+                }
+            }
+
             $defaultFocusedDate = $defaultFocusedDate->setTimezone($this->getTimezone());
         }
 

--- a/packages/forms/src/Components/DateTimePicker.php
+++ b/packages/forms/src/Components/DateTimePicker.php
@@ -434,7 +434,7 @@ class DateTimePicker extends Field implements Contracts\HasAffixActions
         $defaultFocusedDate = $this->evaluate($this->defaultFocusedDate);
 
         if (filled($defaultFocusedDate) && ($timezone = $this->getTimezone())) {
-            $defaultFocusedDate->timezone($timezone);
+            $defaultFocusedDate->setTimezone($timezone);
         }
 
         return $defaultFocusedDate;

--- a/packages/forms/src/Components/DateTimePicker.php
+++ b/packages/forms/src/Components/DateTimePicker.php
@@ -434,7 +434,7 @@ class DateTimePicker extends Field implements Contracts\HasAffixActions
         $defaultFocusedDate = $this->evaluate($this->defaultFocusedDate);
 
         if (filled($defaultFocusedDate)) {
-            $defaultFocusedDate->setTimezone($this->getTimezone());
+            $defaultFocusedDate = $defaultFocusedDate->setTimezone($this->getTimezone());
         }
 
         return $defaultFocusedDate;


### PR DESCRIPTION
I noticed I made one small mistake in #17003, because I assumed the timezone handling was in done in JS because of the `.tz(timezone)` part, but that appears actually to be the current "guessed" timezone from the browser. This PR fixes that by applying the `->setTimezone()` method on the default focused date.

Thanks!