### PR TITLE
Added getResetPasswordNotificationClass function to facilitate future extension

### DIFF
--- a/packages/panels/src/Auth/Pages/PasswordReset/RequestPasswordReset.php
+++ b/packages/panels/src/Auth/Pages/PasswordReset/RequestPasswordReset.php
@@ -78,7 +78,7 @@ class RequestPasswordReset extends SimplePage
                     throw new Exception("Model [{$userClass}] does not have a [notify()] method.");
                 }
 
-                $notification = app(ResetPasswordNotification::class, ['token' => $token]);
+                $notification = app($this->getResetPasswordNotificationClass(), ['token' => $token]);
                 $notification->url = Filament::getResetPasswordUrl($token, $user);
 
                 $user->notify($notification);
@@ -98,6 +98,11 @@ class RequestPasswordReset extends SimplePage
         $this->getSentNotification($status)?->send();
 
         $this->form->fill();
+    }
+
+    protected function getResetPasswordNotificationClass(): string
+    {
+        return ResetPasswordNotification::class;
     }
 
     protected function getRateLimitedNotification(TooManyRequestsException $exception): ?Notification


### PR DESCRIPTION
refact(password-reset): refact class RequestPasswordReset to make it easier to customize the reset password notification without override the whole method.

## Description

- Replaced the direct use of ResetPasswordNotification with a method that returns the notification class.
- Added getResetPasswordNotificationClass function to facilitate future extension.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
