### PR TITLE
fix: remove sidebar collapse button rotation logic

### DIFF
--- a/packages/panels/resources/views/components/sidebar/index.blade.php
+++ b/packages/panels/resources/views/components/sidebar/index.blade.php
@@ -165,9 +165,6 @@
                     group.querySelector(
                         '.fi-sidebar-group-items',
                     ).style.display = 'none'
-                    group
-                        .querySelector('.fi-sidebar-group-collapse-button')
-                        .classList.add('rotate-180')
                 })
         </script>
 

--- a/packages/panels/resources/views/components/sidebar/index.blade.php
+++ b/packages/panels/resources/views/components/sidebar/index.blade.php
@@ -165,6 +165,9 @@
                     group.querySelector(
                         '.fi-sidebar-group-items',
                     ).style.display = 'none'
+                    group
+                        .querySelector('.fi-sidebar-group-collapse-button')
+                        .classList.add('-rotate-180')
                 })
         </script>
 


### PR DESCRIPTION
fix: prevent double rotation of sidebar collapse button

Removed the JavaScript code that was manually adding 'rotate-180' class to
sidebar group collapse buttons. This was causing the chevron icons to rotate
180 degrees twice when using the `collapsed()` method on NavigationGroup,
resulting in incorrect orientation.

The rotation is now handled properly by Filament's built-in functionality
when using the `collapsed()` method, making the manual rotation redundant
and problematic.