### PR TITLE
fix: handle 'as' alias in orderBy correctly in Select component

### DIFF
--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -149,7 +149,13 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
             $relationshipTitleAttribute = $component->getRelationshipTitleAttribute();
 
             if (empty($relationshipQuery->getQuery()->orders)) {
-                $relationshipQuery->orderBy($relationshipQuery->qualifyColumn($relationshipTitleAttribute));
+                $relationshipOrderByAttribute = $relationshipTitleAttribute;
+
+                if (str_contains($relationshipOrderByAttribute, ' as ')) {
+                    $relationshipOrderByAttribute = (string) str($relationshipOrderByAttribute)->before(' as ');
+                }
+
+                $relationshipQuery->orderBy($relationshipQuery->qualifyColumn($relationshipOrderByAttribute));
             }
 
             if (str_contains($relationshipTitleAttribute, '->')) {

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -799,8 +799,8 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
             if (empty($relationshipQuery->getQuery()->orders)) {
                 $relationshipOrderByAttribute = $relationshipTitleAttribute;
 
-                if (str_contains($relationshipTitleAttribute, ' as ')) {
-                    $relationshipOrderByAttribute = substr($relationshipTitleAttribute, 0, strpos($relationshipTitleAttribute, ' as '));
+                if (str_contains($relationshipOrderByAttribute, ' as ')) {
+                    $relationshipOrderByAttribute = (string) str($relationshipOrderByAttribute)->before(' as ');
                 }
 
                 $relationshipQuery->orderBy($relationshipQuery->qualifyColumn($relationshipOrderByAttribute));
@@ -863,8 +863,8 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
             if (empty($relationshipQuery->getQuery()->orders)) {
                 $relationshipOrderByAttribute = $relationshipTitleAttribute;
 
-                if (str_contains($relationshipTitleAttribute, ' as ')) {
-                    $relationshipOrderByAttribute = substr($relationshipTitleAttribute, 0, strpos($relationshipTitleAttribute, ' as '));
+                if (str_contains($relationshipOrderByAttribute, ' as ')) {
+                    $relationshipOrderByAttribute = (string) str($relationshipOrderByAttribute)->before(' as ');
                 }
 
                 $relationshipQuery->orderBy($relationshipQuery->qualifyColumn($relationshipOrderByAttribute));

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -797,7 +797,13 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
             $relationshipTitleAttribute = $component->getRelationshipTitleAttribute();
 
             if (empty($relationshipQuery->getQuery()->orders)) {
-                $relationshipQuery->orderBy($relationshipQuery->qualifyColumn($relationshipTitleAttribute));
+                $relationshipOrderByAttribute = $relationshipTitleAttribute;
+
+                if (str_contains($relationshipTitleAttribute, ' as ')) {
+                    $relationshipOrderByAttribute = substr($relationshipTitleAttribute, 0, strpos($relationshipTitleAttribute, ' as '));
+                }
+
+                $relationshipQuery->orderBy($relationshipQuery->qualifyColumn($relationshipOrderByAttribute));
             }
 
             if (str_contains($relationshipTitleAttribute, '->')) {
@@ -855,7 +861,13 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
             $relationshipTitleAttribute = $component->getRelationshipTitleAttribute();
 
             if (empty($relationshipQuery->getQuery()->orders)) {
-                $relationshipQuery->orderBy($relationshipQuery->qualifyColumn($relationshipTitleAttribute));
+                $relationshipOrderByAttribute = $relationshipTitleAttribute;
+
+                if (str_contains($relationshipTitleAttribute, ' as ')) {
+                    $relationshipOrderByAttribute = substr($relationshipTitleAttribute, 0, strpos($relationshipTitleAttribute, ' as '));
+                }
+
+                $relationshipQuery->orderBy($relationshipQuery->qualifyColumn($relationshipOrderByAttribute));
             }
 
             if (str_contains($relationshipTitleAttribute, '->')) {

--- a/packages/tables/src/Columns/SelectColumn.php
+++ b/packages/tables/src/Columns/SelectColumn.php
@@ -592,7 +592,13 @@ class SelectColumn extends Column implements Editable, HasEmbeddedView
             $relationshipTitleAttribute = $column->getOptionsRelationshipTitleAttribute();
 
             if (empty($relationshipQuery->getQuery()->orders)) {
-                $relationshipQuery->orderBy($relationshipQuery->qualifyColumn($relationshipTitleAttribute));
+                $relationshipOrderByAttribute = $relationshipTitleAttribute;
+
+                if (str_contains($relationshipOrderByAttribute, ' as ')) {
+                    $relationshipOrderByAttribute = (string) str($relationshipOrderByAttribute)->before(' as ');
+                }
+
+                $relationshipQuery->orderBy($relationshipQuery->qualifyColumn($relationshipOrderByAttribute));
             }
 
             if (str_contains($relationshipTitleAttribute, '->')) {
@@ -646,7 +652,13 @@ class SelectColumn extends Column implements Editable, HasEmbeddedView
             $relationshipTitleAttribute = $column->getOptionsRelationshipTitleAttribute();
 
             if (empty($relationshipQuery->getQuery()->orders)) {
-                $relationshipQuery->orderBy($relationshipQuery->qualifyColumn($relationshipTitleAttribute));
+                $relationshipOrderByAttribute = $relationshipTitleAttribute;
+
+                if (str_contains($relationshipOrderByAttribute, ' as ')) {
+                    $relationshipOrderByAttribute = (string) str($relationshipOrderByAttribute)->before(' as ');
+                }
+
+                $relationshipQuery->orderBy($relationshipQuery->qualifyColumn($relationshipOrderByAttribute));
             }
 
             if (str_contains($relationshipTitleAttribute, '->')) {

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -367,7 +367,13 @@ class SelectFilter extends BaseFilter
                     $relationshipTitleAttribute = $component->getRelationshipTitleAttribute();
 
                     if (empty($relationshipQuery->getQuery()->orders)) {
-                        $relationshipQuery->orderBy($relationshipQuery->qualifyColumn($relationshipTitleAttribute));
+                        $relationshipOrderByAttribute = $relationshipTitleAttribute;
+
+                        if (str_contains($relationshipOrderByAttribute, ' as ')) {
+                            $relationshipOrderByAttribute = (string) str($relationshipOrderByAttribute)->before(' as ');
+                        }
+
+                        $relationshipQuery->orderBy($relationshipQuery->qualifyColumn($relationshipOrderByAttribute));
                     }
 
                     if (str_contains($relationshipTitleAttribute, '->')) {
@@ -427,7 +433,13 @@ class SelectFilter extends BaseFilter
                     $relationshipTitleAttribute = $component->getRelationshipTitleAttribute();
 
                     if (empty($relationshipQuery->getQuery()->orders)) {
-                        $relationshipQuery->orderBy($relationshipQuery->qualifyColumn($relationshipTitleAttribute));
+                        $relationshipOrderByAttribute = $relationshipTitleAttribute;
+
+                        if (str_contains($relationshipOrderByAttribute, ' as ')) {
+                            $relationshipOrderByAttribute = (string) str($relationshipOrderByAttribute)->before(' as ');
+                        }
+
+                        $relationshipQuery->orderBy($relationshipQuery->qualifyColumn($relationshipOrderByAttribute));
                     }
 
                     if (str_contains($relationshipTitleAttribute, '->')) {


### PR DESCRIPTION
## Description

Adjust the orderBy logic in the Select component's relationship method to correctly handle attributes that use aliases ('as' syntax). This ensures the query orders by the actual column name instead of the alias, preventing certain database errors. This change resolves issues when dealing with complex queries where attributes are aliased.

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
