### PR TITLE
Fix: ToggleButtons and Radio buttons lose keyboard focus

### DIFF
--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -36,9 +36,27 @@
                     ], escape: false);
             @endphp
 
-            <label class="fi-fo-radio-label">
+            <label class="fi-fo-radio-label" 
+                x-data="{
+                    init() {
+                        Livewire.hook('morph.updated', () => {
+                            if (window.focusAfterMorph) {
+                                const el = document.getElementById(window.focusAfterMorph)
+                                if (el) {
+                                    el.focus()
+                                }
+                                window.focusAfterMorph = null
+                            }
+                        })
+                    },
+                    handleChange(event) {
+                        window.focusAfterMorph = event.target.id
+                    }
+                }"
+                >
                 <input
                     type="radio"
+                    @change="handleChange"
                     {{
                         $inputAttributes->class([
                             'fi-radio-input',

--- a/packages/forms/resources/views/components/toggle-buttons/index.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/index.blade.php
@@ -30,6 +30,22 @@
                     'fi-inline' => $isInline,
                 ])
         }}
+        x-data="{
+            init() {
+                Livewire.hook('morph.updated', () => {
+                    if (window.focusAfterMorph) {
+                        const el = document.getElementById(window.focusAfterMorph)
+                        if (el) {
+                            el.focus()
+                        }
+                        window.focusAfterMorph = null
+                    }
+                })
+            },
+            handleChange(event) {
+                window.focusAfterMorph = event.target.id
+            }
+        }"
     >
         @foreach ($getOptions() as $value => $label)
             @php
@@ -41,6 +57,7 @@
 
             <div class="fi-fo-toggle-buttons-btn-ctn">
                 <input
+                    @change="handleChange"
                     @disabled($shouldOptionBeDisabled)
                     id="{{ $inputId }}"
                     @if (! $isMultiple)


### PR DESCRIPTION
## Description
Fixes #16946
I was unable to fix this with with Livewire. Focus state is supposed to be preserved, but I think the morphing process is causing the elements to be replaced in the browser with an evil twin.

## Visual changes
This fix causes live radio buttons to flash.  I understand if this doesn't make the cut.

https://github.com/user-attachments/assets/214ccaad-eb52-4b5e-83fd-71e2020668ff



## Functional changes
Lifecycle hook to refocus element after morph.

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
