### PR TITLE
fix: `->helperText()` method returning `null`

### DIFF
--- a/packages/forms/src/Components/Concerns/HasHelperText.php
+++ b/packages/forms/src/Components/Concerns/HasHelperText.php
@@ -11,8 +11,16 @@ trait HasHelperText
 {
     public function helperText(string | Htmlable | Closure | null $text): static
     {
-        $this->belowContent(fn (Component $component): Text => Text::make($component->evaluate($text)));
-
+	    $this->belowContent(function (Component $component) use ($text): ?Text {
+		    $content = $component->evaluate($text);
+		    
+		    if (blank($content)) {
+			    return null;
+		    }
+		    
+		    return Text::make($content);
+	    });
+		
         return $this;
     }
 }

--- a/packages/forms/src/Components/Concerns/HasHelperText.php
+++ b/packages/forms/src/Components/Concerns/HasHelperText.php
@@ -11,16 +11,16 @@ trait HasHelperText
 {
     public function helperText(string | Htmlable | Closure | null $text): static
     {
-	    $this->belowContent(function (Component $component) use ($text): ?Text {
-		    $content = $component->evaluate($text);
-		    
-		    if (blank($content)) {
-			    return null;
-		    }
-		    
-		    return Text::make($content);
-	    });
-		
+        $this->belowContent(function (Component $component) use ($text): ?Text {
+            $content = $component->evaluate($text);
+
+            if (blank($content)) {
+                return null;
+            }
+
+            return Text::make($content);
+        });
+
         return $this;
     }
 }

--- a/packages/infolists/src/Components/Concerns/HasHelperText.php
+++ b/packages/infolists/src/Components/Concerns/HasHelperText.php
@@ -11,8 +11,16 @@ trait HasHelperText
 {
     public function helperText(string | Htmlable | Closure | null $text): static
     {
-        $this->belowContent(fn (Component $component): Text => Text::make($component->evaluate($text)));
-
+	    $this->belowContent(function (Component $component) use ($text): ?Text {
+		    $content = $component->evaluate($text);
+		    
+		    if (blank($content)) {
+			    return null;
+		    }
+		    
+		    return Text::make($content);
+	    });
+		
         return $this;
     }
 }

--- a/packages/infolists/src/Components/Concerns/HasHelperText.php
+++ b/packages/infolists/src/Components/Concerns/HasHelperText.php
@@ -11,16 +11,16 @@ trait HasHelperText
 {
     public function helperText(string | Htmlable | Closure | null $text): static
     {
-	    $this->belowContent(function (Component $component) use ($text): ?Text {
-		    $content = $component->evaluate($text);
-		    
-		    if (blank($content)) {
-			    return null;
-		    }
-		    
-		    return Text::make($content);
-	    });
-		
+        $this->belowContent(function (Component $component) use ($text): ?Text {
+            $content = $component->evaluate($text);
+
+            if (blank($content)) {
+                return null;
+            }
+
+            return Text::make($content);
+        });
+
         return $this;
     }
 }


### PR DESCRIPTION
If you have a `helperText()` method that optionally returned `null`:
```php
TextInput::make('name')
    ->helperText(fn (?Record $record) => $record ? 'Something' : null)
```
Then in V3 this would hide the helper text in full. However, in V4 this results in still a `Text` element being created with an empty content, still taking up space below the field. To solve this, a `Text` component must only be returned when there is an actual content and not in all cases.

Thanks!