### PR TITLE
[4.x] Fix mounting action from method with union return type

### DIFF
--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -23,6 +23,7 @@ use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Url;
 use ReflectionMethod;
 use ReflectionNamedType;
+use ReflectionUnionType;
 use Throwable;
 
 use function Livewire\store;
@@ -512,13 +513,13 @@ trait InteractsWithActions
                 return null;
             }
 
-            if (! $returnTypeReflection instanceof ReflectionNamedType) {
-                return null;
-            }
+            $returnTypes = $returnTypeReflection instanceof ReflectionUnionType ? $returnTypeReflection->getTypes() : [$returnTypeReflection];
 
-            $type = $returnTypeReflection->getName();
+            $hasActionReturnType = collect($returnTypes)
+                ->filter(fn ($returnType) => $returnType instanceof ReflectionNamedType)
+                ->contains(fn (ReflectionNamedType $returnType) => is_a($returnType->getName(), Action::class, allow_string: true));
 
-            if (! is_a($type, Action::class, allow_string: true)) {
+            if (! $hasActionReturnType) {
                 return null;
             }
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR resolves an issue, preventing an action from mounting, when the return type of an action method is a `ReflectionUnionType`.

When mounting an action, Filament checks if the return type of the action method is from type `Action`. But this does not work, if as a return type, two different action classes are defined.
Here is an example:

```php
// works
public function deleteAction(): Action
{
    return TagDeleteAction::make('deleteAction');
}

// works
public function deleteAction(): TagDeleteAction
{
    return TagDeleteAction::make('deleteAction');
}

// works
public function deleteAction(): Action
{
    return $this->tag->users->count() > 1
        ? TagDeleteOrLeaveAction::make('deleteAction')
        : TagDeleteAction::make('deleteAction');
}

// does only work with this PR -> otherwise the action is not mounted without any error
public function deleteAction(): TagDeleteAction|TagDeleteOrLeaveAction
{
    return $this->tag->users->count() > 1
        ? TagDeleteOrLeaveAction::make('deleteAction')
        : TagDeleteAction::make('deleteAction');
}

```

## Visual changes

There are no visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] ~~Documentation is up-to-date.~~ (no change required)
