### PR TITLE
fix column update if current state is null and not present in options…

### DIFF
--- a/packages/tables/src/Columns/SelectColumn.php
+++ b/packages/tables/src/Columns/SelectColumn.php
@@ -146,7 +146,7 @@ class SelectColumn extends Column implements Editable, HasEmbeddedView
     {
         $optionLabel = $this->getOptionLabel(withDefault: false);
 
-        if (blank($optionLabel)) {
+        if (blank($optionLabel) && filled($this->getState())) {
             return [
                 ...$this->getBaseRules(),
                 Rule::in([]),


### PR DESCRIPTION
## Description

This will address the issue #17375 and fix the column update if current state is null and not present in options.

## Visual changes

none

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
