### PR TITLE
Improve parent record access authorization to include edit permissions

### DIFF
--- a/packages/panels/src/Resources/Pages/Concerns/InteractsWithParentRecord.php
+++ b/packages/panels/src/Resources/Pages/Concerns/InteractsWithParentRecord.php
@@ -42,7 +42,7 @@ trait InteractsWithParentRecord
 
     protected function authorizeParentRecordAccess(): void
     {
-        abort_unless(static::getParentResource()::canView($this->getParentRecord()), 403);
+        abort_unless(static::getParentResource()::canView($this->getParentRecord() || static::getParentResource()::canEdit($this->getParentRecord()), 403);
     }
 
     /**

--- a/packages/panels/src/Resources/Pages/Concerns/InteractsWithParentRecord.php
+++ b/packages/panels/src/Resources/Pages/Concerns/InteractsWithParentRecord.php
@@ -42,7 +42,7 @@ trait InteractsWithParentRecord
 
     protected function authorizeParentRecordAccess(): void
     {
-        abort_unless(static::getParentResource()::canView($this->getParentRecord() || static::getParentResource()::canEdit($this->getParentRecord()), 403);
+        abort_unless(static::getParentResource()::canView($this->getParentRecord()) || static::getParentResource()::canEdit($this->getParentRecord()), 403);
     }
 
     /**


### PR DESCRIPTION
Issue: 
The authorizeParentRecordAccess() method currently only checks canView() permissions, preventing users with edit-only permissions from accessing child resources.

Solution: 
Expand the authorization check to include canEdit() .

Why:
Users with edit permissions should be able to access parent records to manage child resources. Edit permissions typically include read access in the context of the operation. No breaking changes - only expands access, never restricts it.



## Description

Expand the authorization check to include canEdit(). 

Issue: 
The authorizeParentRecordAccess() method currently only checks canView() permissions, preventing users with edit-only permissions from accessing child resources.

Why:
Users with edit permissions should be able to access parent records to manage child resources. Edit permissions typically include read access in the context of the operation. No breaking changes - only expands access, never restricts it.

## Visual changes

Before:
https://github.com/user-attachments/assets/2628b110-293c-4305-8e46-fb7743530124

After:
https://github.com/user-attachments/assets/b77d5482-f19f-47a4-b050-c3c8e32dd11c


## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
