### PR TITLE
Fix tooltip alignment by moving x-tooltip to a span.

### DIFF
--- a/packages/infolists/resources/css/components/text.css
+++ b/packages/infolists/resources/css/components/text.css
@@ -115,6 +115,24 @@
     }
 }
 
+/* Pointer only applied to in-text-content when copyable */
+.fi-copyable > .fi-in-text-content {
+    @apply cursor-pointer;
+}
+
+/* Tooltip alignment fix for child element */
+.fi-in-text-content {
+    @apply inline-flex items-center gap-1.5;
+
+    & > .fi-icon {
+        @apply shrink-0 text-gray-400 dark:text-gray-500;
+
+        &.fi-color {
+            @apply text-color-500;
+        }
+    }
+}
+
 .fi-in-text-item {
     @apply text-gray-950 dark:text-white;
 
@@ -125,10 +143,6 @@
     &:not(.fi-bulleted li.fi-in-text-item) {
         /* Line clamping sets the `display` property of the list item to `-webkit-box` instead of `list-item`, which hides the bullet point. */
         @apply line-clamp-(--line-clamp,none);
-    }
-
-    &.fi-copyable {
-        @apply cursor-pointer;
     }
 
     &.fi-size-xs {

--- a/packages/infolists/src/Components/TextEntry.php
+++ b/packages/infolists/src/Components/TextEntry.php
@@ -196,7 +196,7 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
                 <?php } ?>
             </div>
 
-        <?php return $this->wrapEmbeddedHtml(ob_get_clean());
+            <?php return $this->wrapEmbeddedHtml(ob_get_clean());
         }
 
         $shouldOpenUrlInNewTab = $this->shouldOpenUrlInNewTab();
@@ -337,17 +337,17 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
                         ->merge([
                             'x-on:click' => $isCopyable
                                 ? <<<JS
-                            window.navigator.clipboard.writeText({$copyableStateJs})
-                            \$tooltip({$copyMessageJs}, {
-                                theme: \$store.theme,
-                                timeout: {$copyMessageDurationJs},
-                            })
-                            JS
+                                    window.navigator.clipboard.writeText({$copyableStateJs})
+                                    \$tooltip({$copyMessageJs}, {
+                                        theme: \$store.theme,
+                                        timeout: {$copyMessageDurationJs},
+                                    })
+                                    JS
                                 : null,
                             'x-tooltip' => filled($tooltip = $this->getTooltip($stateItem))
                                 ? '{
-                            content: ' . Js::from($tooltip) . ',
-                            theme: $store.theme,
+                                    content: ' . Js::from($tooltip) . ',
+                                    theme: $store.theme,
                         }'
                                 : null,
                         ], escape: false)
@@ -394,18 +394,22 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
                 ->toHtml() ?>>
                 <?php if ($isBadge) { ?>
                     <span <?= $stateItemBadgeAttributes->toHtml() ?>>
-                    <?php } else { ?>
-                        <span <?= $stateItemInnerAttributes->toHtml() ?>>
-                        <?php } ?>
+                <?php } else { ?>
+                    < <?= $stateItemInnerAttributes->toHtml() ?>>
+                <?php } ?>
 
-                        <?= $stateItemIconBeforeHtml ?>
-                        <?= $formatState($stateItem) ?>
-                        <?= $stateItemIconAfterHtml ?>
+                <?= $stateItemIconBeforeHtml ?>
+                <?= $formatState($stateItem) ?>
+                <?= $stateItemIconAfterHtml ?>
 
-                        </span>
+                <?php if ($isBadge) { ?>
+                    </span>
+                <?php } else { ?>
+                    </span>
+                <?php } ?>
             </div>
 
-        <?php return $this->wrapEmbeddedHtml(ob_get_clean());
+            <?php return $this->wrapEmbeddedHtml(ob_get_clean());
         }
 
         $attributes = $attributes

--- a/packages/infolists/src/Components/TextEntry.php
+++ b/packages/infolists/src/Components/TextEntry.php
@@ -439,70 +439,77 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
 
                 <?php if ($prefixActions || $suffixActions) { ?>
                     <div class="fi-in-text-affixed-content">
-                    <?php } ?>
+                <?php } ?>
 
-                    <ul>
-                        <?php $stateIteration = 1; ?>
+                <ul>
+                    <?php $stateIteration = 1; ?>
 
-                        <?php foreach ($state as $stateItem) { ?>
-                            <?php [
-                                'attributes' => $stateItemAttributes,
-                                'innerAttributes' => $stateItemInnerAttributes,
-                                'badgeAttributes' => $stateItemBadgeAttributes,
-                                'iconAfterHtml' => $stateItemIconAfterHtml,
-                                'iconBeforeHtml' => $stateItemIconBeforeHtml,
-                            ] = $getStateItem($stateItem); ?>
+                    <?php foreach ($state as $stateItem) { ?>
+                        <?php [
+                            'attributes' => $stateItemAttributes,
+                            'innerAttributes' => $stateItemInnerAttributes,
+                            'badgeAttributes' => $stateItemBadgeAttributes,
+                            'iconAfterHtml' => $stateItemIconAfterHtml,
+                            'iconBeforeHtml' => $stateItemIconBeforeHtml,
+                        ] = $getStateItem($stateItem); ?>
 
-                            <li
-                                <?php if ($stateIteration > $listLimit) { ?>
+                        <li
+                            <?php if ($stateIteration > $listLimit) { ?>
                                 x-show="! isLimited"
                                 x-cloak
                                 x-transition
-                                <?php } ?>
-                                <?= $stateItemAttributes->toHtml() ?>>
-                                <?php if ($isBadge) { ?>
-                                    <span <?= $stateItemBadgeAttributes->toHtml() ?>>
-                                    <?php } else { ?>
-                                        <span <?= $stateItemInnerAttributes->toHtml() ?>>
-                                        <?php } ?>
-
-                                        <?= $stateItemIconBeforeHtml ?>
-                                        <?= $formatState($stateItem) ?>
-                                        <?= $stateItemIconAfterHtml ?>
-
-                                        </span>
-                            </li>
-
-                            <?php $stateIteration++ ?>
-                        <?php } ?>
-                    </ul>
-
-                    <?php if ($stateOverListLimitCount) { ?>
-                        <div class="fi-in-text-list-limited-message">
-                            <?php if ($isLimitedListExpandable) { ?>
-                                <div
-                                    role="button"
-                                    x-on:click.prevent.stop="isLimited = false"
-                                    x-show="isLimited"
-                                    class="fi-link fi-size-xs">
-                                    <?= trans_choice('filament-infolists::components.entries.text.actions.expand_list', $stateOverListLimitCount) ?>
-                                </div>
-
-                                <div
-                                    role="button"
-                                    x-on:click.prevent.stop="isLimited = true"
-                                    x-cloak
-                                    x-show="! isLimited"
-                                    class="fi-link fi-size-xs">
-                                    <?= trans_choice('filament-infolists::components.entries.text.actions.collapse_list', $stateOverListLimitCount) ?>
-                                </div>
-                            <?php } else { ?>
-                                <?= trans_choice('filament-infolists::components.entries.text.more_list_items', $stateOverListLimitCount) ?>
                             <?php } ?>
-                        </div>
-                    <?php } ?>
+                            <?= $stateItemAttributes->toHtml() ?>
+                        >
+                            <?php if ($isBadge) { ?>
+                                <span <?= $stateItemBadgeAttributes->toHtml() ?>>
+                            <?php } else { ?>
+                                <span <?= $stateItemInnerAttributes->toHtml() ?>>
+                            <?php } ?>
 
-                    <?php if ($prefixActions || $suffixActions) { ?>
+                            <?= $stateItemIconBeforeHtml ?>
+                            <?= $formatState($stateItem) ?>
+                            <?= $stateItemIconAfterHtml ?>
+
+                            <?php if ($isBadge) { ?>
+                                </span> 
+                            <?php } else { ?>
+                                </span>
+                            <?php } ?>
+                        </li>
+
+                        <?php $stateIteration++ ?>
+                    <?php } ?>
+                </ul>
+
+                <?php if ($stateOverListLimitCount) { ?>
+                    <div class="fi-in-text-list-limited-message">
+                        <?php if ($isLimitedListExpandable) { ?>
+                            <div
+                                role="button"
+                                x-on:click.prevent.stop="isLimited = false"
+                                x-show="isLimited"
+                                class="fi-link fi-size-xs"
+                            >
+                                <?= trans_choice('filament-infolists::components.entries.text.actions.expand_list', $stateOverListLimitCount) ?>
+                            </div>
+
+                            <div
+                                role="button"
+                                x-on:click.prevent.stop="isLimited = true"
+                                x-cloak
+                                x-show="! isLimited"
+                                class="fi-link fi-size-xs"
+                            >
+                                <?= trans_choice('filament-infolists::components.entries.text.actions.collapse_list', $stateOverListLimitCount) ?>
+                            </div>
+                        <?php } else { ?>
+                            <?= trans_choice('filament-infolists::components.entries.text.more_list_items', $stateOverListLimitCount) ?>
+                        <?php } ?>
+                    </div>
+                <?php } ?>
+
+                <?php if ($prefixActions || $suffixActions) { ?>
                     </div>
                 <?php } ?>
 
@@ -515,7 +522,7 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
                 <?php } ?>
             </div>
 
-        <?php return $this->wrapEmbeddedHtml(ob_get_clean());
+            <?php return $this->wrapEmbeddedHtml(ob_get_clean());
         }
 
         ob_start(); ?>
@@ -533,21 +540,24 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
                 <li <?= $stateItemAttributes->toHtml() ?>>
                     <?php if ($isBadge) { ?>
                         <span <?= $stateItemBadgeAttributes->toHtml() ?>>
-                        <?php } else { ?>
-                            <span <?= $stateItemInnerAttributes->toHtml() ?>>
-                            <?php } ?>
+                    <?php } else { ?>
+                        <span <?= $stateItemInnerAttributes->toHtml() ?>>
+                    <?php } ?>
 
-                            <?= $stateItemIconBeforeHtml ?>
-                            <?= $formatState($stateItem) ?>
-                            <?= $stateItemIconAfterHtml ?>
+                    <?= $stateItemIconBeforeHtml ?>
+                    <?= $formatState($stateItem) ?>
+                    <?= $stateItemIconAfterHtml ?>
 
-                            </span>
+                    <?php if ($isBadge) { ?>
+                        </span>
+                    <?php } else { ?>
+                        </span>
+                    <?php } ?>
                 </li>
-
             <?php } ?>
         </ul>
 
-<?php return $this->wrapEmbeddedHtml(ob_get_clean());
+        <?php return $this->wrapEmbeddedHtml(ob_get_clean());
     }
 
     public function canWrapByDefault(): bool

--- a/packages/infolists/src/Components/TextEntry.php
+++ b/packages/infolists/src/Components/TextEntry.php
@@ -301,17 +301,17 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
                 ->merge([
                     'x-on:click' => $isCopyable
                         ? <<<JS
-                    window.navigator.clipboard.writeText({$copyableStateJs})
-                    \$tooltip({$copyMessageJs}, {
-                        theme: \$store.theme,
-                        timeout: {$copyMessageDurationJs},
-                    })
-                    JS
+                            window.navigator.clipboard.writeText({$copyableStateJs})
+                            \$tooltip({$copyMessageJs}, {
+                                theme: \$store.theme,
+                                timeout: {$copyMessageDurationJs},
+                            })
+                            JS
                         : null,
                     'x-tooltip' => filled($tooltip = $this->getTooltip($stateItem))
                         ? '{
-                    content: ' . Js::from($tooltip) . ',
-                    theme: $store.theme,
+                            content: ' . Js::from($tooltip) . ',
+                            theme: $store.theme,
                 }'
                         : null,
                 ], escape: false)

--- a/packages/infolists/src/Components/TextEntry.php
+++ b/packages/infolists/src/Components/TextEntry.php
@@ -196,7 +196,7 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
                 <?php } ?>
             </div>
 
-            <?php return $this->wrapEmbeddedHtml(ob_get_clean());
+        <?php return $this->wrapEmbeddedHtml(ob_get_clean());
         }
 
         $shouldOpenUrlInNewTab = $this->shouldOpenUrlInNewTab();
@@ -287,45 +287,70 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
                 $copyMessageDurationJs = Js::from($this->getCopyMessageDuration($stateItem));
             }
 
-            return [
-                'attributes' => (new ComponentAttributeBag)
-                    ->merge([
-                        'x-on:click' => $isCopyable
-                            ? <<<JS
-                                window.navigator.clipboard.writeText({$copyableStateJs})
-                                \$tooltip({$copyMessageJs}, {
-                                    theme: \$store.theme,
-                                    timeout: {$copyMessageDurationJs},
-                                })
-                                JS
-                            : null,
-                        'x-tooltip' => filled($tooltip = $this->getTooltip($stateItem))
-                            ? '{
-                                content: ' . Js::from($tooltip) . ',
-                                theme: $store.theme,
-                            }'
-                            : null,
-                    ], escape: false)
+            // Container attributes (WITHOUT click handler)
+            $containerAttributes = (new ComponentAttributeBag)
+                ->class([
+                    'fi-in-text-item',
+                    'fi-prose' => $isProse || $isMarkdown,
+                    (($fontFamily = $this->getFontFamily($stateItem)) instanceof FontFamily) ? "fi-font-{$fontFamily->value}" : (is_string($fontFamily) ? $fontFamily : ''),
+                    'fi-copyable' => $isCopyable,
+                ]);
+
+            // Inner content attributes (WITH both tooltip AND click handler)
+            $innerAttributes = (new ComponentAttributeBag)
+                ->merge([
+                    'x-on:click' => $isCopyable
+                        ? <<<JS
+                    window.navigator.clipboard.writeText({$copyableStateJs})
+                    \$tooltip({$copyMessageJs}, {
+                        theme: \$store.theme,
+                        timeout: {$copyMessageDurationJs},
+                    })
+                    JS
+                        : null,
+                    'x-tooltip' => filled($tooltip = $this->getTooltip($stateItem))
+                        ? '{
+                    content: ' . Js::from($tooltip) . ',
+                    theme: $store.theme,
+                }'
+                        : null,
+                ], escape: false)
+                ->class(['fi-in-text-content inline-flex items-center gap-1.5']);
+
+            if (! $isBadge) {
+                $containerAttributes = $containerAttributes
                     ->class([
-                        'fi-in-text-item',
-                        'fi-prose' => $isProse || $isMarkdown,
-                        (($fontFamily = $this->getFontFamily($stateItem)) instanceof FontFamily) ? "fi-font-{$fontFamily->value}" : (is_string($fontFamily) ? $fontFamily : ''),
-                        'fi-copyable' => $isCopyable,
+                        ($size instanceof TextSize) ? "fi-size-{$size->value}" : $size,
+                        (($weight = $this->getWeight($stateItem)) instanceof FontWeight) ? "fi-font-{$weight->value}" : (is_string($weight) ? $weight : ''),
                     ])
-                    ->when(
-                        ! $isBadge,
-                        fn (ComponentAttributeBag $attributes) => $attributes
-                            ->class([
-                                ($size instanceof TextSize) ? "fi-size-{$size->value}" : $size,
-                                (($weight = $this->getWeight($stateItem)) instanceof FontWeight) ? "fi-font-{$weight->value}" : (is_string($weight) ? $weight : ''),
-                            ])
-                            ->when($lineClamp, fn (ComponentAttributeBag $attributes) => $attributes->style([
-                                "--line-clamp: {$lineClamp}",
-                            ]))
-                            ->color(ItemComponent::class, $color)
-                    ),
+                    ->when($lineClamp, fn (ComponentAttributeBag $attributes) => $attributes->style([
+                        "--line-clamp: {$lineClamp}",
+                    ]))
+                    ->color(ItemComponent::class, $color);
+            }
+
+            return [
+                'attributes' => $containerAttributes,
+                'innerAttributes' => $innerAttributes,
                 'badgeAttributes' => $isBadge
                     ? (new ComponentAttributeBag)
+                        ->merge([
+                            'x-on:click' => $isCopyable
+                                ? <<<JS
+                            window.navigator.clipboard.writeText({$copyableStateJs})
+                            \$tooltip({$copyMessageJs}, {
+                                theme: \$store.theme,
+                                timeout: {$copyMessageDurationJs},
+                            })
+                            JS
+                                : null,
+                            'x-tooltip' => filled($tooltip = $this->getTooltip($stateItem))
+                                ? '{
+                            content: ' . Js::from($tooltip) . ',
+                            theme: $store.theme,
+                        }'
+                                : null,
+                        ], escape: false)
                         ->class([
                             'fi-badge',
                             ($size instanceof TextSize) ? "fi-size-{$size->value}" : $size,
@@ -356,6 +381,7 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
             $stateItem = Arr::first($state);
             [
                 'attributes' => $stateItemAttributes,
+                'innerAttributes' => $stateItemInnerAttributes,
                 'badgeAttributes' => $stateItemBadgeAttributes,
                 'iconAfterHtml' => $stateItemIconAfterHtml,
                 'iconBeforeHtml' => $stateItemIconBeforeHtml,
@@ -367,19 +393,19 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
                 ->merge($stateItemAttributes->getAttributes(), escape: false)
                 ->toHtml() ?>>
                 <?php if ($isBadge) { ?>
-                <span <?= $stateItemBadgeAttributes->toHtml() ?>>
-                <?php } ?>
+                    <span <?= $stateItemBadgeAttributes->toHtml() ?>>
+                    <?php } else { ?>
+                        <span <?= $stateItemInnerAttributes->toHtml() ?>>
+                        <?php } ?>
 
-                <?= $stateItemIconBeforeHtml ?>
-                <?= $formatState($stateItem) ?>
-                <?= $stateItemIconAfterHtml ?>
+                        <?= $stateItemIconBeforeHtml ?>
+                        <?= $formatState($stateItem) ?>
+                        <?= $stateItemIconAfterHtml ?>
 
-                <?php if ($isBadge) { ?>
-                    </span>
-            <?php } ?>
+                        </span>
             </div>
 
-            <?php return $this->wrapEmbeddedHtml(ob_get_clean());
+        <?php return $this->wrapEmbeddedHtml(ob_get_clean());
         }
 
         $attributes = $attributes
@@ -413,72 +439,70 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
 
                 <?php if ($prefixActions || $suffixActions) { ?>
                     <div class="fi-in-text-affixed-content">
-                <?php } ?>
+                    <?php } ?>
 
-                <ul>
-                    <?php $stateIteration = 1; ?>
+                    <ul>
+                        <?php $stateIteration = 1; ?>
 
-                    <?php foreach ($state as $stateItem) { ?>
-                        <?php [
-                            'attributes' => $stateItemAttributes,
-                            'badgeAttributes' => $stateItemBadgeAttributes,
-                            'iconAfterHtml' => $stateItemIconAfterHtml,
-                            'iconBeforeHtml' => $stateItemIconBeforeHtml,
-                        ] = $getStateItem($stateItem); ?>
+                        <?php foreach ($state as $stateItem) { ?>
+                            <?php [
+                                'attributes' => $stateItemAttributes,
+                                'innerAttributes' => $stateItemInnerAttributes,
+                                'badgeAttributes' => $stateItemBadgeAttributes,
+                                'iconAfterHtml' => $stateItemIconAfterHtml,
+                                'iconBeforeHtml' => $stateItemIconBeforeHtml,
+                            ] = $getStateItem($stateItem); ?>
 
-                        <li
-                            <?php if ($stateIteration > $listLimit) { ?>
+                            <li
+                                <?php if ($stateIteration > $listLimit) { ?>
                                 x-show="! isLimited"
                                 x-cloak
                                 x-transition
-                            <?php } ?>
-                            <?= $stateItemAttributes->toHtml() ?>
-                        >
-                            <?php if ($isBadge) { ?>
-                            <span <?= $stateItemBadgeAttributes->toHtml() ?>>
-                            <?php } ?>
+                                <?php } ?>
+                                <?= $stateItemAttributes->toHtml() ?>>
+                                <?php if ($isBadge) { ?>
+                                    <span <?= $stateItemBadgeAttributes->toHtml() ?>>
+                                    <?php } else { ?>
+                                        <span <?= $stateItemInnerAttributes->toHtml() ?>>
+                                        <?php } ?>
 
-                            <?= $stateItemIconBeforeHtml ?>
-                            <?= $formatState($stateItem) ?>
-                            <?= $stateItemIconAfterHtml ?>
+                                        <?= $stateItemIconBeforeHtml ?>
+                                        <?= $formatState($stateItem) ?>
+                                        <?= $stateItemIconAfterHtml ?>
 
-                            <?php if ($isBadge) { ?>
-                                </span>
+                                        </span>
+                            </li>
+
+                            <?php $stateIteration++ ?>
                         <?php } ?>
-                        </li>
+                    </ul>
 
-                        <?php $stateIteration++ ?>
+                    <?php if ($stateOverListLimitCount) { ?>
+                        <div class="fi-in-text-list-limited-message">
+                            <?php if ($isLimitedListExpandable) { ?>
+                                <div
+                                    role="button"
+                                    x-on:click.prevent.stop="isLimited = false"
+                                    x-show="isLimited"
+                                    class="fi-link fi-size-xs">
+                                    <?= trans_choice('filament-infolists::components.entries.text.actions.expand_list', $stateOverListLimitCount) ?>
+                                </div>
+
+                                <div
+                                    role="button"
+                                    x-on:click.prevent.stop="isLimited = true"
+                                    x-cloak
+                                    x-show="! isLimited"
+                                    class="fi-link fi-size-xs">
+                                    <?= trans_choice('filament-infolists::components.entries.text.actions.collapse_list', $stateOverListLimitCount) ?>
+                                </div>
+                            <?php } else { ?>
+                                <?= trans_choice('filament-infolists::components.entries.text.more_list_items', $stateOverListLimitCount) ?>
+                            <?php } ?>
+                        </div>
                     <?php } ?>
-                </ul>
 
-                <?php if ($stateOverListLimitCount) { ?>
-                    <div class="fi-in-text-list-limited-message">
-                        <?php if ($isLimitedListExpandable) { ?>
-                            <div
-                                role="button"
-                                x-on:click.prevent.stop="isLimited = false"
-                                x-show="isLimited"
-                                class="fi-link fi-size-xs"
-                            >
-                                <?= trans_choice('filament-infolists::components.entries.text.actions.expand_list', $stateOverListLimitCount) ?>
-                            </div>
-
-                            <div
-                                role="button"
-                                x-on:click.prevent.stop="isLimited = true"
-                                x-cloak
-                                x-show="! isLimited"
-                                class="fi-link fi-size-xs"
-                            >
-                                <?= trans_choice('filament-infolists::components.entries.text.actions.collapse_list', $stateOverListLimitCount) ?>
-                            </div>
-                        <?php } else { ?>
-                            <?= trans_choice('filament-infolists::components.entries.text.more_list_items', $stateOverListLimitCount) ?>
-                        <?php } ?>
-                    </div>
-                <?php } ?>
-
-                <?php if ($prefixActions || $suffixActions) { ?>
+                    <?php if ($prefixActions || $suffixActions) { ?>
                     </div>
                 <?php } ?>
 
@@ -491,7 +515,7 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
                 <?php } ?>
             </div>
 
-            <?php return $this->wrapEmbeddedHtml(ob_get_clean());
+        <?php return $this->wrapEmbeddedHtml(ob_get_clean());
         }
 
         ob_start(); ?>
@@ -500,6 +524,7 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
             <?php foreach ($state as $stateItem) { ?>
                 <?php [
                     'attributes' => $stateItemAttributes,
+                    'innerAttributes' => $stateItemInnerAttributes,
                     'badgeAttributes' => $stateItemBadgeAttributes,
                     'iconAfterHtml' => $stateItemIconAfterHtml,
                     'iconBeforeHtml' => $stateItemIconBeforeHtml,
@@ -507,21 +532,22 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
 
                 <li <?= $stateItemAttributes->toHtml() ?>>
                     <?php if ($isBadge) { ?>
-                    <span <?= $stateItemBadgeAttributes->toHtml() ?>>
-                    <?php } ?>
+                        <span <?= $stateItemBadgeAttributes->toHtml() ?>>
+                        <?php } else { ?>
+                            <span <?= $stateItemInnerAttributes->toHtml() ?>>
+                            <?php } ?>
 
-                    <?= $stateItemIconBeforeHtml ?>
-                    <?= $formatState($stateItem) ?>
-                    <?= $stateItemIconAfterHtml ?>
+                            <?= $stateItemIconBeforeHtml ?>
+                            <?= $formatState($stateItem) ?>
+                            <?= $stateItemIconAfterHtml ?>
 
-                    <?php if ($isBadge) { ?>
-                        </span>
-                <?php } ?>
+                            </span>
                 </li>
+
             <?php } ?>
         </ul>
 
-        <?php return $this->wrapEmbeddedHtml(ob_get_clean());
+<?php return $this->wrapEmbeddedHtml(ob_get_clean());
     }
 
     public function canWrapByDefault(): bool

--- a/packages/tables/resources/css/columns/text.css
+++ b/packages/tables/resources/css/columns/text.css
@@ -109,6 +109,18 @@
     }
 }
 
+.fi-copyable > .fi-ta-text-content {
+    @apply cursor-pointer;
+}
+
+.fi-ta-text-content {
+    @apply inline-flex items-center gap-1.5;
+
+    & > .fi-icon {
+        @apply shrink-0 text-gray-400 dark:text-gray-500;
+    }
+}
+
 .fi-ta-text-item {
     @apply text-gray-950 dark:text-white;
 
@@ -119,10 +131,6 @@
     &:not(.fi-bulleted li.fi-ta-text-item) {
         /* Line clamping sets the `display` property of the list item to `-webkit-box` instead of `list-item`, which hides the bullet point. */
         @apply line-clamp-(--line-clamp,none);
-    }
-
-    &.fi-copyable {
-        @apply cursor-pointer;
     }
 
     &.fi-size-xs {

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -205,7 +205,7 @@ class TextColumn extends Column implements HasEmbeddedView
                 <?php } ?>
             </div>
 
-        <?php return ob_get_clean();
+            <?php return ob_get_clean();
         }
 
         $shouldOpenUrlInNewTab = $this->shouldOpenUrlInNewTab();
@@ -250,14 +250,14 @@ class TextColumn extends Column implements HasEmbeddedView
                 implode(
                     ', ',
                     array_map(
-                        fn (mixed $stateItem): string => $formatState($stateItem),
+                        fn(mixed $stateItem): string => $formatState($stateItem),
                         $state,
                     ),
                 ),
             ];
 
             $stateCount = 1;
-            $formatState = fn (mixed $stateItem): string => $stateItem;
+            $formatState = fn(mixed $stateItem): string => $stateItem;
         }
 
         $attributes = $attributes
@@ -278,10 +278,10 @@ class TextColumn extends Column implements HasEmbeddedView
 
             $iconHtml = generate_icon_html($this->getIcon($stateItem), attributes: (new ComponentAttributeBag)
                 ->color(IconComponent::class, $iconColor), size: match ($size) {
-                    TextSize::Medium => IconSize::Medium,
-                    TextSize::Large => IconSize::Large,
-                    default => IconSize::Small,
-                })?->toHtml();
+                TextSize::Medium => IconSize::Medium,
+                TextSize::Large => IconSize::Large,
+                default => IconSize::Small,
+            })?->toHtml();
 
             $isCopyable = $this->isCopyable($stateItem);
 
@@ -326,7 +326,7 @@ class TextColumn extends Column implements HasEmbeddedView
                         ($size instanceof TextSize) ? "fi-size-{$size->value}" : $size,
                         (($weight = $this->getWeight($stateItem)) instanceof FontWeight) ? "fi-font-{$weight->value}" : (is_string($weight) ? $weight : ''),
                     ])
-                    ->when($lineClamp, fn (ComponentAttributeBag $attributes) => $attributes->style([
+                    ->when($lineClamp, fn(ComponentAttributeBag $attributes) => $attributes->style([
                         "--line-clamp: {$lineClamp}",
                     ]))
                     ->color(ItemComponent::class, $color);
@@ -337,28 +337,28 @@ class TextColumn extends Column implements HasEmbeddedView
                 'innerAttributes' => $innerAttributes,
                 'badgeAttributes' => $isBadge
                     ? (new ComponentAttributeBag)
-                        ->merge([
-                            'x-on:click' => $isCopyable
-                                ? <<<JS
+                    ->merge([
+                        'x-on:click' => $isCopyable
+                            ? <<<JS
                             window.navigator.clipboard.writeText({$copyableStateJs})
                             \$tooltip({$copyMessageJs}, {
                                 theme: \$store.theme,
                                 timeout: {$copyMessageDurationJs},
                             })
                             JS
-                                : null,
-                            'x-tooltip' => filled($tooltip = $this->getTooltip($stateItem))
-                                ? '{
+                            : null,
+                        'x-tooltip' => filled($tooltip = $this->getTooltip($stateItem))
+                            ? '{
                             content: ' . Js::from($tooltip) . ',
                             theme: $store.theme,
                         }'
-                                : null,
-                        ], escape: false)
-                        ->class([
-                            'fi-badge',
-                            ($size instanceof TextSize) ? "fi-size-{$size->value}" : $size,
-                        ])
-                        ->color(BadgeComponent::class, $color ?? 'primary')
+                            : null,
+                    ], escape: false)
+                    ->class([
+                        'fi-badge',
+                        ($size instanceof TextSize) ? "fi-size-{$size->value}" : $size,
+                    ])
+                    ->color(BadgeComponent::class, $color ?? 'primary')
                     : null,
                 'iconAfterHtml' => ($iconPosition === IconPosition::After) ? $iconHtml : '',
                 'iconBeforeHtml' => ($iconPosition === IconPosition::Before) ? $iconHtml : '',
@@ -386,26 +386,26 @@ class TextColumn extends Column implements HasEmbeddedView
             ob_start(); ?>
 
             <div <?= $attributes
-                ->merge($stateItemAttributes->getAttributes(), escape: false)
-                ->toHtml() ?>>
+                        ->merge($stateItemAttributes->getAttributes(), escape: false)
+                        ->toHtml() ?>>
                 <?php if ($isBadge) { ?>
                     <span <?= $stateItemBadgeAttributes->toHtml() ?>>
-                    <?php } else { ?>
-                        <span <?= $stateItemInnerAttributes->toHtml() ?>>
-                        <?php } ?>
+                <?php } else { ?>
+                    <span <?= $stateItemInnerAttributes->toHtml() ?>>
+                <?php } ?>
 
-                        <?= $stateItemIconBeforeHtml ?>
-                        <?= $formatState($stateItem) ?>
-                        <?= $stateItemIconAfterHtml ?>
+                <?= $stateItemIconBeforeHtml ?>
+                <?= $formatState($stateItem) ?>
+                <?= $stateItemIconAfterHtml ?>
 
-                        <?php if ($isBadge) { ?>
-                        </span>
-                    <?php } else { ?>
+                <?php if ($isBadge) { ?>
+                    </span>
+                <?php } else { ?>
                     </span>
                 <?php } ?>
             </div>
 
-        <?php return ob_get_clean();
+            <?php return ob_get_clean();
         }
 
         $attributes = $attributes
@@ -437,7 +437,7 @@ class TextColumn extends Column implements HasEmbeddedView
 
                 <?php if (($stateCount === 1) && (! $isBulleted)) { ?>
                     <?php
-                    $stateItem = Arr::first($state);
+                        $stateItem = Arr::first($state);
                     [
                         'attributes' => $stateItemAttributes,
                         'innerAttributes' => $stateItemInnerAttributes,
@@ -450,17 +450,17 @@ class TextColumn extends Column implements HasEmbeddedView
                     <p <?= $stateItemAttributes->toHtml() ?>>
                         <?php if ($isBadge) { ?>
                             <span <?= $stateItemBadgeAttributes->toHtml() ?>>
-                            <?php } else { ?>
-                                <span <?= $stateItemInnerAttributes->toHtml() ?>>
-                                <?php } ?>
+                        <?php } else { ?>
+                            <span <?= $stateItemInnerAttributes->toHtml() ?>>
+                        <?php } ?>
 
-                                <?= $stateItemIconBeforeHtml ?>
-                                <?= $formatState($stateItem) ?>
-                                <?= $stateItemIconAfterHtml ?>
+                        <?= $stateItemIconBeforeHtml ?>
+                        <?= $formatState($stateItem) ?>
+                        <?= $stateItemIconAfterHtml ?>
 
-                                <?php if ($isBadge) { ?>
-                                </span>
-                            <?php } else { ?>
+                        <?php if ($isBadge) { ?>
+                            </span>
+                        <?php } else { ?>
                             </span>
                         <?php } ?>
                     </p>
@@ -479,24 +479,25 @@ class TextColumn extends Column implements HasEmbeddedView
 
                             <li
                                 <?php if ($stateIteration > $listLimit) { ?>
-                                x-show="! isLimited"
-                                x-cloak
-                                x-transition
+                                    x-show="! isLimited"
+                                    x-cloak
+                                    x-transition
                                 <?php } ?>
-                                <?= $stateItemAttributes->toHtml() ?>>
+                                <?= $stateItemAttributes->toHtml() ?>
+                            >
                                 <?php if ($isBadge) { ?>
                                     <span <?= $stateItemBadgeAttributes->toHtml() ?>>
-                                    <?php } else { ?>
-                                        <span <?= $stateItemInnerAttributes->toHtml() ?>>
-                                        <?php } ?>
+                                <?php } else { ?>
+                                    <span <?= $stateItemInnerAttributes->toHtml() ?>>
+                                <?php } ?>
 
-                                        <?= $stateItemIconBeforeHtml ?>
-                                        <?= $formatState($stateItem) ?>
-                                        <?= $stateItemIconAfterHtml ?>
+                                <?= $stateItemIconBeforeHtml ?>
+                                <?= $formatState($stateItem) ?>
+                                <?= $stateItemIconAfterHtml ?>
 
-                                        <?php if ($isBadge) { ?>
-                                        </span>
-                                    <?php } else { ?>
+                                <?php if ($isBadge) { ?>
+                                    </span>
+                                <?php } else { ?>
                                     </span>
                                 <?php } ?>
                             </li>
@@ -513,7 +514,8 @@ class TextColumn extends Column implements HasEmbeddedView
                                 role="button"
                                 x-on:click.prevent.stop="isLimited = false"
                                 x-show="isLimited"
-                                class="fi-link fi-size-xs">
+                                class="fi-link fi-size-xs"
+                            >
                                 <?= trans_choice('filament-tables::table.columns.text.actions.expand_list', $stateOverListLimitCount) ?>
                             </div>
 
@@ -522,7 +524,8 @@ class TextColumn extends Column implements HasEmbeddedView
                                 x-on:click.prevent.stop="isLimited = true"
                                 x-cloak
                                 x-show="! isLimited"
-                                class="fi-link fi-size-xs">
+                                class="fi-link fi-size-xs"
+                            >
                                 <?= trans_choice('filament-tables::table.columns.text.actions.collapse_list', $stateOverListLimitCount) ?>
                             </div>
                         <?php } else { ?>
@@ -538,7 +541,7 @@ class TextColumn extends Column implements HasEmbeddedView
                 <?php } ?>
             </div>
 
-        <?php return ob_get_clean();
+            <?php return ob_get_clean();
         }
 
         ob_start(); ?>
@@ -556,17 +559,17 @@ class TextColumn extends Column implements HasEmbeddedView
                 <li <?= $stateItemAttributes->toHtml() ?>>
                     <?php if ($isBadge) { ?>
                         <span <?= $stateItemBadgeAttributes->toHtml() ?>>
-                        <?php } else { ?>
-                            <span <?= $stateItemInnerAttributes->toHtml() ?>>
-                            <?php } ?>
+                    <?php } else { ?>
+                        <span <?= $stateItemInnerAttributes->toHtml() ?>>
+                    <?php } ?>
 
-                            <?= $stateItemIconBeforeHtml ?>
-                            <?= $formatState($stateItem) ?>
-                            <?= $stateItemIconAfterHtml ?>
+                    <?= $stateItemIconBeforeHtml ?>
+                    <?= $formatState($stateItem) ?>
+                    <?= $stateItemIconAfterHtml ?>
 
-                            <?php if ($isBadge) { ?>
-                            </span>
-                        <?php } else { ?>
+                    <?php if ($isBadge) { ?>
+                        </span>
+                    <?php } else { ?>
                         </span>
                     <?php } ?>
                 </li>

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -278,10 +278,10 @@ class TextColumn extends Column implements HasEmbeddedView
 
             $iconHtml = generate_icon_html($this->getIcon($stateItem), attributes: (new ComponentAttributeBag)
                 ->color(IconComponent::class, $iconColor), size: match ($size) {
-                TextSize::Medium => IconSize::Medium,
-                TextSize::Large => IconSize::Large,
-                default => IconSize::Small,
-            })?->toHtml();
+                    TextSize::Medium => IconSize::Medium,
+                    TextSize::Large => IconSize::Large,
+                    default => IconSize::Small,
+                })?->toHtml();
 
             $isCopyable = $this->isCopyable($stateItem);
 
@@ -340,17 +340,17 @@ class TextColumn extends Column implements HasEmbeddedView
                     ->merge([
                         'x-on:click' => $isCopyable
                             ? <<<JS
-                            window.navigator.clipboard.writeText({$copyableStateJs})
-                            \$tooltip({$copyMessageJs}, {
-                                theme: \$store.theme,
-                                timeout: {$copyMessageDurationJs},
-                            })
-                            JS
+                                window.navigator.clipboard.writeText({$copyableStateJs})
+                                \$tooltip({$copyMessageJs}, {
+                                    theme: \$store.theme,
+                                    timeout: {$copyMessageDurationJs},
+                                })
+                                JS
                             : null,
                         'x-tooltip' => filled($tooltip = $this->getTooltip($stateItem))
                             ? '{
-                            content: ' . Js::from($tooltip) . ',
-                            theme: $store.theme,
+                                content: ' . Js::from($tooltip) . ',
+                                theme: $store.theme,
                         }'
                             : null,
                     ], escape: false)
@@ -386,8 +386,8 @@ class TextColumn extends Column implements HasEmbeddedView
             ob_start(); ?>
 
             <div <?= $attributes
-                        ->merge($stateItemAttributes->getAttributes(), escape: false)
-                        ->toHtml() ?>>
+                ->merge($stateItemAttributes->getAttributes(), escape: false)
+                ->toHtml() ?>>
                 <?php if ($isBadge) { ?>
                     <span <?= $stateItemBadgeAttributes->toHtml() ?>>
                 <?php } else { ?>
@@ -576,6 +576,6 @@ class TextColumn extends Column implements HasEmbeddedView
             <?php } ?>
         </ul>
 
-<?php return ob_get_clean();
+        <?php return ob_get_clean();
     }
 }

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -205,7 +205,7 @@ class TextColumn extends Column implements HasEmbeddedView
                 <?php } ?>
             </div>
 
-            <?php return ob_get_clean();
+        <?php return ob_get_clean();
         }
 
         $shouldOpenUrlInNewTab = $this->shouldOpenUrlInNewTab();
@@ -291,44 +291,69 @@ class TextColumn extends Column implements HasEmbeddedView
                 $copyMessageDurationJs = Js::from($this->getCopyMessageDuration($stateItem));
             }
 
-            return [
-                'attributes' => (new ComponentAttributeBag)
-                    ->merge([
-                        'x-on:click' => $isCopyable
-                            ? <<<JS
-                                window.navigator.clipboard.writeText({$copyableStateJs})
-                                \$tooltip({$copyMessageJs}, {
-                                    theme: \$store.theme,
-                                    timeout: {$copyMessageDurationJs},
-                                })
-                                JS
-                            : null,
-                        'x-tooltip' => filled($tooltip = $this->getTooltip($stateItem))
-                            ? '{
-                                content: ' . Js::from($tooltip) . ',
-                                theme: $store.theme,
-                            }'
-                            : null,
-                    ], escape: false)
+            // Container attributes (WITHOUT click handler)
+            $containerAttributes = (new ComponentAttributeBag)
+                ->class([
+                    'fi-ta-text-item',
+                    (($fontFamily = $this->getFontFamily($stateItem)) instanceof FontFamily) ? "fi-font-{$fontFamily->value}" : (is_string($fontFamily) ? $fontFamily : ''),
+                    'fi-copyable' => $isCopyable,
+                ]);
+
+            // Inner content attributes (WITH both tooltip AND click handler)
+            $innerAttributes = (new ComponentAttributeBag)
+                ->merge([
+                    'x-on:click' => $isCopyable
+                        ? <<<JS
+                    window.navigator.clipboard.writeText({$copyableStateJs})
+                    \$tooltip({$copyMessageJs}, {
+                        theme: \$store.theme,
+                        timeout: {$copyMessageDurationJs},
+                    })
+                    JS
+                        : null,
+                    'x-tooltip' => filled($tooltip = $this->getTooltip($stateItem))
+                        ? '{
+                    content: ' . Js::from($tooltip) . ',
+                    theme: $store.theme,
+                }'
+                        : null,
+                ], escape: false)
+                ->class(['fi-ta-text-content']);
+
+            if (! $isBadge) {
+                $containerAttributes = $containerAttributes
                     ->class([
-                        'fi-ta-text-item',
-                        (($fontFamily = $this->getFontFamily($stateItem)) instanceof FontFamily) ? "fi-font-{$fontFamily->value}" : (is_string($fontFamily) ? $fontFamily : ''),
-                        'fi-copyable' => $isCopyable,
+                        ($size instanceof TextSize) ? "fi-size-{$size->value}" : $size,
+                        (($weight = $this->getWeight($stateItem)) instanceof FontWeight) ? "fi-font-{$weight->value}" : (is_string($weight) ? $weight : ''),
                     ])
-                    ->when(
-                        ! $isBadge,
-                        fn (ComponentAttributeBag $attributes) => $attributes
-                            ->class([
-                                ($size instanceof TextSize) ? "fi-size-{$size->value}" : $size,
-                                (($weight = $this->getWeight($stateItem)) instanceof FontWeight) ? "fi-font-{$weight->value}" : (is_string($weight) ? $weight : ''),
-                            ])
-                            ->when($lineClamp, fn (ComponentAttributeBag $attributes) => $attributes->style([
-                                "--line-clamp: {$lineClamp}",
-                            ]))
-                            ->color(ItemComponent::class, $color)
-                    ),
+                    ->when($lineClamp, fn (ComponentAttributeBag $attributes) => $attributes->style([
+                        "--line-clamp: {$lineClamp}",
+                    ]))
+                    ->color(ItemComponent::class, $color);
+            }
+
+            return [
+                'attributes' => $containerAttributes,
+                'innerAttributes' => $innerAttributes,
                 'badgeAttributes' => $isBadge
                     ? (new ComponentAttributeBag)
+                        ->merge([
+                            'x-on:click' => $isCopyable
+                                ? <<<JS
+                            window.navigator.clipboard.writeText({$copyableStateJs})
+                            \$tooltip({$copyMessageJs}, {
+                                theme: \$store.theme,
+                                timeout: {$copyMessageDurationJs},
+                            })
+                            JS
+                                : null,
+                            'x-tooltip' => filled($tooltip = $this->getTooltip($stateItem))
+                                ? '{
+                            content: ' . Js::from($tooltip) . ',
+                            theme: $store.theme,
+                        }'
+                                : null,
+                        ], escape: false)
                         ->class([
                             'fi-badge',
                             ($size instanceof TextSize) ? "fi-size-{$size->value}" : $size,
@@ -352,6 +377,7 @@ class TextColumn extends Column implements HasEmbeddedView
             $stateItem = Arr::first($state);
             [
                 'attributes' => $stateItemAttributes,
+                'innerAttributes' => $stateItemInnerAttributes,
                 'badgeAttributes' => $stateItemBadgeAttributes,
                 'iconAfterHtml' => $stateItemIconAfterHtml,
                 'iconBeforeHtml' => $stateItemIconBeforeHtml,
@@ -364,18 +390,22 @@ class TextColumn extends Column implements HasEmbeddedView
                 ->toHtml() ?>>
                 <?php if ($isBadge) { ?>
                     <span <?= $stateItemBadgeAttributes->toHtml() ?>>
-                <?php } ?>
+                    <?php } else { ?>
+                        <span <?= $stateItemInnerAttributes->toHtml() ?>>
+                        <?php } ?>
 
-                <?= $stateItemIconBeforeHtml ?>
-                <?= $formatState($stateItem) ?>
-                <?= $stateItemIconAfterHtml ?>
+                        <?= $stateItemIconBeforeHtml ?>
+                        <?= $formatState($stateItem) ?>
+                        <?= $stateItemIconAfterHtml ?>
 
-                <?php if ($isBadge) { ?>
+                        <?php if ($isBadge) { ?>
+                        </span>
+                    <?php } else { ?>
                     </span>
                 <?php } ?>
             </div>
 
-            <?php return ob_get_clean();
+        <?php return ob_get_clean();
         }
 
         $attributes = $attributes
@@ -407,9 +437,10 @@ class TextColumn extends Column implements HasEmbeddedView
 
                 <?php if (($stateCount === 1) && (! $isBulleted)) { ?>
                     <?php
-                        $stateItem = Arr::first($state);
+                    $stateItem = Arr::first($state);
                     [
                         'attributes' => $stateItemAttributes,
+                        'innerAttributes' => $stateItemInnerAttributes,
                         'badgeAttributes' => $stateItemBadgeAttributes,
                         'iconAfterHtml' => $stateItemIconAfterHtml,
                         'iconBeforeHtml' => $stateItemIconBeforeHtml,
@@ -419,13 +450,17 @@ class TextColumn extends Column implements HasEmbeddedView
                     <p <?= $stateItemAttributes->toHtml() ?>>
                         <?php if ($isBadge) { ?>
                             <span <?= $stateItemBadgeAttributes->toHtml() ?>>
-                        <?php } ?>
+                            <?php } else { ?>
+                                <span <?= $stateItemInnerAttributes->toHtml() ?>>
+                                <?php } ?>
 
-                        <?= $stateItemIconBeforeHtml ?>
-                        <?= $formatState($stateItem) ?>
-                        <?= $stateItemIconAfterHtml ?>
+                                <?= $stateItemIconBeforeHtml ?>
+                                <?= $formatState($stateItem) ?>
+                                <?= $stateItemIconAfterHtml ?>
 
-                        <?php if ($isBadge) { ?>
+                                <?php if ($isBadge) { ?>
+                                </span>
+                            <?php } else { ?>
                             </span>
                         <?php } ?>
                     </p>
@@ -436,6 +471,7 @@ class TextColumn extends Column implements HasEmbeddedView
                         <?php foreach ($state as $stateItem) { ?>
                             <?php [
                                 'attributes' => $stateItemAttributes,
+                                'innerAttributes' => $stateItemInnerAttributes,
                                 'badgeAttributes' => $stateItemBadgeAttributes,
                                 'iconAfterHtml' => $stateItemIconAfterHtml,
                                 'iconBeforeHtml' => $stateItemIconBeforeHtml,
@@ -443,21 +479,24 @@ class TextColumn extends Column implements HasEmbeddedView
 
                             <li
                                 <?php if ($stateIteration > $listLimit) { ?>
-                                    x-show="! isLimited"
-                                    x-cloak
-                                    x-transition
+                                x-show="! isLimited"
+                                x-cloak
+                                x-transition
                                 <?php } ?>
-                                <?= $stateItemAttributes->toHtml() ?>
-                            >
+                                <?= $stateItemAttributes->toHtml() ?>>
                                 <?php if ($isBadge) { ?>
                                     <span <?= $stateItemBadgeAttributes->toHtml() ?>>
-                                <?php } ?>
+                                    <?php } else { ?>
+                                        <span <?= $stateItemInnerAttributes->toHtml() ?>>
+                                        <?php } ?>
 
-                                <?= $stateItemIconBeforeHtml ?>
-                                <?= $formatState($stateItem) ?>
-                                <?= $stateItemIconAfterHtml ?>
+                                        <?= $stateItemIconBeforeHtml ?>
+                                        <?= $formatState($stateItem) ?>
+                                        <?= $stateItemIconAfterHtml ?>
 
-                                <?php if ($isBadge) { ?>
+                                        <?php if ($isBadge) { ?>
+                                        </span>
+                                    <?php } else { ?>
                                     </span>
                                 <?php } ?>
                             </li>
@@ -474,8 +513,7 @@ class TextColumn extends Column implements HasEmbeddedView
                                 role="button"
                                 x-on:click.prevent.stop="isLimited = false"
                                 x-show="isLimited"
-                                class="fi-link fi-size-xs"
-                            >
+                                class="fi-link fi-size-xs">
                                 <?= trans_choice('filament-tables::table.columns.text.actions.expand_list', $stateOverListLimitCount) ?>
                             </div>
 
@@ -484,8 +522,7 @@ class TextColumn extends Column implements HasEmbeddedView
                                 x-on:click.prevent.stop="isLimited = true"
                                 x-cloak
                                 x-show="! isLimited"
-                                class="fi-link fi-size-xs"
-                            >
+                                class="fi-link fi-size-xs">
                                 <?= trans_choice('filament-tables::table.columns.text.actions.collapse_list', $stateOverListLimitCount) ?>
                             </div>
                         <?php } else { ?>
@@ -501,7 +538,7 @@ class TextColumn extends Column implements HasEmbeddedView
                 <?php } ?>
             </div>
 
-            <?php return ob_get_clean();
+        <?php return ob_get_clean();
         }
 
         ob_start(); ?>
@@ -510,6 +547,7 @@ class TextColumn extends Column implements HasEmbeddedView
             <?php foreach ($state as $stateItem) { ?>
                 <?php [
                     'attributes' => $stateItemAttributes,
+                    'innerAttributes' => $stateItemInnerAttributes,
                     'badgeAttributes' => $stateItemBadgeAttributes,
                     'iconAfterHtml' => $stateItemIconAfterHtml,
                     'iconBeforeHtml' => $stateItemIconBeforeHtml,
@@ -518,19 +556,23 @@ class TextColumn extends Column implements HasEmbeddedView
                 <li <?= $stateItemAttributes->toHtml() ?>>
                     <?php if ($isBadge) { ?>
                         <span <?= $stateItemBadgeAttributes->toHtml() ?>>
-                    <?php } ?>
+                        <?php } else { ?>
+                            <span <?= $stateItemInnerAttributes->toHtml() ?>>
+                            <?php } ?>
 
-                    <?= $stateItemIconBeforeHtml ?>
-                    <?= $formatState($stateItem) ?>
-                    <?= $stateItemIconAfterHtml ?>
+                            <?= $stateItemIconBeforeHtml ?>
+                            <?= $formatState($stateItem) ?>
+                            <?= $stateItemIconAfterHtml ?>
 
-                    <?php if ($isBadge) { ?>
+                            <?php if ($isBadge) { ?>
+                            </span>
+                        <?php } else { ?>
                         </span>
                     <?php } ?>
                 </li>
             <?php } ?>
         </ul>
 
-        <?php return ob_get_clean();
+<?php return ob_get_clean();
     }
 }


### PR DESCRIPTION
## Description

Tooltips for `TextEntry` and `TextColumn` don't align to the actual text content of the entry/column content. This new update adds the content as a span and attaches the x-tooltip to the span therefore allowing the tooltip to inherit it's position from the actual content and not the full width column.

Ref: https://github.com/filamentphp/filament/issues/13335

## Visual changes

**Old behavior**
https://github.com/user-attachments/assets/0b1e07e3-271e-4e95-bea4-80ec14b92ea5

**New behavior**
https://github.com/user-attachments/assets/e0015fce-a377-4914-b3c2-04b1bb91edb6

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
