### PR TITLE
Skip rendering Livewire component on certain test methods

### DIFF
--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -66,7 +66,9 @@
                 </div>
             @endif
 
-            <div {{ $getExtraInputAttributeBag()->class(['fi-fo-rich-editor-main']) }}>
+            <div
+                {{ $getExtraInputAttributeBag()->class(['fi-fo-rich-editor-main']) }}
+            >
                 <div class="fi-fo-rich-editor-content fi-prose" x-ref="editor">
                     @foreach ($floatingToolbars as $nodeName => $buttons)
                         <div

--- a/packages/schemas/src/Concerns/InteractsWithSchemas.php
+++ b/packages/schemas/src/Concerns/InteractsWithSchemas.php
@@ -143,6 +143,8 @@ trait InteractsWithSchemas
         }
 
         $this->areSchemaStateUpdateHooksDisabledForTesting = true;
+
+        $this->skipRender();
     }
 
     public function enableSchemaStateUpdateHooksForTesting(): void
@@ -152,6 +154,8 @@ trait InteractsWithSchemas
         }
 
         $this->areSchemaStateUpdateHooksDisabledForTesting = false;
+
+        $this->skipRender();
     }
 
     public function getSchemaComponent(string $key, bool $withHidden = false, ?Component $skipComponentChildContainersWhileSearching = null): Component | Action | ActionGroup | null
@@ -430,6 +434,8 @@ trait InteractsWithSchemas
 
             $this->unsetMissingNumericArrayKeys($this->{$statePath}, $value, $statePath, $schemaStatePath);
         }
+
+        $this->skipRender();
     }
 
     /**


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR skips Livewire rendering on certain methods used while testing Filament forms. This improves the testing performance for Filament resources by around 15%.

The reason is that `TestForms::fillForm()` currently triggers three unnecessary renderings of the Livewire component.

## Visual changes

There are no visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] ~~Documentation is up-to-date.~~ (no change required)
