### PR TITLE
Update deprecated method in  02-action.md

### DIFF
--- a/docs/12-components/02-action.md
+++ b/docs/12-components/02-action.md
@@ -233,7 +233,7 @@ use Filament\Actions\Action;
 public function editAction(): Action
 {
     return Action::make('edit')
-        ->form([
+        ->schema([
             // ...
         ])
         // ...


### PR DESCRIPTION
Action ->form() is deprecated in v4 rename it to ->schema() in the example.