### PR TITLE
[4.x] Docs(fix): Correct the highlight extension example

### DIFF
--- a/packages/forms/docs/10-rich-editor.md
+++ b/packages/forms/docs/10-rich-editor.md
@@ -607,7 +607,7 @@ class HighlightRichContentPlugin implements RichContentPlugin
                 ->jsHandler('$getEditor()?.chain().focus().toggleHighlight().run()')
                 ->icon(Heroicon::CursorArrowRays),
             RichEditorTool::make('highlightWithCustomColor')
-                ->action(arguments: '{ color: $getEditor().getAttributes(\'mark\')?.data-color }')
+                ->action(arguments: '{ color: $getEditor().getAttributes(\'highlight\')?.[\'data-color\'] }')
                 ->icon(Heroicon::CursorArrowRipple),
         ];
     }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

I attempted to implement an extension to the Rich Editor and followed the example in the documentation to understand how it works. When implementing this, I came across an issue where the `highlightWithCustomColor` button didn't work. After doing some digging I realised that there were two corrections to be made.

1. The `mark` in the example should actually reference the TipTap mark you are hooking into. In this example, that is the highlight.
2. You can't reference object properties that contain a hyphen using the dot notation. I've updated the example to use bracket notation which fixes this problem.

If you want to test my changes, try and implement the highlight extension by following the exact directions [here](https://filamentphp.com/docs/4.x/forms/rich-editor#extending-the-rich-editor). You will see you get console errors on `highlightWithCustomColor`. Replacing the JS line with the one in this PR will fix these issues.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
