### PR TITLE
Fix/dropdown loading indicator

### DIFF
--- a/packages/panels/resources/lang/lv/pages/auth/password-reset/request-password-reset.php
+++ b/packages/panels/resources/lang/lv/pages/auth/password-reset/request-password-reset.php
@@ -32,7 +32,7 @@ return [
 
     'notifications' => [
 
-         'sent' => [
+        'sent' => [
             'body' => 'Jūs saņemsiet e-pastu, ja Jūsu konts eksistē.',
         ],
 

--- a/packages/panels/src/GlobalSearch/GlobalSearchResult.php
+++ b/packages/panels/src/GlobalSearch/GlobalSearchResult.php
@@ -12,9 +12,9 @@ class GlobalSearchResult
      * @param  array<Action>  $actions
      */
     public function __construct(
-        readonly public string | Htmlable $title,
-        readonly public string $url,
-        readonly public array $details = [],
-        readonly public array $actions = [],
+        public readonly string | Htmlable $title,
+        public readonly string $url,
+        public readonly array $details = [],
+        public readonly array $actions = [],
     ) {}
 }

--- a/packages/panels/src/Resources/RelationManagers/RelationManagerConfiguration.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManagerConfiguration.php
@@ -9,7 +9,7 @@ class RelationManagerConfiguration
      * @param  array<string, mixed>  $properties
      */
     public function __construct(
-        readonly public string $relationManager,
+        public readonly string $relationManager,
         protected array $properties = [],
     ) {}
 

--- a/packages/support/resources/views/components/dropdown/list/item.blade.php
+++ b/packages/support/resources/views/components/dropdown/list/item.blade.php
@@ -90,7 +90,7 @@
     $hasLoadingIndicator = filled($wireTarget);
 
     if ($hasLoadingIndicator) {
-        $loadingIndicatorTarget = html_entity_decode($wireTarget, ENT_QUOTES);
+        $loadingIndicatorTarget = $wireTarget;
     }
 
     $hasTooltip = filled($tooltip);

--- a/packages/widgets/src/WidgetConfiguration.php
+++ b/packages/widgets/src/WidgetConfiguration.php
@@ -9,7 +9,7 @@ class WidgetConfiguration
      * @param  array<string, mixed>  $properties
      */
     public function __construct(
-        readonly public string $widget,
+        public readonly string $widget,
         protected array $properties = [],
     ) {}
 


### PR DESCRIPTION

## Description

### Fixes #13925

### Problem
Loading indicators in dropdown list items were not showing during Livewire operations. The chevron icon would disappear but no loading indicator would appear, making it unclear to users that an action was processing.

### Root Cause
The issue was caused by improper attribute escaping in the loading indicator component. The `wire:target` attribute was being escaped with backslashes (`\"`) instead of HTML entities (`&quot;`), which broke Livewire's ability to properly detect and bind loading states.

**Problematic output:**
```html
wire:target="changeTeam({\"id\":5,\"name\":\"DJ Banser\"})"
```

**Expected output:**
```html
wire:target="changeTeam({&quot;id&quot;:5,&quot;name&quot;:&quot;DJ Banser&quot;})"
```

### Solution
The fix aligns the loading indicator component with the icon component's attribute handling by removing an unnecessary `html_entity_decode()` call that was causing the escaping inconsistency.

**Changes:**
- Removed `html_entity_decode($wireTarget, ENT_QUOTES)` 
- Now passes `$wireTarget` directly through `ComponentAttributeBag`
- Both icon and loading indicator components now handle attributes consistently

### Testing
Tested with a Livewire component containing a 5-second processing delay:
- ✅ Loading indicator now shows correctly during wire operations
- ✅ Chevron icon properly disappears/reappears as expected
- ✅ No regression in existing dropdown functionality
- ✅ Proper HTML entity escaping maintained

### Files Changed
- `resources/views/components/dropdown/list/item.blade.php`

### Environment
- **Package**: filament/support v3.2.98
- **Laravel**: v11.20.0  
- **Livewire**: v3.5.4
- **PHP**: 8.3.10

This change ensures architectural consistency between components while maintaining Laravel's standard attribute escaping behavior.

## Visual changes

<img width="487" height="220" alt="image" src="https://github.com/user-attachments/assets/64cc5a53-f129-4f65-9463-4853a141c2db" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
