### PR TITLE
Fix parameter type for livewireComponents method

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasComponents.php
+++ b/packages/panels/src/Panel/Concerns/HasComponents.php
@@ -467,7 +467,7 @@ trait HasComponents
     }
 
     /**
-     * @param  array<string, class-string<Component>>  $components
+     * @param  array<class-string<Component>>  $components
      */
     public function livewireComponents(array $components): static
     {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fixed parameter type annotation.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
