### PR TITLE
fix: resources overview docs typo

### DIFF
--- a/docs/03-resources/01-overview.md
+++ b/docs/03-resources/01-overview.md
@@ -91,7 +91,7 @@ In this example, the model should exist at `Custom\Path\Models\Customer`. Please
 
 Now when [generating the resource](#automatically-generating-forms-and-tables), Filament will be able to locate the model and read the database schema.
 
-### Generating the model, migration and factory at the same name
+### Generating the model, migration and factory at the same time
 
 If you'd like to save time when scaffolding your resources, Filament can also generate the model, migration and factory for the new resource at the same time using the `--model`, `--migration` and `--factory` flags in any combination:
 


### PR DESCRIPTION
## Description

This PR fixes a minor typo in the resources overview docs.

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
