### PR TITLE
Implement HasRenderHookScopes on RelationManager

### DIFF
--- a/packages/panels/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManager.php
@@ -32,6 +32,7 @@ use Filament\Schemas\Components\EmbeddedTable;
 use Filament\Schemas\Components\RenderHook;
 use Filament\Schemas\Components\Tabs\Tab;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasRenderHookScopes;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use Filament\Support\Concerns\CanBeLazy;
@@ -48,7 +49,7 @@ use Livewire\Component;
 
 use function Filament\authorize;
 
-class RelationManager extends Component implements HasActions, HasSchemas, HasTable
+class RelationManager extends Component implements HasActions, HasRenderHookScopes, HasSchemas, HasTable
 {
     use CanBeLazy;
     use InteractsWithActions;


### PR DESCRIPTION
The RelationManager class wasn't implementing `HasRenderHookScopes` causing `getScopes()` to return an empty array for RelationManagers and therefore any Renderhook scoped to the RelationManager class wouldn't be shown.