### PR TITLE
Improve schema performance, especially in repeaters/builders

### DIFF
--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1054,6 +1054,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         $this->state(
             $this->getStateFromRelatedRecords($this->getCachedExistingRecords()),
         );
+        $this->clearCachedDefaultChildSchemas();
     }
 
     /**

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1054,7 +1054,6 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         $this->state(
             $this->getStateFromRelatedRecords($this->getCachedExistingRecords()),
         );
-        $this->clearCachedDefaultChildSchemas();
     }
 
     /**

--- a/packages/schemas/src/Components/Concerns/HasChildComponents.php
+++ b/packages/schemas/src/Components/Concerns/HasChildComponents.php
@@ -17,6 +17,11 @@ trait HasChildComponents
     protected array $childComponents = [];
 
     /**
+     * @var array<Schema> | null
+     */
+    protected ?array $cachedDefaultChildSchemas = null;
+
+    /**
      * @param  array<Component | Action | ActionGroup | string | Htmlable> | Closure  $components
      */
     public function components(array | Closure $components): static
@@ -67,8 +72,8 @@ trait HasChildComponents
      */
     public function getChildSchema($key = null): ?Schema
     {
-        if (filled($key) && array_key_exists($key, $containers = $this->getDefaultChildSchemas())) {
-            return $containers[$key];
+        if (filled($key) && array_key_exists($key, $this->cachedDefaultChildSchemas ??= $this->getDefaultChildSchemas())) {
+            return $this->cachedDefaultChildSchemas[$key];
         }
 
         $key ??= 'default';
@@ -133,7 +138,7 @@ trait HasChildComponents
         }
 
         return [
-            ...(array_key_exists('default', $this->childComponents) ? $this->getDefaultChildSchemas() : []),
+            ...(array_key_exists('default', $this->childComponents) ? ($this->cachedDefaultChildSchemas ??= $this->getDefaultChildSchemas()) : []),
             ...array_reduce(
                 array_keys($this->childComponents),
                 function (array $carry, string $key): array {
@@ -168,6 +173,11 @@ trait HasChildComponents
     public function getDefaultChildSchemas(): array
     {
         return ['default' => $this->getChildSchema()];
+    }
+
+    public function clearCachedDefaultChildSchemas(): void
+    {
+        $this->cachedDefaultChildSchemas = null;
     }
 
     protected function cloneChildComponents(): static

--- a/packages/schemas/src/Components/Concerns/HasState.php
+++ b/packages/schemas/src/Components/Concerns/HasState.php
@@ -552,6 +552,11 @@ trait HasState
 
         data_set($livewire, $this->getStatePath(), $this->evaluate($state));
 
+        // For components such as repeaters and builders, the default child schemas depend on the state of the component.
+        // When loading state into these fields after the state is already present, the cached child schemas need to be
+        // cleared so that they can be re-evaluated based on the new state. `rawState()` is called during this process.
+        $this->clearCachedDefaultChildSchemas();
+
         return $this;
     }
 

--- a/packages/schemas/src/Components/Utilities/Get.php
+++ b/packages/schemas/src/Components/Utilities/Get.php
@@ -16,12 +16,14 @@ class Get
 
         $path = $this->component->resolveRelativeStatePath($path, $isAbsolute);
 
-        $component = $this->component->getRootContainer()->getComponentByStatePath(
-            $path,
-            withHidden: true,
-            withAbsoluteStatePath: true,
-            skipComponentChildContainersWhileSearching: $this->component,
-        );
+        $component = ($this->component->getStatePath() === $path)
+            ? $this->component
+            : $this->component->getRootContainer()->getComponentByStatePath(
+                $path,
+                withHidden: true,
+                withAbsoluteStatePath: true,
+                skipComponentChildContainersWhileSearching: $this->component,
+            );
 
         if (! $component) {
             return data_get($livewire, $path);

--- a/packages/schemas/src/Components/Utilities/Set.php
+++ b/packages/schemas/src/Components/Utilities/Set.php
@@ -16,12 +16,14 @@ class Set
 
         $path = $this->component->resolveRelativeStatePath($path, $isAbsolute);
 
-        $component = $this->component->getRootContainer()->getComponentByStatePath(
-            $path,
-            withHidden: true,
-            withAbsoluteStatePath: true,
-            skipComponentChildContainersWhileSearching: $this->component,
-        );
+        $component = ($this->component->getStatePath() === $path)
+            ? $this->component
+            : $this->component->getRootContainer()->getComponentByStatePath(
+                $path,
+                withHidden: true,
+                withAbsoluteStatePath: true,
+                skipComponentChildContainersWhileSearching: $this->component,
+            );
 
         $state = $this->component->evaluate($state);
 

--- a/packages/schemas/src/Concerns/HasComponents.php
+++ b/packages/schemas/src/Concerns/HasComponents.php
@@ -30,6 +30,11 @@ trait HasComponents
     protected ?array $cachedComponents = null;
 
     /**
+     * @var array<array<array<string, Component>>>
+     */
+    protected array $cachedComponentsByStatePath = [];
+
+    /**
      * @param  array<Component | Action | ActionGroup | string | Htmlable> | Component | Action | ActionGroup | string | Htmlable | Closure  $components
      */
     public function components(array | Component | Action | ActionGroup | string | Htmlable | Closure $components): static
@@ -226,7 +231,7 @@ trait HasComponents
             return null;
         };
 
-        return $search($this);
+        return $this->cachedComponentsByStatePath[$withHidden][$skipComponentChildContainersWhileSearching ? spl_object_id($skipComponentChildContainersWhileSearching) : null][$statePath] ??= $search($this);
     }
 
     /**

--- a/packages/schemas/src/Concerns/HasComponents.php
+++ b/packages/schemas/src/Concerns/HasComponents.php
@@ -42,6 +42,7 @@ trait HasComponents
         $this->components = $components;
         $this->cachedComponents = null;
         $this->cachedFlatComponents = [];
+        $this->cachedComponentsByStatePath = [];
 
         return $this;
     }
@@ -357,6 +358,7 @@ trait HasComponents
 
             $this->cachedComponents = null;
             $this->cachedFlatComponents = [];
+            $this->cachedComponentsByStatePath = [];
         }
 
         return $this;


### PR DESCRIPTION
Fixes #18019.
Fixes #18026.

Introduces default child schema caching to reduce the number of times that repeater/builder child schemas are instantiated (and each component inside cloned).

Introduces early checks for the get/set helpers to avoid searching for the current component in the schema.

Introduces an object cache for the get/set helpers to avoid searching for a component more than once in the schema.