### PR TITLE
[4.x] Configurable Repeater TableColumn

### DIFF
--- a/packages/forms/src/Components/Repeater/TableColumn.php
+++ b/packages/forms/src/Components/Repeater/TableColumn.php
@@ -24,7 +24,11 @@ class TableColumn extends Component
 
     public static function make(string | Closure $label): static
     {
-        return app(static::class, ['label' => $label]);
+        $static = app(static::class, ['label' => $label]);
+
+        $static->configure();
+
+        return $static;
     }
 
     public function hiddenHeaderLabel(bool | Closure $condition = true): static


### PR DESCRIPTION
## Description

Currently when using `configureUsing` on TableColumn in Repeater it take no effect. The change allows this to be configured in the project.

```php
TableColumn::configureUsing(function (TableColumn $column): void {
    $column->alignStart();
 });
```

## Visual changes

No visual changes.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
