### PR TITLE
feat(auth): add autocomplete attributes to form inputs

### DIFF
--- a/packages/panels/src/Auth/Pages/EditProfile.php
+++ b/packages/panels/src/Auth/Pages/EditProfile.php
@@ -287,7 +287,6 @@ class EditProfile extends Page
         return TextInput::make('email')
             ->label(__('filament-panels::auth/pages/edit-profile.form.email.label'))
             ->email()
-            ->autocomplete('username')
             ->required()
             ->maxLength(255)
             ->unique(ignoreRecord: true)

--- a/packages/panels/src/Auth/Pages/EditProfile.php
+++ b/packages/panels/src/Auth/Pages/EditProfile.php
@@ -273,7 +273,7 @@ class EditProfile extends Page
         return null;
     }
 
-    protected function getNameFormComponent(): Component
+    protected function getNameFormComponent(): TextInput
     {
         return TextInput::make('name')
             ->label(__('filament-panels::auth/pages/edit-profile.form.name.label'))
@@ -282,18 +282,19 @@ class EditProfile extends Page
             ->autofocus();
     }
 
-    protected function getEmailFormComponent(): Component
+    protected function getEmailFormComponent(): TextInput
     {
         return TextInput::make('email')
             ->label(__('filament-panels::auth/pages/edit-profile.form.email.label'))
             ->email()
+            ->autocomplete('username')
             ->required()
             ->maxLength(255)
             ->unique(ignoreRecord: true)
             ->live(debounce: 500);
     }
 
-    protected function getPasswordFormComponent(): Component
+    protected function getPasswordFormComponent(): TextInput
     {
         return TextInput::make('password')
             ->label(__('filament-panels::auth/pages/edit-profile.form.password.label'))
@@ -309,25 +310,27 @@ class EditProfile extends Page
             ->same('passwordConfirmation');
     }
 
-    protected function getPasswordConfirmationFormComponent(): Component
+    protected function getPasswordConfirmationFormComponent(): TextInput
     {
         return TextInput::make('passwordConfirmation')
             ->label(__('filament-panels::auth/pages/edit-profile.form.password_confirmation.label'))
             ->validationAttribute(__('filament-panels::auth/pages/edit-profile.form.password_confirmation.validation_attribute'))
             ->password()
+            ->autocomplete('new-password')
             ->revealable(filament()->arePasswordsRevealable())
             ->required()
             ->visible(fn (Get $get): bool => filled($get('password')))
             ->dehydrated(false);
     }
 
-    protected function getCurrentPasswordFormComponent(): Component
+    protected function getCurrentPasswordFormComponent(): TextInput
     {
         return TextInput::make('currentPassword')
             ->label(__('filament-panels::auth/pages/edit-profile.form.current_password.label'))
             ->validationAttribute(__('filament-panels::auth/pages/edit-profile.form.current_password.validation_attribute'))
             ->belowContent(__('filament-panels::auth/pages/edit-profile.form.current_password.below_content'))
             ->password()
+            ->autocomplete('current-password')
             ->currentPassword(guard: Filament::getAuthGuard())
             ->revealable(filament()->arePasswordsRevealable())
             ->required()

--- a/packages/panels/src/Auth/Pages/EditProfile.php
+++ b/packages/panels/src/Auth/Pages/EditProfile.php
@@ -273,7 +273,7 @@ class EditProfile extends Page
         return null;
     }
 
-    protected function getNameFormComponent(): TextInput
+    protected function getNameFormComponent(): Component
     {
         return TextInput::make('name')
             ->label(__('filament-panels::auth/pages/edit-profile.form.name.label'))
@@ -282,7 +282,7 @@ class EditProfile extends Page
             ->autofocus();
     }
 
-    protected function getEmailFormComponent(): TextInput
+    protected function getEmailFormComponent(): Component
     {
         return TextInput::make('email')
             ->label(__('filament-panels::auth/pages/edit-profile.form.email.label'))
@@ -294,7 +294,7 @@ class EditProfile extends Page
             ->live(debounce: 500);
     }
 
-    protected function getPasswordFormComponent(): TextInput
+    protected function getPasswordFormComponent(): Component
     {
         return TextInput::make('password')
             ->label(__('filament-panels::auth/pages/edit-profile.form.password.label'))
@@ -310,7 +310,7 @@ class EditProfile extends Page
             ->same('passwordConfirmation');
     }
 
-    protected function getPasswordConfirmationFormComponent(): TextInput
+    protected function getPasswordConfirmationFormComponent(): Component
     {
         return TextInput::make('passwordConfirmation')
             ->label(__('filament-panels::auth/pages/edit-profile.form.password_confirmation.label'))
@@ -323,7 +323,7 @@ class EditProfile extends Page
             ->dehydrated(false);
     }
 
-    protected function getCurrentPasswordFormComponent(): TextInput
+    protected function getCurrentPasswordFormComponent(): Component
     {
         return TextInput::make('currentPassword')
             ->label(__('filament-panels::auth/pages/edit-profile.form.current_password.label'))

--- a/packages/panels/src/Auth/Pages/PasswordReset/ResetPassword.php
+++ b/packages/panels/src/Auth/Pages/PasswordReset/ResetPassword.php
@@ -143,19 +143,21 @@ class ResetPassword extends SimplePage
             ]);
     }
 
-    protected function getEmailFormComponent(): Component
+    protected function getEmailFormComponent(): TextInput
     {
         return TextInput::make('email')
             ->label(__('filament-panels::auth/pages/password-reset/reset-password.form.email.label'))
             ->disabled()
+            ->autocomplete('username')
             ->autofocus();
     }
 
-    protected function getPasswordFormComponent(): Component
+    protected function getPasswordFormComponent(): TextInput
     {
         return TextInput::make('password')
             ->label(__('filament-panels::auth/pages/password-reset/reset-password.form.password.label'))
             ->password()
+            ->autocomplete('new-password')
             ->revealable(filament()->arePasswordsRevealable())
             ->required()
             ->rule(PasswordRule::default())
@@ -163,11 +165,12 @@ class ResetPassword extends SimplePage
             ->validationAttribute(__('filament-panels::auth/pages/password-reset/reset-password.form.password.validation_attribute'));
     }
 
-    protected function getPasswordConfirmationFormComponent(): Component
+    protected function getPasswordConfirmationFormComponent(): TextInput
     {
         return TextInput::make('passwordConfirmation')
             ->label(__('filament-panels::auth/pages/password-reset/reset-password.form.password_confirmation.label'))
             ->password()
+            ->autocomplete('new-password')
             ->revealable(filament()->arePasswordsRevealable())
             ->required()
             ->dehydrated(false);

--- a/packages/panels/src/Auth/Pages/PasswordReset/ResetPassword.php
+++ b/packages/panels/src/Auth/Pages/PasswordReset/ResetPassword.php
@@ -148,7 +148,6 @@ class ResetPassword extends SimplePage
         return TextInput::make('email')
             ->label(__('filament-panels::auth/pages/password-reset/reset-password.form.email.label'))
             ->disabled()
-            ->autocomplete('username')
             ->autofocus();
     }
 

--- a/packages/panels/src/Auth/Pages/PasswordReset/ResetPassword.php
+++ b/packages/panels/src/Auth/Pages/PasswordReset/ResetPassword.php
@@ -143,7 +143,7 @@ class ResetPassword extends SimplePage
             ]);
     }
 
-    protected function getEmailFormComponent(): TextInput
+    protected function getEmailFormComponent(): Component
     {
         return TextInput::make('email')
             ->label(__('filament-panels::auth/pages/password-reset/reset-password.form.email.label'))
@@ -152,7 +152,7 @@ class ResetPassword extends SimplePage
             ->autofocus();
     }
 
-    protected function getPasswordFormComponent(): TextInput
+    protected function getPasswordFormComponent(): Component
     {
         return TextInput::make('password')
             ->label(__('filament-panels::auth/pages/password-reset/reset-password.form.password.label'))
@@ -165,7 +165,7 @@ class ResetPassword extends SimplePage
             ->validationAttribute(__('filament-panels::auth/pages/password-reset/reset-password.form.password.validation_attribute'));
     }
 
-    protected function getPasswordConfirmationFormComponent(): TextInput
+    protected function getPasswordConfirmationFormComponent(): Component
     {
         return TextInput::make('passwordConfirmation')
             ->label(__('filament-panels::auth/pages/password-reset/reset-password.form.password_confirmation.label'))


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Add autocomplete attributes to improve user experience and accessibility in authentication forms. This helps browsers autofill fields correctly and follows best practices for form input handling.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

<img width="1375" height="816" alt="Screenshot 2025-08-28 at 14 19 26" src="https://github.com/user-attachments/assets/da6952bf-d75b-432b-aae1-b901321aa519" />

<img width="1168" height="740" alt="Screenshot 2025-08-28 at 14 20 06" src="https://github.com/user-attachments/assets/49b8cac2-0e78-4655-9bf5-a0cd282f9044" />

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
