### PR TITLE
fix: Remove redundant column prefixing in table summaries

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -277,7 +277,7 @@
                                     if (! grouping) {
                                         group = null
                                         direction = null
-                                        
+
                                         return
                                     }
 

--- a/packages/tables/src/Concerns/CanSummarizeRecords.php
+++ b/packages/tables/src/Concerns/CanSummarizeRecords.php
@@ -43,10 +43,7 @@ trait CanSummarizeRecords
                 continue;
             }
 
-            /** @var Connection $queryConnection */
-            $queryConnection = $query->getConnection();
-
-            $qualifiedAttribute = $queryConnection->getTablePrefix() . $query->getModel()->qualifyColumn($column->getName());
+            $qualifiedAttribute = $query->getModel()->qualifyColumn($column->getName());
 
             foreach ($summarizers as $summarizer) {
                 if ($summarizer->hasQueryModification()) {

--- a/packages/tables/src/Concerns/CanSummarizeRecords.php
+++ b/packages/tables/src/Concerns/CanSummarizeRecords.php
@@ -4,7 +4,6 @@ namespace Filament\Tables\Concerns;
 
 use Closure;
 use Filament\Support\Services\RelationshipJoiner;
-use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Str;

--- a/packages/upgrade/src/Commands/UpgradeDirectoryStructureToV4Command.php
+++ b/packages/upgrade/src/Commands/UpgradeDirectoryStructureToV4Command.php
@@ -262,7 +262,6 @@ class UpgradeDirectoryStructureToV4Command extends Command
     }
 
     /**
-     * @param  string  $directory
      * @return array<int, string>
      */
     protected function findPhpFiles(string $directory): array


### PR DESCRIPTION
- Reverts PR #10420 changes in CanSummarizeRecords.php
- In Filament v4, columns are now prefixed inside the getSelectStatements() method
- Eliminates duplicate prefixing that caused SQL query issues
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR reverts changes from PR #10420 in the `CanSummarizeRecords.php` file to fix redundant column prefixing in table summaries. In Filament v4, columns are now automatically prefixed inside the `getSelectStatements()` method of summarizers, making the external `qualifyColumn()` call redundant and causing SQL queries to generate invalid column references with duplicate table prefixes.

This revert fixes the issue #17210.

## Visual changes

No visual changes - this is a backend fix that resolves SQL query generation issues.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

The fix ensures that table summary queries generate properly formatted SQL without redundant column prefixes, maintaining compatibility with Filament v4's improved column handling system.