### PR TITLE
fix: add missing Russian translation keys

### DIFF
--- a/packages/forms/resources/lang/ru/components.php
+++ b/packages/forms/resources/lang/ru/components.php
@@ -481,7 +481,8 @@ return [
             'bold' => 'Жирный',
             'bullet_list' => 'Маркированный список',
             'clear_formatting' => 'Очистить форматирование',
-            'code_block' => 'Код',
+            'code' => 'Код',
+            'code_block' => 'Блок кода',
             'custom_blocks' => 'Блоки',
             'details' => 'Детали',
             'h1' => 'Название',
@@ -513,6 +514,8 @@ return [
             'underline' => 'Подчеркнутый',
             'undo' => 'Отменить',
         ],
+
+        'uploading_file_message' => 'Загрузка файла...',
 
     ],
 
@@ -592,6 +595,11 @@ return [
     'text_input' => [
 
         'actions' => [
+
+            'copy' => [
+                'label' => 'Копировать',
+                'message' => 'Скопировано',
+            ],
 
             'hide_password' => [
                 'label' => 'Скрыть пароль',


### PR DESCRIPTION
- Add rich_editor.tools.code to forms translation
- Add rich_editor.uploading_file_message to forms translation
- Add text_input.actions.copy.label to forms translation
- Add text_input.actions.copy.message to forms translation

## Description

Added new translations for the form:
• rich_editor.tools.code — signature of the code insertion tool in the rich editor.
• rich_editor.uploading_file_message — message about uploading a file in the rich editor.
• text_input.actions.copy.label — signature of the text copy button.
• text_input.actions.copy.message — message upon successful text copying.

Previously, the keys were missing, which led to incorrect UI display.

## Visual changes

There are no visual changes other than the display in the UI translation.

## Functional changes

The lack of localization does not cause errors.
