### PR TITLE
[4.x] Fix: Live updating non native DateTimePicker Component on hasDate, hasTime, and hasSeconds

### DIFF
--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -5,7 +5,9 @@
     $extraAlpineAttributes = $getExtraAlpineAttributes();
     $extraAttributeBag = $getExtraAttributeBag();
     $extraInputAttributeBag = $getExtraInputAttributeBag();
+    $hasDate = $hasDate();
     $hasTime = $hasTime();
+    $hasSeconds = $hasSeconds();
     $id = $getId();
     $isDisabled = $isDisabled();
     $isAutofocused = $isAutofocused();
@@ -100,6 +102,9 @@
                         $isReadOnly,
                         $maxDate,
                         $minDate,
+                        $hasDate,
+                        $hasTime,
+                        $hasSeconds
                     ])), 0, 64)
                 }}"
                 x-on:keydown.esc="isOpen() && $event.stopPropagation()"
@@ -163,7 +168,7 @@
                         'fi-fo-date-time-picker-panel',
                     ])
                 >
-                    @if ($hasDate())
+                    @if ($hasDate)
                         <div class="fi-fo-date-time-picker-panel-header">
                             <select
                                 x-model="focusedMonth"
@@ -256,7 +261,7 @@
                                 x-model.debounce="minute"
                             />
 
-                            @if ($hasSeconds())
+                            @if ($hasSeconds)
                                 <span
                                     class="fi-fo-date-time-picker-time-input-separator"
                                 >


### PR DESCRIPTION
## Description

This PR fix bug on live updating of non native DateTimePicker Component because the key not based on hasDate, hasTime, and hasSeconds value. This update only add thats value to the wire:key serialized value

## Visual changes

none

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
