### PR TITLE
Feature table hide select all checkbox

### DIFF
--- a/packages/tables/docs/04-actions.md
+++ b/packages/tables/docs/04-actions.md
@@ -257,15 +257,15 @@ BulkAction::make('delete')
                     if (($failureCount === 1) && ($totalCount === 1)) {
                         return 'One user failed to delete.';
                     }
-        
+
                     if ($failureCount === $totalCount) {
                         return 'All users failed to delete.';
                     }
-        
+
                     if ($failureCount === 1) {
                         return 'One of the selected users failed to delete.';
                     }
-        
+
                     return "{$failureCount} of the selected users failed to delete.";
                 },
             );
@@ -379,6 +379,20 @@ public function table(Table $table): Table
             // ...
         ])
         ->maxSelectableRecords(4);
+}
+```
+
+### Disable the select all records checkbox
+
+You may want to disable the funciotnality to select all records at once.
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->selectAllAvailable(false)
 }
 ```
 

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -89,6 +89,7 @@
     $isGlobalSearchVisible = $isSearchable();
     $isSearchOnBlur = $isSearchOnBlur();
     $isSelectionEnabled = $isSelectionEnabled() && (! $isGroupsOnly);
+    $isSelectAllAvailable = $isSelectAllAvailable();
     $selectsCurrentPageOnly = $selectsCurrentPageOnly();
     $recordCheckboxPosition = $getRecordCheckboxPosition();
     $isStriped = $isStriped();
@@ -606,16 +607,18 @@
                         {{ FilamentView::renderHook(TablesRenderHook::SELECTION_INDICATOR_ACTIONS_BEFORE, scopes: static::class) }}
 
                         <div class="fi-ta-selection-indicator-actions-ctn">
-                            <x-filament::link
-                                color="primary"
-                                tag="button"
-                                x-on:click="selectAllRecords"
-                                x-show="canSelectAllRecords()"
-                                {{-- Make sure the Alpine attributes get re-evaluated after a Livewire request: --}}
-                                :wire:key="$this->getId() . 'table.selection.indicator.actions.select-all.' . $allSelectableRecordsCount . '.' . $page"
-                            >
-                                {{ trans_choice('filament-tables::table.selection_indicator.actions.select_all.label', $allSelectableRecordsCount, ['count' => \Illuminate\Support\Number::format($allSelectableRecordsCount, locale: app()->getLocale())]) }}
-                            </x-filament::link>
+                            @if ($isSelectAllAvailable)
+                                <x-filament::link
+                                    color="primary"
+                                    tag="button"
+                                    x-on:click="selectAllRecords"
+                                    x-show="canSelectAllRecords()"
+                                    {{-- Make sure the Alpine attributes get re-evaluated after a Livewire request: --}}
+                                    :wire:key="$this->getId() . 'table.selection.indicator.actions.select-all.' . $allSelectableRecordsCount . '.' . $page"
+                                >
+                                    {{ trans_choice('filament-tables::table.selection_indicator.actions.select_all.label', $allSelectableRecordsCount, ['count' => \Illuminate\Support\Number::format($allSelectableRecordsCount, locale: app()->getLocale())]) }}
+                                </x-filament::link>
+                            @endif
 
                             <x-filament::link
                                 color="danger"
@@ -706,7 +709,7 @@
 
                         @if ($isSelectionEnabled || count($sortableColumns))
                             <div class="fi-ta-content-header">
-                                @if ($isSelectionEnabled && ($maxSelectableRecords !== 1) && (! $isReordering))
+                                @if ($isSelectAllAvailable && $isSelectionEnabled && ($maxSelectableRecords !== 1) && (! $isReordering))
                                     <input
                                         aria-label="{{ __('filament-tables::table.fields.bulk_select_page.label') }}"
                                         type="checkbox"
@@ -1297,7 +1300,7 @@
                                             <th
                                                 class="fi-ta-cell fi-ta-selection-cell"
                                             >
-                                                @if ($maxSelectableRecords !== 1)
+                                                @if ($isSelectAllAvailable && $maxSelectableRecords !== 1)
                                                     <input
                                                         aria-label="{{ __('filament-tables::table.fields.bulk_select_page.label') }}"
                                                         type="checkbox"
@@ -1439,7 +1442,7 @@
                                         <th
                                             class="fi-ta-cell fi-ta-selection-cell"
                                         >
-                                            @if ($maxSelectableRecords !== 1)
+                                            @if ($isSelectAllAvailable && $maxSelectableRecords !== 1)
                                                 <input
                                                     aria-label="{{ __('filament-tables::table.fields.bulk_select_page.label') }}"
                                                     type="checkbox"

--- a/packages/tables/src/Table/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Table/Concerns/HasBulkActions.php
@@ -15,6 +15,8 @@ trait HasBulkActions
 
     protected bool | Closure | null $selectsCurrentPageOnly = false;
 
+    protected bool | Closure | null $selectAllAvailable = true;
+
     protected RecordCheckboxPosition | Closure | null $recordCheckboxPosition = null;
 
     protected bool | Closure | null $isSelectable = null;
@@ -61,6 +63,13 @@ trait HasBulkActions
         return $this;
     }
 
+    public function selectAllAvailable(bool | Closure $condition = true): static
+    {
+        $this->selectAllAvailable = $condition;
+
+        return $this;
+    }
+
     public function checkIfRecordIsSelectableUsing(?Closure $callback): static
     {
         $this->checkIfRecordIsSelectableUsing = $callback;
@@ -73,6 +82,11 @@ trait HasBulkActions
         $this->selectsCurrentPageOnly = $condition;
 
         return $this;
+    }
+
+    public function isSelectAllAvailable(): bool
+    {
+        return (bool) $this->evaluate($this->selectAllAvailable);
     }
 
     /**


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Ive added the option to hide the table select all records checkbox.
The feature was also requested here: https://github.com/filamentphp/filament/discussions/5608

## Visual changes

<img width="1247" height="108" alt="image" src="https://github.com/user-attachments/assets/0aa056e9-dc2e-4aae-b7a2-dcedacc8b253" />
<img width="1236" height="108" alt="image" src="https://github.com/user-attachments/assets/bb344247-14b4-4e17-9dcc-96dc83b71632" />



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
