### PR TITLE
fix: default state for simple `Repeater` fields

### DIFF
--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1019,8 +1019,6 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         $state = $this->getRawState();
         $items = $this->hydratedDefaultState;
 
-        $simpleFieldName = $this->getSimpleField()?->getName();
-
         foreach ($items as $itemKey => $itemData) {
             $items[$itemKey] = [
                 ...$state[$itemKey] ?? [],

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1022,11 +1022,9 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         $simpleFieldName = $this->getSimpleField()?->getName();
 
         foreach ($items as $itemKey => $itemData) {
-            $items[$itemKey] = blank($simpleFieldName) ? [
+            $items[$itemKey] = [
                 ...$state[$itemKey] ?? [],
                 ...$itemData,
-            ] : [
-                $simpleFieldName => $itemData,
             ];
         }
 

--- a/tests/src/Forms/Components/RepeaterTest.php
+++ b/tests/src/Forms/Components/RepeaterTest.php
@@ -112,6 +112,95 @@ it('can fill and assert data in a repeater', function (array $data): void {
     ]],
 ]);
 
+it('can fill and assert default data in a repeater', function (array $data): void {
+    $undoRepeaterFake = Repeater::fake();
+
+    try {
+        livewire(TestComponentWithRepeater::class)
+            ->assertSchemaStateSet($data);
+    } catch (RootTagMissingFromViewException $exception) {
+        // Flaky test
+    }
+
+    $undoRepeaterFake();
+})->with([
+    'normal' => fn (): array => ['normal' => [
+        [
+            'title' => 'title 1',
+            'category' => 'category 1',
+        ],
+        [
+            'title' => 'title 2',
+            'category' => 'category 2',
+        ],
+        [
+            'title' => 'title 3',
+            'category' => 'category 3',
+        ],
+    ]],
+    'simple' => fn (): array => ['simple' => [
+        ['title' => 'simple 1'],
+        ['title' => 'simple 2'],
+        ['title' => 'simple 3'],
+    ]],
+    'nested' => fn (): array => ['parent' => [
+        [
+            'title' => 'title 1',
+            'category' => 'category 1',
+            'nested' => [
+                [
+                    'name' => '1 nested name 1',
+                ],
+                [
+                    'name' => '1 nested name 2',
+                ],
+                [
+                    'name' => '1 nested name 3',
+                ],
+            ],
+            'nestedSimple' => [
+                ['name' => null],
+            ],
+        ],
+        [
+            'title' => 'title 2',
+            'category' => 'category 2',
+            'nested' => [
+                [
+                    'name' => '2 nested name 1',
+                ],
+                [
+                    'name' => '2 nested name 2',
+                ],
+                [
+                    'name' => '2 nested name 3',
+                ],
+            ],
+            'nestedSimple' => [
+                ['name' => null],
+            ],
+        ],
+        [
+            'title' => 'title 3',
+            'category' => 'category 3',
+            'nested' => [
+                [
+                    'name' => '3 nested name 1',
+                ],
+                [
+                    'name' => '3 nested name 2',
+                ],
+                [
+                    'name' => '3 nested name 3',
+                ],
+            ],
+            'nestedSimple' => [
+                ['name' => null],
+            ],
+        ],
+    ]],
+]);
+
 it('can remove items from a repeater', function (): void {
     $undoRepeaterFake = Repeater::fake();
 
@@ -206,6 +295,11 @@ it('can use select options from an enum with `disableOptionsWhenSelectedInSiblin
 
 class TestComponentWithRepeater extends Livewire
 {
+    public function mount(): void
+    {
+        $this->form->fill();
+    }
+
     public function form(Schema $form): Schema
     {
         return $form
@@ -217,9 +311,28 @@ class TestComponentWithRepeater extends Livewire
                     ->schema([
                         TextInput::make('title'),
                         TextInput::make('category'),
+                    ])
+                    ->default([
+                        [
+                            'title' => 'title 1',
+                            'category' => 'category 1',
+                        ],
+                        [
+                            'title' => 'title 2',
+                            'category' => 'category 2',
+                        ],
+                        [
+                            'title' => 'title 3',
+                            'category' => 'category 3',
+                        ],
                     ]),
                 Repeater::make('simple')
-                    ->simple(TextInput::make('title')),
+                    ->simple(TextInput::make('title'))
+                    ->default([
+                        'simple 1',
+                        'simple 2',
+                        'simple 3',
+                    ]),
                 Repeater::make('parent')
                     ->itemLabel(fn (array $state) => $state['title'] . $state['category'])
                     ->schema([
@@ -232,6 +345,53 @@ class TestComponentWithRepeater extends Livewire
                             ]),
                         Repeater::make('nestedSimple')
                             ->simple(TextInput::make('name')),
+                    ])
+                    ->default([
+                        [
+                            'title' => 'title 1',
+                            'category' => 'category 1',
+                            'nested' => [
+                                [
+                                    'name' => '1 nested name 1',
+                                ],
+                                [
+                                    'name' => '1 nested name 2',
+                                ],
+                                [
+                                    'name' => '1 nested name 3',
+                                ],
+                            ],
+                        ],
+                        [
+                            'title' => 'title 2',
+                            'category' => 'category 2',
+                            'nested' => [
+                                [
+                                    'name' => '2 nested name 1',
+                                ],
+                                [
+                                    'name' => '2 nested name 2',
+                                ],
+                                [
+                                    'name' => '2 nested name 3',
+                                ],
+                            ],
+                        ],
+                        [
+                            'title' => 'title 3',
+                            'category' => 'category 3',
+                            'nested' => [
+                                [
+                                    'name' => '3 nested name 1',
+                                ],
+                                [
+                                    'name' => '3 nested name 2',
+                                ],
+                                [
+                                    'name' => '3 nested name 3',
+                                ],
+                            ],
+                        ],
                     ]),
             ])
             ->statePath('data');


### PR DESCRIPTION
The default state for simple repeater fields is already wrapped in the simple field name in the `->default()` method:

```php
parent::default(function (Repeater $component) use ($state) {
    $state = $component->evaluate($state);

    $simpleField = $component->getSimpleField();

    $items = [];

    foreach ($state ?? [] as $itemData) {
        if ($simpleField) {
            $itemData = [$simpleField->getName() => $itemData];
        }

        if ($uuid = $component->generateUuid()) {
            $items[$uuid] = $itemData;
        } else {
            $items[] = $itemData;
        }
    }

    $component->hydratedDefaultState = $items;

    return $items;
});
```

Therefore, when merging the hydrated default state with the items state we don't need to apply this wrapping again, otherwise it gets wrapped double.