### PR TITLE
feat(translations): add support for heading and description translations

### DIFF
--- a/packages/schemas/src/Components/Concerns/HasDescription.php
+++ b/packages/schemas/src/Components/Concerns/HasDescription.php
@@ -9,6 +9,8 @@ trait HasDescription
 {
     protected string | Htmlable | Closure | null $description = null;
 
+    protected bool $shouldTranslateDescription = false;
+
     public function description(string | Htmlable | Closure | null $description = null): static
     {
         $this->description = $description;
@@ -16,8 +18,19 @@ trait HasDescription
         return $this;
     }
 
+    public function translateDescription(bool $shouldTranslateDescription = true): static
+    {
+        $this->shouldTranslateDescription = $shouldTranslateDescription;
+
+        return $this;
+    }
+
     public function getDescription(): string | Htmlable | null
     {
-        return $this->evaluate($this->description);
+        $description = $this->evaluate($this->description);
+
+        return (is_string($description) && $this->shouldTranslateDescription) ?
+            __($description) :
+            $description;
     }
 }

--- a/packages/schemas/src/Components/Concerns/HasHeading.php
+++ b/packages/schemas/src/Components/Concerns/HasHeading.php
@@ -9,6 +9,8 @@ trait HasHeading
 {
     protected string | Htmlable | Closure | null $heading = null;
 
+    protected bool $shouldTranslateHeading = false;
+
     public function heading(string | Htmlable | Closure | null $heading = null): static
     {
         $this->heading = $heading;
@@ -16,8 +18,19 @@ trait HasHeading
         return $this;
     }
 
+    public function translateHeading(bool $shouldTranslateHeading = true): static
+    {
+        $this->shouldTranslateHeading = $shouldTranslateHeading;
+
+        return $this;
+    }
+
     public function getHeading(): string | Htmlable | null
     {
-        return $this->evaluate($this->heading);
+        $heading = $this->evaluate($this->heading);
+
+        return (is_string($heading) && $this->shouldTranslateHeading) ?
+            __($heading) :
+            $heading;
     }
 }


### PR DESCRIPTION
Introduce `translateHeading` and `translateDescription` methods to handle conditional translation for headings and descriptions. Enhancements provide greater flexibility in localization by automatically translating string values when enabled.