### PR TITLE
fix: use line-clamp in columns to handle text overflow

### DIFF
--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -347,7 +347,8 @@ class TextColumn extends Column implements HasEmbeddedView
         if (
             ($stateCount === 1) &&
             (! $isBulleted) &&
-            (! $hasDescriptions)
+            (! $hasDescriptions) &&
+            (! $lineClamp)
         ) {
             $stateItem = Arr::first($state);
             [
@@ -359,20 +360,20 @@ class TextColumn extends Column implements HasEmbeddedView
 
             ob_start(); ?>
 
-            <div <?= $attributes->toHtml() ?>>
-                <p <?= $stateItemAttributes->toHtml() ?>>
-                    <?php if ($isBadge) { ?>
-                        <span <?= $stateItemBadgeAttributes->toHtml() ?>>
-                    <?php } ?>
+            <div <?= $attributes
+                ->merge($stateItemAttributes->getAttributes(), escape: false)
+                ->toHtml() ?>>
+                <?php if ($isBadge) { ?>
+                <span <?= $stateItemBadgeAttributes->toHtml() ?>>
+                <?php } ?>
 
-                    <?= $stateItemIconBeforeHtml ?>
-                    <?= $formatState($stateItem) ?>
-                    <?= $stateItemIconAfterHtml ?>
+                <?= $stateItemIconBeforeHtml ?>
+                <?= $formatState($stateItem) ?>
+                <?= $stateItemIconAfterHtml ?>
 
-                    <?php if ($isBadge) { ?>
-                        </span>
-                    <?php } ?>
-                </p>
+                <?php if ($isBadge) { ?>
+                    </span>
+                <?php } ?>
             </div>
 
             <?php return ob_get_clean();

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -408,12 +408,12 @@ class TextColumn extends Column implements HasEmbeddedView
                 <?php if (($stateCount === 1) && (! $isBulleted)) { ?>
                     <?php
                         $stateItem = Arr::first($state);
-                        [
-                            'attributes' => $stateItemAttributes,
-                            'badgeAttributes' => $stateItemBadgeAttributes,
-                            'iconAfterHtml' => $stateItemIconAfterHtml,
-                            'iconBeforeHtml' => $stateItemIconBeforeHtml,
-                        ] = $getStateItem($stateItem);
+                    [
+                        'attributes' => $stateItemAttributes,
+                        'badgeAttributes' => $stateItemBadgeAttributes,
+                        'iconAfterHtml' => $stateItemIconAfterHtml,
+                        'iconBeforeHtml' => $stateItemIconBeforeHtml,
+                    ] = $getStateItem($stateItem);
                     ?>
 
                     <p <?= $stateItemAttributes->toHtml() ?>>

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -359,20 +359,20 @@ class TextColumn extends Column implements HasEmbeddedView
 
             ob_start(); ?>
 
-            <div <?= $attributes
-                ->merge($stateItemAttributes->getAttributes(), escape: false)
-                ->toHtml() ?>>
-                <?php if ($isBadge) { ?>
-                    <span <?= $stateItemBadgeAttributes->toHtml() ?>>
-                <?php } ?>
+            <div <?= $attributes->toHtml() ?>>
+                <p <?= $stateItemAttributes->toHtml() ?>>
+                    <?php if ($isBadge) { ?>
+                        <span <?= $stateItemBadgeAttributes->toHtml() ?>>
+                    <?php } ?>
 
-                <?= $stateItemIconBeforeHtml ?>
-                <?= $formatState($stateItem) ?>
-                <?= $stateItemIconAfterHtml ?>
+                    <?= $stateItemIconBeforeHtml ?>
+                    <?= $formatState($stateItem) ?>
+                    <?= $stateItemIconAfterHtml ?>
 
-                <?php if ($isBadge) { ?>
-                    </span>
-                <?php } ?>
+                    <?php if ($isBadge) { ?>
+                        </span>
+                    <?php } ?>
+                </p>
             </div>
 
             <?php return ob_get_clean();
@@ -408,12 +408,12 @@ class TextColumn extends Column implements HasEmbeddedView
                 <?php if (($stateCount === 1) && (! $isBulleted)) { ?>
                     <?php
                         $stateItem = Arr::first($state);
-                    [
-                        'attributes' => $stateItemAttributes,
-                        'badgeAttributes' => $stateItemBadgeAttributes,
-                        'iconAfterHtml' => $stateItemIconAfterHtml,
-                        'iconBeforeHtml' => $stateItemIconBeforeHtml,
-                    ] = $getStateItem($stateItem);
+                        [
+                            'attributes' => $stateItemAttributes,
+                            'badgeAttributes' => $stateItemBadgeAttributes,
+                            'iconAfterHtml' => $stateItemIconAfterHtml,
+                            'iconBeforeHtml' => $stateItemIconBeforeHtml,
+                        ] = $getStateItem($stateItem);
                     ?>
 
                     <p <?= $stateItemAttributes->toHtml() ?>>


### PR DESCRIPTION
## Description

fixes: #17867

Missing a container, so the element is displayed in the padding area.



----

Currently, using `badge()` or `bulleted()` does not support controlling the number of lines with `lineClamp()`. I think this can be implemented, and the bullet point in front of the li can be retained. If you think my suggestion is reasonable, please let me know and I can submit a PR for this.

## Visual changes

# Before
<img width="1236" height="355" alt="image" src="https://github.com/user-attachments/assets/d9436c13-9cd1-438e-aeea-b6593185e9ae" />

# After

<img width="1186" height="379" alt="image" src="https://github.com/user-attachments/assets/b7c84fd6-3e17-4c6a-a68d-d9012172cd4f" />


use  `badge` &&  `bulleted`  the same as before the change

<img width="1070" height="489" alt="image" src="https://github.com/user-attachments/assets/6408b330-4250-409a-99d0-c73786c681f7" />

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
