### PR TITLE
Use "state snapshot" for repeaters and builders

### DIFF
--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -1135,7 +1135,7 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
      */
     public function getRawItemState(string $key): array
     {
-        return $this->getChildSchema($key)->getRawState();
+        return $this->getChildSchema($key)->getStateSnapshot();
     }
 
     public function getHeadingsCount(): int

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1163,7 +1163,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
             'item' => $container,
             'key' => $key,
             'schema' => $container,
-            'state' => $container->getRawState(),
+            'state' => $container->getStateSnapshot(),
             'uuid' => $key,
         ]);
     }
@@ -1350,7 +1350,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
      */
     public function getRawItemState(string $key): array
     {
-        return $this->getChildSchema($key)->getRawState();
+        return $this->getChildSchema($key)->getStateSnapshot();
     }
 
     public function getHeadingsCount(): int

--- a/packages/schemas/src/Concerns/HasState.php
+++ b/packages/schemas/src/Concerns/HasState.php
@@ -449,6 +449,34 @@ trait HasState
     }
 
     /**
+     * @internal Do not use this method outside the internals of Filament. It is subject to breaking changes in minor and patch releases.
+     *
+     * @return array<string, mixed>
+     */
+    public function getStateSnapshot(): array
+    {
+        return Component::withVisibilityCache(function (): array {
+            $statePath = $this->getStatePath();
+
+            if (filled($statePath)) {
+                $state = [];
+                data_set($state, $statePath, $this->getRawState());
+            } else {
+                $state = $this->getRawState();
+            }
+
+            $this->dehydrateState($state);
+            $this->mutateDehydratedState($state);
+
+            if ($statePath) {
+                $state = data_get($state, $statePath) ?? [];
+            }
+
+            return $state;
+        });
+    }
+
+    /**
      * @return array<string, mixed> | Arrayable
      */
     public function getRawState(): array | Arrayable

--- a/packages/tables/src/Filters/QueryBuilder/Forms/Components/RuleBuilder.php
+++ b/packages/tables/src/Filters/QueryBuilder/Forms/Components/RuleBuilder.php
@@ -90,7 +90,7 @@ class RuleBuilder extends Builder
                                                 throw new LogicException('No block component found.');
                                             }
 
-                                            return $block->getLabel($schema->getRawState(), $blockUuid);
+                                            return $block->getLabel($schema->getStateSnapshot(), $blockUuid);
                                         });
 
                                     if ($blockLabels->isEmpty()) {


### PR DESCRIPTION
Currently, repeater and builder data is not cast before their state is used to determine item labels. This PR casts the state first to make it easier to use.