### PR TITLE
fix: EditAction gray color in ActionGroup

### DIFF
--- a/packages/tables/src/Actions/EditAction.php
+++ b/packages/tables/src/Actions/EditAction.php
@@ -33,6 +33,8 @@ class EditAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::edit.single.notifications.saved.title'));
 
+        $this->defaultColor('warning');
+
         $this->icon(FilamentIcon::resolve('actions::edit-action') ?? 'heroicon-m-pencil-square');
 
         $this->fillForm(function (Model $record, Table $table): array {

--- a/packages/tables/src/Actions/EditAction.php
+++ b/packages/tables/src/Actions/EditAction.php
@@ -33,7 +33,7 @@ class EditAction extends Action
 
         $this->successNotificationTitle(__('filament-actions::edit.single.notifications.saved.title'));
 
-        $this->defaultColor('warning');
+        $this->defaultColor('primary');
 
         $this->icon(FilamentIcon::resolve('actions::edit-action') ?? 'heroicon-m-pencil-square');
 


### PR DESCRIPTION
## Description
If use an EditAction inside an ActionGroup, its color will be gray, the same as the ViewAction default color. Apparently, there's a line of code missing in the EditAction.php file for $this->defaultColor('warning').

## Visual changes
Before
<img width="441" height="377" alt="image" src="https://github.com/user-attachments/assets/a721f49d-82f5-4c21-b5e6-09f681d32157" />

After
<img width="429" height="401" alt="image" src="https://github.com/user-attachments/assets/da22e61d-d6ac-4d6a-b8a2-37ed9f981d2b" />
