### PR TITLE
 Fix: Allow array records in  ListRecords page default closures 

### DIFF
--- a/packages/panels/src/Resources/Pages/ListRecords.php
+++ b/packages/panels/src/Resources/Pages/ListRecords.php
@@ -126,7 +126,7 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
             ->modifyQueryUsing($this->modifyQueryWithActiveTab(...))
             ->when($this->getModelLabel(), fn (Table $table, string $modelLabel): Table => $table->modelLabel($modelLabel))
             ->when($this->getPluralModelLabel(), fn (Table $table, string $pluralModelLabel): Table => $table->pluralModelLabel($pluralModelLabel))
-            ->recordAction(function (Model $record, Table $table): ?string {
+            ->recordAction(function (Model|array $record, Table $table): ?string {
                 foreach (['view', 'edit'] as $action) {
                     $action = $table->getAction($action);
 
@@ -150,7 +150,7 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
 
                 return null;
             })
-            ->recordUrl(function (Model $record, Table $table): ?string {
+            ->recordUrl(function (Model|array $record, Table $table): ?string {
                 foreach (['view', 'edit'] as $action) {
                     $action = $table->getAction($action);
 


### PR DESCRIPTION
## Description

This PR addresses a `TypeError` that occurs on `Filament\Resources\Pages\ListRecords` pages when using the Table builder's custom data source feature (populating the table with an array via the `records()` method).

 

The `Filament\Resources\Pages\ListRecords` class provides helpful default implementations for `recordUrl()` and `recordAction()`.

Because of this assumption, the closures for these defaults in the `makeTable()` method are strictly type-hinted to accept `Illuminate\Database\Eloquent\Model`:

```php
// in Filament\Resources\Pages\ListRecords.php

// ...
->recordAction(function (Model $record, Table $table): ?string {
    // ...
})
->recordUrl(function (Model $record, Table $table): ?string {
    // ...
})
```
 

While the Table builder itself fully supports custom array data sources, the `ListRecords` page does not. When a developer uses `->records()` to provide an array, the table component passes each array item (a record) to these default closures, resulting in a `TypeError`:

```
TypeError: Filament\Resources\Pages\ListRecords::{closure}(): Argument #1 ($record) must be of type Illuminate\Database\Eloquent\Model, array given
```

This makes even the example code snippet on https://filamentphp.com/docs/4.x/tables/custom-data#introduction fail:

```
use Filament\Tables\Columns\IconColumn;
use Filament\Tables\Columns\TextColumn;
use Filament\Tables\Table;

public function table(Table $table): Table
{
    return $table
        ->records(fn (): array => [
            1 => [
                'title' => 'First item',
                'slug' => 'first-item',
                'is_featured' => true,
            ],
            2 => [
                'title' => 'Second item',
                'slug' => 'second-item',
                'is_featured' => false,
            ],
            3 => [
                'title' => 'Third item',
                'slug' => 'third-item',
                'is_featured' => true,
            ],
        ])
        ->columns([
            TextColumn::make('title'),
            TextColumn::make('slug'),
            IconColumn::make('is_featured')
                ->boolean(),
        ]);
}
```
This fix resolves (or at least hides) the issue by making the default closures more flexible. It updates the type hint for the `$record` parameter to accept either a `Model` or an `array`:

```diff
- ->recordAction(function (Model $record, Table $table): ?string {
+ ->recordAction(function (Model|array $record, Table $table): ?string {
```

```diff
- ->recordUrl(function (Model $record, Table $table): ?string {
+ ->recordUrl(function (Model|array $record, Table $table): ?string {
```

This small change makes the `ListRecords` page compatible with the Table builder's custom data feature out of the box:


*   If `$record` is a `Model`, the existing logic works as intended.
*   If `$record` is an `array`, the `instanceof Model` checks within the closures will fail, and the functions will return `null`, effectively disabling the default actions/URL for that array-based record without crashing the application.


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
