### PR TITLE
fix a11y radio and toggle button lose focus when live

### DIFF
--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -31,7 +31,6 @@
                         'id' => $id . '-' . $value,
                         'name' => $id,
                         'value' => $value,
-                        'wire:loading.attr' => 'disabled',
                         $wireModelAttribute => $statePath,
                     ], escape: false);
             @endphp

--- a/packages/forms/resources/views/components/toggle-buttons/index.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/index.blade.php
@@ -48,7 +48,6 @@
                     @endif
                     type="{{ $isMultiple ? 'checkbox' : 'radio' }}"
                     value="{{ $value }}"
-                    wire:loading.attr="disabled"
                     {{ $wireModelAttribute }}="{{ $statePath }}"
                     {{ $extraInputAttributeBag }}
                 />


### PR DESCRIPTION
## Description
Fixes #16946
While it's best practice to disable components on update, this removes focus as the component is disable during a livewire morph. The risk of a race condition for these components are much less due to the nature of the component.

## Visual changes

None

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
