### PR TITLE
Add ID to section to allow persistent collapse

### DIFF
--- a/packages/schemas/resources/views/components/section.blade.php
+++ b/packages/schemas/resources/views/components/section.blade.php
@@ -46,6 +46,7 @@
     @endif
 
     <x-filament::section
+        :id="$getId().'::section-ctn'"
         :after-header="$afterHeader"
         :aside="$isAside"
         :collapsed="$isCollapsed"

--- a/packages/schemas/resources/views/components/section.blade.php
+++ b/packages/schemas/resources/views/components/section.blade.php
@@ -16,13 +16,14 @@
     $iconSize = $getIconSize();
     $shouldPersistCollapsed = $shouldPersistCollapsed();
     $isSecondary = $isSecondary();
+    $id = $getId();
 @endphp
 
 <div
     {{
         $attributes
             ->merge([
-                'id' => $getId(),
+                'id' => $id,
             ], escape: false)
             ->merge($getExtraAttributes(), escape: false)
             ->merge($getExtraAlpineAttributes(), escape: false)
@@ -46,10 +47,10 @@
     @endif
 
     <x-filament::section
-        :id="$getId() . '::section-ctn'"
         :after-header="$afterHeader"
         :aside="$isAside"
         :collapsed="$isCollapsed"
+        :collapse-id="$id"
         :collapsible="$isCollapsible && (! $isAside)"
         :compact="$isCompact"
         :contained="$isContained"

--- a/packages/schemas/resources/views/components/section.blade.php
+++ b/packages/schemas/resources/views/components/section.blade.php
@@ -46,7 +46,7 @@
     @endif
 
     <x-filament::section
-        :id="$getId().'::section-ctn'"
+        :id="$getId() . '::section-ctn'"
         :after-header="$afterHeader"
         :aside="$isAside"
         :collapsed="$isCollapsed"

--- a/packages/support/resources/views/components/section/index.blade.php
+++ b/packages/support/resources/views/components/section/index.blade.php
@@ -10,6 +10,7 @@
     'afterHeader' => null,
     'aside' => false,
     'collapsed' => false,
+    'collapseId' => null,
     'collapsible' => false,
     'compact' => false,
     'contained' => true,
@@ -41,14 +42,14 @@
 <section
     {{-- TODO: Investigate Livewire bug - https://github.com/filamentphp/filament/pull/8511 --}}
     x-data="{
-        isCollapsed: @if ($persistCollapsed) $persist(@js($collapsed)).as(`section-${$el.id}-isCollapsed`) @else @js($collapsed) @endif,
+        isCollapsed: @if ($persistCollapsed) $persist(@js($collapsed)).as(`section-${@js($collapseId) ?? $el.id}-isCollapsed`) @else @js($collapsed) @endif,
     }"
     @if ($collapsible)
-        x-on:collapse-section.window="if ($event.detail.id == $el.id) isCollapsed = true"
+        x-on:collapse-section.window="if ($event.detail.id == @js($collapseId) ?? $el.id) isCollapsed = true"
         x-on:expand="isCollapsed = false"
-        x-on:expand-section.window="if ($event.detail.id == $el.id) isCollapsed = false"
-        x-on:open-section.window="if ($event.detail.id == $el.id) isCollapsed = false"
-        x-on:toggle-section.window="if ($event.detail.id == $el.id) isCollapsed = ! isCollapsed"
+        x-on:expand-section.window="if ($event.detail.id == @js($collapseId) ?? $el.id) isCollapsed = false"
+        x-on:open-section.window="if ($event.detail.id == @js($collapseId) ?? $el.id) isCollapsed = false"
+        x-on:toggle-section.window="if ($event.detail.id == @js($collapseId) ?? $el.id) isCollapsed = ! isCollapsed"
         x-bind:class="isCollapsed && 'fi-collapsed'"
     @endif
     {{


### PR DESCRIPTION
## Description

The docs say:
> To persist the collapse state, the local storage needs a unique ID to store the state. 

But the ID is no longer passed to `x-filament::section`: both the automatic one or the user defined id, so when the are more collapsible sections with `persistCollapse` as `true` they are all closed/opened.

I simply added the ID again. Not sure if it's the best way to do so, but this way it works as intended.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
