### PR TITLE
[4.x] Fix: Prevent relationship errors when resource model is tenant model

### DIFF
--- a/packages/panels/src/Resources/Resource/Concerns/BelongsToTenant.php
+++ b/packages/panels/src/Resources/Resource/Concerns/BelongsToTenant.php
@@ -23,6 +23,10 @@ trait BelongsToTenant
     {
         $tenant ??= Filament::getTenant();
 
+        if ($query->getModel()::class === Filament::getCurrentPanel()?->getTenantModel()) {
+            return $query->where($tenant->getTable() . '.' . $tenant->getKeyName(), $tenant->getKey());
+        }
+
         $tenantOwnershipRelationship = static::getTenantOwnershipRelationship($query->getModel());
         $tenantOwnershipRelationshipName = static::getTenantOwnershipRelationshipName();
 

--- a/packages/panels/src/Resources/Resource/Concerns/BelongsToTenant.php
+++ b/packages/panels/src/Resources/Resource/Concerns/BelongsToTenant.php
@@ -23,7 +23,7 @@ trait BelongsToTenant
     {
         $tenant ??= Filament::getTenant();
 
-        if ($query->getModel()::class === Filament::getCurrentPanel()?->getTenantModel()) {
+        if ($query->getModel()::class === $tenant::class) {
             return $query->whereKey($tenant);
         }
 

--- a/packages/panels/src/Resources/Resource/Concerns/BelongsToTenant.php
+++ b/packages/panels/src/Resources/Resource/Concerns/BelongsToTenant.php
@@ -24,7 +24,7 @@ trait BelongsToTenant
         $tenant ??= Filament::getTenant();
 
         if ($query->getModel()::class === Filament::getCurrentPanel()?->getTenantModel()) {
-            return $query->where($tenant->getTable() . '.' . $tenant->getKeyName(), $tenant->getKey());
+            return $query->whereKey($tenant);
         }
 
         $tenantOwnershipRelationship = static::getTenantOwnershipRelationship($query->getModel());


### PR DESCRIPTION
## Description

When creating a resource for the tenant model itself in a multi-tenancy panel, the following error occurs:

```php
The model [App\Models\Tenant] does not have a relationship named [tenant]. 
You can change the relationship being used by passing it to the [ownershipRelationship] 
argument of the [tenant()] method in configuration. You can change the relationship 
being used per-resource by setting it as the [$tenantOwnershipRelationshipName] 
static property on the [App\Filament\App\Resources\Tenants\TenantResource] resource class.
````

**Root Cause:**
The current tenant scoping logic attempts to find a relationship from the tenant model to itself, which doesn't exist.

**Solution:**
A check was added to detect when the resource model is the same as the panel's tenant model. In this edge case, the query is scoped directly to the current tenant instance using a `WHERE` clause on the primary key, bypassing the relationship logic entirely.

This fix preserves all existing tenant scoping behavior for other resources while resolving the edge case of tenant resources.

---

**Feature suggestions:**

- Add a dedicated test for this scenario to ensure the fix works as expected and remains covered in future changes.
- Consider scoping tenants to the HasTenants model (commonly the User model), so that each user only sees their own tenants when accessing a tenant resource in a multi-tenant panel.
- Make this scoping behavior configurable (via a setting or configuration option) to allow flexibility depending on project requirements.

## Functional changes

* [x] Code style has been fixed by running the `composer cs` command.
* [x] Changes have been tested to not break existing functionality.
* [x] Documentation is up-to-date.