### PR TITLE
[4.x] Fix native DateTimePicker format handling for date-time without seconds

### DIFF
--- a/packages/forms/src/Components/DateTimePicker.php
+++ b/packages/forms/src/Components/DateTimePicker.php
@@ -121,7 +121,7 @@ class DateTimePicker extends Field implements HasAffixActions
             return $this->hasSeconds() ? 'H:i:s' : 'H:i';
         }
 
-        return 'Y-m-d H:i:s';
+        return $this->hasSeconds() ? 'Y-m-d H:i:s' : 'Y-m-d H:i';
     }
 
     public function displayFormat(string | Closure | null $format): static

--- a/tests/src/Forms/Components/DateTimePickerTest.php
+++ b/tests/src/Forms/Components/DateTimePickerTest.php
@@ -2,20 +2,20 @@
 
 use Filament\Forms\Components\DateTimePicker;
 
-it('returns full datetime format by default (native with date, time and seconds)', function () {
+it('returns full datetime format by default (native with date, time and seconds)', function (): void {
     $picker = DateTimePicker::make('dt');
 
     expect($picker->getInternalFormat())->toBe('Y-m-d H:i:s');
 });
 
-it('returns date-only format when native and time is disabled', function () {
+it('returns date-only format when native and time is disabled', function (): void {
     $picker = DateTimePicker::make('dt')
         ->time(false);
 
     expect($picker->getInternalFormat())->toBe('Y-m-d');
 });
 
-it('returns time-only format without seconds when native, date disabled and seconds disabled', function () {
+it('returns time-only format without seconds when native, date disabled and seconds disabled', function (): void {
     $picker = DateTimePicker::make('dt')
         ->date(false)
         ->seconds(false);
@@ -23,21 +23,21 @@ it('returns time-only format without seconds when native, date disabled and seco
     expect($picker->getInternalFormat())->toBe('H:i');
 });
 
-it('returns time-only format with seconds when native and date disabled', function () {
+it('returns time-only format with seconds when native and date disabled', function (): void {
     $picker = DateTimePicker::make('dt')
         ->date(false); // seconds enabled by default
 
     expect($picker->getInternalFormat())->toBe('H:i:s');
 });
 
-it('returns datetime format without seconds when native and seconds are disabled', function () {
+it('returns datetime format without seconds when native and seconds are disabled', function (): void {
     $picker = DateTimePicker::make('dt')
         ->seconds(false);
 
     expect($picker->getInternalFormat())->toBe('Y-m-d H:i');
 });
 
-it('returns full datetime format for non-native pickers regardless of other flags', function () {
+it('returns full datetime format for non-native pickers regardless of other flags', function (): void {
     $picker = DateTimePicker::make('dt')
         ->time(false)
         ->date(false)

--- a/tests/src/Forms/Components/DateTimePickerTest.php
+++ b/tests/src/Forms/Components/DateTimePickerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Filament\Forms\Components\DateTimePicker;
+
+it('returns full datetime format by default (native with date, time and seconds)', function () {
+    $picker = DateTimePicker::make('dt');
+
+    expect($picker->getInternalFormat())->toBe('Y-m-d H:i:s');
+});
+
+it('returns date-only format when native and time is disabled', function () {
+    $picker = DateTimePicker::make('dt')
+        ->time(false);
+
+    expect($picker->getInternalFormat())->toBe('Y-m-d');
+});
+
+it('returns time-only format without seconds when native, date disabled and seconds disabled', function () {
+    $picker = DateTimePicker::make('dt')
+        ->date(false)
+        ->seconds(false);
+
+    expect($picker->getInternalFormat())->toBe('H:i');
+});
+
+it('returns time-only format with seconds when native and date disabled', function () {
+    $picker = DateTimePicker::make('dt')
+        ->date(false); // seconds enabled by default
+
+    expect($picker->getInternalFormat())->toBe('H:i:s');
+});
+
+it('returns datetime format without seconds when native and seconds are disabled', function () {
+    $picker = DateTimePicker::make('dt')
+        ->seconds(false);
+
+    expect($picker->getInternalFormat())->toBe('Y-m-d H:i');
+});
+
+it('returns full datetime format for non-native pickers regardless of other flags', function () {
+    $picker = DateTimePicker::make('dt')
+        ->time(false)
+        ->date(false)
+        ->seconds(false)
+        ->native(false);
+
+    expect($picker->getInternalFormat())->toBe('Y-m-d H:i:s');
+});


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

In Filament v4.0.13 this [PR](https://github.com/filamentphp/filament/pull/17772/files) did break native DateTimePickers when `seconds()` is set to `false`.

## Visual changes

Given this `DateTimePicker`:

```php
DateTimePicker::make('created_at')
      ->default(now())
      ->seconds(false),
```

Before v4.0.13
<img width="434" height="85" alt="CleanShot 2025-10-01 at 15 13 12" src="https://github.com/user-attachments/assets/8bbd81df-7c01-4d99-b824-74f91d0c429e" />

Since v4.0.13
<img width="433" height="82" alt="CleanShot 2025-10-01 at 15 12 51" src="https://github.com/user-attachments/assets/b2723995-4a8d-4375-a3af-8ace0baadbd0" />

With this PR
<img width="434" height="85" alt="CleanShot 2025-10-01 at 15 13 12" src="https://github.com/user-attachments/assets/135bce81-38c8-42a0-8ab2-1220551ea39a" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] ~~Documentation is up-to-date.~~ No changes required.
