### PR TITLE
Allow html in table grouping label and title

### DIFF
--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -9,6 +9,7 @@ use Closure;
 use Filament\Support\Components\Component;
 use Filament\Support\Contracts\HasLabel as LabelInterface;
 use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -35,7 +36,7 @@ class Group extends Component
 
     protected ?Closure $scopeQueryByKeyUsing = null;
 
-    protected string | Closure | null $label = null;
+    protected string | Htmlable | Closure | null $label = null;
 
     protected string $id;
 
@@ -88,7 +89,7 @@ class Group extends Component
         return $this;
     }
 
-    public function label(string | Closure | null $label): static
+    public function label(string | Htmlable | Closure | null $label): static
     {
         $this->label = $label;
 
@@ -181,7 +182,7 @@ class Group extends Component
         return $this->id;
     }
 
-    public function getLabel(): string
+    public function getLabel(): string | Htmlable
     {
         return $this->evaluate($this->label) ?? (string) str($this->getId())
             ->beforeLast('.')
@@ -191,7 +192,7 @@ class Group extends Component
             ->ucfirst();
     }
 
-    public function getDescription(Model $record, ?string $title): ?string
+    public function getDescription(Model $record, string | Htmlable | null $title): string | Htmlable | null
     {
         if (! $this->getDescriptionFromRecordUsing) {
             return null;
@@ -250,7 +251,7 @@ class Group extends Component
         return Arr::get($record, $this->getColumn());
     }
 
-    public function getTitle(Model $record): ?string
+    public function getTitle(Model $record): string | Htmlable | null
     {
         $column = $this->getColumn();
 


### PR DESCRIPTION
Allows html in table grouping label, title, and description.

I'm adding it to v3 since this would be helpful in v3, but we'll also need it in v4 as well, which I can PR seperately.