### PR TITLE
fix: 03-resources 01-overview.md wrong path in example, v4 structure

### DIFF
--- a/docs/03-resources/01-overview.md
+++ b/docs/03-resources/01-overview.md
@@ -206,7 +206,7 @@ Resource classes contain a `table()` method that is used to build the table on t
 By default, Filament creates a table file for you, which is referenced in the `table()` method. This is to keep your resource class clean and organized, otherwise it can get quite large:
 
 ```php
-use App\Filament\Resources\Customers\Schemas\CustomersTable;
+use App\Filament\Resources\Customers\Tables\CustomersTable;
 use Filament\Tables\Table;
 
 public static function table(Table $table): Table


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
In resources overview documentation, replaced
`use App\Filament\Resources\Customers\Schemas\CustomersTable;`
with
`use App\Filament\Resources\Customers\Tables\CustomersTable;`


## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
