### PR TITLE
Fix placeholder alignment

### DIFF
--- a/packages/tables/src/Columns/ColorColumn.php
+++ b/packages/tables/src/Columns/ColorColumn.php
@@ -23,10 +23,13 @@ class ColorColumn extends Column implements HasEmbeddedView
             $state = $state->all();
         }
 
+        $alignment = $this->getAlignment();
+
         $attributes = $this->getExtraAttributeBag()
             ->class([
                 'fi-ta-color',
                 'fi-inline' => $this->isInline(),
+                ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : ''),
             ]);
 
         if (blank($state)) {
@@ -57,12 +60,9 @@ class ColorColumn extends Column implements HasEmbeddedView
 
         $state = Arr::wrap($state);
 
-        $alignment = $this->getAlignment();
-
         $attributes = $attributes
             ->class([
                 'fi-wrapped' => $this->canWrap(),
-                ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : ''),
             ]);
 
         ob_start(); ?>

--- a/packages/tables/src/Columns/IconColumn.php
+++ b/packages/tables/src/Columns/IconColumn.php
@@ -265,10 +265,13 @@ class IconColumn extends Column implements HasEmbeddedView
             $state = $state->all();
         }
 
+        $alignment = $this->getAlignment();
+
         $attributes = $this->getExtraAttributeBag()
             ->class([
                 'fi-ta-icon',
                 'fi-inline' => $this->isInline(),
+                ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : ''),
             ]);
 
         if (blank($state)) {
@@ -299,13 +302,10 @@ class IconColumn extends Column implements HasEmbeddedView
 
         $state = Arr::wrap($state);
 
-        $alignment = $this->getAlignment();
-
         $attributes = $attributes
             ->class([
                 'fi-ta-icon-has-line-breaks' => $this->isListWithLineBreaks(),
                 'fi-wrapped' => $this->canWrap(),
-                ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : ''),
             ]);
 
         ob_start(); ?>

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -412,10 +412,13 @@ class ImageColumn extends Column implements HasEmbeddedView
             $state = $state->all();
         }
 
+        $alignment = $this->getAlignment();
+
         $attributes = $this->getExtraAttributeBag()
             ->class([
                 'fi-ta-image',
                 'fi-inline' => $this->isInline(),
+                ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : ''),
             ]);
 
         $defaultImageUrl = $this->getDefaultImageUrl();
@@ -463,7 +466,6 @@ class ImageColumn extends Column implements HasEmbeddedView
             $state = array_slice($state, 0, $limit);
         }
 
-        $alignment = $this->getAlignment();
         $isCircular = $this->isCircular();
         $isSquare = $this->isSquare();
         $isStacked = $this->isStacked();
@@ -479,7 +481,6 @@ class ImageColumn extends Column implements HasEmbeddedView
                 'fi-stacked' => $isStacked,
                 ($isStacked && is_int($ring = $this->getRing())) ? "fi-ta-image-ring fi-ta-image-ring-{$ring}" : '',
                 ($isStacked && ($overlap = ($this->getOverlap() ?? 2))) ? "fi-ta-image-overlap-{$overlap}" : '',
-                ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : ''),
             ]);
 
         $shouldOpenUrlInNewTab = $this->shouldOpenUrlInNewTab();

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -175,6 +175,15 @@ class TextColumn extends Column implements HasEmbeddedView
                 'fi-inline' => $this->isInline(),
             ]);
 
+        $alignment = $this->getAlignment();
+
+        $attributes = $attributes
+            ->class([
+                'fi-ta-text-has-badges' => $isBadge,
+                'fi-wrapped' => $this->canWrap(),
+                ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : ''),
+            ]);
+
         if (blank($state)) {
             $attributes = $attributes
                 ->merge([
@@ -252,15 +261,6 @@ class TextColumn extends Column implements HasEmbeddedView
             $stateCount = 1;
             $formatState = fn (mixed $stateItem): string => $stateItem;
         }
-
-        $alignment = $this->getAlignment();
-
-        $attributes = $attributes
-            ->class([
-                'fi-ta-text-has-badges' => $isBadge,
-                'fi-wrapped' => $this->canWrap(),
-                ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : ''),
-            ]);
 
         $lineClamp = $this->getLineClamp();
         $iconPosition = $this->getIconPosition();

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -179,8 +179,6 @@ class TextColumn extends Column implements HasEmbeddedView
 
         $attributes = $attributes
             ->class([
-                'fi-ta-text-has-badges' => $isBadge,
-                'fi-wrapped' => $this->canWrap(),
                 ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : ''),
             ]);
 
@@ -261,6 +259,12 @@ class TextColumn extends Column implements HasEmbeddedView
             $stateCount = 1;
             $formatState = fn (mixed $stateItem): string => $stateItem;
         }
+
+        $attributes = $attributes
+            ->class([
+                'fi-ta-text-has-badges' => $isBadge,
+                'fi-wrapped' => $this->canWrap(),
+            ]);
 
         $lineClamp = $this->getLineClamp();
         $iconPosition = $this->getIconPosition();


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR fixes an issue in TextColumn where placeholders weren't correctly aligned.
(Reported by luizcristino on discord)

To reproduce the bug just do the following:

```php
TextColumn::make('myFakeColumn')
    ->alignEnd()
    ->placeholder('Placeholder'),
```

The css classes like `fi-align-*` weren't in the output because the `blank($state)` condition is evaluated too early, before the alignment adds classes to attributes.

The fix is simply to move the alignment classes logic above this condition.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->
### BEFORE
<img width="711" height="661" alt="before 2025-09-01 at 21 43 45" src="https://github.com/user-attachments/assets/ed7f26cf-1518-4bcd-b145-35e4173553a5" />

### AFTER
<img width="711" height="661" alt="after 2025-09-01 at 21 43 30" src="https://github.com/user-attachments/assets/965e2e19-ce52-4069-af7f-65f67eeb8d8f" />


## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
