### PR TITLE
[4.x] Fix: DetailsContentExtension.php parseHTML error

### DIFF
--- a/packages/forms/src/Components/RichEditor/TipTapExtensions/DetailsContentExtension.php
+++ b/packages/forms/src/Components/RichEditor/TipTapExtensions/DetailsContentExtension.php
@@ -29,8 +29,7 @@ class DetailsContentExtension extends Node
     {
         return [
             [
-                'tag' => 'div[data-type]',
-                'getAttrs' => fn ($value): bool => $value === 'detailsContent',
+                'tag' => 'div[data-type="detailsContent"]',
             ],
         ];
     }


### PR DESCRIPTION
## Description

Fixes error in DetailsContentExtension that improperly parses the extension from HTML.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
