### PR TITLE
Resolve `BroadcastNotification` from container and forward configuration

### DIFF
--- a/packages/notifications/src/BroadcastNotification.php
+++ b/packages/notifications/src/BroadcastNotification.php
@@ -33,6 +33,8 @@ class BroadcastNotification extends BaseNotification implements ShouldQueue
      */
     public function toBroadcast($notifiable): BroadcastMessage
     {
-        return new BroadcastMessage($this->data);
+        return (new BroadcastMessage($this->data))
+            ->onConnection($this->connection)
+            ->onQueue($this->queue);
     }
 }

--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -205,7 +205,7 @@ class Notification extends ViewComponent implements Arrayable, HasEmbeddedView
         $data = $this->toArray();
         $data['format'] = 'filament';
 
-        return new BroadcastNotification($data);
+        return app(BroadcastNotification::class, ['data' => $data]);
     }
 
     public function toDatabase(): DatabaseNotification


### PR DESCRIPTION
## Description

I'm trying to customise the queue that the `BroadcastNotification` notification (and resulting `BroadcastNotificationCreated` event) runs on. 

I can call the `->toBroadcast()` method on the notification, specify a queue, and `notify()` the user, however when `toBroadcast()` is in turn called on `BroadcastNotification`, the resulting `BroadcastMessage` does not inherit the queue-related modifications to the notification as exposed by `Queueable`.

This means that whilst the `BroadcastNotification` can be made to run on a different queue, the actual broadcasting of it (`BroadcastNotificationCreated`) falls back to the default queue.

My two modifications simplify this process:

1. Resolving `BroadcastNotification` from the container, giving us the ability to modify it further.

2.  Forwarding the connection and queue specified to the resulting `BroadcastMessage`. There may be additional properties we want to forward on, however this is a start.

We can see that in Illuminate's `BroadcastChannel` the same forwarding of connection and queue is happening.

This PR could also be ported to 3.x., although unsure if that version is still receiving feature updates.

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

Unsure if this warrants a documentation update. Realising something can be bound is usually done through source diving for an advanced use case.
