### PR TITLE
[3.x] Backport: bug: Toggle and Radio buttons lose focus on live

### DIFF
--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -42,7 +42,6 @@
                                     'id' => $id . '-' . $value,
                                     'name' => $id,
                                     'value' => $value,
-                                    'wire:loading.attr' => 'disabled',
                                     $applyStateBindingModifiers('wire:model') => $statePath,
                                 ], escape: false)
                                 ->class(['mt-1'])

--- a/packages/forms/resources/views/components/toggle-buttons/index.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/index.blade.php
@@ -61,7 +61,6 @@
                     @endif
                     type="{{ $isMultiple ? 'checkbox' : 'radio' }}"
                     value="{{ $value }}"
-                    wire:loading.attr="disabled"
                     {{ $applyStateBindingModifiers('wire:model') }}="{{ $statePath }}"
                     {{ $getExtraInputAttributeBag()->class(['peer pointer-events-none absolute opacity-0']) }}
                 />


### PR DESCRIPTION
## Description
Accessibility Issue: ToggleButtons and Radio buttons lose keyboard focus after live updates 
fixed #16946

## Visual changes

None

## Functional changes
Despite best practice to disable components on update, it was breaking focus after morph.

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
