### PR TITLE
Docs: Fix link to "optimizing local development"

### DIFF
--- a/docs/13-deployment.md
+++ b/docs/13-deployment.md
@@ -7,7 +7,7 @@ import Aside from "@components/Aside.astro"
 
 Deploying a Laravel app using Filament to production is similar to deploying any other Laravel app. However, there are a few additional steps you should take to ensure that your Filament panel is optimized for performance and security.
 
-For tips focused on local development performance, see [Optimizing local dev](introduction/optimizing-local-dev).
+For tips focused on local development performance, see [Optimizing local development](introduction/optimizing-local-development).
 
 ## Ensure that users are authorized to access panels
 


### PR DESCRIPTION
## Description

This PR fixes a link to the "Optimizing Local Development" page.

The document name was changed during [this commit](https://github.com/filamentphp/filament/commit/51cbe6fa5045f487c6e8e39e2df543e659bf1273) and broke the direct link.

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
