### PR TITLE
[4.x] Fix typo in Icon column docs

### DIFF
--- a/packages/tables/docs/02-columns/03-icon.md
+++ b/packages/tables/docs/02-columns/03-icon.md
@@ -14,7 +14,7 @@ use Filament\Tables\Columns\IconColumn;
 use Filament\Support\Icons\Heroicon;
 
 IconColumn::make('status')
-    ->icon(fn (string $state): Herocicon => match ($state) {
+    ->icon(fn (string $state): Heroicon => match ($state) {
         'draft' => Heroicon::OutlinedPencil,
         'reviewing' => Heroicon::OutlinedClock,
         'published' => Heroicon::OutlinedCheckCircle,


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

It was written as “Herocicon” instead of “Heroicon.”

https://filamentphp.com/docs/4.x/tables/columns/icon

## Visual changes

Before:

<img width="928" height="369" alt="image" src="https://github.com/user-attachments/assets/fc894b9c-d484-4b4c-92da-ee15d9c6b350" />

After:

<img width="917" height="372" alt="image" src="https://github.com/user-attachments/assets/f43166d8-e217-4e7b-ad40-f3d3921f7317" />


## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
