### PR TITLE
Introduced and tested stacked/pipeline dehydrateStateUsing

### DIFF
--- a/packages/forms/docs/01-overview.md
+++ b/packages/forms/docs/01-overview.md
@@ -1257,6 +1257,42 @@ TextInput::make('name')
     ->dehydrateStateUsing(fn (string $state): string => ucwords($state))
 ```
 
+#### Stacking dehydration functions
+
+You can also stack multiple dehydration functions using the `dehydrateStateUsing()` method.
+
+```php
+use Filament\Forms\Components\TextInput;
+
+TextInput::make('name')
+    ->required()
+    ->dehydrateStateUsing(fn (string $state): string => trim($state))
+    ->dehydrateStateUsing(fn (string $state): string => ucwords($state))
+```
+
+This is useful if you want to extract common logic into component classes, and then stack them on top of each other. For example:
+
+```php
+use Illuminate\Support\Str;
+
+class CustomTextInput extends TextInput
+{
+    public function removeWhitespace(): static
+    {
+        return $this->dehydrateStateUsing(fn ($state) => Str::squish($state));
+    }
+
+    public function capitalise(): static
+    {
+        return $this->dehydrateStateUsing(fn ($state) => Str::upper($state));
+    }
+}
+```
+
+<Aside variant="info">
+    To read more about component classes, see the Code Quality Tips documentation in the resources section.
+</Aside>
+
 #### Preventing a field from being dehydrated
 
 You may also prevent a field from being dehydrated altogether using `dehydrated(false)`. In this example, the field will not be present in the array returned from `getState()`:

--- a/packages/schemas/src/Components/Concerns/HasState.php
+++ b/packages/schemas/src/Components/Concerns/HasState.php
@@ -41,7 +41,10 @@ trait HasState
 
     protected mixed $defaultState = null;
 
-    protected ?Closure $dehydrateStateUsing = null;
+    /**
+     * @var array<int, Closure>
+     */
+    protected array $dehydrateStateUsing = [];
 
     protected ?Closure $mutateDehydratedStateUsing = null;
 
@@ -271,10 +274,10 @@ trait HasState
             $state = $stateCast->get($state);
         }
 
-        if ($callback = $this->dehydrateStateUsing) {
-            return [$this->getStatePath() => $this->evaluate($callback, [
+        foreach ($this->dehydrateStateUsing as $callback) {
+            $state = $this->evaluate($callback, [
                 'state' => $state,
-            ])];
+            ]);
         }
 
         return [$this->getStatePath() => $state];
@@ -322,7 +325,7 @@ trait HasState
 
     public function dehydrateStateUsing(?Closure $callback): static
     {
-        $this->dehydrateStateUsing = $callback;
+        $this->dehydrateStateUsing[] = $callback;
 
         return $this;
     }

--- a/tests/src/Forms/Components/TextInputTest.php
+++ b/tests/src/Forms/Components/TextInputTest.php
@@ -22,6 +22,19 @@ it('can trim whitespace from TextInput', function (mixed $input, mixed $expected
     [123, 123],
 ]);
 
+it('can utilise multiple dehydrateStateUsing', function (mixed $input, mixed $expected): void {
+    livewire(TestComponentWithTextInputTrim::class)
+        ->fillForm(['post_code' => $input])
+        ->call('save')
+        ->assertSet('data.post_code', $expected);
+})->with([
+    ['  po12 9AJ  ', 'PO12 9AJ'],
+    ['po12 9AJ', 'PO12 9AJ'],
+    [null, null],
+    ['', ''],
+    [123, 123],
+]);
+
 class TestComponentWithTextInputTrim extends Livewire
 {
     public $data = [];
@@ -30,8 +43,8 @@ class TestComponentWithTextInputTrim extends Livewire
     {
         return $form
             ->schema([
-                TextInput::make('name')
-                    ->trim(),
+                TextInput::make('name')->trim(),
+                StackedDehydrateTestTextInput::make('post_code')->removeWhitespace()->capitalise(),
             ])
             ->statePath('data');
     }
@@ -39,5 +52,18 @@ class TestComponentWithTextInputTrim extends Livewire
     public function save(): void
     {
         $this->data = $this->form->getState();
+    }
+}
+
+class StackedDehydrateTestTextInput extends TextInput
+{
+    public function removeWhitespace(): static
+    {
+        return $this->dehydrateStateUsing(fn ($state) => Str::squish($state));
+    }
+
+    public function capitalise(): static
+    {
+        return $this->dehydrateStateUsing(fn ($state) => Str::upper($state));
     }
 }

--- a/tests/src/Forms/Components/TextInputTest.php
+++ b/tests/src/Forms/Components/TextInputTest.php
@@ -28,7 +28,7 @@ it('can utilise multiple dehydrateStateUsing', function (mixed $input, mixed $ex
         ->call('save')
         ->assertSet('data.post_code', $expected);
 })->with([
-    ['  po12 9AJ  ', 'PO12 9AJ'],
+    ['  po12     9AJ  ', 'PO12 9AJ'],
     ['po12 9AJ', 'PO12 9AJ'],
     [null, null],
     ['', ''],


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

This pull request proposes an enhancement to how dehydrateStateUsing() functions can be applied in Filament form components.

Currently, calling dehydrateStateUsing() on a form field replaces any previously set callback. This makes it difficult to compose multiple transformations, such as removing whitespace and capitalising text for a single input.

For example, consider a postcode input where we want to:
	•	Remove extra spaces (" wo98  0AJ" → "WO98 0AJ")
	•	Capitalise the result

Using the current approach, only one transformation can be applied at a time. My proposed change allows stacking multiple dehydration callbacks, like a pipeline, which makes code more readable and reusable.

This aligns with the goal of improved code quality and reusability, as outlined in the Filament docs:
https://filamentphp.com/docs/4.x/resources/code-quality-tips

*Before*
```
TextInput::make('post_code')
    ->dehydrateStateUsing(fn ($state) => Str::squish($state));
```

*After (proposed)*
```
TextInput::make('post_code')
    ->removeWhitespace()
    ->capitalise();
```

This is enabled by extending the TextInput component and allowing multiple dehydration callbacks to be queued:

```
class TextInput extends BaseTextInput
{
    public function removeWhitespace(): static
    {
        return $this->appendDehydrateStateUsing(fn ($state) => Str::squish($state));
    }

    public function capitalise(): static
    {
        return $this->appendDehydrateStateUsing(fn ($state) => Str::upper($state));
    }
}
```

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

None.

## Functional changes

- [ ] Introduced the ability to stack multiple dehydrateStateUsing() callbacks, enabling more composable field behaviour.
- [ ] This allows more expressive and reusable custom field components in extended schema classes.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation updated.
