### PR TITLE
Adds IntegerStateCast class for state casting

### DIFF
--- a/packages/schemas/src/Components/StateCasts/IntegerStateCast
+++ b/packages/schemas/src/Components/StateCasts/IntegerStateCast
@@ -1,0 +1,30 @@
+<?php
+
+namespace Filament\Schemas\Components\StateCasts;
+
+use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
+
+class IntegerStateCast implements StateCast
+{
+    public function __construct(
+        protected bool $isNullable = true,
+    ) {}
+
+    public function get(mixed $state): ?int
+    {
+        if ($this->isNullable && blank($state)) {
+            return null;
+        }
+
+        return intval($state);
+    }
+
+    public function set(mixed $state): ?int
+    {
+        if ($this->isNullable && blank($state)) {
+            return null;
+        }
+
+        return intval($state);
+    }
+}


### PR DESCRIPTION
## Description

The state-casting change in https://github.com/filamentphp/filament/pull/17810 provides a more reliable way to ensure data is cast properly.  However, when dealing with relationship-data (e.g. storing IDs in the DB), I'd like to ensure as much type-consistency as possible.

With the change mentioned above, the relationship on a `Select` form field is being cast as a string, before then getting re-converted back to an integer.  My proposal here is to allow for an optional cast to an integer, which could be applicable to any field that uses cast, but in particular here if the relationship you are saving uses integer IDs in your table.  

## Visual changes

n/a

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
