### PR TITLE
docs: rename fileAttachmentsProvider for rich content in docs

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/README.md
+++ b/packages/spatie-laravel-media-library-plugin/README.md
@@ -190,7 +190,7 @@ class Post extends Model implements HasRichContent
     public function setUpRichContent(): void
     {
         $this->registerRichContent('content')
-            ->fileAttachmentsProvider(SpatieMediaLibraryFileAttachmentProvider::make());
+            ->fileAttachmentProvider(SpatieMediaLibraryFileAttachmentProvider::make());
     }
 }
 ```
@@ -212,7 +212,7 @@ class Post extends Model implements HasRichContent
     public function setUpRichContent(): void
     {
         $this->registerRichContent('content')
-            ->fileAttachmentsProvider(
+            ->fileAttachmentProvider(
                 SpatieMediaLibraryFileAttachmentProvider::make()
                     ->collection('content-file-attachments'),
             );


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The method `fileAttachmentsProvider` does not exist and seems to be a typo. Updated docs to `fileAttachmentProvider`

<img width="1057" height="206" alt="image" src="https://github.com/user-attachments/assets/12614cc2-4b51-40bf-b193-8eef971b9161" />


<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->
### Before
<img width="298" height="92" alt="image" src="https://github.com/user-attachments/assets/79a391b3-8fb4-4c65-8db5-f6f60bcd47a4" />

### After
<img width="347" height="112" alt="Screenshot 2025-09-12 at 10 28 39 AM" src="https://github.com/user-attachments/assets/761f6459-bd20-46ad-a43c-90a23afa6645" />



## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
