### PR TITLE
Allow relative links in RichEditor LinkAction

### DIFF
--- a/packages/forms/src/Components/RichEditor/Actions/LinkAction.php
+++ b/packages/forms/src/Components/RichEditor/Actions/LinkAction.php
@@ -23,8 +23,7 @@ class LinkAction
             ])
             ->schema([
                 TextInput::make('url')
-                    ->label(__('filament-forms::components.rich_editor.actions.link.modal.form.url.label'))
-                    ->url(),
+                    ->label(__('filament-forms::components.rich_editor.actions.link.modal.form.url.label')),
                 Checkbox::make('shouldOpenInNewTab')
                     ->label(__('filament-forms::components.rich_editor.actions.link.modal.form.should_open_in_new_tab.label')),
             ])

--- a/packages/forms/src/Components/RichEditor/Actions/LinkAction.php
+++ b/packages/forms/src/Components/RichEditor/Actions/LinkAction.php
@@ -23,7 +23,8 @@ class LinkAction
             ])
             ->schema([
                 TextInput::make('url')
-                    ->label(__('filament-forms::components.rich_editor.actions.link.modal.form.url.label')),
+                    ->label(__('filament-forms::components.rich_editor.actions.link.modal.form.url.label'))
+                     ->inputMode("url"),
                 Checkbox::make('shouldOpenInNewTab')
                     ->label(__('filament-forms::components.rich_editor.actions.link.modal.form.should_open_in_new_tab.label')),
             ])

--- a/packages/forms/src/Components/RichEditor/Actions/LinkAction.php
+++ b/packages/forms/src/Components/RichEditor/Actions/LinkAction.php
@@ -24,7 +24,7 @@ class LinkAction
             ->schema([
                 TextInput::make('url')
                     ->label(__('filament-forms::components.rich_editor.actions.link.modal.form.url.label'))
-                    ->inputMode("url"),
+                    ->inputMode('url'),
                 Checkbox::make('shouldOpenInNewTab')
                     ->label(__('filament-forms::components.rich_editor.actions.link.modal.form.should_open_in_new_tab.label')),
             ])

--- a/packages/forms/src/Components/RichEditor/Actions/LinkAction.php
+++ b/packages/forms/src/Components/RichEditor/Actions/LinkAction.php
@@ -24,7 +24,7 @@ class LinkAction
             ->schema([
                 TextInput::make('url')
                     ->label(__('filament-forms::components.rich_editor.actions.link.modal.form.url.label'))
-                     ->inputMode("url"),
+                    ->inputMode("url"),
                 Checkbox::make('shouldOpenInNewTab')
                     ->label(__('filament-forms::components.rich_editor.actions.link.modal.form.should_open_in_new_tab.label')),
             ])


### PR DESCRIPTION
Allow relative links in URL

## Description


## Visual changes

Reopen problem in Issue #12514 
Allow creating links with relative paths. For example, if the site is on several different domains, etc.