### PR TITLE
Fix: Use getAuthPasswordName() and getRememberTokenName() instead of hardcoded field names

### DIFF
--- a/packages/panels/src/Auth/Pages/PasswordReset/ResetPassword.php
+++ b/packages/panels/src/Auth/Pages/PasswordReset/ResetPassword.php
@@ -90,8 +90,8 @@ class ResetPassword extends SimplePage
                 }
 
                 $user->forceFill([
-                    'password' => Hash::make($data['password']),
-                    'remember_token' => Str::random(60),
+                    $user->getAuthPasswordName() => Hash::make($data['password']),
+                    $user->getRememberTokenName() => Str::random(60),
                 ])->save();
 
                 event(new PasswordReset($user));


### PR DESCRIPTION
## Description

This PR updates ResetPassword.php to avoid hardcoded field names when resetting a user’s password:

```php
$user->forceFill([
    $user->getAuthPasswordName() => Hash::make($data['password']),
    $user->getRememberTokenName() => Str::random(60),
])->save();
```

### Why

- In the password reset flow, the `password` and `remember_token` fields were hardcoded.
- Laravel allows customizing these field names via `getAuthPasswordName()` and `getRememberTokenName()` on the Authenticatable model.
- By using these methods, the password reset feature works reliably even when projects use non-standard field names.

### Benefits

- Improves flexibility and compatibility with custom authentication setups.
- Makes the password reset process fully respect Laravel’s API.
- No breaking changes: default Laravel setups continue to work as before.

## Visual changes

No visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
