### PR TITLE
Correct the form of a word in the Slovak translation

### DIFF
--- a/packages/actions/resources/lang/sk/create.php
+++ b/packages/actions/resources/lang/sk/create.php
@@ -27,7 +27,7 @@ return [
         'notifications' => [
 
             'created' => [
-                'title' => 'Vytvoriť',
+                'title' => 'Vytvorené',
             ],
 
         ],


### PR DESCRIPTION
This pull request makes a minor localization update to the Slovak language resource file. The notification title for creation events has been corrected for clarity.

* Changed the notification title from 'Vytvoriť' (Create) to 'Vytvorené' (Created)

No visual or functional changes.