### PR TITLE
[4.x] fix: Fix the order for the replaceEnd method

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -187,7 +187,7 @@ trait HasRoutes
                 $tenantRoutePrefix .= '/';
             }
 
-            return url(Str::replaceEnd($this->getPath(), '/', '') . '/' . $tenantRoutePrefix . (filled($tenantSlugAttribute) ? $tenant->getAttributeValue($tenantSlugAttribute) : $tenant->getRouteKey()));
+            return url(Str::replaceEnd('/', '', $this->getPath()) . '/' . $tenantRoutePrefix . (filled($tenantSlugAttribute) ? $tenant->getAttributeValue($tenantSlugAttribute) : $tenant->getRouteKey()));
         }
 
         return url($this->getPath());

--- a/tests/src/Panels/Tenancy/ResolveTenantTest.php
+++ b/tests/src/Panels/Tenancy/ResolveTenantTest.php
@@ -58,15 +58,5 @@ it('resolves the tenant with custom path correctly from the route', function ():
     Filament::setCurrentPanel($panel);
     Filament::setTenant($team);
 
-    $routeName = 'filament.tenancy.resources.posts.index';
-    $route = Route::getRoutes()->getByName($routeName);
-
-    $request = Request::create(route($routeName, [
-        'tenant' => $team,
-    ]));
-
-    $request->setRouteResolver(fn () => $route->bind($request));
-
-    $resolvedTenant = $panel->getTenant($team->getKey());
-    expect($resolvedTenant)->toBeSameModel($team);
+    expect(Filament::getUrl($team))->toBe('http://localhost/tenancy/1');
 });

--- a/tests/src/Panels/Tenancy/ResolveTenantTest.php
+++ b/tests/src/Panels/Tenancy/ResolveTenantTest.php
@@ -50,3 +50,23 @@ it('resolves the tenant correctly using domain', function (): void {
     $resolvedTenant = $panel->getTenant($team->getRouteKey());
     expect($resolvedTenant)->toBeSameModel($team);
 });
+
+it('resolves the tenant with custom path correctly from the route', function (): void {
+    $team = Team::factory()->create();
+
+    $panel = Filament::getPanel('tenancy');
+    Filament::setCurrentPanel($panel);
+    Filament::setTenant($team);
+
+    $routeName = 'filament.tenancy.resources.posts.index';
+    $route = Route::getRoutes()->getByName($routeName);
+
+    $request = Request::create(route($routeName, [
+        'tenant' => $team,
+    ]));
+
+    $request->setRouteResolver(fn () => $route->bind($request));
+
+    $resolvedTenant = $panel->getTenant($team->getKey());
+    expect($resolvedTenant)->toBeSameModel($team);
+});


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Saw issue #17396 and decided to update the ordering of the `replaceEnd` parameters as described in the ticket.

Implemented to validate new behavior.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
