### PR TITLE
fix: add helper methods to get Livewire ID

### DIFF
--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -12,6 +12,7 @@
     $options = $getOptions();
     $livewireKey = $getLivewireKey();
     $wireModelAttribute = $applyStateBindingModifiers('wire:model');
+    $livewireId = $getLivewireId();
 @endphp
 
 <x-dynamic-component :component="$fieldWrapperView" :field="$field">
@@ -19,8 +20,8 @@
         x-load
         x-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('checkbox-list', 'filament/forms') }}"
         x-data="checkboxListFormComponent({
-                    livewireId: @js($this->getId()),
-                })"
+            livewireId: @js($livewireId),
+        })"
         {{ $getExtraAlpineAttributeBag()->class(['fi-fo-checkbox-list']) }}
     >
         @if (! $isDisabled)

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -20,8 +20,8 @@
         x-load
         x-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('checkbox-list', 'filament/forms') }}"
         x-data="checkboxListFormComponent({
-            livewireId: @js($livewireId),
-        })"
+                    livewireId: @js($livewireId),
+                })"
         {{ $getExtraAlpineAttributeBag()->class(['fi-fo-checkbox-list']) }}
     >
         @if (! $isDisabled)

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -26,6 +26,7 @@
     $statePath = $getStatePath();
     $state = $getState();
     $livewireKey = $getLivewireKey();
+    $livewireId = $getLivewireId();
 @endphp
 
 <x-dynamic-component
@@ -161,7 +162,7 @@
                             isDisabled: @js($isDisabled),
                             isMultiple: @js($isMultiple),
                             isSearchable: @js($isSearchable),
-                            livewireId: @js($this->getId()),
+                            livewireId: @js($livewireId),
                             hasDynamicOptions: @js($hasDynamicOptions()),
                             hasDynamicSearchResults: @js($hasDynamicSearchResults()),
                             loadingMessage: @js($getLoadingMessage()),

--- a/packages/schemas/src/Components/Concerns/BelongsToContainer.php
+++ b/packages/schemas/src/Components/Concerns/BelongsToContainer.php
@@ -37,8 +37,13 @@ trait BelongsToContainer
         })();
     }
 
-    public function getLivewire(): Component & HasSchemas
+    public function getLivewire(): Component&HasSchemas
     {
         return $this->getContainer()->getLivewire();
+    }
+
+    public function getLivewireId(): string
+    {
+        return $this->getLivewire()->getId();
     }
 }

--- a/packages/schemas/src/Components/Concerns/BelongsToContainer.php
+++ b/packages/schemas/src/Components/Concerns/BelongsToContainer.php
@@ -37,7 +37,7 @@ trait BelongsToContainer
         })();
     }
 
-    public function getLivewire(): Component&HasSchemas
+    public function getLivewire(): Component & HasSchemas
     {
         return $this->getContainer()->getLivewire();
     }

--- a/packages/schemas/src/Concerns/BelongsToLivewire.php
+++ b/packages/schemas/src/Concerns/BelongsToLivewire.php
@@ -7,17 +7,22 @@ use Livewire\Component;
 
 trait BelongsToLivewire
 {
-    protected (Component & HasSchemas) | null $livewire = null;
+    protected (Component&HasSchemas)|null $livewire = null;
 
-    public function livewire((Component & HasSchemas) | null $livewire = null): static
+    public function livewire((Component&HasSchemas)|null $livewire = null): static
     {
         $this->livewire = $livewire;
 
         return $this;
     }
 
-    public function getLivewire(): Component & HasSchemas
+    public function getLivewire(): Component&HasSchemas
     {
         return $this->livewire;
+    }
+
+    public function getLivewireId(): string
+    {
+        return $this->getLivewire()->getId();
     }
 }

--- a/packages/schemas/src/Concerns/BelongsToLivewire.php
+++ b/packages/schemas/src/Concerns/BelongsToLivewire.php
@@ -7,16 +7,16 @@ use Livewire\Component;
 
 trait BelongsToLivewire
 {
-    protected (Component&HasSchemas)|null $livewire = null;
+    protected (Component & HasSchemas) | null $livewire = null;
 
-    public function livewire((Component&HasSchemas)|null $livewire = null): static
+    public function livewire((Component & HasSchemas) | null $livewire = null): static
     {
         $this->livewire = $livewire;
 
         return $this;
     }
 
-    public function getLivewire(): Component&HasSchemas
+    public function getLivewire(): Component & HasSchemas
     {
         return $this->livewire;
     }


### PR DESCRIPTION
This pull request adds helper methods for schema fields to get the livewire id to avoid using `$this` in non object context.

## Problem

Fields like Select and CheckboxList, use `$this` object to get the Livewire ID. When passing these two fields to a custom Filter, the `$this` object is not available in the view files where it gets the Livewire ID using `$this->getId()`. Therefore, it throws an exception.

**Example:**

```php
Filter::make('name')
    ->schema([
        Select::make('operator')
            ->label('Operator')
            ->options([
                'contains' => 'Contains',
                'starts_with' => 'Starts with',
                'ends_with' => 'Ends with',
                'equals' => 'Equals',
                'not_contains' => 'Does not contain',
            ])
            ->default('contains')
            ->live()
            ->required(),
        TextInput::make('name'),
    ])
```

## Solution

This pull request adds helper methods for schema fields to get the Livewire ID to avoid using `$this` in non object context. So, now instead of using `$this->getId()`, now we can use `$getLivewireId()`.
