### PR TITLE
Fix spa cmd click to open in new window

### DIFF
--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -135,7 +135,7 @@ if (! function_exists('Filament\Support\generate_href_html')) {
             if (FilamentView::hasSpaPrefetching()) {
                 $html .= ' wire:navigate.hover';
             } elseif ($hasNestedClickEventHandler) {
-                $html .= ' x-on:click.prevent="Alpine.navigate(' . "'{$url}'" . ')"';
+                $html .= ' x-on:click="if (!(($event.which === 1) && !$event.altKey && !$event.ctrlKey && !$event.metaKey && !$event.shiftKey)) return; $event.preventDefault(); Alpine.navigate(' . "'{$url}'" . ')"';
             } else {
                 $html .= ' wire:navigate';
             }

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -135,7 +135,7 @@ if (! function_exists('Filament\Support\generate_href_html')) {
             if (FilamentView::hasSpaPrefetching()) {
                 $html .= ' wire:navigate.hover';
             } elseif ($hasNestedClickEventHandler) {
-                $html .= ' x-on:click="if (!(($event.which === 1) && !$event.altKey && !$event.ctrlKey && !$event.metaKey && !$event.shiftKey)) return; $event.preventDefault(); Alpine.navigate(' . "'{$url}'" . ')"';
+                $html .= ' x-on:click="if (($event.which === 1) && (! $event.altKey) && (! $event.ctrlKey) && (! $event.metaKey) && (! $event.shiftKey)) { $event.preventDefault(); Alpine.navigate(' . "'{$url}'" . ') }"';
             } else {
                 $html .= ' wire:navigate';
             }

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -135,7 +135,7 @@ if (! function_exists('Filament\Support\generate_href_html')) {
             if (FilamentView::hasSpaPrefetching()) {
                 $html .= ' wire:navigate.hover';
             } elseif ($hasNestedClickEventHandler) {
-                $html .= ' x-on:click="if (($event.which === 1) && (! $event.altKey) && (! $event.ctrlKey) && (! $event.metaKey) && (! $event.shiftKey)) { $event.preventDefault(); Alpine.navigate(' . "'{$url}'" . ') }"';
+                $html .= ' x-on:click="if (! ($event.altKey || $event.ctrlKey || $event.metaKey || $event.shiftKey)) { $event.preventDefault(); Alpine.navigate(' . "'{$url}'" . ') }"';
             } else {
                 $html .= ' wire:navigate';
             }

--- a/tests/src/Support/SpaModeTest.php
+++ b/tests/src/Support/SpaModeTest.php
@@ -196,7 +196,7 @@ test('`hasNestedClickEventHandler` forces Alpine navigation when SPA mode is ena
     FilamentView::spa(true, false);
 
     expect(generate_href_html('http://localhost/page', hasNestedClickEventHandler: true))
-        ->toHtml()->toBe('href="http://localhost/page" x-on:click="if (!(($event.which === 1) && !$event.altKey && !$event.ctrlKey && !$event.metaKey && !$event.shiftKey)) return; $event.preventDefault(); Alpine.navigate(\'http://localhost/page\')"');
+        ->toHtml()->toBe('href="http://localhost/page" x-on:click="if (($event.which === 1) && (! $event.altKey) && (! $event.ctrlKey) && (! $event.metaKey) && (! $event.shiftKey)) { $event.preventDefault(); Alpine.navigate(\'http://localhost/page\') }"');
 
     expect(generate_href_html('http://localhost/page', hasNestedClickEventHandler: false))
         ->toHtml()->toBe('href="http://localhost/page" wire:navigate');
@@ -236,7 +236,7 @@ test('`hasNestedClickEventHandler` works with `shouldOpenInSpaMode` parameter ov
     FilamentView::spa(false);
 
     expect(generate_href_html('http://localhost/page', shouldOpenInSpaMode: true, hasNestedClickEventHandler: true))
-        ->toHtml()->toBe('href="http://localhost/page" x-on:click="if (!(($event.which === 1) && !$event.altKey && !$event.ctrlKey && !$event.metaKey && !$event.shiftKey)) return; $event.preventDefault(); Alpine.navigate(\'http://localhost/page\')"');
+        ->toHtml()->toBe('href="http://localhost/page" x-on:click="if (($event.which === 1) && (! $event.altKey) && (! $event.ctrlKey) && (! $event.metaKey) && (! $event.shiftKey)) { $event.preventDefault(); Alpine.navigate(\'http://localhost/page\') }"');
 
     expect(generate_href_html('http://localhost/page', shouldOpenInSpaMode: true, hasNestedClickEventHandler: false))
         ->toHtml()->toBe('href="http://localhost/page" wire:navigate');

--- a/tests/src/Support/SpaModeTest.php
+++ b/tests/src/Support/SpaModeTest.php
@@ -196,7 +196,7 @@ test('`hasNestedClickEventHandler` forces Alpine navigation when SPA mode is ena
     FilamentView::spa(true, false);
 
     expect(generate_href_html('http://localhost/page', hasNestedClickEventHandler: true))
-        ->toHtml()->toMatch('/^href="http:\/\/localhost\/page" x-on:click="[^"]*Alpine\.navigate\\(\'http:\/\/localhost\/page\'\\)[^"]*"$/');
+        ->toHtml()->toBe('href="http://localhost/page" x-on:click="if (!(($event.which === 1) && !$event.altKey && !$event.ctrlKey && !$event.metaKey && !$event.shiftKey)) return; $event.preventDefault(); Alpine.navigate(\'http://localhost/page\')"');
 
     expect(generate_href_html('http://localhost/page', hasNestedClickEventHandler: false))
         ->toHtml()->toBe('href="http://localhost/page" wire:navigate');
@@ -236,7 +236,7 @@ test('`hasNestedClickEventHandler` works with `shouldOpenInSpaMode` parameter ov
     FilamentView::spa(false);
 
     expect(generate_href_html('http://localhost/page', shouldOpenInSpaMode: true, hasNestedClickEventHandler: true))
-        ->toHtml()->toMatch('/^href="http:\/\/localhost\/page" x-on:click="[^"]*Alpine\.navigate\\(\'http:\/\/localhost\/page\'\\)[^"]*"$/');
+        ->toHtml()->toBe('href="http://localhost/page" x-on:click="if (!(($event.which === 1) && !$event.altKey && !$event.ctrlKey && !$event.metaKey && !$event.shiftKey)) return; $event.preventDefault(); Alpine.navigate(\'http://localhost/page\')"');
 
     expect(generate_href_html('http://localhost/page', shouldOpenInSpaMode: true, hasNestedClickEventHandler: false))
         ->toHtml()->toBe('href="http://localhost/page" wire:navigate');

--- a/tests/src/Support/SpaModeTest.php
+++ b/tests/src/Support/SpaModeTest.php
@@ -196,7 +196,7 @@ test('`hasNestedClickEventHandler` forces Alpine navigation when SPA mode is ena
     FilamentView::spa(true, false);
 
     expect(generate_href_html('http://localhost/page', hasNestedClickEventHandler: true))
-        ->toHtml()->toBe('href="http://localhost/page" x-on:click.prevent="Alpine.navigate(\'http://localhost/page\')"');
+        ->toHtml()->toMatch('/^href="http:\/\/localhost\/page" x-on:click="[^"]*Alpine\.navigate\\(\'http:\/\/localhost\/page\'\\)[^"]*"$/');
 
     expect(generate_href_html('http://localhost/page', hasNestedClickEventHandler: false))
         ->toHtml()->toBe('href="http://localhost/page" wire:navigate');
@@ -236,7 +236,7 @@ test('`hasNestedClickEventHandler` works with `shouldOpenInSpaMode` parameter ov
     FilamentView::spa(false);
 
     expect(generate_href_html('http://localhost/page', shouldOpenInSpaMode: true, hasNestedClickEventHandler: true))
-        ->toHtml()->toBe('href="http://localhost/page" x-on:click.prevent="Alpine.navigate(\'http://localhost/page\')"');
+        ->toHtml()->toMatch('/^href="http:\/\/localhost\/page" x-on:click="[^"]*Alpine\.navigate\\(\'http:\/\/localhost\/page\'\\)[^"]*"$/');
 
     expect(generate_href_html('http://localhost/page', shouldOpenInSpaMode: true, hasNestedClickEventHandler: false))
         ->toHtml()->toBe('href="http://localhost/page" wire:navigate');

--- a/tests/src/Support/SpaModeTest.php
+++ b/tests/src/Support/SpaModeTest.php
@@ -196,7 +196,7 @@ test('`hasNestedClickEventHandler` forces Alpine navigation when SPA mode is ena
     FilamentView::spa(true, false);
 
     expect(generate_href_html('http://localhost/page', hasNestedClickEventHandler: true))
-        ->toHtml()->toBe('href="http://localhost/page" x-on:click="if (($event.which === 1) && (! $event.altKey) && (! $event.ctrlKey) && (! $event.metaKey) && (! $event.shiftKey)) { $event.preventDefault(); Alpine.navigate(\'http://localhost/page\') }"');
+        ->toHtml()->toBe('href="http://localhost/page" x-on:click="if (! ($event.altKey || $event.ctrlKey || $event.metaKey || $event.shiftKey)) { $event.preventDefault(); Alpine.navigate(\'http://localhost/page\') }"');
 
     expect(generate_href_html('http://localhost/page', hasNestedClickEventHandler: false))
         ->toHtml()->toBe('href="http://localhost/page" wire:navigate');
@@ -236,7 +236,7 @@ test('`hasNestedClickEventHandler` works with `shouldOpenInSpaMode` parameter ov
     FilamentView::spa(false);
 
     expect(generate_href_html('http://localhost/page', shouldOpenInSpaMode: true, hasNestedClickEventHandler: true))
-        ->toHtml()->toBe('href="http://localhost/page" x-on:click="if (($event.which === 1) && (! $event.altKey) && (! $event.ctrlKey) && (! $event.metaKey) && (! $event.shiftKey)) { $event.preventDefault(); Alpine.navigate(\'http://localhost/page\') }"');
+        ->toHtml()->toBe('href="http://localhost/page" x-on:click="if (! ($event.altKey || $event.ctrlKey || $event.metaKey || $event.shiftKey)) { $event.preventDefault(); Alpine.navigate(\'http://localhost/page\') }"');
 
     expect(generate_href_html('http://localhost/page', shouldOpenInSpaMode: true, hasNestedClickEventHandler: false))
         ->toHtml()->toBe('href="http://localhost/page" wire:navigate');


### PR DESCRIPTION
Allow links to be opened in a new window when Ctrl/Cmd is pressed while clicking.

This adds to the code that was recently added that prevented it:
https://github.com/filamentphp/filament/pull/17709 

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
