### PR TITLE
Fix broken link by removing .html from Laravel Spark installation URL

### DIFF
--- a/docs/07-users/03-tenancy.md
+++ b/docs/07-users/03-tenancy.md
@@ -243,7 +243,7 @@ $tenant = Filament::getTenant();
 
 Filament provides a billing integration with [Laravel Spark](https://spark.laravel.com). Your users can start subscriptions and manage their billing information.
 
-To install the integration, first [install Spark](https://spark.laravel.com/docs/installation.html) and configure it for your tenant model.
+To install the integration, first [install Spark](https://spark.laravel.com/docs/installation) and configure it for your tenant model.
 
 Now, you can install the Filament billing provider for Spark using Composer:
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The Laravel Spark installation link was pointing to an incorrect `.html` URL. 
This PR removes `.html` to fix the broken link.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
