### PR TITLE
Fix deprecated reference

### DIFF
--- a/packages/actions/docs/05-edit.md
+++ b/packages/actions/docs/05-edit.md
@@ -39,7 +39,7 @@ EditAction::make()
 
 ## Customizing data before saving
 
-Sometimes, you may wish to modify form data before it is finally saved to the database. To do this, you may use the `mutateFormDataUsing()` method, which has access to the `$data` as an array, and returns the modified version:
+Sometimes, you may wish to modify form data before it is finally saved to the database. To do this, you may use the `mutateDataUsing()` method, which has access to the `$data` as an array, and returns the modified version:
 
 ```php
 use Filament\Actions\EditAction;


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

`mutateFormDataUsing` is deprecated.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
