### PR TITLE
Passes through missing arguments

### DIFF
--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -523,7 +523,9 @@ trait InteractsWithActions
                 return null;
             }
 
-            $resolvedAction = $this->{$methodName}();
+            $methodArguments = $action['arguments'] ?? null;
+
+            $resolvedAction = $this->{$methodName}($methodArguments);
 
             if (! $resolvedAction instanceof Action) {
                 throw new ActionNotResolvableException('Actions must be an instance of ' . Action::class . ". The [{$methodName}] method on the Livewire component returned an instance of [" . get_class($resolvedAction) . '].');


### PR DESCRIPTION
## Description

The `mountAction` method accepts the method name, arguments, and context. The arguments are not passed into the method. This PR passes along the given arguments, should they exist.

## Visual changes

There are no visual changes.

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date. (this bit is only documented from JavaScript)
