### PR TITLE
Fix:  Actions in builders no longer function since

### DIFF
--- a/packages/panels/src/Auth/MultiFactor/App/AppAuthentication.php
+++ b/packages/panels/src/Auth/MultiFactor/App/AppAuthentication.php
@@ -2,6 +2,8 @@
 
 namespace Filament\Auth\MultiFactor\App;
 
+use BaconQrCode\Renderer\ImageRenderer;
+use BaconQrCode\Writer;
 use Closure;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
@@ -144,8 +146,8 @@ class AppAuthentication implements MultiFactorAuthenticationProvider
 
         // This is a fallback for when `bacon/bacon-qr-code` is installed but the `imagick` extension is not.
         if (
-            class_exists(\BaconQrCode\Writer::class)
-            && class_exists(\BaconQrCode\Renderer\ImageRenderer::class)
+            class_exists(Writer::class)
+            && class_exists(ImageRenderer::class)
             && (! extension_loaded('imagick'))
         ) {
             $inlineQrCode = 'data:image/svg+xml;base64,' . base64_encode($inlineQrCode);

--- a/packages/schemas/src/Concerns/HasComponents.php
+++ b/packages/schemas/src/Concerns/HasComponents.php
@@ -54,24 +54,18 @@ trait HasComponents
     public function getAction(string $actionName, ?string $nestedContainerKey = null): ?Action
     {
         foreach ($this->getComponents() as $component) {
-            if (blank($nestedContainerKey)) {
-                if (
-                    ($component instanceof Action) &&
-                    ($component->getName() === $actionName)
-                ) {
-                    return $component;
-                }
-
-                if (
-                    ($component instanceof ActionGroup) &&
-                    ($action = ($component->getFlatActions()[$actionName] ?? null))
-                ) {
-                    return $action;
-                }
+            if (
+                ($component instanceof Action) &&
+                ($component->getName() === $actionName)
+            ) {
+                return $component;
             }
 
-            if (($component instanceof Action) || ($component instanceof ActionGroup)) {
-                continue;
+            if (
+                ($component instanceof ActionGroup) &&
+                ($action = ($component->getFlatActions()[$actionName] ?? null))
+            ) {
+                return $action;
             }
 
             $componentKey = $component->getKey(isAbsolute: false);
@@ -104,17 +98,7 @@ trait HasComponents
             }
 
             foreach ($component->getChildSchemas() as $childSchema) {
-                $childSchemaNestedContainerKey = $componentNestedContainerKey;
-
-                if (filled($childSchemaNestedContainerKey)) {
-                    $childSchemaName = $childSchema->getKey(isAbsolute: false);
-
-                    if (filled($childSchemaName) && str($childSchemaNestedContainerKey)->startsWith("{$childSchemaName}.")) {
-                        $childSchemaNestedContainerKey = (string) str($childSchemaNestedContainerKey)->after("{$childSchemaName}.");
-                    }
-                }
-
-                if ($action = $childSchema->getAction($actionName, $childSchemaNestedContainerKey)) {
+                if ($action = $childSchema->getAction($actionName, $componentNestedContainerKey)) {
                     return $action;
                 }
             }

--- a/packages/schemas/src/Concerns/HasComponents.php
+++ b/packages/schemas/src/Concerns/HasComponents.php
@@ -54,18 +54,24 @@ trait HasComponents
     public function getAction(string $actionName, ?string $nestedContainerKey = null): ?Action
     {
         foreach ($this->getComponents() as $component) {
-            if (
-                ($component instanceof Action) &&
-                ($component->getName() === $actionName)
-            ) {
-                return $component;
+            if (blank($nestedContainerKey)) {
+                if (
+                    ($component instanceof Action) &&
+                    ($component->getName() === $actionName)
+                ) {
+                    return $component;
+                }
+
+                if (
+                    ($component instanceof ActionGroup) &&
+                    ($action = ($component->getFlatActions()[$actionName] ?? null))
+                ) {
+                    return $action;
+                }
             }
 
-            if (
-                ($component instanceof ActionGroup) &&
-                ($action = ($component->getFlatActions()[$actionName] ?? null))
-            ) {
-                return $action;
+            if (($component instanceof Action) || ($component instanceof ActionGroup)) {
+                continue;
             }
 
             $componentKey = $component->getKey(isAbsolute: false);
@@ -98,7 +104,28 @@ trait HasComponents
             }
 
             foreach ($component->getChildSchemas() as $childSchema) {
-                if ($action = $childSchema->getAction($actionName, $componentNestedContainerKey)) {
+                $childSchemaName = $childSchema->getKey(isAbsolute: false);
+
+                if (filled($childSchemaName)) {
+                    if (blank($componentNestedContainerKey)) {
+                        continue;
+                    }
+
+                    if (
+                        ($componentNestedContainerKey !== $childSchemaName)
+                        && (! str($componentNestedContainerKey)->startsWith("{$childSchemaName}."))
+                    ) {
+                        continue;
+                    }
+
+                    $childSchemaNestedContainerKey = ($componentNestedContainerKey === $childSchemaName)
+                        ? null
+                        : (string) str($componentNestedContainerKey)->after("{$childSchemaName}.");
+                } else {
+                    $childSchemaNestedContainerKey = $componentNestedContainerKey;
+                }
+
+                if ($action = $childSchema->getAction($actionName, $childSchemaNestedContainerKey)) {
                     return $action;
                 }
             }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

fixes: #17725

added stricter checks when searching for actions within child schemas.   Now, the code only continues to search a child schema if the key matches exactly or starts with the child schema’s name, and skips the search if the key is blank or irrelevant.   This ensures more accurate and efficient action retrieval.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

https://github.com/user-attachments/assets/c90609b9-04fa-4161-87dc-16da8a646f1d


<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
