### PR TITLE
fix: spacing within `RepeatableEntry`

### DIFF
--- a/packages/infolists/resources/css/components/repeatable.css
+++ b/packages/infolists/resources/css/components/repeatable.css
@@ -1,7 +1,5 @@
 .fi-in-repeatable {
-    &ul {
-        @apply gap-4;
-    }
+    @apply gap-4;
 
     & .fi-in-repeatable-item {
         @apply block;


### PR DESCRIPTION
Currently there is no spacing between `RepeatableEntry`'s as the class `fi-in-repeatable` is applied to the `ul`, and the `ul` is therefore not a child of it.