### PR TITLE
Fix for extra attributes for ToggleColumn

### DIFF
--- a/packages/tables/src/Columns/ToggleColumn.php
+++ b/packages/tables/src/Columns/ToggleColumn.php
@@ -42,7 +42,7 @@ class ToggleColumn extends Column implements Editable, HasEmbeddedView
         $onIcon = $this->getOnIcon();
         $state = (bool) $this->getState();
 
-        $attributes = (new ComponentAttributeBag)
+        $attributes = $this->getExtraAttributeBag()
             ->merge([
                 'x-load' => true,
                 'x-load-src' => FilamentAsset::getAlpineComponentSrc('columns/toggle', 'filament/tables'),


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fix: ToggleColumn ignores extraAttributes

## Visual changes

No visual changes

## Functional changes

Now ->extraAttributes() call works same way on ToggleColumn as on SelectColumn, TextColumn, etc.
Previously extra attributes were ignored by ToggleColumn

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
