### PR TITLE
[4.x] fix(forms): escape placeholder attributes so quotes render correctly

### DIFF
--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -17,6 +17,8 @@
     $suffixIconColor = $getSuffixIconColor();
     $suffixLabel = $getSuffixLabel();
     $statePath = $getStatePath();
+    $placeholder = $getPlaceholder();
+    $placeholder = $getPlaceholder();
 @endphp
 
 <x-dynamic-component
@@ -67,7 +69,7 @@
                             'autocomplete' => 'off',
                             'disabled' => $isDisabled,
                             'id' => $getId(),
-                            'placeholder' => ($getPlaceholder() === null) ? null : e((string) $getPlaceholder()),
+                            'placeholder' => filled($placeholder) ? e($placeholder) : null,
                             'required' => $isRequired() && (! $isConcealed()),
                             'type' => 'text',
                             'x-model' . ($isLiveDebounced ? '.debounce.' . $liveDebounce : null) => 'state',

--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -67,7 +67,7 @@
                             'autocomplete' => 'off',
                             'disabled' => $isDisabled,
                             'id' => $getId(),
-                            'placeholder' => $getPlaceholder(),
+                            'placeholder' => ($getPlaceholder() === null) ? null : e((string) $getPlaceholder()),
                             'required' => $isRequired() && (! $isConcealed()),
                             'type' => 'text',
                             'x-model' . ($isLiveDebounced ? '.debounce.' . $liveDebounce : null) => 'state',

--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -18,7 +18,6 @@
     $suffixLabel = $getSuffixLabel();
     $statePath = $getStatePath();
     $placeholder = $getPlaceholder();
-    $placeholder = $getPlaceholder();
 @endphp
 
 <x-dynamic-component

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -63,7 +63,7 @@
                             'list' => $datalistOptions ? $id . '-list' : null,
                             'max' => $hasTime ? $maxDate : ($maxDate ? \Carbon\Carbon::parse($maxDate)->toDateString() : null),
                             'min' => $hasTime ? $minDate : ($minDate ? \Carbon\Carbon::parse($minDate)->toDateString() : null),
-                            'placeholder' => $placeholder,
+                            'placeholder' => ($placeholder === null) ? null : e((string) $placeholder),
                             'readonly' => $isReadOnly,
                             'required' => $isRequired && (! $isConcealed),
                             'step' => $step,

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -63,7 +63,7 @@
                             'list' => $datalistOptions ? $id . '-list' : null,
                             'max' => $hasTime ? $maxDate : ($maxDate ? \Carbon\Carbon::parse($maxDate)->toDateString() : null),
                             'min' => $hasTime ? $minDate : ($minDate ? \Carbon\Carbon::parse($minDate)->toDateString() : null),
-                            'placeholder' => ($placeholder === null) ? null : e((string) $placeholder),
+                            'placeholder' => filled($placeholder) ? e($placeholder) : null,
                             'readonly' => $isReadOnly,
                             'required' => $isRequired && (! $isConcealed),
                             'step' => $step,

--- a/packages/forms/resources/views/components/one-time-code-input.blade.php
+++ b/packages/forms/resources/views/components/one-time-code-input.blade.php
@@ -1,5 +1,6 @@
 @php
     $fieldWrapperView = $getFieldWrapperView();
+    $placeholder = $getPlaceholder();
     $extraAttributes = $getExtraAttributeBag()
         ->merge($getExtraInputAttributes(), escape: false)
         ->merge($getExtraAlpineAttributes(), escape: false)
@@ -9,7 +10,7 @@
             'disabled' => $isDisabled(),
             'id' => $getId(),
             'length' => $getLength(),
-            'placeholder' => ($getPlaceholder() === null) ? null : e((string) $getPlaceholder()),
+            'placeholder' => filled($placeholder) ? e($placeholder) : null,
             'readonly' => $isReadOnly(),
             'required' => $isRequired() && (! $isConcealed()),
             $applyStateBindingModifiers('wire:model') => $getStatePath(),

--- a/packages/forms/resources/views/components/one-time-code-input.blade.php
+++ b/packages/forms/resources/views/components/one-time-code-input.blade.php
@@ -9,7 +9,7 @@
             'disabled' => $isDisabled(),
             'id' => $getId(),
             'length' => $getLength(),
-            'placeholder' => $getPlaceholder(),
+            'placeholder' => ($getPlaceholder() === null) ? null : e((string) $getPlaceholder()),
             'readonly' => $isReadOnly(),
             'required' => $isRequired() && (! $isConcealed()),
             $applyStateBindingModifiers('wire:model') => $getStatePath(),

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -68,7 +68,7 @@
                             'disabled' => $isDisabled,
                             'id' => $id,
                             'list' => $id . '-suggestions',
-                            'placeholder' => ($placeholder === null) ? null : e((string) $placeholder),
+                            'placeholder' => filled($placeholder) ? e($placeholder) : null,
                             'type' => 'text',
                             'x-bind' => 'input',
                         ], escape: false)

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -68,7 +68,7 @@
                             'disabled' => $isDisabled,
                             'id' => $id,
                             'list' => $id . '-suggestions',
-                            'placeholder' => $placeholder,
+                            'placeholder' => ($placeholder === null) ? null : e((string) $placeholder),
                             'type' => 'text',
                             'x-bind' => 'input',
                         ], escape: false)

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -23,6 +23,7 @@
     $suffixIconColor = $getSuffixIconColor();
     $suffixLabel = $getSuffixLabel();
     $statePath = $getStatePath();
+    $placeholder = $getPlaceholder();
 
     if ($isPasswordRevealable) {
         $xData = '{ isPasswordRevealed: false }';
@@ -56,7 +57,7 @@
             'maxlength' => (! $isConcealed) ? $getMaxLength() : null,
             'min' => (! $isConcealed) ? $getMinValue() : null,
             'minlength' => (! $isConcealed) ? $getMinLength() : null,
-            'placeholder' => ($getPlaceholder() === null) ? null : e((string) $getPlaceholder()),
+            'placeholder' => filled($placeholder) ? e($placeholder) : null,
             'readonly' => $isReadOnly(),
             'required' => $isRequired() && (! $isConcealed),
             'step' => $getStep(),

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -56,7 +56,7 @@
             'maxlength' => (! $isConcealed) ? $getMaxLength() : null,
             'min' => (! $isConcealed) ? $getMinValue() : null,
             'minlength' => (! $isConcealed) ? $getMinLength() : null,
-            'placeholder' => $getPlaceholder(),
+            'placeholder' => ($getPlaceholder() === null) ? null : e((string) $getPlaceholder()),
             'readonly' => $isReadOnly(),
             'required' => $isRequired() && (! $isConcealed),
             'step' => $getStep(),

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -58,7 +58,7 @@
                             'id' => $getId(),
                             'maxlength' => (! $isConcealed) ? $getMaxLength() : null,
                             'minlength' => (! $isConcealed) ? $getMinLength() : null,
-                            'placeholder' => $getPlaceholder(),
+                            'placeholder' => ($getPlaceholder() === null) ? null : e((string) $getPlaceholder()),
                             'readonly' => $isReadOnly(),
                             'required' => $isRequired() && (! $isConcealed),
                             'rows' => $rows,

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -8,7 +8,6 @@
     $shouldAutosize = $shouldAutosize();
     $placeholder = $getPlaceholder();
     $statePath = $getStatePath();
-    $placeholder = $getPlaceholder();
 
     $initialHeight = (($rows ?? 2) * 1.5) + 0.75;
 @endphp

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -6,7 +6,9 @@
     $isDisabled = $isDisabled();
     $rows = $getRows();
     $shouldAutosize = $shouldAutosize();
+    $placeholder = $getPlaceholder();
     $statePath = $getStatePath();
+    $placeholder = $getPlaceholder();
 
     $initialHeight = (($rows ?? 2) * 1.5) + 0.75;
 @endphp
@@ -58,7 +60,7 @@
                             'id' => $getId(),
                             'maxlength' => (! $isConcealed) ? $getMaxLength() : null,
                             'minlength' => (! $isConcealed) ? $getMinLength() : null,
-                            'placeholder' => ($getPlaceholder() === null) ? null : e((string) $getPlaceholder()),
+                            'placeholder' => filled($placeholder) ? e($placeholder) : null,
                             'readonly' => $isReadOnly(),
                             'required' => $isRequired() && (! $isConcealed),
                             'rows' => $rows,


### PR DESCRIPTION
## Description

Escape placeholder values when rendering HTML attributes in Blade views so double quotes do not break the attribute or render as backslashes.
The fix is applied at output time in the view, not in setters.

* Affected views:
  `text-input`, `textarea`, `tags-input`, `color-picker`, `one-time-code-input`, `date-time-picker` (native input only)
* JS-driven placeholders are unchanged because they already use `@js(...)`.

Fixes #17170.

## Context

Placeholders that contain `"` either broke the HTML attribute or appeared with backslashes. Escaping at render time aligns with Blade practice and avoids mutating stored values.

## Scope of changes

Updated placeholder attribute handling in:

* `packages/forms/resources/views/components/text-input.blade.php`
* `packages/forms/resources/views/components/textarea.blade.php`
* `packages/forms/resources/views/components/tags-input.blade.php`
* `packages/forms/resources/views/components/color-picker.blade.php`
* `packages/forms/resources/views/components/one-time-code-input.blade.php`
* `packages/forms/resources/views/components/date-time-picker.blade.php`

## Implementation details

Use the null-safe escape when emitting the HTML attribute:

```php
'placeholder' => ($getPlaceholder() === null) ? null : e((string) $getPlaceholder()),
```

* Preserves `null` so no empty attributes are added.
* Casts to string before `e()` to avoid type warnings.
* Leaves JS-config placeholders as-is since `@js(...)` handles encoding.

## Visual changes

**Before**
<img width="2518" height="1472" alt="withoutfix" src="https://github.com/user-attachments/assets/7bb7f858-28c1-4ed1-9296-563b6342274c" />

**After**
<img width="2548" height="1436" alt="afterfix" src="https://github.com/user-attachments/assets/bc6d2641-dde1-4df2-baaf-0f8f098dd0bd" />

## QA

* Verified in a fresh Laravel app that placeholders containing `"` render correctly in: TextInput, Textarea, TagsInput, ColorPicker, OneTimeCodeInput, and the native DateTimePicker input.
* JS-driven editors and selects remain unchanged and behave as before.