### PR TITLE
Allow direct editing per type in morphtoselect

### DIFF
--- a/packages/forms/docs/03-select.md
+++ b/packages/forms/docs/03-select.md
@@ -582,6 +582,64 @@ MorphToSelect::make('commentable')
     Many of the same options in the select field are available for `MorphToSelect`, including `searchable()`, `preload()`, `native()`, `allowHtml()`, and `optionsLimit()`.
 </Aside>
 
+#### Customizing the morph select fields
+
+You may further customize the "key" select field for a specific morph type using the `modifyKeySelectUsing()` method:
+
+```php
+use Filament\Forms\Components\MorphToSelect;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+
+MorphToSelect::make('commentable')
+    ->types([
+        MorphToSelect\Type::make(Product::class)
+            ->titleAttribute('name')
+            ->modifyKeySelectUsing(fn (Select $select): Select => $select
+                ->createOptionForm([
+                    TextInput::make('title')
+                        ->required(),
+                ])
+                ->createOptionUsing(function (array $data): int {
+                    return Product::create($data)->getKey();
+                })),
+        MorphToSelect\Type::make(Post::class)
+            ->titleAttribute('title'),
+    ])
+```
+
+This is useful if you want to customize the "key" select field for each morphed type individually. If you want to customize the key select for all types, you can use the `modifyKeySelectUsing()` method on the `MorphToSelect` component itself:
+
+```php
+use Filament\Forms\Components\MorphToSelect;
+use Filament\Forms\Components\Select;
+
+MorphToSelect::make('commentable')
+    ->types([
+        MorphToSelect\Type::make(Product::class)
+            ->titleAttribute('name'),
+        MorphToSelect\Type::make(Post::class)
+            ->titleAttribute('title'),
+    ])
+    ->modifyKeySelectUsing(fn (Select $select): Select => $select->native())
+```
+
+You can also modify the "type" select field using the `modifyTypeSelectUsing()` method:
+
+```php
+use Filament\Forms\Components\MorphToSelect;
+use Filament\Forms\Components\Select;
+
+MorphToSelect::make('commentable')
+    ->types([
+        MorphToSelect\Type::make(Product::class)
+            ->titleAttribute('name'),
+        MorphToSelect\Type::make(Post::class)
+            ->titleAttribute('title'),
+    ])
+    ->modifyTypeSelectUsing(fn (Select $select): Select => $select->native())
+```
+
 ## Allowing HTML in the option labels
 
 By default, Filament will escape any HTML in the option labels. If you'd like to allow HTML, you can use the `allowHtml()` method:

--- a/packages/forms/src/Components/MorphToSelect.php
+++ b/packages/forms/src/Components/MorphToSelect.php
@@ -76,7 +76,6 @@ class MorphToSelect extends Component
             $types = $component->getTypes();
             $isRequired = $component->isRequired();
 
-            /** @var ?Type $selectedType */
             $selectedTypeKey = $component->getRawState()[$typeColumn] ?? null;
             $selectedType = $selectedTypeKey ? ($component->getTypes()[$selectedTypeKey] ?? null) : null;
 

--- a/packages/forms/src/Components/MorphToSelect.php
+++ b/packages/forms/src/Components/MorphToSelect.php
@@ -77,8 +77,8 @@ class MorphToSelect extends Component
             $isRequired = $component->isRequired();
 
             /** @var ?Type $selectedType */
-            $selectedTypeKey = data_get($this->container->getConstantState(), $typeColumn);
-            $selectedType = $selectedTypeKey ? data_get($this->getTypes(), $selectedTypeKey) : null;
+            $selectedTypeKey = $component->getRawState()[$typeColumn] ?? null;
+            $selectedType = $selectedTypeKey ? ($component->getTypes()[$selectedTypeKey] ?? null) : null;
 
             $typeSelect = Select::make($typeColumn)
                 ->label($component->getLabel())

--- a/packages/forms/src/Components/MorphToSelect.php
+++ b/packages/forms/src/Components/MorphToSelect.php
@@ -76,6 +76,10 @@ class MorphToSelect extends Component
             $types = $component->getTypes();
             $isRequired = $component->isRequired();
 
+            /** @var ?Type $selectedType */
+            $selectedTypeKey = data_get($this->container->getConstantState(), $typeColumn);
+            $selectedType = $selectedTypeKey ? data_get($this->getTypes(), $selectedTypeKey) : null;
+
             $typeSelect = Select::make($typeColumn)
                 ->label($component->getLabel())
                 ->hiddenLabel()
@@ -125,6 +129,12 @@ class MorphToSelect extends Component
             }
 
             if ($callback = $component->getModifyKeySelectUsingCallback()) {
+                $keySelect = $component->evaluate($callback, [
+                    'select' => $keySelect,
+                ]) ?? $keySelect;
+            }
+
+            if ($callback = $selectedType?->getModifyKeySelectUsingCallback()) {
                 $keySelect = $component->evaluate($callback, [
                     'select' => $keySelect,
                 ]) ?? $keySelect;

--- a/packages/forms/src/Components/MorphToSelect/Type.php
+++ b/packages/forms/src/Components/MorphToSelect/Type.php
@@ -24,6 +24,8 @@ class Type
 
     public Closure $getOptionsUsing;
 
+    public ?Closure $modifyKeySelectUsing = null;
+
     protected ?Closure $modifyOptionsQueryUsing = null;
 
     /**
@@ -238,6 +240,13 @@ class Type
         return $this;
     }
 
+    public function modifyKeySelectUsing(?Closure $callback): static
+    {
+        $this->modifyKeySelectUsing = $callback;
+
+        return $this;
+    }
+
     public function modifyOptionsQueryUsing(?Closure $callback): static
     {
         $this->modifyOptionsQueryUsing = $callback;
@@ -281,6 +290,11 @@ class Type
     public function hasOptionLabelFromRecordUsingCallback(): bool
     {
         return $this->getOptionLabelFromRecordUsing !== null;
+    }
+
+    public function getModifyKeySelectUsingCallback(): ?Closure
+    {
+        return $this->modifyKeySelectUsing;
     }
 
     /**


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Currently there is no way to modify the select for morphToSelect Types directly. Instead, you can hack `modifyKeySelectUsing` and then have an if-else statement to check the label: `if ($select->getLabel() == 'label X)`. This allows you to edit the select inline directly

See https://github.com/filamentphp/filament/pull/17025 for previous discussion. I believe this should work on the new 4.x branch

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
