### PR TITLE
Fix ColorColumn namespace in documentation

### DIFF
--- a/packages/tables/docs/02-columns/05-color.md
+++ b/packages/tables/docs/02-columns/05-color.md
@@ -10,7 +10,7 @@ import UtilityInjection from "@components/UtilityInjection.astro"
 The color column allows you to show the color preview from a CSS color definition, typically entered using the [color picker field](../../forms/color-picker), in one of the supported formats (HEX, HSL, RGB, RGBA).
 
 ```php
-use Filament\Tables\Components\ColorColumn;
+use Filament\Tables\Columns\ColorColumn;
 
 ColorColumn::make('color')
 ```
@@ -22,7 +22,7 @@ ColorColumn::make('color')
 You may make the color copyable, such that clicking on the preview copies the CSS value to the clipboard, and optionally specify a custom confirmation message and duration in milliseconds. This feature only works when SSL is enabled for the app.
 
 ```php
-use Filament\Tables\Components\ColorColumn;
+use Filament\Tables\Columns\ColorColumn;
 
 ColorColumn::make('color')
     ->copyable()
@@ -35,7 +35,7 @@ ColorColumn::make('color')
 Optionally, you may pass a boolean value to control if the text should be copyable or not:
 
 ```php
-use Filament\Tables\Components\ColorColumn;
+use Filament\Tables\Columns\ColorColumn;
 
 ColorColumn::make('color')
     ->copyable(FeatureFlag::active())


### PR DESCRIPTION
Updated namespace for ColorColumn usage in documentation.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
