### PR TITLE
fix: allow getting tenant menu items even if the tenant menu has been…

### DIFF
--- a/packages/panels/src/Livewire/Concerns/HasTenantMenu.php
+++ b/packages/panels/src/Livewire/Concerns/HasTenantMenu.php
@@ -10,7 +10,7 @@ trait HasTenantMenu
     /**
      * @var array<Action>
      */
-    protected array $tenantMenuItems = [];
+    protected ?array $tenantMenuItems = null;
 
     public function bootHasTenantMenu(): void
     {
@@ -36,6 +36,11 @@ trait HasTenantMenu
      */
     protected function getTenantMenuItems(): array
     {
+        if (! isset($this->tenantMenuItems)) {
+            // If tenant menu items are not set, fetch them from Filament
+            $this->tenantMenuItems = Filament::getTenantMenuItems();
+        }
+
         return $this->tenantMenuItems;
     }
 }

--- a/packages/panels/src/Livewire/Concerns/HasTenantMenu.php
+++ b/packages/panels/src/Livewire/Concerns/HasTenantMenu.php
@@ -10,7 +10,7 @@ trait HasTenantMenu
     /**
      * @var array<Action>
      */
-    protected ?array $tenantMenuItems = null;
+    protected array $tenantMenuItems = [];
 
     public function bootHasTenantMenu(): void
     {

--- a/packages/panels/src/Livewire/Concerns/HasTenantMenu.php
+++ b/packages/panels/src/Livewire/Concerns/HasTenantMenu.php
@@ -8,14 +8,17 @@ use Filament\Facades\Filament;
 trait HasTenantMenu
 {
     /**
-     * @var array<Action>
+     * @var ?array<Action>
      */
-    protected array $tenantMenuItems = [];
+    protected ?array $tenantMenuItems;
 
-    public function bootHasTenantMenu(): void
+    /**
+     * @return array<Action>
+     */
+    protected function getTenantMenuItems(): array
     {
-        if (! Filament::hasTenancy()) {
-            return;
+        if (isset($this->tenantMenuItems)) {
+            return $this->tenantMenuItems;
         }
 
         $this->tenantMenuItems = Filament::getTenantMenuItems();
@@ -25,13 +28,7 @@ trait HasTenantMenu
 
             $this->cacheAction($action);
         }
-    }
 
-    /**
-     * @return array<Action>
-     */
-    protected function getTenantMenuItems(): array
-    {
         return $this->tenantMenuItems;
     }
 }

--- a/packages/panels/src/Livewire/Concerns/HasTenantMenu.php
+++ b/packages/panels/src/Livewire/Concerns/HasTenantMenu.php
@@ -18,10 +18,6 @@ trait HasTenantMenu
             return;
         }
 
-        if (! Filament::hasTenantMenu()) {
-            return;
-        }
-
         $this->tenantMenuItems = Filament::getTenantMenuItems();
 
         foreach ($this->tenantMenuItems as $action) {
@@ -36,11 +32,6 @@ trait HasTenantMenu
      */
     protected function getTenantMenuItems(): array
     {
-        if (! isset($this->tenantMenuItems)) {
-            // If tenant menu items are not set, fetch them from Filament
-            $this->tenantMenuItems = Filament::getTenantMenuItems();
-        }
-
         return $this->tenantMenuItems;
     }
 }


### PR DESCRIPTION
… disabled

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

In Filament v4, if you load the tenant menu and you have done `->tenantMenu(false)` in your panel configuration, the register tenant button will not show.

I assume this was intended as a performance fix, but it regressed functionality, making filament that little bit less customizable.

This allows the tenant menu items to be fetched even if the tenant menu is disabled, while still not affecting the performance of those who do not with to show the menu anywhere.

## Why

For my application, I use the render hooks in order to inject the tenant menu into the user menu items. I don't want it to register in the default location, so I did `tenantMenu(false)` to disable it.

In Filament v3, this worked fine, I could call upon the livewire component in a blade template and register this blade template in a Render Hook, in order to then show.

However, in Filament v4, this stopped working. The dropdown would show with the tenant selector, however the register tenant item would not.

I traced the issue to this problem, and have instead allowed the possibility of lazy-loading the menu items _if they should be called upon_

## Visual changes

Before:
<img width="289" height="142" alt="image" src="https://github.com/user-attachments/assets/f48e2b04-7699-4df4-8e3f-4fd70cb854fc" />


After:

<img width="226" height="172" alt="image" src="https://github.com/user-attachments/assets/369f3403-1f57-4735-811f-2281ce007f7c" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
