### PR TITLE
fix: Simple page max width configuration

### DIFF
--- a/packages/panels/src/Auth/Pages/EditProfile.php
+++ b/packages/panels/src/Auth/Pages/EditProfile.php
@@ -428,7 +428,8 @@ class EditProfile extends Page
     {
         return [
             'hasTopbar' => $this->hasTopbar(),
-            'maxWidth' => $this->getMaxWidth(),
+            'maxContentWidth' => $maxContentWidth = $this->getMaxWidth() ?? $this->getMaxContentWidth(),
+            'maxWidth' => $maxContentWidth,
         ];
     }
 

--- a/packages/panels/src/Pages/SimplePage.php
+++ b/packages/panels/src/Pages/SimplePage.php
@@ -15,7 +15,8 @@ abstract class SimplePage extends BasePage
     {
         return [
             'hasTopbar' => $this->hasTopbar(),
-            'maxWidth' => $this->getMaxWidth(),
+            'maxContentWidth' => $maxContentWidth = $this->getMaxWidth() ?? $this->getMaxContentWidth(),
+            'maxWidth' => $maxContentWidth,
         ];
     }
 


### PR DESCRIPTION
Fixes #17947, allows v3 `$maxWidth` property to continue to work