### PR TITLE
[4.x] Remove sticky actions scroll throttle

### DIFF
--- a/packages/schemas/resources/views/components/actions.blade.php
+++ b/packages/schemas/resources/views/components/actions.blade.php
@@ -14,7 +14,7 @@
 <div
     @if ($isSticky())
         x-data="filamentActionsSchemaComponent()"
-        x-on:scroll.window.throttle="evaluatePageScrollPosition"
+        x-on:scroll.window="evaluatePageScrollPosition"
         x-bind:class="{
             'fi-sticky': isSticky,
         }"


### PR DESCRIPTION
## Description

Remove sticky actions scroll throttle because it misses the bottom point very ofter because of the throttle.

## Visual changes

**Before**

https://github.com/user-attachments/assets/1c2c93b4-ea46-4702-b596-1e6eff36cfe6

**After**

https://github.com/user-attachments/assets/81110f95-61fc-4887-abf3-38421b422bb6

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
