### PR TITLE
[4.x] Fix Modal Close when there is autofocus on an element in a section in forms

### DIFF
--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -181,7 +181,7 @@
                             icon-size="lg"
                             :label="__('filament::components/modal.actions.close.label')"
                             tabindex="-1"
-                            :x-on:click="$closeEventHandler"
+                            :x-on:mousedown="$closeEventHandler"
                             class="fi-modal-close-btn"
                         />
                     @endif
@@ -230,6 +230,13 @@
                     @if (filled($id))
                         wire:key="{{ isset($this) ? "{$this->getId()}." : '' }}modal.{{ $id }}.footer"
                     @endif
+                    x-on:mousedown.capture="
+                        if ($event.target.closest('button, .fi-btn')) {
+                            $event.preventDefault();
+                            $event.stopPropagation();
+                            $event.target.closest('button, .fi-btn').click();
+                        }
+                    "
                     @class([
                         'fi-modal-footer',
                         'fi-sticky' => $stickyFooter,


### PR DESCRIPTION
## Description

When a modal contains autofocused inputs in sections, clicking the close button (X) or footer cancel button requires two clicks to close the modal. The first click removes focus from the autofocused input, and only the second click actually closes the modal.

This happens because Alpine.js focus trap (x-trap) intercepts the first click event to manage focus, preventing the close handler from executing on the first click.

**Solution:**
- Changed X button close handler from `x-on:click` to `x-on:mousedown`
- Added `x-on:mousedown.capture` event handler to modal footer to intercept footer button clicks before the focus trap

This allows close actions to execute immediately without focus trap interference while preserving all existing modal functionality and autofocus behavior.

## Visual changes

No visual changes - this is a behavioral fix. The modal appearance remains the same, but close buttons now work on the first click instead of requiring two clicks.

## Functional changes

- [x ] Code style has been fixed by running the `composer cs` command.
- [x ] Changes have been tested to not break existing functionality.
- [x ] Documentation is up-to-date.
