### PR TITLE
Update 03-testing-tables.md - "Testing that a column can be sorted"

### DIFF
--- a/docs/10-testing/03-testing-tables.md
+++ b/docs/10-testing/03-testing-tables.md
@@ -118,7 +118,7 @@ it('can sort posts by title', function () {
     Post::factory()->count(10)->create();
 
     $sortedPostsAsc = Post::orderBy('title')->get();
-    $sortedPostsDesc = Post::orderBy('title', 'desc')->get();
+    $sortedPostsDesc = Post::orderByDesc('title')->get();
 
     livewire(PostResource\Pages\ListPosts::class)
         ->sortTable('title')

--- a/docs/10-testing/03-testing-tables.md
+++ b/docs/10-testing/03-testing-tables.md
@@ -115,15 +115,24 @@ Once the table is sorted, you can ensure that the table records are rendered in 
 use function Pest\Livewire\livewire;
 
 it('can sort posts by title', function () {
-    $posts = Post::factory()->count(10)->create();
+    Post::factory()->count(10)->create();
+
+    $sortedPostsAsc = Post::query()->orderBy('title')->get();
+    $sortedPostsDesc = Post::query()->orderBy('title', 'desc')->get();
 
     livewire(PostResource\Pages\ListPosts::class)
         ->sortTable('title')
-        ->assertCanSeeTableRecords($posts->sortBy('title'), inOrder: true)
+        ->assertCanSeeTableRecords($sortedPostsAsc, inOrder: true)
         ->sortTable('title', 'desc')
-        ->assertCanSeeTableRecords($posts->sortByDesc('title'), inOrder: true);
+        ->assertCanSeeTableRecords($sortedPostsDesc, inOrder: true);
 });
 ```
+
+<Aside variant="info">
+    Records are **sorted** according to the database's sorting strategy (MySQL and PostgreSQL use different sorting strategies).  
+    Therefore, you cannot use the `sortBy()` collection method on the factory results.  
+    Instead, make sure to order them explicitly in your query using `orderBy()`.
+</Aside>
 
 ### Testing the state of a column
 

--- a/docs/10-testing/03-testing-tables.md
+++ b/docs/10-testing/03-testing-tables.md
@@ -118,7 +118,7 @@ it('can sort posts by title', function () {
     Post::factory()->count(10)->create();
 
     $sortedPostsAsc = Post::query()->orderBy('title')->get();
-    $sortedPostsDesc = Post::query()->orderByDesc('title')->get();
+    $sortedPostsDesc = Post::query()->orderBy('title', 'desc')->get();
 
     livewire(PostResource\Pages\ListPosts::class)
         ->sortTable('title')

--- a/docs/10-testing/03-testing-tables.md
+++ b/docs/10-testing/03-testing-tables.md
@@ -129,7 +129,7 @@ it('can sort posts by title', function () {
 ```
 
 <Aside variant="info">
-    Records are **sorted** according to the database's sorting strategy (MySQL and PostgreSQL use different sorting strategies).  
+    Records are **sorted** according to the database's sorting strategy (e.g. MySQL and PostgreSQL use different sorting strategies).  
     Therefore, you cannot use the `sortBy()` collection method on the factory results.  
     Instead, make sure to order them explicitly in your query using `orderBy()`.
 </Aside>

--- a/docs/10-testing/03-testing-tables.md
+++ b/docs/10-testing/03-testing-tables.md
@@ -117,8 +117,8 @@ use function Pest\Livewire\livewire;
 it('can sort posts by title', function () {
     Post::factory()->count(10)->create();
 
-    $sortedPostsAsc = Post::query()->orderBy('title')->get();
-    $sortedPostsDesc = Post::query()->orderBy('title', 'desc')->get();
+    $sortedPostsAsc = Post::orderBy('title')->get();
+    $sortedPostsDesc = Post::orderBy('title', 'desc')->get();
 
     livewire(PostResource\Pages\ListPosts::class)
         ->sortTable('title')

--- a/docs/10-testing/03-testing-tables.md
+++ b/docs/10-testing/03-testing-tables.md
@@ -117,8 +117,8 @@ use function Pest\Livewire\livewire;
 it('can sort posts by title', function () {
     Post::factory()->count(10)->create();
 
-    $sortedPostsAsc = Post::orderBy('title')->get();
-    $sortedPostsDesc = Post::orderByDesc('title')->get();
+    $sortedPostsAsc = Post::query()->orderBy('title')->get();
+    $sortedPostsDesc = Post::query()->orderByDesc('title')->get();
 
     livewire(PostResource\Pages\ListPosts::class)
         ->sortTable('title')
@@ -129,9 +129,7 @@ it('can sort posts by title', function () {
 ```
 
 <Aside variant="info">
-    Records are **sorted** according to the database's sorting strategy (e.g. MySQL and PostgreSQL use different sorting strategies).  
-    Therefore, you cannot use the `sortBy()` collection method on the factory results.  
-    Instead, make sure to order them explicitly in your query using `orderBy()`.
+    Filament tables use a SQL `order` statement to sort records before they are output. Different database drivers can use different sorting strategies, and they can differ from PHP's own sorting strategy, so you should ensure that test records are sorted using `orderBy()` on a database query rather than `sortBy()` on a collection of models.
 </Aside>
 
 ### Testing the state of a column


### PR DESCRIPTION
## Description

See issue #17817

Currently, the documentation includes a flaky test as an example for sorting a column. This is because Filament sorts its table records according to the underlying database strategy.

Previously, the documentation suggested using the `sortBy()` method on the collection returned by the factory. However, this approach does not account for differences in how various databases handle sorting, which can lead to inconsistent test results.

With this commit, the documentation has been updated. The example test now uses a stable approach that explicitly orders records through the database query, ensuring reliable behavior across different database systems.

## Visual changes
N/A

## Functional changes
- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
