### PR TITLE
[4.X] Avoid loop when using EditAction inside a EditRecord page

### DIFF
--- a/packages/panels/src/Resources/Pages/Page.php
+++ b/packages/panels/src/Resources/Pages/Page.php
@@ -346,14 +346,16 @@ abstract class Page extends BasePage
 
         if (
             ($action instanceof EditAction) &&
-            (static::getResource()::hasPage('edit'))
+            (static::getResource()::hasPage('edit')) &&
+            (! $this instanceof EditRecord)
         ) {
             return $this->getResourceUrl('edit', ['record' => $action->getRecord()]);
         }
 
         if (
             ($action instanceof ViewAction) &&
-            (static::getResource()::hasPage('view'))
+            (static::getResource()::hasPage('view')) &&
+            (! $this instanceof ViewRecord)
         ) {
             return $this->getResourceUrl('view', ['record' => $action->getRecord()]);
         }


### PR DESCRIPTION
## Description

Currently, when using an EditAction within an EditRecord page, the action will just redirect you to the page you are already on. This happens because the resource page overrides the action’s URL, replacing it with the EditRecord page URL.

This PR introduces a safeguard to prevent the EditAction URL from being overridden when it’s already rendered inside an EditRecord page. The same logic is applied for ViewAction within a ViewRecord page.

This change enables the use of nested edit or view actions inside a EditRecord or ViewRecord page. For example, you can now include secondary edit actions for fields that are rarely updated, without causing redirect loops.

From my testing i have not found any scenarios where this implementation brakes any existing applications


## Example use case:
Updating a subset of fields in a separate edit action:
<img width="1343" height="855" alt="CleanShot 2025-08-06 at 15 27 59" src="https://github.com/user-attachments/assets/0107526f-52d4-4500-aa8e-27b224d5fd21" />


## Visual changes
No visual changes

## Functional changes
 - getDefaultActionUrl(Action $action) returns null if EditAction if rendered in an EditRecord page. 
 - getDefaultActionUrl(Action $action) returns null if ViewAction if rendered in an ViewReocrd page. 
   
- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
