### PR TITLE
Add Schema component support to Table repeater

### DIFF
--- a/packages/forms/resources/views/components/repeater/table.blade.php
+++ b/packages/forms/resources/views/components/repeater/table.blade.php
@@ -140,8 +140,8 @@
                                 @foreach ($item->getComponents(withHidden: true) as $component)
                                     @php
                                         throw_unless(
-                                            $component instanceof \Filament\Schemas\Components\Component || $component instanceof \Filament\Forms\Components\Field || $component instanceof \Filament\Infolists\Components\Entry,
-                                            new \Exception('Table repeaters must only contain schema components, form fields and infolist entries, but [' . $component::class . '] was used.'),
+                                            $component instanceof \Filament\Schemas\Components\Component,
+                                            new \Exception('Table repeaters must only contain schema components, but [' . $component::class . '] was used.'),
                                         );
                                     @endphp
 

--- a/packages/forms/resources/views/components/repeater/table.blade.php
+++ b/packages/forms/resources/views/components/repeater/table.blade.php
@@ -140,8 +140,8 @@
                                 @foreach ($item->getComponents(withHidden: true) as $component)
                                     @php
                                         throw_unless(
-                                            $component instanceof \Filament\Forms\Components\Field || $component instanceof \Filament\Infolists\Components\Entry,
-                                            new \Exception('Table repeaters must only contain form fields and infolist entries, but [' . $component::class . '] was used.'),
+                                            $component instanceof \Filament\Schemas\Components\Component || $component instanceof \Filament\Forms\Components\Field || $component instanceof \Filament\Infolists\Components\Entry,
+                                            new \Exception('Table repeaters must only contain schema components, form fields and infolist entries, but [' . $component::class . '] was used.'),
                                         );
                                     @endphp
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

PR https://github.com/filamentphp/filament/pull/17406 shows that we can't use a `TableRepeater` with a dynamic field.
With this changes, `TableRepeater` supports [Schema components](https://filamentphp.com/docs/4.x/schemas/overview), allowing us to use a `Group` component to create dynamic fields with reactivity.

```php
Repeater::make('data')
->table([
    TableColumn::make('type'),
    TableColumn::make('value'),
    TableColumn::make('date'),
])
->schema([
    Select::make('data')
        ->options([
            '1' => 'Height',
            '2' => 'Blood type',
        ])
        ->default('1')
        ->live(),
    Group::make(fn (Get $get): array => match ($get('data')) {
        default => [],
        '1' => [
            TextInput::make('value')
                ->numeric()
                ->required(),
        ],
        '2' => [
            Select::make('value')
                ->options([
                    'A+' => 'A+',
                    'A-' => 'A-',
                ])
                ->required(),
        ]
    }),
    DatePicker::make('date')
        ->required(),
]),
```

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<img width="615" height="294" alt="image" src="https://github.com/user-attachments/assets/ae28644d-d988-48e2-aeed-678ee180c33d" />

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
