### PR TITLE
feat: allow binding value object constant state

### DIFF
--- a/packages/infolists/src/Components/RepeatableEntry.php
+++ b/packages/infolists/src/Components/RepeatableEntry.php
@@ -30,7 +30,7 @@ class RepeatableEntry extends Entry implements HasEmbeddedView
 
             if ($itemData instanceof Model) {
                 $container->record($itemData);
-            } elseif (is_array($itemData)) {
+            } elseif (is_array($itemData) || is_object($itemData)) {
                 $container->constantState($itemData);
             }
 

--- a/packages/schemas/src/Concerns/HasState.php
+++ b/packages/schemas/src/Concerns/HasState.php
@@ -17,9 +17,9 @@ trait HasState
     protected string $cachedAbsoluteStatePath;
 
     /**
-     * @var object | array<string, mixed> | null
+     * @var array<string, mixed> | object | null
      */
-    protected object | array | null $constantState = null;
+    protected array | object | null $constantState = null;
 
     protected bool | Closure $shouldPartiallyRender = false;
 
@@ -29,9 +29,9 @@ trait HasState
     protected ?array $dehydratedComponentsCache = null;
 
     /**
-     * @param  object | array<string, mixed> | null  $state
+     * @param  array<string, mixed> | object | null  $state
      */
-    public function state(object | array | null $state): static
+    public function state(array | object | null $state): static
     {
         $this->constantState($state);
 
@@ -77,7 +77,7 @@ trait HasState
     }
 
     /**
-     * @param  object | array<string, mixed> | null  $state
+     * @param  array<string, mixed> | object | null  $state
      */
     public function constantState(array | object | null $state): static
     {
@@ -384,9 +384,9 @@ trait HasState
     /**
      * @internal Do not use this method outside the internals of Filament. It is subject to breaking changes in minor and patch releases.
      *
-     * @return object | array<string, mixed>
+     * @return array<string, mixed> | object
      */
-    public function getConstantState(): object | array
+    public function getConstantState(): array | object
     {
         return $this->constantState ?? $this->getRecord(withParentComponentRecord: false) ?? $this->getParentComponent()?->getContainer()->getConstantState() ?? $this->getRecord() ?? throw new Exception('Schema has no [record()] or [state()] set.');
     }

--- a/packages/schemas/src/Concerns/HasState.php
+++ b/packages/schemas/src/Concerns/HasState.php
@@ -8,7 +8,6 @@ use Filament\Infolists\Components\Entry;
 use Filament\Schemas\Components\Component;
 use Filament\Support\Livewire\Partials\PartialsComponentHook;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 
 trait HasState
@@ -18,9 +17,9 @@ trait HasState
     protected string $cachedAbsoluteStatePath;
 
     /**
-     * @var array<string, mixed> | null
+     * @var object | array<string, mixed> | null
      */
-    protected ?array $constantState = null;
+    protected object | array | null $constantState = null;
 
     protected bool | Closure $shouldPartiallyRender = false;
 
@@ -30,9 +29,9 @@ trait HasState
     protected ?array $dehydratedComponentsCache = null;
 
     /**
-     * @param  array<string, mixed> | null  $state
+     * @param  object | array<string, mixed> | null  $state
      */
-    public function state(?array $state): static
+    public function state(object | array | null $state): static
     {
         $this->constantState($state);
 
@@ -78,9 +77,9 @@ trait HasState
     }
 
     /**
-     * @param  array<string, mixed> | null  $state
+     * @param  object | array<string, mixed> | null  $state
      */
-    public function constantState(?array $state): static
+    public function constantState(array | object | null $state): static
     {
         $this->constantState = $state;
 
@@ -385,9 +384,9 @@ trait HasState
     /**
      * @internal Do not use this method outside the internals of Filament. It is subject to breaking changes in minor and patch releases.
      *
-     * @return Model | array<string, mixed>
+     * @return object | array<string, mixed>
      */
-    public function getConstantState(): Model | array
+    public function getConstantState(): object | array
     {
         return $this->constantState ?? $this->getRecord(withParentComponentRecord: false) ?? $this->getParentComponent()?->getContainer()->getConstantState() ?? $this->getRecord() ?? throw new Exception('Schema has no [record()] or [state()] set.');
     }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

We're using Value Objects heavily in our application, and would like to keep using them in Infolists. Changes in Filament 4's state mechanisms prevent us from using non-Model Value Objects effectively.

One issue lies in the fact that `constantState` only accepts `array`. We'd like to be able to bind objects to the state of schemas without having to convert it back to arrays.

Another blocker is that `RepeatableEntry` only sets the container state when it's a `Model` or an `array`, and silently ignores if it's anything else.

```php
public function content(Schema $schema): Schema
{
    return $schema
        ->state(new Profile(
            id: 'some-id',
            results: [
                new Result(
                    date: new \DateTime(),
                    score: 100,
                ),
            ],
        ))
        ->schema([
            TextEntry::make('id'),
            RepeatableEntry::make('results')
                ->schema([
                    TextEntry::make('date')->date(),

                    TextEntry::make('score')->numeric(),
                ])
        ]);
}
```

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
