### PR TITLE
Update Form docs, to use better alternative

### DIFF
--- a/packages/forms/docs/01-overview.md
+++ b/packages/forms/docs/01-overview.md
@@ -1247,14 +1247,14 @@ function (Set $set) {
 
 Dehydration is the process that gets data from the fields in your schemas, optionally transforms it, and returns it. It runs when you call the schema's `getState()` method, which is usually called when a form is submitted.
 
-You may customize how the state is transformed when it is dehydrated using the `dehydrateStateUsing()` function. In this example, the `name` field will always be dehydrated with the correctly capitalized name:
+You may customize how the state is transformed when it is dehydrated using the `mutateDehydratedStateUsing()` function. In this example, the `name` field will always be dehydrated with the correctly capitalized name:
 
 ```php
 use Filament\Forms\Components\TextInput;
 
 TextInput::make('name')
     ->required()
-    ->dehydrateStateUsing(fn (string $state): string => ucwords($state))
+    ->mutateDehydratedStateUsing(fn (string $state): string => ucwords($state))
 ```
 
 #### Preventing a field from being dehydrated


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The function (`dehydrateStateUsing()`) mentioned for customizing dehydrated fields hides a landmine in Filament 4. 

What we ran into, is we need a few fields never to have null values, but to be empty strings instead.

Because of this https://github.com/filamentphp/filament/commit/571a0f16d9006147ea9a88b94ec9d30a99075999 commit empty strings are reverted back to null. If you use `mutateDehydratedStateUsing()` you can circumvent this issue

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
