### PR TITLE
[4.x] Fixes file visibility to configured filesystem disk

### DIFF
--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -539,7 +539,7 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
             return $visibility;
         }
 
-        if ($this->getCustomDiskName() !== 'public') {
+        if ($this->getDiskName() !== 'public') {
             return $visibility;
         }
 

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -498,17 +498,7 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
             return $name;
         }
 
-        $name = config('filament.default_filesystem_disk');
-
-        if ($name !== 'public') {
-            return $name;
-        }
-
-        if ($this->getVisibility() !== 'private') {
-            return $name;
-        }
-
-        return 'local';
+        return config('filament.default_filesystem_disk');
     }
 
     public function getCustomDiskName(): ?string

--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -8,12 +8,12 @@ use Carbon\CarbonInterface;
 use Closure;
 use Filament\Support\Components\Component;
 use Filament\Support\Contracts\HasLabel as LabelInterface;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Arr;
-use Illuminate\Contracts\Support\Htmlable;
 
 class Group extends Component
 {

--- a/tests/src/Forms/Components/FileUploadTest.php
+++ b/tests/src/Forms/Components/FileUploadTest.php
@@ -12,23 +12,42 @@ use function Filament\Tests\livewire;
 
 uses(TestCase::class);
 
-describe('upload filesystem', function (): void {
-    it('should have local filesystem by default', function (): void {
-        $disk = config('filament.default_filesystem_disk');
+describe('upload disk & visibility', function (): void {
+    describe('disk', function () {
+        it('should have local disk by default', function (): void {
+            $disk = config('filament.default_filesystem_disk');
 
-        $uploader = FileUpload::make('test_file');
-        expect($uploader->getDiskName())->toBe($disk);
+            $uploader = FileUpload::make('test_file');
+            expect($uploader->getDiskName())->toBe($disk);
+        });
+
+        it('overrides disk name using config', function (): void {
+            Config::set('filament.default_filesystem_disk', 'public');
+
+            $disk = config('filament.default_filesystem_disk');
+
+            $uploader = FileUpload::make('test_file');
+            expect($uploader->getDiskName())->toBe($disk);
+        });
     });
 
-    it('overrides local filesystem using config', function (): void {
-        Config::set('filament.default_filesystem_disk', 'public');
+    describe('visibility', function (): void {
+        it('should have private visibility by default', function (): void {
+            $uploader = FileUpload::make('test_file');
+            expect($uploader->getVisibility())->toBe('private');
+        });
 
-        $disk = config('filament.default_filesystem_disk');
+        it('overrides visibility using config', function (): void {
+            Config::set('filament.default_filesystem_disk', 'public');
 
-        $uploader = FileUpload::make('test_file');
-        expect($uploader->getDiskName())->toBe($disk);
+            $publicVisibility = config('filesystems.disks.public.visibility', 'public');
+
+            $uploader = FileUpload::make('test_file');
+            expect($uploader->getDiskName())->toBe('public');
+            expect($uploader->getVisibility())->toBe($publicVisibility);
+        });
     });
-});
+})->only();
 it('UploadedFile should be converted to TemporaryUploadedFile', function (): void {
     try {
         livewire(TestComponentWithFileUpload::class)

--- a/tests/src/Forms/Components/FileUploadTest.php
+++ b/tests/src/Forms/Components/FileUploadTest.php
@@ -43,9 +43,9 @@ describe('uploader test', function (): void {
 
         it('overrides visibility using config', function (): void {
             Config::set('filament.default_filesystem_disk', 'public');
-            Config::set('filesystems.disks.public.visibility', 'private');
+            Config::set('filesystems.disks.public.visibility', 'public');
 
-            $publicVisibility = config('filesystems.disks.public.visibility', 'private');
+            $publicVisibility = config('filesystems.disks.public.visibility', 'public');
 
             $uploader = FileUpload::make('test_file');
             expect($uploader->getDiskName())->toBe('public');
@@ -72,7 +72,8 @@ describe('uploader test', function (): void {
             expect($uploader2->getVisibility())->toBe('private');
         });
     });
-});
+})->only();
+
 it('UploadedFile should be converted to TemporaryUploadedFile', function (): void {
     try {
         livewire(TestComponentWithFileUpload::class)

--- a/tests/src/Forms/Components/FileUploadTest.php
+++ b/tests/src/Forms/Components/FileUploadTest.php
@@ -12,6 +12,23 @@ use function Filament\Tests\livewire;
 
 uses(TestCase::class);
 
+describe('upload filesystem', function (): void {
+    it('should have local filesystem by default', function (): void {
+        $disk = config('filament.default_filesystem_disk');
+
+        $uploader = FileUpload::make('test_file');
+        expect($uploader->getDiskName())->toBe($disk);
+    });
+
+    it('overrides local filesystem using config', function (): void {
+        Config::set('filament.default_filesystem_disk', 'public');
+
+        $disk = config('filament.default_filesystem_disk');
+
+        $uploader = FileUpload::make('test_file');
+        expect($uploader->getDiskName())->toBe($disk);
+    });
+});
 it('UploadedFile should be converted to TemporaryUploadedFile', function (): void {
     try {
         livewire(TestComponentWithFileUpload::class)

--- a/tests/src/Forms/Components/FileUploadTest.php
+++ b/tests/src/Forms/Components/FileUploadTest.php
@@ -61,7 +61,7 @@ describe('uploader test', function (): void {
             expect($uploader2->getVisibility())->toBe('private');
         });
     });
-})->only();
+});
 
 it('UploadedFile should be converted to TemporaryUploadedFile', function (): void {
     try {

--- a/tests/src/Forms/Components/FileUploadTest.php
+++ b/tests/src/Forms/Components/FileUploadTest.php
@@ -41,17 +41,6 @@ describe('uploader test', function (): void {
             expect($uploader->getVisibility())->toBe('private');
         });
 
-        it('overrides visibility using config', function (): void {
-            Config::set('filament.default_filesystem_disk', 'public');
-            Config::set('filesystems.disks.public.visibility', 'public');
-
-            $publicVisibility = config('filesystems.disks.public.visibility', 'public');
-
-            $uploader = FileUpload::make('test_file');
-            expect($uploader->getDiskName())->toBe('public');
-            expect($uploader->getVisibility())->toBe($publicVisibility);
-        });
-
         it('overrides visibility from disk', function (): void {
             $uploader1 = FileUpload::make('test_file')
                 ->disk('public');

--- a/tests/src/Forms/Components/FileUploadTest.php
+++ b/tests/src/Forms/Components/FileUploadTest.php
@@ -29,6 +29,12 @@ describe('upload disk & visibility', function (): void {
             $uploader = FileUpload::make('test_file');
             expect($uploader->getDiskName())->toBe($disk);
         });
+
+        it('prioritizes disk name from method', function (): void {
+            $uploader = FileUpload::make('test_file')
+                ->disk('s3');
+            expect($uploader->getDiskName())->toBe('s3');
+        });
     });
 
     describe('visibility', function (): void {

--- a/tests/src/Forms/Components/FileUploadTest.php
+++ b/tests/src/Forms/Components/FileUploadTest.php
@@ -12,13 +12,11 @@ use function Filament\Tests\livewire;
 
 uses(TestCase::class);
 
-describe('upload disk & visibility', function (): void {
+describe('uploader test', function (): void {
     describe('disk', function () {
         it('should have local disk by default', function (): void {
-            $disk = config('filament.default_filesystem_disk');
-
             $uploader = FileUpload::make('test_file');
-            expect($uploader->getDiskName())->toBe($disk);
+            expect($uploader->getDiskName())->toBe('local');
         });
 
         it('overrides disk name using config', function (): void {
@@ -45,21 +43,36 @@ describe('upload disk & visibility', function (): void {
 
         it('overrides visibility using config', function (): void {
             Config::set('filament.default_filesystem_disk', 'public');
+            Config::set('filesystems.disks.public.visibility', 'private');
 
-            $publicVisibility = config('filesystems.disks.public.visibility', 'public');
+            $publicVisibility = config('filesystems.disks.public.visibility', 'private');
 
             $uploader = FileUpload::make('test_file');
             expect($uploader->getDiskName())->toBe('public');
             expect($uploader->getVisibility())->toBe($publicVisibility);
         });
 
+        it('overrides visibility from disk', function (): void {
+            $uploader1 = FileUpload::make('test_file')
+                ->disk('public');
+            expect($uploader1->getVisibility())->toBe('public');
+
+            $uploader2 = FileUpload::make('test_file')
+                ->disk('local');
+            expect($uploader2->getVisibility())->toBe('private');
+        });
+
         it('prioritizes visibility from method', function (): void {
-            $uploader = FileUpload::make('test_file')
+            $uploader1 = FileUpload::make('test_file')
                 ->visibility('public');
-            expect($uploader->getVisibility())->toBe('public');
+            expect($uploader1->getVisibility())->toBe('public');
+
+            $uploader2 = FileUpload::make('test_file')
+                ->visibility('private');
+            expect($uploader2->getVisibility())->toBe('private');
         });
     });
-})->only();
+});
 it('UploadedFile should be converted to TemporaryUploadedFile', function (): void {
     try {
         livewire(TestComponentWithFileUpload::class)

--- a/tests/src/Forms/Components/FileUploadTest.php
+++ b/tests/src/Forms/Components/FileUploadTest.php
@@ -13,7 +13,7 @@ use function Filament\Tests\livewire;
 uses(TestCase::class);
 
 describe('uploader test', function (): void {
-    describe('disk', function () {
+    describe('disk', function (): void {
         it('should have local disk by default', function (): void {
             $uploader = FileUpload::make('test_file');
             expect($uploader->getDiskName())->toBe('local');

--- a/tests/src/Forms/Components/FileUploadTest.php
+++ b/tests/src/Forms/Components/FileUploadTest.php
@@ -52,6 +52,12 @@ describe('upload disk & visibility', function (): void {
             expect($uploader->getDiskName())->toBe('public');
             expect($uploader->getVisibility())->toBe($publicVisibility);
         });
+
+        it('prioritizes visibility from method', function (): void {
+            $uploader = FileUpload::make('test_file')
+                ->visibility('public');
+            expect($uploader->getVisibility())->toBe('public');
+        });
     });
 })->only();
 it('UploadedFile should be converted to TemporaryUploadedFile', function (): void {


### PR DESCRIPTION
Continues #17453 

## Description

This PR updates the `BaseFileUpload` component’s `getDiskName()` method to align with configuration.

## Visual changes

- no UI changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
