### PR TITLE
Use the correct name for the logout button icon

### DIFF
--- a/packages/panels/resources/views/widgets/account-widget.blade.php
+++ b/packages/panels/resources/views/widgets/account-widget.blade.php
@@ -29,7 +29,7 @@
 
             <x-filament::button
                 color="gray"
-                :icon="\Filament\Support\Icons\Heroicon::ArrowLeftOnRectangle"
+                :icon="\Filament\Support\Icons\Heroicon::ArrowLeftEndOnRectangle"
                 :icon-alias="\Filament\View\PanelsIconAlias::WIDGETS_ACCOUNT_LOGOUT_BUTTON"
                 labeled-from="sm"
                 tag="button"

--- a/packages/panels/src/Panel/Concerns/HasUserMenu.php
+++ b/packages/panels/src/Panel/Concerns/HasUserMenu.php
@@ -68,7 +68,7 @@ trait HasUserMenu
     {
         $action = Action::make('logout')
             ->label(__('filament-panels::layout.actions.logout.label'))
-            ->icon(FilamentIcon::resolve(PanelsIconAlias::USER_MENU_LOGOUT_BUTTON) ?? Heroicon::ArrowLeftOnRectangle)
+            ->icon(FilamentIcon::resolve(PanelsIconAlias::USER_MENU_LOGOUT_BUTTON) ?? Heroicon::ArrowLeftEndOnRectangle)
             ->url(Filament::getLogoutUrl())
             ->postToUrl()
             ->sort(PHP_INT_MAX);


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Currently, the `arrow-left-on-rectangle` icon is used as default for the logout button, which is not available in the smallest icon size.

This will break the application when the default action icon size is set to small:
```php
Action::configureUsing(
    fn(Action $action): Action => $action
        ->iconSize(IconSize::Small)
);
```

This PR fixes this by changing the icon to `arrow-left-end-on-rectangle` which is identical to `arrow-left-on-rectangle` but exists in the smallest icon set.

## Visual changes

There are no visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] ~~Documentation is up-to-date.~~ (no change required)
