### PR TITLE
[4.x] Add key to form actions content component for use with testing

### DIFF
--- a/packages/panels/src/Auth/Pages/EditProfile.php
+++ b/packages/panels/src/Auth/Pages/EditProfile.php
@@ -450,7 +450,8 @@ class EditProfile extends Page
                 Actions::make($this->getFormActions())
                     ->alignment($this->getFormActionsAlignment())
                     ->fullWidth($this->hasFullWidthFormActions())
-                    ->sticky((! static::isSimple()) && $this->areFormActionsSticky()),
+                    ->sticky((! static::isSimple()) && $this->areFormActionsSticky())
+                    ->key('form-actions'),
             ]);
     }
 

--- a/packages/panels/src/Auth/Pages/Login.php
+++ b/packages/panels/src/Auth/Pages/Login.php
@@ -405,7 +405,8 @@ class Login extends SimplePage
             ->footer([
                 Actions::make($this->getFormActions())
                     ->alignment($this->getFormActionsAlignment())
-                    ->fullWidth($this->hasFullWidthFormActions()),
+                    ->fullWidth($this->hasFullWidthFormActions())
+                    ->key('form-actions'),
             ])
             ->visible(fn (): bool => blank($this->userUndertakingMultiFactorAuthentication));
     }

--- a/packages/panels/src/Auth/Pages/PasswordReset/RequestPasswordReset.php
+++ b/packages/panels/src/Auth/Pages/PasswordReset/RequestPasswordReset.php
@@ -224,7 +224,8 @@ class RequestPasswordReset extends SimplePage
             ->footer([
                 Actions::make($this->getFormActions())
                     ->alignment($this->getFormActionsAlignment())
-                    ->fullWidth($this->hasFullWidthFormActions()),
+                    ->fullWidth($this->hasFullWidthFormActions())
+                    ->key('form-actions'),
             ]);
     }
 

--- a/packages/panels/src/Auth/Pages/PasswordReset/ResetPassword.php
+++ b/packages/panels/src/Auth/Pages/PasswordReset/ResetPassword.php
@@ -225,7 +225,8 @@ class ResetPassword extends SimplePage
             ->footer([
                 Actions::make($this->getFormActions())
                     ->alignment($this->getFormActionsAlignment())
-                    ->fullWidth($this->hasFullWidthFormActions()),
+                    ->fullWidth($this->hasFullWidthFormActions())
+                    ->key('form-actions'),
             ]);
     }
 

--- a/packages/panels/src/Auth/Pages/Register.php
+++ b/packages/panels/src/Auth/Pages/Register.php
@@ -302,7 +302,8 @@ class Register extends SimplePage
             ->footer([
                 Actions::make($this->getFormActions())
                     ->alignment($this->getFormActionsAlignment())
-                    ->fullWidth($this->hasFullWidthFormActions()),
+                    ->fullWidth($this->hasFullWidthFormActions())
+                    ->key('form-actions'),
             ]);
     }
 }

--- a/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
+++ b/packages/panels/src/Pages/Tenancy/EditTenantProfile.php
@@ -243,7 +243,8 @@ abstract class EditTenantProfile extends Page
                 Actions::make($this->getFormActions())
                     ->alignment($this->getFormActionsAlignment())
                     ->fullWidth($this->hasFullWidthFormActions())
-                    ->sticky($this->areFormActionsSticky()),
+                    ->sticky($this->areFormActionsSticky())
+                    ->key('form-actions'),
             ]);
     }
 

--- a/packages/panels/src/Pages/Tenancy/RegisterTenant.php
+++ b/packages/panels/src/Pages/Tenancy/RegisterTenant.php
@@ -202,7 +202,8 @@ abstract class RegisterTenant extends SimplePage
                 Actions::make($this->getFormActions())
                     ->alignment($this->getFormActionsAlignment())
                     ->fullWidth($this->hasFullWidthFormActions())
-                    ->sticky($this->areFormActionsSticky()),
+                    ->sticky($this->areFormActionsSticky())
+                    ->key('form-actions'),
             ]);
     }
 }

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -387,7 +387,8 @@ class CreateRecord extends Page
         return Actions::make($this->getFormActions())
             ->alignment($this->getFormActionsAlignment())
             ->fullWidth($this->hasFullWidthFormActions())
-            ->sticky($this->areFormActionsSticky());
+            ->sticky($this->areFormActionsSticky())
+            ->key('form-actions-content-component');
     }
 
     public function hasFormWrapper(): bool

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -388,7 +388,7 @@ class CreateRecord extends Page
             ->alignment($this->getFormActionsAlignment())
             ->fullWidth($this->hasFullWidthFormActions())
             ->sticky($this->areFormActionsSticky())
-            ->key('form-actions-content-component');
+            ->key('form-actions');
     }
 
     public function hasFormWrapper(): bool

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -441,7 +441,8 @@ class EditRecord extends Page
         return Actions::make($this->getFormActions())
             ->alignment($this->getFormActionsAlignment())
             ->fullWidth($this->hasFullWidthFormActions())
-            ->sticky($this->areFormActionsSticky());
+            ->sticky($this->areFormActionsSticky())
+            ->key('form-actions-content-component');
     }
 
     public function hasFormWrapper(): bool

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -442,7 +442,7 @@ class EditRecord extends Page
             ->alignment($this->getFormActionsAlignment())
             ->fullWidth($this->hasFullWidthFormActions())
             ->sticky($this->areFormActionsSticky())
-            ->key('form-actions-content-component');
+            ->key('form-actions');
     }
 
     public function hasFormWrapper(): bool

--- a/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
+++ b/packages/spatie-laravel-settings-plugin/src/Pages/SettingsPage.php
@@ -221,7 +221,8 @@ class SettingsPage extends Page
         return Actions::make($this->getFormActions())
             ->alignment($this->getFormActionsAlignment())
             ->fullWidth($this->hasFullWidthFormActions())
-            ->sticky($this->areFormActionsSticky());
+            ->sticky($this->areFormActionsSticky())
+            ->key('form-actions');
     }
 
     protected function getSubmitFormLivewireMethodName(): string


### PR DESCRIPTION
## Description

This is a proposal to add an explicit key to the default form action components.  

If there is any modification to the behavior of the default actions in the form, such as a modal to confirm saving changes, these actions cannot currently be verified or accessed via tests due to the integer-based array-keys when trying to retrieve the schema component.  

The change here would make the following `TestAction` viable to access the default 'save' action:

```
TestAction::make('save')->schemaComponent('form-actions-content-component', 'content')
```

### Further consideration

There are no other references in the code-base related to adding explicit `key()`s to components, so this may stray from conventions, so I'm open to alternatives to achieve the same result.


## Visual changes


## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
