### PR TITLE
Apply Explicit Bool Comparison for $failedRowsCount check

### DIFF
--- a/packages/actions/src/Commands/FileGenerators/ImporterClassGenerator.php
+++ b/packages/actions/src/Commands/FileGenerators/ImporterClassGenerator.php
@@ -274,7 +274,7 @@ class ImporterClassGenerator extends ClassGenerator
             ->setBody(<<<PHP
                 \$body = 'Your {$this->getModelLabel()} import has completed and ' . {$this->simplifyFqn(Number::class)}::format(\$import->successful_rows) . ' ' . str('row')->plural(\$import->successful_rows) . ' imported.';
 
-                if (\$failedRowsCount = \$import->getFailedRowsCount()) {
+                if ((\$failedRowsCount = \$import->getFailedRowsCount()) !== 0) {
                     \$body .= ' ' . {$this->simplifyFqn(Number::class)}::format(\$failedRowsCount) . ' ' . str('row')->plural(\$failedRowsCount) . ' failed to import.';
                 }
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Replaced the implicit truthy check of `$failedRowsCount` with an explicit comparison to 0.

This change was made according to [ExplicitBoolCompareRector rules](https://getrector.com/rule-detail/explicit-bool-compare-rector), to improve readability and avoid potential unintended truthy evaluations.

```diff
- if ($failedRowsCount = $import->getFailedRowsCount()) {
+ if (($failedRowsCount = $import->getFailedRowsCount()) !== 0) {
```

Reasoning:

-Makes the intention of checking “non-zero failed rows” explicit.
-Prevents ambiguity when the value might be 0, null, or other falsy values.
-Improves code clarity and complies with Rector’s explicit boolean comparison principle.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
