### PR TITLE
[v4] Fix (docs): Correction in documentation of Modals

### DIFF
--- a/packages/actions/docs/02-modals.md
+++ b/packages/actions/docs/02-modals.md
@@ -671,7 +671,7 @@ Action::make('updateAuthor')
 
 <UtilityInjection set="actions" version="4.x">The `closeModalByClickingAway()` method also accepts a function to dynamically calculate the value. You can inject various utilities into the function as parameters.</UtilityInjection>
 
-If you'd like to change the behavior for all modals in the application, you can do so by calling `Modal::closedByClickingAway()` inside a service provider or middleware:
+If you'd like to change the behavior for all modals in the application, you can do so by calling `ModalComponent::closedByClickingAway()` inside a service provider or middleware:
 
 ```php
 use Filament\Support\View\Components\ModalComponent;
@@ -698,7 +698,7 @@ Action::make('updateAuthor')
 
 <UtilityInjection set="actions" version="4.x">The `closeModalByEscaping()` method also accepts a function to dynamically calculate the value. You can inject various utilities into the function as parameters.</UtilityInjection>
 
-If you'd like to change the behavior for all modals in the application, you can do so by calling `Modal::closedByEscaping()` inside a service provider or middleware:
+If you'd like to change the behavior for all modals in the application, you can do so by calling `ModalComponent::closedByEscaping()` inside a service provider or middleware:
 
 ```php
 use Filament\Support\View\Components\ModalComponent;
@@ -725,7 +725,7 @@ Action::make('updateAuthor')
 
 <UtilityInjection set="actions" version="4.x">The `modalCloseButton()` method also accepts a function to dynamically calculate the value. You can inject various utilities into the function as parameters.</UtilityInjection>
 
-If you'd like to hide the close button for all modals in the application, you can do so by calling `Modal::closeButton(false)` inside a service provider or middleware:
+If you'd like to hide the close button for all modals in the application, you can do so by calling `ModalComponent::closeButton(false)` inside a service provider or middleware:
 
 ```php
 use Filament\Support\View\Components\ModalComponent;
@@ -752,7 +752,7 @@ Action::make('updateAuthor')
 
 <UtilityInjection set="actions" version="4.x">The `modalAutofocus()` method also accepts a function to dynamically calculate the value. You can inject various utilities into the function as parameters.</UtilityInjection>
 
-If you'd like to disable autofocus for all modals in the application, you can do so by calling `Modal::autofocus(false)` inside a service provider or middleware:
+If you'd like to disable autofocus for all modals in the application, you can do so by calling `ModalComponent::autofocus(false)` inside a service provider or middleware:
 
 ```php
 use Filament\Support\View\Components\ModalComponent;


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

In the filament (v4) documentations on the page [https://filamentphp.com/docs/4.x/actions/modals](https://filamentphp.com/docs/4.x/actions/modals) , there is a typing mistake at various places on the documentation page. 

It is mentioned : 
- Modal::closedByClickingAway()
- Modal::closedByEscaping()
- Modal::closeButton(false)
- Modal::autofocus(false)

Instead of Modal, it has to be ModalComponent class.

Changes : 
- ModalComponent::closedByClickingAway()
- ModalComponent::closedByEscaping()
- ModalComponent::closeButton(false)
- ModalComponent::autofocus(false)

In the code blocks, correct class (ModalComponent) is mentioned, its typing mistake in text outside the code blocks in the documentation.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

Before (Check Text Above the Code Block):
<img width="1087" height="258" alt="Screenshot 2025-08-22 155518" src="https://github.com/user-attachments/assets/e2de9738-d7ad-44d4-928e-0c691d38dfab" />
<img width="1086" height="249" alt="Screenshot 2025-08-22 155535" src="https://github.com/user-attachments/assets/12d816bd-420b-49b6-a0e1-e7ec6ca5f5f0" />
<img width="1089" height="241" alt="Screenshot 2025-08-22 155548" src="https://github.com/user-attachments/assets/3130c0be-af12-4f36-a3cb-f2c2a479bcbf" />
<img width="1088" height="251" alt="Screenshot 2025-08-22 155605" src="https://github.com/user-attachments/assets/607ff091-a80f-4ada-8b0c-cd5e1af27fbc" />


After (Code Editor's Screenshots): 
<img width="1745" height="260" alt="Screenshot 2025-08-22 155947" src="https://github.com/user-attachments/assets/fc313b42-127a-455e-9480-f4f8bc99cb69" />
<img width="1753" height="253" alt="Screenshot 2025-08-22 160000" src="https://github.com/user-attachments/assets/0a7ce914-d8fe-4cd7-b728-4591f48d219e" />
<img width="1750" height="252" alt="Screenshot 2025-08-22 160014" src="https://github.com/user-attachments/assets/ae757c85-82bd-4988-a063-2d4786a476ca" />
<img width="1754" height="251" alt="Screenshot 2025-08-22 160026" src="https://github.com/user-attachments/assets/b787b9d7-1d71-47ea-aa99-df4b8ed048c0" />




## Functional changes

- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
