### PR TITLE
fix: user and tenant menu on guest panel

### DIFF
--- a/packages/panels/src/Livewire/Concerns/HasTenantMenu.php
+++ b/packages/panels/src/Livewire/Concerns/HasTenantMenu.php
@@ -14,6 +14,10 @@ trait HasTenantMenu
 
     public function bootHasTenantMenu(): void
     {
+        if (Filament::auth()->guest()) {
+            return;
+        }
+
         if (! Filament::hasTenancy()) {
             return;
         }

--- a/packages/panels/src/Livewire/Concerns/HasUserMenu.php
+++ b/packages/panels/src/Livewire/Concerns/HasUserMenu.php
@@ -14,6 +14,10 @@ trait HasUserMenu
 
     public function bootHasUserMenu(): void
     {
+        if (Filament::auth()->guest()) {
+            return;
+        }
+
         if (! Filament::hasUserMenu()) {
             return;
         }


### PR DESCRIPTION
## Description
When your [setting up guest access to a panel](https://filamentphp.com/docs/4.x/users/overview#setting-up-guest-access-to-a-panel), there is an exception : 

> Filament\FilamentManager::getUserName(): Argument #1 ($user) must be of type Illuminate\Database\Eloquent\Model|Illuminate\Contracts\Auth\Authenticatable, null given

## Visual changes
Exception trace : 
<img width="1456" height="486" alt="image" src="https://github.com/user-attachments/assets/b070c839-2a25-41cf-ae71-b6a0d24e9a1d" />

With authentication check : 
<img width="1030" height="469" alt="image" src="https://github.com/user-attachments/assets/d9627e52-5030-41a5-80b8-9b3e6dcbf0d7" />

## Functional changes
- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

---

This PR fix issue https://github.com/filamentphp/filament/issues/17543 
