### PR TITLE
Dont flip filter and column manager dropdowns

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -498,6 +498,7 @@
                                         :max-height="$filtersFormMaxHeight"
                                         placement="bottom-end"
                                         shift
+                                        :flip="false"
                                         :width="$filtersFormWidth ?? Width::ExtraSmall"
                                         :wire:key="$this->getId() . '.table.filters'"
                                         class="fi-ta-filters-dropdown"
@@ -528,6 +529,7 @@
                                     :max-height="$columnManagerMaxHeight"
                                     placement="bottom-end"
                                     shift
+                                    :flip="false"
                                     :width="$columnManagerWidth"
                                     :wire:key="$this->getId() . '.table.column-manager'"
                                     class="fi-ta-col-manager-dropdown"


### PR DESCRIPTION
This PR fixes #17643 by not allowing the dropdowns to flip up. While forcing the dropdown to open down when there is sufficient space above for it to flip up may not be ideal (even though others may prefer the dropdown to consistently open down), the reality is that there are conditions where the dropdown can flip up and there is no easy* way to force it to flip back down. When this happens the content in the dropdown that is above the page is clipped and cannot be accessed.

By turning flipping off, the dropdown will always go down, and the page will become scrollable if needed. 

*There are actually two ways to force it to flip down. 1) Make your browser window larger. If someone doesn't have their browser window full screen, then making the window taller could create the condition where there is sufficient space below the button and it will flip back down. However, most users won't know to do this. 2) Zoom your browser out. By zooming out more vertical height is created, creating the condition where there is space for it to flip back down. However, even fewer users would know to do this, and this might not be possible for others due to accessibilty reasons. 

This is why I believe the best solution is to consistely have it flip down and, if needed, users can naturally scroll down to access the rest of the dropdown.