### PR TITLE
fix: Cast ModalTableSelect HasMany state to strings to fix selection

### DIFF
--- a/packages/forms/src/Components/ModalTableSelect.php
+++ b/packages/forms/src/Components/ModalTableSelect.php
@@ -269,8 +269,9 @@ class ModalTableSelect extends Field
                 $relatedRecords = $relationship->getResults();
 
                 $component->state(
-                    // Cast the related keys to a string, otherwise JavaScript does not
-                    // know how to handle deselection.
+                    // @js() in the frontend casts numbers to strings.
+                    // Therefore, we need to cast array values to strings, too.
+                    // Otherwise, selection and deselection will break.
                     //
                     // https://github.com/filamentphp/filament/issues/1111
                     $relatedRecords
@@ -300,8 +301,14 @@ class ModalTableSelect extends Field
                 $relatedRecords = $relationship->getResults();
 
                 $component->state(
+                    // @js() in the frontend casts numbers to strings.
+                    // Therefore, we need to cast array values to strings, too.
+                    // Otherwise, selection and deselection will break.
+                    //
+                    // https://github.com/filamentphp/filament/issues/1111
                     $relatedRecords
                         ->pluck($relationship->getLocalKeyName())
+                        ->map(static fn ($key): string => strval($key))
                         ->all(),
                 );
 

--- a/packages/forms/src/Components/ModalTableSelect.php
+++ b/packages/forms/src/Components/ModalTableSelect.php
@@ -269,9 +269,8 @@ class ModalTableSelect extends Field
                 $relatedRecords = $relationship->getResults();
 
                 $component->state(
-                    // @js() in the frontend casts numbers to strings.
-                    // Therefore, we need to cast array values to strings, too.
-                    // Otherwise, selection and deselection will break.
+                    // Cast the related keys to a string, otherwise JavaScript does not
+                    // know how to handle deselection.
                     //
                     // https://github.com/filamentphp/filament/issues/1111
                     $relatedRecords
@@ -301,9 +300,8 @@ class ModalTableSelect extends Field
                 $relatedRecords = $relationship->getResults();
 
                 $component->state(
-                    // @js() in the frontend casts numbers to strings.
-                    // Therefore, we need to cast array values to strings, too.
-                    // Otherwise, selection and deselection will break.
+                    // Cast the related keys to a string, otherwise JavaScript does not
+                    // know how to handle deselection.
                     //
                     // https://github.com/filamentphp/filament/issues/1111
                     $relatedRecords


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

When using `ModalTableSelect` with a `HasMany` relationship and preselected values, currently it shows "3 selected records" but doesn't select the actual records. 

That's because the we compare string values in the frontend, to our IDs which are int values if not casted. The error was already fixed for `BelongsToMany` but apparently overlooked for `HasMany`

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
