### PR TITLE
Hide blank column labels in the column manager

### DIFF
--- a/packages/tables/resources/views/components/column-manager.blade.php
+++ b/packages/tables/resources/views/components/column-manager.blade.php
@@ -57,7 +57,7 @@
             }}
         >
             <template
-                x-for="(column, index) in columns.filter((column) => ! column.isHidden)"
+                x-for="(column, index) in columns.filter((column) => ! column.isHidden && column.label)"
                 x-bind:key="(column.type === 'group' ? 'group::' : 'column::') + column.name + '_' + index"
             >
                 <div
@@ -104,7 +104,10 @@
                                 class="fi-ta-col-manager-group-items"
                             >
                                 <template
-                                    x-for="(groupColumn, index) in column.columns.filter((column) => ! column.isHidden)"
+                                    x-for="
+                                        (groupColumn, index) in
+                                            column.columns.filter((column) => ! column.isHidden && column.label)
+                                    "
                                     x-bind:key="'column::' + groupColumn.name + '_' + index"
                                 >
                                     <div

--- a/packages/tables/src/Columns/Concerns/CanBeToggled.php
+++ b/packages/tables/src/Columns/Concerns/CanBeToggled.php
@@ -36,6 +36,12 @@ trait CanBeToggled
             return false;
         }
 
+        // When a column label is blank, it must be toggleable so that
+        // column groups can be collectively toggled on/off.
+        if (blank($this->getLabel())) {
+            return true;
+        }
+
         return (bool) $this->evaluate($this->isToggleable);
     }
 

--- a/packages/tables/src/Concerns/HasColumnManager.php
+++ b/packages/tables/src/Concerns/HasColumnManager.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Tables\Concerns;
 
+use Exception;
 use Filament\Schemas\Schema;
 use Filament\Support\Components\Component;
 use Filament\Tables\Columns\Column;
@@ -25,6 +26,8 @@ trait HasColumnManager
      * @var ?array<int, array{type: string, name: string, label: string, isHidden: bool, isToggled: bool, isToggleable: bool, isToggledHiddenByDefault: ?bool, isToggled: bool, isToggleable: bool, isToggledHiddenByDefault: ?bool,columns?: array<int, array{type: string, name: string, label: string, isHidden: bool, isToggled: bool, isToggleable: bool, isToggledHiddenByDefault: ?bool}>}>
      */
     protected ?array $cachedDefaultTableColumnState = null;
+
+    protected ?bool $hasReorderableTableColumns = null;
 
     public function initTableColumnManager(): void
     {
@@ -68,17 +71,15 @@ trait HasColumnManager
      */
     public function applyTableColumnManager(?array $state = null): void
     {
-        $hasReorderableColumns = $this->getTable()->hasReorderableColumns();
-
         if (filled($state)) {
             $this->tableColumns = $state;
 
-            if ($hasReorderableColumns) {
+            if ($this->hasReorderableTableColumns()) {
                 $this->persistHasReorderedTableColumns();
             }
         }
 
-        $hasReorderableColumns && session()->get($this->getHasReorderedTableColumnsSessionKey())
+        $this->hasReorderableTableColumns() && session()->get($this->getHasReorderedTableColumnsSessionKey())
             ? $this->syncReorderableColumnsFromDefaultTableColumnState()
             : $this->syncStaticColumnsFromTableColumnState();
 
@@ -89,7 +90,7 @@ trait HasColumnManager
     {
         $this->tableColumns = $this->getDefaultTableColumnState();
 
-        if ($this->getTable()->hasReorderableColumns()) {
+        if ($this->hasReorderableTableColumns()) {
             $this->updateTableColumns();
             $this->persistHasReorderedTableColumns();
         }
@@ -218,10 +219,16 @@ trait HasColumnManager
      */
     protected function mapTableColumnToArray(Column $column): array
     {
+        $label = (string) $column->getLabel();
+
+        if (blank($label) && $this->hasReorderableTableColumns()) {
+            throw new Exception("The column [{$column->getName()}] has a blank label. Columns must have labels when reorderable columns is enabled.");
+        }
+
         return [
             'type' => self::TABLE_COLUMN_MANAGER_COLUMN_TYPE,
             'name' => $column->getName(),
-            'label' => (string) $column->getLabel(),
+            'label' => $label,
             'isHidden' => $column->isHidden(),
             'isToggled' => ! $column->isToggleable() || ! $column->isToggledHiddenByDefault(),
             'isToggleable' => $column->isToggleable(),
@@ -432,6 +439,11 @@ trait HasColumnManager
                 fn (array $candidate) => $candidate['type'] === $item['type'] &&
                 $candidate['name'] === $item['name']
             );
+    }
+
+    protected function hasReorderableTableColumns(): bool
+    {
+        return $this->hasReorderableTableColumns ??= $this->getTable()->hasReorderableColumns();
     }
 
     protected function hasReorderedTableColumns(): bool

--- a/packages/tables/src/Concerns/HasColumnManager.php
+++ b/packages/tables/src/Concerns/HasColumnManager.php
@@ -222,7 +222,7 @@ trait HasColumnManager
         $label = (string) $column->getLabel();
 
         if (blank($label) && $this->hasReorderableTableColumns()) {
-            throw new Exception("The column [{$column->getName()}] has a blank label. Columns must have labels when reorderable columns is enabled.");
+            throw new Exception("The table column [{$column->getName()}] has a blank label. All columns must have labels when they are reorderable.");
         }
 
         return [


### PR DESCRIPTION
Fixes #17378 

Not showing a column with a blank label in the column manager was easy enough to implement in `column-manager.blade.php`

However, for column groups to work properly, a column with a blank label _must_ be toggleable so that the entire group can be toggled off. The easiest way to enforce that was in the `canBeToggled()` method. I don't love comments in methods, but what I added seems so random that I felt a comment was needed. Whenever I backfill tests, I should be able to remove that comment and let the test catch it. 

Since we need to check if reorderable columns is enabled when the label is blank, I cached that in a new property so we don't have to evaluate it each time.

Finally, I went ahead and chose option A from my last comment in the issue. If I need to implement option B just let me know.