### PR TITLE
Laravel Eloquent, the Builder class does not have a getLimit() method, so using getQuery()->limit

### DIFF
--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -132,8 +132,8 @@ trait CanExportRecords
 
             $totalRows = $records ? $records->count() : $query->toBase()->getCountForPagination();
 
-            if ((! $records) && $query->getLimit()) {
-                $totalRows = min($totalRows, $query->getLimit());
+            if ((! $records) && $query->getQuery()->limit) {
+                $totalRows = min($totalRows, $query->getQuery()->limit);
             }
 
             $maxRows = $action->getMaxRows() ?? $totalRows;


### PR DESCRIPTION
Fixes #17940 

$query->getQuery() gives the underlying Illuminate\Database\Query\Builder object.

That object does have a limit property that stores the LIMIT value of the query.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

 Fixed an issue where applying a limit directly
   on the query in Filament exporters wasn't
  working properly. The solution uses
  getQuery()->limit to access the underlying
  query builder's limit property, ensuring the
  export respects the specified row limit.


## Visual changes

before the fix
<img width="1763" height="857" alt="image" src="https://github.com/user-attachments/assets/deec9416-e3e1-4087-b650-41b30ad499bd" />

after the fix
<img width="396" height="158" alt="image" src="https://github.com/user-attachments/assets/859b0472-70af-40e0-9c01-83ed549fd1ac" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
