### PR TITLE
fix helper text color in dark mode

### DIFF
--- a/packages/forms/resources/views/components/field-wrapper/helper-text.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/helper-text.blade.php
@@ -1,5 +1,5 @@
 <div
-    {{ $attributes->class(['fi-fo-field-wrp-helper-text break-words text-sm text-gray-500']) }}
+    {{ $attributes->class(['fi-fo-field-wrp-helper-text break-words text-sm text-gray-500 dark:text-gray-400']) }}
 >
     {{ $slot }}
 </div>

--- a/packages/infolists/resources/views/components/entry-wrapper/helper-text.blade.php
+++ b/packages/infolists/resources/views/components/entry-wrapper/helper-text.blade.php
@@ -1,5 +1,5 @@
 <div
-    {{ $attributes->class(['fi-in-entry-wrp-helper-text break-words text-sm text-gray-500']) }}
+    {{ $attributes->class(['fi-in-entry-wrp-helper-text break-words text-sm text-gray-500 dark:text-gray-400']) }}
 >
     {{ $slot }}
 </div>


### PR DESCRIPTION
## Description

Add dark mode color for helper text

## Visual changes

Before (dark):
<img width="418" height="98" alt="helper-text--before" src="https://github.com/user-attachments/assets/8c69c07a-b3ae-489d-b23b-7b355081b729" />
After (dark)
<img width="418" height="98" alt="helper-text--after" src="https://github.com/user-attachments/assets/338948d6-1a42-4af3-9e84-49355a2c9987" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
