### PR TITLE
Fix required validation on RichEditor

### DIFF
--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -66,7 +66,9 @@
                 </div>
             @endif
 
-            <div {{ $getExtraInputAttributeBag()->class(['fi-fo-rich-editor-main']) }}>
+            <div
+                {{ $getExtraInputAttributeBag()->class(['fi-fo-rich-editor-main']) }}
+            >
                 <div class="fi-fo-rich-editor-content fi-prose" x-ref="editor">
                     @foreach ($floatingToolbars as $nodeName => $buttons)
                         <div

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -762,7 +762,7 @@ trait CanBeValidated
         return $this->evaluate($this->regexPattern);
     }
 
-    public function getRequiredValidationRule(): string
+    public function getRequiredValidationRule(): string | Closure
     {
         return $this->isRequired() ? 'required' : 'nullable';
     }

--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -882,4 +882,25 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
 
         return $rules;
     }
+
+    public function getRequiredValidationRule(): string | Closure
+    {
+        if (! $this->isRequired()) {
+            return 'nullable';
+        }
+
+        return function (string $_attribute, mixed $value, Closure $fail): void {
+            if (blank($value)) {
+                return;
+            }
+
+            $value = trim($this->getTipTapEditor()
+                ->setContent($value)
+                ->getHTML());
+
+            if ($value === '' || $value === '<p></p>') {
+                $fail('validation.required')->translate();
+            }
+        };
+    }
 }

--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -894,11 +894,12 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
                 return;
             }
 
-            $value = trim($this->getTipTapEditor()
-                ->setContent($value)
-                ->getHTML());
+            $isEmpty = $value['type'] === 'doc' &&
+                count($value['content']) === 1 &&
+                $value['content'][0]['type'] === 'paragraph' &&
+                (! isset($value['content'][0]['content']) || blank($value['content'][0]['content']));
 
-            if ($value === '' || $value === '<p></p>') {
+            if ($isEmpty) {
                 $fail('validation.required')->translate();
             }
         };

--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -894,10 +894,11 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
                 return;
             }
 
-            $isEmpty = ($value['type'] === 'doc')
-                && (count($value['content']) === 1)
-                && ($value['content'][0]['type'] === 'paragraph')
-                && ((! isset($value['content'][0]['content'])) || blank($value['content'][0]['content']));
+            $isEmpty = is_array($value)
+                && (($value['type'] ?? null) === 'doc')
+                && (count($value['content'] ?? []) === 1)
+                && (($value['content'][0]['type'] ?? null) === 'paragraph')
+                && blank($value['content'][0]['content'] ?? []);
 
             if ($isEmpty) {
                 $fail('validation.required')->translate();

--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -827,7 +827,7 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
         $rules = [];
 
         if (filled($maxLength = $this->getMaxLength())) {
-            $rules[] = function (string $_attribute, mixed $value, Closure $fail) use ($maxLength): void {
+            $rules[] = function (string $attribute, mixed $value, Closure $fail) use ($maxLength): void {
                 if (blank($value)) {
                     return;
                 }
@@ -845,7 +845,7 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
         }
 
         if (filled($minLength = $this->getMinLength())) {
-            $rules[] = function (string $_attribute, mixed $value, Closure $fail) use ($minLength): void {
+            $rules[] = function (string $attribute, mixed $value, Closure $fail) use ($minLength): void {
                 if (blank($value)) {
                     return;
                 }
@@ -863,7 +863,7 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
         }
 
         if (filled($length = $this->getLength())) {
-            $rules[] = function (string $_attribute, mixed $value, Closure $fail) use ($length): void {
+            $rules[] = function (string $attribute, mixed $value, Closure $fail) use ($length): void {
                 if (blank($value)) {
                     return;
                 }
@@ -889,15 +889,15 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
             return 'nullable';
         }
 
-        return function (string $_attribute, mixed $value, Closure $fail): void {
+        return function (string $attribute, mixed $value, Closure $fail): void {
             if (blank($value)) {
                 return;
             }
 
-            $isEmpty = $value['type'] === 'doc' &&
-                count($value['content']) === 1 &&
-                $value['content'][0]['type'] === 'paragraph' &&
-                (! isset($value['content'][0]['content']) || blank($value['content'][0]['content']));
+            $isEmpty = ($value['type'] === 'doc')
+                && (count($value['content']) === 1)
+                && ($value['content'][0]['type'] === 'paragraph')
+                && ((! isset($value['content'][0]['content'])) || blank($value['content'][0]['content']));
 
             if ($isEmpty) {
                 $fail('validation.required')->translate();

--- a/tests/src/Forms/Components/RichEditorTest.php
+++ b/tests/src/Forms/Components/RichEditorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Filament\Forms\Components\RichEditor;
+use Filament\Schemas\Schema;
+use Filament\Tests\Fixtures\Livewire\Livewire;
+use Filament\Tests\TestCase;
+use Illuminate\Validation\ValidationException;
+
+uses(TestCase::class);
+
+test('fields can be required', function (): void {
+    $errors = [];
+
+    try {
+        Schema::make(Livewire::make())
+            ->statePath('data')
+            ->components([
+                $field = (new RichEditor('content'))
+                    ->required(),
+            ])
+            ->fill([
+                'content' => '',
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $errors = $exception->validator->errors()->get($field->getStatePath());
+    }
+
+    expect($errors)
+        ->toContain('The content field is required.');
+});


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR introduces an implementation of the `required()` rule for the `RichEditor` as the default implementation does not work, because an empty editor is technically not empty. It always contains at least an empty paragraph.

This fixes https://github.com/filamentphp/filament/issues/17342

As discussed in the issue, we need to check if the rendered HTML is an empty paragraph.

## Visual changes

With this change, the missing validation message appears and form submission is prevented.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] ~~Documentation is up-to-date.~~ (No change required)
