### PR TITLE
Markdown editor should sanitize HTML after parsing markdown

### DIFF
--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -11,7 +11,7 @@
 <x-dynamic-component :component="$fieldWrapperView" :field="$field">
     @if ($isDisabled())
         <div id="{{ $id }}" class="fi-fo-markdown-editor fi-disabled fi-prose">
-            {!! str($getState())->sanitizeHtml()->markdown($getCommonMarkOptions(), $getCommonMarkExtensions()) !!}
+            {!! str($getState())->markdown($getCommonMarkOptions(), $getCommonMarkExtensions())->sanitizeHtml() !!}
         </div>
     @else
         <x-filament::input.wrapper


### PR DESCRIPTION
## Description

I initially added markdown extension support in: https://github.com/filamentphp/filament/pull/14419.
As part of that I swapped the order of markdown parsing and html sanitization. The idea was to sanitize html before parsing markdown so that markdown extensions, such as this [youtube](https://github.com/trovster/commonmark-ext-youtube-iframe) one, would be able to generate `<iframe>` tags without them being stripped.

This had an unfortunate side-effect of breaking code blocks: https://github.com/filamentphp/filament/issues/15881 (it would replace `` ` `` with `&#96;`)
Sanitization order was reverted in: https://github.com/filamentphp/filament/pull/16650

However, `packages/forms/resources/views/components/markdown-editor.blade.php` was overlooked. The issue is only really present if you display a form with markdown editor inside a view page where it actually renders the markdown.

Docs are already written this way:
https://github.com/filamentphp/filament/blob/432c627bb5a9f6afc336657f6838f90a242eb21e/packages/forms/docs/11-markdown-editor.md?plain=1#L19-L27

---

As a side node for my original issue, I found out that Filament instantiates `HtmlSanitizer` here: https://github.com/filamentphp/filament/blob/432c627bb5a9f6afc336657f6838f90a242eb21e/packages/support/src/SupportServiceProvider.php#L101-L112

I was able to bind this in my own `AppServiceProvider::boot` and add support for iframes this way:
```php
this->app->scoped(
    HtmlSanitizerInterface::class,
    fn(): HtmlSanitizer => new HtmlSanitizer(
        (new HtmlSanitizerConfig)
            ->allowSafeElements()
            ->allowRelativeLinks()
            ->allowRelativeMedias()
            ->allowElement('iframe')
            ->allowAttribute('width', ['iframe'])
            ->allowAttribute('height', ['iframe'])
            ->allowAttribute('src', ['iframe', 'img'])
            ->allowAttribute('frameborder', ['iframe'])
            ->allowAttribute('allowfullscreen', ['iframe'])
            ->allowAttribute('allow', ['iframe'])
            ->allowAttribute('class', allowedElements: '*')
            ->allowAttribute('style', allowedElements: '*')
            ->withMaxInputLength(500000),
    ),
);
```


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
