### PR TITLE
Allow icon columns to display nothing

### DIFF
--- a/packages/tables/src/Columns/IconColumn.php
+++ b/packages/tables/src/Columns/IconColumn.php
@@ -315,7 +315,7 @@ class IconColumn extends Column implements HasEmbeddedView
                             : null,
                     ], escape: false)
                     ->color(IconComponent::class, $color), size: $size ?? IconSize::Large)
-                    ->toHtml() ?>
+                    ?->toHtml() ?>
             <?php } ?>
         </div>
 


### PR DESCRIPTION
## Description

There are situations where you may want to pass in a blank value for the state of an icon so that nothing shows when that condition is met. Take, for example, an `is_admin` column on a users table. You may not want to show a red x icon in almost every row when you only have a handful of admins.

Previously, v3 would allow you to pass an empty string or null to `IconColumn` and the column wouldn't render an icon. In v4, attempting to the do the same throws the following exception:

```
Call to a member function toHtml() on null
```

This fix provides some additional flexibility to allow a blank value if the developer so chooses.

## Visual changes

No visual changes. This simply allows for nothing to be rendered in the column if a blank value is passed in.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
