### PR TITLE
Fix incorrect table configuration class in `ModalTableSelect` arguments example in docs

### DIFF
--- a/packages/forms/docs/03-select.md
+++ b/packages/forms/docs/03-select.md
@@ -957,7 +957,7 @@ use Filament\Tables\Columns\TextColumn;
 use Illuminate\Database\Eloquent\Builder;
 use Filament\Tables\Table;
 
-class EmployeesTable
+class ProductsTable
 {
     public static function configure(Table $table): Table
     {


### PR DESCRIPTION
## Description

In #17093, I've committed the incorrect name for the table configuration class in the documentation. It should be ProductsTable instead of EmployeesTable, as that's what's referenced above.

