### PR TITLE
chore: add back `Entry` `getStateUsing()` method

### DIFF
--- a/packages/infolists/src/Components/Entry.php
+++ b/packages/infolists/src/Components/Entry.php
@@ -114,6 +114,13 @@ class Entry extends Component
         return $this;
     }
 
+    public function getStateUsing(mixed $callback): static
+    {
+        $this->state($callback);
+
+        return $this;
+    }
+
     /**
      * @param  array<Component | Action | ActionGroup | string | Htmlable> | Schema | Component | Action | ActionGroup | string | Htmlable | Closure | null  $components
      */


### PR DESCRIPTION
This PR adds back the `getStateUsing()` method on all infolist entries.