### PR TITLE
fix: prevent duplicate notifications

### DIFF
--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -292,8 +292,6 @@ trait CanExportRecords
             );
         });
 
-        $this->successNotificationTitle(__('filament-actions::export.notifications.started.title'));
-
         $this->defaultColor('gray');
 
         $this->modalWidth(static fn (ExportAction | ExportBulkAction $action): Width => match ($action->getColumnMappingColumns()) {
@@ -302,6 +300,8 @@ trait CanExportRecords
             3 => Width::FiveExtraLarge,
             default => Width::SevenExtraLarge,
         });
+
+        $this->successNotificationTitle(__('filament-actions::export.notifications.started.title'));
 
         if (! $this instanceof ExportBulkAction) {
             $this->model(fn (ExportAction $action): string => $action->getExporter()::getModel());

--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -156,12 +156,15 @@ trait CanExportRecords
             $maxRows = $action->getMaxRows() ?? $totalRows;
 
             if ($maxRows < $totalRows) {
-                $this->failureNotification(Notification::make()
-                    ->title(__('filament-actions::export.notifications.max_rows.title'))
-                    ->body(trans_choice('filament-actions::export.notifications.max_rows.body', $maxRows, [
-                        'count' => Number::format($maxRows),
-                    ]))
-                    ->danger());
+                $this->failureNotification(
+                    Notification::make()
+                        ->title(__('filament-actions::export.notifications.max_rows.title'))
+                        ->body(trans_choice('filament-actions::export.notifications.max_rows.body', $maxRows, [
+                            'count' => Number::format($maxRows),
+                        ]))
+                        ->danger()
+                );
+
                 $this->failure();
 
                 return;
@@ -269,16 +272,19 @@ trait CanExportRecords
                 )
                 ->dispatch();
 
+            $this->successNotificationTitle(__('filament-actions::export.notifications.started.title'));
             if (
                 (filled($jobConnection) && ($jobConnection !== 'sync')) ||
                 (blank($jobConnection) && (config('queue.default') !== 'sync'))
             ) {
-                $this->successNotification(Notification::make()
-                    ->title($action->getSuccessNotificationTitle())
-                    ->body(trans_choice('filament-actions::export.notifications.started.body', $export->total_rows, [
-                        'count' => Number::format($export->total_rows),
-                    ]))
-                    ->success());
+                $this->successNotification(
+                    Notification::make()
+                        ->title($action->getSuccessNotificationTitle())
+                        ->body(trans_choice('filament-actions::export.notifications.started.body', $export->total_rows, [
+                            'count' => Number::format($export->total_rows),
+                        ]))
+                        ->success()
+                );
             }
         });
 
@@ -290,8 +296,6 @@ trait CanExportRecords
             3 => Width::FiveExtraLarge,
             default => Width::SevenExtraLarge,
         });
-
-        $this->successNotificationTitle(__('filament-actions::export.notifications.started.title'));
 
         if (! $this instanceof ExportBulkAction) {
             $this->model(fn (ExportAction $action): string => $action->getExporter()::getModel());

--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -156,16 +156,16 @@ trait CanExportRecords
             $maxRows = $action->getMaxRows() ?? $totalRows;
 
             if ($maxRows < $totalRows) {
-                $this->failureNotification(
+                $action->failureNotification(
                     Notification::make()
                         ->title(__('filament-actions::export.notifications.max_rows.title'))
                         ->body(trans_choice('filament-actions::export.notifications.max_rows.body', $maxRows, [
                             'count' => Number::format($maxRows),
                         ]))
-                        ->danger()
+                        ->danger(),
                 );
 
-                $this->failure();
+                $action->failure();
 
                 return;
             }
@@ -272,21 +272,27 @@ trait CanExportRecords
                 )
                 ->dispatch();
 
-            $this->successNotificationTitle(__('filament-actions::export.notifications.started.title'));
             if (
-                (filled($jobConnection) && ($jobConnection !== 'sync')) ||
-                (blank($jobConnection) && (config('queue.default') !== 'sync'))
+                ($jobConnection === 'sync')
+                || (blank($jobConnection) && (config('queue.default') === 'sync'))
             ) {
-                $this->successNotification(
-                    Notification::make()
-                        ->title($action->getSuccessNotificationTitle())
-                        ->body(trans_choice('filament-actions::export.notifications.started.body', $export->total_rows, [
-                            'count' => Number::format($export->total_rows),
-                        ]))
-                        ->success()
-                );
+                $action->successNotification(null);
+                $action->successNotificationTitle(null);
+
+                return;
             }
+
+            $action->successNotification(
+                Notification::make()
+                    ->title($action->getSuccessNotificationTitle())
+                    ->body(trans_choice('filament-actions::export.notifications.started.body', $export->total_rows, [
+                        'count' => Number::format($export->total_rows),
+                    ]))
+                    ->success(),
+            );
         });
+
+        $this->successNotificationTitle(__('filament-actions::export.notifications.started.title'));
 
         $this->defaultColor('gray');
 

--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -156,13 +156,13 @@ trait CanExportRecords
             $maxRows = $action->getMaxRows() ?? $totalRows;
 
             if ($maxRows < $totalRows) {
-                Notification::make()
+                $this->failureNotification(Notification::make()
                     ->title(__('filament-actions::export.notifications.max_rows.title'))
                     ->body(trans_choice('filament-actions::export.notifications.max_rows.body', $maxRows, [
                         'count' => Number::format($maxRows),
                     ]))
-                    ->danger()
-                    ->send();
+                    ->danger());
+                $this->failure();
 
                 return;
             }
@@ -273,13 +273,12 @@ trait CanExportRecords
                 (filled($jobConnection) && ($jobConnection !== 'sync')) ||
                 (blank($jobConnection) && (config('queue.default') !== 'sync'))
             ) {
-                Notification::make()
+                $this->successNotification(Notification::make()
                     ->title($action->getSuccessNotificationTitle())
                     ->body(trans_choice('filament-actions::export.notifications.started.body', $export->total_rows, [
                         'count' => Number::format($export->total_rows),
                     ]))
-                    ->success()
-                    ->send();
+                    ->success());
             }
         });
 

--- a/packages/actions/src/ImportAction.php
+++ b/packages/actions/src/ImportAction.php
@@ -319,67 +319,35 @@ class ImportAction extends Action
                                     ->markAsRead(),
                             ]),
                         )
-                        ->sendToDatabase($import->user, isEventDispatched: true);
+                        ->when(
+                            ($jobConnection === 'sync') ||
+                            (blank($jobConnection) && (config('queue.default') === 'sync')),
+                            fn (Notification $notification) => $notification
+                                ->persistent()
+                                ->send(),
+                            fn (Notification $notification) => $notification->sendToDatabase($import->user, isEventDispatched: true),
+                        );
                 })
                 ->dispatch();
 
             if (
-                (filled($jobConnection) && ($jobConnection !== 'sync')) ||
-                (blank($jobConnection) && (config('queue.default') !== 'sync'))
+                ($jobConnection === 'sync')
+                || (blank($jobConnection) && (config('queue.default') === 'sync'))
             ) {
-                $action->successNotification(
-                    Notification::make()
-                        ->title($action->getSuccessNotificationTitle())
-                        ->body(trans_choice('filament-actions::import.notifications.started.body', $import->total_rows, [
-                            'count' => Number::format($import->total_rows),
-                        ]))
-                        ->success(),
-                );
+                $action->successNotification(null);
+                $action->successNotificationTitle(null);
 
                 return;
             }
 
-            $import->refresh();
-
-            $failedRowsCount = $import->getFailedRowsCount();
-
-            $notification = Notification::make()
-                ->title($import->importer::getCompletedNotificationTitle($import))
-                ->body($import->importer::getCompletedNotificationBody($import))
-                ->when(
-                    ! $failedRowsCount,
-                    fn (Notification $notification) => $notification->success(),
-                )
-                ->when(
-                    $failedRowsCount && ($failedRowsCount < $import->total_rows),
-                    fn (Notification $notification) => $notification->warning(),
-                )
-                ->when(
-                    $failedRowsCount === $import->total_rows,
-                    fn (Notification $notification) => $notification->danger(),
-                )
-                ->when(
-                    $failedRowsCount,
-                    fn (Notification $notification) => $notification->actions([
-                        Action::make('downloadFailedRowsCsv')
-                            ->label(trans_choice('filament-actions::import.notifications.completed.actions.download_failed_rows_csv.label', $failedRowsCount, [
-                                'count' => Number::format($failedRowsCount),
-                            ]))
-                            ->color('danger')
-                            ->url(URL::signedRoute('filament.imports.failed-rows.download', ['authGuard' => $authGuard, 'import' => $import], absolute: false), shouldOpenInNewTab: true)
-                            ->markAsRead(),
-                    ]),
-                )
-                ->persistent();
-
-            if ($failedRowsCount > 0) {
-                $action->failureNotification($notification);
-                $action->failure();
-
-                return;
-            }
-
-            $action->successNotification($notification);
+            $action->successNotification(
+                Notification::make()
+                    ->title($action->getSuccessNotificationTitle())
+                    ->body(trans_choice('filament-actions::import.notifications.started.body', $import->total_rows, [
+                        'count' => Number::format($import->total_rows),
+                    ]))
+                    ->success(),
+            );
         });
 
         $this->registerModalActions([

--- a/packages/actions/src/ImportAction.php
+++ b/packages/actions/src/ImportAction.php
@@ -283,13 +283,6 @@ class ImportAction extends Action
                         return;
                     }
 
-                    if (
-                        ($jobConnection === 'sync')
-                        || (blank($jobConnection) && (config('queue.default') === 'sync'))
-                    ) {
-                        return;
-                    }
-
                     $failedRowsCount = $import->getFailedRowsCount();
 
                     Notification::make()

--- a/packages/actions/src/ImportAction.php
+++ b/packages/actions/src/ImportAction.php
@@ -202,13 +202,16 @@ class ImportAction extends Action
             $maxRows = $action->getMaxRows() ?? $totalRows;
 
             if ($maxRows < $totalRows) {
-                Notification::make()
-                    ->title(__('filament-actions::import.notifications.max_rows.title'))
-                    ->body(trans_choice('filament-actions::import.notifications.max_rows.body', $maxRows, [
-                        'count' => Number::format($maxRows),
-                    ]))
-                    ->danger()
-                    ->send();
+                $action->failureNotification(
+                    Notification::make()
+                        ->title(__('filament-actions::import.notifications.max_rows.title'))
+                        ->body(trans_choice('filament-actions::import.notifications.max_rows.body', $maxRows, [
+                            'count' => Number::format($maxRows),
+                        ]))
+                        ->danger(),
+                );
+
+                $action->failure();
 
                 return;
             }
@@ -280,6 +283,13 @@ class ImportAction extends Action
                         return;
                     }
 
+                    if (
+                        ($jobConnection === 'sync')
+                        || (blank($jobConnection) && (config('queue.default') === 'sync'))
+                    ) {
+                        return;
+                    }
+
                     $failedRowsCount = $import->getFailedRowsCount();
 
                     Notification::make()
@@ -309,14 +319,7 @@ class ImportAction extends Action
                                     ->markAsRead(),
                             ]),
                         )
-                        ->when(
-                            ($jobConnection === 'sync') ||
-                                (blank($jobConnection) && (config('queue.default') === 'sync')),
-                            fn (Notification $notification) => $notification
-                                ->persistent()
-                                ->send(),
-                            fn (Notification $notification) => $notification->sendToDatabase($import->user, isEventDispatched: true),
-                        );
+                        ->sendToDatabase($import->user, isEventDispatched: true);
                 })
                 ->dispatch();
 
@@ -324,14 +327,59 @@ class ImportAction extends Action
                 (filled($jobConnection) && ($jobConnection !== 'sync')) ||
                 (blank($jobConnection) && (config('queue.default') !== 'sync'))
             ) {
-                Notification::make()
-                    ->title($action->getSuccessNotificationTitle())
-                    ->body(trans_choice('filament-actions::import.notifications.started.body', $import->total_rows, [
-                        'count' => Number::format($import->total_rows),
-                    ]))
-                    ->success()
-                    ->send();
+                $action->successNotification(
+                    Notification::make()
+                        ->title($action->getSuccessNotificationTitle())
+                        ->body(trans_choice('filament-actions::import.notifications.started.body', $import->total_rows, [
+                            'count' => Number::format($import->total_rows),
+                        ]))
+                        ->success(),
+                );
+
+                return;
             }
+
+            $import->refresh();
+
+            $failedRowsCount = $import->getFailedRowsCount();
+
+            $notification = Notification::make()
+                ->title($import->importer::getCompletedNotificationTitle($import))
+                ->body($import->importer::getCompletedNotificationBody($import))
+                ->when(
+                    ! $failedRowsCount,
+                    fn (Notification $notification) => $notification->success(),
+                )
+                ->when(
+                    $failedRowsCount && ($failedRowsCount < $import->total_rows),
+                    fn (Notification $notification) => $notification->warning(),
+                )
+                ->when(
+                    $failedRowsCount === $import->total_rows,
+                    fn (Notification $notification) => $notification->danger(),
+                )
+                ->when(
+                    $failedRowsCount,
+                    fn (Notification $notification) => $notification->actions([
+                        Action::make('downloadFailedRowsCsv')
+                            ->label(trans_choice('filament-actions::import.notifications.completed.actions.download_failed_rows_csv.label', $failedRowsCount, [
+                                'count' => Number::format($failedRowsCount),
+                            ]))
+                            ->color('danger')
+                            ->url(URL::signedRoute('filament.imports.failed-rows.download', ['authGuard' => $authGuard, 'import' => $import], absolute: false), shouldOpenInNewTab: true)
+                            ->markAsRead(),
+                    ]),
+                )
+                ->persistent();
+
+            if ($failedRowsCount > 0) {
+                $action->failureNotification($notification);
+                $action->failure();
+
+                return;
+            }
+
+            $action->successNotification($notification);
         });
 
         $this->registerModalActions([


### PR DESCRIPTION
## Description
Fixes #17518
Export notifications are uniformly notified using InteractsWithActions


## Visual changes



https://github.com/user-attachments/assets/f5d88cf2-8a9b-4a50-9cce-3aea3e78f435



<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
