### PR TITLE
fix: unable to open another `modal` within a `modal`

### DIFF
--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -65,7 +65,11 @@
 
     <div
         @if (! $trigger->attributes->get('disabled'))
-            x-on:click="$el.nextElementSibling.dispatchEvent(new CustomEvent(@js($openEventName)))"
+            @if ($id)
+                x-on:click="$dispatch(@js($openEventName), { id: @js($id) })"
+            @else
+                x-on:click="$el.nextElementSibling.dispatchEvent(new CustomEvent(@js($openEventName)))"
+            @endif
         @endif
         {{ $trigger->attributes->except(['disabled'])->class(['fi-modal-trigger']) }}
     >
@@ -90,10 +94,11 @@
         x-on:{{ $closeEventName }}.window="if (($event.detail.id === @js($id)) && isOpen) close()"
         x-on:{{ $closeQuietlyEventName }}.window="if (($event.detail.id === @js($id)) && isOpen) closeQuietly()"
         x-on:{{ $openEventName }}.window="if (($event.detail.id === @js($id)) && (! isOpen)) open()"
+    @else
+        x-on:{{ $closeEventName }}.stop="if (isOpen) close()"
+        x-on:{{ $closeQuietlyEventName }}.stop="if (isOpen) closeQuietly()"
+        x-on:{{ $openEventName }}.stop="if (! isOpen) open()"
     @endif
-    x-on:{{ $closeEventName }}.stop="if (isOpen) close()"
-    x-on:{{ $closeQuietlyEventName }}.stop="if (isOpen) closeQuietly()"
-    x-on:{{ $openEventName }}.stop="if (! isOpen) open()"
     x-bind:class="{
         'fi-modal-open': isOpen,
     }"


### PR DESCRIPTION


<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fixes: #17630

Fixes an issue where events could not be triggered when using id in modals. Edge cases are handled where both id and trigger are used together.

view file:

``` blade
<x-filament-panels::page>
    <div>
        <div class="">
            <x-filament::button
                @click="console.log('open 1st') ; $dispatch('open-modal', { id: '1st_modal' })"
            >Open 1st
            </x-filament::button>
        </div>

        <x-filament::modal
            id="1st_modal"
            class="sections-modal"
            :slide-over="true"
        >
            This is a 1st modal

            <x-filament::button
                @click="
                    console.log('open 2nd')
                    $dispatch('open-modal', { id: '2nd_modal' })
                "
            >
                Open 2nd
            </x-filament::button>

        </x-filament::modal>

        <x-filament::modal
            id="2nd_modal"
            class="sections-modal"
            :slide-over="true"
        >
            <x-slot name="trigger">
                <x-filament::button >
                    Open 2nd (trigger)
                </x-filament::button>
            </x-slot>
            This is a 2nd modal
        </x-filament::modal>
    </div>
</x-filament-panels::page>

```


<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

# Before:


https://github.com/user-attachments/assets/c2ad5338-e69f-4e20-9174-907e485e9250

# After:

https://github.com/user-attachments/assets/602da75e-8f64-457d-b864-961a9e9f4d44




<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
