### PR TITLE
add toArray() to RichEditor

### DIFF
--- a/packages/forms/src/Components/RichEditor/RichContentRenderer.php
+++ b/packages/forms/src/Components/RichEditor/RichContentRenderer.php
@@ -360,14 +360,9 @@ class RichContentRenderer implements Htmlable
         }
 
         $editor = $this->getEditor();
-
-        if ($decoded) {
-            return json_decode($editor->getJSON(), true);
-        }
-
         $this->processMergeTags($editor);
 
-        return $editor->getJSON();
+        return $decoded ? json_decode($editor->getJSON(), true) : $editor->getJSON();
     }
 
     /**

--- a/packages/forms/src/Components/RichEditor/RichContentRenderer.php
+++ b/packages/forms/src/Components/RichEditor/RichContentRenderer.php
@@ -55,7 +55,7 @@ class RichContentRenderer implements Htmlable
     /**
      * @var string | array<string, mixed>
      */
-    protected string | array | null $content = null;
+    protected string|array|null $content = null;
 
     protected ?string $fileAttachmentsDiskName = null;
 
@@ -84,17 +84,17 @@ class RichContentRenderer implements Htmlable
     protected array $cachedMergeTagValues = [];
 
     /**
-     * @param  string | array<string, mixed> | null  $content
+     * @param string | array<string, mixed> | null $content
      */
-    public function __construct(string | array | null $content = null)
+    public function __construct(string|array|null $content = null)
     {
         $this->content($content);
     }
 
     /**
-     * @param  string | array<string, mixed> | null  $content
+     * @param string | array<string, mixed> | null $content
      */
-    public static function make(string | array | null $content = null): static
+    public static function make(string|array|null $content = null): static
     {
         return app(static::class, [
             'content' => $content,
@@ -102,9 +102,9 @@ class RichContentRenderer implements Htmlable
     }
 
     /**
-     * @param  string | array<string, mixed> | null  $content
+     * @param string | array<string, mixed> | null $content
      */
-    public function content(string | array | null $content): static
+    public function content(string|array|null $content): static
     {
         $this->content = $content;
         $this->cachedMergeTagValues = [];
@@ -140,7 +140,7 @@ class RichContentRenderer implements Htmlable
         $storage = Storage::disk($disk);
 
         try {
-            if (! $storage->exists($file)) {
+            if (!$storage->exists($file)) {
                 return null;
             }
         } catch (UnableToCheckFileExistence $exception) {
@@ -162,7 +162,7 @@ class RichContentRenderer implements Htmlable
     }
 
     /**
-     * @param  array<RichContentPlugin>  $plugins
+     * @param array<RichContentPlugin> $plugins
      */
     public function plugins(array $plugins): static
     {
@@ -228,7 +228,7 @@ class RichContentRenderer implements Htmlable
             }
 
             $node->content = [
-                (object) [
+                (object)[
                     'type' => 'text',
                     'text' => $this->getMergeTagValue($node->attrs->id),
                 ],
@@ -292,7 +292,7 @@ class RichContentRenderer implements Htmlable
             app(Underline::class),
             ...array_reduce(
                 $this->getPlugins(),
-                fn (array $carry, RichContentPlugin $plugin): array => [
+                fn(array $carry, RichContentPlugin $plugin): array => [
                     ...$carry,
                     ...$plugin->getTipTapPhpExtensions(),
                 ],
@@ -351,7 +351,21 @@ class RichContentRenderer implements Htmlable
     }
 
     /**
-     * @param  ?array<string, mixed>  $tags
+     * @return string|array<string, mixed>
+     */
+    public function toJson(bool $decoded = false): string|array
+    {
+        $editor = $this->getEditor();
+
+        if ($decoded) {
+            return json_decode($editor->getJSON(), true);
+        }
+
+        return $editor->getJSON();
+    }
+
+    /**
+     * @param  ?array<string, mixed> $tags
      */
     public function mergeTags(?array $tags): static
     {
@@ -367,7 +381,7 @@ class RichContentRenderer implements Htmlable
     }
 
     /**
-     * @param  ?array<class-string<RichContentCustomBlock> | array<string, mixed> | Closure>  $blocks
+     * @param  ?array<class-string<RichContentCustomBlock> | array<string, mixed> | Closure> $blocks
      */
     public function customBlocks(?array $blocks): static
     {
@@ -377,7 +391,7 @@ class RichContentRenderer implements Htmlable
     }
 
     /**
-     * @param  array<string, mixed>  $config
+     * @param array<string, mixed> $config
      */
     public function getCustomBlockHtml(string $id, array $config): ?string
     {

--- a/packages/forms/src/Components/RichEditor/RichContentRenderer.php
+++ b/packages/forms/src/Components/RichEditor/RichContentRenderer.php
@@ -55,7 +55,7 @@ class RichContentRenderer implements Htmlable
     /**
      * @var string | array<string, mixed>
      */
-    protected string|array|null $content = null;
+    protected string | array | null $content = null;
 
     protected ?string $fileAttachmentsDiskName = null;
 
@@ -84,17 +84,17 @@ class RichContentRenderer implements Htmlable
     protected array $cachedMergeTagValues = [];
 
     /**
-     * @param string | array<string, mixed> | null $content
+     * @param  string | array<string, mixed> | null  $content
      */
-    public function __construct(string|array|null $content = null)
+    public function __construct(string | array | null $content = null)
     {
         $this->content($content);
     }
 
     /**
-     * @param string | array<string, mixed> | null $content
+     * @param  string | array<string, mixed> | null  $content
      */
-    public static function make(string|array|null $content = null): static
+    public static function make(string | array | null $content = null): static
     {
         return app(static::class, [
             'content' => $content,
@@ -102,9 +102,9 @@ class RichContentRenderer implements Htmlable
     }
 
     /**
-     * @param string | array<string, mixed> | null $content
+     * @param  string | array<string, mixed> | null  $content
      */
-    public function content(string|array|null $content): static
+    public function content(string | array | null $content): static
     {
         $this->content = $content;
         $this->cachedMergeTagValues = [];
@@ -140,7 +140,7 @@ class RichContentRenderer implements Htmlable
         $storage = Storage::disk($disk);
 
         try {
-            if (!$storage->exists($file)) {
+            if (! $storage->exists($file)) {
                 return null;
             }
         } catch (UnableToCheckFileExistence $exception) {
@@ -162,7 +162,7 @@ class RichContentRenderer implements Htmlable
     }
 
     /**
-     * @param array<RichContentPlugin> $plugins
+     * @param  array<RichContentPlugin>  $plugins
      */
     public function plugins(array $plugins): static
     {
@@ -228,7 +228,7 @@ class RichContentRenderer implements Htmlable
             }
 
             $node->content = [
-                (object)[
+                (object) [
                     'type' => 'text',
                     'text' => $this->getMergeTagValue($node->attrs->id),
                 ],
@@ -292,7 +292,7 @@ class RichContentRenderer implements Htmlable
             app(Underline::class),
             ...array_reduce(
                 $this->getPlugins(),
-                fn(array $carry, RichContentPlugin $plugin): array => [
+                fn (array $carry, RichContentPlugin $plugin): array => [
                     ...$carry,
                     ...$plugin->getTipTapPhpExtensions(),
                 ],
@@ -353,7 +353,7 @@ class RichContentRenderer implements Htmlable
     /**
      * @return string|array<string, mixed>
      */
-    public function toJson(bool $decoded = false): string|array
+    public function toJson(bool $decoded = false): string | array
     {
         $editor = $this->getEditor();
 
@@ -361,11 +361,13 @@ class RichContentRenderer implements Htmlable
             return json_decode($editor->getJSON(), true);
         }
 
+        $this->processMergeTags($editor);
+
         return $editor->getJSON();
     }
 
     /**
-     * @param  ?array<string, mixed> $tags
+     * @param  ?array<string, mixed>  $tags
      */
     public function mergeTags(?array $tags): static
     {
@@ -381,7 +383,7 @@ class RichContentRenderer implements Htmlable
     }
 
     /**
-     * @param  ?array<class-string<RichContentCustomBlock> | array<string, mixed> | Closure> $blocks
+     * @param  ?array<class-string<RichContentCustomBlock> | array<string, mixed> | Closure>  $blocks
      */
     public function customBlocks(?array $blocks): static
     {
@@ -391,7 +393,7 @@ class RichContentRenderer implements Htmlable
     }
 
     /**
-     * @param array<string, mixed> $config
+     * @param  array<string, mixed>  $config
      */
     public function getCustomBlockHtml(string $id, array $config): ?string
     {

--- a/packages/forms/src/Components/RichEditor/RichContentRenderer.php
+++ b/packages/forms/src/Components/RichEditor/RichContentRenderer.php
@@ -355,6 +355,10 @@ class RichContentRenderer implements Htmlable
      */
     public function toJson(bool $decoded = false): string | array
     {
+        if (empty($this->content)) {
+            return $decoded ? [] : '';
+        }
+
         $editor = $this->getEditor();
 
         if ($decoded) {

--- a/packages/forms/src/Components/RichEditor/RichContentRenderer.php
+++ b/packages/forms/src/Components/RichEditor/RichContentRenderer.php
@@ -351,18 +351,18 @@ class RichContentRenderer implements Htmlable
     }
 
     /**
-     * @return string|array<string, mixed>
+     * @return array<string, mixed>
      */
-    public function toJson(bool $decoded = false): string | array
+    public function toArray(): array
     {
         if (empty($this->content)) {
-            return $decoded ? [] : '';
+            return [];
         }
 
         $editor = $this->getEditor();
         $this->processMergeTags($editor);
 
-        return $decoded ? json_decode($editor->getJSON(), true) : $editor->getJSON();
+        return json_decode($editor->getJSON(), true);
     }
 
     /**


### PR DESCRIPTION
## Description

Brings the toJson functionality over (This existed in the awcodes tiptapeditor) and was pretty useful for converting things like Markdown HTML into what TipTap expected from a structure POV, to then iterate through. now as toArray as you can just json_encode the array if you still need that....

IE: 

Provides an array of the TipTap Structure of the content that you can go through
```
    $markdown = new Markdown('This is a **snippet** of _example_ Markdown.');

    $richContent = RichContentRenderer::make($markdown->toHtml())->toArray();
```

```
array:2 [▼
  "type" => "doc"
  "content" => array:1 [▶]
]
```

This is really only useful I think if you're doing edits before inserts and modifications outside of the typical filament panel. IE: Commands to bring in articles or format things differently. We use it all the time, so kinda need this.


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
