### PR TITLE
Allow alignment to affect slideovers

### DIFF
--- a/packages/actions/resources/lang/it/delete.php
+++ b/packages/actions/resources/lang/it/delete.php
@@ -68,7 +68,6 @@ return [
             'missing_processing_failure_message' => ':count non possono essere eliminati.',
         ],
 
-
     ],
 
 ];

--- a/packages/actions/resources/lang/it/restore.php
+++ b/packages/actions/resources/lang/it/restore.php
@@ -66,7 +66,6 @@ return [
                 'missing_processing_failure_message' => ':count non possono essere ripristinati.',
             ],
 
-
         ],
 
     ],

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -157,7 +157,7 @@
                     'fi-modal-window-has-icon' => $hasIcon,
                     'fi-modal-window-has-sticky-header' => $stickyHeader,
                     'fi-hidden' => ! $visible,
-                    (($alignment instanceof Alignment) && (! $slideOver)) ? "fi-align-{$alignment->value}" : null,
+                    ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : null,
                     ($width instanceof Width) ? "fi-width-{$width->value}" : (is_string($width) ? $width : null),
                 ])
             }}


### PR DESCRIPTION
## Description

This fixes #17317 by allowing the alignment prop to affect slideovers.

## Visual changes

See the referenced issue for how the notifications slideover looked in v3. This makes it look the same as in v3.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
