### PR TITLE
Fix(Form/Repeater): update event handling for sortable items to prevent unnecessary reordering

### DIFF
--- a/packages/forms/resources/views/components/repeater/index.blade.php
+++ b/packages/forms/resources/views/components/repeater/index.blade.php
@@ -81,7 +81,7 @@
                         ->grid($getGridColumns())
                         ->merge([
                             'data-sortable-animation-duration' => $getReorderAnimationDuration(),
-                            'wire:end.stop' => 'mountAction(\'reorder\', { items: $event.target.sortable.toArray() }, { schemaComponent: \'' . $key . '\' })',
+                            'x-on:end.stop' => '$event.oldIndex !== $event.newIndex && $wire.mountAction(\'reorder\', { items: $event.target.sortable.toArray() }, { schemaComponent: \'' . $key . '\' })',
                         ], escape: false)
                         ->class(['fi-fo-repeater-items'])
                 }}

--- a/packages/forms/resources/views/components/repeater/simple.blade.php
+++ b/packages/forms/resources/views/components/repeater/simple.blade.php
@@ -42,7 +42,7 @@
                         ->grid($getGridColumns())
                         ->merge([
                             'data-sortable-animation-duration' => $getReorderAnimationDuration(),
-                            'wire:end.stop' => 'mountAction(\'reorder\', { items: $event.target.sortable.toArray() }, { schemaComponent: \'' . $key . '\' })',
+                            'x-on:end.stop' => '$event.oldIndex !== $event.newIndex && $wire.mountAction(\'reorder\', { items: $event.target.sortable.toArray() }, { schemaComponent: \'' . $key . '\' })',
                         ], escape: false)
                         ->class(['fi-fo-simple-repeater-items'])
                 }}

--- a/packages/forms/resources/views/components/repeater/table.blade.php
+++ b/packages/forms/resources/views/components/repeater/table.blade.php
@@ -82,7 +82,7 @@
                         {{ (new ComponentAttributeBag)
                                 ->merge([
                                     'data-sortable-animation-duration' => $getReorderAnimationDuration(),
-                                    'wire:end.stop' => 'mountAction(\'reorder\', { items: $event.target.sortable.toArray() }, { schemaComponent: \'' . $key . '\' })',
+                                    'x-on:end.stop' => '$event.oldIndex !== $event.newIndex && $wire.mountAction(\'reorder\', { items: $event.target.sortable.toArray() }, { schemaComponent: \'' . $key . '\' })',
                                 ], escape: false) }}
                     >
                         @foreach ($items as $itemKey => $item)


### PR DESCRIPTION

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When sorting, only request the backend for an update when the order is actually changed, to avoid unnecessary requests.

### Before


https://github.com/user-attachments/assets/73fd6d87-0d00-43ee-9724-c92a65ac97ff


### After


https://github.com/user-attachments/assets/cff30006-e530-48cf-929a-7f0ff1ace7ee


<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

Component interaction is more smooth

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
