### PR TITLE
fix: More predictable key inheritance

### DIFF
--- a/packages/schemas/src/Components/Concerns/Cloneable.php
+++ b/packages/schemas/src/Components/Concerns/Cloneable.php
@@ -23,7 +23,7 @@ trait Cloneable
         $clone = clone $this;
         $clone->flushCachedAbsoluteKey();
         $clone->flushCachedAbsoluteStatePath();
-        $clone->flushCachedInheritanceKey();
+        $clone->flushCachedAbsoluteInheritanceKey();
         $clone->cloneChildComponents();
 
         foreach ($this->afterCloned as $callback) {

--- a/packages/schemas/src/Components/Concerns/HasKey.php
+++ b/packages/schemas/src/Components/Concerns/HasKey.php
@@ -14,9 +14,9 @@ trait HasKey
 
     protected bool $hasCachedAbsoluteKey = false;
 
-    protected ?string $cachedInheritanceKey = null;
+    protected ?string $cachedAbsoluteInheritanceKey = null;
 
-    protected bool $hasCachedInheritanceKey = false;
+    protected bool $hasCachedAbsoluteInheritanceKey = false;
 
     public function key(string | Closure | null $key, bool $isInheritable = true): static
     {
@@ -53,21 +53,25 @@ trait HasKey
         return $this->cacheAbsoluteKey(implode('.', $keyComponents));
     }
 
-    public function getInheritanceKey(): ?string
+    public function getInheritanceKey(bool $isAbsolute = true): ?string
     {
-        if ($this->hasCachedInheritanceKey) {
-            return $this->cachedInheritanceKey;
+        if ($isAbsolute && $this->hasCachedAbsoluteInheritanceKey) {
+            return $this->cachedAbsoluteInheritanceKey;
+        }
+
+        if (! $isAbsolute) {
+            return $this->isKeyInheritable ? $this->getKey(isAbsolute: false) : null;
         }
 
         if ($this->isKeyInheritable) {
             $key = $this->getKey();
 
             if (filled($key)) {
-                return $this->cacheInheritanceKey($key);
+                return $this->cacheAbsoluteInheritanceKey($key);
             }
         }
 
-        return $this->cacheInheritanceKey($this->getContainer()->getInheritanceKey());
+        return $this->cacheAbsoluteInheritanceKey($this->getContainer()->getInheritanceKey());
     }
 
     protected function cacheAbsoluteKey(?string $key): ?string
@@ -79,12 +83,12 @@ trait HasKey
         }
     }
 
-    protected function cacheInheritanceKey(?string $key): ?string
+    protected function cacheAbsoluteInheritanceKey(?string $key): ?string
     {
         try {
-            return $this->cachedInheritanceKey = $key;
+            return $this->cachedAbsoluteInheritanceKey = $key;
         } finally {
-            $this->hasCachedInheritanceKey = true;
+            $this->hasCachedAbsoluteInheritanceKey = true;
         }
     }
 
@@ -94,10 +98,10 @@ trait HasKey
         $this->hasCachedAbsoluteKey = false;
     }
 
-    protected function flushCachedInheritanceKey(): void
+    protected function flushCachedAbsoluteInheritanceKey(): void
     {
-        $this->cachedInheritanceKey = null;
-        $this->hasCachedInheritanceKey = false;
+        $this->cachedAbsoluteInheritanceKey = null;
+        $this->hasCachedAbsoluteInheritanceKey = false;
     }
 
     public function getLivewireKey(): ?string

--- a/packages/schemas/src/Components/Concerns/HasKey.php
+++ b/packages/schemas/src/Components/Concerns/HasKey.php
@@ -8,6 +8,8 @@ trait HasKey
 {
     protected string | Closure | null $key = null;
 
+    protected bool $isKeyInheritable = true;
+
     protected ?string $cachedAbsoluteKey = null;
 
     protected bool $hasCachedAbsoluteKey = false;
@@ -16,9 +18,10 @@ trait HasKey
 
     protected bool $hasCachedInheritanceKey = false;
 
-    public function key(string | Closure | null $key): static
+    public function key(string | Closure | null $key, bool $isInheritable = true): static
     {
         $this->key = $key;
+        $this->isKeyInheritable = $isInheritable;
 
         return $this;
     }
@@ -56,10 +59,12 @@ trait HasKey
             return $this->cachedInheritanceKey;
         }
 
-        $key = $this->getKey();
+        if ($this->isKeyInheritable) {
+            $key = $this->getKey();
 
-        if (filled($key)) {
-            return $this->cacheInheritanceKey($key);
+            if (filled($key)) {
+                return $this->cacheInheritanceKey($key);
+            }
         }
 
         return $this->cacheInheritanceKey($this->getContainer()->getInheritanceKey());

--- a/packages/schemas/src/Components/Section.php
+++ b/packages/schemas/src/Components/Section.php
@@ -102,7 +102,7 @@ class Section extends Component implements CanConcealComponents, CanEntangleWith
             $statePath = $component->getStatePath();
 
             return Str::slug(Str::transliterate($heading, strict: true)) . '::' . (filled($statePath) ? "{$statePath}::section" : 'section');
-        });
+        }, isInheritable: false);
 
         $this->afterHeader(fn (Section $component): array => $component->getHeaderActions());
         $this->footer(function (Section $component): Schema {

--- a/packages/schemas/src/Components/Tabs.php
+++ b/packages/schemas/src/Components/Tabs.php
@@ -68,7 +68,7 @@ class Tabs extends Component
             $statePath = $component->getStatePath();
 
             return Str::slug(Str::transliterate($label, strict: true)) . '::' . (filled($statePath) ? "{$statePath}::tabs" : 'tabs');
-        });
+        }, isInheritable: false);
     }
 
     /**

--- a/packages/schemas/src/Components/Tabs/Tab.php
+++ b/packages/schemas/src/Components/Tabs/Tab.php
@@ -58,7 +58,7 @@ class Tab extends Component implements CanConcealComponents
             $statePath = $component->getStatePath();
 
             return Str::slug(Str::transliterate($label, strict: true)) . '::' . (filled($statePath) ? "{$statePath}::tab" : 'tab');
-        });
+        }, isInheritable: false);
     }
 
     /**

--- a/packages/schemas/src/Components/Wizard.php
+++ b/packages/schemas/src/Components/Wizard.php
@@ -78,7 +78,7 @@ class Wizard extends Component
             }
 
             return Str::slug(Str::transliterate($label, strict: true)) . '::' . (filled($statePath) ? "{$statePath}::wizard" : 'wizard');
-        });
+        }, isInheritable: false);
 
         $this->registerActions([
             fn (Wizard $component): Action => $component->getNextAction(),

--- a/packages/schemas/src/Components/Wizard/Step.php
+++ b/packages/schemas/src/Components/Wizard/Step.php
@@ -52,7 +52,7 @@ class Step extends Component implements CanConcealComponents
             $statePath = $component->getStatePath();
 
             return Str::slug(Str::transliterate($label, strict: true)) . '::' . (filled($statePath) ? "{$statePath}::wizard-step" : 'wizard-step');
-        });
+        }, isInheritable: false);
     }
 
     public function afterValidation(?Closure $callback): static

--- a/packages/schemas/src/Concerns/HasComponents.php
+++ b/packages/schemas/src/Concerns/HasComponents.php
@@ -77,13 +77,13 @@ trait HasComponents
             $componentKey = $component->getKey(isAbsolute: false);
 
             if (filled($componentKey)) {
-                if (blank($nestedContainerKey)) {
-                    continue;
-                }
+                $componentInheritanceKey = $component->getInheritanceKey(isAbsolute: false);
 
                 if (
+                    filled($nestedContainerKey) &&
                     ($nestedContainerKey !== $componentKey) &&
-                    (! str($nestedContainerKey)->startsWith("{$componentKey}."))
+                    filled($componentInheritanceKey) &&
+                    (! str($nestedContainerKey)->startsWith("{$componentInheritanceKey}."))
                 ) {
                     continue;
                 }
@@ -94,36 +94,17 @@ trait HasComponents
                     }
 
                     $componentNestedContainerKey = null;
+                } elseif (filled($nestedContainerKey) && filled($componentInheritanceKey)) {
+                    $componentNestedContainerKey = (string) str($nestedContainerKey)->after("{$componentInheritanceKey}.");
                 } else {
-                    $componentNestedContainerKey = (string) str($nestedContainerKey)->after("{$componentKey}.");
+                    $componentNestedContainerKey = $nestedContainerKey;
                 }
             } else {
                 $componentNestedContainerKey = $nestedContainerKey;
             }
 
             foreach ($component->getChildSchemas() as $childSchema) {
-                $childSchemaName = $childSchema->getKey(isAbsolute: false);
-
-                if (filled($childSchemaName)) {
-                    if (blank($componentNestedContainerKey)) {
-                        continue;
-                    }
-
-                    if (
-                        ($componentNestedContainerKey !== $childSchemaName)
-                        && (! str($componentNestedContainerKey)->startsWith("{$childSchemaName}."))
-                    ) {
-                        continue;
-                    }
-
-                    $childSchemaNestedContainerKey = ($componentNestedContainerKey === $childSchemaName)
-                        ? null
-                        : (string) str($componentNestedContainerKey)->after("{$childSchemaName}.");
-                } else {
-                    $childSchemaNestedContainerKey = $componentNestedContainerKey;
-                }
-
-                if ($action = $childSchema->getAction($actionName, $childSchemaNestedContainerKey)) {
+                if ($action = $childSchema->getAction($actionName, $componentNestedContainerKey)) {
                     return $action;
                 }
             }
@@ -173,7 +154,9 @@ trait HasComponents
                     continue;
                 }
 
-                if (blank($componentKey) || str_starts_with($findComponentUsing, "{$componentKey}.")) {
+                $componentInheritanceKey = $component->getInheritanceKey();
+
+                if (blank($componentInheritanceKey) || str_starts_with($findComponentUsing, "{$componentInheritanceKey}.")) {
                     foreach ($component->getChildSchemas($withHidden) as $childSchema) {
                         if ($foundComponent = $childSchema->getComponent($findComponentUsing, $withActions, $withHidden, $isAbsoluteKey, $skipComponentChildContainersWhileSearching)) {
                             return $foundComponent;


### PR DESCRIPTION
v4 made it more difficult to understand the key structure of components and actions inside schemas, by providing default keys for components like Section.

These keys are now not inherited by child components and actions.

This could break existing test suites that were changed during the v4 upgrade to work with the v4 key structure, but it will bring it more in line with v3 which should make future upgrades easier, and make the tests more readable.

I see this as more of a fix for an unintended v4 breaking change, rather than a breaking change itself. I did not intend for people to need to prefix their field/action assertions with the schema heading for example.