### PR TITLE
[4.x] Missing Arabic translations

### DIFF
--- a/packages/actions/resources/lang/nb/import.php
+++ b/packages/actions/resources/lang/nb/import.php
@@ -11,12 +11,12 @@ return [
         'form' => [
 
             'file' => [
-                    'label' => 'Fil',
-                    'placeholder' => 'Last opp en CSV fil',
-                    'rules' => [
-                        'duplicate_columns' => '{0} Filen kan ikke inneholde mer enn én tom kolonneoverskrift.|{1,*} Filen kan ikke inneholde dupliserte kolonneoverskrifter: :columns.',
-                    ],
+                'label' => 'Fil',
+                'placeholder' => 'Last opp en CSV fil',
+                'rules' => [
+                    'duplicate_columns' => '{0} Filen kan ikke inneholde mer enn én tom kolonneoverskrift.|{1,*} Filen kan ikke inneholde dupliserte kolonneoverskrifter: :columns.',
                 ],
+            ],
 
             'columns' => [
                 'label' => 'Kolonner',

--- a/packages/forms/resources/lang/ar/components.php
+++ b/packages/forms/resources/lang/ar/components.php
@@ -481,6 +481,7 @@ return [
             'bold' => 'عريض',
             'bullet_list' => 'قائمة نقطية',
             'clear_formatting' => 'مسح التنسيق',
+            'code' => 'كود',
             'code_block' => 'نص برمجي',
             'custom_blocks' => 'الكتل المخصصة',
             'details' => 'التفاصيل',
@@ -592,6 +593,11 @@ return [
     'text_input' => [
 
         'actions' => [
+
+            'copy' => [
+                'label' => 'نسخ',
+                'message' => 'تم النسخ',
+            ],
 
             'hide_password' => [
                 'label' => 'إخفاء كلمة المرور',

--- a/packages/panels/resources/lang/ar/resources/pages/edit-record.php
+++ b/packages/panels/resources/lang/ar/resources/pages/edit-record.php
@@ -6,6 +6,8 @@ return [
 
     'breadcrumb' => 'تعديل',
 
+    'navigation_label' => 'تعديل',
+
     'form' => [
 
         'actions' => [

--- a/packages/panels/resources/lang/ar/resources/pages/manage-related-records.php
+++ b/packages/panels/resources/lang/ar/resources/pages/manage-related-records.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'title' => 'إدارة :label :relationship',
+
+];

--- a/packages/panels/resources/lang/ar/resources/pages/view-record.php
+++ b/packages/panels/resources/lang/ar/resources/pages/view-record.php
@@ -6,6 +6,8 @@ return [
 
     'breadcrumb' => 'عرض',
 
+    'navigation_label' => 'عرض',
+
     'content' => [
 
         'tab' => [

--- a/packages/tables/resources/lang/ar/table.php
+++ b/packages/tables/resources/lang/ar/table.php
@@ -26,6 +26,20 @@ return [
             'label' => 'إجراء | إجراءات',
         ],
 
+        'select' => [
+
+            'loading_message' => 'جاري التحميل...',
+
+            'no_search_results_message' => 'لا توجد خيارات مطابقة لبحثك.',
+
+            'placeholder' => 'اختر',
+
+            'searching_message' => 'جاري البحث...',
+
+            'search_prompt' => 'ابدأ الكتابة للبحث...',
+
+        ],
+
         'text' => [
 
             'actions' => [
@@ -186,7 +200,6 @@ return [
 
             'group' => [
                 'label' => 'تجميع حسب',
-                'placeholder' => 'تجميع حسب',
             ],
 
             'direction' => [
@@ -247,6 +260,6 @@ return [
 
     ],
 
-    'default_model_label' => 'سِجِلّ',
+    'default_model_label' => 'سجل',
 
 ];


### PR DESCRIPTION
This pull request updates and adds Arabic language translations for several UI components across the forms, panels, and tables packages. The changes improve localization coverage and consistency, especially for new features and navigation labels.

**Forms package translation updates:**

* Added translation for the "code" formatting option in `components.php`.
* Added translations for the "copy" action, including label and success message, in `components.php`.

**Panels package translation updates:**

* Added navigation label translations for "edit" and "view" record pages in `edit-record.php` and `view-record.php`.
* Added a new translation file `manage-related-records.php` for managing related records, including a dynamic title.

**Tables package translation updates:**

* Added translations for select input states (loading, searching, no results, placeholder, search prompt) in `table.php`.
* Removed redundant placeholder from the "group by" option in `table.php` for consistency.
* Corrected the translation for the default model label "سِجِلّ" to "سجل" in `table.php`.