### PR TITLE
fix: grouping when `getTitleFromRecordUsing` contains HtmlString

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -894,7 +894,7 @@
                                     );
                                 @endphp
 
-                                @if ($recordGroupTitle !== $previousRecordGroupTitle)
+                                @if ((string) $recordGroupTitle !== (string) $previousRecordGroupTitle)
                                     @if ($hasSummary && (! $isReordering) && filled($previousRecordGroupTitle))
                                         <table
                                             @class([
@@ -1582,7 +1582,7 @@
                                             );
                                         @endphp
 
-                                        @if ($recordGroupTitle !== $previousRecordGroupTitle)
+                                        @if ((string) $recordGroupTitle !== (string) $previousRecordGroupTitle)
                                             @if ($hasSummary && (! $isReordering) && filled($previousRecordGroupTitle))
                                                 @php
                                                     $groupColumn = $group->getColumn();

--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -8,12 +8,12 @@ use Carbon\CarbonInterface;
 use Closure;
 use Filament\Support\Components\Component;
 use Filament\Support\Contracts\HasLabel as LabelInterface;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Arr;
-use Illuminate\Contracts\Support\Htmlable;
 
 class Group extends Component
 {


### PR DESCRIPTION
## Description

I recently introduced support for `HtmlString` inside `getTitleFromRecordUsing` (#17448)  but I noticed that it was not working completely as expected. 

The grouping is now fixed by casting the group titles to string before checking them. 

<img width="718" height="613" alt="Screenshot 2025-09-12 at 14 57 53" src="https://github.com/user-attachments/assets/7e26e9a2-6224-49e6-983e-9e60156f7d94" />

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
