### PR TITLE
fix: [v4] allow custom relations with tenant.

### DIFF
--- a/packages/panels/src/Resources/Resource/Concerns/BelongsToTenant.php
+++ b/packages/panels/src/Resources/Resource/Concerns/BelongsToTenant.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use LogicException;
+use Znck\Eloquent\Relations\BelongsToThrough;
 
 trait BelongsToTenant
 {
@@ -176,7 +177,7 @@ trait BelongsToTenant
 
             $relationship = static::getTenantOwnershipRelationship($record);
 
-            if ($relationship instanceof BelongsTo) {
+            if ($relationship instanceof BelongsTo || $relationship instanceof BelongsToThrough) {
                 return;
             }
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Hi, 
With the v4 migration, I now have an error when trying to create a new entry of a model linked to a tenant via a [BelongsToThrough](https://github.com/staudenmeir/belongs-to-through) relationship.

I've updated the hook to ensure that a non-existent `save` function is not called for any custom relationship class.

Thanks.

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
