### PR TITLE
[4.x] feat: Apply state binding modifiers on TableSelect

### DIFF
--- a/packages/forms/resources/views/components/table-select.blade.php
+++ b/packages/forms/resources/views/components/table-select.blade.php
@@ -24,7 +24,7 @@
             'relationshipName' => $getRelationshipName(),
             'tableConfiguration' => base64_encode($getTableConfiguration()),
             'tableArguments' => $getTableArguments(),
-            'wire:model' => $getStatePath(),
+            $applyStateBindingModifiers('wire:model') => $getStatePath(),
         ], key($getLivewireKey()))
     </div>
 </x-dynamic-component>


### PR DESCRIPTION
I know this component is more of an helper for the Modal Table Select, but i lowkey think this component itself is super useful and should be documented and fixed up.

## Description

This component hardcoded a `wire:model` to the underlying livewire component, which is wrong. I just applied the state binding modifier when binding to the modelable `TableSelectLivewireComponent`.

## Visual changes

No visual changes made.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality. (Only used in the Modal version, and there it wasn't modeled live before, and isn't modeled live now.)
- [x] Documentation is up-to-date. (This component is one of the few that isn't documented at all)
