### PR TITLE
[4.x] Remove HasExtraInputAttributes trait from RichEditor

### DIFF
--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -29,7 +29,6 @@ use Tiptap\Editor;
 class RichEditor extends Field implements Contracts\CanBeLengthConstrained
 {
     use Concerns\CanBeLengthConstrained;
-    use Concerns\HasExtraInputAttributes;
     use Concerns\HasFileAttachments;
     use Concerns\HasPlaceholder;
     use Concerns\InteractsWithToolbarButtons;


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->
Hi,
Thanks for your amazing work!

## Description

The component doesn't use the `extraInputAttributes` anymore. I had a regression while migrating.
No need to add the methods that are not used, and so the people using them in the past will now have an error while migrating.

## Visual changes
N/A

<img width="793" height="108" alt="Screenshot 2025-08-25 at 17 07 44" src="https://github.com/user-attachments/assets/58a23401-6480-451c-b11e-01219a4145e7" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
