### PR TITLE
Add false to boolean icon allowing default icon to be disabled

### DIFF
--- a/packages/infolists/src/Components/IconEntry.php
+++ b/packages/infolists/src/Components/IconEntry.php
@@ -36,14 +36,14 @@ class IconEntry extends Entry implements HasEmbeddedView
      */
     protected string | array | Closure | null $falseColor = null;
 
-    protected string | BackedEnum | Closure | null $falseIcon = null;
+    protected string | BackedEnum | Closure | false | null $falseIcon = null;
 
     /**
      * @var string | array<string> | Closure | null
      */
     protected string | array | Closure | null $trueColor = null;
 
-    protected string | BackedEnum | Closure | null $trueIcon = null;
+    protected string | BackedEnum | Closure | false | null $trueIcon = null;
 
     protected IconSize | string | Closure | null $size = null;
 
@@ -59,7 +59,7 @@ class IconEntry extends Entry implements HasEmbeddedView
     /**
      * @param  string | array<int | string, string | int> | Closure | null  $color
      */
-    public function false(string | BackedEnum | Closure | null $icon = null, string | array | Closure | null $color = null): static
+    public function false(string | BackedEnum | Closure | false | null $icon = null, string | array | Closure | null $color = null): static
     {
         $this->falseIcon($icon);
         $this->falseColor($color);
@@ -78,7 +78,7 @@ class IconEntry extends Entry implements HasEmbeddedView
         return $this;
     }
 
-    public function falseIcon(string | BackedEnum | Closure | null $icon): static
+    public function falseIcon(string | BackedEnum | Closure | false | null $icon): static
     {
         $this->boolean();
         $this->falseIcon = $icon;
@@ -89,7 +89,7 @@ class IconEntry extends Entry implements HasEmbeddedView
     /**
      * @param  string | array<int | string, string | int> | Closure | null  $color
      */
-    public function true(string | BackedEnum | Closure | null $icon = null, string | array | Closure | null $color = null): static
+    public function true(string | BackedEnum | Closure | false | null $icon = null, string | array | Closure | null $color = null): static
     {
         $this->trueIcon($icon);
         $this->trueColor($color);
@@ -108,7 +108,7 @@ class IconEntry extends Entry implements HasEmbeddedView
         return $this;
     }
 
-    public function trueIcon(string | BackedEnum | Closure | null $icon): static
+    public function trueIcon(string | BackedEnum | Closure | false | null $icon): static
     {
         $this->boolean();
         $this->trueIcon = $icon;
@@ -175,9 +175,15 @@ class IconEntry extends Entry implements HasEmbeddedView
         return $this->evaluate($this->falseColor) ?? 'danger';
     }
 
-    public function getFalseIcon(): string | BackedEnum
+    public function getFalseIcon(): string | BackedEnum | null
     {
-        return $this->evaluate($this->falseIcon)
+        $icon = $this->evaluate($this->falseIcon);
+
+        if ($icon === false) {
+            return null;
+        }
+
+        return $icon
             ?? FilamentIcon::resolve(InfolistsIconAlias::COMPONENTS_ICON_ENTRY_FALSE)
             ?? Heroicon::OutlinedXCircle;
     }
@@ -190,9 +196,15 @@ class IconEntry extends Entry implements HasEmbeddedView
         return $this->evaluate($this->trueColor) ?? 'success';
     }
 
-    public function getTrueIcon(): string | BackedEnum
+    public function getTrueIcon(): string | BackedEnum | null
     {
-        return $this->evaluate($this->trueIcon)
+        $icon = $this->evaluate($this->trueIcon);
+
+        if ($icon === false) {
+            return null;
+        }
+
+        return $icon
             ?? FilamentIcon::resolve(InfolistsIconAlias::COMPONENTS_ICON_ENTRY_TRUE)
             ?? Heroicon::OutlinedCheckCircle;
     }
@@ -273,11 +285,17 @@ class IconEntry extends Entry implements HasEmbeddedView
         <div <?= $attributes->toHtml() ?>>
             <?php foreach ($state as $stateItem) { ?>
                 <?php
+                $icon = $this->getIcon($stateItem);
+
+                if (blank($icon)) {
+                    continue;
+                }
+
                 $color = $this->getColor($stateItem);
                 $size = $this->getSize($stateItem);
                 ?>
 
-                <?= generate_icon_html($this->getIcon($stateItem), attributes: (new ComponentAttributeBag)
+                <?= generate_icon_html($icon, attributes: (new ComponentAttributeBag)
                     ->merge([
                         'x-tooltip' => filled($tooltip = $this->getTooltip($stateItem))
                             ? '{

--- a/packages/tables/src/Columns/IconColumn.php
+++ b/packages/tables/src/Columns/IconColumn.php
@@ -37,14 +37,14 @@ class IconColumn extends Column implements HasEmbeddedView
      */
     protected string | array | Closure | null $falseColor = null;
 
-    protected string | BackedEnum | Closure | null $falseIcon = null;
+    protected string | BackedEnum | Closure | false | null $falseIcon = null;
 
     /**
      * @var string | array<string> | Closure | null
      */
     protected string | array | Closure | null $trueColor = null;
 
-    protected string | BackedEnum | Closure | null $trueIcon = null;
+    protected string | BackedEnum | Closure | false | null $trueIcon = null;
 
     protected bool | Closure $isListWithLineBreaks = false;
 
@@ -67,7 +67,7 @@ class IconColumn extends Column implements HasEmbeddedView
     /**
      * @param  string | array<int | string, string | int> | Closure | null  $color
      */
-    public function false(string | BackedEnum | Closure | null $icon = null, string | array | Closure | null $color = null): static
+    public function false(string | BackedEnum | Closure | false | null $icon = null, string | array | Closure | null $color = null): static
     {
         $this->falseIcon($icon);
         $this->falseColor($color);
@@ -86,7 +86,7 @@ class IconColumn extends Column implements HasEmbeddedView
         return $this;
     }
 
-    public function falseIcon(string | BackedEnum | Closure | null $icon): static
+    public function falseIcon(string | BackedEnum | Closure | false | null $icon): static
     {
         $this->boolean();
         $this->falseIcon = $icon;
@@ -97,7 +97,7 @@ class IconColumn extends Column implements HasEmbeddedView
     /**
      * @param  string | array<int | string, string | int> | Closure | null  $color
      */
-    public function true(string | BackedEnum | Closure | null $icon = null, string | array | Closure | null $color = null): static
+    public function true(string | BackedEnum | Closure | false | null $icon = null, string | array | Closure | null $color = null): static
     {
         $this->trueIcon($icon);
         $this->trueColor($color);
@@ -116,7 +116,7 @@ class IconColumn extends Column implements HasEmbeddedView
         return $this;
     }
 
-    public function trueIcon(string | BackedEnum | Closure | null $icon): static
+    public function trueIcon(string | BackedEnum | Closure | false | null $icon): static
     {
         $this->boolean();
         $this->trueIcon = $icon;
@@ -209,9 +209,15 @@ class IconColumn extends Column implements HasEmbeddedView
         return $this->evaluate($this->falseColor) ?? 'danger';
     }
 
-    public function getFalseIcon(): string | BackedEnum
+    public function getFalseIcon(): string | BackedEnum | null
     {
-        return $this->evaluate($this->falseIcon)
+        $icon = $this->evaluate($this->falseIcon);
+
+        if ($icon === false) {
+            return null;
+        }
+
+        return $icon
             ?? FilamentIcon::resolve(TablesIconAlias::COLUMNS_ICON_COLUMN_FALSE)
             ?? Heroicon::OutlinedXCircle;
     }
@@ -224,9 +230,15 @@ class IconColumn extends Column implements HasEmbeddedView
         return $this->evaluate($this->trueColor) ?? 'success';
     }
 
-    public function getTrueIcon(): string | BackedEnum
+    public function getTrueIcon(): string | BackedEnum | null
     {
-        return $this->evaluate($this->trueIcon)
+        $icon = $this->evaluate($this->trueIcon);
+
+        if ($icon === false) {
+            return null;
+        }
+
+        return $icon
             ?? FilamentIcon::resolve(TablesIconAlias::COLUMNS_ICON_COLUMN_TRUE)
             ?? Heroicon::OutlinedCheckCircle;
     }
@@ -301,11 +313,17 @@ class IconColumn extends Column implements HasEmbeddedView
         <div <?= $attributes->toHtml() ?>>
             <?php foreach ($state as $stateItem) { ?>
                 <?php
-                    $color = $this->getColor($stateItem);
+                $icon = $this->getIcon($stateItem);
+
+                if (blank($icon)) {
+                    continue;
+                }
+
+                $color = $this->getColor($stateItem);
                 $size = $this->getSize($stateItem);
                 ?>
 
-                <?= generate_icon_html($this->getIcon($stateItem), attributes: (new ComponentAttributeBag)
+                <?= generate_icon_html($icon, attributes: (new ComponentAttributeBag)
                     ->merge([
                         'x-tooltip' => filled($tooltip = $this->getTooltip($stateItem))
                             ? '{


### PR DESCRIPTION
Allow the ability to pass false to a boolean icon column/entry and not display the default icon. 

```php
IconColumn::make('featured')
    ->trueIcon('heroicon-o-star')
    ->falseIcon(false)
```

Before - no way of disabling the default icon
<img width="162" height="244" alt="Screenshot 2025-08-07 at 07 48 53" src="https://github.com/user-attachments/assets/74627c43-24ed-4b30-a7f6-67dea8d38e68" />

After
<img width="178" height="250" alt="Screenshot 2025-08-07 at 07 49 28" src="https://github.com/user-attachments/assets/14623255-415e-4bf2-9772-979691fb8bbd" />

Added `false` so that it does not affect previous behaviour, where both will still show the default icon.
```php
IconColumn::make('featured')
    ->trueIcon('heroicon-o-star'),
IconColumn::make('featured')
    ->trueIcon('heroicon-o-star')
    ->falseIcon(null)
```

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [] Documentation is up-to-date.
