### PR TITLE
Fix render HTML on option label in modal table select

### DIFF
--- a/packages/forms/src/Components/ModalTableSelect.php
+++ b/packages/forms/src/Components/ModalTableSelect.php
@@ -523,7 +523,7 @@ class ModalTableSelect extends Field
         return $this->getOptionLabelFromRecordUsing !== null;
     }
 
-    public function getOptionLabelFromRecord(Model $record): string | Htmlable | null
+    public function getOptionLabelFromRecord(Model $record): string | Htmlable
     {
         return $this->evaluate(
             $this->getOptionLabelFromRecordUsing,

--- a/packages/forms/src/Components/ModalTableSelect.php
+++ b/packages/forms/src/Components/ModalTableSelect.php
@@ -523,7 +523,7 @@ class ModalTableSelect extends Field
         return $this->getOptionLabelFromRecordUsing !== null;
     }
 
-    public function getOptionLabelFromRecord(Model $record): string
+    public function getOptionLabelFromRecord(Model $record): string | Htmlable | null
     {
         return $this->evaluate(
             $this->getOptionLabelFromRecordUsing,


### PR DESCRIPTION
## Description

Currently using HtmlString in getOptionLabelFromRecordUsing in Modal Table Select only render regular string instead of HTML

## Visual changes
Before
<img width="652" height="416" alt="image" src="https://github.com/user-attachments/assets/947e0c64-bb8d-4009-866f-7df17ca3735b" />
After
<img width="632" height="304" alt="image" src="https://github.com/user-attachments/assets/b14ffd3d-4ed0-4ef9-827a-cd9fac16892a" />

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
