### PR TITLE
[4.x] Allow global search placeholder update

### DIFF
--- a/docs/03-resources/10-global-search.md
+++ b/docs/03-resources/10-global-search.md
@@ -159,6 +159,21 @@ public function panel(Panel $panel): Panel
 }
 ```
 
+## Configuring the global search placeholder
+
+You can customize the placeholder text of the global search input field by using the `globalSearchPlaceholder()` method in the [configuration](../panel-configuration):
+
+```php
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->globalSearchPlaceholder('Search all records...');
+}
+```
+
 ## Configuring the global search debounce
 
 Global search has a default debounce time of 500ms, to limit the number of requests that are made while the user is typing. You can alter this by using the `globalSearchDebounce()` method in the [configuration](../panel-configuration):

--- a/packages/panels/resources/views/livewire/global-search.blade.php
+++ b/packages/panels/resources/views/livewire/global-search.blade.php
@@ -8,42 +8,62 @@
 <div class="fi-global-search-ctn">
     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::GLOBAL_SEARCH_START) }}
 
-    <div x-on:focus-first-global-search-result.stop="$el.querySelector('.fi-global-search-result-link')?.focus()"
-        class="fi-global-search">
+    <div
+        x-on:focus-first-global-search-result.stop="$el.querySelector('.fi-global-search-result-link')?.focus()"
+        class="fi-global-search"
+    >
         <div x-id="['input']" class="fi-global-search-field">
             <label x-bind:for="$id('input')" class="fi-sr-only">
                 {{ __('filament-panels::global-search.field.label') }}
             </label>
 
-            <x-filament::input.wrapper :prefix-icon="\Filament\Support\Icons\Heroicon::MagnifyingGlass" :prefix-icon-alias="\Filament\View\PanelsIconAlias::GLOBAL_SEARCH_FIELD" inline-prefix :suffix="$suffix" inline-suffix
-                wire:target="search">
-                <input autocomplete="off" maxlength="1000"
+            <x-filament::input.wrapper
+                :prefix-icon="\Filament\Support\Icons\Heroicon::MagnifyingGlass"
+                :prefix-icon-alias="\Filament\View\PanelsIconAlias::GLOBAL_SEARCH_FIELD"
+                inline-prefix
+                :suffix="$suffix"
+                inline-suffix
+                wire:target="search"
+            >
+                <input
+                    autocomplete="off"
+                    maxlength="1000"
                     placeholder="{{ $placeholder ?? __('filament-panels::global-search.field.placeholder') }}"
-                    type="search" wire:key="global-search.field.input" x-bind:id="$id('input')"
+                    type="search"
+                    wire:key="global-search.field.input"
+                    x-bind:id="$id('input')"
                     x-on:keydown.down.prevent.stop="$dispatch('focus-first-global-search-result')"
                     wire:model.live.debounce.{{ $debounce }}="search"
-                    x-mousetrap.global.{{ collect($keyBindings)->map(fn(string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($id('input')).focus()"
-                    class="fi-input fi-input-has-inline-prefix" />
+                    x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($id('input')).focus()"
+                    class="fi-input fi-input-has-inline-prefix"
+                />
             </x-filament::input.wrapper>
         </div>
 
         @if ($results !== null)
-            <div x-data="{
-                isOpen: false,
+            <div
+                x-data="{
+                    isOpen: false,
 
-                open(event) {
-                    this.isOpen = true
-                },
+                    open(event) {
+                        this.isOpen = true
+                    },
 
-                close(event) {
-                    this.isOpen = false
-                },
-            }" x-init="$nextTick(() => open())" x-on:click.away="close()"
-                x-on:keydown.escape.window="close()" x-on:keydown.up.prevent="$focus.wrap().previous()"
+                    close(event) {
+                        this.isOpen = false
+                    },
+                }"
+                x-init="$nextTick(() => open())"
+                x-on:click.away="close()"
+                x-on:keydown.escape.window="close()"
+                x-on:keydown.up.prevent="$focus.wrap().previous()"
                 x-on:keydown.down.prevent="$focus.wrap().next()"
-                x-on:open-global-search-results.window="$nextTick(() => open())" x-show="isOpen"
-                x-transition:enter-start="fi-transition-enter-start" x-transition:leave-end="fi-transition-leave-end"
-                class="fi-global-search-results-ctn">
+                x-on:open-global-search-results.window="$nextTick(() => open())"
+                x-show="isOpen"
+                x-transition:enter-start="fi-transition-enter-start"
+                x-transition:leave-end="fi-transition-leave-end"
+                class="fi-global-search-results-ctn"
+            >
                 @if ($results->getCategories()->isEmpty())
                     <p class="fi-global-search-no-results-message">
                         {{ __('filament-panels::global-search.no_results_message') }}
@@ -52,37 +72,56 @@
                     <ul class="fi-global-search-results">
                         @foreach ($results->getCategories() as $group => $groupedResults)
                             <li class="fi-global-search-result-group">
-                                <h3 class="fi-global-search-result-group-header">
+                                <h3
+                                    class="fi-global-search-result-group-header"
+                                >
                                     {{ $group }}
                                 </h3>
 
-                                <ul class="fi-global-search-result-group-results">
+                                <ul
+                                    class="fi-global-search-result-group-results"
+                                >
                                     @foreach ($groupedResults as $result)
                                         @php
                                             $resultVisibleActions = $result->getVisibleActions();
                                         @endphp
 
-                                        <li @class([
-                                            'fi-global-search-result',
-                                            'fi-global-search-result-has-actions' => $resultVisibleActions,
-                                        ])>
-                                            <a {{ \Filament\Support\generate_href_html($result->url) }}
-                                                x-on:click="close()" class="fi-global-search-result-link">
-                                                <h4 class="fi-global-search-result-heading">
+                                        <li
+                                            @class([
+                                                'fi-global-search-result',
+                                                'fi-global-search-result-has-actions' => $resultVisibleActions,
+                                            ])
+                                        >
+                                            <a
+                                                {{ \Filament\Support\generate_href_html($result->url) }}
+                                                x-on:click="close()"
+                                                class="fi-global-search-result-link"
+                                            >
+                                                <h4
+                                                    class="fi-global-search-result-heading"
+                                                >
                                                     {{ $result->title }}
                                                 </h4>
 
                                                 @if ($result->details)
-                                                    <dl class="fi-global-search-result-details">
+                                                    <dl
+                                                        class="fi-global-search-result-details"
+                                                    >
                                                         @foreach ($result->details as $label => $value)
-                                                            <div class="fi-global-search-result-detail">
+                                                            <div
+                                                                class="fi-global-search-result-detail"
+                                                            >
                                                                 @if ($isAssoc ??= \Illuminate\Support\Arr::isAssoc($result->details))
-                                                                    <dt class="fi-global-search-result-detail-label">
+                                                                    <dt
+                                                                        class="fi-global-search-result-detail-label"
+                                                                    >
                                                                         {{ $label }}:
                                                                     </dt>
                                                                 @endif
 
-                                                                <dd class="fi-global-search-result-detail-value">
+                                                                <dd
+                                                                    class="fi-global-search-result-detail-value"
+                                                                >
                                                                     {{ $value }}
                                                                 </dd>
                                                             </div>
@@ -92,7 +131,9 @@
                                             </a>
 
                                             @if ($resultVisibleActions)
-                                                <div class="fi-global-search-result-actions">
+                                                <div
+                                                    class="fi-global-search-result-actions"
+                                                >
                                                     @foreach ($resultVisibleActions as $action)
                                                         {{ $action }}
                                                     @endforeach

--- a/packages/panels/resources/views/livewire/global-search.blade.php
+++ b/packages/panels/resources/views/livewire/global-search.blade.php
@@ -2,67 +2,48 @@
     $debounce = filament()->getGlobalSearchDebounce();
     $keyBindings = filament()->getGlobalSearchKeyBindings();
     $suffix = filament()->getGlobalSearchFieldSuffix();
+    $placeholder = filament()->getGlobalSearchFieldPlaceholder();
 @endphp
 
 <div class="fi-global-search-ctn">
     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::GLOBAL_SEARCH_START) }}
 
-    <div
-        x-on:focus-first-global-search-result.stop="$el.querySelector('.fi-global-search-result-link')?.focus()"
-        class="fi-global-search"
-    >
+    <div x-on:focus-first-global-search-result.stop="$el.querySelector('.fi-global-search-result-link')?.focus()"
+        class="fi-global-search">
         <div x-id="['input']" class="fi-global-search-field">
             <label x-bind:for="$id('input')" class="fi-sr-only">
                 {{ __('filament-panels::global-search.field.label') }}
             </label>
 
-            <x-filament::input.wrapper
-                :prefix-icon="\Filament\Support\Icons\Heroicon::MagnifyingGlass"
-                :prefix-icon-alias="\Filament\View\PanelsIconAlias::GLOBAL_SEARCH_FIELD"
-                inline-prefix
-                :suffix="$suffix"
-                inline-suffix
-                wire:target="search"
-            >
-                <input
-                    autocomplete="off"
-                    maxlength="1000"
-                    placeholder="{{ __('filament-panels::global-search.field.placeholder') }}"
-                    type="search"
-                    wire:key="global-search.field.input"
-                    x-bind:id="$id('input')"
+            <x-filament::input.wrapper :prefix-icon="\Filament\Support\Icons\Heroicon::MagnifyingGlass" :prefix-icon-alias="\Filament\View\PanelsIconAlias::GLOBAL_SEARCH_FIELD" inline-prefix :suffix="$suffix" inline-suffix
+                wire:target="search">
+                <input autocomplete="off" maxlength="1000"
+                    placeholder="{{ $placeholder ?? __('filament-panels::global-search.field.placeholder') }}"
+                    type="search" wire:key="global-search.field.input" x-bind:id="$id('input')"
                     x-on:keydown.down.prevent.stop="$dispatch('focus-first-global-search-result')"
                     wire:model.live.debounce.{{ $debounce }}="search"
-                    x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($id('input')).focus()"
-                    class="fi-input fi-input-has-inline-prefix"
-                />
+                    x-mousetrap.global.{{ collect($keyBindings)->map(fn(string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($id('input')).focus()"
+                    class="fi-input fi-input-has-inline-prefix" />
             </x-filament::input.wrapper>
         </div>
 
         @if ($results !== null)
-            <div
-                x-data="{
-                    isOpen: false,
+            <div x-data="{
+                isOpen: false,
 
-                    open(event) {
-                        this.isOpen = true
-                    },
+                open(event) {
+                    this.isOpen = true
+                },
 
-                    close(event) {
-                        this.isOpen = false
-                    },
-                }"
-                x-init="$nextTick(() => open())"
-                x-on:click.away="close()"
-                x-on:keydown.escape.window="close()"
-                x-on:keydown.up.prevent="$focus.wrap().previous()"
+                close(event) {
+                    this.isOpen = false
+                },
+            }" x-init="$nextTick(() => open())" x-on:click.away="close()"
+                x-on:keydown.escape.window="close()" x-on:keydown.up.prevent="$focus.wrap().previous()"
                 x-on:keydown.down.prevent="$focus.wrap().next()"
-                x-on:open-global-search-results.window="$nextTick(() => open())"
-                x-show="isOpen"
-                x-transition:enter-start="fi-transition-enter-start"
-                x-transition:leave-end="fi-transition-leave-end"
-                class="fi-global-search-results-ctn"
-            >
+                x-on:open-global-search-results.window="$nextTick(() => open())" x-show="isOpen"
+                x-transition:enter-start="fi-transition-enter-start" x-transition:leave-end="fi-transition-leave-end"
+                class="fi-global-search-results-ctn">
                 @if ($results->getCategories()->isEmpty())
                     <p class="fi-global-search-no-results-message">
                         {{ __('filament-panels::global-search.no_results_message') }}
@@ -71,56 +52,37 @@
                     <ul class="fi-global-search-results">
                         @foreach ($results->getCategories() as $group => $groupedResults)
                             <li class="fi-global-search-result-group">
-                                <h3
-                                    class="fi-global-search-result-group-header"
-                                >
+                                <h3 class="fi-global-search-result-group-header">
                                     {{ $group }}
                                 </h3>
 
-                                <ul
-                                    class="fi-global-search-result-group-results"
-                                >
+                                <ul class="fi-global-search-result-group-results">
                                     @foreach ($groupedResults as $result)
                                         @php
                                             $resultVisibleActions = $result->getVisibleActions();
                                         @endphp
 
-                                        <li
-                                            @class([
-                                                'fi-global-search-result',
-                                                'fi-global-search-result-has-actions' => $resultVisibleActions,
-                                            ])
-                                        >
-                                            <a
-                                                {{ \Filament\Support\generate_href_html($result->url) }}
-                                                x-on:click="close()"
-                                                class="fi-global-search-result-link"
-                                            >
-                                                <h4
-                                                    class="fi-global-search-result-heading"
-                                                >
+                                        <li @class([
+                                            'fi-global-search-result',
+                                            'fi-global-search-result-has-actions' => $resultVisibleActions,
+                                        ])>
+                                            <a {{ \Filament\Support\generate_href_html($result->url) }}
+                                                x-on:click="close()" class="fi-global-search-result-link">
+                                                <h4 class="fi-global-search-result-heading">
                                                     {{ $result->title }}
                                                 </h4>
 
                                                 @if ($result->details)
-                                                    <dl
-                                                        class="fi-global-search-result-details"
-                                                    >
+                                                    <dl class="fi-global-search-result-details">
                                                         @foreach ($result->details as $label => $value)
-                                                            <div
-                                                                class="fi-global-search-result-detail"
-                                                            >
+                                                            <div class="fi-global-search-result-detail">
                                                                 @if ($isAssoc ??= \Illuminate\Support\Arr::isAssoc($result->details))
-                                                                    <dt
-                                                                        class="fi-global-search-result-detail-label"
-                                                                    >
+                                                                    <dt class="fi-global-search-result-detail-label">
                                                                         {{ $label }}:
                                                                     </dt>
                                                                 @endif
 
-                                                                <dd
-                                                                    class="fi-global-search-result-detail-value"
-                                                                >
+                                                                <dd class="fi-global-search-result-detail-value">
                                                                     {{ $value }}
                                                                 </dd>
                                                             </div>
@@ -130,9 +92,7 @@
                                             </a>
 
                                             @if ($resultVisibleActions)
-                                                <div
-                                                    class="fi-global-search-result-actions"
-                                                >
+                                                <div class="fi-global-search-result-actions">
                                                     @foreach ($resultVisibleActions as $action)
                                                         {{ $action }}
                                                     @endforeach

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -242,6 +242,11 @@ class FilamentManager
         return $this->getCurrentOrDefaultPanel()->getGlobalSearchFieldSuffix();
     }
 
+    public function getGlobalSearchFieldPlaceholder(): ?string
+    {
+        return $this->getCurrentOrDefaultPanel()->getGlobalSearchFieldPlaceholder();
+    }
+
     public function getGlobalSearchProvider(): ?GlobalSearchProvider
     {
         return $this->getCurrentOrDefaultPanel()->getGlobalSearchProvider();

--- a/packages/panels/src/Panel/Concerns/HasGlobalSearch.php
+++ b/packages/panels/src/Panel/Concerns/HasGlobalSearch.php
@@ -23,6 +23,8 @@ trait HasGlobalSearch
 
     protected string | Closure | null $globalSearchFieldSuffix = null;
 
+    protected string | Closure | null $globalSearchFieldPlaceholder = null;
+
     public function globalSearch(string | bool $provider = true): static
     {
         if (is_string($provider) && (! in_array(GlobalSearchProvider::class, class_implements($provider)))) {
@@ -54,6 +56,13 @@ trait HasGlobalSearch
     public function globalSearchFieldSuffix(string | Closure | null $suffix): static
     {
         $this->globalSearchFieldSuffix = $suffix;
+
+        return $this;
+    }
+
+    public function globalSearchFieldPlaceholder(string | Closure | null $placeholder): static
+    {
+        $this->globalSearchFieldPlaceholder = $placeholder;
 
         return $this;
     }
@@ -110,6 +119,11 @@ trait HasGlobalSearch
     public function getGlobalSearchFieldSuffix(): ?string
     {
         return $this->evaluate($this->globalSearchFieldSuffix);
+    }
+
+    public function getGlobalSearchFieldPlaceholder(): ?string
+    {
+        return $this->evaluate($this->globalSearchFieldPlaceholder);
     }
 
     public function getGlobalSearchProvider(): ?GlobalSearchProvider


### PR DESCRIPTION
## Description

Allow changing the default global search placeholder text via panel configuration. 

## Visual changes

<img width="252" height="40" alt="image" src="https://github.com/user-attachments/assets/58b78dc6-a6fa-416e-a9e2-9da21c952f76" />

<img width="253" height="42" alt="image" src="https://github.com/user-attachments/assets/01dd11f4-0142-4127-ab6d-3296236525e7" />

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
