### PR TITLE
Fix SPA mode key binding errors

### DIFF
--- a/packages/panels/resources/views/livewire/global-search.blade.php
+++ b/packages/panels/resources/views/livewire/global-search.blade.php
@@ -31,6 +31,16 @@
                     type="search"
                     wire:key="global-search.field.input"
                     x-bind:id="$id('input')"
+                    x-init="
+                        const bindings = @js($keyBindings)
+                        document.addEventListener(
+                            'livewire:navigating',
+                            () => {
+                                bindings.forEach((b) => Mousetrap.unbind(b))
+                            },
+                            { once: true },
+                        )
+                    "
                     x-on:keydown.down.prevent.stop="$dispatch('focus-first-global-search-result')"
                     wire:model.live.debounce.{{ $debounce }}="search"
                     x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($id('input')).focus()"

--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -60,10 +60,14 @@
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"
         x-init="
-            const bindings = @js($keyBindings);
-            document.addEventListener('livewire:navigating', () => {
-                bindings.forEach(b => Mousetrap.unbind(b));
-            }, { once: true });
+            const bindings = @js($keyBindings)
+            document.addEventListener(
+                'livewire:navigating',
+                () => {
+                    bindings.forEach((b) => Mousetrap.unbind(b))
+                },
+                { once: true },
+            )
         "
         x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id).click()"
     @endif

--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -59,6 +59,12 @@
     @endif
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"
+        x-init="
+            const bindings = @js($keyBindings);
+            document.addEventListener('livewire:navigating', () => {
+                bindings.forEach(b => Mousetrap.unbind(b));
+            }, { once: true });
+        "
         x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id).click()"
     @endif
     @if ($hasTooltip)

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -100,10 +100,14 @@
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"
         x-init="
-            const bindings = @js($keyBindings);
-            document.addEventListener('livewire:navigating', () => {
-                bindings.forEach(b => Mousetrap.unbind(b));
-            }, { once: true });
+            const bindings = @js($keyBindings)
+            document.addEventListener(
+                'livewire:navigating',
+                () => {
+                    bindings.forEach((b) => Mousetrap.unbind(b))
+                },
+                { once: true },
+            )
         "
         x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id).click()"
     @endif

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -99,6 +99,12 @@
     @endif
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"
+        x-init="
+            const bindings = @js($keyBindings);
+            document.addEventListener('livewire:navigating', () => {
+                bindings.forEach(b => Mousetrap.unbind(b));
+            }, { once: true });
+        "
         x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id).click()"
     @endif
     @if ($hasTooltip)

--- a/packages/support/resources/views/components/dropdown/list/item.blade.php
+++ b/packages/support/resources/views/components/dropdown/list/item.blade.php
@@ -58,10 +58,14 @@
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"
         x-init="
-            const bindings = @js($keyBindings);
-            document.addEventListener('livewire:navigating', () => {
-                bindings.forEach(b => Mousetrap.unbind(b));
-            }, { once: true });
+            const bindings = @js($keyBindings)
+            document.addEventListener(
+                'livewire:navigating',
+                () => {
+                    bindings.forEach((b) => Mousetrap.unbind(b))
+                },
+                { once: true },
+            )
         "
         x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id).click()"
     @endif

--- a/packages/support/resources/views/components/dropdown/list/item.blade.php
+++ b/packages/support/resources/views/components/dropdown/list/item.blade.php
@@ -57,6 +57,12 @@
     @endif
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"
+        x-init="
+            const bindings = @js($keyBindings);
+            document.addEventListener('livewire:navigating', () => {
+                bindings.forEach(b => Mousetrap.unbind(b));
+            }, { once: true });
+        "
         x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id).click()"
     @endif
     @if ($hasTooltip)

--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -65,6 +65,12 @@
     @endif
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"
+        x-init="
+            const bindings = @js($keyBindings);
+            document.addEventListener('livewire:navigating', () => {
+                bindings.forEach(b => Mousetrap.unbind(b));
+            }, { once: true });
+        "
         x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id).click()"
     @endif
     @if ($hasTooltip)

--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -66,10 +66,14 @@
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"
         x-init="
-            const bindings = @js($keyBindings);
-            document.addEventListener('livewire:navigating', () => {
-                bindings.forEach(b => Mousetrap.unbind(b));
-            }, { once: true });
+            const bindings = @js($keyBindings)
+            document.addEventListener(
+                'livewire:navigating',
+                () => {
+                    bindings.forEach((b) => Mousetrap.unbind(b))
+                },
+                { once: true },
+            )
         "
         x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id).click()"
     @endif

--- a/packages/support/resources/views/components/link.blade.php
+++ b/packages/support/resources/views/components/link.blade.php
@@ -76,6 +76,12 @@
     @endif
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"
+        x-init="
+            const bindings = @js($keyBindings);
+            document.addEventListener('livewire:navigating', () => {
+                bindings.forEach(b => Mousetrap.unbind(b));
+            }, { once: true });
+        "
         x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id).click()"
     @endif
     @if ($hasTooltip)

--- a/packages/support/resources/views/components/link.blade.php
+++ b/packages/support/resources/views/components/link.blade.php
@@ -77,10 +77,14 @@
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"
         x-init="
-            const bindings = @js($keyBindings);
-            document.addEventListener('livewire:navigating', () => {
-                bindings.forEach(b => Mousetrap.unbind(b));
-            }, { once: true });
+            const bindings = @js($keyBindings)
+            document.addEventListener(
+                'livewire:navigating',
+                () => {
+                    bindings.forEach((b) => Mousetrap.unbind(b))
+                },
+                { once: true },
+            )
         "
         x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id).click()"
     @endif

--- a/packages/support/src/View/Concerns/CanGenerateBadgeHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateBadgeHtml.php
@@ -120,6 +120,12 @@ trait CanGenerateBadgeHtml
             <?php } ?>
             <?php if ($keyBindings) { ?>
                 x-bind:id="$id('key-bindings')"
+                x-init="
+                    const bindings = <?= Js::from($keyBindings) ?>;
+                    document.addEventListener('livewire:navigating', () => {
+                        bindings.forEach(b => Mousetrap.unbind(b));
+                    }, { once: true });
+                "
                 x-mousetrap.global.<?= collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') ?>="document.getElementById($el.id).click()"
             <?php } ?>
             <?php if ($hasTooltip) { ?>

--- a/packages/support/src/View/Concerns/CanGenerateButtonHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateButtonHtml.php
@@ -176,6 +176,12 @@ trait CanGenerateButtonHtml
             <?php } ?>
             <?php if ($keyBindings) { ?>
                 x-bind:id="$id('key-bindings')"
+                x-init="
+                    const bindings = <?= Js::from($keyBindings) ?>;
+                    document.addEventListener('livewire:navigating', () => {
+                        bindings.forEach(b => Mousetrap.unbind(b));
+                    }, { once: true });
+                "
                 x-mousetrap.global.<?= collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') ?>="document.getElementById($el.id).click()"
             <?php } ?>
             <?php if ($hasTooltip) { ?>

--- a/packages/support/src/View/Concerns/CanGenerateDropdownItemHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateDropdownItemHtml.php
@@ -103,6 +103,12 @@ trait CanGenerateDropdownItemHtml
             <?php } ?>
             <?php if ($keyBindings) { ?>
                 x-bind:id="$id('key-bindings')"
+                x-init="
+                    const bindings = <?= Js::from($keyBindings) ?>;
+                    document.addEventListener('livewire:navigating', () => {
+                        bindings.forEach(b => Mousetrap.unbind(b));
+                    }, { once: true });
+                "
                 x-mousetrap.global.<?= collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') ?>="document.getElementById($el.id).click()"
             <?php } ?>
             <?php if ($hasTooltip) { ?>

--- a/packages/support/src/View/Concerns/CanGenerateIconButtonHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateIconButtonHtml.php
@@ -123,6 +123,12 @@ trait CanGenerateIconButtonHtml
             <?php } ?>
             <?php if ($keyBindings) { ?>
                 x-bind:id="$id('key-bindings')"
+                x-init="
+                    const bindings = <?= Js::from($keyBindings) ?>;
+                    document.addEventListener('livewire:navigating', () => {
+                        bindings.forEach(b => Mousetrap.unbind(b));
+                    }, { once: true });
+                "
                 x-mousetrap.global.<?= collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') ?>="document.getElementById($el.id).click()"
             <?php } ?>
             <?php if ($hasTooltip) { ?>

--- a/packages/support/src/View/Concerns/CanGenerateLinkHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateLinkHtml.php
@@ -142,6 +142,12 @@ trait CanGenerateLinkHtml
             <?php } ?>
             <?php if ($keyBindings) { ?>
                 x-bind:id="$id('key-bindings')"
+                x-init="
+                    const bindings = <?= Js::from($keyBindings) ?>;
+                    document.addEventListener('livewire:navigating', () => {
+                        bindings.forEach(b => Mousetrap.unbind(b));
+                    }, { once: true });
+                "
                 x-mousetrap.global.<?= collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') ?>="document.getElementById($el.id).click()"
             <?php } ?>
             <?php if ($hasTooltip) { ?>


### PR DESCRIPTION
Fixes https://github.com/filamentphp/filament/issues/17711

This PR fixes keyboard bindings persisting across `wire:navigate` transitions in SPA mode, causing JS errors and blocking keypresses on the new page. The problem occurs because global Mousetrap event handlers aren't cleaned up when navigating away from a page, so they keep trying to interact with elements that no longer exist in the DOM.

The fix adds an `x-init` block to all components with kb bindings that registers a `livewire:navigating` cleanup listener. This makes sure all Mousetrap bindings for that component are unbound before navigation completes.