### PR TITLE
fix disableToolbarButtons() removes entire toolbar

### DIFF
--- a/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
+++ b/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
@@ -31,7 +31,7 @@ trait InteractsWithToolbarButtons
         }
 
         $this->toolbarButtons = array_reduce(
-            $this->toolbarButtons ?? [],
+            $this->toolbarButtons ?? $this->getDefaultToolbarButtons(),
             function ($carry, $button) use ($buttonsToDisable) {
                 if (is_array($button)) {
                     $carry[] = array_values(array_filter(

--- a/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
+++ b/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
@@ -60,7 +60,7 @@ trait InteractsWithToolbarButtons
         }
 
         $this->toolbarButtons = [
-            ...$this->toolbarButtons ?? [],
+            ...$this->toolbarButtons ?? $this->getDefaultToolbarButtons(),
             ...$buttonsToEnable,
         ];
 


### PR DESCRIPTION
## Description

`array_reduce($this->toolbarButtons ?? [], ...)`
in `disableToolbarButtons()` removes all toolbar buttons if none are defined.

To reproduce:
```php
MarkdownEditor::make('foo')
    ->disableToolbarButtons([
        'codeBlock',
        'attachFiles',
]),
``` 

you will get a markdown editor without any buttons at all.

If `$this->toolbarButtons` is `null`, we need to iterate over the default toolbar button set.


## Visual changes
Current:
<img width="524" height="29" alt="image" src="https://github.com/user-attachments/assets/61eb51cb-6bdb-4a45-9c0a-1832404e384a" />


Issue solved:
<img width="524" height="74" alt="image" src="https://github.com/user-attachments/assets/72b37654-f7a9-43ac-818c-93d72a09dbef" />


## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
