### PR TITLE
Add --dev flag to remove script in upgrade guide

### DIFF
--- a/docs/14-upgrade-guide.md
+++ b/docs/14-upgrade-guide.md
@@ -75,7 +75,7 @@ php artisan filament:upgrade-directory-structure-to-v4
     This directory upgrade script is not able to perfectly update any references to classes in the same namespace that were present in resource and cluster files, and those references will need to be updated manually after the script has run. You should use tools like [PHPStan](https://phpstan.org) to identify references to classes that are broken after the upgrade.
 </Aside>
 
-You can now `composer remove filament/upgrade` as you don't need it anymore.
+You can now `composer remove filament/upgrade --dev` as you don't need it anymore.
 
 ## Publishing the configuration file
 


### PR DESCRIPTION
Add --dev flag to composer remove filament/upgrade

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

If following the guide, the filament/upgrade library will be added to require-dev. But in the guide the remove script doesn't include the --dev flag so it will trigger a confirmation when removing.
This commit adds the --dev flag to the guide

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
