### PR TITLE
Fix: QR code generation for MFA when bacon QR is installed but imagick is not

### DIFF
--- a/packages/panels/src/Auth/MultiFactor/App/AppAuthentication.php
+++ b/packages/panels/src/Auth/MultiFactor/App/AppAuthentication.php
@@ -142,11 +142,11 @@ class AppAuthentication implements MultiFactorAuthenticationProvider
             $secret,
         );
 
-        // This is a fallback for when bacon/bacon-qr-code is installed but imagick extension is not
+        // This is a fallback for when `bacon/bacon-qr-code` is installed but the `imagick` extension is not.
         if (
-            class_exists('BaconQrCode\Writer') &&
-            class_exists('BaconQrCode\Renderer\ImageRenderer') &&
-            ! extension_loaded('imagick')
+            class_exists(\BaconQrCode\Writer::class)
+            && class_exists(\BaconQrCode\Renderer\ImageRenderer::class)
+            && (! extension_loaded('imagick'))
         ) {
             $inlineQrCode = 'data:image/svg+xml;base64,' . base64_encode($inlineQrCode);
         }

--- a/packages/panels/src/Auth/MultiFactor/App/AppAuthentication.php
+++ b/packages/panels/src/Auth/MultiFactor/App/AppAuthentication.php
@@ -146,7 +146,7 @@ class AppAuthentication implements MultiFactorAuthenticationProvider
         if (
             class_exists('BaconQrCode\Writer') &&
             class_exists('BaconQrCode\Renderer\ImageRenderer') &&
-            !extension_loaded('imagick')
+            ! extension_loaded('imagick')
         ) {
             $inlineQrCode = 'data:image/svg+xml;base64,' . base64_encode($inlineQrCode);
         }

--- a/packages/panels/src/Auth/MultiFactor/App/AppAuthentication.php
+++ b/packages/panels/src/Auth/MultiFactor/App/AppAuthentication.php
@@ -136,11 +136,22 @@ class AppAuthentication implements MultiFactorAuthenticationProvider
         /** @var HasAppAuthentication $user */
         $user = Filament::auth()->user();
 
-        return $this->google2FA->getQRCodeInline(
+        $inlineQrCode = $this->google2FA->getQRCodeInline(
             $this->getBrandName(),
             $this->getHolderName($user),
             $secret,
         );
+
+        // This is a fallback for when bacon/bacon-qr-code is installed but imagick extension is not
+        if (
+            class_exists('BaconQrCode\Writer') &&
+            class_exists('BaconQrCode\Renderer\ImageRenderer') &&
+            !extension_loaded('imagick')
+        ) {
+            $inlineQrCode = 'data:image/svg+xml;base64,' . base64_encode($inlineQrCode);
+        }
+
+        return $inlineQrCode;
     }
 
     /**


### PR DESCRIPTION
## Description
This is a fix for #17710 

## Visual changes
Before:

<img width="453" height="536" alt="Image" src="https://github.com/user-attachments/assets/ed51bc5e-a204-44ed-8aee-0ae395740877" />

After (ignore the color difference):
<img width="512" height="604" alt="image" src="https://github.com/user-attachments/assets/20a0ee42-3405-4f62-bd0b-4bc643cdd1a2" />

## Functional changes
When you have bacon/bacon-qr-code installed, but do not have the imagick extension loaded it will now still generate a valid base64 encoded string to be used in the src attribute on the 2FA setup app authentication action.

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
