### PR TITLE
fix: merge extraInputAttributes in RichEditor

### DIFF
--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -19,6 +19,7 @@
         x-cloak
         :attributes="
             \Filament\Support\prepare_inherited_attributes($extraAttributeBag)
+                ->merge($getExtraInputAttributes())
                 ->class(['fi-fo-rich-editor'])
         "
     >

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -19,7 +19,6 @@
         x-cloak
         :attributes="
             \Filament\Support\prepare_inherited_attributes($extraAttributeBag)
-                ->merge($getExtraInputAttributes())
                 ->class(['fi-fo-rich-editor'])
         "
     >
@@ -67,7 +66,7 @@
                 </div>
             @endif
 
-            <div class="fi-fo-rich-editor-main">
+            <div {{ $getExtraInputAttributeBag()->class(['fi-fo-rich-editor-main']) }}>
                 <div class="fi-fo-rich-editor-content fi-prose" x-ref="editor">
                     @foreach ($floatingToolbars as $nodeName => $buttons)
                         <div


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

With v4, the `extraInputAttributes` were allowed, but not used anymore.

Following https://github.com/filamentphp/filament/pull/17505#issuecomment-3221723627, this PR apply the given attributes to the component, so migrating from v3 to v4 will be without any regression.

Thanks.

## Visual changes

Extra input attributes are reapplied.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
