### PR TITLE
fix: Allow `RichEditor` to work without registering rich content attributes

### DIFF
--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -603,6 +603,13 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
 
     public function getContentAttribute(): ?RichContentAttribute
     {
+        // Do not read content attributes from the model when the rich editor is nested
+        // inside a custom block action modal, since the content attribute should only
+        // be used to configure the parent rich editor.
+        if ($this->getRootContainer()->getOperation() === CustomBlockAction::NAME) {
+            return null;
+        }
+
         $model = $this->getModelInstance();
 
         if (! ($model instanceof HasRichContent)) {

--- a/packages/forms/src/Components/RichEditor/Actions/CustomBlockAction.php
+++ b/packages/forms/src/Components/RichEditor/Actions/CustomBlockAction.php
@@ -9,9 +9,11 @@ use Filament\Support\Enums\Width;
 
 class CustomBlockAction
 {
+    public const NAME = 'customBlock';
+
     public static function make(): Action
     {
-        return Action::make('customBlock')
+        return Action::make(static::NAME)
             ->fillForm(fn (array $arguments): array => $arguments['config'] ?? [])
             ->modalHeading(function (array $arguments, RichEditor $component): ?string {
                 $block = $component->getCustomBlock($arguments['id']);

--- a/packages/forms/src/Components/RichEditor/Models/Concerns/InteractsWithRichContent.php
+++ b/packages/forms/src/Components/RichEditor/Models/Concerns/InteractsWithRichContent.php
@@ -40,7 +40,7 @@ trait InteractsWithRichContent /** @phpstan-ignore trait.unused */
 
     public function getRichContentAttribute(string $attribute): ?RichContentAttribute
     {
-        return $this->getRichContentAttributes()[$attribute];
+        return $this->getRichContentAttributes()[$attribute] ?? null;
     }
 
     public function hasRichContentAttribute(string $attribute): bool


### PR DESCRIPTION
## Description

fixes: #17745

If `RichEditor` is used again in the `custom blocks` of `RichEditor`, it will point to the same model.  Therefore, it will retrieve the `rich content attributes` from the model again.  If it is not registered, an error will occur.  I think it should be allowed to run without registration.

## Visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
