### PR TITLE
[Testing] Fix enum handling in table column state assertions

### DIFF
--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -241,7 +241,7 @@ class TestsColumns
 
             $displayState = is_object($state) ? get_debug_type($state) : var_export($state, true);
 
-            Assert::assertEquals(
+            Assert::assertNotEquals(
                 $state,
                 $actualState,
                 "Failed asserting that a table column with name [{$name}] does not have a value of [{$displayState}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -202,7 +202,13 @@ class TestsColumns
             Assert::assertEquals(
                 $state,
                 $actualState,
-                "Failed asserting that a table column with name [{$name}] has value of [{$state}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+                sprintf(
+                    'Failed asserting that a table column with name [%s] has value of [%s] for record [%s] on the [%s] component.',
+                    $name,
+                    is_object($state) ? get_debug_type($state) : var_export($state, true),
+                    $record->getKey(),
+                    $livewireClass,
+                ),
             );
 
             return $this;
@@ -240,7 +246,13 @@ class TestsColumns
             Assert::assertNotEquals(
                 $state,
                 $actualState,
-                "Failed asserting that a table column with name [{$name}] does not have a value of [{$state}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+                sprintf(
+                    'Failed asserting that a table column with name [%s] does not have a value of [%s] for record [%s] on the [%s] component.',
+                    $name,
+                    is_object($state) ? get_debug_type($state) : var_export($state, true),
+                    $record->getKey(),
+                    $livewireClass,
+                ),
             );
 
             return $this;

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -199,16 +199,12 @@ class TestsColumns
                 $state = json_encode($state);
             }
 
+            $displayState = is_object($state) ? get_debug_type($state) : var_export($state, true);
+
             Assert::assertEquals(
                 $state,
                 $actualState,
-                sprintf(
-                    'Failed asserting that a table column with name [%s] has value of [%s] for record [%s] on the [%s] component.',
-                    $name,
-                    is_object($state) ? get_debug_type($state) : var_export($state, true),
-                    $record->getKey(),
-                    $livewireClass,
-                ),
+                "Failed asserting that a table column with name [{$name}] has value of [{$displayState}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -243,16 +239,12 @@ class TestsColumns
                 $state = json_encode($state);
             }
 
-            Assert::assertNotEquals(
+            $displayState = is_object($state) ? get_debug_type($state) : var_export($state, true);
+
+            Assert::assertEquals(
                 $state,
                 $actualState,
-                sprintf(
-                    'Failed asserting that a table column with name [%s] does not have a value of [%s] for record [%s] on the [%s] component.',
-                    $name,
-                    is_object($state) ? get_debug_type($state) : var_export($state, true),
-                    $record->getKey(),
-                    $livewireClass,
-                ),
+                "Failed asserting that a table column with name [{$name}] does not have a value of [{$displayState}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
             );
 
             return $this;


### PR DESCRIPTION
## Description

Fixes a bug where `assertTableColumnStateSet()` and `assertTableColumnStateNotSet()` could throw an error when the expected or actual table column state was an enum.

Previously, the assertion message interpolated `$state` directly into a string, causing:

```log 
Error: Object of class App\Enums\SomeEnum could not be converted to string
```

This made testing the state of enum columns impossible as it systematically resulted in an error.

This PR updates the failure message to safely handle any type by using `get_debug_type()` for objects (including enums) and `var_export()` for scalars. Comparisons are unchanged; only the error message construction is affected.

This improves stability and makes failure output clearer.

## Visual changes

N/A — testing helpers only, no UI changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
