### PR TITLE
Allow HTML in ActionGroup label

### DIFF
--- a/packages/actions/src/ActionGroup.php
+++ b/packages/actions/src/ActionGroup.php
@@ -26,6 +26,7 @@ use Filament\Support\View\Concerns\CanGenerateDropdownItemHtml;
 use Filament\Support\View\Concerns\CanGenerateIconButtonHtml;
 use Filament\Support\View\Concerns\CanGenerateLinkHtml;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
@@ -220,11 +221,13 @@ class ActionGroup extends ViewComponent implements Arrayable, HasEmbeddedView
         return $this->getTriggerView() === static::LINK_VIEW;
     }
 
-    public function getLabel(): string
+    public function getLabel(): string | Htmlable | null
     {
         $label = $this->evaluate($this->label) ?? __('filament-actions::group.trigger.label');
 
-        return $this->shouldTranslateLabel ? __($label) : $label;
+        return is_string($label) && $this->shouldTranslateLabel
+            ? __($label)
+            : $label;
     }
 
     /**


### PR DESCRIPTION
## Description
This change enables the use of HTML tags in ActionGroup labels, providing greater flexibility in styling and displaying labels in the user interface.

## Visual changes
- ActionGroup labels can now contain HTML tags that will be properly rendered
- No change to the overall design, just added capability to use HTML

## Functional changes
- Updated the method that displays the label to allow HTML content
- Maintained backward compatibility with regular text labels

## Testing performed
- [x] Code style has been fixed by running the `composer cs` command
- [x] Changes have been tested to not break existing functionality
- [x] Documentation is up-to-date

## Usage
```php
ActionGroup::make('settings')
    ->label('<span class="text-primary">Settings</span>')
    ->icon('heroicon-s-cog')
    ->actions([
        // actions here
    ]);