### PR TITLE
Fix FileUpload component initialization in tabs

### DIFF
--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -28,7 +28,7 @@
         @if (FilamentView::hasSpaMode())
             {{-- format-ignore-start --}}x-load="visible || event (ax-modal-opened)"{{-- format-ignore-end --}}
         @else
-            x-load
+            x-load="visible"
         @endif
         x-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('file-upload', 'filament/forms') }}"
         x-data="fileUploadFormComponent({


### PR DESCRIPTION
- Change x-load attribute from bare 'x-load' to 'x-load="visible"' in non-SPA mode
- Ensures FilePond components initialize properly when placed inside tabs
- Resolves issue where file uploads in secondary tabs would show background color instead of image previews
- Maintains consistency with SPA mode behavior which already uses x-load="visible || event (ax-modal-opened)"

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
