### PR TITLE
fix: error when only resources are configured for multi-tenancy and the authenticated user has no tenant

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -179,7 +179,7 @@ trait HasRoutes
             return $this->getRedirectUrl($tenant);
         }
 
-        if (Route::has($homeRouteName = $this->generateRouteName('home'))) {
+        if ((! $hasTenancy || $tenant) && Route::has($homeRouteName = $this->generateRouteName('home'))) {
             return route($homeRouteName, $tenant ? ['tenant' => $tenant] : []);
         }
 

--- a/packages/panels/src/Panel/Concerns/HasRoutes.php
+++ b/packages/panels/src/Panel/Concerns/HasRoutes.php
@@ -179,7 +179,7 @@ trait HasRoutes
             return $this->getRedirectUrl($tenant);
         }
 
-        if ((! $hasTenancy || $tenant) && Route::has($homeRouteName = $this->generateRouteName('home'))) {
+        if (((! $hasTenancy) || $tenant) && Route::has($homeRouteName = $this->generateRouteName('home'))) {
             return route($homeRouteName, $tenant ? ['tenant' => $tenant] : []);
         }
 


### PR DESCRIPTION
## Description

Fixes:  #17952 

The error occurs when pages are specified using only `->resources`: when entering the homepage, if multi-tenancy is enabled a tenant must be present to access the homepage; otherwise it is not required.


## Visual changes

# Before


https://github.com/user-attachments/assets/de92d6d4-8662-46fe-9264-43569791117c



# After


https://github.com/user-attachments/assets/84ea5aba-6917-4505-b458-79fbdc39ff24



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
