### PR TITLE
fix SelectFilter column reference "foo" is ambiguous

### DIFF
--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -187,7 +187,7 @@ class SelectFilter extends BaseFilter
 
         if (! $this->queriesRelationships()) {
             return $query->{$isMultiple ? 'whereIn' : 'where'}(
-                $this->getAttribute(),
+                $query->qualifyColumn($this->getAttribute()),
                 $values,
             );
         }


### PR DESCRIPTION
## Description

**Avoid error: "column reference "foo" is ambiguous"** with SelectFilter

Sometimes when combining filters the query becomes complex and the query must qualify columns .

## Visual changes

none

## Functional changes

- [x ] Code style has been fixed by running the `composer cs` command.
- [x ] Changes have been tested to not break existing functionality.
- [x ] Documentation is up-to-date.
