### PR TITLE
Fix Toggle component error (#17347)

### DIFF
--- a/packages/forms/src/Components/Toggle.php
+++ b/packages/forms/src/Components/Toggle.php
@@ -24,7 +24,7 @@ class Toggle extends Field
     {
         parent::setUp();
 
-        $this->default(false);
+        $this->default(null);
 
         $this->rule('boolean');
     }
@@ -36,7 +36,7 @@ class Toggle extends Field
     {
         return [
             ...parent::getDefaultStateCasts(),
-            app(BooleanStateCast::class, ['isNullable' => false]),
+            app(BooleanStateCast::class, ['isNullable' => true]),
         ];
     }
 }


### PR DESCRIPTION
Fixes Toggle component error in Filament V4.

## What was wrong
Toggle component was throwing an error when using default(false).

## What I fixed
- Changed default(false) to default(null)
- Updated BooleanStateCast settings

## Files changed
packages/forms/src/Components/Toggle.php


Fixes #17347