### PR TITLE
Move navigation loading inside of conditional for top navigation

### DIFF
--- a/packages/panels/resources/views/livewire/topbar.blade.php
+++ b/packages/panels/resources/views/livewire/topbar.blade.php
@@ -1,6 +1,5 @@
 <div class="fi-topbar-ctn">
     @php
-        $navigation = filament()->getNavigation();
         $isRtl = __('filament-panels::layout.direction') === 'rtl';
         $isSidebarCollapsibleOnDesktop = filament()->isSidebarCollapsibleOnDesktop();
         $isSidebarFullyCollapsibleOnDesktop = filament()->isSidebarFullyCollapsibleOnDesktop();
@@ -106,6 +105,10 @@
             @endif
 
             @if ($hasNavigation)
+                @php
+                    $navigation = filament()->getNavigation();
+                @endphp
+
                 <ul class="fi-topbar-nav-groups">
                     @foreach ($navigation as $group)
                         @php

--- a/packages/support/resources/views/components/pagination/item.blade.php
+++ b/packages/support/resources/views/components/pagination/item.blade.php
@@ -32,7 +32,7 @@
 
         @if (filled($label))
             <span class="fi-pagination-item-label">
-               {{ is_numeric($label) ? \Illuminate\Support\Number::format($label) : ($label ?? '...') }}
+                {{ is_numeric($label) ? \Illuminate\Support\Number::format($label) : ($label ?? '...') }}
             </span>
         @endif
     </button>


### PR DESCRIPTION
Don't load the navigation unnecessarily when the top navigation is disabled. 

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
