### PR TITLE
[v4] Fix (docs): Correction in documentation to hide close button for all modals in the application

### DIFF
--- a/packages/actions/docs/02-modals.md
+++ b/packages/actions/docs/02-modals.md
@@ -725,7 +725,7 @@ Action::make('updateAuthor')
 
 <UtilityInjection set="actions" version="4.x">The `modalCloseButton()` method also accepts a function to dynamically calculate the value. You can inject various utilities into the function as parameters.</UtilityInjection>
 
-If you'd like to hide the close button for all modals in the application, you can do so by calling `Modal::closeButton(false)` inside a service provider or middleware:
+If you'd like to hide the close button for all modals in the application, you can do so by calling `ModalComponent::closeButton(false)` inside a service provider or middleware:
 
 ```php
 use Filament\Support\View\Components\ModalComponent;


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
In the filament (v4) documentations on the page [https://filamentphp.com/docs/4.x/actions/modals](https://filamentphp.com/docs/4.x/actions/modals) , there is a typing mistake and it is mentioned : 

"If you’d like to hide the close button for all modals in the application, you can do so by calling Modal::closeButton(false) inside a service provider or middleware:"

But, instead of  **Modal::closeButton(false)** , it has to be **ModalComponent::closeButton(false)**

## Visual changes

<!-- Add screenshots/recordings of before and after. -->
If you’d like to hide the close button for all modals in the application, you can do so by calling ModalComponent::closeButton(false) inside a service provider or middleware:

## Functional changes

- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
