### PR TITLE
fix: `TextEntry` component not displaying related information on the edit

### DIFF
--- a/packages/schemas/src/Components/Concerns/CanGetStateFromRelationships.php
+++ b/packages/schemas/src/Components/Concerns/CanGetStateFromRelationships.php
@@ -113,6 +113,6 @@ trait CanGetStateFromRelationships
 
     public function getStateRelationshipPath(): ?string
     {
-        return $this->getStatePath();
+        return $this->getStatePath(false);
     }
 }

--- a/packages/schemas/src/Components/Concerns/CanGetStateFromRelationships.php
+++ b/packages/schemas/src/Components/Concerns/CanGetStateFromRelationships.php
@@ -113,6 +113,6 @@ trait CanGetStateFromRelationships
 
     public function getStateRelationshipPath(): ?string
     {
-        return $this->getStatePath(false);
+        return $this->getStatePath(isAbsolute: false);
     }
 }


### PR DESCRIPTION

## Description

fixes: #17749

do not use absolute path when getting the state relationship path to avoid appending `data.` during edit

## Visual changes
# Before
<img width="1324" height="855" alt="Before" src="https://github.com/user-attachments/assets/3033fa7e-bc9b-4ad6-805d-625cd4c5b48e" />

# After

<img width="1365" height="803" alt="After" src="https://github.com/user-attachments/assets/46732c27-4a4c-40d4-8c12-cebcb4d032f0" />

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
