### PR TITLE
Restore hint icon color functionality

### DIFF
--- a/packages/forms/src/Components/Concerns/HasHint.php
+++ b/packages/forms/src/Components/Concerns/HasHint.php
@@ -73,6 +73,12 @@ trait HasHint
                         $parentComponent = $component->getContainer()->getParentComponent();
 
                         return filled($parentComponent->getHintIcon());
+                    })
+                    ->color(static function (Icon $component): string | array | null {
+                        /** @var self $parentComponent */
+                        $parentComponent = $component->getContainer()->getParentComponent();
+
+                        return $parentComponent->getHintColor();
                     });
             }
 

--- a/packages/infolists/src/Components/Concerns/HasHint.php
+++ b/packages/infolists/src/Components/Concerns/HasHint.php
@@ -72,6 +72,12 @@ trait HasHint
                         $parentComponent = $component->getContainer()->getParentComponent();
 
                         return filled($parentComponent->getHintIcon());
+                    })
+                    ->color(static function (Icon $component): string | array | null {
+                        /** @var self $parentComponent */
+                        $parentComponent = $component->getContainer()->getParentComponent();
+
+                        return $parentComponent->getHintColor();
                     });
             }
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

In v3 you could set the color of a hint icon on a component like so:
```php
->hintIcon('heroicon-o-x-circle')
->hintColor('danger');
```
This appears to have been removed in v4 resulting in the hint icon just being the primary color.

## Visual changes

In v3:

<img width="97" height="63" alt="Screenshot 2025-09-23 at 11 57 55 AM" src="https://github.com/user-attachments/assets/4d8e35d4-9f76-4a16-84a6-f43205006368" />

In v4 prior to this change:

<img width="100" height="56" alt="Screenshot 2025-09-23 at 11 59 56 AM" src="https://github.com/user-attachments/assets/3b5faa51-e31d-4848-9fcd-8f966a1506aa" />

After this change:

<img width="98" height="56" alt="Screenshot 2025-09-25 at 7 26 00 PM" src="https://github.com/user-attachments/assets/bcc49366-28c0-47de-93b4-ecfe28f8bbf0" />

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
