### PR TITLE
Fix PostgreSQL JSON field search syntax error (fixes #17237)

### DIFF
--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -165,10 +165,7 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
 
         $column = match ($driverName) {
             'pgsql' => (
-                str($column)->contains('->>')
-                    ? $column
-                    : (
-                        str($column)->contains('->')
+                str($column)->contains('->')
                             ? (
                                 // Handle `table.field` part with double quotes
                                 str($column)
@@ -178,6 +175,18 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
                                     ->implode('.')
                             ) . collect(str($column)->after('->')->explode('->')) // Handle JSON path parts
                                 ->map(function ($segment, $index) use ($column): string {
+                                    // if segment already contains '>something' (from ->> operator), preserve it
+                                    $isExplicitOperatorPrefixed = str($segment)->startsWith('>');
+                                    $segment = $isExplicitOperatorPrefixed ? (string) str($segment)->after('>') : $segment;
+
+                                    // Remove single quotes from segment if present to avoid redundant quoting
+                                    $isWrappedWithSingleQuotes = str($segment)->startsWith("'") && str($segment)->endsWith("'");
+                                    $segment = $isWrappedWithSingleQuotes ? (string) str($segment)->trim("'") : $segment;
+
+                                    if ($isExplicitOperatorPrefixed) {
+                                        return "->>'{$segment}'";
+                                    }
+
                                     $totalParts = substr_count($column, '->');
 
                                     return ($index === ($totalParts - 1))
@@ -189,7 +198,6 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
                                 ->explode('.')
                                 ->map(fn (string $part): string => (string) str($part)->wrap('"'))
                                 ->implode('.')
-                    )
             ) . '::text',
             default => $column,
         };

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -176,7 +176,7 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
                                     ->explode('.')
                                     ->map(fn (string $part): string => (string) str($part)->wrap('"'))
                                     ->implode('.')
-                            ).collect(str($column)->after('->')->explode('->')) // Handle JSON path parts
+                            ) . collect(str($column)->after('->')->explode('->')) // Handle JSON path parts
                                 ->map(function ($segment, $index) use ($column): string {
                                     $totalParts = substr_count($column, '->');
 
@@ -190,7 +190,7 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
                                 ->map(fn (string $part): string => (string) str($part)->wrap('"'))
                                 ->implode('.')
                     )
-            ).'::text',
+            ) . '::text',
             default => $column,
         };
 

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -165,28 +165,32 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
 
         $column = match ($driverName) {
             'pgsql' => (
-                str($column)->contains('->')
-                    ? (
-                        // Handle `table.field` part with double quotes
-                        str($column)
-                            ->before('->')
-                            ->explode('.')
-                            ->map(fn (string $part): string => (string) str($part)->wrap('"'))
-                            ->implode('.')
-                    ) . collect(str($column)->after('->')->explode('->')) // Handle JSON path parts
-                        ->map(function ($segment, $index) use ($column): string {
-                            $totalParts = substr_count($column, '->');
+                str($column)->contains('->>')
+                    ? $column
+                    : (
+                        str($column)->contains('->')
+                            ? (
+                                // Handle `table.field` part with double quotes
+                                str($column)
+                                    ->before('->')
+                                    ->explode('.')
+                                    ->map(fn (string $part): string => (string) str($part)->wrap('"'))
+                                    ->implode('.')
+                            ).collect(str($column)->after('->')->explode('->')) // Handle JSON path parts
+                                ->map(function ($segment, $index) use ($column): string {
+                                    $totalParts = substr_count($column, '->');
 
-                            return ($index === ($totalParts - 1))
-                                ? "->>'{$segment}'"
-                                : "->'{$segment}'";
-                        })
-                        ->implode('')
-                    : str($column)
-                        ->explode('.')
-                        ->map(fn (string $part): string => (string) str($part)->wrap('"'))
-                        ->implode('.')
-            ) . '::text',
+                                    return ($index === ($totalParts - 1))
+                                        ? "->>'{$segment}'"
+                                        : "->'{$segment}'";
+                                })
+                                ->implode('')
+                            : str($column)
+                                ->explode('.')
+                                ->map(fn (string $part): string => (string) str($part)->wrap('"'))
+                                ->implode('.')
+                    )
+            ).'::text',
             default => $column,
         };
 

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -175,7 +175,7 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
                                     ->implode('.')
                             ) . collect(str($column)->after('->')->explode('->')) // Handle JSON path parts
                                 ->map(function ($segment, $index) use ($column): string {
-                                    // if segment already contains '>something' (from ->> operator), preserve it
+                                    // If segment already starts with `>` (from `->>` operator), preserve it
                                     $isExplicitOperatorPrefixed = str($segment)->startsWith('>');
                                     $segment = $isExplicitOperatorPrefixed ? (string) str($segment)->after('>') : $segment;
 

--- a/tests/src/Support/helpersTest.php
+++ b/tests/src/Support/helpersTest.php
@@ -112,3 +112,67 @@ it('will generate a column expression for Postgres with colons in the table name
         ['blog:posts.title', 'lower("blog:posts"."title"::text)'],
         ['blog:posts:comments.author.name', 'lower("blog:posts:comments"."author"."name"::text)'],
     ]);
+
+it('will handle PostgreSQL columns that already contain ->> operator', function () {
+    $column = 'name->>\'ar\'';
+    $isSearchForcedCaseInsensitive = true;
+
+    $databaseConnection = Mockery::mock(Connection::class);
+    $databaseConnection->shouldReceive('getDriverName')->andReturn('pgsql');
+    $databaseConnection->shouldReceive('getConfig')->with('search_collation')->andReturn(null);
+
+    $grammar = new PostgresGrammar($databaseConnection);
+
+    $expression = generate_search_column_expression($column, $isSearchForcedCaseInsensitive, $databaseConnection);
+
+    expect($expression->getValue($grammar))
+        ->toBe("lower(name->>'ar'::text)");
+});
+
+it('will handle PostgreSQL columns with table prefix that already contain ->> operator', function () {
+    $column = 'products.name->>\'en\'';
+    $isSearchForcedCaseInsensitive = true;
+
+    $databaseConnection = Mockery::mock(Connection::class);
+    $databaseConnection->shouldReceive('getDriverName')->andReturn('pgsql');
+    $databaseConnection->shouldReceive('getConfig')->with('search_collation')->andReturn(null);
+
+    $grammar = new PostgresGrammar($databaseConnection);
+
+    $expression = generate_search_column_expression($column, $isSearchForcedCaseInsensitive, $databaseConnection);
+
+    expect($expression->getValue($grammar))
+        ->toBe("lower(products.name->>'en'::text)");
+});
+
+it('will handle PostgreSQL columns from relationships that already contain ->> operator', function () {
+    $column = 'categories.name->>\'ar\'';
+    $isSearchForcedCaseInsensitive = true;
+
+    $databaseConnection = Mockery::mock(Connection::class);
+    $databaseConnection->shouldReceive('getDriverName')->andReturn('pgsql');
+    $databaseConnection->shouldReceive('getConfig')->with('search_collation')->andReturn(null);
+
+    $grammar = new PostgresGrammar($databaseConnection);
+
+    $expression = generate_search_column_expression($column, $isSearchForcedCaseInsensitive, $databaseConnection);
+
+    expect($expression->getValue($grammar))
+        ->toBe("lower(categories.name->>'ar'::text)");
+});
+
+it('will handle PostgreSQL columns from nested relationships that already contain ->> operator', function () {
+    $column = 'categories.parent.name->>\'en\'';
+    $isSearchForcedCaseInsensitive = true;
+
+    $databaseConnection = Mockery::mock(Connection::class);
+    $databaseConnection->shouldReceive('getDriverName')->andReturn('pgsql');
+    $databaseConnection->shouldReceive('getConfig')->with('search_collation')->andReturn(null);
+
+    $grammar = new PostgresGrammar($databaseConnection);
+
+    $expression = generate_search_column_expression($column, $isSearchForcedCaseInsensitive, $databaseConnection);
+
+    expect($expression->getValue($grammar))
+        ->toBe("lower(categories.parent.name->>'en'::text)");
+});

--- a/tests/src/Support/helpersTest.php
+++ b/tests/src/Support/helpersTest.php
@@ -113,8 +113,8 @@ it('will generate a column expression for Postgres with colons in the table name
         ['blog:posts:comments.author.name', 'lower("blog:posts:comments"."author"."name"::text)'],
     ]);
 
-it('will handle PostgreSQL columns that already contain ->> operator', function () {
-    $column = 'name->>\'ar\'';
+it('will generate a JSON search column expression for Postgres with explicit ->> operator', function () {
+    $column = 'data->>name';
     $isSearchForcedCaseInsensitive = true;
 
     $databaseConnection = Mockery::mock(Connection::class);
@@ -126,11 +126,11 @@ it('will handle PostgreSQL columns that already contain ->> operator', function 
     $expression = generate_search_column_expression($column, $isSearchForcedCaseInsensitive, $databaseConnection);
 
     expect($expression->getValue($grammar))
-        ->toBe("lower(name->>'ar'::text)");
+        ->toBe("lower(\"data\"->>'name'::text)");
 });
 
-it('will handle PostgreSQL columns with table prefix that already contain ->> operator', function () {
-    $column = 'products.name->>\'en\'';
+it('will generate a nested JSON search column expression for Postgres with explicit ->> operator on the last segment', function () {
+    $column = 'data->name->>ar';
     $isSearchForcedCaseInsensitive = true;
 
     $databaseConnection = Mockery::mock(Connection::class);
@@ -142,11 +142,11 @@ it('will handle PostgreSQL columns with table prefix that already contain ->> op
     $expression = generate_search_column_expression($column, $isSearchForcedCaseInsensitive, $databaseConnection);
 
     expect($expression->getValue($grammar))
-        ->toBe("lower(products.name->>'en'::text)");
+        ->toBe("lower(\"data\"->'name'->>'ar'::text)");
 });
 
-it('will handle PostgreSQL columns from relationships that already contain ->> operator', function () {
-    $column = 'categories.name->>\'ar\'';
+it('will generate a JSON search column expression for Postgres with explicit ->> operator and simple key', function () {
+    $column = 'name->>\'en\'';
     $isSearchForcedCaseInsensitive = true;
 
     $databaseConnection = Mockery::mock(Connection::class);
@@ -158,21 +158,5 @@ it('will handle PostgreSQL columns from relationships that already contain ->> o
     $expression = generate_search_column_expression($column, $isSearchForcedCaseInsensitive, $databaseConnection);
 
     expect($expression->getValue($grammar))
-        ->toBe("lower(categories.name->>'ar'::text)");
-});
-
-it('will handle PostgreSQL columns from nested relationships that already contain ->> operator', function () {
-    $column = 'categories.parent.name->>\'en\'';
-    $isSearchForcedCaseInsensitive = true;
-
-    $databaseConnection = Mockery::mock(Connection::class);
-    $databaseConnection->shouldReceive('getDriverName')->andReturn('pgsql');
-    $databaseConnection->shouldReceive('getConfig')->with('search_collation')->andReturn(null);
-
-    $grammar = new PostgresGrammar($databaseConnection);
-
-    $expression = generate_search_column_expression($column, $isSearchForcedCaseInsensitive, $databaseConnection);
-
-    expect($expression->getValue($grammar))
-        ->toBe("lower(categories.parent.name->>'en'::text)");
+        ->toBe("lower(\"name\"->>'en'::text)");
 });


### PR DESCRIPTION
## Description
This PR fixes a bug with searching JSON fields in PostgreSQL. Before, search did not work and gave an error. Now, it works again.

**Fixes #17237**

- The problem started in version 3.3.31.
- The fix checks if the column already has `->>` and does not change it again.
- No changes for MySQL, SQLite, or SQL Server.

## Visual changes
No visual changes

## Functional changes
- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
