### PR TITLE
[4.x] Include content method when creating a CustomPage

### DIFF
--- a/packages/panels/src/Commands/FileGenerators/CustomPageClassGenerator.php
+++ b/packages/panels/src/Commands/FileGenerators/CustomPageClassGenerator.php
@@ -4,6 +4,7 @@ namespace Filament\Commands\FileGenerators;
 
 use Filament\Clusters\Cluster;
 use Filament\Pages\Page;
+use Filament\Schemas\Schema;
 use Filament\Support\Commands\FileGenerators\ClassGenerator;
 use Filament\Support\Commands\FileGenerators\Concerns\CanGenerateViewProperty;
 use Nette\PhpGenerator\ClassType;
@@ -37,6 +38,7 @@ class CustomPageClassGenerator extends ClassGenerator
         $extendsBasename = class_basename($extends);
 
         return [
+            Schema::class,
             ...(($extendsBasename === class_basename($this->getFqn())) ? [$extends => "Base{$extendsBasename}"] : [$extends]),
             ...($this->hasCluster() ? (($this->getClusterBasename() === 'Page') ? [$this->getClusterFqn() => 'PageCluster'] : [$this->getClusterFqn()]) : []),
         ];
@@ -99,5 +101,25 @@ class CustomPageClassGenerator extends ClassGenerator
     public function hasCluster(): bool
     {
         return filled($this->getClusterFqn());
+    }
+
+    protected function addMethodsToClass(ClassType $class): void
+    {
+        $this->addContentMethodToClass($class);
+    }
+
+    protected function addContentMethodToClass(ClassType $class): void
+    {
+        $method = $class->addMethod('content')
+            ->setPublic()
+            ->setReturnType(Schema::class)
+            ->setBody(<<<'PHP'
+                return $schema
+                    ->components([
+                        //
+                    ]);
+                PHP);
+        $method->addParameter('schema')
+            ->setType(Schema::class);
     }
 }

--- a/packages/panels/stubs/PageView.stub
+++ b/packages/panels/stubs/PageView.stub
@@ -1,3 +1,3 @@
 <x-filament-panels::page>
-    {{-- Page content --}}
+    {{ $this->content }}
 </x-filament-panels::page>


### PR DESCRIPTION
## Description

It took me a lot of digging to understand how to render components in the blade filed of a custom page, in hindsight it's very straightforward because it's the same as any other page!

The setup for the content method is mirrored on https://github.com/filamentphp/filament/blob/7ea7b8e6f2e44eba6f2e85b8a850f4fa6947e3bd/packages/schemas/src/Commands/FileGenerators/LivewireSchemaComponentClassGenerator.php#L94

It felt intuitive to include a default content() method the same way other pages do, so this PR adds that.

https://filamentphp.com/docs/4.x/navigation/custom-pages

## Visual changes

None

## Functional changes

- [ ] `php artisan make:filament-page` command includes a `content()` method in the generated class and `{{ $this->content }}` in the view file

The documentation doesn't include any code examples of custom pages, so there's nothing to edit.

All the tests are passing and phpstan is happy.