### PR TITLE
[4.x] Fix Notification Flashes When Closing

### DIFF
--- a/packages/notifications/resources/css/notification.css
+++ b/packages/notifications/resources/css/notification.css
@@ -1,5 +1,5 @@
 .fi-no-notification {
-    @apply pointer-events-auto invisible flex w-full shrink-0 gap-3 overflow-hidden p-4 transition duration-300;
+    @apply pointer-events-auto invisible flex w-full shrink-0 gap-3 overflow-hidden p-4 transition-[opacity,scale,transform,translate] duration-300;
 
     & .fi-no-notification-icon {
         @apply text-gray-400;


### PR DESCRIPTION
## Description

Fixes [Issue #17090](https://github.com/filamentphp/filament/issues/17090)

Tailwind in [v4.1.5](https://github.com/tailwindlabs/tailwindcss/releases/tag/v4.1.5) added a discrete properties to `transition-property` defaults, but hadn't mentioned it as breaking change nor provide alert in docs.

Without new property `transition-behavior: allow-discrete` `visibility` doesn't animating, but transition-duration still applies. Therefore the issue appears.

I've created [Issue #18793](https://github.com/tailwindlabs/tailwindcss/issues/18793) in the tailwind repository.

What happens before:
1. Class `fi-transition-leave-end` applied on a notification
2. After 300ms the class removed. So animation is going back (reverse)
3. Same time `visibility: hidden` style applied
4. Visibility should instantly become hidden, but it delays by transition-duration. So we seeing animation reverse. (In normal scenario animation still plays back, but it never renders due to conflict with `visibilty: hidden` - no flashing appears)
5. After 300ms notification becomes hidden

## Visual changes
Before:

https://github.com/user-attachments/assets/102ad1ec-cd66-4277-b124-83a4d4561b4a

After:

https://github.com/user-attachments/assets/14fa695c-69f0-48e3-91b4-f414e4ddc111

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
