### PR TITLE
fix(tables/translations): fix incorrect "empty" french gender transla…

### DIFF
--- a/packages/tables/resources/lang/fr/table.php
+++ b/packages/tables/resources/lang/fr/table.php
@@ -119,7 +119,7 @@ return [
 
     'empty' => [
 
-        'heading' => 'Aucun :model',
+        'heading' => 'Aucun(e) :model',
 
         'description' => 'Créer un(e) :model pour commencer.',
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This pull request simply intends to adjust the "empty" french translation, as french is a non-neutral gender language.

## Visual changes

**Before**

<img width="1282" height="382" alt="Capture d’écran du 2025-08-29 18-35-00" src="https://github.com/user-attachments/assets/f1009541-5041-4482-9f55-194088a10b60" />

**After**

<img width="1282" height="382" alt="Capture d’écran du 2025-08-29 18-34-50" src="https://github.com/user-attachments/assets/3a2dab4d-22f1-4cbe-8432-c8e7ab013b6f" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
