### PR TITLE
Allow null as title

### DIFF
--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -250,7 +250,7 @@ class Group extends Component
         return Arr::get($record, $this->getColumn());
     }
 
-    public function getTitle(Model $record): string | Htmlable
+    public function getTitle(Model $record): ?(string | Htmlable)
     {
         $column = $this->getColumn();
 

--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -250,7 +250,7 @@ class Group extends Component
         return Arr::get($record, $this->getColumn());
     }
 
-    public function getTitle(Model $record): ?(string | Htmlable)
+    public function getTitle(Model $record): string | Htmlable | null
     {
         $column = $this->getColumn();
 


### PR DESCRIPTION
Re-adds the possibility to group by null values

## Description

In V3, one could group on a field that was nullable. In V4, this breaks. This is because in V3 (https://github.com/filamentphp/filament/blob/3.x/packages/tables/src/Grouping/Group.php#L253), the getTitle() had null as a return type. This pull request re-adds null as a accepted return type.

This solves #17546.

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
