### PR TITLE
fix: add Spanish translation for restored_none.title

### DIFF
--- a/packages/actions/resources/lang/es/restore.php
+++ b/packages/actions/resources/lang/es/restore.php
@@ -61,7 +61,7 @@ return [
             ],
 
             'restored_none' => [
-                'title' => 'Failed to restore',
+                'title' => 'Ningún registro restaurado',
                 'missing_authorization_failure_message' => 'Usted no tiene permiso para restaurar :count.',
                 'missing_processing_failure_message' => ':count no se pudieron restaurar.',
             ],


### PR DESCRIPTION
## Description

Locale: **es** · Package: **actions**

Fix a leftover English string in the Spanish locale for the **Restore** action.

- **Key:** `restored_none.title`  
- **Change:** `"Failed to restore"` → `"Ningún registro restaurado"`  
- **Rationale:** Keep consistency with the rest of the Spanish messages (“Registro restaurado” / “Registros restaurados”) and provide a clear, natural title when no records are restored.

**File touched** (may vary depending on repository structure):
- `packages/actions/resources/lang/es/restore.php`

---

## Visual changes

Text-only change (no UI or layout modifications).

**Before**
```php
'restored_none' => [
    'title' => 'Failed to restore',
    // ...
]
```
**Before**
```
'restored_none' => [
    'title' => 'Ningún registro restaurado',
    // ...
]
```

## Functional changes
- ** No functional changes.
- ** No API changes.
- ** No documentation impact.
