### PR TITLE
Add Dutch translations for grid-related components in forms

### DIFF
--- a/packages/forms/resources/lang/nl/components.php
+++ b/packages/forms/resources/lang/nl/components.php
@@ -443,6 +443,71 @@ return [
 
             ],
 
+            'grid' => [
+
+                'label' => 'Raster',
+
+                'modal' => [
+
+                    'heading' => 'Raster',
+
+                    'form' => [
+
+                        'preset' => [
+
+                            'label' => 'Voorinstelling',
+
+                            'placeholder' => 'Geen',
+
+                            'options' => [
+                                'two' => 'Twee',
+                                'three' => 'Drie',
+                                'four' => 'Vier',
+                                'five' => 'Vijf',
+                                'two_start_third' => 'Twee (Start Derde)',
+                                'two_end_third' => 'Twee (Einde Derde)',
+                                'two_start_fourth' => 'Twee (Start Vierde)',
+                                'two_end_fourth' => 'Twee (Einde Vierde)',
+                            ],
+                        ],
+
+                        'columns' => [
+                            'label' => 'Kolommen',
+                        ],
+
+                        'from_breakpoint' => [
+
+                            'label' => 'Vanaf breekpunt',
+
+                            'options' => [
+                                'default' => 'Alle',
+                                'sm' => 'Klein',
+                                'md' => 'Medium',
+                                'lg' => 'Groot',
+                                'xl' => 'Extra groot',
+                                '2xl' => 'Twee keer extra groot',
+                            ],
+
+                        ],
+
+                        'is_asymmetric' => [
+                            'label' => 'Twee asymmetrische kolommen',
+                        ],
+
+                        'start_span' => [
+                            'label' => 'Start bereik',
+                        ],
+
+                        'end_span' => [
+                            'label' => 'Eind bereik',
+                        ],
+
+                    ],
+
+                ],
+
+            ],
+
             'link' => [
 
                 'label' => 'Bewerken',


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
Added missing Dutch translations for Grid extension in Rich Editor

## Visual changes

<!-- Add screenshots/recordings of before and after. -->
No visual changes - translation updates only.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
