### PR TITLE
Add support for Htmlable to TableColumn

### DIFF
--- a/packages/forms/src/Components/Repeater/TableColumn.php
+++ b/packages/forms/src/Components/Repeater/TableColumn.php
@@ -7,6 +7,7 @@ use Filament\Support\Components\Component;
 use Filament\Support\Concerns\CanWrapHeader;
 use Filament\Support\Concerns\HasAlignment;
 use Filament\Support\Concerns\HasWidth;
+use Illuminate\Contracts\Support\Htmlable;
 
 class TableColumn extends Component
 {
@@ -20,9 +21,9 @@ class TableColumn extends Component
 
     protected bool | Closure $isMarkedAsRequired = false;
 
-    public function __construct(protected string | Closure $label) {}
+    public function __construct(protected string | Htmlable | Closure $label) {}
 
-    public static function make(string | Closure $label): static
+    public static function make(string | Htmlable | Closure $label): static
     {
         $static = app(static::class, ['label' => $label]);
 
@@ -38,7 +39,7 @@ class TableColumn extends Component
         return $this;
     }
 
-    public function getLabel(): string
+    public function getLabel(): string | Htmlable
     {
         return $this->evaluate($this->label);
     }


### PR DESCRIPTION
## Description

Hi, this small improvement enables the use of HtmlString for table repeater's columns.

Example:

```
Repeater::make('list')
    ->table([
        TableColumn::make(new HtmlString('<span style="color: #C00">Name</span>'))
    ])
```

## Visual changes

Before:

<img width="799" height="192" alt="{3A93EBFC-0196-43B4-B84F-556F4F67B873}" src="https://github.com/user-attachments/assets/90872c3a-6c2a-48ca-b399-0f6e084bdf84" />

<img width="793" height="194" alt="{4D514608-7E4E-4989-B2C8-DCE760148CA3}" src="https://github.com/user-attachments/assets/4c5e7233-341f-43e7-ba6f-469f55c9951c" />

After:

<img width="793" height="188" alt="{E1F33BB5-1438-46AC-83B5-68C6003D1AEB}" src="https://github.com/user-attachments/assets/6f862723-1e46-4262-8c55-9de0475c4c7f" />

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
