### PR TITLE
Fix(TenantDropdown): Tenant dropdown now shows correctly on Safari

### DIFF
--- a/packages/panels/resources/views/components/tenant-menu.blade.php
+++ b/packages/panels/resources/views/components/tenant-menu.blade.php
@@ -1,3 +1,7 @@
+@props([
+    'teleport' => false,
+])
+
 @php
     use Filament\Actions\Action;
     use Illuminate\Support\Arr;
@@ -28,6 +32,7 @@
 <x-filament::dropdown
     placement="bottom-start"
     size
+    :teleport="$teleport"
     :attributes="
         \Filament\Support\prepare_inherited_attributes($attributes)
             ->class(['fi-tenant-menu'])

--- a/packages/panels/resources/views/livewire/topbar.blade.php
+++ b/packages/panels/resources/views/livewire/topbar.blade.php
@@ -101,7 +101,7 @@
 
         @if ($hasTopNavigation || (! $hasNavigation))
             @if ($hasTenancy && filament()->hasTenantMenu())
-                <x-filament-panels::tenant-menu />
+                <x-filament-panels::tenant-menu teleport="true"/>
             @endif
 
             @if ($hasNavigation)

--- a/packages/panels/resources/views/livewire/topbar.blade.php
+++ b/packages/panels/resources/views/livewire/topbar.blade.php
@@ -101,7 +101,7 @@
 
         @if ($hasTopNavigation || (! $hasNavigation))
             @if ($hasTenancy && filament()->hasTenantMenu())
-                <x-filament-panels::tenant-menu teleport="true"/>
+                <x-filament-panels::tenant-menu teleport />
             @endif
 
             @if ($hasNavigation)


### PR DESCRIPTION
## Description

The tenant dropdown was being clipped on safari when rendered in the top bar. This is due to an issue with overflow in Safari.

User Dropdown wasn't having the same visual bug due to it using teleport.

Updated tenant dropdown to mirror user dropdown behavior when rendering in top bar.

Note: The filament dropdown menu isn't positioned correctly in the sidebar if used with teleport. That's why teleport is only used in topbar.

Fixes #16603 

## Visual changes

Before (Dropdown clipped):

<img width="367" height="96" alt="image" src="https://github.com/user-attachments/assets/6b4393f6-bfe8-4bad-97b6-77c5391dfc2b" />

After (Dropdown no longer clipped):

<img width="312" height="143" alt="image" src="https://github.com/user-attachments/assets/31ed4671-33f0-498c-a966-48838a300f41" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.


### Commits

- Add teleport prop (default: false) to tenant dropdown
- Topbar sets teleport to false on tenant dropdown
- Now renders correctly on safari
