### PR TITLE
[3.x] fix(forms): escape placeholder attributes so quotes render correctly

### DIFF
--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -71,7 +71,7 @@
                             'id' => $getId(),
                             'inlinePrefix' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
                             'inlineSuffix' => $isSuffixInline && (count($suffixActions) || $suffixIcon || filled($suffixLabel)),
-                            'placeholder' => $getPlaceholder(),
+                            'placeholder' => ($getPlaceholder() === null) ? null : e((string) $getPlaceholder()),
                             'required' => $isRequired() && (! $isConcealed()),
                             'type' => 'text',
                             'x-model' . ($isLiveDebounced ? '.debounce.' . $liveDebounce : null) => 'state',

--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -15,6 +15,7 @@
     $suffixIcon = $getSuffixIcon();
     $suffixLabel = $getSuffixLabel();
     $statePath = $getStatePath();
+    $placeholder = $getPlaceholder();
 @endphp
 
 <x-dynamic-component
@@ -71,7 +72,7 @@
                             'id' => $getId(),
                             'inlinePrefix' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
                             'inlineSuffix' => $isSuffixInline && (count($suffixActions) || $suffixIcon || filled($suffixLabel)),
-                            'placeholder' => ($getPlaceholder() === null) ? null : e((string) $getPlaceholder()),
+                            'placeholder' => filled($placeholder) ? e($placeholder) : null,
                             'required' => $isRequired() && (! $isConcealed()),
                             'type' => 'text',
                             'x-model' . ($isLiveDebounced ? '.debounce.' . $liveDebounce : null) => 'state',

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -55,7 +55,7 @@
                             'list' => $datalistOptions ? $id . '-list' : null,
                             'max' => $hasTime ? $maxDate : ($maxDate ? \Carbon\Carbon::parse($maxDate)->toDateString() : null),
                             'min' => $hasTime ? $minDate : ($minDate ? \Carbon\Carbon::parse($minDate)->toDateString() : null),
-                            'placeholder' => $getPlaceholder(),
+                            'placeholder' => ($getPlaceholder() === null) ? null : e((string) $getPlaceholder()),
                             'readonly' => $isReadOnly(),
                             'required' => $isRequired() && (! $isConcealed()),
                             'step' => $getStep(),

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -18,6 +18,7 @@
     $suffixIcon = $getSuffixIcon();
     $suffixLabel = $getSuffixLabel();
     $statePath = $getStatePath();
+    $placeholder = $getPlaceholder();
     $disabledDates = $getDisabledDates();
 @endphp
 
@@ -55,7 +56,7 @@
                             'list' => $datalistOptions ? $id . '-list' : null,
                             'max' => $hasTime ? $maxDate : ($maxDate ? \Carbon\Carbon::parse($maxDate)->toDateString() : null),
                             'min' => $hasTime ? $minDate : ($minDate ? \Carbon\Carbon::parse($minDate)->toDateString() : null),
-                            'placeholder' => ($getPlaceholder() === null) ? null : e((string) $getPlaceholder()),
+                            'placeholder' => filled($placeholder) ? e($placeholder) : null,
                             'readonly' => $isReadOnly(),
                             'required' => $isRequired() && (! $isConcealed()),
                             'step' => $getStep(),

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -88,7 +88,7 @@
                         'maxlength' => (! $isConcealed) ? $getMaxLength() : null,
                         'min' => (! $isConcealed) ? $getMinValue() : null,
                         'minlength' => (! $isConcealed) ? $getMinLength() : null,
-                        'placeholder' => $getPlaceholder(),
+                        'placeholder' => ($getPlaceholder() === null) ? null : e((string) $getPlaceholder()),
                         'readonly' => $isReadOnly(),
                         'required' => $isRequired() && (! $isConcealed),
                         'step' => $getStep(),

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -19,6 +19,7 @@
     $suffixIcon = $getSuffixIcon();
     $suffixLabel = $getSuffixLabel();
     $statePath = $getStatePath();
+    $placeholder = $getPlaceholder();
 
     if ($isPasswordRevealable) {
         $xData = '{ isPasswordRevealed: false }';
@@ -88,7 +89,7 @@
                         'maxlength' => (! $isConcealed) ? $getMaxLength() : null,
                         'min' => (! $isConcealed) ? $getMinValue() : null,
                         'minlength' => (! $isConcealed) ? $getMinLength() : null,
-                        'placeholder' => ($getPlaceholder() === null) ? null : e((string) $getPlaceholder()),
+                        'placeholder' => filled($placeholder) ? e($placeholder) : null,
                         'readonly' => $isReadOnly(),
                         'required' => $isRequired() && (! $isConcealed),
                         'step' => $getStep(),

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -67,7 +67,7 @@
                             'id' => $getId(),
                             'maxlength' => (! $isConcealed) ? $getMaxLength() : null,
                             'minlength' => (! $isConcealed) ? $getMinLength() : null,
-                            'placeholder' => $getPlaceholder(),
+                            'placeholder' => ($getPlaceholder() === null) ? null : e((string) $getPlaceholder()),
                             'readonly' => $isReadOnly(),
                             'required' => $isRequired() && (! $isConcealed),
                             'rows' => $rows,

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -5,6 +5,7 @@
     $isConcealed = $isConcealed();
     $isDisabled = $isDisabled();
     $rows = $getRows();
+    $placeholder = $getPlaceholder();
     $shouldAutosize = $shouldAutosize();
     $statePath = $getStatePath();
 
@@ -67,7 +68,7 @@
                             'id' => $getId(),
                             'maxlength' => (! $isConcealed) ? $getMaxLength() : null,
                             'minlength' => (! $isConcealed) ? $getMinLength() : null,
-                            'placeholder' => ($getPlaceholder() === null) ? null : e((string) $getPlaceholder()),
+                            'placeholder' => filled($placeholder) ? e($placeholder) : null,
                             'readonly' => $isReadOnly(),
                             'required' => $isRequired() && (! $isConcealed),
                             'rows' => $rows,


### PR DESCRIPTION
## Description

Escape placeholder values when rendering HTML attributes in Blade views so double quotes do not break the attribute or render as backslashes.
The fix is applied at output time in the view, not in setters.

Fixes #17170.

Version for [3.x] - submitted version for [4.x] #17408.

## Context

Placeholders that contain `"` either broke the HTML attribute or appeared with backslashes. Escaping at render time aligns with Blade practice and avoids mutating stored values.

## Scope of changes

Updated placeholder attribute handling in:

* `packages/forms/resources/views/components/text-input.blade.php`
* `packages/forms/resources/views/components/textarea.blade.php`
* `packages/forms/resources/views/components/color-picker.blade.php`
* `packages/forms/resources/views/components/date-time-picker.blade.php`

## Implementation details

Use the null-safe escape when emitting the HTML attribute:

```php
'placeholder' => ($getPlaceholder() === null) ? null : e((string) $getPlaceholder()),
```