### PR TITLE
[4.x] Use laravel provided namespace

### DIFF
--- a/docs-assets/app/app/Providers/Filament/AdminPanelProvider.php
+++ b/docs-assets/app/app/Providers/Filament/AdminPanelProvider.php
@@ -32,12 +32,12 @@ class AdminPanelProvider extends PanelProvider
             ->colors([
                 'primary' => Color::Amber,
             ])
-            ->discoverResources(in: app_path('Filament/Resources'), for: app()->getNamespace() . 'Filament\\Resources')
-            ->discoverPages(in: app_path('Filament/Pages'), for: app()->getNamespace() . 'Filament\\Pages')
+            ->discoverResources(in: app_path('Filament/Resources'), for: "'" . app()->getNamespace() . "Filament\\Resources'")
+            ->discoverPages(in: app_path('Filament/Pages'), for: "'" . app()->getNamespace() . "Filament\\Pages'")
             ->pages([
                 Pages\Dashboard::class,
             ])
-            ->discoverWidgets(in: app_path('Filament/Widgets'), for: app()->getNamespace() . 'Filament\\Widgets')
+            ->discoverWidgets(in: app_path('Filament/Widgets'), for: "'" . app()->getNamespace() . "Filament\\Widgets'")
             ->widgets([
                 Widgets\AccountWidget::class,
                 Widgets\FilamentInfoWidget::class,

--- a/docs-assets/app/app/Providers/Filament/AdminPanelProvider.php
+++ b/docs-assets/app/app/Providers/Filament/AdminPanelProvider.php
@@ -2,7 +2,6 @@
 
 namespace App\Providers\Filament;
 
-use Filament\Facades\Filament;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -33,12 +32,12 @@ class AdminPanelProvider extends PanelProvider
             ->colors([
                 'primary' => Color::Amber,
             ])
-            ->discoverResources(in: app_path('Filament/Resources'), for: Filament::namespaceFor('Filament\\Resources'))
-            ->discoverPages(in: app_path('Filament/Pages'), for: Filament::namespaceFor('Filament\\Pages'))
+            ->discoverResources(in: app_path('Filament/Resources'), for: app()->getNamespace() . 'Filament\\Resources')
+            ->discoverPages(in: app_path('Filament/Pages'), for: app()->getNamespace() . 'Filament\\Pages')
             ->pages([
                 Pages\Dashboard::class,
             ])
-            ->discoverWidgets(in: app_path('Filament/Widgets'), for: Filament::namespaceFor('Filament\\Widgets'))
+            ->discoverWidgets(in: app_path('Filament/Widgets'), for: app()->getNamespace() . 'Filament\\Widgets')
             ->widgets([
                 Widgets\AccountWidget::class,
                 Widgets\FilamentInfoWidget::class,

--- a/docs-assets/app/app/Providers/Filament/AdminPanelProvider.php
+++ b/docs-assets/app/app/Providers/Filament/AdminPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use Filament\Facades\Filament;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -32,12 +33,12 @@ class AdminPanelProvider extends PanelProvider
             ->colors([
                 'primary' => Color::Amber,
             ])
-            ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
-            ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
+            ->discoverResources(in: app_path('Filament/Resources'), for: Filament::namespaceFor('Filament\\Resources'))
+            ->discoverPages(in: app_path('Filament/Pages'), for: Filament::namespaceFor('Filament\\Pages'))
             ->pages([
                 Pages\Dashboard::class,
             ])
-            ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
+            ->discoverWidgets(in: app_path('Filament/Widgets'), for: Filament::namespaceFor('Filament\\Widgets'))
             ->widgets([
                 Widgets\AccountWidget::class,
                 Widgets\FilamentInfoWidget::class,

--- a/docs-assets/app/app/Providers/Filament/AdminPanelProvider.php
+++ b/docs-assets/app/app/Providers/Filament/AdminPanelProvider.php
@@ -32,12 +32,12 @@ class AdminPanelProvider extends PanelProvider
             ->colors([
                 'primary' => Color::Amber,
             ])
-            ->discoverResources(in: app_path('Filament/Resources'), for: "'" . app()->getNamespace() . "Filament\\Resources'")
-            ->discoverPages(in: app_path('Filament/Pages'), for: "'" . app()->getNamespace() . "Filament\\Pages'")
+            ->discoverResources(in: app_path('Filament/Resources'), for: app()->getNamespace() . 'Filament\\Resources')
+            ->discoverPages(in: app_path('Filament/Pages'), for: app()->getNamespace() . 'Filament\\Pages')
             ->pages([
                 Pages\Dashboard::class,
             ])
-            ->discoverWidgets(in: app_path('Filament/Widgets'), for: "'" . app()->getNamespace() . "Filament\\Widgets'")
+            ->discoverWidgets(in: app_path('Filament/Widgets'), for: app()->getNamespace() . 'Filament\\Widgets')
             ->widgets([
                 Widgets\AccountWidget::class,
                 Widgets\FilamentInfoWidget::class,

--- a/docs/06-navigation/04-clusters.md
+++ b/docs/06-navigation/04-clusters.md
@@ -23,9 +23,9 @@ public function panel(Panel $panel): Panel
 {
     return $panel
         // ...
-        ->discoverResources(in: app_path('Filament/Resources'), for: Filament::namespaceFor('Filament\\Resources'))
-        ->discoverPages(in: app_path('Filament/Pages'), for: Filament::namespaceFor('Filament\\Pages'))
-        ->discoverClusters(in: app_path('Filament/Clusters'), for: Filament::namespaceFor('Filament\\Clusters'));
+        ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
+        ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
+        ->discoverClusters(in: app_path('Filament/Clusters'), for: 'App\\Filament\\Clusters');
 }
 ```
 

--- a/docs/06-navigation/04-clusters.md
+++ b/docs/06-navigation/04-clusters.md
@@ -23,9 +23,9 @@ public function panel(Panel $panel): Panel
 {
     return $panel
         // ...
-        ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
-        ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
-        ->discoverClusters(in: app_path('Filament/Clusters'), for: 'App\\Filament\\Clusters');
+        ->discoverResources(in: app_path('Filament/Resources'), for: Filament::namespaceFor('Filament\\Resources'))
+        ->discoverPages(in: app_path('Filament/Pages'), for: Filament::namespaceFor('Filament\\Pages'))
+        ->discoverClusters(in: app_path('Filament/Clusters'), for: Filament::namespaceFor('Filament\\Clusters'));
 }
 ```
 

--- a/packages/actions/src/Commands/MakeExporterCommand.php
+++ b/packages/actions/src/Commands/MakeExporterCommand.php
@@ -3,6 +3,7 @@
 namespace Filament\Actions\Commands;
 
 use Filament\Actions\Commands\FileGenerators\ExporterClassGenerator;
+use Filament\Facades\Filament;
 use Filament\Support\Commands\Concerns\CanAskForComponentLocation;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
 use Filament\Support\Commands\Exceptions\FailureCommandOutput;
@@ -84,7 +85,7 @@ class MakeExporterCommand extends Command
                 name: 'model-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_REQUIRED,
-                description: 'The namespace of the model class, [App\\Models] by default',
+                description: 'The namespace of the model class, [' . Filament::namespaceFor('Models') . '] by default',
             ),
             new InputOption(
                 name: 'force',
@@ -131,7 +132,7 @@ class MakeExporterCommand extends Command
                 $this->modelFqnEnd = 'Resource';
             }
 
-            $modelNamespace = $this->option('model-namespace') ?? 'App\\Models';
+            $modelNamespace = $this->option('model-namespace') ?? Filament::namespaceFor('Models');
 
             $this->modelFqn = "{$modelNamespace}\\{$this->modelFqnEnd}";
         } else {
@@ -151,7 +152,7 @@ class MakeExporterCommand extends Command
                         fn (string $class): bool => str($class)->replace(['\\', '/'], '')->contains($search, ignoreCase: true),
                     );
                 },
-                placeholder: 'App\\Models\\BlogPost',
+                placeholder: Filament::namespaceFor('Models\\BlogPost'),
                 required: true,
             );
 

--- a/packages/actions/src/Commands/MakeExporterCommand.php
+++ b/packages/actions/src/Commands/MakeExporterCommand.php
@@ -3,7 +3,6 @@
 namespace Filament\Actions\Commands;
 
 use Filament\Actions\Commands\FileGenerators\ExporterClassGenerator;
-use Filament\Facades\Filament;
 use Filament\Support\Commands\Concerns\CanAskForComponentLocation;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
 use Filament\Support\Commands\Exceptions\FailureCommandOutput;
@@ -85,7 +84,7 @@ class MakeExporterCommand extends Command
                 name: 'model-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_REQUIRED,
-                description: 'The namespace of the model class, [' . Filament::namespaceFor('Models') . '] by default',
+                description: 'The namespace of the model class, [' . app()->getNamespace() . 'Models] by default',
             ),
             new InputOption(
                 name: 'force',
@@ -132,7 +131,7 @@ class MakeExporterCommand extends Command
                 $this->modelFqnEnd = 'Resource';
             }
 
-            $modelNamespace = $this->option('model-namespace') ?? Filament::namespaceFor('Models');
+            $modelNamespace = $this->option('model-namespace') ?? app()->getNamespace() . 'Models';
 
             $this->modelFqn = "{$modelNamespace}\\{$this->modelFqnEnd}";
         } else {
@@ -152,7 +151,7 @@ class MakeExporterCommand extends Command
                         fn (string $class): bool => str($class)->replace(['\\', '/'], '')->contains($search, ignoreCase: true),
                     );
                 },
-                placeholder: Filament::namespaceFor('Models\\BlogPost'),
+                placeholder: app()->getNamespace() . 'Models\\BlogPost',
                 required: true,
             );
 

--- a/packages/actions/src/Commands/MakeImporterCommand.php
+++ b/packages/actions/src/Commands/MakeImporterCommand.php
@@ -3,7 +3,6 @@
 namespace Filament\Actions\Commands;
 
 use Filament\Actions\Commands\FileGenerators\ImporterClassGenerator;
-use Filament\Facades\Filament;
 use Filament\Support\Commands\Concerns\CanAskForComponentLocation;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
 use Filament\Support\Commands\Exceptions\FailureCommandOutput;
@@ -91,7 +90,7 @@ class MakeImporterCommand extends Command
                 name: 'model-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_REQUIRED,
-                description: 'The namespace of the model class, [' . Filament::namespaceFor('Models') . '] by default',
+                description: 'The namespace of the model class, [' . app()->getNamespace() . 'Models] by default',
             ),
             new InputOption(
                 name: 'force',
@@ -139,7 +138,7 @@ class MakeImporterCommand extends Command
                 $this->modelFqnEnd = 'Resource';
             }
 
-            $modelNamespace = $this->option('model-namespace') ?? Filament::namespaceFor('Models');
+            $modelNamespace = $this->option('model-namespace') ?? app()->getNamespace() . 'Models';
 
             $this->modelFqn = "{$modelNamespace}\\{$this->modelFqnEnd}";
         } else {
@@ -159,7 +158,7 @@ class MakeImporterCommand extends Command
                         fn (string $class): bool => str($class)->replace(['\\', '/'], '')->contains($search, ignoreCase: true),
                     );
                 },
-                placeholder: Filament::namespaceFor('Models\\BlogPost'),
+                placeholder: app()->getNamespace() . 'Models\\BlogPost',
                 required: true,
             );
 

--- a/packages/actions/src/Commands/MakeImporterCommand.php
+++ b/packages/actions/src/Commands/MakeImporterCommand.php
@@ -3,6 +3,7 @@
 namespace Filament\Actions\Commands;
 
 use Filament\Actions\Commands\FileGenerators\ImporterClassGenerator;
+use Filament\Facades\Filament;
 use Filament\Support\Commands\Concerns\CanAskForComponentLocation;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
 use Filament\Support\Commands\Exceptions\FailureCommandOutput;
@@ -90,7 +91,7 @@ class MakeImporterCommand extends Command
                 name: 'model-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_REQUIRED,
-                description: 'The namespace of the model class, [App\\Models] by default',
+                description: 'The namespace of the model class, [' . Filament::namespaceFor('Models') . '] by default',
             ),
             new InputOption(
                 name: 'force',
@@ -138,7 +139,7 @@ class MakeImporterCommand extends Command
                 $this->modelFqnEnd = 'Resource';
             }
 
-            $modelNamespace = $this->option('model-namespace') ?? 'App\\Models';
+            $modelNamespace = $this->option('model-namespace') ?? Filament::namespaceFor('Models');
 
             $this->modelFqn = "{$modelNamespace}\\{$this->modelFqnEnd}";
         } else {
@@ -158,7 +159,7 @@ class MakeImporterCommand extends Command
                         fn (string $class): bool => str($class)->replace(['\\', '/'], '')->contains($search, ignoreCase: true),
                     );
                 },
-                placeholder: 'App\\Models\\BlogPost',
+                placeholder: Filament::namespaceFor('Models\\BlogPost'),
                 required: true,
             );
 

--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -8,7 +8,6 @@ use Filament\Actions\ActionGroup;
 use Filament\Actions\Exports\Enums\Contracts\ExportFormat as ExportFormatInterface;
 use Filament\Actions\Exports\Enums\ExportFormat;
 use Filament\Actions\Exports\Models\Export;
-use Filament\Facades\Filament;
 use Filament\Schemas\Components\Component;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -78,7 +77,7 @@ abstract class Exporter
     {
         return static::$model ?? (string) str(class_basename(static::class))
             ->beforeLast('Exporter')
-            ->prepend(Filament::namespaceFor('Models\\'));
+            ->prepend(app()->getNamespace() . 'Models\\');
     }
 
     abstract public static function getCompletedNotificationBody(Export $export): string;

--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -8,6 +8,7 @@ use Filament\Actions\ActionGroup;
 use Filament\Actions\Exports\Enums\Contracts\ExportFormat as ExportFormatInterface;
 use Filament\Actions\Exports\Enums\ExportFormat;
 use Filament\Actions\Exports\Models\Export;
+use Filament\Facades\Filament;
 use Filament\Schemas\Components\Component;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -77,7 +78,7 @@ abstract class Exporter
     {
         return static::$model ?? (string) str(class_basename(static::class))
             ->beforeLast('Exporter')
-            ->prepend('App\\Models\\');
+            ->prepend(Filament::namespaceFor('Models\\'));
     }
 
     abstract public static function getCompletedNotificationBody(Export $export): string;

--- a/packages/actions/src/Exports/Models/Export.php
+++ b/packages/actions/src/Exports/Models/Export.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Actions\Exports\Models;
 
-use App\Models\User;
 use Carbon\CarbonInterface;
 use Exception;
 use Filament\Actions\Exports\Exporter;
@@ -59,12 +58,14 @@ class Export extends Model
             return $this->belongsTo($authenticatable::class);
         }
 
-        if (! class_exists(User::class)) {
-            throw new Exception('No [' . Filament::namespaceFor('Models\\User') . '] model found. Please bind an authenticatable model to the [Illuminate\\Contracts\\Auth\\Authenticatable] interface in a service provider\'s [register()] method.');
+        $userClass = Filament::namespaceFor('Models\\User');
+
+        if (! class_exists($userClass)) {
+            throw new Exception('No [' . $userClass . '] model found. Please bind an authenticatable model to the [Illuminate\\Contracts\\Auth\\Authenticatable] interface in a service provider\'s [register()] method.');
         }
 
         /** @phpstan-ignore-next-line */
-        return $this->belongsTo(User::class);
+        return $this->belongsTo($userClass);
     }
 
     /**

--- a/packages/actions/src/Exports/Models/Export.php
+++ b/packages/actions/src/Exports/Models/Export.php
@@ -5,7 +5,6 @@ namespace Filament\Actions\Exports\Models;
 use Carbon\CarbonInterface;
 use Exception;
 use Filament\Actions\Exports\Exporter;
-use Filament\Facades\Filament;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Database\Eloquent\Model;
@@ -58,7 +57,7 @@ class Export extends Model
             return $this->belongsTo($authenticatable::class);
         }
 
-        $userClass = Filament::namespaceFor('Models\\User');
+        $userClass = app()->getNamespace() . 'Models\\User';
 
         if (! class_exists($userClass)) {
             throw new Exception('No [' . $userClass . '] model found. Please bind an authenticatable model to the [Illuminate\\Contracts\\Auth\\Authenticatable] interface in a service provider\'s [register()] method.');

--- a/packages/actions/src/Exports/Models/Export.php
+++ b/packages/actions/src/Exports/Models/Export.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Carbon\CarbonInterface;
 use Exception;
 use Filament\Actions\Exports\Exporter;
+use Filament\Facades\Filament;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Database\Eloquent\Model;
@@ -59,7 +60,7 @@ class Export extends Model
         }
 
         if (! class_exists(User::class)) {
-            throw new Exception('No [App\\Models\\User] model found. Please bind an authenticatable model to the [Illuminate\\Contracts\\Auth\\Authenticatable] interface in a service provider\'s [register()] method.');
+            throw new Exception('No [' . Filament::namespaceFor('Models\\User') . '] model found. Please bind an authenticatable model to the [Illuminate\\Contracts\\Auth\\Authenticatable] interface in a service provider\'s [register()] method.');
         }
 
         /** @phpstan-ignore-next-line */

--- a/packages/actions/src/Imports/Importer.php
+++ b/packages/actions/src/Imports/Importer.php
@@ -6,7 +6,6 @@ use Carbon\CarbonInterface;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\Imports\Models\Import;
-use Filament\Facades\Filament;
 use Filament\Schemas\Components\Component;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
@@ -294,7 +293,7 @@ abstract class Importer
     {
         return static::$model ?? (string) str(class_basename(static::class))
             ->beforeLast('Importer')
-            ->prepend(Filament::namespaceFor('Models\\'));
+            ->prepend(app()->getNamespace() . 'Models\\');
     }
 
     abstract public static function getCompletedNotificationBody(Import $import): string;

--- a/packages/actions/src/Imports/Importer.php
+++ b/packages/actions/src/Imports/Importer.php
@@ -6,6 +6,7 @@ use Carbon\CarbonInterface;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\Imports\Models\Import;
+use Filament\Facades\Filament;
 use Filament\Schemas\Components\Component;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
@@ -293,7 +294,7 @@ abstract class Importer
     {
         return static::$model ?? (string) str(class_basename(static::class))
             ->beforeLast('Importer')
-            ->prepend('App\\Models\\');
+            ->prepend(Filament::namespaceFor('Models\\'));
     }
 
     abstract public static function getCompletedNotificationBody(Import $import): string;

--- a/packages/actions/src/Imports/Models/Import.php
+++ b/packages/actions/src/Imports/Models/Import.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Actions\Imports\Models;
 
-use App\Models\User;
 use Carbon\CarbonInterface;
 use Exception;
 use Filament\Actions\Imports\Importer;
@@ -65,12 +64,14 @@ class Import extends Model
             return $this->belongsTo($authenticatable::class);
         }
 
-        if (! class_exists(User::class)) {
-            throw new Exception('No [' . Filament::namespaceFor('Models\\User') . '] model found. Please bind an authenticatable model to the [Illuminate\\Contracts\\Auth\\Authenticatable] interface in a service provider\'s [register()] method.');
+        $userClass = Filament::namespaceFor('Models\\User');
+
+        if (! class_exists($userClass)) {
+            throw new Exception('No [' . $userClass . '] model found. Please bind an authenticatable model to the [Illuminate\\Contracts\\Auth\\Authenticatable] interface in a service provider\'s [register()] method.');
         }
 
         /** @phpstan-ignore-next-line */
-        return $this->belongsTo(User::class);
+        return $this->belongsTo($userClass);
     }
 
     /**

--- a/packages/actions/src/Imports/Models/Import.php
+++ b/packages/actions/src/Imports/Models/Import.php
@@ -5,7 +5,6 @@ namespace Filament\Actions\Imports\Models;
 use Carbon\CarbonInterface;
 use Exception;
 use Filament\Actions\Imports\Importer;
-use Filament\Facades\Filament;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -64,7 +63,7 @@ class Import extends Model
             return $this->belongsTo($authenticatable::class);
         }
 
-        $userClass = Filament::namespaceFor('Models\\User');
+        $userClass = app()->getNamespace() . 'Models\\User';
 
         if (! class_exists($userClass)) {
             throw new Exception('No [' . $userClass . '] model found. Please bind an authenticatable model to the [Illuminate\\Contracts\\Auth\\Authenticatable] interface in a service provider\'s [register()] method.');

--- a/packages/actions/src/Imports/Models/Import.php
+++ b/packages/actions/src/Imports/Models/Import.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Carbon\CarbonInterface;
 use Exception;
 use Filament\Actions\Imports\Importer;
+use Filament\Facades\Filament;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -65,7 +66,7 @@ class Import extends Model
         }
 
         if (! class_exists(User::class)) {
-            throw new Exception('No [App\\Models\\User] model found. Please bind an authenticatable model to the [Illuminate\\Contracts\\Auth\\Authenticatable] interface in a service provider\'s [register()] method.');
+            throw new Exception('No [' . Filament::namespaceFor('Models\\User') . '] model found. Please bind an authenticatable model to the [Illuminate\\Contracts\\Auth\\Authenticatable] interface in a service provider\'s [register()] method.');
         }
 
         /** @phpstan-ignore-next-line */

--- a/packages/forms/src/Commands/MakeFormCommand.php
+++ b/packages/forms/src/Commands/MakeFormCommand.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Forms\Commands;
 
-use Filament\Facades\Filament;
 use Filament\Forms\Commands\FileGenerators\FormSchemaClassGenerator;
 use Filament\Support\Commands\Concerns\CanAskForComponentLocation;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
@@ -82,7 +81,7 @@ class MakeFormCommand extends Command
                 name: 'model-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_REQUIRED,
-                description: 'The namespace of the model class, [' . Filament::namespaceFor('Models') . '] by default',
+                description: 'The namespace of the model class, [' . app()->getNamespace() . 'Models] by default',
             ),
             new InputOption(
                 name: 'force',
@@ -135,7 +134,7 @@ class MakeFormCommand extends Command
                 ->studly()
                 ->replace('/', '\\');
 
-            $modelNamespace = $this->option('model-namespace') ?? Filament::namespaceFor('Models');
+            $modelNamespace = $this->option('model-namespace') ?? app()->getNamespace() . 'Models';
 
             $this->modelFqn = "{$modelNamespace}\\{$this->modelFqnEnd}";
 
@@ -165,7 +164,7 @@ class MakeFormCommand extends Command
                     fn (string $class): bool => str($class)->replace(['\\', '/'], '')->contains($search, ignoreCase: true),
                 );
             },
-            placeholder: Filament::namespaceFor('Models\\BlogPost'),
+            placeholder: app()->getNamespace() . 'Models\\BlogPost',
             required: true,
         );
 

--- a/packages/forms/src/Commands/MakeFormCommand.php
+++ b/packages/forms/src/Commands/MakeFormCommand.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Forms\Commands;
 
+use Filament\Facades\Filament;
 use Filament\Forms\Commands\FileGenerators\FormSchemaClassGenerator;
 use Filament\Support\Commands\Concerns\CanAskForComponentLocation;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
@@ -81,7 +82,7 @@ class MakeFormCommand extends Command
                 name: 'model-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_REQUIRED,
-                description: 'The namespace of the model class, [App\\Models] by default',
+                description: 'The namespace of the model class, [' . Filament::namespaceFor('Models') . '] by default',
             ),
             new InputOption(
                 name: 'force',
@@ -134,7 +135,7 @@ class MakeFormCommand extends Command
                 ->studly()
                 ->replace('/', '\\');
 
-            $modelNamespace = $this->option('model-namespace') ?? 'App\\Models';
+            $modelNamespace = $this->option('model-namespace') ?? Filament::namespaceFor('Models');
 
             $this->modelFqn = "{$modelNamespace}\\{$this->modelFqnEnd}";
 
@@ -164,7 +165,7 @@ class MakeFormCommand extends Command
                     fn (string $class): bool => str($class)->replace(['\\', '/'], '')->contains($search, ignoreCase: true),
                 );
             },
-            placeholder: 'App\\Models\\BlogPost',
+            placeholder: Filament::namespaceFor('Models\\BlogPost'),
             required: true,
         );
 

--- a/packages/forms/src/Commands/MakeLivewireFormCommand.php
+++ b/packages/forms/src/Commands/MakeLivewireFormCommand.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Forms\Commands;
 
-use Filament\Facades\Filament;
 use Filament\Forms\Commands\FileGenerators\LivewireFormComponentClassGenerator;
 use Filament\Support\Commands\Concerns\CanAskForLivewireComponentLocation;
 use Filament\Support\Commands\Concerns\CanAskForViewLocation;
@@ -110,7 +109,7 @@ class MakeLivewireFormCommand extends Command
                 name: 'model-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_REQUIRED,
-                description: 'The namespace of the model class, [' . Filament::namespaceFor('Models') . '] by default',
+                description: 'The namespace of the model class, [' . app()->getNamespace() . 'Models] by default',
             ),
             new InputOption(
                 name: 'force',
@@ -167,7 +166,7 @@ class MakeLivewireFormCommand extends Command
                 ->studly()
                 ->replace('/', '\\');
 
-            $modelNamespace = $this->option('model-namespace') ?? Filament::namespaceFor('Models');
+            $modelNamespace = $this->option('model-namespace') ?? app()->getNamespace() . 'Models';
 
             $this->modelFqn = "{$modelNamespace}\\{$this->modelFqnEnd}";
 
@@ -197,7 +196,7 @@ class MakeLivewireFormCommand extends Command
                     fn (string $class): bool => str($class)->replace(['\\', '/'], '')->contains($search, ignoreCase: true),
                 );
             },
-            placeholder: Filament::namespaceFor('Models\\BlogPost'),
+            placeholder: app()->getNamespace() . 'Models\\BlogPost',
             required: true,
         );
 

--- a/packages/forms/src/Commands/MakeLivewireFormCommand.php
+++ b/packages/forms/src/Commands/MakeLivewireFormCommand.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Forms\Commands;
 
+use Filament\Facades\Filament;
 use Filament\Forms\Commands\FileGenerators\LivewireFormComponentClassGenerator;
 use Filament\Support\Commands\Concerns\CanAskForLivewireComponentLocation;
 use Filament\Support\Commands\Concerns\CanAskForViewLocation;
@@ -109,7 +110,7 @@ class MakeLivewireFormCommand extends Command
                 name: 'model-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_REQUIRED,
-                description: 'The namespace of the model class, [App\\Models] by default',
+                description: 'The namespace of the model class, [' . Filament::namespaceFor('Models') . '] by default',
             ),
             new InputOption(
                 name: 'force',
@@ -166,7 +167,7 @@ class MakeLivewireFormCommand extends Command
                 ->studly()
                 ->replace('/', '\\');
 
-            $modelNamespace = $this->option('model-namespace') ?? 'App\\Models';
+            $modelNamespace = $this->option('model-namespace') ?? Filament::namespaceFor('Models');
 
             $this->modelFqn = "{$modelNamespace}\\{$this->modelFqnEnd}";
 
@@ -196,7 +197,7 @@ class MakeLivewireFormCommand extends Command
                     fn (string $class): bool => str($class)->replace(['\\', '/'], '')->contains($search, ignoreCase: true),
                 );
             },
-            placeholder: 'App\\Models\\BlogPost',
+            placeholder: Filament::namespaceFor('Models\\BlogPost'),
             required: true,
         );
 

--- a/packages/panels/src/Commands/FileGenerators/PanelProviderClassGenerator.php
+++ b/packages/panels/src/Commands/FileGenerators/PanelProviderClassGenerator.php
@@ -121,12 +121,12 @@ class PanelProviderClassGenerator extends ClassGenerator
                     ->colors([
                         'primary' => {$this->simplifyFqn(Color::class)}::Amber,
                     ])
-                    ->discoverResources(in: app_path('Filament/{$componentsDirectory}Resources'), for: {$this->simplifyFqn(Filament::class)}->namespaceFor('Filament\\{$componentsNamespace}Resources'))
-                    ->discoverPages(in: app_path('Filament/{$componentsDirectory}Pages'), for: {$this->simplifyFqn(Filament::class)}->namespaceFor('Filament\\{$componentsNamespace}Pages'))
+                    ->discoverResources(in: app_path('Filament/{$componentsDirectory}Resources'), for: {$this->simplifyFqn(Filament::class)}::namespaceFor('Filament\\{$componentsNamespace}Resources'))
+                    ->discoverPages(in: app_path('Filament/{$componentsDirectory}Pages'), for: {$this->simplifyFqn(Filament::class)}::namespaceFor('Filament\\{$componentsNamespace}Pages'))
                     ->pages([
                         {$this->simplifyFqn(Dashboard::class)}::class,
                     ])
-                    ->discoverWidgets(in: app_path('Filament/{$componentsDirectory}Widgets'), for: {$this->simplifyFqn(Filament::class)}->namespaceFor('Filament\\{$componentsNamespace}Widgets'))
+                    ->discoverWidgets(in: app_path('Filament/{$componentsDirectory}Widgets'), for: {$this->simplifyFqn(Filament::class)}::namespaceFor('Filament\\{$componentsNamespace}Widgets'))
                     ->widgets([
                         {$this->simplifyFqn(AccountWidget::class)}::class,
                         {$this->simplifyFqn(FilamentInfoWidget::class)}::class,

--- a/packages/panels/src/Commands/FileGenerators/PanelProviderClassGenerator.php
+++ b/packages/panels/src/Commands/FileGenerators/PanelProviderClassGenerator.php
@@ -127,7 +127,7 @@ class PanelProviderClassGenerator extends ClassGenerator
                     ->pages([
                         {$this->simplifyFqn(Dashboard::class)}::class,
                     ])
-                    ->discoverWidgets(in: app_path('Filament/{$componentsDirectory}Widgets'), for: '{$rootNamespace}Filament\\{$componentsNamespace}Widgets")}')
+                    ->discoverWidgets(in: app_path('Filament/{$componentsDirectory}Widgets'), for: '{$rootNamespace}Filament\\{$componentsNamespace}Widgets')
                     ->widgets([
                         {$this->simplifyFqn(AccountWidget::class)}::class,
                         {$this->simplifyFqn(FilamentInfoWidget::class)}::class,

--- a/packages/panels/src/Commands/FileGenerators/PanelProviderClassGenerator.php
+++ b/packages/panels/src/Commands/FileGenerators/PanelProviderClassGenerator.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Commands\FileGenerators;
 
-use Filament\Facades\Filament;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -121,12 +120,12 @@ class PanelProviderClassGenerator extends ClassGenerator
                     ->colors([
                         'primary' => {$this->simplifyFqn(Color::class)}::Amber,
                     ])
-                    ->discoverResources(in: app_path('Filament/{$componentsDirectory}Resources'), for: {$this->simplifyFqn(Filament::class)}::namespaceFor('Filament\\{$componentsNamespace}Resources'))
-                    ->discoverPages(in: app_path('Filament/{$componentsDirectory}Pages'), for: {$this->simplifyFqn(Filament::class)}::namespaceFor('Filament\\{$componentsNamespace}Pages'))
+                    ->discoverResources(in: app_path('Filament/{$componentsDirectory}Resources'), for: {$this->simplifyFqn(app()->getNamespace() . "Filament\\{$componentsNamespace}Resources")})
+                    ->discoverPages(in: app_path('Filament/{$componentsDirectory}Pages'), for: {$this->simplifyFqn(app()->getNamespace() . "Filament\\{$componentsNamespace}Pages")})
                     ->pages([
                         {$this->simplifyFqn(Dashboard::class)}::class,
                     ])
-                    ->discoverWidgets(in: app_path('Filament/{$componentsDirectory}Widgets'), for: {$this->simplifyFqn(Filament::class)}::namespaceFor('Filament\\{$componentsNamespace}Widgets'))
+                    ->discoverWidgets(in: app_path('Filament/{$componentsDirectory}Widgets'), for: {$this->simplifyFqn(app()->getNamespace() . "Filament\\{$componentsNamespace}Widgets")})
                     ->widgets([
                         {$this->simplifyFqn(AccountWidget::class)}::class,
                         {$this->simplifyFqn(FilamentInfoWidget::class)}::class,

--- a/packages/panels/src/Commands/FileGenerators/PanelProviderClassGenerator.php
+++ b/packages/panels/src/Commands/FileGenerators/PanelProviderClassGenerator.php
@@ -112,6 +112,8 @@ class PanelProviderClassGenerator extends ClassGenerator
         $componentsDirectory = $isDefault ? '' : (Str::studly($id) . '/');
         $componentsNamespace = $isDefault ? '' : (Str::studly($id) . '\\');
 
+        $rootNamespace = app()->getNamespace();
+
         return new Literal(
             <<<PHP
                 return \$panel{$defaultOutput}
@@ -120,8 +122,8 @@ class PanelProviderClassGenerator extends ClassGenerator
                     ->colors([
                         'primary' => {$this->simplifyFqn(Color::class)}::Amber,
                     ])
-                    ->discoverResources(in: app_path('Filament/{$componentsDirectory}Resources'), for: '{$this->simplifyFqn(app()->getNamespace() . "Filament\\{$componentsNamespace}Resources")}')
-                    ->discoverPages(in: app_path('Filament/{$componentsDirectory}Pages'), for: '{$this->simplifyFqn(app()->getNamespace() . "Filament\\{$componentsNamespace}Pages")}')
+                    ->discoverResources(in: app_path('Filament/{$componentsDirectory}Resources'), for: '{$rootNamespace}Filament\\{$componentsNamespace}Resources')
+                    ->discoverPages(in: app_path('Filament/{$componentsDirectory}Pages'), for: '{$rootNamespace}Filament\\{$componentsNamespace}Pages')
                     ->pages([
                         {$this->simplifyFqn(Dashboard::class)}::class,
                     ])

--- a/packages/panels/src/Commands/FileGenerators/PanelProviderClassGenerator.php
+++ b/packages/panels/src/Commands/FileGenerators/PanelProviderClassGenerator.php
@@ -120,12 +120,12 @@ class PanelProviderClassGenerator extends ClassGenerator
                     ->colors([
                         'primary' => {$this->simplifyFqn(Color::class)}::Amber,
                     ])
-                    ->discoverResources(in: app_path('Filament/{$componentsDirectory}Resources'), for: {$this->simplifyFqn(app()->getNamespace() . "Filament\\{$componentsNamespace}Resources")})
-                    ->discoverPages(in: app_path('Filament/{$componentsDirectory}Pages'), for: {$this->simplifyFqn(app()->getNamespace() . "Filament\\{$componentsNamespace}Pages")})
+                    ->discoverResources(in: app_path('Filament/{$componentsDirectory}Resources'), for: '{$this->simplifyFqn(app()->getNamespace() . "Filament\\{$componentsNamespace}Resources")}')
+                    ->discoverPages(in: app_path('Filament/{$componentsDirectory}Pages'), for: '{$this->simplifyFqn(app()->getNamespace() . "Filament\\{$componentsNamespace}Pages")}')
                     ->pages([
                         {$this->simplifyFqn(Dashboard::class)}::class,
                     ])
-                    ->discoverWidgets(in: app_path('Filament/{$componentsDirectory}Widgets'), for: {$this->simplifyFqn(app()->getNamespace() . "Filament\\{$componentsNamespace}Widgets")})
+                    ->discoverWidgets(in: app_path('Filament/{$componentsDirectory}Widgets'), for: '{$this->simplifyFqn(app()->getNamespace() . "Filament\\{$componentsNamespace}Widgets")}')
                     ->widgets([
                         {$this->simplifyFqn(AccountWidget::class)}::class,
                         {$this->simplifyFqn(FilamentInfoWidget::class)}::class,

--- a/packages/panels/src/Commands/FileGenerators/PanelProviderClassGenerator.php
+++ b/packages/panels/src/Commands/FileGenerators/PanelProviderClassGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Commands\FileGenerators;
 
+use Filament\Facades\Filament;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -120,12 +121,12 @@ class PanelProviderClassGenerator extends ClassGenerator
                     ->colors([
                         'primary' => {$this->simplifyFqn(Color::class)}::Amber,
                     ])
-                    ->discoverResources(in: app_path('Filament/{$componentsDirectory}Resources'), for: 'App\\Filament\\{$componentsNamespace}Resources')
-                    ->discoverPages(in: app_path('Filament/{$componentsDirectory}Pages'), for: 'App\\Filament\\{$componentsNamespace}Pages')
+                    ->discoverResources(in: app_path('Filament/{$componentsDirectory}Resources'), for: {$this->simplifyFqn(Filament::class)}->namespaceFor('Filament\\{$componentsNamespace}Resources'))
+                    ->discoverPages(in: app_path('Filament/{$componentsDirectory}Pages'), for: {$this->simplifyFqn(Filament::class)}->namespaceFor('Filament\\{$componentsNamespace}Pages'))
                     ->pages([
                         {$this->simplifyFqn(Dashboard::class)}::class,
                     ])
-                    ->discoverWidgets(in: app_path('Filament/{$componentsDirectory}Widgets'), for: 'App\\Filament\\{$componentsNamespace}Widgets')
+                    ->discoverWidgets(in: app_path('Filament/{$componentsDirectory}Widgets'), for: {$this->simplifyFqn(Filament::class)}->namespaceFor('Filament\\{$componentsNamespace}Widgets'))
                     ->widgets([
                         {$this->simplifyFqn(AccountWidget::class)}::class,
                         {$this->simplifyFqn(FilamentInfoWidget::class)}::class,

--- a/packages/panels/src/Commands/FileGenerators/PanelProviderClassGenerator.php
+++ b/packages/panels/src/Commands/FileGenerators/PanelProviderClassGenerator.php
@@ -127,7 +127,7 @@ class PanelProviderClassGenerator extends ClassGenerator
                     ->pages([
                         {$this->simplifyFqn(Dashboard::class)}::class,
                     ])
-                    ->discoverWidgets(in: app_path('Filament/{$componentsDirectory}Widgets'), for: '{$this->simplifyFqn(app()->getNamespace() . "Filament\\{$componentsNamespace}Widgets")}')
+                    ->discoverWidgets(in: app_path('Filament/{$componentsDirectory}Widgets'), for: '{$rootNamespace}Filament\\{$componentsNamespace}Widgets")}')
                     ->widgets([
                         {$this->simplifyFqn(AccountWidget::class)}::class,
                         {$this->simplifyFqn(FilamentInfoWidget::class)}::class,

--- a/packages/panels/src/Commands/MakeClusterCommand.php
+++ b/packages/panels/src/Commands/MakeClusterCommand.php
@@ -3,7 +3,6 @@
 namespace Filament\Commands;
 
 use Filament\Commands\FileGenerators\ClusterClassGenerator;
-use Filament\Facades\Filament;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
 use Filament\Support\Commands\Concerns\HasPanel;
 use Filament\Support\Commands\Exceptions\FailureCommandOutput;
@@ -160,7 +159,7 @@ class MakeClusterCommand extends Command
         }
 
         if (count($namespaces) < 2) {
-            $this->clustersNamespace = (Arr::first($namespaces) ?? Filament::namespaceFor('Filament\\Clusters'));
+            $this->clustersNamespace = (Arr::first($namespaces) ?? app()->getNamespace() . 'Filament\\Clusters');
             $this->clustersDirectory = (Arr::first($directories) ?? app_path('Filament/Clusters/'));
 
             return;

--- a/packages/panels/src/Commands/MakeClusterCommand.php
+++ b/packages/panels/src/Commands/MakeClusterCommand.php
@@ -3,6 +3,7 @@
 namespace Filament\Commands;
 
 use Filament\Commands\FileGenerators\ClusterClassGenerator;
+use Filament\Facades\Filament;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
 use Filament\Support\Commands\Concerns\HasPanel;
 use Filament\Support\Commands\Exceptions\FailureCommandOutput;
@@ -159,7 +160,7 @@ class MakeClusterCommand extends Command
         }
 
         if (count($namespaces) < 2) {
-            $this->clustersNamespace = (Arr::first($namespaces) ?? 'App\\Filament\\Clusters');
+            $this->clustersNamespace = (Arr::first($namespaces) ?? Filament::namespaceFor('Filament\\Clusters'));
             $this->clustersDirectory = (Arr::first($directories) ?? app_path('Filament/Clusters/'));
 
             return;

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -382,7 +382,7 @@ class MakePageCommand extends Command
                     ->whenContains(
                         'Filament\\',
                         fn (Stringable $fqn) => $fqn->after('Filament\\')->prepend('Filament\\'),
-                        fn (Stringable $fqn) => $fqn->replaceFirst(Filament::getRootNamespace(), ''),
+                        fn (Stringable $fqn) => $fqn->replaceFirst(app()->getNamespace(), ''),
                     )
                     ->replace('\\', '/')
                     ->explode('/')

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -8,6 +8,7 @@ use Filament\Commands\FileGenerators\Resources\Pages\ResourceCustomPageClassGene
 use Filament\Commands\FileGenerators\Resources\Pages\ResourceEditRecordPageClassGenerator;
 use Filament\Commands\FileGenerators\Resources\Pages\ResourceManageRelatedRecordsPageClassGenerator;
 use Filament\Commands\FileGenerators\Resources\Pages\ResourceViewRecordPageClassGenerator;
+use Filament\Facades\Filament;
 use Filament\Resources\Pages\CreateRecord;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Resources\Pages\ManageRelatedRecords;
@@ -149,7 +150,7 @@ class MakePageCommand extends Command
                 name: 'resource-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_OPTIONAL,
-                description: 'The namespace of the resource class, such as [App\\Filament\\Resources]',
+                description: 'The namespace of the resource class, such as [' . Filament::namespaceFor('Filament\\Resources') . ']',
             ),
             new InputOption(
                 name: 'type',
@@ -336,7 +337,7 @@ class MakePageCommand extends Command
         }
 
         if (count($namespaces) < 2) {
-            $this->pagesNamespace = (Arr::first($namespaces) ?? 'App\\Filament\\Pages');
+            $this->pagesNamespace = (Arr::first($namespaces) ?? Filament::namespaceFor('Filament\\Pages'));
             $this->pagesDirectory = (Arr::first($directories) ?? app_path('Filament/Pages/'));
 
             return;
@@ -381,7 +382,7 @@ class MakePageCommand extends Command
                     ->whenContains(
                         'Filament\\',
                         fn (Stringable $fqn) => $fqn->after('Filament\\')->prepend('Filament\\'),
-                        fn (Stringable $fqn) => $fqn->replaceFirst('App\\', ''),
+                        fn (Stringable $fqn) => $fqn->replaceFirst(Filament::getRootNamespace(), ''),
                     )
                     ->replace('\\', '/')
                     ->explode('/')
@@ -584,7 +585,7 @@ class MakePageCommand extends Command
                 $formSchemaFqn = $this->askForSchema(
                     intialQuestion: 'Should an existing form schema class be used?',
                     question: 'Which form schema class would you like to use?',
-                    questionPlaceholder: 'App\\Filament\\Resources\\Users\\Schemas\\UserForm',
+                    questionPlaceholder: Filament::namespaceFor('Filament\\Resources\\Users\\Schemas\\UserForm'),
                 );
             }
 
@@ -604,7 +605,7 @@ class MakePageCommand extends Command
                     $infolistSchemaFqn = $this->askForSchema(
                         intialQuestion: 'Would you like to use an existing infolist schema class?',
                         question: 'Which infolist schema class would you like to use?',
-                        questionPlaceholder: 'App\\Filament\\Resources\\Users\\Schemas\\UserInfolist',
+                        questionPlaceholder: Filament::namespaceFor('Filament\\Resources\\Users\\Schemas\\UserInfolist'),
                     );
                 }
 
@@ -621,7 +622,7 @@ class MakePageCommand extends Command
                 $tableFqn = $this->askForSchema(
                     intialQuestion: 'Would you like to use an existing table class?',
                     question: 'Which table class would you like to use?',
-                    questionPlaceholder: 'App\\Filament\\Resources\\Users\\Tables\\UsersTable',
+                    questionPlaceholder: Filament::namespaceFor('Filament\\Resources\\Users\\Tables\\UsersTable'),
                 );
             }
 

--- a/packages/panels/src/Commands/MakePageCommand.php
+++ b/packages/panels/src/Commands/MakePageCommand.php
@@ -8,7 +8,6 @@ use Filament\Commands\FileGenerators\Resources\Pages\ResourceCustomPageClassGene
 use Filament\Commands\FileGenerators\Resources\Pages\ResourceEditRecordPageClassGenerator;
 use Filament\Commands\FileGenerators\Resources\Pages\ResourceManageRelatedRecordsPageClassGenerator;
 use Filament\Commands\FileGenerators\Resources\Pages\ResourceViewRecordPageClassGenerator;
-use Filament\Facades\Filament;
 use Filament\Resources\Pages\CreateRecord;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Resources\Pages\ManageRelatedRecords;
@@ -150,7 +149,7 @@ class MakePageCommand extends Command
                 name: 'resource-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_OPTIONAL,
-                description: 'The namespace of the resource class, such as [' . Filament::namespaceFor('Filament\\Resources') . ']',
+                description: 'The namespace of the resource class, such as [' . app()->getNamespace() . 'Filament\\Resources]',
             ),
             new InputOption(
                 name: 'type',
@@ -337,7 +336,7 @@ class MakePageCommand extends Command
         }
 
         if (count($namespaces) < 2) {
-            $this->pagesNamespace = (Arr::first($namespaces) ?? Filament::namespaceFor('Filament\\Pages'));
+            $this->pagesNamespace = (Arr::first($namespaces) ?? app()->getNamespace() . 'Filament\\Pages');
             $this->pagesDirectory = (Arr::first($directories) ?? app_path('Filament/Pages/'));
 
             return;
@@ -585,7 +584,7 @@ class MakePageCommand extends Command
                 $formSchemaFqn = $this->askForSchema(
                     intialQuestion: 'Should an existing form schema class be used?',
                     question: 'Which form schema class would you like to use?',
-                    questionPlaceholder: Filament::namespaceFor('Filament\\Resources\\Users\\Schemas\\UserForm'),
+                    questionPlaceholder: app()->getNamespace() . 'Filament\\Resources\\Users\\Schemas\\UserForm',
                 );
             }
 
@@ -605,7 +604,7 @@ class MakePageCommand extends Command
                     $infolistSchemaFqn = $this->askForSchema(
                         intialQuestion: 'Would you like to use an existing infolist schema class?',
                         question: 'Which infolist schema class would you like to use?',
-                        questionPlaceholder: Filament::namespaceFor('Filament\\Resources\\Users\\Schemas\\UserInfolist'),
+                        questionPlaceholder: app()->getNamespace() . 'Filament\\Resources\\Users\\Schemas\\UserInfolist',
                     );
                 }
 
@@ -622,7 +621,7 @@ class MakePageCommand extends Command
                 $tableFqn = $this->askForSchema(
                     intialQuestion: 'Would you like to use an existing table class?',
                     question: 'Which table class would you like to use?',
-                    questionPlaceholder: Filament::namespaceFor('Filament\\Resources\\Users\\Tables\\UsersTable'),
+                    questionPlaceholder: app()->getNamespace() . 'Filament\\Resources\\Users\\Tables\\UsersTable',
                 );
             }
 

--- a/packages/panels/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/panels/src/Commands/MakeRelationManagerCommand.php
@@ -3,7 +3,6 @@
 namespace Filament\Commands;
 
 use Filament\Commands\FileGenerators\Resources\RelationManagerClassGenerator;
-use Filament\Facades\Filament;
 use Filament\Support\Commands\Concerns\CanAskForRelatedModel;
 use Filament\Support\Commands\Concerns\CanAskForRelatedResource;
 use Filament\Support\Commands\Concerns\CanAskForResource;
@@ -207,7 +206,7 @@ class MakeRelationManagerCommand extends Command
                 name: 'resource-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_OPTIONAL,
-                description: 'The namespace of the resource class, such as [' . Filament::namespaceFor('Filament\\Resources') . ']',
+                description: 'The namespace of the resource class, such as [' . app()->getNamespace() . 'Filament\\Resources]',
             ),
             new InputOption(
                 name: 'soft-deletes',
@@ -402,7 +401,7 @@ class MakeRelationManagerCommand extends Command
             : $this->askForSchema(
                 intialQuestion: 'Would you like to use an existing form schema class?',
                 question: 'Which form schema class would you like to use?',
-                questionPlaceholder: Filament::namespaceFor('Filament\\Resources\\Users\\Schemas\\UserForm'),
+                questionPlaceholder: app()->getNamespace() . 'Filament\\Resources\\Users\\Schemas\\UserForm',
             );
     }
 
@@ -465,7 +464,7 @@ class MakeRelationManagerCommand extends Command
             : $this->askForSchema(
                 intialQuestion: 'Would you like to use an existing infolist schema class?',
                 question: 'Which infolist schema class would you like to use?',
-                questionPlaceholder: Filament::namespaceFor('Filament\\Resources\\Users\\Schemas\\UserInfolist'),
+                questionPlaceholder: app()->getNamespace() . 'Filament\\Resources\\Users\\Schemas\\UserInfolist',
             );
     }
 
@@ -482,7 +481,7 @@ class MakeRelationManagerCommand extends Command
             : $this->askForSchema(
                 intialQuestion: 'Would you like to use an existing table class?',
                 question: 'Which table class would you like to use?',
-                questionPlaceholder: Filament::namespaceFor('Filament\\Resources\\Users\\Tables\\UsersTable'),
+                questionPlaceholder: app()->getNamespace() . 'Filament\\Resources\\Users\\Tables\\UsersTable',
             );
     }
 

--- a/packages/panels/src/Commands/MakeRelationManagerCommand.php
+++ b/packages/panels/src/Commands/MakeRelationManagerCommand.php
@@ -3,6 +3,7 @@
 namespace Filament\Commands;
 
 use Filament\Commands\FileGenerators\Resources\RelationManagerClassGenerator;
+use Filament\Facades\Filament;
 use Filament\Support\Commands\Concerns\CanAskForRelatedModel;
 use Filament\Support\Commands\Concerns\CanAskForRelatedResource;
 use Filament\Support\Commands\Concerns\CanAskForResource;
@@ -206,7 +207,7 @@ class MakeRelationManagerCommand extends Command
                 name: 'resource-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_OPTIONAL,
-                description: 'The namespace of the resource class, such as [App\\Filament\\Resources]',
+                description: 'The namespace of the resource class, such as [' . Filament::namespaceFor('Filament\\Resources') . ']',
             ),
             new InputOption(
                 name: 'soft-deletes',
@@ -401,7 +402,7 @@ class MakeRelationManagerCommand extends Command
             : $this->askForSchema(
                 intialQuestion: 'Would you like to use an existing form schema class?',
                 question: 'Which form schema class would you like to use?',
-                questionPlaceholder: 'App\\Filament\\Resources\\Users\\Schemas\\UserForm',
+                questionPlaceholder: Filament::namespaceFor('Filament\\Resources\\Users\\Schemas\\UserForm'),
             );
     }
 
@@ -464,7 +465,7 @@ class MakeRelationManagerCommand extends Command
             : $this->askForSchema(
                 intialQuestion: 'Would you like to use an existing infolist schema class?',
                 question: 'Which infolist schema class would you like to use?',
-                questionPlaceholder: 'App\\Filament\\Resources\\Users\\Schemas\\UserInfolist',
+                questionPlaceholder: Filament::namespaceFor('Filament\\Resources\\Users\\Schemas\\UserInfolist'),
             );
     }
 
@@ -481,7 +482,7 @@ class MakeRelationManagerCommand extends Command
             : $this->askForSchema(
                 intialQuestion: 'Would you like to use an existing table class?',
                 question: 'Which table class would you like to use?',
-                questionPlaceholder: 'App\\Filament\\Resources\\Users\\Tables\\UsersTable',
+                questionPlaceholder: Filament::namespaceFor('Filament\\Resources\\Users\\Tables\\UsersTable'),
             );
     }
 

--- a/packages/panels/src/Commands/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/MakeResourceCommand.php
@@ -11,6 +11,7 @@ use Filament\Commands\FileGenerators\Resources\ResourceClassGenerator;
 use Filament\Commands\FileGenerators\Resources\Schemas\ResourceFormSchemaClassGenerator;
 use Filament\Commands\FileGenerators\Resources\Schemas\ResourceInfolistSchemaClassGenerator;
 use Filament\Commands\FileGenerators\Resources\Schemas\ResourceTableClassGenerator;
+use Filament\Facades\Filament;
 use Filament\Resources\Pages\Page;
 use Filament\Support\Commands\Concerns\CanAskForResource;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
@@ -180,7 +181,7 @@ class MakeResourceCommand extends Command
                 name: 'model-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_REQUIRED,
-                description: 'The namespace of the model class, [App\\Models] by default',
+                description: 'The namespace of the model class, [' . Filament::namespaceFor('Models') . '] by default',
             ),
             new InputOption(
                 name: 'nested',
@@ -211,7 +212,7 @@ class MakeResourceCommand extends Command
                 name: 'resource-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_OPTIONAL,
-                description: 'The namespace of the resource class, such as [App\\Filament\\Resources]',
+                description: 'The namespace of the resource class, such as [' . Filament::namespaceFor('Filament\\Resources') . ']',
             ),
             new InputOption(
                 name: 'simple',
@@ -301,7 +302,7 @@ class MakeResourceCommand extends Command
                 $this->modelFqnEnd = 'Resource';
             }
 
-            $modelNamespace = $this->option('model-namespace') ?? 'App\\Models';
+            $modelNamespace = $this->option('model-namespace') ?? Filament::namespaceFor('Models');
 
             $this->modelFqn = "{$modelNamespace}\\{$this->modelFqnEnd}";
         } else {
@@ -321,7 +322,7 @@ class MakeResourceCommand extends Command
                         fn (string $class): bool => str($class)->replace(['\\', '/'], '')->contains($search, ignoreCase: true),
                     );
                 },
-                placeholder: 'App\\Models\\BlogPost',
+                placeholder: Filament::namespaceFor('Models\\BlogPost'),
                 required: true,
             );
 

--- a/packages/panels/src/Commands/MakeResourceCommand.php
+++ b/packages/panels/src/Commands/MakeResourceCommand.php
@@ -11,7 +11,6 @@ use Filament\Commands\FileGenerators\Resources\ResourceClassGenerator;
 use Filament\Commands\FileGenerators\Resources\Schemas\ResourceFormSchemaClassGenerator;
 use Filament\Commands\FileGenerators\Resources\Schemas\ResourceInfolistSchemaClassGenerator;
 use Filament\Commands\FileGenerators\Resources\Schemas\ResourceTableClassGenerator;
-use Filament\Facades\Filament;
 use Filament\Resources\Pages\Page;
 use Filament\Support\Commands\Concerns\CanAskForResource;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
@@ -181,7 +180,7 @@ class MakeResourceCommand extends Command
                 name: 'model-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_REQUIRED,
-                description: 'The namespace of the model class, [' . Filament::namespaceFor('Models') . '] by default',
+                description: 'The namespace of the model class, [' . app()->getNamespace() . 'Models] by default',
             ),
             new InputOption(
                 name: 'nested',
@@ -212,7 +211,7 @@ class MakeResourceCommand extends Command
                 name: 'resource-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_OPTIONAL,
-                description: 'The namespace of the resource class, such as [' . Filament::namespaceFor('Filament\\Resources') . ']',
+                description: 'The namespace of the resource class, such as [' . app()->getNamespace() . 'Filament\\Resources]',
             ),
             new InputOption(
                 name: 'simple',
@@ -302,7 +301,7 @@ class MakeResourceCommand extends Command
                 $this->modelFqnEnd = 'Resource';
             }
 
-            $modelNamespace = $this->option('model-namespace') ?? Filament::namespaceFor('Models');
+            $modelNamespace = $this->option('model-namespace') ?? app()->getNamespace() . 'Models';
 
             $this->modelFqn = "{$modelNamespace}\\{$this->modelFqnEnd}";
         } else {
@@ -322,7 +321,7 @@ class MakeResourceCommand extends Command
                         fn (string $class): bool => str($class)->replace(['\\', '/'], '')->contains($search, ignoreCase: true),
                     );
                 },
-                placeholder: Filament::namespaceFor('Models\\BlogPost'),
+                placeholder: app()->getNamespace() . 'Models\\BlogPost',
                 required: true,
             );
 

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -48,7 +48,7 @@ class FilamentManager
 
     protected ?Model $tenant = null;
 
-    protected string|null $rootNamespace = null;
+    protected ?string $rootNamespace = null;
 
     public function auth(): Guard
     {
@@ -846,9 +846,9 @@ class FilamentManager
     }
 
     /**
-     * @deprecated Use the `navigationGroups()` method on the panel configuration instead.
-     *
      * @param  array<string | int, NavigationGroup | string>  $groups
+     *
+     * @deprecated Use the `navigationGroups()` method on the panel configuration instead.
      */
     public function registerNavigationGroups(array $groups): void
     {
@@ -860,9 +860,9 @@ class FilamentManager
     }
 
     /**
-     * @deprecated Use the `navigationItems()` method on the panel configuration instead.
-     *
      * @param  array<NavigationItem>  $items
+     *
+     * @deprecated Use the `navigationItems()` method on the panel configuration instead.
      */
     public function registerNavigationItems(array $items): void
     {
@@ -874,9 +874,9 @@ class FilamentManager
     }
 
     /**
-     * @deprecated Use the `pages()` method on the panel configuration instead.
-     *
      * @param  array<class-string>  $pages
+     *
+     * @deprecated Use the `pages()` method on the panel configuration instead.
      */
     public function registerPages(array $pages): void
     {
@@ -896,9 +896,9 @@ class FilamentManager
     }
 
     /**
-     * @deprecated Use the `resources()` method on the panel configuration instead.
-     *
      * @param  array<class-string>  $resources
+     *
+     * @deprecated Use the `resources()` method on the panel configuration instead.
      */
     public function registerResources(array $resources): void
     {
@@ -910,9 +910,9 @@ class FilamentManager
     }
 
     /**
-     * @deprecated Register scripts using the `FilamentAsset` facade instead.
-     *
      * @param  array<mixed>  $scripts
+     *
+     * @deprecated Register scripts using the `FilamentAsset` facade instead.
      */
     public function registerScripts(array $scripts, bool $shouldBeLoadedBeforeCoreScripts = false): void
     {
@@ -920,9 +920,9 @@ class FilamentManager
     }
 
     /**
-     * @deprecated Register script data using the `FilamentAsset` facade instead.
-     *
      * @param  array<string, mixed>  $data
+     *
+     * @deprecated Register script data using the `FilamentAsset` facade instead.
      */
     public function registerScriptData(array $data): void
     {
@@ -930,9 +930,9 @@ class FilamentManager
     }
 
     /**
-     * @deprecated Register styles using the `FilamentAsset` facade instead.
-     *
      * @param  array<mixed>  $styles
+     *
+     * @deprecated Register styles using the `FilamentAsset` facade instead.
      */
     public function registerStyles(array $styles): void
     {
@@ -952,9 +952,9 @@ class FilamentManager
     }
 
     /**
-     * @deprecated Use the `viteTheme()` method on the panel configuration instead.
-     *
      * @param  string | array<string>  $theme
+     *
+     * @deprecated Use the `viteTheme()` method on the panel configuration instead.
      */
     public function registerViteTheme(string | array $theme, ?string $buildDirectory = null): void
     {
@@ -966,9 +966,9 @@ class FilamentManager
     }
 
     /**
-     * @deprecated Use the `userMenuItems()` method on the panel configuration instead.
-     *
      * @param  array<MenuItem>  $items
+     *
+     * @deprecated Use the `userMenuItems()` method on the panel configuration instead.
      */
     public function registerUserMenuItems(array $items): void
     {
@@ -980,9 +980,9 @@ class FilamentManager
     }
 
     /**
-     * @deprecated Use the `widgets()` method on the panel configuration instead.
-     *
      * @param  array<class-string>  $widgets
+     *
+     * @deprecated Use the `widgets()` method on the panel configuration instead.
      */
     public function registerWidgets(array $widgets): void
     {
@@ -1064,5 +1064,14 @@ class FilamentManager
     public function getRootNamespace(): string
     {
         return $this->rootNamespace ?? app()->getNamespace();
+    }
+
+    /**
+     * @param  class-string|non-empty-string  $namespace
+     * @return class-string
+     */
+    public function namespaceFor(string $namespace): string
+    {
+        return $this->getRootNamespace() . $namespace;
     }
 }

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -48,6 +48,8 @@ class FilamentManager
 
     protected ?Model $tenant = null;
 
+    protected string|null $rootNamespace = null;
+
     public function auth(): Guard
     {
         return $this->getCurrentOrDefaultPanel()->auth();
@@ -1052,5 +1054,15 @@ class FilamentManager
     public function getErrorNotifications(): array
     {
         return $this->getCurrentOrDefaultPanel()->getErrorNotifications();
+    }
+
+    public function setRootNamespace(string $namespace): void
+    {
+        $this->rootNamespace = $namespace;
+    }
+
+    public function getRootNamespace(): string
+    {
+        return $this->rootNamespace ?? app()->getNamespace();
     }
 }

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -1053,13 +1053,4 @@ class FilamentManager
     {
         return $this->getCurrentOrDefaultPanel()->getErrorNotifications();
     }
-
-    /**
-     * @param  class-string|non-empty-string  $namespace
-     * @return class-string
-     */
-    public function namespaceFor(string $namespace): string
-    {
-        return app()->getNamespace() . $namespace;
-    }
 }

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -48,8 +48,6 @@ class FilamentManager
 
     protected ?Model $tenant = null;
 
-    protected ?string $rootNamespace = null;
-
     public function auth(): Guard
     {
         return $this->getCurrentOrDefaultPanel()->auth();
@@ -1056,22 +1054,12 @@ class FilamentManager
         return $this->getCurrentOrDefaultPanel()->getErrorNotifications();
     }
 
-    public function setRootNamespace(string $namespace): void
-    {
-        $this->rootNamespace = $namespace;
-    }
-
-    public function getRootNamespace(): string
-    {
-        return $this->rootNamespace ?? app()->getNamespace();
-    }
-
     /**
      * @param  class-string|non-empty-string  $namespace
      * @return class-string
      */
     public function namespaceFor(string $namespace): string
     {
-        return $this->getRootNamespace() . $namespace;
+        return app()->getNamespace() . $namespace;
     }
 }

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Resources;
 
+use Filament\Facades\Filament;
 use Filament\Panel;
 use Filament\Resources\RelationManagers\RelationGroup;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -76,7 +77,7 @@ abstract class Resource
     {
         return static::$model ?? (string) str(class_basename(static::class))
             ->beforeLast('Resource')
-            ->prepend('App\\Models\\');
+            ->prepend(Filament::namespaceFor('Models\\'));
     }
 
     /**

--- a/packages/panels/src/Resources/Resource.php
+++ b/packages/panels/src/Resources/Resource.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Resources;
 
-use Filament\Facades\Filament;
 use Filament\Panel;
 use Filament\Resources\RelationManagers\RelationGroup;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -77,7 +76,7 @@ abstract class Resource
     {
         return static::$model ?? (string) str(class_basename(static::class))
             ->beforeLast('Resource')
-            ->prepend(Filament::namespaceFor('Models\\'));
+            ->prepend(app()->getNamespace() . 'Models\\');
     }
 
     /**

--- a/packages/spatie-laravel-settings-plugin/src/Commands/MakeSettingsPageCommand.php
+++ b/packages/spatie-laravel-settings-plugin/src/Commands/MakeSettingsPageCommand.php
@@ -3,7 +3,6 @@
 namespace Filament\Commands;
 
 use Filament\Commands\FileGenerators\SettingsPageClassGenerator;
-use Filament\Facades\Filament;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
 use Filament\Support\Commands\Concerns\HasCluster;
 use Filament\Support\Commands\Concerns\HasClusterPagesLocation;
@@ -189,7 +188,7 @@ class MakeSettingsPageCommand extends Command
 
                 return array_filter($settingsFqns, fn (string $modelFqn): bool => str($modelFqn)->replace(['\\', '/'], '')->contains($search, ignoreCase: true));
             },
-            placeholder: Filament::namespaceFor('Settings\\SiteSettings'),
+            placeholder: app()->getNamespace() . 'Settings\\SiteSettings',
             hint: 'Please provide the fully-qualified class name.',
         );
     }
@@ -233,7 +232,7 @@ class MakeSettingsPageCommand extends Command
         }
 
         if (count($namespaces) < 2) {
-            $this->pagesNamespace = (Arr::first($namespaces) ?? Filament::namespaceFor('Filament\\Pages'));
+            $this->pagesNamespace = (Arr::first($namespaces) ?? app()->getNamespace() . 'Filament\\Pages');
             $this->pagesDirectory = (Arr::first($directories) ?? app_path('Filament/Pages/'));
 
             return;

--- a/packages/spatie-laravel-settings-plugin/src/Commands/MakeSettingsPageCommand.php
+++ b/packages/spatie-laravel-settings-plugin/src/Commands/MakeSettingsPageCommand.php
@@ -3,6 +3,7 @@
 namespace Filament\Commands;
 
 use Filament\Commands\FileGenerators\SettingsPageClassGenerator;
+use Filament\Facades\Filament;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
 use Filament\Support\Commands\Concerns\HasCluster;
 use Filament\Support\Commands\Concerns\HasClusterPagesLocation;
@@ -188,7 +189,7 @@ class MakeSettingsPageCommand extends Command
 
                 return array_filter($settingsFqns, fn (string $modelFqn): bool => str($modelFqn)->replace(['\\', '/'], '')->contains($search, ignoreCase: true));
             },
-            placeholder: 'App\\Settings\\SiteSettings',
+            placeholder: Filament::namespaceFor('Settings\\SiteSettings'),
             hint: 'Please provide the fully-qualified class name.',
         );
     }
@@ -232,7 +233,7 @@ class MakeSettingsPageCommand extends Command
         }
 
         if (count($namespaces) < 2) {
-            $this->pagesNamespace = (Arr::first($namespaces) ?? 'App\\Filament\\Pages');
+            $this->pagesNamespace = (Arr::first($namespaces) ?? Filament::namespaceFor('Filament\\Pages'));
             $this->pagesDirectory = (Arr::first($directories) ?? app_path('Filament/Pages/'));
 
             return;

--- a/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
+++ b/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
@@ -4,6 +4,7 @@ namespace Filament\Pages;
 
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
+use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Filament\Pages\Concerns\CanUseDatabaseTransactions;
 use Filament\Pages\Concerns\HasUnsavedDataChangesAlert;
@@ -146,7 +147,7 @@ class SettingsPage extends Page
     {
         return static::$settings ?? (string) str(class_basename(static::class))
             ->beforeLast('Settings')
-            ->prepend('App\\Settings\\')
+            ->prepend(Filament::namespaceFor('Settings\\'))
             ->append('Settings');
     }
 

--- a/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
+++ b/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
@@ -4,7 +4,6 @@ namespace Filament\Pages;
 
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
-use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Filament\Pages\Concerns\CanUseDatabaseTransactions;
 use Filament\Pages\Concerns\HasUnsavedDataChangesAlert;
@@ -147,7 +146,7 @@ class SettingsPage extends Page
     {
         return static::$settings ?? (string) str(class_basename(static::class))
             ->beforeLast('Settings')
-            ->prepend(Filament::namespaceFor('Settings\\'))
+            ->prepend(app()->getNamespace() . 'Settings\\')
             ->append('Settings');
     }
 

--- a/packages/support/src/Commands/Concerns/CanAskForComponentLocation.php
+++ b/packages/support/src/Commands/Concerns/CanAskForComponentLocation.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Support\Commands\Concerns;
 
+use Filament\Facades\Filament;
 use Filament\Support\Facades\FilamentCli;
 
 use function Laravel\Prompts\select;
@@ -23,14 +24,14 @@ trait CanAskForComponentLocation
 
         if (blank($locations)) {
             return [
-                "App\\Filament\\{$pathNamespace}",
+                Filament::namespaceFor("Filament\\{$pathNamespace}"),
                 app_path('Filament' . DIRECTORY_SEPARATOR . $path),
                 '',
             ];
         }
 
         $options = [
-            null => "App\\Filament\\{$pathNamespace}",
+            null => Filament::namespaceFor("Filament\\{$pathNamespace}"),
             ...array_map(
                 fn (string $namespace): string => "{$namespace}\\{$pathNamespace}",
                 array_combine(
@@ -47,7 +48,7 @@ trait CanAskForComponentLocation
 
         if (blank($namespace)) {
             return [
-                "App\\Filament\\{$pathNamespace}",
+                Filament::namespaceFor("Filament\\{$pathNamespace}"),
                 app_path('Filament' . DIRECTORY_SEPARATOR . $path),
                 '',
             ];

--- a/packages/support/src/Commands/Concerns/CanAskForComponentLocation.php
+++ b/packages/support/src/Commands/Concerns/CanAskForComponentLocation.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Support\Commands\Concerns;
 
-use Filament\Facades\Filament;
 use Filament\Support\Facades\FilamentCli;
 
 use function Laravel\Prompts\select;
@@ -24,14 +23,14 @@ trait CanAskForComponentLocation
 
         if (blank($locations)) {
             return [
-                Filament::namespaceFor("Filament\\{$pathNamespace}"),
+                app()->getNamespace() . "Filament\\{$pathNamespace}",
                 app_path('Filament' . DIRECTORY_SEPARATOR . $path),
                 '',
             ];
         }
 
         $options = [
-            null => Filament::namespaceFor("Filament\\{$pathNamespace}"),
+            null => app()->getNamespace() . "Filament\\{$pathNamespace}",
             ...array_map(
                 fn (string $namespace): string => "{$namespace}\\{$pathNamespace}",
                 array_combine(
@@ -48,7 +47,7 @@ trait CanAskForComponentLocation
 
         if (blank($namespace)) {
             return [
-                Filament::namespaceFor("Filament\\{$pathNamespace}"),
+                app()->getNamespace() . "Filament\\{$pathNamespace}",
                 app_path('Filament' . DIRECTORY_SEPARATOR . $path),
                 '',
             ];

--- a/packages/support/src/Commands/Concerns/CanAskForLivewireComponentLocation.php
+++ b/packages/support/src/Commands/Concerns/CanAskForLivewireComponentLocation.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Support\Commands\Concerns;
 
-use Filament\Facades\Filament;
 use Filament\Support\Facades\FilamentCli;
 
 use function Laravel\Prompts\select;
@@ -22,14 +21,14 @@ trait CanAskForLivewireComponentLocation
 
         if (blank($locations)) {
             return [
-                Filament::namespaceFor('Livewire'),
+                app()->getNamespace() . 'Livewire',
                 app_path('Livewire'),
                 '',
             ];
         }
 
         $options = [
-            null => Filament::namespaceFor('Livewire'),
+            null => app()->getNamespace() . 'Livewire',
             ...array_combine(
                 array_keys($locations),
                 array_keys($locations),
@@ -43,7 +42,7 @@ trait CanAskForLivewireComponentLocation
 
         if (blank($namespace)) {
             return [
-                Filament::namespaceFor('Livewire'),
+                app()->getNamespace() . 'Livewire',
                 app_path('Livewire'),
                 '',
             ];

--- a/packages/support/src/Commands/Concerns/CanAskForLivewireComponentLocation.php
+++ b/packages/support/src/Commands/Concerns/CanAskForLivewireComponentLocation.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Support\Commands\Concerns;
 
+use Filament\Facades\Filament;
 use Filament\Support\Facades\FilamentCli;
 
 use function Laravel\Prompts\select;
@@ -21,14 +22,14 @@ trait CanAskForLivewireComponentLocation
 
         if (blank($locations)) {
             return [
-                'App\\Livewire',
+                Filament::namespaceFor('Livewire'),
                 app_path('Livewire'),
                 '',
             ];
         }
 
         $options = [
-            null => 'App\\Livewire',
+            null => Filament::namespaceFor('Livewire'),
             ...array_combine(
                 array_keys($locations),
                 array_keys($locations),
@@ -42,7 +43,7 @@ trait CanAskForLivewireComponentLocation
 
         if (blank($namespace)) {
             return [
-                'App\\Livewire',
+                Filament::namespaceFor('Livewire'),
                 app_path('Livewire'),
                 '',
             ];

--- a/packages/support/src/Commands/Concerns/CanAskForRelatedModel.php
+++ b/packages/support/src/Commands/Concerns/CanAskForRelatedModel.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Support\Commands\Concerns;
 
+use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Model;
 
 use function Filament\Support\discover_app_classes;
@@ -35,7 +36,7 @@ trait CanAskForRelatedModel
 
                 return array_filter($modelFqns, fn (string $modelFqn): bool => str($modelFqn)->replace(['\\', '/'], '')->contains($search, ignoreCase: true));
             },
-            placeholder: 'App\\Models\\User',
+            placeholder: Filament::namespaceFor('Models\\User'),
             hint: 'Please provide the fully-qualified class name.',
         );
     }

--- a/packages/support/src/Commands/Concerns/CanAskForRelatedModel.php
+++ b/packages/support/src/Commands/Concerns/CanAskForRelatedModel.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Support\Commands\Concerns;
 
-use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Model;
 
 use function Filament\Support\discover_app_classes;
@@ -36,7 +35,7 @@ trait CanAskForRelatedModel
 
                 return array_filter($modelFqns, fn (string $modelFqn): bool => str($modelFqn)->replace(['\\', '/'], '')->contains($search, ignoreCase: true));
             },
-            placeholder: Filament::namespaceFor('Models\\User'),
+            placeholder: app()->getNamespace() . 'Models\\User',
             hint: 'Please provide the fully-qualified class name.',
         );
     }

--- a/packages/support/src/Commands/Concerns/CanAskForResource.php
+++ b/packages/support/src/Commands/Concerns/CanAskForResource.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Support\Commands\Concerns;
 
+use Filament\Facades\Filament;
 use Filament\Resources\Resource;
 use Illuminate\Support\Collection;
 
@@ -60,7 +61,7 @@ trait CanAskForResource
         if (! $resourceFqns) {
             return (string) str(text(
                 label: "No resources were found within [{$resourcesNamespace}]. {$question}",
-                placeholder: 'App\\Filament\\Resources\\Posts\\PostResource',
+                placeholder: Filament::namespaceFor('Filament\\Resources\\Posts\\PostResource'),
                 required: true,
                 validate: function (string $value): ?string {
                     $value = (string) str($value)

--- a/packages/support/src/Commands/Concerns/CanAskForResource.php
+++ b/packages/support/src/Commands/Concerns/CanAskForResource.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Support\Commands\Concerns;
 
-use Filament\Facades\Filament;
 use Filament\Resources\Resource;
 use Illuminate\Support\Collection;
 
@@ -61,7 +60,7 @@ trait CanAskForResource
         if (! $resourceFqns) {
             return (string) str(text(
                 label: "No resources were found within [{$resourcesNamespace}]. {$question}",
-                placeholder: Filament::namespaceFor('Filament\\Resources\\Posts\\PostResource'),
+                placeholder: app()->getNamespace() . 'Filament\\Resources\\Posts\\PostResource',
                 required: true,
                 validate: function (string $value): ?string {
                     $value = (string) str($value)

--- a/packages/support/src/Commands/Concerns/CanGeneratePanels.php
+++ b/packages/support/src/Commands/Concerns/CanGeneratePanels.php
@@ -44,7 +44,7 @@ trait CanGeneratePanels
             throw new FailureCommandOutput;
         }
 
-        $fqn = Filament::namespaceFor("Providers\\Filament\\{$basename}");
+        $fqn = app()->getNamespace() . "Providers\\Filament\\{$basename}";
 
         if (empty(Filament::getPanels())) {
             $this->writeFile($path, app(PanelProviderClassGenerator::class, [
@@ -71,8 +71,8 @@ trait CanGeneratePanels
 
             if (! Str::contains($appConfig, "{$fqn}::class")) {
                 file_put_contents(config_path('app.php'), str_replace(
-                    Filament::namespaceFor('Providers\\RouteServiceProvider') . '::class,',
-                    "{$fqn}::class," . PHP_EOL . '        ' . Filament::namespaceFor('Providers\\RouteServiceProvider') . '::class,',
+                    app()->getNamespace() . 'Providers\\RouteServiceProvider::class,',
+                    "{$fqn}::class," . PHP_EOL . '        ' . app()->getNamespace() . 'Providers\\RouteServiceProvider::class,',
                     $appConfig,
                 ));
             }

--- a/packages/support/src/Commands/Concerns/CanGeneratePanels.php
+++ b/packages/support/src/Commands/Concerns/CanGeneratePanels.php
@@ -44,7 +44,7 @@ trait CanGeneratePanels
             throw new FailureCommandOutput;
         }
 
-        $fqn = "App\\Providers\\Filament\\{$basename}";
+        $fqn = Filament::namespaceFor("Providers\\Filament\\{$basename}");
 
         if (empty(Filament::getPanels())) {
             $this->writeFile($path, app(PanelProviderClassGenerator::class, [
@@ -71,8 +71,8 @@ trait CanGeneratePanels
 
             if (! Str::contains($appConfig, "{$fqn}::class")) {
                 file_put_contents(config_path('app.php'), str_replace(
-                    'App\\Providers\\RouteServiceProvider::class,',
-                    "{$fqn}::class," . PHP_EOL . '        App\\Providers\\RouteServiceProvider::class,',
+                    Filament::namespaceFor('Providers\\RouteServiceProvider') . '::class,',
+                    "{$fqn}::class," . PHP_EOL . '        ' . Filament::namespaceFor('Providers\\RouteServiceProvider') . '::class,',
                     $appConfig,
                 ));
             }

--- a/packages/support/src/Commands/Concerns/HasCluster.php
+++ b/packages/support/src/Commands/Concerns/HasCluster.php
@@ -3,6 +3,7 @@
 namespace Filament\Support\Commands\Concerns;
 
 use Filament\Clusters\Cluster;
+use Filament\Facades\Filament;
 use ReflectionClass;
 
 use function Laravel\Prompts\confirm;
@@ -57,7 +58,7 @@ trait HasCluster
         if (empty($clusterFqns)) {
             $clusterFqn = (string) str(text(
                 label: "No clusters were found within the [{$this->panel->getId()}] panel. {$question}",
-                placeholder: 'App\\Filament\\Clusters\\Blog',
+                placeholder: Filament::namespaceFor('Filament\\Clusters\\Blog'),
                 required: true,
                 validate: function (string $value): ?string {
                     $value = (string) str($value)

--- a/packages/support/src/Commands/Concerns/HasCluster.php
+++ b/packages/support/src/Commands/Concerns/HasCluster.php
@@ -3,7 +3,6 @@
 namespace Filament\Support\Commands\Concerns;
 
 use Filament\Clusters\Cluster;
-use Filament\Facades\Filament;
 use ReflectionClass;
 
 use function Laravel\Prompts\confirm;
@@ -58,7 +57,7 @@ trait HasCluster
         if (empty($clusterFqns)) {
             $clusterFqn = (string) str(text(
                 label: "No clusters were found within the [{$this->panel->getId()}] panel. {$question}",
-                placeholder: Filament::namespaceFor('Filament\\Clusters\\Blog'),
+                placeholder: app()->getNamespace() . 'Filament\\Clusters\\Blog',
                 required: true,
                 validate: function (string $value): ?string {
                     $value = (string) str($value)

--- a/packages/support/src/Commands/Concerns/HasResourcesLocation.php
+++ b/packages/support/src/Commands/Concerns/HasResourcesLocation.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Support\Commands\Concerns;
 
+use Filament\Facades\Filament;
 use Illuminate\Support\Arr;
 
 use function Laravel\Prompts\search;
@@ -44,7 +45,7 @@ trait HasResourcesLocation
 
         if (count($namespaces) < 2) {
             return [
-                (Arr::first($namespaces) ?? 'App\\Filament\\Resources'),
+                (Arr::first($namespaces) ?? Filament::namespaceFor('Filament\\Resources')),
                 (Arr::first($directories) ?? app_path('Filament/Resources/')),
             ];
         }

--- a/packages/support/src/Commands/Concerns/HasResourcesLocation.php
+++ b/packages/support/src/Commands/Concerns/HasResourcesLocation.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Support\Commands\Concerns;
 
-use Filament\Facades\Filament;
 use Illuminate\Support\Arr;
 
 use function Laravel\Prompts\search;
@@ -45,7 +44,7 @@ trait HasResourcesLocation
 
         if (count($namespaces) < 2) {
             return [
-                (Arr::first($namespaces) ?? Filament::namespaceFor('Filament\\Resources')),
+                (Arr::first($namespaces) ?? app()->getNamespace() . 'Filament\\Resources'),
                 (Arr::first($directories) ?? app_path('Filament/Resources/')),
             ];
         }

--- a/packages/tables/src/Commands/MakeLivewireTableCommand.php
+++ b/packages/tables/src/Commands/MakeLivewireTableCommand.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Tables\Commands;
 
+use Filament\Facades\Filament;
 use Filament\Support\Commands\Concerns\CanAskForLivewireComponentLocation;
 use Filament\Support\Commands\Concerns\CanAskForViewLocation;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
@@ -98,7 +99,7 @@ class MakeLivewireTableCommand extends Command
                 name: 'model-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_REQUIRED,
-                description: 'The namespace of the model class, [App\\Models] by default',
+                description: 'The namespace of the model class, [' . Filament::namespaceFor('Models') . '] by default',
             ),
             new InputOption(
                 name: 'force',
@@ -153,7 +154,7 @@ class MakeLivewireTableCommand extends Command
                 ->studly()
                 ->replace('/', '\\');
 
-            $modelNamespace = $this->option('model-namespace') ?? 'App\\Models';
+            $modelNamespace = $this->option('model-namespace') ?? Filament::namespaceFor('Models');
 
             $this->modelFqn = "{$modelNamespace}\\{$this->modelFqnEnd}";
 
@@ -176,7 +177,7 @@ class MakeLivewireTableCommand extends Command
                     fn (string $class): bool => str($class)->replace(['\\', '/'], '')->contains($search, ignoreCase: true),
                 );
             },
-            placeholder: 'App\\Models\\BlogPost',
+            placeholder: Filament::namespaceFor('Models\\BlogPost'),
             required: true,
         );
 

--- a/packages/tables/src/Commands/MakeLivewireTableCommand.php
+++ b/packages/tables/src/Commands/MakeLivewireTableCommand.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Tables\Commands;
 
-use Filament\Facades\Filament;
 use Filament\Support\Commands\Concerns\CanAskForLivewireComponentLocation;
 use Filament\Support\Commands\Concerns\CanAskForViewLocation;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
@@ -99,7 +98,7 @@ class MakeLivewireTableCommand extends Command
                 name: 'model-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_REQUIRED,
-                description: 'The namespace of the model class, [' . Filament::namespaceFor('Models') . '] by default',
+                description: 'The namespace of the model class, [' . app()->getNamespace() . 'Models] by default',
             ),
             new InputOption(
                 name: 'force',
@@ -154,7 +153,7 @@ class MakeLivewireTableCommand extends Command
                 ->studly()
                 ->replace('/', '\\');
 
-            $modelNamespace = $this->option('model-namespace') ?? Filament::namespaceFor('Models');
+            $modelNamespace = $this->option('model-namespace') ?? app()->getNamespace() . 'Models';
 
             $this->modelFqn = "{$modelNamespace}\\{$this->modelFqnEnd}";
 
@@ -177,7 +176,7 @@ class MakeLivewireTableCommand extends Command
                     fn (string $class): bool => str($class)->replace(['\\', '/'], '')->contains($search, ignoreCase: true),
                 );
             },
-            placeholder: Filament::namespaceFor('Models\\BlogPost'),
+            placeholder: app()->getNamespace() . 'Models\\BlogPost',
             required: true,
         );
 

--- a/packages/tables/src/Commands/MakeTableCommand.php
+++ b/packages/tables/src/Commands/MakeTableCommand.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Tables\Commands;
 
+use Filament\Facades\Filament;
 use Filament\Support\Commands\Concerns\CanAskForComponentLocation;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
 use Filament\Support\Commands\Exceptions\FailureCommandOutput;
@@ -89,7 +90,7 @@ class MakeTableCommand extends Command
                 name: 'model-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_REQUIRED,
-                description: 'The namespace of the model class, [App\\Models] by default',
+                description: 'The namespace of the model class, [' . Filament::namespaceFor('Models') . '] by default',
             ),
             new InputOption(
                 name: 'force',
@@ -143,7 +144,7 @@ class MakeTableCommand extends Command
                 ->studly()
                 ->replace('/', '\\');
 
-            $modelNamespace = $this->option('model-namespace') ?? 'App\\Models';
+            $modelNamespace = $this->option('model-namespace') ?? Filament::namespaceFor('Models');
 
             $this->modelFqn = "{$modelNamespace}\\{$this->modelFqnEnd}";
 
@@ -166,7 +167,7 @@ class MakeTableCommand extends Command
                     fn (string $class): bool => str($class)->replace(['\\', '/'], '')->contains($search, ignoreCase: true),
                 );
             },
-            placeholder: 'App\\Models\\BlogPost',
+            placeholder: Filament::namespaceFor('Models\\BlogPost'),
             required: true,
         );
 

--- a/packages/tables/src/Commands/MakeTableCommand.php
+++ b/packages/tables/src/Commands/MakeTableCommand.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Tables\Commands;
 
-use Filament\Facades\Filament;
 use Filament\Support\Commands\Concerns\CanAskForComponentLocation;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
 use Filament\Support\Commands\Exceptions\FailureCommandOutput;
@@ -90,7 +89,7 @@ class MakeTableCommand extends Command
                 name: 'model-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_REQUIRED,
-                description: 'The namespace of the model class, [' . Filament::namespaceFor('Models') . '] by default',
+                description: 'The namespace of the model class, [' . app()->getNamespace() . 'Models] by default',
             ),
             new InputOption(
                 name: 'force',
@@ -144,7 +143,7 @@ class MakeTableCommand extends Command
                 ->studly()
                 ->replace('/', '\\');
 
-            $modelNamespace = $this->option('model-namespace') ?? Filament::namespaceFor('Models');
+            $modelNamespace = $this->option('model-namespace') ?? app()->getNamespace() . 'Models';
 
             $this->modelFqn = "{$modelNamespace}\\{$this->modelFqnEnd}";
 
@@ -167,7 +166,7 @@ class MakeTableCommand extends Command
                     fn (string $class): bool => str($class)->replace(['\\', '/'], '')->contains($search, ignoreCase: true),
                 );
             },
-            placeholder: Filament::namespaceFor('Models\\BlogPost'),
+            placeholder: app()->getNamespace() . 'Models\\BlogPost',
             required: true,
         );
 

--- a/packages/widgets/docs/01-overview.md
+++ b/packages/widgets/docs/01-overview.md
@@ -55,7 +55,7 @@ public function panel(Panel $panel): Panel
 {
     return $panel
         // ...
-        ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
+        ->discoverPages(in: app_path('Filament/Pages'), for: Filament::namespaceFor('Filament\\Pages'))
         ->pages([]);
 }
 ```

--- a/packages/widgets/docs/01-overview.md
+++ b/packages/widgets/docs/01-overview.md
@@ -55,7 +55,7 @@ public function panel(Panel $panel): Panel
 {
     return $panel
         // ...
-        ->discoverPages(in: app_path('Filament/Pages'), for: Filament::namespaceFor('Filament\\Pages'))
+        ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
         ->pages([]);
 }
 ```

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Widgets\Commands;
 
-use Filament\Facades\Filament;
 use Filament\Support\Commands\Concerns\CanAskForLivewireComponentLocation;
 use Filament\Support\Commands\Concerns\CanAskForResource;
 use Filament\Support\Commands\Concerns\CanAskForViewLocation;
@@ -140,7 +139,7 @@ class MakeWidgetCommand extends Command
                 name: 'resource-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_OPTIONAL,
-                description: 'The namespace of the resource class, such as [' . Filament::namespaceFor('Filament\\Resources') . ']',
+                description: 'The namespace of the resource class, such as [' . app()->getNamespace() . 'Filament\\Resources]',
             ),
             new InputOption(
                 name: 'stats-overview',
@@ -330,7 +329,7 @@ class MakeWidgetCommand extends Command
         }
 
         if (count($namespaces) < 2) {
-            $this->widgetsNamespace = (Arr::first($namespaces) ?? Filament::namespaceFor('Filament\\Widgets'));
+            $this->widgetsNamespace = (Arr::first($namespaces) ?? app()->getNamespace() . 'Filament\\Widgets');
             $this->widgetsDirectory = (Arr::first($directories) ?? app_path('Filament/Widgets/'));
 
             return;
@@ -487,7 +486,7 @@ class MakeWidgetCommand extends Command
                     fn (string $class): bool => str($class)->replace(['\\', '/'], '')->contains($search, ignoreCase: true),
                 );
             },
-            placeholder: Filament::namespaceFor('Models\\BlogPost'),
+            placeholder: app()->getNamespace() . 'Models\\BlogPost',
         );
 
         $isGenerated = confirm(

--- a/packages/widgets/src/Commands/MakeWidgetCommand.php
+++ b/packages/widgets/src/Commands/MakeWidgetCommand.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Widgets\Commands;
 
+use Filament\Facades\Filament;
 use Filament\Support\Commands\Concerns\CanAskForLivewireComponentLocation;
 use Filament\Support\Commands\Concerns\CanAskForResource;
 use Filament\Support\Commands\Concerns\CanAskForViewLocation;
@@ -139,7 +140,7 @@ class MakeWidgetCommand extends Command
                 name: 'resource-namespace',
                 shortcut: null,
                 mode: InputOption::VALUE_OPTIONAL,
-                description: 'The namespace of the resource class, such as [App\\Filament\\Resources]',
+                description: 'The namespace of the resource class, such as [' . Filament::namespaceFor('Filament\\Resources') . ']',
             ),
             new InputOption(
                 name: 'stats-overview',
@@ -329,7 +330,7 @@ class MakeWidgetCommand extends Command
         }
 
         if (count($namespaces) < 2) {
-            $this->widgetsNamespace = (Arr::first($namespaces) ?? 'App\\Filament\\Widgets');
+            $this->widgetsNamespace = (Arr::first($namespaces) ?? Filament::namespaceFor('Filament\\Widgets'));
             $this->widgetsDirectory = (Arr::first($directories) ?? app_path('Filament/Widgets/'));
 
             return;
@@ -486,7 +487,7 @@ class MakeWidgetCommand extends Command
                     fn (string $class): bool => str($class)->replace(['\\', '/'], '')->contains($search, ignoreCase: true),
                 );
             },
-            placeholder: 'App\\Models\\BlogPost',
+            placeholder: Filament::namespaceFor('Models\\BlogPost'),
         );
 
         $isGenerated = confirm(

--- a/tests/src/Panels/Commands/Legacy/LegacyMakePageCommandTest.php
+++ b/tests/src/Panels/Commands/Legacy/LegacyMakePageCommandTest.php
@@ -97,7 +97,7 @@ it('can generate a page class in a cluster', function (): void {
     $this->artisan('make:filament-page', [
         'name' => 'ManageSettings',
         '--panel' => 'admin',
-        '--cluster' => Filament::namespaceFor('Filament\\Clusters\\Site'),
+        '--cluster' => app()->getNamespace() . 'Filament\\Clusters\\Site',
         '--no-interaction' => true,
     ]);
 
@@ -120,7 +120,7 @@ it('can generate a page view in a cluster', function (): void {
     $this->artisan('make:filament-page', [
         'name' => 'ManageSettings',
         '--panel' => 'admin',
-        '--cluster' => Filament::namespaceFor('Filament\\Clusters\\Site'),
+        '--cluster' => app()->getNamespace() . 'Filament\\Clusters\\Site',
         '--no-interaction' => true,
     ]);
 
@@ -146,7 +146,7 @@ it('can generate a page class in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\UserResource',
     ];
 
     $this->artisan('make:filament-page', [
@@ -179,7 +179,7 @@ it('can generate a page view in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\UserResource',
     ];
 
     $this->artisan('make:filament-page', [
@@ -212,7 +212,7 @@ it('can generate a create page class in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\UserResource',
     ];
 
     $this->artisan('make:filament-page', [
@@ -247,7 +247,7 @@ it('can generate an edit page class in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\UserResource',
     ];
 
     $this->artisan('make:filament-page', [
@@ -282,7 +282,7 @@ it('can generate a view page class in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\UserResource',
     ];
 
     $this->artisan('make:filament-page', [
@@ -334,8 +334,8 @@ $runGenerateManageRelatedRecordsPageCommand = function (TestCase $testCase): Pen
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\TeamResource'),
-        Filament::namespaceFor('Filament\\Resources\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\TeamResource',
+        app()->getNamespace() . 'Filament\\Resources\\UserResource',
     ];
 
     return $testCase->artisan('make:filament-page', [
@@ -385,8 +385,8 @@ it('can generate a manage related records page class in a resource with a relate
     $runGenerateManageRelatedRecordsPageCommand($this)
         ->expectsQuestion($questions['relationship'], 'teams')
         ->expectsQuestion($questions['hasRelatedResource'], true)
-        ->expectsQuestion($questions['relatedResource'], Filament::namespaceFor('Filament\\Resources\\TeamResource'))
-        ->expectsQuestion($questions['relatedResource'], Filament::namespaceFor('Filament\\Resources\\TeamResource')); // Repeat the question as there is a bug when testing `search()` in Prompts
+        ->expectsQuestion($questions['relatedResource'], app()->getNamespace() . 'Filament\\Resources\\TeamResource')
+        ->expectsQuestion($questions['relatedResource'], app()->getNamespace() . 'Filament\\Resources\\TeamResource'); // Repeat the question as there is a bug when testing `search()` in Prompts
 
     assertFileExists($path = app_path('Filament/Resources/UserResource/Pages/ManageUserTeams.php'));
     expect(file_get_contents($path))

--- a/tests/src/Panels/Commands/Legacy/LegacyMakePageCommandTest.php
+++ b/tests/src/Panels/Commands/Legacy/LegacyMakePageCommandTest.php
@@ -97,7 +97,7 @@ it('can generate a page class in a cluster', function (): void {
     $this->artisan('make:filament-page', [
         'name' => 'ManageSettings',
         '--panel' => 'admin',
-        '--cluster' => 'App\\Filament\\Clusters\\Site',
+        '--cluster' => Filament::namespaceFor('Filament\\Clusters\\Site'),
         '--no-interaction' => true,
     ]);
 
@@ -120,7 +120,7 @@ it('can generate a page view in a cluster', function (): void {
     $this->artisan('make:filament-page', [
         'name' => 'ManageSettings',
         '--panel' => 'admin',
-        '--cluster' => 'App\\Filament\\Clusters\\Site',
+        '--cluster' => Filament::namespaceFor('Filament\\Clusters\\Site'),
         '--no-interaction' => true,
     ]);
 
@@ -146,7 +146,7 @@ it('can generate a page class in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\UserResource'),
     ];
 
     $this->artisan('make:filament-page', [
@@ -179,7 +179,7 @@ it('can generate a page view in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\UserResource'),
     ];
 
     $this->artisan('make:filament-page', [
@@ -212,7 +212,7 @@ it('can generate a create page class in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\UserResource'),
     ];
 
     $this->artisan('make:filament-page', [
@@ -247,7 +247,7 @@ it('can generate an edit page class in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\UserResource'),
     ];
 
     $this->artisan('make:filament-page', [
@@ -282,7 +282,7 @@ it('can generate a view page class in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\UserResource'),
     ];
 
     $this->artisan('make:filament-page', [
@@ -334,8 +334,8 @@ $runGenerateManageRelatedRecordsPageCommand = function (TestCase $testCase): Pen
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\TeamResource',
-        'App\\Filament\\Resources\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\TeamResource'),
+        Filament::namespaceFor('Filament\\Resources\\UserResource'),
     ];
 
     return $testCase->artisan('make:filament-page', [
@@ -385,8 +385,8 @@ it('can generate a manage related records page class in a resource with a relate
     $runGenerateManageRelatedRecordsPageCommand($this)
         ->expectsQuestion($questions['relationship'], 'teams')
         ->expectsQuestion($questions['hasRelatedResource'], true)
-        ->expectsQuestion($questions['relatedResource'], 'App\\Filament\\Resources\\TeamResource')
-        ->expectsQuestion($questions['relatedResource'], 'App\\Filament\\Resources\\TeamResource'); // Repeat the question as there is a bug when testing `search()` in Prompts
+        ->expectsQuestion($questions['relatedResource'], Filament::namespaceFor('Filament\\Resources\\TeamResource'))
+        ->expectsQuestion($questions['relatedResource'], Filament::namespaceFor('Filament\\Resources\\TeamResource')); // Repeat the question as there is a bug when testing `search()` in Prompts
 
     assertFileExists($path = app_path('Filament/Resources/UserResource/Pages/ManageUserTeams.php'));
     expect(file_get_contents($path))

--- a/tests/src/Panels/Commands/Legacy/LegacyMakeRelationManagerCommandTest.php
+++ b/tests/src/Panels/Commands/Legacy/LegacyMakeRelationManagerCommandTest.php
@@ -47,8 +47,8 @@ beforeEach(function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\TeamResource'),
-        Filament::namespaceFor('Filament\\Resources\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\TeamResource',
+        app()->getNamespace() . 'Filament\\Resources\\UserResource',
     ];
 
     MakeRelationManagerCommand::$shouldCheckModelsForSoftDeletes = false;
@@ -74,7 +74,7 @@ it('can generate a relation manager with a related resource', function (): void 
     $this->artisan('make:filament-relation-manager', [
         'resource' => 'Users',
         'relationship' => 'teams',
-        '--related-resource' => Filament::namespaceFor('Filament\\Resources\\TeamResource'),
+        '--related-resource' => app()->getNamespace() . 'Filament\\Resources\\TeamResource',
         '--panel' => 'admin',
         '--no-interaction' => true,
     ]);

--- a/tests/src/Panels/Commands/Legacy/LegacyMakeRelationManagerCommandTest.php
+++ b/tests/src/Panels/Commands/Legacy/LegacyMakeRelationManagerCommandTest.php
@@ -47,8 +47,8 @@ beforeEach(function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\TeamResource',
-        'App\\Filament\\Resources\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\TeamResource'),
+        Filament::namespaceFor('Filament\\Resources\\UserResource'),
     ];
 
     MakeRelationManagerCommand::$shouldCheckModelsForSoftDeletes = false;
@@ -74,7 +74,7 @@ it('can generate a relation manager with a related resource', function (): void 
     $this->artisan('make:filament-relation-manager', [
         'resource' => 'Users',
         'relationship' => 'teams',
-        '--related-resource' => 'App\\Filament\\Resources\\TeamResource',
+        '--related-resource' => Filament::namespaceFor('Filament\\Resources\\TeamResource'),
         '--panel' => 'admin',
         '--no-interaction' => true,
     ]);

--- a/tests/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest.php
+++ b/tests/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest.php
@@ -8,7 +8,6 @@ use Carbon\CarbonInterface;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
-use Filament\Facades\Filament;
 use Filament\Support\Commands\FileGenerators\FileGenerationFlag;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Arr;
@@ -66,7 +65,7 @@ it('can generate a page class in a cluster', function (): void {
     $this->artisan('make:filament-settings-page', [
         'name' => 'ManageSettings',
         'settings' => Settings::class,
-        '--cluster' => Filament::namespaceFor('Filament\\Clusters\\Site'),
+        '--cluster' => app()->getNamespace() . 'Filament\\Clusters\\Site',
         '--panel' => 'admin',
         '--no-interaction' => true,
     ]);

--- a/tests/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest.php
+++ b/tests/src/Panels/Commands/Legacy/LegacyMakeSettingsPageCommandTest.php
@@ -8,6 +8,7 @@ use Carbon\CarbonInterface;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
+use Filament\Facades\Filament;
 use Filament\Support\Commands\FileGenerators\FileGenerationFlag;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Arr;
@@ -65,7 +66,7 @@ it('can generate a page class in a cluster', function (): void {
     $this->artisan('make:filament-settings-page', [
         'name' => 'ManageSettings',
         'settings' => Settings::class,
-        '--cluster' => 'App\\Filament\\Clusters\\Site',
+        '--cluster' => Filament::namespaceFor('Filament\\Clusters\\Site'),
         '--panel' => 'admin',
         '--no-interaction' => true,
     ]);

--- a/tests/src/Panels/Commands/MakePageCommandTest.php
+++ b/tests/src/Panels/Commands/MakePageCommandTest.php
@@ -88,7 +88,7 @@ it('can generate a page class in a cluster', function (): void {
     $this->artisan('make:filament-page', [
         'name' => 'ManageSettings',
         '--panel' => 'admin',
-        '--cluster' => 'App\\Filament\\Clusters\\Site\\SiteCluster',
+        '--cluster' => Filament::namespaceFor('Filament\\Clusters\\Site\\SiteCluster'),
         '--no-interaction' => true,
     ]);
 
@@ -111,7 +111,7 @@ it('can generate a page view in a cluster', function (): void {
     $this->artisan('make:filament-page', [
         'name' => 'ManageSettings',
         '--panel' => 'admin',
-        '--cluster' => 'App\\Filament\\Clusters\\Site\\SiteCluster',
+        '--cluster' => Filament::namespaceFor('Filament\\Clusters\\Site\\SiteCluster'),
         '--no-interaction' => true,
     ]);
 
@@ -137,7 +137,7 @@ it('can generate a page class in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\Users\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
     ];
 
     $this->artisan('make:filament-page', [
@@ -170,7 +170,7 @@ it('can generate a page view in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\Users\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
     ];
 
     $this->artisan('make:filament-page', [
@@ -203,7 +203,7 @@ it('can generate a create page class in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\Users\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
     ];
 
     $this->artisan('make:filament-page', [
@@ -238,7 +238,7 @@ it('can generate an edit page class in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\Users\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
     ];
 
     $this->artisan('make:filament-page', [
@@ -273,7 +273,7 @@ it('can generate a view page class in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\Users\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
     ];
 
     $this->artisan('make:filament-page', [
@@ -325,8 +325,8 @@ $runGenerateManageRelatedRecordsPageCommand = function (TestCase $testCase): Pen
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\Teams\\TeamResource',
-        'App\\Filament\\Resources\\Users\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\Teams\\TeamResource'),
+        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
     ];
 
     return $testCase->artisan('make:filament-page', [
@@ -384,8 +384,8 @@ it('can generate a manage related records page class in a resource with a relate
     $runGenerateManageRelatedRecordsPageCommand($this)
         ->expectsQuestion($questions['relationship'], 'teams')
         ->expectsQuestion($questions['hasRelatedResource'], true)
-        ->expectsQuestion($questions['relatedResource'], 'App\\Filament\\Resources\\Teams\\TeamResource')
-        ->expectsQuestion($questions['relatedResource'], 'App\\Filament\\Resources\\Teams\\TeamResource'); // Repeat the question as there is a bug when testing `search()` in Prompts
+        ->expectsQuestion($questions['relatedResource'], Filament::namespaceFor('Filament\\Resources\\Teams\\TeamResource'))
+        ->expectsQuestion($questions['relatedResource'], Filament::namespaceFor('Filament\\Resources\\Teams\\TeamResource')); // Repeat the question as there is a bug when testing `search()` in Prompts
 
     assertFileExists($path = app_path('Filament/Resources/Users/Pages/ManageUserTeams.php'));
     expect(file_get_contents($path))
@@ -399,7 +399,7 @@ it('can generate a manage related records page class in a resource with a form s
         ->expectsQuestion($questions['relationship'], 'teams')
         ->expectsQuestion($questions['hasRelatedResource'], false)
         ->expectsQuestion($questions['hasFormSchemaClass'], true)
-        ->expectsQuestion($questions['formSchemaClass'], 'App\\Filament\\Resources\\Teams\\Schemas\\TeamForm')
+        ->expectsQuestion($questions['formSchemaClass'], Filament::namespaceFor('Filament\\Resources\\Teams\\Schemas\\TeamForm'))
         ->expectsQuestion($questions['hasViewOperation'], false)
         ->expectsQuestion($questions['hasTableClass'], false)
         ->expectsQuestion($questions['titleAttribute'], 'name')
@@ -463,7 +463,7 @@ it('can generate a manage related records page class in a resource with an infol
         ->expectsQuestion($questions['titleAttribute'], 'name')
         ->expectsQuestion($questions['hasViewOperation'], true)
         ->expectsQuestion($questions['hasInfolistSchemaClass'], true)
-        ->expectsQuestion($questions['infolistSchemaClass'], 'App\\Filament\\Resources\\Teams\\Schemas\\TeamInfolist')
+        ->expectsQuestion($questions['infolistSchemaClass'], Filament::namespaceFor('Filament\\Resources\\Teams\\Schemas\\TeamInfolist'))
         ->expectsQuestion($questions['hasTableClass'], false)
         ->expectsQuestion($questions['isSoftDeletable'], false)
         ->expectsQuestion($questions['relationshipType'], BelongsToMany::class);
@@ -484,7 +484,7 @@ it('can generate a manage related records page class in a resource with a table 
         ->expectsQuestion($questions['titleAttribute'], 'name')
         ->expectsQuestion($questions['hasViewOperation'], false)
         ->expectsQuestion($questions['hasTableClass'], true)
-        ->expectsQuestion($questions['tableClass'], 'App\\Filament\\Resources\\Teams\\Tables\\TeamsTable');
+        ->expectsQuestion($questions['tableClass'], Filament::namespaceFor('Filament\\Resources\\Teams\\Tables\\TeamsTable'));
 
     assertFileExists($path = app_path('Filament/Resources/Users/Pages/ManageUserTeams.php'));
     expect(file_get_contents($path))
@@ -546,7 +546,7 @@ it('can generate a custom record page class in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\Users\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
     ];
 
     $this->mockConsoleOutput = true;

--- a/tests/src/Panels/Commands/MakePageCommandTest.php
+++ b/tests/src/Panels/Commands/MakePageCommandTest.php
@@ -88,7 +88,7 @@ it('can generate a page class in a cluster', function (): void {
     $this->artisan('make:filament-page', [
         'name' => 'ManageSettings',
         '--panel' => 'admin',
-        '--cluster' => Filament::namespaceFor('Filament\\Clusters\\Site\\SiteCluster'),
+        '--cluster' => app()->getNamespace() . 'Filament\\Clusters\\Site\\SiteCluster',
         '--no-interaction' => true,
     ]);
 
@@ -111,7 +111,7 @@ it('can generate a page view in a cluster', function (): void {
     $this->artisan('make:filament-page', [
         'name' => 'ManageSettings',
         '--panel' => 'admin',
-        '--cluster' => Filament::namespaceFor('Filament\\Clusters\\Site\\SiteCluster'),
+        '--cluster' => app()->getNamespace() . 'Filament\\Clusters\\Site\\SiteCluster',
         '--no-interaction' => true,
     ]);
 
@@ -137,7 +137,7 @@ it('can generate a page class in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\Users\\UserResource',
     ];
 
     $this->artisan('make:filament-page', [
@@ -170,7 +170,7 @@ it('can generate a page view in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\Users\\UserResource',
     ];
 
     $this->artisan('make:filament-page', [
@@ -203,7 +203,7 @@ it('can generate a create page class in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\Users\\UserResource',
     ];
 
     $this->artisan('make:filament-page', [
@@ -238,7 +238,7 @@ it('can generate an edit page class in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\Users\\UserResource',
     ];
 
     $this->artisan('make:filament-page', [
@@ -273,7 +273,7 @@ it('can generate a view page class in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\Users\\UserResource',
     ];
 
     $this->artisan('make:filament-page', [
@@ -325,8 +325,8 @@ $runGenerateManageRelatedRecordsPageCommand = function (TestCase $testCase): Pen
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\Teams\\TeamResource'),
-        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\Teams\\TeamResource',
+        app()->getNamespace() . 'Filament\\Resources\\Users\\UserResource',
     ];
 
     return $testCase->artisan('make:filament-page', [
@@ -384,8 +384,8 @@ it('can generate a manage related records page class in a resource with a relate
     $runGenerateManageRelatedRecordsPageCommand($this)
         ->expectsQuestion($questions['relationship'], 'teams')
         ->expectsQuestion($questions['hasRelatedResource'], true)
-        ->expectsQuestion($questions['relatedResource'], Filament::namespaceFor('Filament\\Resources\\Teams\\TeamResource'))
-        ->expectsQuestion($questions['relatedResource'], Filament::namespaceFor('Filament\\Resources\\Teams\\TeamResource')); // Repeat the question as there is a bug when testing `search()` in Prompts
+        ->expectsQuestion($questions['relatedResource'], app()->getNamespace() . 'Filament\\Resources\\Teams\\TeamResource')
+        ->expectsQuestion($questions['relatedResource'], app()->getNamespace() . 'Filament\\Resources\\Teams\\TeamResource'); // Repeat the question as there is a bug when testing `search()` in Prompts
 
     assertFileExists($path = app_path('Filament/Resources/Users/Pages/ManageUserTeams.php'));
     expect(file_get_contents($path))
@@ -399,7 +399,7 @@ it('can generate a manage related records page class in a resource with a form s
         ->expectsQuestion($questions['relationship'], 'teams')
         ->expectsQuestion($questions['hasRelatedResource'], false)
         ->expectsQuestion($questions['hasFormSchemaClass'], true)
-        ->expectsQuestion($questions['formSchemaClass'], Filament::namespaceFor('Filament\\Resources\\Teams\\Schemas\\TeamForm'))
+        ->expectsQuestion($questions['formSchemaClass'], app()->getNamespace() . 'Filament\\Resources\\Teams\\Schemas\\TeamForm')
         ->expectsQuestion($questions['hasViewOperation'], false)
         ->expectsQuestion($questions['hasTableClass'], false)
         ->expectsQuestion($questions['titleAttribute'], 'name')
@@ -463,7 +463,7 @@ it('can generate a manage related records page class in a resource with an infol
         ->expectsQuestion($questions['titleAttribute'], 'name')
         ->expectsQuestion($questions['hasViewOperation'], true)
         ->expectsQuestion($questions['hasInfolistSchemaClass'], true)
-        ->expectsQuestion($questions['infolistSchemaClass'], Filament::namespaceFor('Filament\\Resources\\Teams\\Schemas\\TeamInfolist'))
+        ->expectsQuestion($questions['infolistSchemaClass'], app()->getNamespace() . 'Filament\\Resources\\Teams\\Schemas\\TeamInfolist')
         ->expectsQuestion($questions['hasTableClass'], false)
         ->expectsQuestion($questions['isSoftDeletable'], false)
         ->expectsQuestion($questions['relationshipType'], BelongsToMany::class);
@@ -484,7 +484,7 @@ it('can generate a manage related records page class in a resource with a table 
         ->expectsQuestion($questions['titleAttribute'], 'name')
         ->expectsQuestion($questions['hasViewOperation'], false)
         ->expectsQuestion($questions['hasTableClass'], true)
-        ->expectsQuestion($questions['tableClass'], Filament::namespaceFor('Filament\\Resources\\Teams\\Tables\\TeamsTable'));
+        ->expectsQuestion($questions['tableClass'], app()->getNamespace() . 'Filament\\Resources\\Teams\\Tables\\TeamsTable');
 
     assertFileExists($path = app_path('Filament/Resources/Users/Pages/ManageUserTeams.php'));
     expect(file_get_contents($path))
@@ -546,7 +546,7 @@ it('can generate a custom record page class in a resource', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\Users\\UserResource',
     ];
 
     $this->mockConsoleOutput = true;

--- a/tests/src/Panels/Commands/MakeRelationManagerCommandTest.php
+++ b/tests/src/Panels/Commands/MakeRelationManagerCommandTest.php
@@ -42,8 +42,8 @@ beforeEach(function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\Teams\\TeamResource',
-        'App\\Filament\\Resources\\Users\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\Teams\\TeamResource'),
+        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
     ];
 
     MakeRelationManagerCommand::$shouldCheckModelsForSoftDeletes = false;
@@ -69,7 +69,7 @@ it('can generate a relation manager with a related resource', function (): void 
     $this->artisan('make:filament-relation-manager', [
         'resource' => 'Users',
         'relationship' => 'teams',
-        '--related-resource' => 'App\\Filament\\Resources\\Teams\\TeamResource',
+        '--related-resource' => Filament::namespaceFor('Filament\\Resources\\Teams\\TeamResource'),
         '--panel' => 'admin',
         '--no-interaction' => true,
     ]);
@@ -85,7 +85,7 @@ it('can generate a relation manager with a form schema class', function (): void
         'relationship' => 'teams',
         'recordTitleAttribute' => 'name',
         '--attach' => true,
-        '--form-schema' => 'App\\Filament\\Resources\\Teams\\Schemas\\TeamForm',
+        '--form-schema' => Filament::namespaceFor('Filament\\Resources\\Teams\\Schemas\\TeamForm'),
         '--panel' => 'admin',
         '--no-interaction' => true,
     ]);
@@ -134,7 +134,7 @@ it('can generate a relation manager with an infolist schema class', function ():
         'relationship' => 'teams',
         'recordTitleAttribute' => 'name',
         '--attach' => true,
-        '--infolist-schema' => 'App\\Filament\\Resources\\Teams\\Schemas\\TeamInfolist',
+        '--infolist-schema' => Filament::namespaceFor('Filament\\Resources\\Teams\\Schemas\\TeamInfolist'),
         '--view' => true,
         '--panel' => 'admin',
         '--no-interaction' => true,
@@ -151,7 +151,7 @@ it('can generate a relation manager with a table class', function (): void {
         'relationship' => 'teams',
         'recordTitleAttribute' => 'name',
         '--attach' => true,
-        '--table' => 'App\\Filament\\Resources\\Teams\\Tables\\TeamsTable',
+        '--table' => Filament::namespaceFor('Filament\\Resources\\Teams\\Tables\\TeamsTable'),
         '--panel' => 'admin',
         '--no-interaction' => true,
     ]);

--- a/tests/src/Panels/Commands/MakeRelationManagerCommandTest.php
+++ b/tests/src/Panels/Commands/MakeRelationManagerCommandTest.php
@@ -42,8 +42,8 @@ beforeEach(function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\Teams\\TeamResource'),
-        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\Teams\\TeamResource',
+        app()->getNamespace() . 'Filament\\Resources\\Users\\UserResource',
     ];
 
     MakeRelationManagerCommand::$shouldCheckModelsForSoftDeletes = false;
@@ -69,7 +69,7 @@ it('can generate a relation manager with a related resource', function (): void 
     $this->artisan('make:filament-relation-manager', [
         'resource' => 'Users',
         'relationship' => 'teams',
-        '--related-resource' => Filament::namespaceFor('Filament\\Resources\\Teams\\TeamResource'),
+        '--related-resource' => app()->getNamespace() . 'Filament\\Resources\\Teams\\TeamResource',
         '--panel' => 'admin',
         '--no-interaction' => true,
     ]);
@@ -85,7 +85,7 @@ it('can generate a relation manager with a form schema class', function (): void
         'relationship' => 'teams',
         'recordTitleAttribute' => 'name',
         '--attach' => true,
-        '--form-schema' => Filament::namespaceFor('Filament\\Resources\\Teams\\Schemas\\TeamForm'),
+        '--form-schema' => app()->getNamespace() . 'Filament\\Resources\\Teams\\Schemas\\TeamForm',
         '--panel' => 'admin',
         '--no-interaction' => true,
     ]);
@@ -134,7 +134,7 @@ it('can generate a relation manager with an infolist schema class', function ():
         'relationship' => 'teams',
         'recordTitleAttribute' => 'name',
         '--attach' => true,
-        '--infolist-schema' => Filament::namespaceFor('Filament\\Resources\\Teams\\Schemas\\TeamInfolist'),
+        '--infolist-schema' => app()->getNamespace() . 'Filament\\Resources\\Teams\\Schemas\\TeamInfolist',
         '--view' => true,
         '--panel' => 'admin',
         '--no-interaction' => true,
@@ -151,7 +151,7 @@ it('can generate a relation manager with a table class', function (): void {
         'relationship' => 'teams',
         'recordTitleAttribute' => 'name',
         '--attach' => true,
-        '--table' => Filament::namespaceFor('Filament\\Resources\\Teams\\Tables\\TeamsTable'),
+        '--table' => app()->getNamespace() . 'Filament\\Resources\\Teams\\Tables\\TeamsTable',
         '--panel' => 'admin',
         '--no-interaction' => true,
     ]);

--- a/tests/src/Panels/Commands/MakeResourceCommandTest.php
+++ b/tests/src/Panels/Commands/MakeResourceCommandTest.php
@@ -476,7 +476,7 @@ it('can generate a nested resource class', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\Users\\UserResource',
     ];
 
     $this->artisan('make:filament-resource', [
@@ -506,7 +506,7 @@ it('can generate a nested resource class with a plural parent resource name', fu
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\Users\\UserResource',
     ];
 
     $this->artisan('make:filament-resource', [
@@ -536,7 +536,7 @@ it('can generate a nested resource class with a parent resource name with `Resou
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\Users\\UserResource',
     ];
 
     $this->artisan('make:filament-resource', [
@@ -566,7 +566,7 @@ it('can generate a nested resource form', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\Users\\UserResource',
     ];
 
     $this->artisan('make:filament-resource', [
@@ -596,7 +596,7 @@ it('can generate a nested resource infolist', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\Users\\UserResource',
     ];
 
     $this->artisan('make:filament-resource', [
@@ -627,7 +627,7 @@ it('can generate a nested resource create page', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\Users\\UserResource',
     ];
 
     $this->artisan('make:filament-resource', [
@@ -657,7 +657,7 @@ it('can generate a nested resource edit page', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\Users\\UserResource',
     ];
 
     $this->artisan('make:filament-resource', [
@@ -687,7 +687,7 @@ it('can generate a nested resource view page', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\Users\\UserResource',
     ];
 
     $this->artisan('make:filament-resource', [
@@ -718,7 +718,7 @@ it('can generate a nested resource class in a nested directory', function (): vo
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
+        app()->getNamespace() . 'Filament\\Resources\\Users\\UserResource',
     ];
 
     $this->artisan('make:filament-resource', [

--- a/tests/src/Panels/Commands/MakeResourceCommandTest.php
+++ b/tests/src/Panels/Commands/MakeResourceCommandTest.php
@@ -476,7 +476,7 @@ it('can generate a nested resource class', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\Users\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
     ];
 
     $this->artisan('make:filament-resource', [
@@ -506,7 +506,7 @@ it('can generate a nested resource class with a plural parent resource name', fu
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\Users\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
     ];
 
     $this->artisan('make:filament-resource', [
@@ -536,7 +536,7 @@ it('can generate a nested resource class with a parent resource name with `Resou
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\Users\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
     ];
 
     $this->artisan('make:filament-resource', [
@@ -566,7 +566,7 @@ it('can generate a nested resource form', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\Users\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
     ];
 
     $this->artisan('make:filament-resource', [
@@ -596,7 +596,7 @@ it('can generate a nested resource infolist', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\Users\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
     ];
 
     $this->artisan('make:filament-resource', [
@@ -627,7 +627,7 @@ it('can generate a nested resource create page', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\Users\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
     ];
 
     $this->artisan('make:filament-resource', [
@@ -657,7 +657,7 @@ it('can generate a nested resource edit page', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\Users\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
     ];
 
     $this->artisan('make:filament-resource', [
@@ -687,7 +687,7 @@ it('can generate a nested resource view page', function (): void {
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\Users\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
     ];
 
     $this->artisan('make:filament-resource', [
@@ -718,7 +718,7 @@ it('can generate a nested resource class in a nested directory', function (): vo
 
     invade(Filament::getCurrentOrDefaultPanel())->resources = [
         ...invade(Filament::getCurrentOrDefaultPanel())->resources,
-        'App\\Filament\\Resources\\Users\\UserResource',
+        Filament::namespaceFor('Filament\\Resources\\Users\\UserResource'),
     ];
 
     $this->artisan('make:filament-resource', [

--- a/tests/src/Panels/Commands/MakeSettingsPageCommandTest.php
+++ b/tests/src/Panels/Commands/MakeSettingsPageCommandTest.php
@@ -8,7 +8,6 @@ use Carbon\CarbonInterface;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
-use Filament\Facades\Filament;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Arr;
 use Spatie\LaravelSettings\Settings as BaseSettings;
@@ -60,7 +59,7 @@ it('can generate a page class in a cluster', function (): void {
     $this->artisan('make:filament-settings-page', [
         'name' => 'ManageSettings',
         'settings' => Settings::class,
-        '--cluster' => Filament::namespaceFor('Filament\\Clusters\\Site\\SiteCluster'),
+        '--cluster' => app()->getNamespace() . 'Filament\\Clusters\\Site\\SiteCluster',
         '--panel' => 'admin',
         '--no-interaction' => true,
     ]);

--- a/tests/src/Panels/Commands/MakeSettingsPageCommandTest.php
+++ b/tests/src/Panels/Commands/MakeSettingsPageCommandTest.php
@@ -8,6 +8,7 @@ use Carbon\CarbonInterface;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
+use Filament\Facades\Filament;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Arr;
 use Spatie\LaravelSettings\Settings as BaseSettings;
@@ -59,7 +60,7 @@ it('can generate a page class in a cluster', function (): void {
     $this->artisan('make:filament-settings-page', [
         'name' => 'ManageSettings',
         'settings' => Settings::class,
-        '--cluster' => 'App\\Filament\\Clusters\\Site\\SiteCluster',
+        '--cluster' => Filament::namespaceFor('Filament\\Clusters\\Site\\SiteCluster'),
         '--panel' => 'admin',
         '--no-interaction' => true,
     ]);

--- a/tests/src/Tables/Commands/MakeTableCommandTest.php
+++ b/tests/src/Tables/Commands/MakeTableCommandTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Filament\Facades\Filament;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Arr;
 
@@ -76,7 +75,7 @@ it('can generate a table class with a model in a custom namespace', function ():
     $this->artisan('make:filament-table', [
         'name' => 'PostsTable',
         'model' => 'Post',
-        '--model-namespace' => Filament::namespaceFor('Models\\Blog'),
+        '--model-namespace' => app()->getNamespace() . 'Models\\Blog',
         '--no-interaction' => true,
     ]);
 

--- a/tests/src/Tables/Commands/MakeTableCommandTest.php
+++ b/tests/src/Tables/Commands/MakeTableCommandTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Filament\Facades\Filament;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Arr;
 
@@ -75,7 +76,7 @@ it('can generate a table class with a model in a custom namespace', function ():
     $this->artisan('make:filament-table', [
         'name' => 'PostsTable',
         'model' => 'Post',
-        '--model-namespace' => 'App\\Models\\Blog',
+        '--model-namespace' => Filament::namespaceFor('Models\\Blog'),
         '--no-interaction' => true,
     ]);
 

--- a/tests/src/Widgets/Commands/MakeWidgetCommandTest.php
+++ b/tests/src/Widgets/Commands/MakeWidgetCommandTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Filament\Facades\Filament;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Arr;
 
@@ -98,7 +97,7 @@ it('can generate a table widget class', function (): void {
         '--no-interaction' => true,
     ])
         ->expectsQuestion('Would you like to create this widget in a resource?', false)
-        ->expectsQuestion('What is the model?', Filament::namespaceFor('Models\\User'))
+        ->expectsQuestion('What is the model?', app()->getNamespace() . 'Models\\User')
         ->expectsQuestion('Should the table columns be generated from the current database columns?', false);
 
     assertFileExists($path = app_path('Filament/Widgets/TableWidget.php'));

--- a/tests/src/Widgets/Commands/MakeWidgetCommandTest.php
+++ b/tests/src/Widgets/Commands/MakeWidgetCommandTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Filament\Facades\Filament;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Arr;
 
@@ -97,7 +98,7 @@ it('can generate a table widget class', function (): void {
         '--no-interaction' => true,
     ])
         ->expectsQuestion('Would you like to create this widget in a resource?', false)
-        ->expectsQuestion('What is the model?', 'App\\Models\\User')
+        ->expectsQuestion('What is the model?', Filament::namespaceFor('Models\\User'))
         ->expectsQuestion('Should the table columns be generated from the current database columns?', false);
 
     assertFileExists($path = app_path('Filament/Widgets/TableWidget.php'));


### PR DESCRIPTION
## Description
Currently, filament does not allow for custom namespaces in (some) commands and defaults, like the make:filament-panel command, it will always use `App\\` as prefix. Some commands allow for a custom namespace to be provided as an option. When using a namespace different from `App\\`, for example when developing a plugin/package (which is my use case) it would be a real improvement DX wise. Laravel itself already allows for custom namespaces (and paths). 

## Visual changes
No visual changes

## Functional changes
This change makes filament use the namespace (prefix) from the laravel app-instance (`::getNamespace`) and uses it as default, replacing hardcoded `App\\` occurrences. ~~The namespace can also be set using the `::setRootNamespace` method on the FilamentManager (Filament facade).~~ ~~The class also provides a `namespaceFor` method: `Filament::namespaceFor('Models\\')`.~~

- [x] Code style has been fixed by running the `composer cs` command.
- [x] No failing tests
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

This PR introduces a not-small-amount of changes, but simple ones, review should be straight forward ❤️
