### PR TITLE
fix: mounting action record with arguments

### DIFF
--- a/packages/actions/resources/lang/it/delete.php
+++ b/packages/actions/resources/lang/it/delete.php
@@ -68,7 +68,6 @@ return [
             'missing_processing_failure_message' => ':count non possono essere eliminati.',
         ],
 
-
     ],
 
 ];

--- a/packages/actions/resources/lang/it/restore.php
+++ b/packages/actions/resources/lang/it/restore.php
@@ -66,7 +66,6 @@ return [
                 'missing_processing_failure_message' => ':count non possono essere ripristinati.',
             ],
 
-
         ],
 
     ],

--- a/packages/actions/src/Action.php
+++ b/packages/actions/src/Action.php
@@ -518,13 +518,11 @@ class Action extends ViewComponent implements Arrayable
 
     public function shouldClearRecordAfter(): bool
     {
-        $record = $this->getRecord();
-
-        if (! ($record instanceof Model)) {
+        if (! ($this->record instanceof Model)) {
             return false;
         }
 
-        return ! $record->exists;
+        return ! $this->record->exists;
     }
 
     public function clearRecordAfter(): void

--- a/tests/src/Actions/ActionTest.php
+++ b/tests/src/Actions/ActionTest.php
@@ -136,7 +136,6 @@ it('can mount an action record with arguments', function (): void {
     livewire(Actions::class)
         ->mountAction([
             TestAction::make('record-arguments')->arguments(['key' => 123]),
-            'record-arguments',
         ])
         ->callMountedAction()
         ->assertDispatched('record-arguments-called', arguments: [

--- a/tests/src/Actions/ActionTest.php
+++ b/tests/src/Actions/ActionTest.php
@@ -3,6 +3,7 @@
 use Filament\Actions\Action;
 use Filament\Actions\Testing\TestAction;
 use Filament\Notifications\Notification;
+use Filament\Pages\Page;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Actions\TestCase;
 use Filament\Tests\Fixtures\Pages\Actions;
@@ -129,6 +130,18 @@ it('can mount an action with arguments', function (): void {
         ->callMountedAction()
         ->assertDispatched('arguments-called', arguments: [
             'payload' => $payload,
+        ]);
+});
+
+it('can mount an action record with arguments', function (): void {
+    livewire(Actions::class)
+        ->mountAction([
+            TestAction::make('record-arguments')->arguments(['key' => 123]),
+            'record-arguments',
+        ])
+        ->callMountedAction()
+        ->assertDispatched('record-arguments-called', arguments: [
+            'key' => 123,
         ]);
 });
 

--- a/tests/src/Actions/ActionTest.php
+++ b/tests/src/Actions/ActionTest.php
@@ -3,7 +3,6 @@
 use Filament\Actions\Action;
 use Filament\Actions\Testing\TestAction;
 use Filament\Notifications\Notification;
-use Filament\Pages\Page;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tests\Actions\TestCase;
 use Filament\Tests\Fixtures\Pages\Actions;

--- a/tests/src/Fixtures/Pages/Actions.php
+++ b/tests/src/Fixtures/Pages/Actions.php
@@ -47,6 +47,8 @@ class Actions extends Page
                             $this->dispatch('nested-called', arguments: $arguments);
                         }),
                 ]),
+            Action::make('record-arguments')
+                ->record(fn (array $arguments) => $arguments['key']),
             Action::make('parent')
                 ->schema([
                     TextInput::make('foo')

--- a/tests/src/Fixtures/Pages/Actions.php
+++ b/tests/src/Fixtures/Pages/Actions.php
@@ -48,7 +48,11 @@ class Actions extends Page
                         }),
                 ]),
             Action::make('record-arguments')
-                ->record(fn (array $arguments) => $arguments['key']),
+                ->record(fn (array $arguments) => $arguments['key'])
+                ->resolveRecordUsing(fn () => null)
+                ->action(function (array $arguments): void {
+                    $this->dispatch('record-arguments-called', arguments: $arguments);
+                }),
             Action::make('parent')
                 ->schema([
                     TextInput::make('foo')


### PR DESCRIPTION
Fixes https://github.com/filamentphp/filament/issues/17303 when action record uses arguments and the arguments are cleared before clearing the record. 

```php
Action::make('test')
    ->record(fn (array $arguments) => $arguments['key'])
```

Not 100% of the implications of this change, and the reason why it was done the other way previously? 

- [x] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
