### PR TITLE
Fix: drag prevention ineffective in `repeater` component during requests

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -144,11 +144,8 @@
                                         class="fi-fo-builder-item-header-start-actions"
                                     >
                                         @if ($reorderActionIsVisible)
-                                            <li
-                                                x-sortable-handle
-                                                x-on:click.stop
-                                            >
-                                                {{ $reorderAction }}
+                                            <li x-on:click.stop>
+                                                {{ $reorderAction->extraAttributes(['x-sortable-handle' => true], merge: true) }}
                                             </li>
                                         @endif
 

--- a/packages/forms/resources/views/components/repeater/index.blade.php
+++ b/packages/forms/resources/views/components/repeater/index.blade.php
@@ -129,11 +129,8 @@
                                         class="fi-fo-repeater-item-header-start-actions"
                                     >
                                         @if ($reorderActionIsVisible)
-                                            <li
-                                                x-sortable-handle
-                                                x-on:click.stop
-                                            >
-                                                {{ $reorderAction }}
+                                            <li x-on:click.stop>
+                                                {{ $reorderAction->extraAttributes(['x-sortable-handle' => true]) }}
                                             </li>
                                         @endif
 

--- a/packages/forms/resources/views/components/repeater/index.blade.php
+++ b/packages/forms/resources/views/components/repeater/index.blade.php
@@ -130,7 +130,7 @@
                                     >
                                         @if ($reorderActionIsVisible)
                                             <li x-on:click.stop>
-                                                {{ $reorderAction->extraAttributes(['x-sortable-handle' => true]) }}
+                                                {{ $reorderAction->extraAttributes(['x-sortable-handle' => true], merge: true) }}
                                             </li>
                                         @endif
 

--- a/packages/forms/resources/views/components/repeater/simple.blade.php
+++ b/packages/forms/resources/views/components/repeater/simple.blade.php
@@ -77,7 +77,7 @@
                             <ul class="fi-fo-simple-repeater-item-actions">
                                 @if ($reorderActionIsVisible)
                                     <li x-on:click.stop>
-                                        {{ $reorderAction->extraAttributes(['x-sortable-handle' => true]) }}
+                                        {{ $reorderAction->extraAttributes(['x-sortable-handle' => true], merge: true) }}
                                     </li>
                                 @endif
 

--- a/packages/forms/resources/views/components/repeater/simple.blade.php
+++ b/packages/forms/resources/views/components/repeater/simple.blade.php
@@ -76,8 +76,8 @@
                         @if ($reorderActionIsVisible || $moveUpActionIsVisible || $moveDownActionIsVisible || $cloneActionIsVisible || $deleteActionIsVisible || $visibleExtraItemActions)
                             <ul class="fi-fo-simple-repeater-item-actions">
                                 @if ($reorderActionIsVisible)
-                                    <li x-sortable-handle x-on:click.stop>
-                                        {{ $reorderAction }}
+                                    <li x-on:click.stop>
+                                        {{ $reorderAction->extraAttributes(['x-sortable-handle' => true]) }}
                                     </li>
                                 @endif
 

--- a/packages/forms/resources/views/components/repeater/table.blade.php
+++ b/packages/forms/resources/views/components/repeater/table.blade.php
@@ -114,7 +114,7 @@
                                         >
                                             @if ($reorderActionIsVisible)
                                                 <div x-on:click.stop>
-                                                    {{ $reorderAction->extraAttributes(['x-sortable-handle' => true]) }}
+                                                    {{ $reorderAction->extraAttributes(['x-sortable-handle' => true], merge: true) }}
                                                 </div>
                                             @endif
 

--- a/packages/forms/resources/views/components/repeater/table.blade.php
+++ b/packages/forms/resources/views/components/repeater/table.blade.php
@@ -113,11 +113,8 @@
                                             class="fi-fo-table-repeater-actions"
                                         >
                                             @if ($reorderActionIsVisible)
-                                                <div
-                                                    x-sortable-handle
-                                                    x-on:click.stop
-                                                >
-                                                    {{ $reorderAction }}
+                                                <div x-on:click.stop>
+                                                    {{ $reorderAction->extraAttributes(['x-sortable-handle' => true]) }}
                                                 </div>
                                             @endif
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

During the process of initiating requests for sorting, adding, and deleting, the disabled attribute has been added to the drag button, but it has not taken effect. If dragging and sorting are performed during this period, it may lead to incorrect data rendering.

As shown in the video, sorting during disabling caused the rendering of old items

# Before
https://github.com/user-attachments/assets/2646fd10-0893-4dd9-bd04-f3b45dbe8a22

# After

Code editor shows: Custom buttons have also been tested


https://github.com/user-attachments/assets/c72d2cc5-91f9-4254-abce-679dec137074


## Visual changes

Dragging is not allowed when the sort button is disabled

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
