### PR TITLE
[4.x] Allow user to configure whether hidden fields in Repeater table occupies columns

### DIFF
--- a/packages/forms/docs/12-repeater.md
+++ b/packages/forms/docs/12-repeater.md
@@ -645,7 +645,7 @@ TableColumn::make('Name')
     ->width('200px')
 ```
 
-### Hidden components
+### Hidden fields
 
 By default, hiding a field using the `visible()` method will still have the invisible field occupy one column in the table.
 

--- a/packages/forms/docs/12-repeater.md
+++ b/packages/forms/docs/12-repeater.md
@@ -645,6 +645,61 @@ TableColumn::make('Name')
     ->width('200px')
 ```
 
+### Hidden components
+
+By default, hiding a field using the `visible()` method will still have the invisible field occupy one column in the table.
+
+To configure the repeater table so that invisible form fields do not occupy table columns, you can use the repeater's `showHidden()` method.
+
+```php
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Repeater\TableColumn;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\DatePicker;
+
+Repeater::make('data')
+    ->columnSpanFull()
+    ->showHidden(false)
+    ->table([
+        // We have three columns
+        TableColumn::make('type'),
+        TableColumn::make('value'),
+        TableColumn::make('date'),
+    ])
+    ->schema([
+        // There are 4 fields but in reality,
+        // only 3 of them are visible at a time.
+        Select::make('data')
+            ->options([
+                '1' => 'Height',
+                '2' => 'Blood type',
+            ])
+            ->default('1')
+            ->required()
+            ->live(),
+        TextInput::make('int_value')
+            ->numeric()
+            ->visible(fn (Get $get) => $get('data') === '1')
+            ->required(),
+        Select::make('str_value')
+            ->visible(fn (Get $get) => $get('data') === '2')
+            ->options([
+                "A+"  => "A+",
+                "A-"  => "A-",
+                "B+"  => "B+",
+                "B-"  => "B-",
+                "AB+" => "AB+",
+                "AB-" => "AB-",
+                "O+"  => "O+",
+                "O-"  => "O-"
+            ])
+            ->required(),
+        DatePicker::make('date')
+            ->required(),
+    ]);
+```
+
 ## Repeater validation
 
 As well as all rules listed on the [validation](validation) page, there are additional rules that are specific to repeaters.

--- a/packages/forms/resources/views/components/repeater/table.blade.php
+++ b/packages/forms/resources/views/components/repeater/table.blade.php
@@ -22,6 +22,7 @@
     $isDeletable = $isDeletable();
     $isReorderableWithButtons = $isReorderableWithButtons();
     $isReorderableWithDragAndDrop = $isReorderableWithDragAndDrop();
+    $isShowingHidden = $isShowingHidden();
 
     $key = $getKey();
     $statePath = $getStatePath();
@@ -137,7 +138,7 @@
                                     $counter = 0
                                 @endphp
 
-                                @foreach ($item->getComponents(withHidden: true) as $component)
+                                @foreach ($item->getComponents(withHidden: $isShowingHidden) as $component)
                                     @php
                                         throw_unless(
                                             $component instanceof \Filament\Forms\Components\Field || $component instanceof \Filament\Infolists\Components\Entry,

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -53,6 +53,8 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
 
     protected bool | Closure $isReorderableWithButtons = false;
 
+    protected bool | Closure $isShowingHidden = true;
+
     protected ?Collection $cachedExistingRecords = null;
 
     protected string | Closure | null $orderColumn = null;
@@ -797,6 +799,13 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return $this;
     }
 
+    public function showHidden(bool | Closure $condition = true): static
+    {
+        $this->isShowingHidden = $condition;
+
+        return $this;
+    }
+
     /**
      * @deprecated No longer part of the design system.
      */
@@ -861,6 +870,11 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     public function isReorderableWithButtons(): bool
     {
         return $this->evaluate($this->isReorderableWithButtons) && $this->isReorderable();
+    }
+
+    public function isShowingHidden(): bool
+    {
+        return (bool) $this->evaluate($this->isShowingHidden);
     }
 
     public function isAddable(): bool


### PR DESCRIPTION
## Description

There are times when using a Repeater configured to show as a table, a field gets hidden. Before, such hidden fields still occupy a column on the table even when it is not displayed.

This option allows the user to choose whether a hidden field occupies a column in the table or not.

## Visual changes

Before:

<img width="914" height="240" alt="image" src="https://github.com/user-attachments/assets/634c4662-7119-42d3-8d0c-1232936a372b" />

After:

<img width="911" height="232" alt="image" src="https://github.com/user-attachments/assets/b40034d2-7d6b-4de3-8c25-7371b548f217" />

## Functional changes

A new method for Repeater `showHidden(bool | Closure $condition = true): static` is added:

```php
Repeater::make('data')
    ->columnSpanFull()
    ->showHidden(false)
    ->table([
        // We have three columns
        TableColumn::make('type'),
        TableColumn::make('value'),
        TableColumn::make('date'),
    ])
    ->schema([
        // There are 4 fields but in reality,
        // only 3 of them are visible at a time.
        Select::make('data')
            ->options([
                '1' => 'Height',
                '2' => 'Blood type',
            ])
            ->default('1')
            ->required()
            ->live(),
        TextInput::make('int_value')
            ->numeric()
            ->visible(fn (Get $get) => $get('data') === '1')
            ->required(),
        Select::make('str_value')
            ->visible(fn (Get $get) => $get('data') === '2')
            ->options([
                "A+"  => "A+",
                "A-"  => "A-",
                // ...
            ])
            ->required(),
        DatePicker::make('date')
            ->required(),
    ]);
```

I could not run `composer cs` because I can't configure composer to use my forked repository...

However, I did test it as much as I can. I also updated the documentation to show the new function.

- [ ] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.

This is my first time contributing to Filament (or any major repository) so please forgive me if I make mistakes. I will be happy to fix any mistakes if I can.