### PR TITLE
update greek (el) table translations

### DIFF
--- a/packages/tables/resources/lang/el/table.php
+++ b/packages/tables/resources/lang/el/table.php
@@ -6,9 +6,39 @@ return [
 
         'heading' => 'Στήλες',
 
+        'actions' => [
+
+            'apply' => [
+                'label' => 'Εφαρμογή στήλων',
+            ],
+
+            'reset' => [
+                'label' => 'Επαναφορά',
+            ],
+
+        ],
+
     ],
 
     'columns' => [
+
+        'actions' => [
+            'label' => 'Ενέργεια|Ενέργειες',
+        ],
+
+        'select' => [
+
+            'loading_message' => 'Φόρτωση...',
+
+            'no_search_results_message' => 'Δεν βρέθηκαν επιλογές που ταιριάζουν στην αναζήτησή σας.',
+
+            'placeholder' => 'Επιλέξτε',
+
+            'searching_message' => 'Αναζήτηση...',
+
+            'search_prompt' => 'Ξεκινήστε να πληκτρολογείτε για αναζήτηση...',
+
+        ],
 
         'text' => [
 
@@ -142,6 +172,10 @@ return [
 
         'select' => [
             'placeholder' => 'Όλα',
+
+            'relationship' => [
+                'empty_option_label' => 'Κανένα',
+            ],
         ],
 
         'trashed' => [
@@ -164,7 +198,6 @@ return [
 
             'group' => [
                 'label' => 'Ομαδοποίηση βάσει',
-                'placeholder' => 'Ομαδοποίηση βάσει',
             ],
 
             'direction' => [
@@ -224,5 +257,7 @@ return [
         ],
 
     ],
+
+    'default_model_label' => 'Εγγραφή',
 
 ];


### PR DESCRIPTION
Add missing translations and remove unused ones in the `el` files for tables.

## Description

Add the missing translations in the table translation files for the greek (el) language

## Visual changes

Now it shows the translated items instead of the missing translation path.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
