### PR TITLE
[3.x] Backport: Fix: ToggleButtons and Radio buttons lose keyboard focus

### DIFF
--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -42,7 +42,6 @@
                                     'id' => $id . '-' . $value,
                                     'name' => $id,
                                     'value' => $value,
-                                    'wire:loading.attr' => 'disabled',
                                     $applyStateBindingModifiers('wire:model') => $statePath,
                                 ], escape: false)
                                 ->class(['mt-1'])

--- a/packages/forms/resources/views/components/toggle-buttons/index.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/index.blade.php
@@ -61,7 +61,6 @@
                     @endif
                     type="{{ $isMultiple ? 'checkbox' : 'radio' }}"
                     value="{{ $value }}"
-                    wire:loading.attr="disabled"
                     {{ $applyStateBindingModifiers('wire:model') }}="{{ $statePath }}"
                     {{ $getExtraInputAttributeBag()->class(['peer pointer-events-none absolute opacity-0']) }}
                 />


### PR DESCRIPTION
## Description
Fixes #16946
Toggle and Radio buttons lose focus when disabled on Livewire update

## Visual changes

None

## Functional changes
Elements are no longer disabled on Livewire update so they don't lose focus

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
