### PR TITLE
Add HTML rendering support to ModalTableSelect labels

### DIFF
--- a/packages/forms/resources/views/components/modal-table-select.blade.php
+++ b/packages/forms/resources/views/components/modal-table-select.blade.php
@@ -6,6 +6,7 @@
     $id = $getId();
     $isDisabled = $isDisabled();
     $isMultiple = $isMultiple();
+    $isHtmlAllowed = $isHtmlAllowed();
 @endphp
 
 <x-dynamic-component :component="$fieldWrapperView" :field="$field">
@@ -28,7 +29,11 @@
                 <div class="fi-fo-modal-table-select-badges-ctn">
                     @foreach ($optionLabels as $optionLabel)
                         <x-filament::badge>
-                            {{ $optionLabel }}
+                            @if ($isHtmlAllowed)
+                                {!! $optionLabel !!}
+                            @else
+                                {{ $optionLabel }}
+                            @endif
                         </x-filament::badge>
                     @endforeach
                 </div>
@@ -45,7 +50,11 @@
             @endif
         @else
             @if (filled($optionLabel = $getOptionLabel()))
-                {{ $optionLabel }}
+                @if ($isHtmlAllowed)
+                    {!! $optionLabel !!}
+                @else
+                    {{ $optionLabel }}
+                @endif
             @elseif (filled($placeholder = $getPlaceholder()))
                 <div class="fi-fo-modal-table-select-placeholder">
                     {{ $placeholder }}

--- a/packages/forms/src/Components/ModalTableSelect.php
+++ b/packages/forms/src/Components/ModalTableSelect.php
@@ -25,6 +25,7 @@ use Znck\Eloquent\Relations\BelongsToThrough;
 
 class ModalTableSelect extends Field
 {
+    use Concerns\CanAllowHtml;
     use Concerns\CanLimitItemsLength;
     use Concerns\HasPivotData;
     use Concerns\HasPlaceholder;


### PR DESCRIPTION
## Description
Introduces the ability to render option labels as HTML in the ModalTableSelect component by using the CanAllowHtml concern and updating the Blade view to conditionally render HTML when allowed.

This is to have feature parity with Select Component which also has allow html for its option label

## Visual changes

Before
<img width="2522" height="820" alt="image" src="https://github.com/user-attachments/assets/14e63942-5cf2-4407-9823-a70159d71f7b" />

After
<img width="2626" height="874" alt="image" src="https://github.com/user-attachments/assets/42dec462-c8bd-4808-bffd-b7d8b7b41a88" />

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.

Documentation should be still the same with this section https://filamentphp.com/docs/4.x/forms/select#allowing-html-in-the-option-labels
