### PR TITLE
fix: `defaultKeySort` did not work as expected

### DIFF
--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -111,7 +111,7 @@ trait CanSortRecords
             $query = $defaultSort;
         }
 
-        if (filled($query->getQuery()->orders) && (! $this->getTable()->hasDefaultKeySort())) {
+        if (! $this->getTable()->hasDefaultKeySort()) {
             return $query;
         }
 


### PR DESCRIPTION
## Description

fixes: #17720

Hi, the [issue](https://github.com/filamentphp/filament/issues/17720) is caused by the default sorting behavior having a higher priority than `Global Scopes`, so it appears that the scopes are not taking effect. However, I noticed that the upgrade guide mentions you can use `defaultKeySort` to disable the default sorting behavior, but it doesn't work as expected, which is why I created this PR.

<img width="872" height="742" alt="image" src="https://github.com/user-attachments/assets/92ccdab6-cf2c-47c3-b0ef-2fdfa8432019" />



## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
