### PR TITLE
Merge extraAttributes in Action when postToUrl() is used

### DIFF
--- a/packages/support/src/View/Concerns/CanGenerateDropdownItemHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateDropdownItemHtml.php
@@ -80,6 +80,7 @@ trait CanGenerateDropdownItemHtml
                 'wire:loading.attr' => $tag === 'button' ? 'disabled' : null,
                 'wire:target' => ($hasLoadingIndicator && $loadingIndicatorTarget) ? $loadingIndicatorTarget : null,
             ], escape: false)
+            ->merge($this->getExtraAttributes(), escape: false)
             ->when(
                 $isDisabled && $hasTooltip,
                 fn (ComponentAttributeBag $attributes) => $attributes->filter(


### PR DESCRIPTION
## Description

This PR ensures that the extraAttributes() defined on the Action are applied to the <form> element when postToUrl() is used — just as they would be applied to the element rendered otherwise.

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
