### PR TITLE
Revise authentication page class references

### DIFF
--- a/docs/07-users/01-overview.md
+++ b/docs/07-users/01-overview.md
@@ -230,11 +230,11 @@ class EditProfile extends BaseEditProfile
 
 This class extends the base profile page class from the Filament codebase. Other page classes you could extend include:
 
-- `Filament\Pages\Auth\Login`
-- `Filament\Pages\Auth\Register`
-- `Filament\Pages\Auth\EmailVerification\EmailVerificationPrompt`
-- `Filament\Pages\Auth\PasswordReset\RequestPasswordReset`
-- `Filament\Pages\Auth\PasswordReset\ResetPassword`
+- `Filament\Auth\Pages\Login`
+- `Filament\Auth\Pages\Register`
+- `Filament\Auth\Pages\EmailVerification\EmailVerificationPrompt`
+- `Filament\Auth\Pages\PasswordReset\RequestPasswordReset`
+- `Filament\Auth\Pages\PasswordReset\ResetPassword`
 
 In the `form()` method of the example, we call methods like `getNameFormComponent()` to get the default form components for the page. You can customize these components as required. For all the available customization options, see the base `EditProfile` page class in the Filament codebase - it contains all the methods that you can override to make changes.
 


### PR DESCRIPTION
This pull request updates documentation to reflect changes in the Filament codebase, specifically updating the namespace references for several authentication-related page classes. The main change is to ensure the documentation matches the current structure of the Filament framework.

Documentation updates:

* Updated namespace references for authentication page classes in `docs/07-users/01-overview.md` from `Filament\Pages\Auth\...` to `Filament\Auth\Pages\...` to align with the latest Filament codebase organization.