### PR TITLE
Update parameter type in beforeStateDehydrated RichEditor method to f…

### DIFF
--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -300,7 +300,7 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
                 ->iconAlias('forms:components.rich-editor.toolbar.clear_formatting'),
         ]);
 
-        $this->beforeStateDehydrated(function (RichEditor $component, ?array $rawState, ?Model $record): void {
+        $this->beforeStateDehydrated(function (RichEditor $component, array|string|null $rawState, ?Model $record): void {
             $fileAttachmentProvider = $component->getFileAttachmentProvider();
 
             if ($fileAttachmentProvider?->isExistingRecordRequiredToSaveNewFileAttachments() && (! $record)) {


### PR DESCRIPTION
Fix #17472

as stated in #17472 when setting the content of a rich editor through a livewire form testing, this exception is thrown:

> Filament\Forms\Components\RichEditor::{closure:Filament\Forms\Components\RichEditor::setUp():303}(): Argument #2 ($rawState) must be of type ?array, string given

this PR will allow to pass a string as $rawState, as TipTapEditor `->setContent` method accepts a string as well
