### PR TITLE
Add missing SK & CZ translations

### DIFF
--- a/packages/forms/resources/lang/cs/components.php
+++ b/packages/forms/resources/lang/cs/components.php
@@ -594,6 +594,11 @@ return [
 
         'actions' => [
 
+            'copy' => [
+                'label' => 'Kopírovat',
+                'message' => 'Zkopírováno',
+            ],
+
             'hide_password' => [
                 'label' => 'Skrýt heslo',
             ],

--- a/packages/forms/resources/lang/sk/components.php
+++ b/packages/forms/resources/lang/sk/components.php
@@ -594,6 +594,11 @@ return [
 
         'actions' => [
 
+            'copy' => [
+                'label' => 'Kopírovať',
+                'message' => 'Skopírované',
+            ],
+
             'hide_password' => [
                 'label' => 'Skryť heslo',
             ],

--- a/packages/panels/resources/lang/cs/resources/pages/edit-record.php
+++ b/packages/panels/resources/lang/cs/resources/pages/edit-record.php
@@ -6,6 +6,8 @@ return [
 
     'breadcrumb' => 'Upravit',
 
+    'navigation_label' => 'Upravit',
+
     'form' => [
 
         'actions' => [

--- a/packages/panels/resources/lang/cs/resources/pages/manage-related-records.php
+++ b/packages/panels/resources/lang/cs/resources/pages/manage-related-records.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+
+    'title' => 'Spravovat :label :relationship',
+];

--- a/packages/panels/resources/lang/cs/resources/pages/view-record.php
+++ b/packages/panels/resources/lang/cs/resources/pages/view-record.php
@@ -6,6 +6,8 @@ return [
 
     'breadcrumb' => 'Zobrazit',
 
+    'navigation_label' => 'Zobrazit',
+
     'content' => [
 
         'tab' => [

--- a/packages/panels/resources/lang/sk/resources/pages/edit-record.php
+++ b/packages/panels/resources/lang/sk/resources/pages/edit-record.php
@@ -6,6 +6,8 @@ return [
 
     'breadcrumb' => 'Upraviť',
 
+    'navigation_label' => 'Upraviť',
+
     'form' => [
 
         'actions' => [

--- a/packages/panels/resources/lang/sk/resources/pages/manage-related-records.php
+++ b/packages/panels/resources/lang/sk/resources/pages/manage-related-records.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+
+    'title' => 'Spravovať :label :relationship',
+];

--- a/packages/panels/resources/lang/sk/resources/pages/view-record.php
+++ b/packages/panels/resources/lang/sk/resources/pages/view-record.php
@@ -6,6 +6,8 @@ return [
 
     'breadcrumb' => 'Detail',
 
+    'navigation_label' => 'Detail',
+
     'content' => [
 
         'tab' => [

--- a/packages/tables/resources/lang/cs/table.php
+++ b/packages/tables/resources/lang/cs/table.php
@@ -26,6 +26,20 @@ return [
             'label' => 'Akce|Akce',
         ],
 
+        'select' => [
+
+            'loading_message' => 'Načítává se...',
+
+            'no_search_results_message' => 'Žádné možnosti neodpovídají vašemu hledání.',
+
+            'placeholder' => 'Vyberte možnost',
+
+            'searching_message' => 'Vyhledává se...',
+
+            'search_prompt' => 'Začněte psát pro vyhledávání...',
+
+        ],
+
         'text' => [
 
             'actions' => [
@@ -185,7 +199,6 @@ return [
 
             'group' => [
                 'label' => 'Seskupit podle',
-                'placeholder' => 'Seskupit podle',
             ],
 
             'direction' => [

--- a/packages/tables/resources/lang/sk/table.php
+++ b/packages/tables/resources/lang/sk/table.php
@@ -26,6 +26,20 @@ return [
             'label' => 'Akcia|Akcie',
         ],
 
+        'select' => [
+
+            'loading_message' => 'Načítava sa...',
+
+            'no_search_results_message' => 'Žiadne možnosti nezodpovedajú vášmu vyhľadávaniu.',
+
+            'placeholder' => 'Vyberte možnosť',
+
+            'searching_message' => 'Vyhľadáva sa...',
+
+            'search_prompt' => 'Začnite písať pre vyhľadávanie...',
+
+        ],
+
         'text' => [
 
             'actions' => [
@@ -186,7 +200,6 @@ return [
 
             'group' => [
                 'label' => 'Zoskupiť podľa',
-                'placeholder' => 'Zoskupiť podľa',
             ],
 
             'direction' => [


### PR DESCRIPTION
## Description

Add missing SK & CZ translations in forms, panels and tables.

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
