### PR TITLE
fix: return tenant registration URL if no tenant is found for authenticated user

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -172,6 +172,9 @@ trait HasRoutes
 
         if ((! $tenant) && $hasTenancy && $this->auth()->hasUser()) {
             $tenant = Filament::getUserDefaultTenant($this->auth()->user());
+            if (! $tenant) {
+                return $this->getTenantRegistrationUrl();
+            }
         }
 
         if (Route::has($homeRouteName = $this->generateRouteName('home'))) {


### PR DESCRIPTION
## Description

This resolves an issue where a missing parameter was passed to a panel's home route.
The `$tenant` variable is null when a user doesn't have a tenant yet, but the home route doesn't allow this.
We now check if the `$tenant` variable is set, if not, the user gets redirected to the tenant registration page.

## Functional changes

- [x] Redirect user to registration tenant page when they don't have a tenant yet.
