### PR TITLE
Update submitAction in wizards documentation

### DIFF
--- a/packages/schemas/docs/05-wizards.md
+++ b/packages/schemas/docs/05-wizards.md
@@ -64,6 +64,7 @@ Wizard::make([
 ])->submitAction(new HtmlString(Blade::render(<<<BLADE
     <x-filament::button
         type="submit"
+        wire:target="callMountedAction"
         size="sm"
     >
         Submit


### PR DESCRIPTION
## Description

When using `<x-filament::button />` in the submitAction of the wizard you need to set the `wire:target` for the loading button to work. If you don't set the target the button in still disabled on loading but the default loading indicator isn't shown. This is only an enhancement of the documentation.
