### PR TITLE
[4.x] Fix: Save multiple files at once in the Rich Editor with spatie-laravel-media-library-plugin

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/RichEditor/FileAttachmentProviders/SpatieMediaLibraryFileAttachmentProvider.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/RichEditor/FileAttachmentProviders/SpatieMediaLibraryFileAttachmentProvider.php
@@ -94,11 +94,14 @@ class SpatieMediaLibraryFileAttachmentProvider implements FileAttachmentProvider
 
     public function saveUploadedFileAttachment(TemporaryUploadedFile $file): mixed
     {
-        return $this->getExistingModel() /** @phpstan-ignore method.notFound */
+        $media = $this->getExistingModel() /** @phpstan-ignore method.notFound */
             ->addMediaFromString($file->get())
             ->usingFileName(((string) Str::ulid()) . '.' . $file->getClientOriginalExtension())
-            ->toMediaCollection($this->getCollection(), diskName: $this->attribute->getFileAttachmentsDiskName() ?? '')
-            ->uuid;
+            ->toMediaCollection($this->getCollection(), diskName: $this->attribute->getFileAttachmentsDiskName() ?? '');
+
+        $this->getMedia()->put($media->uuid, $media);
+
+        return $media->uuid;
     }
 
     /**


### PR DESCRIPTION
## Description

This fixes the bug that prevented media URLs from being saved in rich editor content when multiple new files were saved using SpatieMediaLibraryFileAttachmentProvider.
See #17432

Because laravel-medialibrary caches the database query results in the model, media saved after the first one cannot be retrieved from the database.

In addition, the spatie-laravel-media-library-plugin plugin also caches the response in a provider variable ($this->media).

The fix is to add new media to the spatie-laravel-media-library-plugin cache each time they are added.

## Visual changes

**Before:**
```php
  public function saveUploadedFileAttachment(TemporaryUploadedFile $file): mixed
  {
      return $this->getExistingModel() /** @phpstan-ignore method.notFound */
          ->addMediaFromString($file->get())
          ->usingFileName(((string) Str::ulid()) . '.' . $file->getClientOriginalExtension())
          ->toMediaCollection($this->getCollection(), diskName: $this->attribute->getFileAttachmentsDiskName() ?? '')
          ->uuid;
  }
```

**After:**
```php
  public function saveUploadedFileAttachment(TemporaryUploadedFile $file): mixed
  {
      $media = $this->getExistingModel() /** @phpstan-ignore method.notFound */
          ->addMediaFromString($file->get())
          ->usingFileName(((string) Str::ulid()) . '.' . $file->getClientOriginalExtension())
          ->toMediaCollection($this->getCollection(), diskName: $this->attribute->getFileAttachmentsDiskName() ?? '');

      $this->getMedia()->put($media->uuid, $media);

      return $media->uuid;
  }
```
## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
