### PR TITLE
Add missing Japanese translations for Profile page

### DIFF
--- a/packages/panels/resources/lang/ja/auth/pages/edit-profile.php
+++ b/packages/panels/resources/lang/ja/auth/pages/edit-profile.php
@@ -16,10 +16,18 @@ return [
 
         'password' => [
             'label' => '新しいパスワード',
+            'validation_attribute' => 'パスワード',
         ],
 
         'password_confirmation' => [
             'label' => '新しいパスワードの確認',
+            'validation_attribute' => 'パスワード確認',
+        ],
+
+        'current_password' => [
+            'label' => '現在のパスワード',
+            'below_content' => 'セキュリティのため、続行するにはパスワードを確認してください。',
+            'validation_attribute' => '現在のパスワード',
         ],
 
         'actions' => [
@@ -32,7 +40,16 @@ return [
 
     ],
 
+    'multi_factor_authentication' => [
+        'label' => '二要素認証 (2FA)',
+    ],
+
     'notifications' => [
+
+        'email_change_verification_sent' => [
+            'title' => 'メールアドレス変更リクエストを送信しました',
+            'body' => 'メールアドレスの変更リクエストが :email に送信されました。変更を確認するためにメールをご確認ください。',
+        ],
 
         'saved' => [
             'title' => '保存しました',


### PR DESCRIPTION
## Description

Add missing Japanese translations for Profile page

## Visual changes

No visual changes - translation updates only.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
