### PR TITLE
fix saveFormComponentOnly, keep container

### DIFF
--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -192,11 +192,15 @@ class EditRecord extends Page
 
             $this->callHook('beforeValidate');
 
+            $oldContainer = $component->getContainer();
+
             $data = Schema::make($component->getLivewire())
                 ->components([$component])
                 ->model($component->getRecord())
                 ->statePath('data')
                 ->getState();
+
+            $component->container($oldContainer);
 
             $this->callHook('afterValidate');
 


### PR DESCRIPTION
## Description

Fixes `EditRecord` `saveFormComponentOnly()`
The example below, would make the action button disappear after save.

```php 
Action::make('foo')
            ->action(function (Section $component, EditRecord $livewire) {
                $livewire->saveFormComponentOnly($component);
            })
            ->visible(fn (string $operation): bool => $operation === 'edit');
```
