### PR TITLE
Adjust example test for testing schema components

### DIFF
--- a/docs/10-testing/04-testing-schemas.md
+++ b/docs/10-testing/04-testing-schemas.md
@@ -240,7 +240,7 @@ it('does not have a conditional component', function () {
 });
 ```
 
-To check if the component exists and passes a given truth test, you can pass a function to the second argument of `assertSchemaComponentExists()`, returning true or false if the component passes the test or not:
+To check if the component exists and passes a given truth test, you can pass a function to the `checkComponentUsing` argument of `assertSchemaComponentExists()`, returning true or false if the component passes the test or not:
 
 ```php
 use Filament\Forms\Components\Component;
@@ -250,7 +250,7 @@ use function Pest\Livewire\livewire;
 test('comments section has heading', function () {
     livewire(EditPost::class)
         ->assertSchemaComponentExists(
-            key: 'comments-section',
+            'comments-section',
             checkComponentUsing: function (Component $component): bool {
                 return $component->getHeading() === 'Comments';
             },
@@ -269,7 +269,7 @@ use function Pest\Livewire\livewire;
 test('comments section is enabled', function () {
     livewire(EditPost::class)
         ->assertSchemaComponentExists(
-            key: 'comments-section',
+            'comments-section',
             checkComponentUsing: function (Component $component): bool {
                 Assert::assertTrue(
                     $component->isEnabled(),

--- a/docs/10-testing/04-testing-schemas.md
+++ b/docs/10-testing/04-testing-schemas.md
@@ -250,8 +250,8 @@ use function Pest\Livewire\livewire;
 test('comments section has heading', function () {
     livewire(EditPost::class)
         ->assertSchemaComponentExists(
-            'comments-section',
-            function (Component $component): bool {
+            key: 'comments-section',
+            checkComponentUsing: function (Component $component): bool {
                 return $component->getHeading() === 'Comments';
             },
         );
@@ -269,8 +269,8 @@ use function Pest\Livewire\livewire;
 test('comments section is enabled', function () {
     livewire(EditPost::class)
         ->assertSchemaComponentExists(
-            'comments-section',
-            function (Component $component): bool {
+            key: 'comments-section',
+            checkComponentUsing: function (Component $component): bool {
                 Assert::assertTrue(
                     $component->isEnabled(),
                     'Failed asserting that comments-section is enabled.',


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
In the docs you currently see:

```php
test('comments section has heading', function () {
    livewire(EditPost::class)
        ->assertSchemaComponentExists(
            'comments-section',
            function (Component $component): bool {
                return $component->getHeading() === 'Comments';
            },
        );
});
```

The shown example would lead to an error:

```php
 Livewire\Features\SupportTesting\Testable::{closure:Filament\Schemas\Testing\TestsSchemas::assertSchemaComponentExists():25}(): Argument #2 ($schema) must be of type ?string, Closure given,
```

because the 2nd parameter is expected to be a `Schema`

I suppose there is two options now, adding `null` as 2nd parameter in the examples or simply using named arguments. Named arguments looked like the better approach 😊

## Visual changes

```php
test('comments section has heading', function () {
    livewire(EditPost::class)
        ->assertSchemaComponentExists(
            key: 'comments-section',
            checkComponentUsing: function (Component $component): bool {
                return $component->getHeading() === 'Comments';
            },
        );
});
```

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
