### PR TITLE
[4.x] Add `BackedEnum` support for money's currency and locale parameters

### DIFF
--- a/packages/infolists/src/Components/Concerns/CanFormatState.php
+++ b/packages/infolists/src/Components/Concerns/CanFormatState.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Infolists\Components\Concerns;
 
+use BackedEnum;
 use Closure;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Support\Concerns\CanConfigureCommonMark;
@@ -213,7 +214,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function money(string | Closure | null $currency = null, int | Closure $divideBy = 0, string | Closure | null $locale = null, int | Closure | null $decimalPlaces = null): static
+    public function money(string | BackedEnum | Closure | null $currency = null, int | Closure $divideBy = 0, string | BackedEnum | Closure | null $locale = null, int | Closure | null $decimalPlaces = null): static
     {
         $this->isMoney = true;
 
@@ -232,6 +233,14 @@ trait CanFormatState
 
             if ($divideBy = $component->evaluate($divideBy)) {
                 $state /= $divideBy;
+            }
+
+            if ($currency instanceof BackedEnum) {
+                $currency = (string) $currency->value;
+            }
+
+            if ($locale instanceof BackedEnum) {
+                $locale = (string) $locale->value;
             }
 
             return Number::currency($state, $currency, $locale, $decimalPlaces);

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Tables\Columns\Concerns;
 
+use BackedEnum;
 use Closure;
 use Filament\Support\Concerns\CanConfigureCommonMark;
 use Filament\Support\Contracts\HasLabel as LabelInterface;
@@ -213,7 +214,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function money(string | Closure | null $currency = null, int | Closure $divideBy = 0, string | Closure | null $locale = null, int | Closure | null $decimalPlaces = null): static
+    public function money(string | BackedEnum | Closure | null $currency = null, int | Closure $divideBy = 0, string | BackedEnum | Closure | null $locale = null, int | Closure | null $decimalPlaces = null): static
     {
         $this->isMoney = true;
 
@@ -232,6 +233,14 @@ trait CanFormatState
 
             if ($divideBy = $column->evaluate($divideBy)) {
                 $state /= $divideBy;
+            }
+
+            if ($currency instanceof BackedEnum) {
+                $currency = (string) $currency->value;
+            }
+
+            if ($locale instanceof BackedEnum) {
+                $locale = (string) $locale->value;
             }
 
             return Number::currency($state, $currency, $locale, $decimalPlaces);

--- a/packages/tables/src/Columns/Summarizers/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Summarizers/Concerns/CanFormatState.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Tables\Columns\Summarizers\Concerns;
 
+use BackedEnum;
 use Closure;
 use Filament\Support\Concerns\CanConfigureCommonMark;
 use Filament\Support\Enums\ArgumentValue;
@@ -47,7 +48,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function money(string | Closure | null $currency = null, int $divideBy = 0, string | Closure | null $locale = null, int | Closure | null $decimalPlaces = null): static
+    public function money(string | BackedEnum |  Closure | null $currency = null, int $divideBy = 0, string | BackedEnum | Closure | null $locale = null, int | Closure | null $decimalPlaces = null): static
     {
         $this->formatStateUsing(static function ($state, Summarizer $summarizer) use ($currency, $divideBy, $locale, $decimalPlaces): ?string {
             if (blank($state)) {
@@ -64,6 +65,14 @@ trait CanFormatState
 
             if ($divideBy) {
                 $state /= $divideBy;
+            }
+
+            if ($currency instanceof BackedEnum) {
+                $currency = (string) $currency->value;
+            }
+
+            if ($locale instanceof BackedEnum) {
+                $locale = (string) $locale->value;
             }
 
             return Number::currency($state, $currency, $locale, $decimalPlaces);

--- a/packages/tables/src/Columns/Summarizers/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Summarizers/Concerns/CanFormatState.php
@@ -48,7 +48,7 @@ trait CanFormatState
         return $this;
     }
 
-    public function money(string | BackedEnum |  Closure | null $currency = null, int $divideBy = 0, string | BackedEnum | Closure | null $locale = null, int | Closure | null $decimalPlaces = null): static
+    public function money(string | BackedEnum | Closure | null $currency = null, int $divideBy = 0, string | BackedEnum | Closure | null $locale = null, int | Closure | null $decimalPlaces = null): static
     {
         $this->formatStateUsing(static function ($state, Summarizer $summarizer) use ($currency, $divideBy, $locale, $decimalPlaces): ?string {
             if (blank($state)) {


### PR DESCRIPTION
## Description

Adds support for `BackedEnum` types in the `money()` method's `$currency` and `$locale` parameters to integrate with e.g. the PrinsFrank/standards package's standardized enum definitions.


### Problem

Currently, the method only accepts string values for currency and locale, requiring manual conversion when using standardized enums from PrinsFrank/standards or any other enums (e.g., `Currency::EUR`, `LocaleTag::EN_US`).

### Solution

Accept `BackedEnum` types alongside existing string parameters
Extract enum values using `$enum->value` within the formatting closure
Maintains backward compatibility with existing string-based usage

### Benefits

- Seamless integration with PrinsFrank/standards enums
- Type safety and IDE autocompletion for currency/locale values
- Consistent API pattern already established in the codebase
- Zero breaking changes

## Visual changes

```php
// Before
->money(Currency::USD->value, locale: LocaleTag::EN_US->value)

// After
->money(Currency::USD, locale: LocaleTag::EN_US)
```

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
