### PR TITLE
[4.x] Fix undefined $shouldOpenUrlInNewTab variable in entry wrapper

### DIFF
--- a/packages/infolists/resources/views/components/entry-wrapper.blade.php
+++ b/packages/infolists/resources/views/components/entry-wrapper.blade.php
@@ -17,6 +17,7 @@
         $label ??= $entry->getLabel();
         $labelSrOnly ??= $entry->isLabelHidden();
         $url ??= $entry->getUrl();
+        $shouldOpenUrlInNewTab ??= $entry->shouldOpenUrlInNewTab();
     }
 
     if (! $alignment instanceof Alignment) {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

- Add missing `$shouldOpenUrlInNewTab` variable assignment in entry wrapper template
- The variable was being used on line 91 but never defined, causing undefined variable errors

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
