### PR TITLE
feat(panels): add flag to toggle page head padding

### DIFF
--- a/packages/panels/resources/views/components/page/index.blade.php
+++ b/packages/panels/resources/views/components/page/index.blade.php
@@ -1,5 +1,6 @@
 @props([
     'fullHeight' => false,
+    'headerPadding' => true,
 ])
 
 @php
@@ -23,7 +24,14 @@
 >
     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_START, scopes: $this->getRenderHookScopes()) }}
 
-    <div class="fi-page-header-main-ctn">
+    <div
+        {{
+            $attributes->class([
+                'fi-page-header-main-ctn',
+                'p-0' => ! $headerPadding,
+            ])
+        }}
+    >
         @if ($subNavigation)
             <div
                 class="fi-page-main-sub-navigation-mobile-menu-render-hook-ctn"


### PR DESCRIPTION
Recently I've decided to use more often the "Guest Panel" to build landing pages and every time that I start a new project, I need to copy the vendor `filament-panels::page.index` and add a new flag to remove the padding only.

See the white gap between the edges:

<details>

<img width="1243" height="261" alt="image" src="https://github.com/user-attachments/assets/c3c6fbfd-1172-4790-b23b-8036a8437b90" />

<img width="1243" height="219" alt="image" src="https://github.com/user-attachments/assets/536d6cba-fb46-408a-bd35-da7cbc468496" />

</details>

## Proposal

By adding a new component property `headerPadding`, we can easily solve it when creating custom pages that require the navbar.

```php
@props([
    'fullHeight' => false,
    'headerPadding' => true, // added item
])

@php
    use Filament\Pages\Enums\SubNavigationPosition;

    $subNavigation = $this->getCachedSubNavigation();
    $subNavigationPosition = $this->getSubNavigationPosition();
    $widgetData = $this->getWidgetData();
@endphp
// ... rest of the component

<div
        {{
            $attributes->class([
                'fi-page-header-main-ctn',
                'p-0' => ! $headerPadding,
            ])
        }}
    >
```

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.


Closes #17730 