### PR TITLE
Documentation: Rich content attribute must be nullable in database.

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/README.md
+++ b/packages/spatie-laravel-media-library-plugin/README.md
@@ -195,6 +195,8 @@ class Post extends Model implements HasRichContent
 }
 ```
 
+> Using `SpatieMediaLibraryFileAttachmentProvider` requires that the rich content attribute (`content` in this example) must be defined as nullable in database.
+
 A media collection with the same name as the attribute (`content` in this example) will be used for the file attachments. The collection must not contain any other media apart from file attachments for that attribute, since Filament will clear any unused media from the collection when the model is saved. To customize the name of the collection, you can pass it to the `collection()` method of the provider:
 
 ```php


### PR DESCRIPTION
## Description

fix #17331 
Update documentation to show that the use of SpatieMediaLibraryFileAttachmentProvider requires the rich content attribute to be nullable in the database.

## Visual changes

<img width="851" height="834" alt="image" src="https://github.com/user-attachments/assets/dd61436f-3365-4a9a-bf18-13f088058734" />
