### PR TITLE
feat(translations): enhance pt_BR localization for auth, actions, and pages

### DIFF
--- a/packages/actions/resources/lang/pt_BR/delete.php
+++ b/packages/actions/resources/lang/pt_BR/delete.php
@@ -53,11 +53,13 @@ return [
             'deleted' => [
                 'title' => 'Excluído',
             ],
+
             'deleted_partial' => [
                 'title' => 'Excluídos :count de :total',
                 'missing_authorization_failure_message' => 'Você não tem permissão para excluir :count.',
                 'missing_processing_failure_message' => ':count não pôde(m) ser excluído(s).',
             ],
+
             'deleted_none' => [
                 'title' => 'Falha ao excluir',
                 'missing_authorization_failure_message' => 'Você não tem permissão para excluir :count.',

--- a/packages/actions/resources/lang/pt_BR/force-delete.php
+++ b/packages/actions/resources/lang/pt_BR/force-delete.php
@@ -53,11 +53,13 @@ return [
             'deleted' => [
                 'title' => 'Excluído',
             ],
+
             'deleted_partial' => [
                 'title' => 'Excluídos :count de :total',
                 'missing_authorization_failure_message' => 'Você não tem permissão para excluir :count.',
                 'missing_processing_failure_message' => ':count não pôde(m) ser excluído(s).',
             ],
+
             'deleted_none' => [
                 'title' => 'Falha ao excluir',
                 'missing_authorization_failure_message' => 'Você não tem permissão para excluir :count.',

--- a/packages/actions/resources/lang/pt_BR/restore.php
+++ b/packages/actions/resources/lang/pt_BR/restore.php
@@ -54,6 +54,18 @@ return [
                 'title' => 'Restaurado',
             ],
 
+            'restored_partial' => [
+                'title' => 'Restaurados :count de :total',
+                'missing_authorization_failure_message' => 'Você não tem permissão para restaurar :count.',
+                'missing_processing_failure_message' => ':count não puderam ser restaurados.',
+            ],
+
+            'restored_none' => [
+                'title' => 'Falha ao restaurar',
+                'missing_authorization_failure_message' => 'Você não tem permissão para restaurar :count.',
+                'missing_processing_failure_message' => ':count não puderam ser restaurados.',
+            ],
+
         ],
 
     ],

--- a/packages/panels/resources/lang/pt_BR/auth/pages/login.php
+++ b/packages/panels/resources/lang/pt_BR/auth/pages/login.php
@@ -43,6 +43,30 @@ return [
 
     ],
 
+    'multi_factor' => [
+
+        'heading' => 'Verifique sua identidade',
+
+        'subheading' => 'Para continuar o login, você precisa verificar sua identidade.',
+
+        'form' => [
+
+            'provider' => [
+                'label' => 'Como você gostaria de verificar?',
+            ],
+
+            'actions' => [
+
+                'authenticate' => [
+                    'label' => 'Confirmar login',
+                ],
+
+            ],
+
+        ],
+
+    ],
+
     'messages' => [
 
         'failed' => 'Essas credenciais não correspondem aos nossos registros.',

--- a/packages/panels/resources/lang/pt_BR/resources/pages/edit-record.php
+++ b/packages/panels/resources/lang/pt_BR/resources/pages/edit-record.php
@@ -6,6 +6,8 @@ return [
 
     'breadcrumb' => 'Editar',
 
+    'navigation_label' => 'Editar',
+
     'form' => [
 
         'actions' => [

--- a/packages/panels/resources/lang/pt_BR/resources/pages/view-record.php
+++ b/packages/panels/resources/lang/pt_BR/resources/pages/view-record.php
@@ -6,6 +6,8 @@ return [
 
     'breadcrumb' => 'Visualizar',
 
+    'navigation_label' => 'Visualizar',
+
     'content' => [
 
         'tab' => [


### PR DESCRIPTION
Add Brazilian Portuguese translations for multi-factor authentication, partial and failure messages in delete/restore actions, and navigation labels for editing and viewing pages. Improvements enhance localization coverage and user experience.