### PR TITLE
Allow bypassing failed incompatible plugin check during upgrade

### DIFF
--- a/packages/upgrade/bin/filament-v4
+++ b/packages/upgrade/bin/filament-v4
@@ -274,6 +274,11 @@ try {
             $version = ltrim($compatibility['version'], 'v');
             $isPrerelease = $compatibility['isPrerelease'];
 
+            if ($version === 'unknown') {
+                // Skip suggesting install command for plugins with unknown version (e.g., private/non-Packagist)
+                continue;
+            }
+
             $constraint = null;
             if (! $isPrerelease) {
                 // Prefer using major.minor for pre-v1 packages to avoid ^0.0 or ~0.0

--- a/packages/upgrade/bin/filament-v4
+++ b/packages/upgrade/bin/filament-v4
@@ -44,9 +44,15 @@ HTML);
 require __DIR__ . '/../src/check-compatibility.php';
 
 $directories = $argv[1] ?? ask(<<<HTML
-    <span class="bg-amber-600 text-amber-50 mr-1">
-        Please provide a comma-separated list of directories to process breaking changes in (e.g. app, app-modules, src):
-    </span>
+    <div>
+        Please provide a comma-separated list of directories containing Filament code to upgrade (e.g. <strong>app</strong>, <strong>app-modules</strong>, <strong>src</strong>).
+
+        <br />
+
+        <span class="bg-amber-600 text-amber-50 mr-1">
+             You can skip this if you have a normal Laravel app structure:
+        </span>
+    </div>
     HTML) ?: 'app';
 
 render(<<<HTML
@@ -59,6 +65,7 @@ $rectorScriptPath = implode(DIRECTORY_SEPARATOR, ['vendor', 'bin', 'rector']);
 
 foreach (explode(',', $directories) as $directory) {
     $directory = trim($directory);
+    $directory = trim($directory, DIRECTORY_SEPARATOR);
 
     render(<<<HTML
         <p>

--- a/packages/upgrade/src/check-compatibility.php
+++ b/packages/upgrade/src/check-compatibility.php
@@ -208,7 +208,7 @@ if ($incompatiblePlugins) {
         hint: 'You\'ll need to manually remove / fix the listed plugins.',
     );
 
-    if (!$continue) {
+    if (! $continue) {
         render(<<<'HTML'
             <p class="bg-red-600 text-red-50 mt-1">
                 <strong>Upgrade aborted because of incompatible plugins</strong>

--- a/packages/upgrade/src/check-compatibility.php
+++ b/packages/upgrade/src/check-compatibility.php
@@ -180,6 +180,22 @@ foreach ($plugins as $plugin) {
             }
         }
 
+        // If still unknown and we couldn't fetch any versions from Packagist, but the package exists locally in vendor,
+        // assume it's a private/non-Packagist package and do not block the upgrade.
+        if ($compatibility === null) {
+            $stableEmpty = empty($GLOBALS['FILAMENT_UPGRADE_PACKAGIST']['versions'][$plugin]['stable'] ?? []);
+            $devEmpty = empty($GLOBALS['FILAMENT_UPGRADE_PACKAGIST']['versions'][$plugin]['dev'] ?? []);
+            $isInstalledLocally = file_exists("vendor/{$plugin}/composer.json");
+
+            if ($stableEmpty && $devEmpty && $isInstalledLocally) {
+                // Mark as compatible (unknown) to avoid blocking; we cache this decision.
+                $compatibility = [
+                    'version' => 'unknown',
+                    'isPrerelease' => false,
+                ];
+            }
+        }
+
         if (! array_key_exists($plugin, $GLOBALS['FILAMENT_UPGRADE_PACKAGIST']['compatibility'])) {
             $GLOBALS['FILAMENT_UPGRADE_PACKAGIST']['compatibility'][$plugin] = $compatibility;
         }

--- a/packages/upgrade/src/check-compatibility.php
+++ b/packages/upgrade/src/check-compatibility.php
@@ -203,8 +203,8 @@ if ($incompatiblePlugins) {
     $continue = confirm(
         label: 'Do you want to continue even though there are incompatible plugins?',
         default: false,
-        yes: 'Continue anyway',
-        no: 'Abort upgrade',
+        yes: 'Yes - Continue anyway',
+        no: 'No - Abort upgrade',
         hint: 'You\'ll need to manually remove / fix the listed plugins.',
     );
 

--- a/packages/upgrade/src/check-compatibility.php
+++ b/packages/upgrade/src/check-compatibility.php
@@ -1,5 +1,6 @@
 <?php
 
+use function Laravel\Prompts\confirm;
 use function Termwind\render;
 
 render('<p class="text-blue font-bold">Checking PHP version compatibility with v4...</p>');
@@ -199,11 +200,21 @@ if ($incompatiblePlugins) {
     render("<p class=\"text-red\">{$pluginList}</p>");
     render('<p>You could temporarily remove them from your composer.json file until they\'ve been upgraded, replace them with a similar plugin that is compatible with v4, wait for the plugins to be upgraded before upgrading your app, or even write PRs to help the authors upgrade them.</p>');
 
-    render(<<<'HTML'
-        <p class="bg-red-600 text-red-50 mt-1">
-            <strong>Upgrade aborted because of incompatible plugins</strong>
-        </p>
-    HTML);
+    $continue = confirm(
+        label: 'Do you want to continue even though there are incompatible plugins?',
+        default: false,
+        yes: 'Continue anyway',
+        no: 'Abort upgrade',
+        hint: 'You\'ll need to manually remove / fix the listed plugins.',
+    );
 
-    exit(1);
+    if (!$continue) {
+        render(<<<'HTML'
+            <p class="bg-red-600 text-red-50 mt-1">
+                <strong>Upgrade aborted because of incompatible plugins</strong>
+            </p>
+        HTML);
+
+        exit(1);
+    }
 }


### PR DESCRIPTION
## Description

The current upgrade script will now allow the user to bypass a failing compatible plugin check.

## Visual changes

<img width="834" height="739" alt="image" src="https://github.com/user-attachments/assets/6cc2eba7-8c24-4170-bcca-ebb2f5ca2cbe" />

---
### Aborted Upgrade output

<img width="778" height="193" alt="image" src="https://github.com/user-attachments/assets/1afae8c8-b210-4227-93b8-c0ef87319e2f" />

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

Since this is not a flag and is a prompt, it seems no additional documentation would be required.
