### PR TITLE
add Team model example to tenancy docs

### DIFF
--- a/packages/panels/docs/11-tenancy.md
+++ b/packages/panels/docs/11-tenancy.md
@@ -52,7 +52,28 @@ class PostObserver
 
 ## Setting up tenancy
 
-To set up tenancy, you'll need to specify the "tenant" (like team or organization) model in the [configuration](configuration):
+To set up tenancy, first you'll need to create a model which represents tenants, e.g. `Team`:
+
+```php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Team extends Model
+{
+    /** @use HasFactory<\Database\Factories\TeamFactory> */
+    use HasFactory;
+
+    public function members(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class);
+    }
+}
+```
+
+Then you'll need to specify this "tenant" (like team or organization) model in the [configuration](configuration):
 
 ```php
 use App\Models\Team;


### PR DESCRIPTION
## Description

the docs are missing a tenant model example, this PR adds it

## Visual changes

n/a

## Functional changes

- [ x ] Code style has been fixed by running the `composer cs` command.
- [ x ] Changes have been tested to not break existing functionality.
- [ x ] Documentation is up-to-date.
