### PR TITLE
Fix `initialOptions` label rendering for integer based initial states

### DIFF
--- a/packages/support/resources/js/utilities/select.js
+++ b/packages/support/resources/js/utilities/select.js
@@ -600,7 +600,7 @@ export class Select {
                 }
 
                 // If not found, add to missing values
-                missingValues.push(value)
+                missingValues.push(value.toString())
             }
         }
 

--- a/packages/support/resources/js/utilities/select.js
+++ b/packages/support/resources/js/utilities/select.js
@@ -51,6 +51,12 @@ export class Select {
         statePath = null,
         onStateChange = () => {},
     }) {
+        if (Array.isArray(state)) {
+            state = state.map((item) => item.toString())
+        } else if (state !== null) {
+            state = state.toString()
+        }
+
         this.element = element
         this.options = options
         this.originalOptions = JSON.parse(JSON.stringify(options)) // Keep a copy of original options
@@ -600,7 +606,7 @@ export class Select {
                 }
 
                 // If not found, add to missing values
-                missingValues.push(value.toString())
+                missingValues.push(value)
             }
         }
 

--- a/packages/support/resources/js/utilities/select.js
+++ b/packages/support/resources/js/utilities/select.js
@@ -51,12 +51,6 @@ export class Select {
         statePath = null,
         onStateChange = () => {},
     }) {
-        if (Array.isArray(state)) {
-            state = state.map((item) => item.toString())
-        } else if (state !== null) {
-            state = state.toString()
-        }
-
         this.element = element
         this.options = options
         this.originalOptions = JSON.parse(JSON.stringify(options)) // Keep a copy of original options
@@ -606,7 +600,7 @@ export class Select {
                 }
 
                 // If not found, add to missing values
-                missingValues.push(value)
+                missingValues.push(value.toString())
             }
         }
 


### PR DESCRIPTION
## Description

When the current state of a multi select contains integer based values which are not within the loaded options, instead of the label, the ID is rendered.

The reason for the issue is, that the value for all options is cast to a string by default: https://github.com/filamentphp/filament/blob/4.x/packages/forms/src/Components/Select.php#L152

If the state is now an array of integers, the value can not be found in the list of initial options:
https://github.com/filamentphp/filament/blob/4.x/packages/support/resources/js/utilities/select.js#L621

## Visual changes

Before:
<img width="348" height="366" alt="CleanShot 2025-08-24 at 07 38 51@2x" src="https://github.com/user-attachments/assets/6d113a28-3ee9-4977-a15e-c66d0cef7af8" />

After:
<img width="340" height="422" alt="CleanShot 2025-08-24 at 07 40 08@2x" src="https://github.com/user-attachments/assets/dd7d2671-049e-4e3a-9631-d64fd5f765ef" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date. _(no change required)_
