### PR TITLE
fix hint label color in dark mode

### DIFF
--- a/packages/forms/resources/views/components/field-wrapper/hint.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/hint.blade.php
@@ -17,7 +17,7 @@
             @class([
                 'fi-fo-field-wrp-hint-label',
                 match ($color) {
-                    'gray' => 'text-gray-500',
+                    'gray' => 'text-gray-500 dark:text-gray-400',
                     default => 'fi-color-custom text-custom-600 dark:text-custom-400',
                 },
                 is_string($color) ? "fi-color-{$color}" : null,

--- a/packages/infolists/resources/views/components/entry-wrapper/hint.blade.php
+++ b/packages/infolists/resources/views/components/entry-wrapper/hint.blade.php
@@ -17,7 +17,7 @@
             @class([
                 'fi-in-entry-wrp-hint-label',
                 match ($color) {
-                    'gray' => 'text-gray-500',
+                    'gray' => 'text-gray-500 dark:text-gray-400',
                     default => 'fi-color-custom text-custom-600 dark:text-custom-400',
                 },
                 is_string($color) ? "fi-color-{$color}" : null,


### PR DESCRIPTION
## Description

Add dark mode color for hint labels

## Visual changes

Before (dark):
<img width="484" height="96" alt="hint-label-dark-mode--before" src="https://github.com/user-attachments/assets/a7179c95-774b-4e65-9118-798b86f08502" />
After (dark):
<img width="484" height="96" alt="hint-label-dark-mode--after" src="https://github.com/user-attachments/assets/258c3bc5-0e8b-41fb-9bc5-119a22211336" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
