### PR TITLE
[4.x] Fix SelectColumn crash when using objects as state values 

### DIFF
--- a/packages/tables/src/Columns/SelectColumn.php
+++ b/packages/tables/src/Columns/SelectColumn.php
@@ -31,6 +31,7 @@ use Illuminate\Support\Js;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Livewire\Attributes\Renderless;
+use Stringable;
 use Znck\Eloquent\Relations\BelongsToThrough;
 
 use function Filament\Support\generate_search_column_expression;
@@ -373,7 +374,7 @@ class SelectColumn extends Column implements Editable, HasEmbeddedView
 
             if ($state instanceof BackedEnum) {
                 $state = $state->value;
-            } elseif (is_object($state)) {
+            } elseif ($state instanceof Stringable) {
                 $state = (string) $state;
             }
 

--- a/packages/tables/src/Columns/SelectColumn.php
+++ b/packages/tables/src/Columns/SelectColumn.php
@@ -373,6 +373,8 @@ class SelectColumn extends Column implements Editable, HasEmbeddedView
 
             if ($state instanceof BackedEnum) {
                 $state = $state->value;
+            } elseif (is_object($state)) {
+                $state = (string) $state;
             }
 
             foreach ($options as $groupedOptions) {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

### Problem:

  SelectColumn crashes with "Cannot access offset of type [ObjectType] on array"  
      error when using object instances as state values, particularly common with:    
      - Spatie Model States
      - Any object used as column state 
      
      
<img width="1017" height="735" alt="Screenshot from 2025-08-23 02-17-42" src="https://github.com/user-attachments/assets/99869a32-71a1-4c73-8c14-9c436c481501" />

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
