### PR TITLE
Add a method to lazy load RichEditor images

### DIFF
--- a/packages/forms/docs/10-rich-editor.md
+++ b/packages/forms/docs/10-rich-editor.md
@@ -151,6 +151,16 @@ RichContentRenderer::make($record->content)
     ->toHtml()
 ```
 
+If you want to lazy-load images, you can pass the `lazyLoadImages` option to the renderer:
+
+```php
+use Filament\Forms\Components\RichEditor\RichContentRenderer;
+
+RichContentRenderer::make($record->content)
+    ->lazyLoadImages()
+    ->toHtml()
+```
+
 If you are using [custom blocks](#using-custom-blocks) in the rich editor, you can pass an array of custom blocks to the renderer to ensure that they are rendered correctly:
 
 ```php

--- a/packages/forms/src/Components/RichEditor/RichContentRenderer.php
+++ b/packages/forms/src/Components/RichEditor/RichContentRenderer.php
@@ -61,6 +61,8 @@ class RichContentRenderer implements Htmlable
 
     protected ?string $fileAttachmentsVisibility = null;
 
+    protected bool $lazyLoadImages = false;
+
     /**
      * @var array<RichContentPlugin>
      */
@@ -161,6 +163,18 @@ class RichContentRenderer implements Htmlable
         return $storage->url($file);
     }
 
+    public function lazyLoadImages(bool $lazyLoadImages = true): static
+    {
+        $this->lazyLoadImages = $lazyLoadImages;
+
+        return $this;
+    }
+
+    public function getLazyLoadImages(): bool
+    {
+        return $this->lazyLoadImages;
+    }
+
     /**
      * @param  array<RichContentPlugin>  $plugins
      */
@@ -209,6 +223,10 @@ class RichContentRenderer implements Htmlable
             }
 
             $node->attrs->src = $this->getFileAttachmentUrl($node->attrs->id);
+
+            if($this->lazyLoadImages) {
+                $node->attrs->loading = 'lazy';
+            }
         });
     }
 

--- a/packages/forms/src/Components/RichEditor/RichContentRenderer.php
+++ b/packages/forms/src/Components/RichEditor/RichContentRenderer.php
@@ -224,7 +224,7 @@ class RichContentRenderer implements Htmlable
 
             $node->attrs->src = $this->getFileAttachmentUrl($node->attrs->id);
 
-            if($this->lazyLoadImages) {
+            if ($this->lazyLoadImages) {
                 $node->attrs->loading = 'lazy';
             }
         });

--- a/packages/forms/src/Components/RichEditor/TipTapExtensions/ImageExtension.php
+++ b/packages/forms/src/Components/RichEditor/TipTapExtensions/ImageExtension.php
@@ -32,6 +32,7 @@ class ImageExtension extends BaseImage
                 'parseHTML' => fn ($DOMNode) => $DOMNode->getAttribute('data-id') ?: null,
                 'renderHTML' => fn ($attributes) => ['data-id' => $attributes->id ?? null],
             ],
+            'loading' => '',
         ];
     }
 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR adds a new `lazyLoadImages` method to RichContentRenderer.

```php
use Filament\Forms\Components\RichEditor\RichContentRenderer;

RichContentRenderer::make($record->content)
    ->lazyLoadImages()
    ->toHtml()
```

This will simply add the `loading="lazy"`attribute to all images in RichEditor content:

```html
<img src="https://example.com/storage/img.jpg" loading="lazy">
```

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
