### PR TITLE
fix removeTableFilters to work with nested form filters

### DIFF
--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -37,10 +37,10 @@ trait HasFilters
             ->schema($table->getFiltersFormSchema())
             ->when(
                 $table->hasDeferredFilters(),
-                fn (Schema $schema) => $schema
+                fn(Schema $schema) => $schema
                     ->statePath('tableDeferredFilters')
                     ->partiallyRender(),
-                fn (Schema $schema) => $schema
+                fn(Schema $schema) => $schema
                     ->statePath('tableFilters')
                     ->live(),
             );
@@ -76,7 +76,8 @@ trait HasFilters
         $filter = $this->getTable()->getFilter($filterName);
         $filterResetState = $filter->getResetState();
 
-        $filterFormGroup = $this->getTableFiltersForm()->getComponent($filterName);
+        $filterFormGroup = $this->getTableFiltersForm()
+            ->getComponent(fn($value, $key) => preg_match("/(?:\.|^)$filterName\$/", $key));
 
         if (($filter instanceof QueryBuilder) && blank($field)) {
             $filterFormGroup->getChildSchema()->fill();


### PR DESCRIPTION
## Description
See #17298 for my full bug report. 

Heart of the issue is table filters that are nested inside a section are throwing an error when trying to remove them.

The problem is [removeTableFilters](https://github.com/filamentphp/filament/blob/f00683622449f11c19fccdd02b13a23dfc67c924/packages/tables/src/Concerns/HasFilters.php#L74) uses the name of the filter to find the filter component within the TableFiltersForm. When a filter is placed inside a section, the name of the filter is prefixed with the sections name as well. This causes the filter name to not match its form component, causing the exception.

To fix, I used a regex expression to find components instead of just matching the filter name. 
```
"/(?:\.|^)$filterName\$/"
```
This will match to any filter key that is just the filter name, or has a prefix and the key ends with ".filter_name". Hopefully this pattern is specific enough to not cause issues with a filters who's name is a substring of another filter.

## Functional changes

- [x] HasFilters removeTableFilter now matches filter name and key with a regex
- [x] Changes have been tested to not break existing functionality.
- [x] Unit tests all passing
- [x] Linted with pint
