### PR TITLE
[4.x] Named Sections require absolute keys when asserting field existence

### DIFF
--- a/packages/schemas/src/Components/Concerns/HasState.php
+++ b/packages/schemas/src/Components/Concerns/HasState.php
@@ -742,7 +742,7 @@ trait HasState
     public function resolveRelativeKey(string | Component $key = '', bool $isAbsolute = false): string
     {
         if ($key instanceof Component) {
-            return $key->getKey();
+            return $key->getKey($isAbsolute);
         }
 
         if (str($key)->startsWith('/')) {

--- a/packages/schemas/src/Concerns/HasComponents.php
+++ b/packages/schemas/src/Concerns/HasComponents.php
@@ -163,7 +163,7 @@ trait HasComponents
                     continue;
                 }
 
-                $componentKey = $component->getKey();
+                $componentKey = $component->getKey($isAbsoluteKey);
 
                 if (filled($componentKey) && ($componentKey === $findComponentUsing)) {
                     return $component;
@@ -240,7 +240,7 @@ trait HasComponents
      */
     public function getFlatComponents(bool $withActions = true, bool $withHidden = false, bool $withAbsoluteKeys = false, ?string $containerKey = null): array
     {
-        $containerKey ??= $this->getKey();
+        $containerKey ??= $this->getKey($withAbsoluteKeys);
 
         return $this->cachedFlatComponents[$withActions][$withHidden][$withAbsoluteKeys][$containerKey] ??= array_reduce(
             $this->getComponents($withActions, $withHidden),
@@ -251,7 +251,7 @@ trait HasComponents
                     return $carry;
                 }
 
-                $componentKey = $component->getKey();
+                $componentKey = $component->getKey($withAbsoluteKeys);
 
                 if (blank($componentKey)) {
                     $carry[] = $component;

--- a/packages/support/resources/js/sortable.js
+++ b/packages/support/resources/js/sortable.js
@@ -22,7 +22,8 @@ export default (Alpine) => {
 
                 const { item: draggedNode, to: parentNode, newIndex } = event
                 const draggableSelector = this.options.draggable
-                const previousNode = parentNode.querySelectorAll(draggableSelector)[newIndex - 1]
+                const previousNode =
+                    parentNode.querySelectorAll(draggableSelector)[newIndex - 1]
 
                 if (previousNode) {
                     parentNode.insertBefore(

--- a/packages/support/resources/js/sortable.js
+++ b/packages/support/resources/js/sortable.js
@@ -22,8 +22,7 @@ export default (Alpine) => {
 
                 const { item: draggedNode, to: parentNode, newIndex } = event
                 const draggableSelector = this.options.draggable
-                const previousNode =
-                    parentNode.querySelectorAll(draggableSelector)[newIndex - 1]
+                const previousNode = parentNode.querySelectorAll(draggableSelector)[newIndex - 1]
 
                 if (previousNode) {
                     parentNode.insertBefore(


### PR DESCRIPTION
## Description

Here is an example of a failing test that I believe ought to pass:

```
use App\Filament\Resources\Locations\Pages\EditLocation;
use App\Models\Location;

use function Pest\Livewire\livewire;

it('can select other location', function () {
    $location = Location::factory()->create();

    livewire(EditLocation::class, ['record' => $location->id])
        ->assertFormFieldExists('other_location_id');
});
```

### Failing form Schema

This is the scenario fixed by the PR in question:

```
Section::make('Connected Location')
    ->schema([
        Select::make('other_location_id')
    ]);
```

### Passing form Schema

By removing the section header, the test passes:

```
Section::make()
    ->schema([
        Select::make('other_location_id')
    ]);
```

## Scope of Changes

The failing test given as an example above is the use-case I'm solving for.  However, I did a sweep of the codebase for matches on `getKey` and have additional changes:

### Change for the failing test above

https://github.com/filamentphp/filament/blob/5e7dc929522533ab0842fdca0a426b7b1ef6e901/packages/schemas/src/Concerns/HasComponents.php#L254

### Changes for consistency

To further improve consistency of using absolute keys, I've also made these updates:

https://github.com/filamentphp/filament/blob/5e7dc929522533ab0842fdca0a426b7b1ef6e901/packages/schemas/src/Concerns/HasComponents.php#L243
https://github.com/filamentphp/filament/blob/5e7dc929522533ab0842fdca0a426b7b1ef6e901/packages/schemas/src/Concerns/HasComponents.php#L166

This last change appears to contain an as-yet unused parameter, but I've added it to ensure consistency when passing in `true` for the `$isAbsolute` parameter:
https://github.com/filamentphp/filament/blob/5e7dc929522533ab0842fdca0a426b7b1ef6e901/packages/schemas/src/Components/Concerns/HasState.php#L745

# Not a bug
If this is not considered a bug, and the newly created Schema paradigm requires this to assert the field existence in the 

```
->assertFormFieldExists('connected-location::data::section.other_location_id');
```

I'm happy to open a new PR to add to the relevant [Testing other schema components](https://filamentphp.com/docs/4.x/testing/testing-schemas#testing-other-schema-components) 


## Visual changes

n/a

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
