### PR TITLE
fix: exception when using hasBlockPreviews in Builder component

### DIFF
--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -192,7 +192,7 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
                 ->modalSubmitActionLabel(__('filament-forms::components.builder.actions.add.modal.actions.add.label'))
                 ->schema(function (array $arguments, Builder $component): array {
                     return collect($component->getBlock($arguments['block'])->getDefaultChildComponents())
-                        ->map->getClone()
+                        ->map(fn (Component $childComponent): Component => $childComponent->getClone())
                         ->all();
                 });
         }
@@ -289,7 +289,7 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
                 ->modalSubmitActionLabel(__('filament-forms::components.builder.actions.add_between.modal.actions.add.label'))
                 ->schema(function (array $arguments, Builder $component): array {
                     return collect($component->getBlock($arguments['block'])->getDefaultChildComponents())
-                        ->map->getClone()
+                        ->map(fn (Component $childComponent): Component => $childComponent->getClone())
                         ->all();
                 });
         }

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -6,7 +6,6 @@ use Closure;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Builder\Block;
 use Filament\Forms\View\FormsIconAlias;
-use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Concerns\CanBeCollapsed;
 use Filament\Schemas\Components\Contracts\CanConcealComponents;
 use Filament\Schemas\Components\Contracts\HasExtraItemActions;
@@ -192,13 +191,7 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
                 ]))
                 ->modalSubmitActionLabel(__('filament-forms::components.builder.actions.add.modal.actions.add.label'))
                 ->schema(function (array $arguments, Builder $component): array {
-                    /** @var array<Component> $defaultComponents */
-                    $defaultComponents = $component->getBlock($arguments['block'])->getDefaultChildComponents();
-
-                    return array_map(
-                        fn (Component $childComponent): Component => $childComponent->getClone(),
-                        $defaultComponents,
-                    );
+                    return $component->getBlock($arguments['block'])->getClone()->getDefaultChildComponents();
                 });
         }
 
@@ -293,13 +286,7 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
                 ]))
                 ->modalSubmitActionLabel(__('filament-forms::components.builder.actions.add_between.modal.actions.add.label'))
                 ->schema(function (array $arguments, Builder $component): array {
-                    /** @var array<Component> $defaultComponents */
-                    $defaultComponents = $component->getBlock($arguments['block'])->getDefaultChildComponents();
-
-                    return array_map(
-                        fn (Component $childComponent): Component => $childComponent->getClone(),
-                        $defaultComponents,
-                    );
+                    return $component->getBlock($arguments['block'])->getClone()->getDefaultChildComponents();
                 });
         }
 

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -191,7 +191,9 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
                 ]))
                 ->modalSubmitActionLabel(__('filament-forms::components.builder.actions.add.modal.actions.add.label'))
                 ->schema(function (array $arguments, Builder $component): array {
-                    return $component->getBlock($arguments['block'])->getDefaultChildComponents();
+                    return collect($component->getBlock($arguments['block'])->getDefaultChildComponents())
+                        ->map->getClone()
+                        ->all();
                 });
         }
 
@@ -286,7 +288,9 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
                 ]))
                 ->modalSubmitActionLabel(__('filament-forms::components.builder.actions.add_between.modal.actions.add.label'))
                 ->schema(function (array $arguments, Builder $component): array {
-                    return $component->getBlock($arguments['block'])->getDefaultChildComponents();
+                    return collect($component->getBlock($arguments['block'])->getDefaultChildComponents())
+                        ->map->getClone()
+                        ->all();
                 });
         }
 

--- a/packages/forms/src/Components/Builder.php
+++ b/packages/forms/src/Components/Builder.php
@@ -6,6 +6,7 @@ use Closure;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Builder\Block;
 use Filament\Forms\View\FormsIconAlias;
+use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Concerns\CanBeCollapsed;
 use Filament\Schemas\Components\Contracts\CanConcealComponents;
 use Filament\Schemas\Components\Contracts\HasExtraItemActions;
@@ -191,9 +192,13 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
                 ]))
                 ->modalSubmitActionLabel(__('filament-forms::components.builder.actions.add.modal.actions.add.label'))
                 ->schema(function (array $arguments, Builder $component): array {
-                    return collect($component->getBlock($arguments['block'])->getDefaultChildComponents())
-                        ->map(fn (Component $childComponent): Component => $childComponent->getClone())
-                        ->all();
+                    /** @var array<Component> $defaultComponents */
+                    $defaultComponents = $component->getBlock($arguments['block'])->getDefaultChildComponents();
+
+                    return array_map(
+                        fn (Component $childComponent): Component => $childComponent->getClone(),
+                        $defaultComponents,
+                    );
                 });
         }
 
@@ -288,9 +293,13 @@ class Builder extends Field implements CanConcealComponents, HasExtraItemActions
                 ]))
                 ->modalSubmitActionLabel(__('filament-forms::components.builder.actions.add_between.modal.actions.add.label'))
                 ->schema(function (array $arguments, Builder $component): array {
-                    return collect($component->getBlock($arguments['block'])->getDefaultChildComponents())
-                        ->map(fn (Component $childComponent): Component => $childComponent->getClone())
-                        ->all();
+                    /** @var array<Component> $defaultComponents */
+                    $defaultComponents = $component->getBlock($arguments['block'])->getDefaultChildComponents();
+
+                    return array_map(
+                        fn (Component $childComponent): Component => $childComponent->getClone(),
+                        $defaultComponents,
+                    );
                 });
         }
 

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -372,7 +372,7 @@ class TextColumn extends Column implements HasEmbeddedView
                 ->merge($stateItemAttributes->getAttributes(), escape: false)
                 ->toHtml() ?>>
                 <?php if ($stateItemContentAttributes) { ?>
-                <span <?= $stateItemContentAttributes->toHtml() ?>>
+                    <span <?= $stateItemContentAttributes->toHtml() ?>>
                 <?php } ?>
 
                 <?= $stateItemIconBeforeHtml ?>


### PR DESCRIPTION
## Description

fixes: #17915

Use clone DefaultChildComponents to avoid making modifications in external forms that affect the original ChildComponents

## Visual changes

# Before


https://github.com/user-attachments/assets/576eddcb-459a-4ab8-80c4-5fa2312dc45b

# After

https://github.com/user-attachments/assets/bf8004e8-8a4d-464c-b3b0-05979cd9252e



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
