### PR TITLE
Support HTML in table filter labels

### DIFF
--- a/packages/tables/src/Filters/Concerns/HasLabel.php
+++ b/packages/tables/src/Filters/Concerns/HasLabel.php
@@ -3,14 +3,15 @@
 namespace Filament\Tables\Filters\Concerns;
 
 use Closure;
+use Illuminate\Contracts\Support\Htmlable;
 
 trait HasLabel
 {
-    protected string | Closure | null $label = null;
+    protected string | Htmlable | Closure | null $label = null;
 
     protected bool $shouldTranslateLabel = false;
 
-    public function label(string | Closure | null $label): static
+    public function label(string | Htmlable | Closure | null $label): static
     {
         $this->label = $label;
 
@@ -24,7 +25,7 @@ trait HasLabel
         return $this;
     }
 
-    public function getLabel(): string
+    public function getLabel(): string | Htmlable
     {
         $label = $this->evaluate($this->label) ?? (string) str($this->getName())
             ->before('.')


### PR DESCRIPTION
## Description
Table Filter Labels should as well support direct Htmlable values, see https://github.com/filamentphp/filament/discussions/17840
Having to recreate all filters with forms schemas (incl indicators etc) just complicates too much for nothing.

## Visual changes
Before:  
<img width="453" height="68" alt="grafik" src="https://github.com/user-attachments/assets/74f0e771-d499-428f-bbcb-03678f3f72e3" />  
After:  
<img width="451" height="69" alt="grafik" src="https://github.com/user-attachments/assets/9969dcbc-58db-4d5b-9dd7-fcf9c0303583" />

## Code to write
Before:  
```
Tables\Filters\Filter::make('test')
  ->schema([
      Select::make('test')
          ->label(new HtmlString('Some label with link <a href="/">here</a>:'))
          ->options([
              'No' => 'No',
              'Yes' => 'Yes',
          ])
          ->default('No')
          ->selectablePlaceholder(false),
      ])
  ->query(function (Builder $query, array $data): Builder {
      return $query
          ->when(
              $data['test'] == 'No',
              fn (Builder $query, $date): Builder => $query->where('test', '=', false),
          )
          ->when(
              $data['test'] == 'Yes',
             fn (Builder $query, $date): Builder => $query->where('test', '=', true),
          );
      })
  ->indicateUsing(function (array $data): array {
      $indicators = [];
      $indicator_label = 'Some indicator '.$data['test'];
      $indicators[] = Indicator::make($indicator_label)->removable(false);
      return $indicators;
  }),
```
After:  
```
Tables\Filters\TernaryFilter::make('test')
  ->label(new HtmlString('Some label with link <a href="/">here</a>:'))
  ->placeholder('great')
  ->trueLabel('Yes')
  ->falseLabel('No'),
```



## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
