### PR TITLE
[4.x] Move `observeTenancyModelCreation()` to `ServiceProvider::boot()`

### DIFF
--- a/packages/panels/src/Panel.php
+++ b/packages/panels/src/Panel.php
@@ -68,10 +68,6 @@ class Panel extends Component
 
     public function register(): void
     {
-        foreach ($this->getResources() as $resource) {
-            $resource::observeTenancyModelCreation($this);
-        }
-
         $this->registerLivewireComponents();
         $this->registerLivewirePersistentMiddleware();
 
@@ -88,6 +84,7 @@ class Panel extends Component
     public function boot(): void
     {
         foreach ($this->getResources() as $resource) {
+            $resource::observeTenancyModelCreation($this);
             $resource::registerTenancyModelGlobalScope($this);
         }
 


### PR DESCRIPTION
Registering the tenancy observer in `register()` instead of `boot()` will prevent packages configuring models via a config option, because it runs before the config is booted.

I could only test this with one of the packages I maintain and the existing test set of Filament itself. 

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
