### PR TITLE
fix: added panel render hooks even if user menu has profile header

### DIFF
--- a/packages/panels/resources/views/components/user-menu.blade.php
+++ b/packages/panels/resources/views/components/user-menu.blade.php
@@ -51,9 +51,11 @@
         @endphp
 
         {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::USER_MENU_PROFILE_BEFORE) }}
+
         <x-filament::dropdown.header :color="$itemColor" :icon="$itemIcon">
             {{ $item->getLabel() }}
         </x-filament::dropdown.header>
+
         {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::USER_MENU_PROFILE_AFTER) }}
     @endif
 

--- a/packages/panels/resources/views/components/user-menu.blade.php
+++ b/packages/panels/resources/views/components/user-menu.blade.php
@@ -50,9 +50,11 @@
             unset($itemsBeforeThemeSwitcher['profile']);
         @endphp
 
+        {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::USER_MENU_PROFILE_BEFORE) }}
         <x-filament::dropdown.header :color="$itemColor" :icon="$itemIcon">
             {{ $item->getLabel() }}
         </x-filament::dropdown.header>
+        {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::USER_MENU_PROFILE_AFTER) }}
     @endif
 
     @if ($itemsBeforeThemeSwitcher->isNotEmpty())


### PR DESCRIPTION
## Description

Add the render hooks for when the user menu has the profile header (as they otherwise wont be called due to the unset).

Since upgrading to Filament v4, my render hooks that I was previously using have seized to function. This PR restores the functionality that I had previously.

## Why

In Filament v4, the `profile` key in `$itemsBeforeThemeSwitcher` is unset in favour of a dropdown header that is labelled.

This results in the loop that should then call the render hooks **_never_** activating on the profile key:

```blade
@foreach ($itemsBeforeThemeSwitcher as $key => $item)
    @if ($key === 'profile') {{-- this will never be trigger as profile has been unset if $hasProfileHeader is true  --}}
        {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::USER_MENU_PROFILE_BEFORE) }}

        {{ $item }}

        {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::USER_MENU_PROFILE_AFTER) }}
    @else
        {{ $item }}
    @endif
@endforeach
```

This PR restores this functionality by wrapping these hooks to around the dropdown header as well.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command. *
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.


_\* I have run the cs command -> it changed files not relevant to this PR, and so I haven't committed those:_
`packages/actions/resources/lang/it/delete.php`
`packages/actions/resources/lang/it/restore.php`