### PR TITLE
[4.x] Less generic exceptions. Exception -> LogicException

### DIFF
--- a/packages/actions/src/ActionGroup.php
+++ b/packages/actions/src/ActionGroup.php
@@ -4,7 +4,6 @@ namespace Filament\Actions;
 
 use BackedEnum;
 use Closure;
-use Exception;
 use Filament\Actions\Concerns\InteractsWithRecord;
 use Filament\Actions\View\ActionsIconAlias;
 use Filament\Support\Components\Contracts\HasEmbeddedView;
@@ -31,6 +30,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Illuminate\View\ComponentAttributeBag;
+use LogicException;
 
 class ActionGroup extends ViewComponent implements Arrayable, HasEmbeddedView
 {
@@ -528,7 +528,7 @@ class ActionGroup extends ViewComponent implements Arrayable, HasEmbeddedView
             return $defaultView;
         }
 
-        throw new Exception('Class [' . static::class . '] extends [' . ActionGroup::class . '] but does not have a [$triggerView] property defined.');
+        throw new LogicException('Class [' . static::class . '] extends [' . ActionGroup::class . '] but does not have a [$triggerView] property defined.');
     }
 
     /**

--- a/packages/actions/src/Concerns/CanBeAuthorized.php
+++ b/packages/actions/src/Concerns/CanBeAuthorized.php
@@ -4,7 +4,6 @@ namespace Filament\Actions\Concerns;
 
 use BackedEnum;
 use Closure;
-use Exception;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
@@ -157,7 +156,7 @@ trait CanBeAuthorized
         }
 
         if (blank($response->message())) {
-            throw new Exception('An authorization was denied without a message.');
+            throw new LogicException('An authorization was denied without a message.');
         }
 
         return $response;

--- a/packages/actions/src/Concerns/CanBeAuthorized.php
+++ b/packages/actions/src/Concerns/CanBeAuthorized.php
@@ -9,6 +9,7 @@ use Illuminate\Auth\Access\Response;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Gate;
+use LogicException;
 
 trait CanBeAuthorized
 {
@@ -229,7 +230,7 @@ trait CanBeAuthorized
             : $this->getHasActionsLivewire()->getDefaultActionIndividualRecordAuthorizationResponseResolver($this);
 
         if (! $resolver) {
-            throw new Exception('No function was passed to [authorizeIndividualRecords()].');
+            throw new LogicException('No function was passed to [authorizeIndividualRecords()].');
         }
 
         $response = $resolver($record);

--- a/packages/actions/src/Concerns/HasName.php
+++ b/packages/actions/src/Concerns/HasName.php
@@ -2,7 +2,7 @@
 
 namespace Filament\Actions\Concerns;
 
-use Exception;
+use LogicException;
 
 trait HasName
 {
@@ -20,7 +20,7 @@ trait HasName
         if (blank($this->name)) {
             $actionClass = static::class;
 
-            throw new Exception("Action of class [$actionClass] must have a unique name, passed to the [make()] method.");
+            throw new LogicException("Action of class [$actionClass] must have a unique name, passed to the [make()] method.");
         }
 
         return $this->name;

--- a/packages/actions/src/Concerns/InteractsWithRecord.php
+++ b/packages/actions/src/Concerns/InteractsWithRecord.php
@@ -8,6 +8,7 @@ use Filament\Actions\Action;
 use Filament\Support\ArrayRecord;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use LogicException;
 
 use function Filament\Support\get_model_label;
 use function Filament\Support\locale_has_pluralization;
@@ -152,7 +153,7 @@ trait InteractsWithRecord
     public function resolveRecordKey(Model | array $record): string
     {
         if (is_array($record)) {
-            return $record[ArrayRecord::getKeyName()] ?? throw new Exception('Record arrays must have a unique [' . ArrayRecord::getKeyName() . '] entry for identification.');
+            return $record[ArrayRecord::getKeyName()] ?? throw new LogicException('Record arrays must have a unique [' . ArrayRecord::getKeyName() . '] entry for identification.');
         }
 
         return $record->getKey();

--- a/packages/actions/src/Concerns/InteractsWithRecord.php
+++ b/packages/actions/src/Concerns/InteractsWithRecord.php
@@ -3,7 +3,6 @@
 namespace Filament\Actions\Concerns;
 
 use Closure;
-use Exception;
 use Filament\Actions\Action;
 use Filament\Support\ArrayRecord;
 use Illuminate\Database\Eloquent\Model;
@@ -92,8 +91,6 @@ trait InteractsWithRecord
 
     /**
      * @return Model | array<string, mixed> | null
-     *
-     * @throws Exception
      */
     public function getRecord(bool $withDefault = true): Model | array | null
     {
@@ -102,7 +99,7 @@ trait InteractsWithRecord
         $isRecordKey = filled($record) && (! $record instanceof Model) && (! is_array($record));
 
         if ($isRecordKey && (! $this->resolveRecordUsing)) {
-            throw new Exception("Could not resolve record from key [{$record}] without a [resolveRecordUsing()] callback.");
+            throw new LogicException("Could not resolve record from key [{$record}] without a [resolveRecordUsing()] callback.");
         }
 
         if ($isRecordKey) {
@@ -218,8 +215,6 @@ trait InteractsWithRecord
 
     /**
      * @return class-string<Model>|null
-     *
-     * @throws Exception
      */
     public function getModel(bool $withDefault = true): ?string
     {

--- a/packages/actions/src/Concerns/InteractsWithSelectedRecords.php
+++ b/packages/actions/src/Concerns/InteractsWithSelectedRecords.php
@@ -3,12 +3,12 @@
 namespace Filament\Actions\Concerns;
 
 use Closure;
-use Exception;
 use Filament\Support\Authorization\DenyResponse;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
+use LogicException;
 
 trait InteractsWithSelectedRecords
 {
@@ -47,7 +47,7 @@ trait InteractsWithSelectedRecords
     public function getSelectedRecords(): EloquentCollection | Collection | LazyCollection
     {
         if (! $this->canAccessSelectedRecords()) {
-            throw new Exception("The action [{$this->getName()}] is attempting to access the selected records from the table, but it is not using [accessSelectedRecords()], so they are not available.");
+            throw new LogicException("The action [{$this->getName()}] is attempting to access the selected records from the table, but it is not using [accessSelectedRecords()], so they are not available.");
         }
 
         $records = $this->getLivewire()->getSelectedTableRecords($this->shouldFetchSelectedRecords(), $this->getSelectedRecordsChunkSize());
@@ -63,7 +63,7 @@ trait InteractsWithSelectedRecords
     public function getSelectedRecordsQuery(): Builder
     {
         if (! $this->canAccessSelectedRecords()) {
-            throw new Exception("The action [{$this->getName()}] is attempting to access the selected records query from the table, but it is not using [accessSelectedRecords()], so they are not available.");
+            throw new LogicException("The action [{$this->getName()}] is attempting to access the selected records query from the table, but it is not using [accessSelectedRecords()], so they are not available.");
         }
 
         return $this->getLivewire()->getSelectedTableRecordsQuery($this->shouldFetchSelectedRecords(), $this->getSelectedRecordsChunkSize());

--- a/packages/actions/src/Exports/ExportColumn.php
+++ b/packages/actions/src/Exports/ExportColumn.php
@@ -3,13 +3,13 @@
 namespace Filament\Actions\Exports;
 
 use Closure;
-use Exception;
 use Filament\Support\Components\Component;
 use Filament\Support\Concerns\CanAggregateRelatedModels;
 use Filament\Support\Concerns\HasCellState;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use InvalidArgumentException;
 
 class ExportColumn extends Component
 {
@@ -39,7 +39,7 @@ class ExportColumn extends Component
         $name ??= static::getDefaultName();
 
         if (blank($name)) {
-            throw new Exception("Export column of class [$exportColumnClass] must have a unique name, passed to the [make()] method.");
+            throw new InvalidArgumentException("Export column of class [$exportColumnClass] must have a unique name, passed to the [make()] method.");
         }
 
         $static = app($exportColumnClass, ['name' => $name]);

--- a/packages/actions/src/Exports/Models/Export.php
+++ b/packages/actions/src/Exports/Models/Export.php
@@ -3,7 +3,6 @@
 namespace Filament\Actions\Exports\Models;
 
 use Carbon\CarbonInterface;
-use Exception;
 use Filament\Actions\Exports\Exporter;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Filesystem\Filesystem;
@@ -11,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\Storage;
+use LogicException;
 
 /**
  * @property CarbonInterface | null $completed_at
@@ -60,7 +60,7 @@ class Export extends Model
         $userClass = app()->getNamespace() . 'Models\\User';
 
         if (! class_exists($userClass)) {
-            throw new Exception('No [' . $userClass . '] model found. Please bind an authenticatable model to the [Illuminate\\Contracts\\Auth\\Authenticatable] interface in a service provider\'s [register()] method.');
+            throw new LogicException('No [' . $userClass . '] model found. Please bind an authenticatable model to the [Illuminate\\Contracts\\Auth\\Authenticatable] interface in a service provider\'s [register()] method.');
         }
 
         /** @phpstan-ignore-next-line */

--- a/packages/actions/src/Imports/ImportColumn.php
+++ b/packages/actions/src/Imports/ImportColumn.php
@@ -3,7 +3,6 @@
 namespace Filament\Actions\Imports;
 
 use Closure;
-use Exception;
 use Filament\Forms\Components\Select;
 use Filament\Support\Components\Component;
 use Filament\Support\Services\RelationshipJoiner;
@@ -15,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 
 class ImportColumn extends Component
 {
@@ -98,7 +98,7 @@ class ImportColumn extends Component
         $name ??= static::getDefaultName();
 
         if (blank($name)) {
-            throw new Exception("Import column of class [$importColumnClass] must have a unique name, passed to the [make()] method.");
+            throw new InvalidArgumentException("Import column of class [$importColumnClass] must have a unique name, passed to the [make()] method.");
         }
 
         $static = app($importColumnClass, ['name' => $name]);

--- a/packages/actions/src/Imports/Models/Import.php
+++ b/packages/actions/src/Imports/Models/Import.php
@@ -3,7 +3,6 @@
 namespace Filament\Actions\Imports\Models;
 
 use Carbon\CarbonInterface;
-use Exception;
 use Filament\Actions\Imports\Importer;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Collection;
@@ -11,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use LogicException;
 
 /**
  * @property CarbonInterface | null $completed_at
@@ -66,7 +66,7 @@ class Import extends Model
         $userClass = app()->getNamespace() . 'Models\\User';
 
         if (! class_exists($userClass)) {
-            throw new Exception('No [' . $userClass . '] model found. Please bind an authenticatable model to the [Illuminate\\Contracts\\Auth\\Authenticatable] interface in a service provider\'s [register()] method.');
+            throw new LogicException('No [' . $userClass . '] model found. Please bind an authenticatable model to the [Illuminate\\Contracts\\Auth\\Authenticatable] interface in a service provider\'s [register()] method.');
         }
 
         /** @phpstan-ignore-next-line */

--- a/packages/actions/src/Testing/TestsActions.php
+++ b/packages/actions/src/Testing/TestsActions.php
@@ -4,7 +4,6 @@ namespace Filament\Actions\Testing;
 
 use BackedEnum;
 use Closure;
-use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\ActionName;
@@ -15,6 +14,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Testing\Assert;
 use Livewire\Component;
 use Livewire\Features\SupportTesting\Testable;
+use LogicException;
 use ReflectionClass;
 
 use function Livewire\store;
@@ -631,7 +631,7 @@ class TestsActions
                     $action = $action->toArray(defaultSchema: ($initialMountedActionsCount + $actionNestingIndex) ? ('mountedActionSchema' . ($initialMountedActionsCount + $actionNestingIndex - 1)) : $this->instance()->getDefaultTestingSchemaName());
                 }
 
-                $actionName = $action['name'] ?? throw new Exception("Action name at index [{$actionNestingIndex}] is not specified.");
+                $actionName = $action['name'] ?? throw new LogicException("Action name at index [{$actionNestingIndex}] is not specified.");
 
                 if (
                     class_exists($actionName) &&

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -59,7 +59,7 @@
                     @foreach ($toolbarButtons as $button => $buttonGroup)
                         <div class="fi-fo-rich-editor-toolbar-group">
                             @foreach ($buttonGroup as $button)
-                                {{ $tools[$button] ?? throw new Exception("Toolbar button [{$button}] cannot be found.") }}
+                                {{ $tools[$button] ?? throw new LogicException("Toolbar button [{$button}] cannot be found.") }}
                             @endforeach
                         </div>
                     @endforeach

--- a/packages/forms/src/Components/Builder/Block.php
+++ b/packages/forms/src/Components/Builder/Block.php
@@ -4,12 +4,12 @@ namespace Filament\Forms\Components\Builder;
 
 use BackedEnum;
 use Closure;
-use Exception;
 use Filament\Forms\Components\Concerns;
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Concerns\HasLabel;
 use Filament\Schemas\Components\Concerns\HasName;
 use Illuminate\Contracts\Support\Htmlable;
+use InvalidArgumentException;
 
 class Block extends Component
 {
@@ -35,7 +35,7 @@ class Block extends Component
         $name ??= static::getDefaultName();
 
         if (blank($name)) {
-            throw new Exception("Block of class [$blockClass] must have a unique name, passed to the [make()] method.");
+            throw new InvalidArgumentException("Block of class [$blockClass] must have a unique name, passed to the [make()] method.");
         }
 
         $static = app($blockClass, ['name' => $name]);

--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -3,7 +3,6 @@
 namespace Filament\Forms\Components;
 
 use Closure;
-use Exception;
 use Filament\Actions\Action;
 use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
 use Filament\Schemas\Components\StateCasts\EnumArrayStateCast;
@@ -16,6 +15,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
+use LogicException;
 
 class CheckboxList extends Field implements Contracts\CanDisableOptions, Contracts\HasNestedRecursiveValidationRules
 {
@@ -302,7 +302,7 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
         $record = $this->getModelInstance();
 
         if (! $record->isRelation($name)) {
-            throw new Exception("The relationship [{$name}] does not exist on the model [{$this->getModel()}].");
+            throw new LogicException("The relationship [{$name}] does not exist on the model [{$this->getModel()}].");
         }
 
         return $record->{$name}();

--- a/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
+++ b/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
@@ -3,7 +3,7 @@
 namespace Filament\Forms\Components\Concerns;
 
 use Closure;
-use Exception;
+use LogicException;
 
 trait InteractsWithToolbarButtons
 {
@@ -27,7 +27,7 @@ trait InteractsWithToolbarButtons
     public function disableToolbarButtons(array $buttonsToDisable = []): static
     {
         if ($this->toolbarButtons instanceof Closure) {
-            throw new Exception('You cannot use the `disableToolbarButtons()` method when the toolbar buttons are dynamically returned from a function. Instead, do not return the disabled buttons from the function.');
+            throw new LogicException('You cannot use the `disableToolbarButtons()` method when the toolbar buttons are dynamically returned from a function. Instead, do not return the disabled buttons from the function.');
         }
 
         $this->toolbarButtons = array_reduce(
@@ -56,7 +56,7 @@ trait InteractsWithToolbarButtons
     public function enableToolbarButtons(array $buttonsToEnable = []): static
     {
         if ($this->toolbarButtons instanceof Closure) {
-            throw new Exception('You cannot use the `enableToolbarButtons()` method when the toolbar buttons are dynamically returned from a function. Instead, return the enabled buttons from the function.');
+            throw new LogicException('You cannot use the `enableToolbarButtons()` method when the toolbar buttons are dynamically returned from a function. Instead, return the enabled buttons from the function.');
         }
 
         $this->toolbarButtons = [

--- a/packages/forms/src/Components/Field.php
+++ b/packages/forms/src/Components/Field.php
@@ -3,7 +3,6 @@
 namespace Filament\Forms\Components;
 
 use Closure;
-use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Schemas\Components\Component;
@@ -14,6 +13,7 @@ use Filament\Schemas\Components\StateCasts\EnumStateCast;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\Size;
 use Illuminate\Contracts\Support\Htmlable;
+use InvalidArgumentException;
 
 class Field extends Component implements Contracts\HasValidationRules
 {
@@ -64,7 +64,7 @@ class Field extends Component implements Contracts\HasValidationRules
         $name ??= static::getDefaultName();
 
         if ($name === null) {
-            throw new Exception("Field of class [$fieldClass] must have a unique name, passed to the [make()] method.");
+            throw new InvalidArgumentException("Field of class [$fieldClass] must have a unique name, passed to the [make()] method.");
         }
 
         $static = app($fieldClass, ['name' => $name]);

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -3,12 +3,12 @@
 namespace Filament\Forms\Components;
 
 use Closure;
-use Exception;
 use Filament\Forms\View\FormsIconAlias;
 use Filament\Support\Concerns\HasAlignment;
 use Filament\Support\Concerns\HasExtraAlpineAttributes;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 
 use function Filament\Support\generate_icon_html;
 
@@ -372,7 +372,7 @@ class FileUpload extends BaseFileUpload
     public function imageEditorMode(int $mode): static
     {
         if (! in_array($mode, [1, 2, 3])) {
-            throw new Exception("The file upload editor mode must be either 1, 2 or 3. [{$mode}] given, which is unsupported. See https://github.com/fengyuanchen/cropperjs#viewmode for more information on the available modes. Mode 0 is not supported, as it does not allow configuration via manual inputs.");
+            throw new InvalidArgumentException("The file upload editor mode must be either 1, 2 or 3. [{$mode}] given, which is unsupported. See https://github.com/fengyuanchen/cropperjs#viewmode for more information on the available modes. Mode 0 is not supported, as it does not allow configuration via manual inputs.");
         }
 
         $this->imageEditorMode = $mode;

--- a/packages/forms/src/Components/ModalTableSelect.php
+++ b/packages/forms/src/Components/ModalTableSelect.php
@@ -3,7 +3,6 @@
 namespace Filament\Forms\Components;
 
 use Closure;
-use Exception;
 use Filament\Actions\Action;
 use Filament\Support\Enums\IconPosition;
 use Filament\Support\Icons\Heroicon;
@@ -21,6 +20,7 @@ use Illuminate\Database\Eloquent\Relations\HasOneOrManyThrough;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use LogicException;
 use Znck\Eloquent\Relations\BelongsToThrough;
 
 class ModalTableSelect extends Field
@@ -586,7 +586,7 @@ class ModalTableSelect extends Field
         }
 
         if (! $relationship) {
-            throw new Exception("The relationship [{$relationshipName}] does not exist on the model [{$this->getModel()}].");
+            throw new LogicException("The relationship [{$relationshipName}] does not exist on the model [{$this->getModel()}].");
         }
 
         return $relationship;
@@ -669,7 +669,7 @@ class ModalTableSelect extends Field
 
     public function getTableConfiguration(): string
     {
-        return $this->evaluate($this->tableConfiguration) ?? throw new Exception('The [tableConfiguration()] method must be set when using a [TableSelect] component.');
+        return $this->evaluate($this->tableConfiguration) ?? throw new LogicException('The [tableConfiguration()] method must be set when using a [TableSelect] component.');
     }
 
     /**

--- a/packages/forms/src/Components/MorphToSelect.php
+++ b/packages/forms/src/Components/MorphToSelect.php
@@ -3,7 +3,6 @@
 namespace Filament\Forms\Components;
 
 use Closure;
-use Exception;
 use Filament\Forms\Components\MorphToSelect\Type;
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Concerns\HasLabel;
@@ -13,6 +12,8 @@ use Filament\Schemas\Components\Utilities\Set;
 use Filament\Support\Concerns\CanBeContained;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use InvalidArgumentException;
+use LogicException;
 
 class MorphToSelect extends Component
 {
@@ -55,7 +56,7 @@ class MorphToSelect extends Component
         $name ??= static::getDefaultName();
 
         if (blank($name)) {
-            throw new Exception("MorphToSelect of class [$morphToSelectClass] must have a unique name, passed to the [make()] method.");
+            throw new InvalidArgumentException("MorphToSelect of class [$morphToSelectClass] must have a unique name, passed to the [make()] method.");
         }
 
         $static = app($morphToSelectClass, ['name' => $name]);
@@ -203,7 +204,7 @@ class MorphToSelect extends Component
         $relationshipName = $this->getName();
 
         if (! $record->isRelation($relationshipName)) {
-            throw new Exception("The relationship [{$relationshipName}] does not exist on the model [{$this->getModel()}].");
+            throw new LogicException("The relationship [{$relationshipName}] does not exist on the model [{$this->getModel()}].");
         }
 
         return $record->{$relationshipName}();

--- a/packages/forms/src/Components/MorphToSelect/Type.php
+++ b/packages/forms/src/Components/MorphToSelect/Type.php
@@ -3,12 +3,12 @@
 namespace Filament\Forms\Components\MorphToSelect;
 
 use Closure;
-use Exception;
 use Filament\Forms\Components\Select;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use LogicException;
 
 use function Filament\Support\generate_search_column_expression;
 use function Filament\Support\generate_search_term_expression;
@@ -326,7 +326,7 @@ class Type
     public function getTitleAttribute(): string
     {
         if (blank($this->titleAttribute)) {
-            throw new Exception("MorphToSelect type [{$this->getModel()}] must have a [titleAttribute()] set.");
+            throw new LogicException("MorphToSelect type [{$this->getModel()}] must have a [titleAttribute()] set.");
         }
 
         return $this->titleAttribute;

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -3,7 +3,6 @@
 namespace Filament\Forms\Components;
 
 use Closure;
-use Exception;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Repeater\TableColumn;
 use Filament\Forms\View\FormsIconAlias;
@@ -25,6 +24,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Support\Str;
+use LogicException;
 
 use function Filament\Forms\array_move_after;
 use function Filament\Forms\array_move_before;
@@ -1096,7 +1096,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         $relationshipName = $this->getRelationshipName();
 
         if (! $record->isRelation($relationshipName)) {
-            throw new Exception("The relationship [{$relationshipName}] does not exist on the model [{$this->getModel()}].");
+            throw new LogicException("The relationship [{$relationshipName}] does not exist on the model [{$this->getModel()}].");
         }
 
         return $this->getModelInstance()->{$relationshipName}();

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -4,7 +4,6 @@ namespace Filament\Forms\Components;
 
 use BackedEnum;
 use Closure;
-use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Forms\View\FormsIconAlias;
@@ -36,6 +35,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Livewire\Attributes\Renderless;
+use LogicException;
 use Znck\Eloquent\Relations\BelongsToThrough;
 
 use function Filament\Support\generate_search_column_expression;
@@ -247,7 +247,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
             })
             ->action(static function (Action $action, array $arguments, Select $component, array $data, Schema $schema): void {
                 if (! $component->getCreateOptionUsing()) {
-                    throw new Exception("Select field [{$component->getStatePath()}] must have a [createOptionUsing()] closure set.");
+                    throw new LogicException("Select field [{$component->getStatePath()}] must have a [createOptionUsing()] closure set.");
                 }
 
                 $createdOptionKey = $component->evaluate($component->getCreateOptionUsing(), [
@@ -400,7 +400,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
             ->fillForm(static fn (Select $component): ?array => $component->getEditOptionActionFormData())
             ->action(static function (Action $action, array $arguments, Select $component, array $data, Schema $schema): void {
                 if (! $component->getUpdateOptionUsing()) {
-                    throw new Exception("Select field [{$component->getStatePath()}] must have a [updateOptionUsing()] closure set.");
+                    throw new LogicException("Select field [{$component->getStatePath()}] must have a [updateOptionUsing()] closure set.");
                 }
 
                 $component->evaluate($component->getUpdateOptionUsing(), [
@@ -1266,7 +1266,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
         }
 
         if (! $relationship) {
-            throw new Exception("The relationship [{$relationshipName}] does not exist on the model [{$this->getModel()}].");
+            throw new LogicException("The relationship [{$relationshipName}] does not exist on the model [{$this->getModel()}].");
         }
 
         return $relationship;
@@ -1442,7 +1442,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
 
         if ($this->isMultiple()) {
             if ((! $this->getOptionLabelsUsing) && (! $this->options)) {
-                throw new Exception("Filament failed to validate the [{$this->getStatePath()}] field\'s selected options because it did not have an [options()] or [getOptionLabelsUsing()] configuration. Please use one of these methods to inform Filament which options are valid for this field.");
+                throw new LogicException("Filament failed to validate the [{$this->getStatePath()}] field\'s selected options because it did not have an [options()] or [getOptionLabelsUsing()] configuration. Please use one of these methods to inform Filament which options are valid for this field.");
             }
 
             $state = $this->getState();
@@ -1473,7 +1473,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
         }
 
         if ((! $this->getOptionLabelUsing) && (! $this->options)) {
-            throw new Exception("Filament failed to validate the [{$this->getStatePath()}] field\'s selected options because it did not have an [options()] or [getOptionLabelUsing()] configuration. Please use one of these methods to inform Filament which options are valid for this field.");
+            throw new LogicException("Filament failed to validate the [{$this->getStatePath()}] field\'s selected options because it did not have an [options()] or [getOptionLabelUsing()] configuration. Please use one of these methods to inform Filament which options are valid for this field.");
         }
 
         $optionLabel = $this->getOptionLabel(withDefault: false);

--- a/packages/forms/src/Components/TableSelect.php
+++ b/packages/forms/src/Components/TableSelect.php
@@ -3,7 +3,6 @@
 namespace Filament\Forms\Components;
 
 use Closure;
-use Exception;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -14,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Database\Eloquent\Relations\HasOneOrManyThrough;
 use Illuminate\Support\Arr;
+use LogicException;
 use Znck\Eloquent\Relations\BelongsToThrough;
 
 class TableSelect extends Field
@@ -56,7 +56,7 @@ class TableSelect extends Field
 
     public function getTableConfiguration(): string
     {
-        return $this->evaluate($this->tableConfiguration) ?? throw new Exception('The [tableConfiguration()] method must be set when using a [TableSelect] component.');
+        return $this->evaluate($this->tableConfiguration) ?? throw new LogicException('The [tableConfiguration()] method must be set when using a [TableSelect] component.');
     }
 
     /**
@@ -261,7 +261,7 @@ class TableSelect extends Field
         }
 
         if (! $relationship) {
-            throw new Exception("The relationship [{$relationshipName}] does not exist on the model [{$this->getModel()}].");
+            throw new LogicException("The relationship [{$relationshipName}] does not exist on the model [{$this->getModel()}].");
         }
 
         return $relationship;

--- a/packages/forms/src/Components/TableSelect/Livewire/TableSelectLivewireComponent.php
+++ b/packages/forms/src/Components/TableSelect/Livewire/TableSelectLivewireComponent.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Forms\Components\TableSelect\Livewire;
 
-use Exception;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
 use Filament\Forms\Concerns\InteractsWithForms;
@@ -19,6 +18,7 @@ use Livewire\Attributes\Locked;
 use Livewire\Attributes\Modelable;
 use Livewire\Component;
 use Livewire\WithoutUrlPagination;
+use LogicException;
 
 class TableSelectLivewireComponent extends Component implements HasActions, HasForms, HasTable
 {
@@ -62,11 +62,11 @@ class TableSelectLivewireComponent extends Component implements HasActions, HasF
         $tableConfiguration = base64_decode($this->tableConfiguration);
 
         if (! class_exists($tableConfiguration)) {
-            throw new Exception("Table configuration class [{$tableConfiguration}] does not exist.");
+            throw new LogicException("Table configuration class [{$tableConfiguration}] does not exist.");
         }
 
         if (! method_exists($tableConfiguration, 'configure')) {
-            throw new Exception("Table configuration class [{$tableConfiguration}] does not have a [configure(Table \$table): Table] method.");
+            throw new LogicException("Table configuration class [{$tableConfiguration}] does not have a [configure(Table \$table): Table] method.");
         }
 
         $tableConfiguration::configure($table);

--- a/packages/forms/src/Components/TextInput.php
+++ b/packages/forms/src/Components/TextInput.php
@@ -3,7 +3,6 @@
 namespace Filament\Forms\Components;
 
 use Closure;
-use Exception;
 use Filament\Forms\Components\Contracts\CanHaveNumericState;
 use Filament\Schemas\Components\Concerns\CanStripCharactersFromState;
 use Filament\Schemas\Components\Concerns\CanTrimState;
@@ -12,6 +11,7 @@ use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
 use Filament\Schemas\Components\StateCasts\NumberStateCast;
 use Filament\Support\Concerns\HasExtraAlpineAttributes;
 use Filament\Support\RawJs;
+use LogicException;
 
 class TextInput extends Field implements CanHaveNumericState, Contracts\CanBeLengthConstrained, HasAffixActions
 {
@@ -168,7 +168,7 @@ class TextInput extends Field implements CanHaveNumericState, Contracts\CanBeLen
             return false;
         }
 
-        return $this->isPassword() ?: throw new Exception("The text input [{$this->getStatePath()}] is not a [password()], so it cannot be [revealable()].");
+        return $this->isPassword() ?: throw new LogicException("The text input [{$this->getStatePath()}] is not a [password()], so it cannot be [revealable()].");
     }
 
     public function copyable(

--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -3,13 +3,13 @@
 namespace Filament\Forms\Concerns;
 
 use Closure;
-use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Schema;
 use Illuminate\Database\Eloquent\Model;
+use LogicException;
 
 trait InteractsWithForms /** @phpstan-ignore trait.unused */
 {
@@ -64,7 +64,7 @@ trait InteractsWithForms /** @phpstan-ignore trait.unused */
                     if (! method_exists($this, $form)) {
                         $livewireClass = $this::class;
 
-                        throw new Exception("Form configuration method [{$form}()] is missing from Livewire component [{$livewireClass}].");
+                        throw new LogicException("Form configuration method [{$form}()] is missing from Livewire component [{$livewireClass}].");
                     }
 
                     return [$form => $this->{$form}($this->makeSchema())];

--- a/packages/infolists/src/Components/Entry.php
+++ b/packages/infolists/src/Components/Entry.php
@@ -3,7 +3,6 @@
 namespace Filament\Infolists\Components;
 
 use Closure;
-use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Schemas\Components\Component;
@@ -19,6 +18,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\View\ComponentAttributeBag;
 use Illuminate\View\ComponentSlot;
 
+use LogicException;
 use function Filament\Support\generate_href_html;
 
 class Entry extends Component
@@ -66,7 +66,7 @@ class Entry extends Component
         $name ??= static::getDefaultName();
 
         if (blank($name)) {
-            throw new Exception("Entry of class [$entryClass] must have a unique name, passed to the [make()] method.");
+            throw new LogicException("Entry of class [$entryClass] must have a unique name, passed to the [make()] method.");
         }
 
         $static = app($entryClass, ['name' => $name]);

--- a/packages/panels/src/Auth/MultiFactor/App/AppAuthentication.php
+++ b/packages/panels/src/Auth/MultiFactor/App/AppAuthentication.php
@@ -3,7 +3,6 @@
 namespace Filament\Auth\MultiFactor\App;
 
 use Closure;
-use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Auth\MultiFactor\App\Actions\DisableAppAuthenticationAction;
@@ -24,6 +23,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
+use LogicException;
 use PragmaRX\Google2FAQRCode\Google2FA;
 
 class AppAuthentication implements MultiFactorAuthenticationProvider
@@ -63,7 +63,7 @@ class AppAuthentication implements MultiFactorAuthenticationProvider
     public function isEnabled(Authenticatable $user): bool
     {
         if (! ($user instanceof HasAppAuthentication)) {
-            throw new Exception('The user model must implement the [' . HasAppAuthentication::class . '] interface to use app authentication.');
+            throw new LogicException('The user model must implement the [' . HasAppAuthentication::class . '] interface to use app authentication.');
         }
 
         return filled($user->getAppAuthenticationSecret());
@@ -79,7 +79,7 @@ class AppAuthentication implements MultiFactorAuthenticationProvider
         $secret = $user->getAppAuthenticationSecret();
 
         if (blank($secret)) {
-            throw new Exception('The user does not have a app authentication secret.');
+            throw new LogicException('The user does not have a app authentication secret.');
         }
 
         return $secret;
@@ -98,7 +98,7 @@ class AppAuthentication implements MultiFactorAuthenticationProvider
         $codes = $user->getAppAuthenticationRecoveryCodes();
 
         if (blank($codes)) {
-            throw new Exception('The user does not have any app authentication recovery codes.');
+            throw new LogicException('The user does not have any app authentication recovery codes.');
         }
 
         return $codes;

--- a/packages/panels/src/Auth/MultiFactor/Email/EmailAuthentication.php
+++ b/packages/panels/src/Auth/MultiFactor/Email/EmailAuthentication.php
@@ -3,7 +3,6 @@
 namespace Filament\Auth\MultiFactor\Email;
 
 use Closure;
-use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Auth\MultiFactor\Contracts\HasBeforeChallengeHook;
@@ -22,6 +21,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\RateLimiter;
+use LogicException;
 
 class EmailAuthentication implements HasBeforeChallengeHook, MultiFactorAuthenticationProvider
 {
@@ -49,7 +49,7 @@ class EmailAuthentication implements HasBeforeChallengeHook, MultiFactorAuthenti
     public function isEnabled(Authenticatable $user): bool
     {
         if (! ($user instanceof HasEmailAuthentication)) {
-            throw new Exception('The user model must implement the [' . HasEmailAuthentication::class . '] interface to use email authentication.');
+            throw new LogicException('The user model must implement the [' . HasEmailAuthentication::class . '] interface to use email authentication.');
         }
 
         return $user->hasEmailAuthentication();
@@ -58,13 +58,13 @@ class EmailAuthentication implements HasBeforeChallengeHook, MultiFactorAuthenti
     public function sendCode(HasEmailAuthentication $user): void
     {
         if (! ($user instanceof Model)) {
-            throw new Exception('The [' . $user::class . '] class must be an instance of [' . Model::class . '] to use email authentication.');
+            throw new LogicException('The [' . $user::class . '] class must be an instance of [' . Model::class . '] to use email authentication.');
         }
 
         if (! method_exists($user, 'notify')) {
             $userClass = $user::class;
 
-            throw new Exception("Model [{$userClass}] does not have a [notify()] method.");
+            throw new LogicException("Model [{$userClass}] does not have a [notify()] method.");
         }
 
         $rateLimitingKey = "filament_email_authentication.{$user->getKey()}";
@@ -178,7 +178,7 @@ class EmailAuthentication implements HasBeforeChallengeHook, MultiFactorAuthenti
     public function beforeChallenge(Authenticatable $user): void
     {
         if (! ($user instanceof HasEmailAuthentication)) {
-            throw new Exception('The user model must implement the [' . HasEmailAuthentication::class . '] interface to use email authentication.');
+            throw new LogicException('The user model must implement the [' . HasEmailAuthentication::class . '] interface to use email authentication.');
         }
 
         $this->sendCode($user);

--- a/packages/panels/src/Auth/Pages/EditProfile.php
+++ b/packages/panels/src/Auth/Pages/EditProfile.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Auth\Pages;
 
-use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Auth\MultiFactor\Contracts\MultiFactorAuthenticationProvider;
@@ -35,6 +34,7 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Js;
 use Illuminate\Validation\Rules\Password;
 use League\Uri\Components\Query;
+use LogicException;
 use Throwable;
 
 /**
@@ -95,7 +95,7 @@ class EditProfile extends Page
         $user = Filament::auth()->user();
 
         if (! $user instanceof Model) {
-            throw new Exception('The authenticated user object must be an Eloquent model to allow the profile page to update it.');
+            throw new LogicException('The authenticated user object must be an Eloquent model to allow the profile page to update it.');
         }
 
         return $user;

--- a/packages/panels/src/Auth/Pages/EmailVerification/EmailVerificationPrompt.php
+++ b/packages/panels/src/Auth/Pages/EmailVerification/EmailVerificationPrompt.php
@@ -4,7 +4,6 @@ namespace Filament\Auth\Pages\EmailVerification;
 
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
 use DanHarrin\LivewireRateLimiting\WithRateLimiting;
-use Exception;
 use Filament\Actions\Action;
 use Filament\Auth\Notifications\VerifyEmail;
 use Filament\Facades\Filament;
@@ -15,6 +14,7 @@ use Filament\Schemas\Schema;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\HtmlString;
+use LogicException;
 
 /**
  * @property-read Action $resendNotificationAction
@@ -32,7 +32,7 @@ class EmailVerificationPrompt extends SimplePage
 
     protected function getVerifiable(): MustVerifyEmail
     {
-        /** @var MustVerifyEmail */
+        /** @var MustVerifyEmail $user */
         $user = Filament::auth()->user();
 
         return $user;
@@ -47,7 +47,7 @@ class EmailVerificationPrompt extends SimplePage
         if (! method_exists($user, 'notify')) {
             $userClass = $user::class;
 
-            throw new Exception("Model [{$userClass}] does not have a [notify()] method.");
+            throw new LogicException("Model [{$userClass}] does not have a [notify()] method.");
         }
 
         $notification = app(VerifyEmail::class);

--- a/packages/panels/src/Auth/Pages/PasswordReset/RequestPasswordReset.php
+++ b/packages/panels/src/Auth/Pages/PasswordReset/RequestPasswordReset.php
@@ -4,7 +4,6 @@ namespace Filament\Auth\Pages\PasswordReset;
 
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
 use DanHarrin\LivewireRateLimiting\WithRateLimiting;
-use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Auth\Notifications\ResetPassword as ResetPasswordNotification;
@@ -27,6 +26,7 @@ use Illuminate\Auth\Events\PasswordResetLinkSent;
 use Illuminate\Contracts\Auth\CanResetPassword;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Facades\Password;
+use LogicException;
 
 /**
  * @property-read Action $loginAction
@@ -75,7 +75,7 @@ class RequestPasswordReset extends SimplePage
                 if (! method_exists($user, 'notify')) {
                     $userClass = $user::class;
 
-                    throw new Exception("Model [{$userClass}] does not have a [notify()] method.");
+                    throw new LogicException("Model [{$userClass}] does not have a [notify()] method.");
                 }
 
                 $notification = app(ResetPasswordNotification::class, ['token' => $token]);

--- a/packages/panels/src/Auth/Pages/Register.php
+++ b/packages/panels/src/Auth/Pages/Register.php
@@ -4,7 +4,6 @@ namespace Filament\Auth\Pages;
 
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
 use DanHarrin\LivewireRateLimiting\WithRateLimiting;
-use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Auth\Events\Registered;
@@ -30,6 +29,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\HtmlString;
 use Illuminate\Validation\Rules\Password;
+use LogicException;
 
 /**
  * @property-read Action $loginAction
@@ -139,7 +139,7 @@ class Register extends SimplePage
         if (! method_exists($user, 'notify')) {
             $userClass = $user::class;
 
-            throw new Exception("Model [{$userClass}] does not have a [notify()] method.");
+            throw new LogicException("Model [{$userClass}] does not have a [notify()] method.");
         }
 
         $notification = app(VerifyEmail::class);

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -3,7 +3,6 @@
 namespace Filament;
 
 use Closure;
-use Exception;
 use Filament\Actions\Action;
 use Filament\Auth\MultiFactor\Contracts\MultiFactorAuthenticationProvider;
 use Filament\Contracts\Plugin;
@@ -35,6 +34,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
 use Livewire\Component;
+use LogicException;
 
 class FilamentManager
 {
@@ -853,7 +853,7 @@ class FilamentManager
         try {
             $this->getDefaultPanel()->navigationGroups($groups);
         } catch (NoDefaultPanelSetException $exception) {
-            throw new Exception('Please use the `navigationGroups()` method on the panel configuration to register navigation groups. See the documentation - https://filamentphp.com/docs/panels/navigation#customizing-navigation-groups');
+            throw new LogicException('Please use the `navigationGroups()` method on the panel configuration to register navigation groups. See the documentation - https://filamentphp.com/docs/panels/navigation#customizing-navigation-groups');
         }
     }
 
@@ -867,7 +867,7 @@ class FilamentManager
         try {
             $this->getDefaultPanel()->navigationItems($items);
         } catch (NoDefaultPanelSetException $exception) {
-            throw new Exception('Please use the `navigationItems()` method on the panel configuration to register navigation items. See the documentation - https://filamentphp.com/docs/panels/navigation#registering-custom-navigation-items');
+            throw new LogicException('Please use the `navigationItems()` method on the panel configuration to register navigation items. See the documentation - https://filamentphp.com/docs/panels/navigation#registering-custom-navigation-items');
         }
     }
 
@@ -881,7 +881,7 @@ class FilamentManager
         try {
             $this->getDefaultPanel()->pages($pages);
         } catch (NoDefaultPanelSetException $exception) {
-            throw new Exception('Please use the `pages()` method on the panel configuration to register pages.');
+            throw new LogicException('Please use the `pages()` method on the panel configuration to register pages.');
         }
     }
 
@@ -903,7 +903,7 @@ class FilamentManager
         try {
             $this->getDefaultPanel()->resources($resources);
         } catch (NoDefaultPanelSetException $exception) {
-            throw new Exception('Please use the `resources()` method on the panel configuration to register resources.');
+            throw new LogicException('Please use the `resources()` method on the panel configuration to register resources.');
         }
     }
 
@@ -914,7 +914,7 @@ class FilamentManager
      */
     public function registerScripts(array $scripts, bool $shouldBeLoadedBeforeCoreScripts = false): void
     {
-        throw new Exception('Please use the `FilamentAsset` facade to register scripts. See the documentation - https://filamentphp.com/docs/support/assets#registering-javascript-files');
+        throw new LogicException('Please use the `FilamentAsset` facade to register scripts. See the documentation - https://filamentphp.com/docs/support/assets#registering-javascript-files');
     }
 
     /**
@@ -934,7 +934,7 @@ class FilamentManager
      */
     public function registerStyles(array $styles): void
     {
-        throw new Exception('Please use the `FilamentAsset` facade to register styles. See the documentation - https://filamentphp.com/docs/support/assets#registering-css-files');
+        throw new LogicException('Please use the `FilamentAsset` facade to register styles. See the documentation - https://filamentphp.com/docs/support/assets#registering-css-files');
     }
 
     /**
@@ -945,7 +945,7 @@ class FilamentManager
         try {
             $this->getDefaultPanel()->theme($theme);
         } catch (NoDefaultPanelSetException $exception) {
-            throw new Exception('Please use the `theme()` method on the panel configuration to register themes.');
+            throw new LogicException('Please use the `theme()` method on the panel configuration to register themes.');
         }
     }
 
@@ -959,7 +959,7 @@ class FilamentManager
         try {
             $this->getDefaultPanel()->viteTheme($theme, $buildDirectory);
         } catch (NoDefaultPanelSetException $exception) {
-            throw new Exception('Please use the `viteTheme()` method on the panel configuration to register themes.');
+            throw new LogicException('Please use the `viteTheme()` method on the panel configuration to register themes.');
         }
     }
 
@@ -973,7 +973,7 @@ class FilamentManager
         try {
             $this->getDefaultPanel()->userMenuItems($items);
         } catch (NoDefaultPanelSetException $exception) {
-            throw new Exception('Please use the `userMenuItems()` method on the panel configuration to register user menu items. See the documentation - https://filamentphp.com/docs/panels/navigation#customizing-the-user-menu');
+            throw new LogicException('Please use the `userMenuItems()` method on the panel configuration to register user menu items. See the documentation - https://filamentphp.com/docs/panels/navigation#customizing-the-user-menu');
         }
     }
 
@@ -987,7 +987,7 @@ class FilamentManager
         try {
             $this->getDefaultPanel()->widgets($widgets);
         } catch (NoDefaultPanelSetException $exception) {
-            throw new Exception('Please use the `widgets()` method on the panel configuration to register widgets.');
+            throw new LogicException('Please use the `widgets()` method on the panel configuration to register widgets.');
         }
     }
 
@@ -1012,7 +1012,7 @@ class FilamentManager
         }
 
         if (app()->runningInConsole()) {
-            throw new Exception('The current domain is not set, but multiple domains are registered for the panel. Please use [Filament::currentDomain(\'example.com\')] to set the current domain to ensure that panel URLs are generated correctly.');
+            throw new LogicException('The current domain is not set, but multiple domains are registered for the panel. Please use [Filament::currentDomain(\'example.com\')] to set the current domain to ensure that panel URLs are generated correctly.');
         }
 
         return request()->getHost();

--- a/packages/panels/src/Navigation/NavigationItem.php
+++ b/packages/panels/src/Navigation/NavigationItem.php
@@ -4,11 +4,11 @@ namespace Filament\Navigation;
 
 use BackedEnum;
 use Closure;
-use Exception;
 use Filament\Support\Components\Component;
 use Filament\Support\Concerns\HasBadgeTooltip;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Htmlable;
+use LogicException;
 use UnitEnum;
 
 class NavigationItem extends Component
@@ -184,7 +184,7 @@ class NavigationItem extends Component
         $icon = $this->evaluate($this->icon);
 
         if (blank($icon) && $this->getChildItems()) {
-            throw new Exception("Navigation item [{$this->getLabel()}] has child items but no icon. Parent items must have an icon to ensure a proper user experience.");
+            throw new LogicException("Navigation item [{$this->getLabel()}] has child items but no icon. Parent items must have an icon to ensure a proper user experience.");
         }
 
         return $icon;

--- a/packages/panels/src/Navigation/NavigationManager.php
+++ b/packages/panels/src/Navigation/NavigationManager.php
@@ -2,13 +2,13 @@
 
 namespace Filament\Navigation;
 
-use Exception;
 use Filament\Facades\Filament;
 use Filament\Panel;
 use Filament\Support\Contracts\HasIcon;
 use Filament\Support\Contracts\HasLabel;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use LogicException;
 use UnitEnum;
 
 class NavigationManager
@@ -189,7 +189,7 @@ class NavigationManager
     public function navigationGroups(array | string $groups): static
     {
         if (is_string($groups)) {
-            throw_unless(enum_exists($groups), new Exception("Enum class [{$groups}] does not exist for navigation groups."));
+            throw_unless(enum_exists($groups), new LogicException("Enum class [{$groups}] does not exist for navigation groups."));
 
             $groups = array_reduce(
                 $groups::cases(),

--- a/packages/panels/src/Pages/Dashboard/Actions/FilterAction.php
+++ b/packages/panels/src/Pages/Dashboard/Actions/FilterAction.php
@@ -2,13 +2,13 @@
 
 namespace Filament\Pages\Dashboard\Actions;
 
-use Exception;
 use Filament\Actions\Action;
 use Filament\Pages\Dashboard;
 use Filament\Support\Facades\FilamentIcon;
 use Filament\Support\Icons\Heroicon;
 use Filament\View\PanelsIconAlias;
 use Livewire\Component;
+use LogicException;
 
 class FilterAction extends Action
 {
@@ -33,7 +33,7 @@ class FilterAction extends Action
 
         $this->fillForm(function (Component $livewire): ?array {
             if (! property_exists($livewire, 'filters')) {
-                throw new Exception('The [' . $livewire::class . '] page must implement the [' . Dashboard\Concerns\HasFilters::class . '] trait.');
+                throw new LogicException('The [' . $livewire::class . '] page must implement the [' . Dashboard\Concerns\HasFilters::class . '] trait.');
             }
 
             return $livewire->filters;

--- a/packages/panels/src/Panel/Concerns/CanGenerateResourceUrls.php
+++ b/packages/panels/src/Panel/Concerns/CanGenerateResourceUrls.php
@@ -2,8 +2,8 @@
 
 namespace Filament\Panel\Concerns;
 
-use Exception;
 use Illuminate\Database\Eloquent\Model;
+use InvalidArgumentException;
 
 trait CanGenerateResourceUrls
 {
@@ -14,7 +14,7 @@ trait CanGenerateResourceUrls
     {
         $modelClass = is_string($model) ? $model : $model::class;
 
-        $resource = $this->getModelResource($modelClass) ?? throw new Exception("No Filament resource found for model [{$modelClass}].");
+        $resource = $this->getModelResource($modelClass) ?? throw new InvalidArgumentException("No Filament resource found for model [{$modelClass}].");
 
         if (
             ($model instanceof Model) &&

--- a/packages/panels/src/Panel/Concerns/HasGlobalSearch.php
+++ b/packages/panels/src/Panel/Concerns/HasGlobalSearch.php
@@ -3,12 +3,12 @@
 namespace Filament\Panel\Concerns;
 
 use Closure;
-use Exception;
 use Filament\GlobalSearch\Providers\Contracts\GlobalSearchProvider;
 use Filament\GlobalSearch\Providers\DefaultGlobalSearchProvider;
 use Filament\Support\Enums\Platform;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Stringable;
+use InvalidArgumentException;
 
 trait HasGlobalSearch
 {
@@ -26,7 +26,7 @@ trait HasGlobalSearch
     public function globalSearch(string | bool $provider = true): static
     {
         if (is_string($provider) && (! in_array(GlobalSearchProvider::class, class_implements($provider)))) {
-            throw new Exception("Global search provider {$provider} does not implement the [" . GlobalSearchProvider::class . '] interface.');
+            throw new InvalidArgumentException("Global search provider {$provider} does not implement the [" . GlobalSearchProvider::class . '] interface.');
         }
 
         $this->globalSearchProvider = $provider;

--- a/packages/panels/src/Panel/Concerns/HasId.php
+++ b/packages/panels/src/Panel/Concerns/HasId.php
@@ -2,7 +2,7 @@
 
 namespace Filament\Panel\Concerns;
 
-use Exception;
+use LogicException;
 
 trait HasId
 {
@@ -11,7 +11,7 @@ trait HasId
     public function id(string $id): static
     {
         if (isset($this->id)) {
-            throw new Exception("The panel has already been registered with the ID [{$this->id}].");
+            throw new LogicException("The panel has already been registered with the ID [{$this->id}].");
         }
 
         $this->id = $id;
@@ -24,7 +24,7 @@ trait HasId
     public function getId(): string
     {
         if (! isset($this->id)) {
-            throw new Exception('A panel has been registered without an `id()`.');
+            throw new LogicException('A panel has been registered without an `id()`.');
         }
 
         return $this->id;

--- a/packages/panels/src/Panel/Concerns/HasNavigation.php
+++ b/packages/panels/src/Panel/Concerns/HasNavigation.php
@@ -3,11 +3,11 @@
 namespace Filament\Panel\Concerns;
 
 use Closure;
-use Exception;
 use Filament\Navigation\NavigationBuilder;
 use Filament\Navigation\NavigationGroup;
 use Filament\Navigation\NavigationItem;
 use Filament\Navigation\NavigationManager;
+use LogicException;
 use UnitEnum;
 
 trait HasNavigation
@@ -56,7 +56,7 @@ trait HasNavigation
         }
 
         if (is_string($groups)) {
-            throw_unless(enum_exists($groups), new Exception("Enum class [{$groups}] does not exist for navigation groups."));
+            throw_unless(enum_exists($groups), new LogicException("Enum class [{$groups}] does not exist for navigation groups."));
 
             $groups = array_reduce(
                 $groups::cases(),

--- a/packages/panels/src/Panel/Concerns/HasPlugins.php
+++ b/packages/panels/src/Panel/Concerns/HasPlugins.php
@@ -2,8 +2,8 @@
 
 namespace Filament\Panel\Concerns;
 
-use Exception;
 use Filament\Contracts\Plugin;
+use LogicException;
 
 trait HasPlugins
 {
@@ -42,7 +42,7 @@ trait HasPlugins
 
     public function getPlugin(string $id): Plugin
     {
-        return $this->getPlugins()[$id] ?? throw new Exception("Plugin [{$id}] is not registered for panel [{$this->getId()}].");
+        return $this->getPlugins()[$id] ?? throw new LogicException("Plugin [{$id}] is not registered for panel [{$this->getId()}].");
     }
 
     public function hasPlugin(string $id): bool

--- a/packages/panels/src/Resources/Pages/Page.php
+++ b/packages/panels/src/Resources/Pages/Page.php
@@ -3,7 +3,6 @@
 namespace Filament\Resources\Pages;
 
 use Closure;
-use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\CreateAction;
 use Filament\Actions\DeleteAction;
@@ -28,6 +27,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Route as RouteFacade;
+use LogicException;
 
 use function Filament\Support\original_request;
 
@@ -107,7 +107,7 @@ abstract class Page extends BasePage
             return $pageName;
         }
 
-        throw new Exception('Page [' . static::class . '] is not registered to the resource [' . static::getResource() . '].');
+        throw new LogicException('Page [' . static::class . '] is not registered to the resource [' . static::getResource() . '].');
     }
 
     public static function route(string $path): PageRegistration

--- a/packages/panels/src/Resources/Resource/Concerns/BelongsToTenant.php
+++ b/packages/panels/src/Resources/Resource/Concerns/BelongsToTenant.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Resources\Resource\Concerns;
 
-use Exception;
 use Filament\Facades\Filament;
 use Filament\Panel;
 use Illuminate\Database\Eloquent\Builder;
@@ -10,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use LogicException;
 
 trait BelongsToTenant
 {
@@ -70,7 +70,7 @@ trait BelongsToTenant
             $resourceClass = static::class;
             $recordClass = $record::class;
 
-            throw new Exception("The model [{$recordClass}] does not have a relationship named [{$relationshipName}]. You can change the relationship being used by passing it to the [ownershipRelationship] argument of the [tenant()] method in configuration. You can change the relationship being used per-resource by setting it as the [\$tenantOwnershipRelationshipName] static property on the [{$resourceClass}] resource class.");
+            throw new LogicException("The model [{$recordClass}] does not have a relationship named [{$relationshipName}]. You can change the relationship being used by passing it to the [ownershipRelationship] argument of the [tenant()] method in configuration. You can change the relationship being used per-resource by setting it as the [\$tenantOwnershipRelationshipName] static property on the [{$resourceClass}] resource class.");
         }
 
         return $record->{$relationshipName}();
@@ -92,7 +92,7 @@ trait BelongsToTenant
             $resourceClass = static::class;
             $tenantClass = $tenant::class;
 
-            throw new Exception("The model [{$tenantClass}] does not have a relationship named [{$relationshipName}]. You can change the relationship being used by setting it as the [\$tenantRelationshipName] static property on the [{$resourceClass}] resource class.");
+            throw new LogicException("The model [{$tenantClass}] does not have a relationship named [{$relationshipName}]. You can change the relationship being used by setting it as the [\$tenantRelationshipName] static property on the [{$resourceClass}] resource class.");
         }
 
         return $tenant->{$relationshipName}();

--- a/packages/panels/src/Resources/Resource/Concerns/CanGenerateUrls.php
+++ b/packages/panels/src/Resources/Resource/Concerns/CanGenerateUrls.php
@@ -2,9 +2,9 @@
 
 namespace Filament\Resources\Resource\Concerns;
 
-use Exception;
 use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Model;
+use LogicException;
 
 use function Filament\Support\original_request;
 
@@ -101,7 +101,7 @@ trait CanGenerateUrls
         }
 
         if (! static::hasPage('index')) {
-            throw new Exception('The resource [' . static::class . '] does not have an [index] page. Define [getIndexUrl()] for alternative routing.');
+            throw new LogicException('The resource [' . static::class . '] does not have an [index] page. Define [getIndexUrl()] for alternative routing.');
         }
 
         return static::getUrl('index', $parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters);

--- a/packages/panels/src/Widgets/Concerns/InteractsWithPageTable.php
+++ b/packages/panels/src/Widgets/Concerns/InteractsWithPageTable.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Widgets\Concerns;
 
-use Exception;
 use Filament\Tables\Contracts\HasTable;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Builder;
@@ -10,6 +9,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\Reactive;
+use LogicException;
 
 use function Livewire\trigger;
 
@@ -56,7 +56,7 @@ trait InteractsWithPageTable /** @phpstan-ignore trait.unused */
 
     protected function getTablePage(): string
     {
-        throw new Exception('You must define a `getTablePage()` method on your widget that returns the name of a Livewire component.');
+        throw new LogicException('You must define a `getTablePage()` method on your widget that returns the name of a Livewire component.');
     }
 
     /**

--- a/packages/panels/src/helpers.php
+++ b/packages/panels/src/helpers.php
@@ -2,13 +2,13 @@
 
 namespace Filament;
 
-use Exception;
 use Filament\Facades\Filament;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Gate;
+use LogicException;
 
 if (! function_exists('Filament\authorize')) {
     /**
@@ -47,7 +47,7 @@ if (! function_exists('Filament\get_authorization_response')) {
                 default => null,
             };
 
-            throw new Exception(blank($policyClass)
+            throw new LogicException(blank($policyClass)
                 ? "Strict authorization mode is enabled, but no policy was found for [{$model}]."
                 : "Strict authorization mode is enabled, but no [{$action}()] method was found on [{$policyClass}].");
         }

--- a/packages/schemas/src/Components/Concerns/CanPartiallyRender.php
+++ b/packages/schemas/src/Components/Concerns/CanPartiallyRender.php
@@ -3,8 +3,8 @@
 namespace Filament\Schemas\Components\Concerns;
 
 use Closure;
-use Exception;
 use Filament\Support\Livewire\Partials\PartialsComponentHook;
+use LogicException;
 
 trait CanPartiallyRender
 {
@@ -65,7 +65,7 @@ trait CanPartiallyRender
             $key = $this->getKey();
 
             if (blank($key)) {
-                throw new Exception('A [key()] or [statePath()] is required to partially render a component.');
+                throw new LogicException('A [key()] or [statePath()] is required to partially render a component.');
             }
 
             return [

--- a/packages/schemas/src/Components/Concerns/HasState.php
+++ b/packages/schemas/src/Components/Concerns/HasState.php
@@ -3,7 +3,6 @@
 namespace Filament\Schemas\Components\Concerns;
 
 use Closure;
-use Exception;
 use Filament\Forms\Components\RichEditor\Models\Contracts\HasRichContent;
 use Filament\Infolists\Components\Entry;
 use Filament\Schemas\Components\Component;
@@ -16,6 +15,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
+use LogicException;
 
 use function Livewire\store;
 
@@ -879,7 +879,7 @@ trait HasState
         }
 
         if (! str($statePath)->startsWith("{$containerConstantStatePath}.")) {
-            throw new Exception("The current component\'s state path [$statePath] does not start with the container\'s constant state path [$containerConstantStatePath].");
+            throw new LogicException("The current component\'s state path [$statePath] does not start with the container\'s constant state path [$containerConstantStatePath].");
         }
 
         return (string) str($statePath)->after("{$containerConstantStatePath}.");

--- a/packages/schemas/src/Components/EmbeddedTable.php
+++ b/packages/schemas/src/Components/EmbeddedTable.php
@@ -3,9 +3,9 @@
 namespace Filament\Schemas\Components;
 
 use Closure;
-use Exception;
 use Filament\Tables\Contracts\HasTable;
 use Illuminate\Contracts\View\View;
+use LogicException;
 
 class EmbeddedTable extends Component
 {
@@ -29,7 +29,7 @@ class EmbeddedTable extends Component
         $livewire = $this->getLivewire();
 
         if (! ($livewire instanceof HasTable)) {
-            throw new Exception('The [' . $livewire::class . '] component must have a table defined.');
+            throw new LogicException('The [' . $livewire::class . '] component must have a table defined.');
         }
 
         return $livewire->getTable()->render();

--- a/packages/schemas/src/Concerns/HasState.php
+++ b/packages/schemas/src/Concerns/HasState.php
@@ -3,12 +3,12 @@
 namespace Filament\Schemas\Concerns;
 
 use Closure;
-use Exception;
 use Filament\Infolists\Components\Entry;
 use Filament\Schemas\Components\Component;
 use Filament\Support\Livewire\Partials\PartialsComponentHook;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
+use LogicException;
 
 trait HasState
 {
@@ -388,7 +388,11 @@ trait HasState
      */
     public function getConstantState(): array | object
     {
-        return $this->constantState ?? $this->getRecord(withParentComponentRecord: false) ?? $this->getParentComponent()?->getContainer()->getConstantState() ?? $this->getRecord() ?? throw new Exception('Schema has no [record()] or [state()] set.');
+        return $this->constantState
+            ?? $this->getRecord(withParentComponentRecord: false)
+            ?? $this->getParentComponent()?->getContainer()->getConstantState()
+            ?? $this->getRecord()
+            ?? throw new LogicException('Schema has no [record()] or [state()] set.');
     }
 
     /**
@@ -506,7 +510,7 @@ trait HasState
         }
 
         if (blank($this->getKey())) {
-            throw new Exception('You cannot partially render a schema without a [key()] or [statePath()] defined.');
+            throw new LogicException('You cannot partially render a schema without a [key()] or [statePath()] defined.');
         }
 
         return blank($updatedStatePath) || str($updatedStatePath)->startsWith("{$this->getStatePath()}.");

--- a/packages/spark-billing-provider/src/Http/Middleware/VerifySparkBillableIsSubscribed.php
+++ b/packages/spark-billing-provider/src/Http/Middleware/VerifySparkBillableIsSubscribed.php
@@ -2,15 +2,15 @@
 
 namespace Filament\Billing\Providers\Http\Middleware;
 
-use Exception;
 use Filament\Facades\Filament;
+use LogicException;
 use Spark\Http\Middleware\VerifyBillableIsSubscribed;
 
 // We cannot explicitly require Spark through Composer, as Stripe
 // and Paddle integrations have different packages associated
 // with them. As such, we must check if this class exists.
 if (! class_exists(VerifyBillableIsSubscribed::class)) {
-    throw new Exception('Laravel Spark is not installed.');
+    throw new LogicException('Laravel Spark is not installed.');
 }
 
 class VerifySparkBillableIsSubscribed extends VerifyBillableIsSubscribed

--- a/packages/spark-billing-provider/src/SparkBillingProvider.php
+++ b/packages/spark-billing-provider/src/SparkBillingProvider.php
@@ -3,10 +3,10 @@
 namespace Filament\Billing\Providers;
 
 use Closure;
-use Exception;
 use Filament\Billing\Providers\Http\Middleware\VerifySparkBillableIsSubscribed;
 use Filament\Facades\Filament;
 use Illuminate\Http\RedirectResponse;
+use LogicException;
 use Spark\Spark;
 
 class SparkBillingProvider implements Contracts\BillingProvider
@@ -21,7 +21,7 @@ class SparkBillingProvider implements Contracts\BillingProvider
             // and Paddle integrations have different packages associated
             // with them. As such, we must check if this class exists.
             if (! class_exists(Spark::class)) {
-                throw new Exception('Laravel Spark is not installed.');
+                throw new LogicException('Laravel Spark is not installed.');
             }
 
             $tenant = Filament::getTenant();

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/RichEditor/FileAttachmentProviders/SpatieMediaLibraryFileAttachmentProvider.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/RichEditor/FileAttachmentProviders/SpatieMediaLibraryFileAttachmentProvider.php
@@ -2,11 +2,11 @@
 
 namespace Filament\Forms\Components\RichEditor\FileAttachmentProviders;
 
-use Exception;
 use Filament\Forms\Components\RichEditor\FileAttachmentProviders\Contracts\FileAttachmentProvider;
 use Filament\Forms\Components\RichEditor\RichContentAttribute;
 use Illuminate\Support\Str;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+use LogicException;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Collections\MediaCollection;
 use Throwable;
@@ -47,7 +47,7 @@ class SpatieMediaLibraryFileAttachmentProvider implements FileAttachmentProvider
         }
 
         if (! ($model instanceof HasMedia)) {
-            throw new Exception('The [' . static::class . '] requires the model to implement the [' . HasMedia::class . '] interface from the Spatie Media Library package.');
+            throw new LogicException('The [' . static::class . '] requires the model to implement the [' . HasMedia::class . '] interface from the Spatie Media Library package.');
         }
 
         return $model;

--- a/packages/support/src/Assets/AssetManager.php
+++ b/packages/support/src/Assets/AssetManager.php
@@ -2,10 +2,10 @@
 
 namespace Filament\Support\Assets;
 
-use Exception;
 use Filament\Support\Colors\ColorManager;
 use Filament\Support\Facades\FilamentColor;
 use Illuminate\Support\Arr;
+use LogicException;
 
 class AssetManager
 {
@@ -122,7 +122,7 @@ class AssetManager
             return $component->getSrc();
         }
 
-        throw new Exception("Alpine component with ID [{$id}] not found for package [{$package}].");
+        throw new LogicException("Alpine component with ID [{$id}] not found for package [{$package}].");
     }
 
     /**
@@ -164,7 +164,7 @@ class AssetManager
             return $script->getSrc();
         }
 
-        throw new Exception("Script with ID [{$id}] not found for package [{$package}].");
+        throw new LogicException("Script with ID [{$id}] not found for package [{$package}].");
     }
 
     /**
@@ -244,7 +244,7 @@ class AssetManager
             return $style->getHref();
         }
 
-        throw new Exception("Stylesheet with ID [{$id}] not found for package [{$package}].");
+        throw new LogicException("Stylesheet with ID [{$id}] not found for package [{$package}].");
     }
 
     /**

--- a/packages/support/src/Colors/ColorManager.php
+++ b/packages/support/src/Colors/ColorManager.php
@@ -3,10 +3,10 @@
 namespace Filament\Support\Colors;
 
 use Closure;
-use Exception;
 use Filament\Support\Concerns\EvaluatesClosures;
 use Filament\Support\View\Components\Contracts\HasColor;
 use Filament\Support\View\Components\Contracts\HasDefaultGrayColor;
+use LogicException;
 
 class ColorManager
 {
@@ -149,7 +149,7 @@ class ColorManager
                     'hover:bg' => "hover:fi-bg-color-{$shade}",
                     'hover:text' => "hover:fi-text-color-{$shade}",
                     'text' => "fi-text-color-{$shade}",
-                    default => throw new Exception("Invalid color mapping key [{$key}]."),
+                    default => throw new LogicException("Invalid color mapping key [{$key}]."),
                 },
                 array_values($map),
                 array_keys($map),

--- a/packages/support/src/Components/ViewComponent.php
+++ b/packages/support/src/Components/ViewComponent.php
@@ -3,13 +3,13 @@
 namespace Filament\Support\Components;
 
 use Closure;
-use Exception;
 use Filament\Support\Components\Contracts\HasEmbeddedView;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
 use Illuminate\View\ComponentAttributeBag;
+use LogicException;
 
 abstract class ViewComponent extends Component implements Htmlable
 {
@@ -89,7 +89,7 @@ abstract class ViewComponent extends Component implements Htmlable
             return $defaultView;
         }
 
-        throw new Exception('Class [' . static::class . '] extends [' . ViewComponent::class . '] but does not have a [$view] property defined.');
+        throw new LogicException('Class [' . static::class . '] extends [' . ViewComponent::class . '] but does not have a [$view] property defined.');
     }
 
     public function hasView(): bool

--- a/packages/support/src/Concerns/HasCellState.php
+++ b/packages/support/src/Concerns/HasCellState.php
@@ -3,7 +3,6 @@
 namespace Filament\Support\Concerns;
 
 use Closure;
-use Exception;
 use Filament\Forms\Components\RichEditor\Models\Contracts\HasRichContent;
 use Filament\Support\ArrayRecord;
 use Filament\Tables\Columns\Column;
@@ -14,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Stringable;
+use LogicException;
 use Znck\Eloquent\Relations\BelongsToThrough;
 
 trait HasCellState
@@ -347,7 +347,7 @@ trait HasCellState
                 if (! $record->isRelation($namePart)) {
                     $recordClass = $record::class;
 
-                    throw new Exception("When trying to guess the inverse relationship for column [{$this->getName()}], relationship [{$inverseNestedRelationshipName}] was not found on model [{$recordClass}]. Please define a custom [inverseRelationship()] for this column.");
+                    throw new LogicException("When trying to guess the inverse relationship for column [{$this->getName()}], relationship [{$inverseNestedRelationshipName}] was not found on model [{$recordClass}]. Please define a custom [inverseRelationship()] for this column.");
                 }
 
                 $inverseNestedRelationshipName = $namePart;

--- a/packages/tables/src/Columns/Column.php
+++ b/packages/tables/src/Columns/Column.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Tables\Columns;
 
-use Exception;
 use Filament\Actions\Action;
 use Filament\Support\Components\ViewComponent;
 use Filament\Support\Concerns\CanAggregateRelatedModels;
@@ -21,6 +20,7 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\HtmlString;
 use Illuminate\View\ComponentAttributeBag;
+use LogicException;
 
 use function Filament\Support\generate_href_html;
 
@@ -73,7 +73,7 @@ class Column extends ViewComponent
         $name ??= static::getDefaultName();
 
         if (blank($name)) {
-            throw new Exception("Column of class [$columnClass] must have a unique name, passed to the [make()] method.");
+            throw new LogicException("Column of class [$columnClass] must have a unique name, passed to the [make()] method.");
         }
 
         $static = app($columnClass, ['name' => $name]);
@@ -89,7 +89,7 @@ class Column extends ViewComponent
 
     public function getTable(): Table
     {
-        return $this->table ?? $this->getGroup()?->getTable() ?? $this->getLayout()?->getTable() ?? throw new Exception("The column [{$this->getName()}] is not mounted to a table.");
+        return $this->table ?? $this->getGroup()?->getTable() ?? $this->getLayout()?->getTable() ?? throw new LogicException("The column [{$this->getName()}] is not mounted to a table.");
     }
 
     /**

--- a/packages/tables/src/Columns/Layout/Component.php
+++ b/packages/tables/src/Columns/Layout/Component.php
@@ -3,7 +3,6 @@
 namespace Filament\Tables\Columns\Layout;
 
 use Closure;
-use Exception;
 use Filament\Support\Components\ViewComponent;
 use Filament\Support\Concerns\CanGrow;
 use Filament\Support\Concerns\CanSpanColumns;
@@ -18,6 +17,7 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\HtmlString;
 use Illuminate\View\ComponentAttributeBag;
+use LogicException;
 
 class Component extends ViewComponent
 {
@@ -118,7 +118,7 @@ class Component extends ViewComponent
 
     public function getTable(): Table
     {
-        return $this->table ?? $this->getLayout()?->getTable() ?? throw new Exception('The column layout component is not mounted to a table.');
+        return $this->table ?? $this->getLayout()?->getTable() ?? throw new LogicException('The column layout component is not mounted to a table.');
     }
 
     public function isCollapsible(): bool

--- a/packages/tables/src/Columns/SelectColumn.php
+++ b/packages/tables/src/Columns/SelectColumn.php
@@ -4,7 +4,6 @@ namespace Filament\Tables\Columns;
 
 use BackedEnum;
 use Closure;
-use Exception;
 use Filament\Forms\Components\Concerns\CanDisableOptions;
 use Filament\Forms\Components\Concerns\CanSelectPlaceholder;
 use Filament\Forms\Components\Concerns\HasEnum;
@@ -31,6 +30,7 @@ use Illuminate\Support\Js;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Livewire\Attributes\Renderless;
+use LogicException;
 use Stringable;
 use Znck\Eloquent\Relations\BelongsToThrough;
 
@@ -785,7 +785,7 @@ class SelectColumn extends Column implements Editable, HasEmbeddedView
         if (! $relationship) {
             $model = $record::class;
 
-            throw new Exception("The relationship [{$relationshipName}] does not exist on the model [{$model}].");
+            throw new LogicException("The relationship [{$relationshipName}] does not exist on the model [{$model}].");
         }
 
         return $relationship;

--- a/packages/tables/src/Columns/Summarizers/Count.php
+++ b/packages/tables/src/Columns/Summarizers/Count.php
@@ -2,13 +2,13 @@
 
 namespace Filament\Tables\Columns\Summarizers;
 
-use Exception;
 use Filament\Support\Enums\IconSize;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\View\Components\Columns\Summarizers\CountComponent\IconComponent;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Str;
 use Illuminate\View\ComponentAttributeBag;
+use LogicException;
 
 use function Filament\Support\generate_icon_html;
 
@@ -37,7 +37,7 @@ class Count extends Summarizer
         $column = $this->getColumn();
 
         if (! ($column instanceof IconColumn)) {
-            throw new Exception("The [{$column->getName()}] column must be an IconColumn to show an icon count summary.");
+            throw new LogicException("The [{$column->getName()}] column must be an IconColumn to show an icon count summary.");
         }
 
         $state = [];

--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Tables\Concerns;
 
-use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\BulkAction;
 use Filament\Schemas\Schema;
@@ -13,6 +12,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
+use LogicException;
 
 trait HasBulkActions
 {
@@ -227,7 +227,7 @@ trait HasBulkActions
             $maxSelectableRecords = $table->getMaxSelectableRecords();
 
             if ($maxSelectableRecords && ($resolvedSelectedRecords->count() > $maxSelectableRecords)) {
-                throw new Exception("The total count of selected records [{$resolvedSelectedRecords->count()}] must not exceed the maximum selectable records limit [{$maxSelectableRecords}].");
+                throw new LogicException("The total count of selected records [{$resolvedSelectedRecords->count()}] must not exceed the maximum selectable records limit [{$maxSelectableRecords}].");
             }
 
             return $this->cachedSelectedTableRecords = $resolvedSelectedRecords;

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Tables\Concerns;
 
-use Exception;
 use Filament\Support\ArrayRecord;
 use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Contracts\Pagination\Paginator;
@@ -12,6 +11,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
+use LogicException;
 
 use function Livewire\invade;
 
@@ -161,7 +161,7 @@ trait HasRecords
         if (! $query) {
             $livewireClass = $this::class;
 
-            throw new Exception("Table [{$livewireClass}] must have a [query()], [relationship()], or [records()].");
+            throw new LogicException("Table [{$livewireClass}] must have a [query()], [relationship()], or [records()].");
         }
 
         if (
@@ -230,7 +230,7 @@ trait HasRecords
     public function getTableRecordKey(Model | array $record): string
     {
         if (is_array($record)) {
-            return $record[ArrayRecord::getKeyName()] ?? throw new Exception('Record arrays must have a unique [key] entry for identification.');
+            return $record[ArrayRecord::getKeyName()] ?? throw new LogicException('Record arrays must have a unique [key] entry for identification.');
         }
 
         $table = $this->getTable();

--- a/packages/tables/src/Filters/BaseFilter.php
+++ b/packages/tables/src/Filters/BaseFilter.php
@@ -2,8 +2,8 @@
 
 namespace Filament\Tables\Filters;
 
-use Exception;
 use Filament\Support\Components\Component;
+use LogicException;
 
 class BaseFilter extends Component
 {
@@ -33,7 +33,7 @@ class BaseFilter extends Component
         $name ??= static::getDefaultName();
 
         if (blank($name)) {
-            throw new Exception("Filter of class [$filterClass] must have a unique name, passed to the [make()] method.");
+            throw new LogicException("Filter of class [$filterClass] must have a unique name, passed to the [make()] method.");
         }
 
         $static = app($filterClass, ['name' => $name]);

--- a/packages/tables/src/Filters/Concerns/HasRelationship.php
+++ b/packages/tables/src/Filters/Concerns/HasRelationship.php
@@ -3,13 +3,13 @@
 namespace Filament\Tables\Filters\Concerns;
 
 use Closure;
-use Exception;
 use Filament\Support\Services\RelationshipJoiner;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasOneOrManyThrough;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use LogicException;
 use Znck\Eloquent\Relations\BelongsToThrough;
 
 trait HasRelationship
@@ -75,7 +75,7 @@ trait HasRelationship
         }
 
         if (! $relationship) {
-            throw new Exception("The relationship [{$relationshipName}] does not exist on the model [{$model}].");
+            throw new LogicException("The relationship [{$relationshipName}] does not exist on the model [{$model}].");
         }
 
         return $relationship;

--- a/packages/tables/src/Filters/QueryBuilder.php
+++ b/packages/tables/src/Filters/QueryBuilder.php
@@ -3,7 +3,6 @@
 namespace Filament\Tables\Filters;
 
 use Closure;
-use Exception;
 use Filament\Forms\Components\Repeater;
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Schema;
@@ -12,6 +11,7 @@ use Filament\Tables\Filters\QueryBuilder\Forms\Components\RuleBuilder;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\ValidationException;
+use LogicException;
 
 class QueryBuilder extends BaseFilter
 {
@@ -226,7 +226,7 @@ class QueryBuilder extends BaseFilter
         $builder = $this->getSchema()->getComponent(fn (Component $component): bool => $component instanceof RuleBuilder);
 
         if (! ($builder instanceof RuleBuilder)) {
-            throw new Exception('No rule builder component found.');
+            throw new LogicException('No rule builder component found.');
         }
 
         return $builder;
@@ -240,7 +240,7 @@ class QueryBuilder extends BaseFilter
             ->getComponent(fn (Component $component): bool => $component instanceof RuleBuilder);
 
         if (! ($builder instanceof RuleBuilder)) {
-            throw new Exception('No nested rule builder component found.');
+            throw new LogicException('No nested rule builder component found.');
         }
 
         return $builder;

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/Constraint.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/Constraint.php
@@ -3,7 +3,6 @@
 namespace Filament\Tables\Filters\QueryBuilder\Constraints;
 
 use Closure;
-use Exception;
 use Filament\Forms\Components\Builder\Block;
 use Filament\Forms\Components\Select;
 use Filament\Schemas\Components\Group;
@@ -12,6 +11,7 @@ use Filament\Support\Components\Component;
 use Filament\Support\Concerns\HasIcon;
 use Filament\Tables\Filters\QueryBuilder;
 use Illuminate\Validation\ValidationException;
+use LogicException;
 
 class Constraint extends Component
 {
@@ -53,7 +53,7 @@ class Constraint extends Component
         $name ??= static::getDefaultName();
 
         if (blank($name)) {
-            throw new Exception("Constraint of class [$constraintClass] must have a unique name, passed to the [make()] method.");
+            throw new LogicException("Constraint of class [$constraintClass] must have a unique name, passed to the [make()] method.");
         }
 
         $static = app($constraintClass, ['name' => $name]);

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/NumberConstraint/Operators/Concerns/CanAggregateRelationships.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/NumberConstraint/Operators/Concerns/CanAggregateRelationships.php
@@ -2,12 +2,12 @@
 
 namespace Filament\Tables\Filters\QueryBuilder\Constraints\NumberConstraint\Operators\Concerns;
 
-use Exception;
 use Filament\Forms\Components\Select;
 use Filament\Tables\Filters\QueryBuilder\Constraints\NumberConstraint;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Str;
+use LogicException;
 
 trait CanAggregateRelationships
 {
@@ -124,7 +124,7 @@ trait CanAggregateRelationships
         $constraint = parent::getConstraint();
 
         if (! ($constraint instanceof NumberConstraint)) {
-            throw new Exception('Constraint must be an instance of [' . NumberConstraint::class . '].');
+            throw new LogicException('Constraint must be an instance of [' . NumberConstraint::class . '].');
         }
 
         return $constraint;

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/RelationshipConstraint/Operators/IsRelatedToOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/RelationshipConstraint/Operators/IsRelatedToOperator.php
@@ -3,7 +3,6 @@
 namespace Filament\Tables\Filters\QueryBuilder\Constraints\RelationshipConstraint\Operators;
 
 use Closure;
-use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Forms\Components\Select;
@@ -14,6 +13,7 @@ use Filament\Tables\Filters\QueryBuilder\Constraints\RelationshipConstraint;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
+use LogicException;
 use Znck\Eloquent\Relations\BelongsToThrough;
 
 class IsRelatedToOperator extends Operator
@@ -199,7 +199,7 @@ class IsRelatedToOperator extends Operator
         }
 
         if (! ($constraint instanceof RelationshipConstraint)) {
-            throw new Exception('Is operator can only be used with relationship constraints.');
+            throw new LogicException('Is operator can only be used with relationship constraints.');
         }
 
         return $constraint;

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/SelectConstraint/Operators/IsOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/SelectConstraint/Operators/IsOperator.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Tables\Filters\QueryBuilder\Constraints\SelectConstraint\Operators;
 
-use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Forms\Components\Select;
@@ -11,6 +10,7 @@ use Filament\Tables\Filters\QueryBuilder\Constraints\Operators\Operator;
 use Filament\Tables\Filters\QueryBuilder\Constraints\SelectConstraint;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
+use LogicException;
 
 class IsOperator extends Operator
 {
@@ -113,7 +113,7 @@ class IsOperator extends Operator
         $constraint = parent::getConstraint();
 
         if (! ($constraint instanceof SelectConstraint)) {
-            throw new Exception('Is operator can only be used with select constraints.');
+            throw new LogicException('Is operator can only be used with select constraints.');
         }
 
         return $constraint;

--- a/packages/tables/src/Filters/QueryBuilder/Forms/Components/RuleBuilder.php
+++ b/packages/tables/src/Filters/QueryBuilder/Forms/Components/RuleBuilder.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Tables\Filters\QueryBuilder\Forms\Components;
 
-use Exception;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Builder;
 use Filament\Forms\Components\Repeater;
@@ -12,6 +11,7 @@ use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Filters\QueryBuilder\Concerns\HasConstraints;
 use Filament\Tables\Filters\QueryBuilder\Constraints\Constraint;
 use Illuminate\Support\Str;
+use LogicException;
 
 class RuleBuilder extends Builder
 {
@@ -46,7 +46,7 @@ class RuleBuilder extends Builder
                                 ->getComponent(fn (Component $component): bool => $component instanceof Repeater);
 
                             if (! ($repeater instanceof Repeater)) {
-                                throw new Exception('No repeater component found.');
+                                throw new LogicException('No repeater component found.');
                             }
 
                             $itemLabels = collect($repeater->getItems())
@@ -79,7 +79,7 @@ class RuleBuilder extends Builder
                                     $builder = $schema->getComponent(fn (Component $component): bool => $component instanceof RuleBuilder);
 
                                     if (! ($builder instanceof RuleBuilder)) {
-                                        throw new Exception('No rule builder component found.');
+                                        throw new LogicException('No rule builder component found.');
                                     }
 
                                     $blockLabels = collect($builder->getItems())
@@ -87,7 +87,7 @@ class RuleBuilder extends Builder
                                             $block = $schema->getParentComponent();
 
                                             if (! ($block instanceof Builder\Block)) {
-                                                throw new Exception('No block component found.');
+                                                throw new LogicException('No block component found.');
                                             }
 
                                             return $block->getLabel($schema->getRawState(), $blockUuid);


### PR DESCRIPTION
`\Exception` is too generic. In most cases, you're throwing it because of invalid configuration and invalid parameters. There is a special class for these cases: `LogicException`. phpDoc comment for this class:

`Exception that represents error in the program logic. This kind of exception should lead directly to a fix in your code.`

There is also a checked/unchecked exceptions problem. It exists only in Java, but PHP also has `@throws` phpDoc, and we have to use it for Exception, but not for LogicException, since it's unchecked.