### PR TITLE
RelationManager getIcon breaks with BackedEnum

### DIFF
--- a/packages/panels/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManager.php
@@ -157,7 +157,7 @@ class RelationManager extends Component implements HasActions, HasSchemas, HasTa
             ->iconPosition(static::class::getIconPosition($ownerRecord, $pageClass));
     }
 
-    public static function getIcon(Model $ownerRecord, string $pageClass): ?string
+    public static function getIcon(Model $ownerRecord, string $pageClass): string | BackedEnum | null
     {
         return static::$icon;
     }


### PR DESCRIPTION
## Description

Right now using a BackedEnum as icon for a relation manager results in:

```php
Filament\Resources\RelationManagers\RelationManager::getIcon(): Return value must be of type ?string, Filament\Support\Icons\Heroicon returned
```

This change fixes the return type, making this possible. This aligns with the types of `$icon`.

Not sure if it can also be a `Htmlable`?