### PR TITLE
fix: wrong link

### DIFF
--- a/packages/infolists/docs/01-overview.md
+++ b/packages/infolists/docs/01-overview.md
@@ -129,7 +129,7 @@ TextEntry::make('name')
 ### Hiding an entry's label
 
 <Aside variant="tip">
-    If you're looking to hide an entry's label, it might be the case that you are trying to use an entry for arbitrary text or UI. Entries are specifically designed to display data in a structured way, but [Prime components](../primes) are simple components that are used to render basic stand-alone static content, such as text, images, and buttons (actions). You may want to consider using a Prime component instead.
+    If you're looking to hide an entry's label, it might be the case that you are trying to use an entry for arbitrary text or UI. Entries are specifically designed to display data in a structured way, but [Prime components](../schemas/primes) are simple components that are used to render basic stand-alone static content, such as text, images, and buttons (actions). You may want to consider using a Prime component instead.
 </Aside>
 
 It may be tempting to set the label to an empty string to hide it, but this is not recommended. Setting the label to an empty string will not communicate the purpose of the entry to screen readers, even if the purpose is clear visually. Instead, you should use the `hiddenLabel()` method, so it is hidden visually but still accessible to screen readers:


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
Fix wrong link. The primes documentation is located under the Schemas section (https://filamentphp.com/docs/4.x/schemas/primes), and is not a separate section itself.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
