### PR TITLE
fix: Consistently cast select values to strings

### DIFF
--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -6,6 +6,7 @@ use Closure;
 use Filament\Actions\Action;
 use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
 use Filament\Schemas\Components\StateCasts\EnumArrayStateCast;
+use Filament\Schemas\Components\StateCasts\StringArrayStateCast;
 use Filament\Support\Concerns\HasExtraAlpineAttributes;
 use Filament\Support\Enums\Size;
 use Filament\Support\Services\RelationshipJoiner;
@@ -53,16 +54,6 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
     protected function setUp(): void
     {
         parent::setUp();
-
-        $this->default([]);
-
-        $this->afterStateHydrated(static function (CheckboxList $component, $state): void {
-            if (is_array($state)) {
-                return;
-            }
-
-            $component->state([]);
-        });
 
         $this->searchDebounce(0);
 
@@ -330,6 +321,18 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
             EnumArrayStateCast::class,
             ['enum' => $enum],
         );
+    }
+
+    /**
+     * @return array<StateCast>
+     */
+    public function getDefaultStateCasts(): array
+    {
+        if ($this->hasCustomStateCasts() || filled($this->getEnum())) {
+            return [];
+        }
+
+        return [app(StringArrayStateCast::class)];
     }
 
     /**

--- a/packages/forms/src/Components/ModalTableSelect.php
+++ b/packages/forms/src/Components/ModalTableSelect.php
@@ -4,6 +4,9 @@ namespace Filament\Forms\Components;
 
 use Closure;
 use Filament\Actions\Action;
+use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
+use Filament\Schemas\Components\StateCasts\StringArrayStateCast;
+use Filament\Schemas\Components\StateCasts\StringStateCast;
 use Filament\Support\Enums\IconPosition;
 use Filament\Support\Icons\Heroicon;
 use Filament\Support\Services\RelationshipJoiner;
@@ -64,20 +67,6 @@ class ModalTableSelect extends Field
     protected function setUp(): void
     {
         parent::setUp();
-
-        $this->default(static fn (ModalTableSelect $component): ?array => $component->isMultiple() ? [] : null);
-
-        $this->afterStateHydrated(static function (ModalTableSelect $component, $state): void {
-            if (! $component->isMultiple()) {
-                return;
-            }
-
-            if (is_array($state)) {
-                return;
-            }
-
-            $component->state([]);
-        });
 
         $this->registerActions([
             fn (ModalTableSelect $component): Action => $component->getSelectAction(),
@@ -678,5 +667,21 @@ class ModalTableSelect extends Field
     public function getTableArguments(): array
     {
         return $this->evaluate($this->tableArguments) ?? [];
+    }
+
+    /**
+     * @return array<StateCast>
+     */
+    public function getDefaultStateCasts(): array
+    {
+        if ($this->hasCustomStateCasts()) {
+            return [];
+        }
+
+        if ($this->isMultiple()) {
+            return [app(StringArrayStateCast::class)];
+        }
+
+        return [app(StringStateCast::class, ['isNullable' => true])];
     }
 }

--- a/packages/forms/src/Components/Radio.php
+++ b/packages/forms/src/Components/Radio.php
@@ -4,6 +4,8 @@ namespace Filament\Forms\Components;
 
 use Closure;
 use Filament\Schemas\Components\StateCasts\BooleanStateCast;
+use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
+use Filament\Schemas\Components\StateCasts\StringStateCast;
 
 class Radio extends Field implements Contracts\CanDisableOptions
 {
@@ -55,6 +57,18 @@ class Radio extends Field implements Contracts\CanDisableOptions
         }
 
         return $state;
+    }
+
+    /**
+     * @return array<StateCast>
+     */
+    public function getDefaultStateCasts(): array
+    {
+        if ($this->hasCustomStateCasts() || filled($this->getEnum())) {
+            return [];
+        }
+
+        return [app(StringStateCast::class, ['isNullable' => true])];
     }
 
     /**

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -908,7 +908,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         $this->relationship = $name ?? $this->getName();
         $this->modifyRelationshipQueryUsing = $modifyQueryUsing;
 
-        $this->afterStateHydrated(function (Repeater $component): void {
+        $this->afterStateHydrated(static function (Repeater $component): void {
             if (! is_array($component->hydratedDefaultState)) {
                 return;
             }

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -13,6 +13,9 @@ use Filament\Schemas\Components\StateCasts\BooleanStateCast;
 use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
 use Filament\Schemas\Components\StateCasts\EnumArrayStateCast;
 use Filament\Schemas\Components\StateCasts\EnumStateCast;
+use Filament\Schemas\Components\StateCasts\NumberStateCast;
+use Filament\Schemas\Components\StateCasts\StringArrayStateCast;
+use Filament\Schemas\Components\StateCasts\StringStateCast;
 use Filament\Schemas\Schema;
 use Filament\Support\Components\Attributes\ExposedLivewireMethod;
 use Filament\Support\Concerns\HasExtraAlpineAttributes;
@@ -1412,6 +1415,22 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
             $this->isMultiple() ? EnumArrayStateCast::class : EnumStateCast::class,
             ['enum' => $enum],
         );
+    }
+
+    /**
+     * @return array<StateCast>
+     */
+    public function getDefaultStateCasts(): array
+    {
+        if ($this->hasCustomStateCasts() || filled($this->getEnum())) {
+            return [];
+        }
+
+        if ($this->isMultiple()) {
+            return [app(StringArrayStateCast::class)];
+        }
+
+        return [app(StringStateCast::class, ['isNullable' => true])];
     }
 
     /**

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -133,20 +133,6 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
     {
         parent::setUp();
 
-        $this->default(static fn (Select $component): ?array => $component->isMultiple() ? [] : null);
-
-        $this->afterStateHydrated(static function (Select $component, $state): void {
-            if (! $component->isMultiple()) {
-                return;
-            }
-
-            if (is_array($state)) {
-                return;
-            }
-
-            $component->state([]);
-        });
-
         $this->transformOptionsForJsUsing(static function (Select $component, array $options): array {
             return collect($options)
                 ->map(fn ($label, $value): array => is_array($label)

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -13,7 +13,6 @@ use Filament\Schemas\Components\StateCasts\BooleanStateCast;
 use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
 use Filament\Schemas\Components\StateCasts\EnumArrayStateCast;
 use Filament\Schemas\Components\StateCasts\EnumStateCast;
-use Filament\Schemas\Components\StateCasts\NumberStateCast;
 use Filament\Schemas\Components\StateCasts\StringArrayStateCast;
 use Filament\Schemas\Components\StateCasts\StringStateCast;
 use Filament\Schemas\Schema;

--- a/packages/forms/src/Components/Slider.php
+++ b/packages/forms/src/Components/Slider.php
@@ -82,7 +82,7 @@ class Slider extends Field implements Contracts\HasNestedRecursiveValidationRule
     {
         parent::setUp();
 
-        $this->default(fn (Slider $component): float | int => $component->getMinValue());
+        $this->default(static fn (Slider $component): float | int => $component->getMinValue());
 
         $this->required();
 

--- a/packages/forms/src/Components/TableSelect.php
+++ b/packages/forms/src/Components/TableSelect.php
@@ -3,6 +3,9 @@
 namespace Filament\Forms\Components;
 
 use Closure;
+use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
+use Filament\Schemas\Components\StateCasts\StringArrayStateCast;
+use Filament\Schemas\Components\StateCasts\StringStateCast;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -302,5 +305,21 @@ class TableSelect extends Field
     public function isMultiple(): bool
     {
         return (bool) $this->evaluate($this->isMultiple);
+    }
+
+    /**
+     * @return array<StateCast>
+     */
+    public function getDefaultStateCasts(): array
+    {
+        if ($this->hasCustomStateCasts()) {
+            return [];
+        }
+
+        if ($this->isMultiple()) {
+            return [app(StringArrayStateCast::class)];
+        }
+
+        return [app(StringStateCast::class, ['isNullable' => true])];
     }
 }

--- a/packages/forms/src/Components/ToggleButtons.php
+++ b/packages/forms/src/Components/ToggleButtons.php
@@ -8,6 +8,8 @@ use Filament\Schemas\Components\StateCasts\BooleanStateCast;
 use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
 use Filament\Schemas\Components\StateCasts\EnumArrayStateCast;
 use Filament\Schemas\Components\StateCasts\EnumStateCast;
+use Filament\Schemas\Components\StateCasts\StringArrayStateCast;
+use Filament\Schemas\Components\StateCasts\StringStateCast;
 use Filament\Support\Facades\FilamentIcon;
 use Filament\Support\Icons\Heroicon;
 
@@ -35,25 +37,6 @@ class ToggleButtons extends Field implements Contracts\CanDisableOptions
     protected bool | Closure $isInline = false;
 
     protected bool | Closure $areButtonLabelsHidden = false;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->default(fn (ToggleButtons $component): mixed => $component->isMultiple() ? [] : null);
-
-        $this->afterStateHydrated(static function (ToggleButtons $component, $state): void {
-            if (! $component->isMultiple()) {
-                return;
-            }
-
-            if (is_array($state)) {
-                return;
-            }
-
-            $component->state([]);
-        });
-    }
 
     public function grouped(): static
     {
@@ -141,6 +124,22 @@ class ToggleButtons extends Field implements Contracts\CanDisableOptions
             $this->isMultiple() ? EnumArrayStateCast::class : EnumStateCast::class,
             ['enum' => $enum],
         );
+    }
+
+    /**
+     * @return array<StateCast>
+     */
+    public function getDefaultStateCasts(): array
+    {
+        if ($this->hasCustomStateCasts() || filled($this->getEnum())) {
+            return [];
+        }
+
+        if ($this->isMultiple()) {
+            return [app(StringArrayStateCast::class)];
+        }
+
+        return [app(StringStateCast::class, ['isNullable' => true])];
     }
 
     /**

--- a/packages/schemas/src/Components/Concerns/HasState.php
+++ b/packages/schemas/src/Components/Concerns/HasState.php
@@ -94,6 +94,11 @@ trait HasState
         return $casts;
     }
 
+    public function hasCustomStateCasts(): bool
+    {
+        return filled($this->stateCasts);
+    }
+
     /**
      * @return array<StateCast>
      */

--- a/packages/schemas/src/Components/StateCasts/StringArrayStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/StringArrayStateCast.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Filament\Schemas\Components\StateCasts;
+
+use BackedEnum;
+use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
+
+class StringArrayStateCast implements StateCast
+{
+    /**
+     * @return array<string>
+     */
+    public function get(mixed $state): array
+    {
+        if (blank($state)) {
+            return [];
+        }
+
+        if (! is_array($state)) {
+            $state = json_decode($state, associative: true);
+        }
+
+        return array_reduce(
+            $state,
+            function (array $carry, $stateItem): array {
+                if (blank($stateItem)) {
+                    return $carry;
+                }
+
+                $carry[] = strval($stateItem);
+
+                return $carry;
+            },
+            initial: [],
+        );
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function set(mixed $state): array
+    {
+        if (blank($state)) {
+            return [];
+        }
+
+        if (! is_array($state)) {
+            $state = json_decode($state, associative: true);
+        }
+
+        return array_reduce(
+            $state,
+            function (array $carry, $stateItem): array {
+                if (blank($stateItem)) {
+                    return $carry;
+                }
+
+                $carry[] = strval($stateItem);
+
+                return $carry;
+            },
+            initial: [],
+        );
+    }
+}

--- a/packages/schemas/src/Components/StateCasts/StringArrayStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/StringArrayStateCast.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Schemas\Components\StateCasts;
 
-use BackedEnum;
 use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
 
 class StringArrayStateCast implements StateCast

--- a/packages/schemas/src/Components/StateCasts/StringStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/StringStateCast.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Filament\Schemas\Components\StateCasts;
+
+use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
+
+class StringStateCast implements StateCast
+{
+    public function __construct(
+        protected bool $isNullable = true,
+    ) {}
+
+    public function get(mixed $state): ?string
+    {
+        if ($this->isNullable && blank($state)) {
+            return null;
+        }
+
+        return strval($state);
+    }
+
+    public function set(mixed $state): ?string
+    {
+        if ($this->isNullable && blank($state)) {
+            return null;
+        }
+
+        return strval($state);
+    }
+}


### PR DESCRIPTION
Fixes #17580

When manually selecting an option, it ends up being cast to a string anyway. This makes it consistent so that options that were already selected when the component loaded are also cast to a string.