### PR TITLE
Feat: add mfa concerns with default values in methods for contracts

### DIFF
--- a/docs/07-users/02-multi-factor-authentication.md
+++ b/docs/07-users/02-multi-factor-authentication.md
@@ -75,6 +75,7 @@ class User extends Authenticatable implements FilamentUser, MustVerifyEmail
 ```
 
 Next, you should implement the `HasAppAuthentication` interface on the `User` model. This provides Filament with the necessary methods to interact with the secret code and other information about the integration:
+To use the default column name `app_authentication_secret`, you can import `Filament\Auth\MultiFactor\App\Concerns\InteractsWithAppAuthentication` trait and use it in your `User` model. This trait provides the necessary methods to interact with the app authentication secret:
 
 ```php
 use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthentication;
@@ -183,6 +184,8 @@ class User extends Authenticatable implements FilamentUser, HasAppAuthentication
 ```
 
 Next, you should implement the `HasAppAuthenticationRecovery` interface on the `User` model. This provides Filament with the necessary methods to interact with the recovery codes:
+To use the default column name `app_authentication_recovery_codes`, you can import `Filament\Auth\MultiFactor\App\Concerns\InteractsWithAppAuthenticationRecovery` trait and use it in your `User` model. This trait provides the necessary methods to interact with the app authentication recovery codes:
+
 
 ```php
 use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthentication;
@@ -359,6 +362,7 @@ class User extends Authenticatable implements FilamentUser, MustVerifyEmail
 ```
 
 Next, you should implement the `HasEmailAuthentication` interface on the `User` model. This provides Filament with the necessary methods to interact with the column that indicates whether or not email authentication is enabled:
+To use the default column name `has_email_authentication`, you can import `Filament\Auth\MultiFactor\App\Concerns\InteractsWithEmailAuthentication` trait and use it in your `User` model. This trait provides the necessary methods to interact with the email authentication:
 
 ```php
 use Filament\Auth\MultiFactor\Email\Contracts\HasEmailAuthentication;

--- a/packages/panels/src/Auth/MultiFactor/App/Concerns/InteractsWithAppAuthentication.php
+++ b/packages/panels/src/Auth/MultiFactor/App/Concerns/InteractsWithAppAuthentication.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Filament\Auth\MultiFactor\App\Concerns;
+
+trait InteractsWithAppAuthentication
+{
+    public function getAppAuthenticationSecret(): ?string
+    {
+        return $this->app_authentication_secret;
+    }
+
+    public function saveAppAuthenticationSecret(?string $secret): void
+    {
+        $this->app_authentication_secret = $secret;
+        $this->save();
+    }
+
+    public function getAppAuthenticationRecoveryCodes(): ?array
+    {
+        return $this->app_authentication_recovery_codes;
+    }
+}

--- a/packages/panels/src/Auth/MultiFactor/App/Concerns/InteractsWithAppAuthentication.php
+++ b/packages/panels/src/Auth/MultiFactor/App/Concerns/InteractsWithAppAuthentication.php
@@ -15,8 +15,8 @@ trait InteractsWithAppAuthentication
         $this->save();
     }
 
-    public function getAppAuthenticationRecoveryCodes(): ?array
+    public function getAppAuthenticationHolderName(): string
     {
-        return $this->app_authentication_recovery_codes;
+        return $this->email;
     }
 }

--- a/packages/panels/src/Auth/MultiFactor/App/Concerns/InteractsWithAppAuthenticationRecovery.php
+++ b/packages/panels/src/Auth/MultiFactor/App/Concerns/InteractsWithAppAuthenticationRecovery.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Filament\Auth\MultiFactor\App\Concerns;
+
+trait InteractsWithAppAuthenticationRecovery
+{
+    public function saveAppAuthenticationRecoveryCodes(?array $codes): void
+    {
+        $this->app_authentication_recovery_codes = $codes;
+        $this->save();
+    }
+}

--- a/packages/panels/src/Auth/MultiFactor/App/Concerns/InteractsWithAppAuthenticationRecovery.php
+++ b/packages/panels/src/Auth/MultiFactor/App/Concerns/InteractsWithAppAuthenticationRecovery.php
@@ -4,6 +4,11 @@ namespace Filament\Auth\MultiFactor\App\Concerns;
 
 trait InteractsWithAppAuthenticationRecovery
 {
+    public function getAppAuthenticationRecoveryCodes(): ?array
+    {
+        return $this->app_authentication_recovery_codes;
+    }
+
     public function saveAppAuthenticationRecoveryCodes(?array $codes): void
     {
         $this->app_authentication_recovery_codes = $codes;

--- a/packages/panels/src/Auth/MultiFactor/App/Concerns/InteractsWithEmailAuthentication.php
+++ b/packages/panels/src/Auth/MultiFactor/App/Concerns/InteractsWithEmailAuthentication.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Filament\Auth\MultiFactor\App\Concerns;
+
+trait InteractsWithEmailAuthentication
+{
+    public function hasEmailAuthentication(): bool
+    {
+        return (bool) $this->has_email_authentication;
+    }
+
+    public function toggleEmailAuthentication(bool $condition): void
+    {
+        $this->has_email_authentication = $condition;
+        $this->save();
+    }
+}

--- a/tests/src/Fixtures/Models/User.php
+++ b/tests/src/Fixtures/Models/User.php
@@ -75,11 +75,6 @@ class User extends Authenticatable implements FilamentUser, HasAppAuthentication
         return Team::all();
     }
 
-    public function getAppAuthenticationHolderName(): string
-    {
-        return $this->email;
-    }
-
     public function hasEmailAuthentication(): bool
     {
         return (bool) $this->has_email_authentication;

--- a/tests/src/Fixtures/Models/User.php
+++ b/tests/src/Fixtures/Models/User.php
@@ -4,6 +4,7 @@ namespace Filament\Tests\Fixtures\Models;
 
 use Filament\Auth\MultiFactor\App\Concerns\InteractsWithAppAuthentication;
 use Filament\Auth\MultiFactor\App\Concerns\InteractsWithAppAuthenticationRecovery;
+use Filament\Auth\MultiFactor\App\Concerns\InteractsWithEmailAuthentication;
 use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthentication;
 use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthenticationRecovery;
 use Filament\Auth\MultiFactor\Email\Contracts\HasEmailAuthentication;
@@ -25,6 +26,7 @@ class User extends Authenticatable implements FilamentUser, HasAppAuthentication
     use HasFactory;
     use InteractsWithAppAuthentication;
     use InteractsWithAppAuthenticationRecovery;
+    use InteractsWithEmailAuthentication;
     use Notifiable;
 
     protected $guarded = [];
@@ -73,17 +75,6 @@ class User extends Authenticatable implements FilamentUser, HasAppAuthentication
     public function getTenants(Panel $panel): array | Collection
     {
         return Team::all();
-    }
-
-    public function hasEmailAuthentication(): bool
-    {
-        return (bool) $this->has_email_authentication;
-    }
-
-    public function toggleEmailAuthentication(bool $condition): void
-    {
-        $this->has_email_authentication = $condition;
-        $this->save();
     }
 
     public function teams(): BelongsToMany

--- a/tests/src/Fixtures/Models/User.php
+++ b/tests/src/Fixtures/Models/User.php
@@ -2,6 +2,8 @@
 
 namespace Filament\Tests\Fixtures\Models;
 
+use Filament\Auth\MultiFactor\App\Concerns\InteractsWithAppAuthentication;
+use Filament\Auth\MultiFactor\App\Concerns\InteractsWithAppAuthenticationRecovery;
 use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthentication;
 use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthenticationRecovery;
 use Filament\Auth\MultiFactor\Email\Contracts\HasEmailAuthentication;
@@ -21,6 +23,8 @@ use Illuminate\Support\Collection;
 class User extends Authenticatable implements FilamentUser, HasAppAuthentication, HasAppAuthenticationRecovery, HasEmailAuthentication, HasTenants, MustVerifyEmail
 {
     use HasFactory;
+    use InteractsWithAppAuthentication;
+    use InteractsWithAppAuthenticationRecovery;
     use Notifiable;
 
     protected $guarded = [];
@@ -69,28 +73,6 @@ class User extends Authenticatable implements FilamentUser, HasAppAuthentication
     public function getTenants(Panel $panel): array | Collection
     {
         return Team::all();
-    }
-
-    public function getAppAuthenticationSecret(): ?string
-    {
-        return $this->app_authentication_secret;
-    }
-
-    public function saveAppAuthenticationSecret(?string $secret): void
-    {
-        $this->app_authentication_secret = $secret;
-        $this->save();
-    }
-
-    public function getAppAuthenticationRecoveryCodes(): ?array
-    {
-        return $this->app_authentication_recovery_codes;
-    }
-
-    public function saveAppAuthenticationRecoveryCodes(?array $codes): void
-    {
-        $this->app_authentication_recovery_codes = $codes;
-        $this->save();
     }
 
     public function getAppAuthenticationHolderName(): string


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This pull request introduces new traits to simplify the implementation of multi-factor authentication features on the `User` model. By providing reusable trait implementations for app authentication, recovery codes, and email authentication, the codebase becomes cleaner and easier to maintain. The documentation and tests have also been updated to reflect these changes.

**Multi-factor authentication trait additions:**

* Added `InteractsWithAppAuthentication` trait to encapsulate methods for handling the app authentication secret (`getAppAuthenticationSecret`, `saveAppAuthenticationSecret`, and `getAppAuthenticationHolderName`).
* Added `InteractsWithAppAuthenticationRecovery` trait to manage app authentication recovery codes (`getAppAuthenticationRecoveryCodes` and `saveAppAuthenticationRecoveryCodes`).
* Added `InteractsWithEmailAuthentication` trait for managing email authentication state (`hasEmailAuthentication` and `toggleEmailAuthentication`).

**Documentation updates:**

* Updated the multi-factor authentication documentation to instruct users to use the new traits for default column names and method implementations in the `User` model. 

**Test and model refactoring:**

* Updated the test `User` model to use the new traits and removed the now-redundant method implementations, resulting in a cleaner and more maintainable model.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->
Before: All these methods needed to be added in User model - assuming we stick to Filament conventions
<img width="763" height="775" alt="image" src="https://github.com/user-attachments/assets/0387c8cb-24bc-42d7-90c0-4f808f2578a2" />

After: We just need to import these traits
<img width="730" height="381" alt="image" src="https://github.com/user-attachments/assets/1f117351-9df3-4080-9275-09e265999ecc" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.