### PR TITLE
[4.x] Fix(docs): Add missing form class to singular resources example

### DIFF
--- a/docs/03-resources/09-singular.md
+++ b/docs/03-resources/09-singular.md
@@ -107,7 +107,7 @@ The page Blade view should render the form and a Save button. The `wire:submit` 
 
 ```blade
 <x-filament::page>
-    <form wire:submit="save">
+    <form class="fi-sc-form" id="form" wire:submit="save">
         {{ $this->form }}
     
         <div>

--- a/docs/03-resources/09-singular.md
+++ b/docs/03-resources/09-singular.md
@@ -35,10 +35,13 @@ The page class should contain the following elements:
 namespace App\Filament\Pages;
 
 use App\Models\WebsitePage;
+use Filament\Actions\Action;
 use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Schemas\Components\Actions;
+use Filament\Schemas\Components\Form;
 use Filament\Schemas\Schema;
 
 /**
@@ -46,6 +49,8 @@ use Filament\Schemas\Schema;
  */
 class ManageHomepage extends Page
 {
+    protected string $view = 'filament.pages.manage-homepage';
+
     /**
      * @var array<string, mixed> | null
      */
@@ -60,11 +65,21 @@ class ManageHomepage extends Page
     {
         return $schema
             ->components([
-                TextInput::make('title')
-                    ->required()
-                    ->maxLength(255),
-                RichEditor::make('content'),
-                // ...
+                Form::make([
+                    TextInput::make('title')
+                        ->required()
+                        ->maxLength(255),
+                    RichEditor::make('content'),
+                    // ...
+                ])
+                    ->livewireSubmitHandler('save')
+                    ->footer([
+                        Actions::make([
+                            Action::make('save')
+                                ->submit('save')
+                                ->keyBindings(['mod+s']),
+                        ]),
+                    ]),
             ])
             ->record($this->getRecord())
             ->statePath('data');
@@ -103,18 +118,10 @@ class ManageHomepage extends Page
 }
 ```
 
-The page Blade view should render the form and a Save button. The `wire:submit` directive should be used to call the `save()` method when the form is submitted:
+The page Blade view should render the form:
 
 ```blade
 <x-filament::page>
-    <form class="fi-sc-form" id="form" wire:submit="save">
-        {{ $this->form }}
-    
-        <div>
-            <x-filament::button type="submit">
-                Save
-            </x-filament::button>
-        </div>
-    </form>
+    {{ $this->form }}
 </x-filament::page>
 ```


### PR DESCRIPTION
## Description

This adds the `fi-sc-form` class to the singular resources blade view example, which provides proper padding to the form so the submit button is spaced from the form like in regular resources.

I also added an `id="form"` attribute for good measure, because it's also present in regular resource forms :)

## Visual changes

"Run" is the submit button in this example.

Before:
<img width="213" height="141" alt="Screenshot 2025-08-18 at 17 51 48" src="https://github.com/user-attachments/assets/97f8d768-f992-4cab-80b2-6e5462da6627" />
After:
<img width="219" height="157" alt="Screenshot 2025-08-18 at 17 51 58" src="https://github.com/user-attachments/assets/7379cdb8-171b-4296-961f-f2613239d9f5" />


## Functional changes

- [ ] ~~Code style has been fixed by running the `composer cs` command.~~
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
