### PR TITLE
[4.x] Explicitly cast Phiki result to string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "orchestra/testbench": "^9.0|^10.0",
         "pestphp/pest": "^3.7",
         "pestphp/pest-plugin-laravel": "^3.0",
-        "phiki/phiki": "^1.1",
+        "phiki/phiki": "^2.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^2.1",
         "pragmarx/google2fa": "^8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce5a031238f6edda908581020cd92fae",
+    "content-hash": "832f9e405553f3c07f831fc60c34652e",
     "packages": [],
     "packages-dev": [
         {
@@ -5924,34 +5924,41 @@
         },
         {
             "name": "phiki/phiki",
-            "version": "v1.1.6",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phikiphp/phiki.git",
-                "reference": "3174d8cb309bdccc32b7a33500379de76148256b"
+                "reference": "461f6dd7e91dc3a95463b42f549ac7d0aab4702f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phikiphp/phiki/zipball/3174d8cb309bdccc32b7a33500379de76148256b",
-                "reference": "3174d8cb309bdccc32b7a33500379de76148256b",
+                "url": "https://api.github.com/repos/phikiphp/phiki/zipball/461f6dd7e91dc3a95463b42f549ac7d0aab4702f",
+                "reference": "461f6dd7e91dc3a95463b42f549ac7d0aab4702f",
                 "shasum": ""
             },
             "require": {
+                "ext-mbstring": "*",
                 "league/commonmark": "^2.5.3",
-                "php": "^8.2"
+                "php": "^8.2",
+                "psr/simple-cache": "^3.0"
             },
             "require-dev": {
-                "illuminate/support": "^11.30",
+                "illuminate/support": "^11.45",
                 "laravel/pint": "^1.18.1",
+                "orchestra/testbench": "^9.15",
                 "pestphp/pest": "^3.5.1",
                 "phpstan/extension-installer": "^1.4.3",
                 "phpstan/phpstan": "^2.0",
                 "symfony/var-dumper": "^7.1.6"
             },
-            "bin": [
-                "bin/phiki"
-            ],
             "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Phiki\\Adapters\\Laravel\\PhikiServiceProvider"
+                    ]
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Phiki\\": "src/"
@@ -5972,9 +5979,19 @@
             "description": "Syntax highlighting using TextMate grammars in PHP.",
             "support": {
                 "issues": "https://github.com/phikiphp/phiki/issues",
-                "source": "https://github.com/phikiphp/phiki/tree/v1.1.6"
+                "source": "https://github.com/phikiphp/phiki/tree/v2.0.0"
             },
-            "time": "2025-06-06T20:18:29+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/ryangjchandler",
+                    "type": "github"
+                },
+                {
+                    "url": "https://buymeacoffee.com/ryangjchandler",
+                    "type": "other"
+                }
+            ],
+            "time": "2025-08-28T18:20:27+00:00"
         },
         {
             "name": "php-di/invoker",
@@ -13430,7 +13447,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -13438,6 +13455,6 @@
         "composer-runtime-api": "^2.1",
         "ext-intl": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/docs-assets/app/composer.json
+++ b/docs-assets/app/composer.json
@@ -14,7 +14,7 @@
         "laravel/framework": "^11.0",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.8",
-        "phiki/phiki": "^1.1"
+        "phiki/phiki": "^2.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",

--- a/packages/infolists/src/Components/CodeEntry.php
+++ b/packages/infolists/src/Components/CodeEntry.php
@@ -142,7 +142,7 @@ class CodeEntry extends Entry implements HasEmbeddedView
         ob_start(); ?>
 
         <div <?= $attributes->toHtml() ?>>
-            <?= $phiki->codeToHtml($state, $grammar, [
+            <?= (string) $phiki->codeToHtml($state, $grammar, [
                 'light' => $lightTheme,
                 'dark' => $darkTheme,
             ]) ?>


### PR DESCRIPTION
## Description

I've just tagged v2.0.0 of Phiki which now returns a `Stringable` object.

The object would technically be automatically cast when `echo`'d but I think it's safer and smarter to explicitly cast the value to a `string` instead.

Phiki v1.0 users will still be fine too since Filament doesn't support any of the `gutter` stuff that has changed in the new release.

I've also bumped the Phiki version for testing and the docs app to v2.0 so it should produce some better output now.
