### PR TITLE
Add toggle all columns for testing

### DIFF
--- a/docs/10-testing/03-testing-tables.md
+++ b/docs/10-testing/03-testing-tables.md
@@ -457,9 +457,9 @@ it('can average values in a column', function () {
 });
 ```
 
-### Testing all toggleable columns
+## Testing toggleable columns
 
-Toggle all togglable columns on using `toggleAllTableColumns()`:
+By default, only columns that are toggled on by default in the table will be rendered and testable. You can toggle all columns in the table on using `toggleAllTableColumns()`:
 
 ```php
 use function Pest\Livewire\livewire;
@@ -467,5 +467,16 @@ use function Pest\Livewire\livewire;
 it('can toggle all columns', function () {    
     livewire(PostResource\Pages\ListPosts::class)
         ->toggleAllTableColumns();
+});
+```
+
+You can also toggle all columns off using `toggleAllTableColumns(false)`:
+
+```php
+use function Pest\Livewire\livewire;
+
+it('can toggle all columns off', function () {    
+    livewire(PostResource\Pages\ListPosts::class)
+        ->toggleAllTableColumns(false);
 });
 ```

--- a/docs/10-testing/03-testing-tables.md
+++ b/docs/10-testing/03-testing-tables.md
@@ -456,3 +456,16 @@ it('can average values in a column', function () {
         ->assertTableColumnSummarySet('rating', 'range', [$posts->min('rating'), $posts->max('rating')]);
 });
 ```
+
+### Testing all toggleable columns
+
+Toggle all togglable columns on using `toggleAllTableColumns()`:
+
+```php
+use function Pest\Livewire\livewire;
+
+it('can toggle all columns', function () {    
+    livewire(PostResource\Pages\ListPosts::class)
+        ->toggleAllTableColumns();
+});
+```

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -73,6 +73,8 @@ namespace Livewire\Features\SupportTesting {
 
         public function assertCountTableRecords(int $count): static {}
 
+        public function toggleAllTableColumns(bool $toggle = true): static {}
+
         public function loadTable(): static {}
 
         /**

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -73,7 +73,7 @@ namespace Livewire\Features\SupportTesting {
 
         public function assertCountTableRecords(int $count): static {}
 
-        public function toggleAllTableColumns(bool $toggle = true): static {}
+        public function toggleAllTableColumns(bool $condition = true): static {}
 
         public function loadTable(): static {}
 

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -523,6 +523,7 @@ class TestsColumns
     public function toggleAllTableColumns(): Closure
     {
         return function (bool $show = true): static {
+            /** @phpstan-ignore-next-line */
             $tableColumns = $this->instance()->tableColumns;
 
             foreach ($tableColumns as &$column) {

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -522,7 +522,7 @@ class TestsColumns
 
     public function toggleAllTableColumns(): Closure
     {
-        return function (bool $show = true): static {
+        return function (bool $condition = true): static {
             /** @phpstan-ignore-next-line */
             $tableColumns = $this->instance()->tableColumns;
 
@@ -531,7 +531,7 @@ class TestsColumns
                     continue;
                 }
 
-                $column['isToggled'] = $show;
+                $column['isToggled'] = $condition;
             }
 
             $this->set('tableColumns', $tableColumns);

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -519,4 +519,25 @@ class TestsColumns
             return $this;
         };
     }
+
+    public function toggleAllTableColumns(): Closure
+    {
+        return function (bool $show = true): static {
+            $tableColumns = $this->instance()->tableColumns;
+
+            foreach ($tableColumns as &$column) {
+                if (! $column['isToggleable']) {
+                    continue;
+                }
+
+                $column['isToggled'] = $show;
+            }
+
+            $this->set('tableColumns', $tableColumns);
+
+            $this->call('applyTableColumnManager');
+
+            return $this;
+        };
+    }
 }

--- a/tests/src/Fixtures/Livewire/PostsTable.php
+++ b/tests/src/Fixtures/Livewire/PostsTable.php
@@ -120,7 +120,7 @@ class PostsTable extends Component implements HasActions, HasSchemas, Tables\Con
                     ->searchable()
                     ->prefix(fn (Post $record): string => $record->is_published ? 'published' : 'unpublished'),
                 Tables\Columns\TextColumn::make('toggleable_column')
-                    ->getStateUsing(fn (Post $record): string => 'ToggleableColumnHiddenByDefault')
+                    ->state('Toggleable column state')
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([

--- a/tests/src/Fixtures/Livewire/PostsTable.php
+++ b/tests/src/Fixtures/Livewire/PostsTable.php
@@ -119,6 +119,9 @@ class PostsTable extends Component implements HasActions, HasSchemas, Tables\Con
                     ->sortable()
                     ->searchable()
                     ->prefix(fn (Post $record): string => $record->is_published ? 'published' : 'unpublished'),
+                Tables\Columns\TextColumn::make('toggleable_column')
+                    ->getStateUsing(fn (Post $record): string => 'ToggleableColumnHiddenByDefault')
+                    ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
                 Tables\Filters\Filter::make('is_published')

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -385,3 +385,14 @@ it('can automatically detect boolean cast attribute in icon column', function ()
             return $column->isBoolean();
         }, $post);
 });
+
+it('can toggle all table columns', function (): void {
+    Post::factory()->create();
+    
+    livewire(PostsTable::class)
+        ->assertSuccessful()
+        ->assertCountTableRecords(1)
+        ->assertDontSeeText('ToggleableColumnHiddenByDefault')
+        ->toggleAllTableColumns()
+        ->assertSeeText('ToggleableColumnHiddenByDefault');
+});

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -392,7 +392,9 @@ it('can toggle all table columns', function (): void {
     livewire(PostsTable::class)
         ->assertSuccessful()
         ->assertCountTableRecords(1)
-        ->assertDontSeeText('ToggleableColumnHiddenByDefault')
+        ->assertDontSeeText('Toggleable column state')
         ->toggleAllTableColumns()
-        ->assertSeeText('ToggleableColumnHiddenByDefault');
+        ->assertSeeText('Toggleable column state')
+        ->toggleAllTableColumns(false)
+        ->assertDontSeeText('Toggleable column state');
 });

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -388,7 +388,7 @@ it('can automatically detect boolean cast attribute in icon column', function ()
 
 it('can toggle all table columns', function (): void {
     Post::factory()->create();
-    
+
     livewire(PostsTable::class)
         ->assertSuccessful()
         ->assertCountTableRecords(1)


### PR DESCRIPTION
Add a testing utility for toggling all toggleable columns in tables.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
