### PR TITLE
Render html in column manager

### DIFF
--- a/packages/tables/resources/views/components/column-manager.blade.php
+++ b/packages/tables/resources/views/components/column-manager.blade.php
@@ -81,7 +81,7 @@
                                         />
                                     @endif
 
-                                    <span x-text="column.label"></span>
+                                    <span x-html="column.label"></span>
                                 </label>
 
                                 @if ($hasReorderableColumns)
@@ -131,7 +131,7 @@
                                                 @endif
 
                                                 <span
-                                                    x-text="groupColumn.label"
+                                                    x-html="groupColumn.label"
                                                 ></span>
                                             </label>
 
@@ -165,7 +165,7 @@
                                     />
                                 @endif
 
-                                <span x-text="column.label"></span>
+                                <span x-html="column.label"></span>
                             </label>
 
                             @if ($hasReorderableColumns)

--- a/packages/tables/src/Concerns/HasColumnManager.php
+++ b/packages/tables/src/Concerns/HasColumnManager.php
@@ -197,7 +197,7 @@ trait HasColumnManager
      */
     protected function mapTableColumnGroupToArray(ColumnGroup $group): array
     {
-        $label = (string) e($group->getLabel());
+        $label = e($group->getLabel());
 
         return [
             'type' => self::TABLE_COLUMN_MANAGER_GROUP_TYPE,
@@ -221,7 +221,7 @@ trait HasColumnManager
      */
     protected function mapTableColumnToArray(Column $column): array
     {
-        $label = (string) e($column->getLabel());
+        $label = e($column->getLabel());
 
         if (blank($label) && $this->hasReorderableTableColumns()) {
             throw new LogicException("The table column [{$column->getName()}] has a blank label. All columns must have labels when they are reorderable.");

--- a/packages/tables/src/Concerns/HasColumnManager.php
+++ b/packages/tables/src/Concerns/HasColumnManager.php
@@ -197,10 +197,12 @@ trait HasColumnManager
      */
     protected function mapTableColumnGroupToArray(ColumnGroup $group): array
     {
+        $label = (string) e($group->getLabel());
+
         return [
             'type' => self::TABLE_COLUMN_MANAGER_GROUP_TYPE,
-            'name' => (string) $group->getLabel(),
-            'label' => (string) $group->getLabel(),
+            'name' => $label,
+            'label' => $label,
             'isHidden' => empty(array_filter($group->getColumns(), fn (Column $column): bool => ! $column->isHidden())),
             'isToggled' => true,
             'isToggleable' => true,
@@ -219,7 +221,7 @@ trait HasColumnManager
      */
     protected function mapTableColumnToArray(Column $column): array
     {
-        $label = (string) $column->getLabel();
+        $label = (string) e($column->getLabel());
 
         if (blank($label) && $this->hasReorderableTableColumns()) {
             throw new LogicException("The table column [{$column->getName()}] has a blank label. All columns must have labels when they are reorderable.");


### PR DESCRIPTION
Fixes #17701 

When discussing PR #17443 we talked about adding a fallback `->columnManagerLabel()` but we decided against it so this PR just renders the html in the column manager label.