### PR TITLE
Fix typo in 07-managing-relationships.md

### DIFF
--- a/docs/03-resources/07-managing-relationships.md
+++ b/docs/03-resources/07-managing-relationships.md
@@ -116,7 +116,7 @@ Once a table and form have been defined for the relation manager, visit the [Edi
 
 ### Customizing the relation manager's URL parameter
 
-If you pass a key to the array returned from `getRelations()`, it will be used in the URL for that relation manager when switching been multiple relation managers. For example, you can pass `posts` to use `?relation=posts` in the URL instead of a numeric array index:
+If you pass a key to the array returned from `getRelations()`, it will be used in the URL for that relation manager when switching between multiple relation managers. For example, you can pass `posts` to use `?relation=posts` in the URL instead of a numeric array index:
 
 ```php
 public static function getRelations(): array


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fixed typo ‘between’ instead of ‘been’.

## Visual changes

Not applicable.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
