### PR TITLE
Fix updating table grouping

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -275,6 +275,9 @@
 
                                 $watch('grouping', function () {
                                     if (! grouping) {
+                                        group = null
+                                        direction = null
+                                        
                                         return
                                     }
 
@@ -300,7 +303,7 @@
                                         return
                                     }
 
-                                    direction = 'asc'
+                                    direction ??= 'asc'
                                     grouping = group ? `${group}:${direction}` : null
                                 })
                             "


### PR DESCRIPTION
This PR fixes two issues when internally updating the table grouping as Advanced Tables can do:

1. After applying a table grouping and direction if you then internally set `this->tableGrouping` to null to reset it, the UI group select/direction is not reset due to the early return.
2. If you internally set `$this->tableGrouping = 'country:desc'`, the direction is overridden as the direction is forced to `asc`.