### PR TITLE
fix: closure evaluation of `hintActions()`

### DIFF
--- a/packages/forms/src/Components/Concerns/HasHint.php
+++ b/packages/forms/src/Components/Concerns/HasHint.php
@@ -173,9 +173,9 @@ trait HasHint
      */
     public function getHintActions(): array
     {
-        return array_map(
-            callback: fn (Action | Closure $hintAction): Action => $this->evaluate($hintAction),
-            array: $this->hintActions
-        );
+        return array_filter(array_map(
+            fn (Action | Closure $hintAction): ?Action => $this->evaluate($hintAction),
+            $this->hintActions,
+        ));
     }
 }

--- a/packages/forms/src/Components/Concerns/HasHint.php
+++ b/packages/forms/src/Components/Concerns/HasHint.php
@@ -173,6 +173,6 @@ trait HasHint
      */
     public function getHintActions(): array
     {
-        return $this->evaluate($this->hintActions);
+	    return array_map($this->evaluate(...), $this->hintActions);
     }
 }

--- a/packages/forms/src/Components/Concerns/HasHint.php
+++ b/packages/forms/src/Components/Concerns/HasHint.php
@@ -173,6 +173,9 @@ trait HasHint
      */
     public function getHintActions(): array
     {
-	    return array_map($this->evaluate(...), $this->hintActions);
-    }
+	    return array_map(
+		    callback: fn (Action|Closure $hintAction): Action => $this->evaluate($hintAction),
+		    array: $this->hintActions
+	    );
+	}
 }

--- a/packages/forms/src/Components/Concerns/HasHint.php
+++ b/packages/forms/src/Components/Concerns/HasHint.php
@@ -173,9 +173,9 @@ trait HasHint
      */
     public function getHintActions(): array
     {
-	    return array_map(
-		    callback: fn (Action|Closure $hintAction): Action => $this->evaluate($hintAction),
-		    array: $this->hintActions
-	    );
-	}
+        return array_map(
+            callback: fn (Action | Closure $hintAction): Action => $this->evaluate($hintAction),
+            array: $this->hintActions
+        );
+    }
 }

--- a/packages/infolists/src/Components/Concerns/HasHint.php
+++ b/packages/infolists/src/Components/Concerns/HasHint.php
@@ -172,6 +172,6 @@ trait HasHint
      */
     public function getHintActions(): array
     {
-        return $this->evaluate($this->hintActions);
+	    return array_map($this->evaluate(...), $this->hintActions);
     }
 }

--- a/packages/infolists/src/Components/Concerns/HasHint.php
+++ b/packages/infolists/src/Components/Concerns/HasHint.php
@@ -172,6 +172,9 @@ trait HasHint
      */
     public function getHintActions(): array
     {
-	    return array_map($this->evaluate(...), $this->hintActions);
+	    return array_map(
+			callback: fn (Action|Closure $hintAction): Action => $this->evaluate($hintAction),
+			array: $this->hintActions
+	    );
     }
 }

--- a/packages/infolists/src/Components/Concerns/HasHint.php
+++ b/packages/infolists/src/Components/Concerns/HasHint.php
@@ -172,9 +172,9 @@ trait HasHint
      */
     public function getHintActions(): array
     {
-        return array_map(
-            callback: fn (Action | Closure $hintAction): Action => $this->evaluate($hintAction),
-            array: $this->hintActions
-        );
+        return array_filter(array_map(
+            fn (Action | Closure $hintAction): ?Action => $this->evaluate($hintAction),
+            $this->hintActions,
+        ));
     }
 }

--- a/packages/infolists/src/Components/Concerns/HasHint.php
+++ b/packages/infolists/src/Components/Concerns/HasHint.php
@@ -172,9 +172,9 @@ trait HasHint
      */
     public function getHintActions(): array
     {
-	    return array_map(
-			callback: fn (Action|Closure $hintAction): Action => $this->evaluate($hintAction),
-			array: $this->hintActions
-	    );
+        return array_map(
+            callback: fn (Action | Closure $hintAction): Action => $this->evaluate($hintAction),
+            array: $this->hintActions
+        );
     }
 }


### PR DESCRIPTION
Right now any closure-based `hintActions()` are not evaluated anymore:

```php
Select::make('type')
   ->hintActions([
       fn (?string $state) => Action::make(...)
   ])
```