### PR TITLE
fix docs for the custom column table

### DIFF
--- a/packages/tables/docs/02-columns/10-custom-columns.md
+++ b/packages/tables/docs/02-columns/10-custom-columns.md
@@ -42,11 +42,11 @@ Inside the Blade view, you may access the [state](overview#column-content-state)
 
 ## Accessing the Eloquent record in the Blade view
 
-Inside the Blade view, you may access the current table row's Eloquent record using the `$record` variable:
+Inside the Blade view, you may access the current table row's Eloquent record using the `$getRecord()` function:
 
 ```blade
 <div>
-    {{ $record->name }}
+    {{ $getRecord()->name }}
 </div>
 ```
 


### PR DESCRIPTION


<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

just converting `$record` to `$getRecord()`, since the `$record` is protected, and can be accessed using `$getRecord()`

## Visual changes
none

## Functional changes
fix a typo 