### PR TITLE
[3.x] Add repeater item numbers

### DIFF
--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -435,6 +435,20 @@ Any fields that you use from `$state` should be `live()` if you wish to see the 
 
 <AutoScreenshot name="forms/fields/repeater/labelled" alt="Repeater with item labels" version="3.x" />
 
+## Numbering repeater items
+
+Unlike Builders, items in the repeater don't have a number next to their label by default. You may enable this using the `itemNumbers(true)` method:
+
+```php
+use Filament\Forms\Components\Repeater;
+
+Repeater::make('members')
+    ->schema([
+        // ...
+    ])
+    ->itemNumbers(true)
+```
+
 ## Simple repeaters with one field
 
 You can use the `simple()` method to create a repeater with a single field, using a minimal design

--- a/packages/forms/docs/03-fields/12-repeater.md
+++ b/packages/forms/docs/03-fields/12-repeater.md
@@ -437,7 +437,7 @@ Any fields that you use from `$state` should be `live()` if you wish to see the 
 
 ## Numbering repeater items
 
-Unlike Builders, items in the repeater don't have a number next to their label by default. You may enable this using the `itemNumbers(true)` method:
+You can add the repeater item's number next to its label using the `itemNumbers()` method:
 
 ```php
 use Filament\Forms\Components\Repeater;
@@ -446,7 +446,7 @@ Repeater::make('members')
     ->schema([
         // ...
     ])
-    ->itemNumbers(true)
+    ->itemNumbers()
 ```
 
 ## Simple repeaters with one field

--- a/packages/forms/resources/views/components/repeater/index.blade.php
+++ b/packages/forms/resources/views/components/repeater/index.blade.php
@@ -15,6 +15,7 @@
     $reorderAction = $getAction($getReorderActionName());
     $extraItemActions = $getExtraItemActions();
 
+    $hasItemNumbers = $hasItemNumbers();
     $isAddable = $isAddable();
     $isCloneable = $isCloneable();
     $isCollapsible = $isCollapsible();
@@ -79,7 +80,6 @@
                     @foreach ($containers as $uuid => $item)
                         @php
                             $itemLabel = $getItemLabel($uuid);
-                            $hasItemNumbers = $hasItemNumbers();
                             $visibleExtraItemActions = array_filter(
                                 $extraItemActions,
                                 fn (Action $action): bool => $action(['item' => $uuid])->isVisible(),

--- a/packages/forms/resources/views/components/repeater/index.blade.php
+++ b/packages/forms/resources/views/components/repeater/index.blade.php
@@ -79,6 +79,7 @@
                     @foreach ($containers as $uuid => $item)
                         @php
                             $itemLabel = $getItemLabel($uuid);
+                            $hasItemNumbers = $hasItemNumbers();
                             $visibleExtraItemActions = array_filter(
                                 $extraItemActions,
                                 fn (Action $action): bool => $action(['item' => $uuid])->isVisible(),
@@ -154,6 +155,10 @@
                                             ])
                                         >
                                             {{ $itemLabel }}
+
+                                            @if ($hasItemNumbers)
+                                                {{ $loop->iteration }}
+                                            @endif
                                         </h4>
                                     @endif
 

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -54,6 +54,8 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
 
     protected string | Closure | null $itemLabel = null;
 
+    protected bool | Closure $hasItemNumbers = false;
+
     protected Field | Closure | null $simpleField = null;
 
     protected Alignment | string | Closure | null $addActionAlignment = null;
@@ -1014,6 +1016,13 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
         return $this;
     }
 
+    public function itemNumbers(bool | Closure $condition = true): static
+    {
+        $this->hasItemNumbers = $condition;
+
+        return $this;
+    }
+
     public function fillFromRelationship(): void
     {
         $this->state(
@@ -1138,6 +1147,11 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
     public function hasItemLabels(): bool
     {
         return $this->itemLabel !== null;
+    }
+
+    public function hasItemNumbers(): bool
+    {
+        return (bool) $this->evaluate($this->hasItemNumbers);
     }
 
     public function simple(Field | Closure | null $field): static


### PR DESCRIPTION
I was under the impression that repeaters had numbers just like Builders, but unfortunately that’s not the case.
Since I still have a long way to go before I can migrate my codebase to 4.x, I’m currently targeting 3.x.

Would you consider adding this feature even though 3.x is feature-complete? If needed, I’d be happy to submit a PR for 4.x as well.

Thanks!