### PR TITLE
Ignore current record in unique rule during replicate operation

### DIFF
--- a/packages/actions/src/ReplicateAction.php
+++ b/packages/actions/src/ReplicateAction.php
@@ -144,4 +144,13 @@ class ReplicateAction extends Action
             default => parent::resolveDefaultClosureDependencyForEvaluationByName($parameterName),
         };
     }
+
+    public function getSchema(Schema $schema): ?Schema
+    {
+        // By default, the schema's model will be set to the original record that is being replicated.
+        // However, since the schema is used to create a new replica, it is more appropriate to set
+        // the schema's model to the replica model FQN instead. This ensures that it does not
+        // behave as if the original record is edited instead of a new record being created.
+        return parent::getSchema($schema)?->model($this->getModel());
+    }
 }

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -568,8 +568,8 @@ trait CanBeValidated
 
     public function unique(string | Closure | null $table = null, string | Closure | null $column = null, Model | Closure | null $ignorable = null, ?bool $ignoreRecord = null, ?Closure $modifyRuleUsing = null): static
     {
-        $this->rule(static function (Field $component, ?string $model) use ($column, $ignorable, $ignoreRecord, $modifyRuleUsing, $table) {
-            $ignoreRecord ??= $component->shouldUniqueValidationIgnoreRecordByDefault();
+        $this->rule(static function (Field $component, ?string $model, string $operation) use ($column, $ignorable, $ignoreRecord, $modifyRuleUsing, $table) {
+            $ignoreRecord ??= $component->shouldUniqueValidationIgnoreRecordByDefault() && $operation !== 'replicate';
 
             $table = $component->evaluate($table) ?? $model;
             $column = $component->evaluate($column) ?? $component->getName();

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -568,8 +568,8 @@ trait CanBeValidated
 
     public function unique(string | Closure | null $table = null, string | Closure | null $column = null, Model | Closure | null $ignorable = null, ?bool $ignoreRecord = null, ?Closure $modifyRuleUsing = null): static
     {
-        $this->rule(static function (Field $component, ?string $model, string $operation) use ($column, $ignorable, $ignoreRecord, $modifyRuleUsing, $table) {
-            $ignoreRecord ??= $component->shouldUniqueValidationIgnoreRecordByDefault() && $operation !== 'replicate';
+        $this->rule(static function (Field $component, ?string $model) use ($column, $ignorable, $ignoreRecord, $modifyRuleUsing, $table) {
+            $ignoreRecord ??= $component->shouldUniqueValidationIgnoreRecordByDefault();
 
             $table = $component->evaluate($table) ?? $model;
             $column = $component->evaluate($column) ?? $component->getName();


### PR DESCRIPTION
## Description

This update fixes an issue where the unique validation rule did not behave correctly within Filament’s ReplicateAction.

Previously, when attempting to replicate a record that includes fields with unique validation (e.g., a unique slug or email), the rule would not exclude the original record from the check. As a result, the validation would fail even if the data being replicated came from a valid, existing record.

With this change, the validation now correctly ignores the current record when used inside the ReplicateAction, allowing for smooth cloning of models while still preserving unique constraints for future edits.

I’m not entirely sure whether this adjustment is happening in the most appropriate place, so I’m open to feedback or suggestions for a better approach.

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
