### PR TITLE
Add Filament animation helper classes

### DIFF
--- a/packages/notifications/src/Notification.php
+++ b/packages/notifications/src/Notification.php
@@ -347,6 +347,8 @@ class Notification extends ViewComponent implements Arrayable, HasEmbeddedView
         <div
             x-data="notificationComponent({ notification: <?= Js::from($this->toArray()) ?> })"
             x-transition:enter-start="fi-transition-enter-start"
+            x-transition:enter-end="fi-transition-enter-end"
+            x-transition:leave-start="fi-transition-leave-start"
             x-transition:leave-end="fi-transition-leave-end"
             <?= $attributes ?>
         >


### PR DESCRIPTION
## Description

As you know, the current Filament animations are a bit glitchy, when they get interrupted by Livewire updates. Like using notification positioning of bottom right (end, end) and things will snap to be pulled from the top when the Livewire component hits a `$refresh`.

I can't quite come up with an elegant solution yet, but I managed to override the current animation using 2 more helper classes on the notification template; which I think are going to truly help the designers to customize it with ease...  

## Visual changes

NOTHING. Just some very useful helpers though.

You can utilize them to accomplish something like this:

https://github.com/user-attachments/assets/8917485f-3694-42de-8403-3bbe360d71f3

## Functional changes

- [x] Simply added the `enter-end` and `leave-start` related styling classes for the notification template. 
