### PR TITLE
fix: restore nullable grouping behavior in table grouping

### DIFF
--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -133,7 +133,7 @@ trait HasBulkActions
     /**
      * @return array<string>
      */
-    public function getGroupedSelectableTableRecordKeys(string $group): array
+    public function getGroupedSelectableTableRecordKeys(?string $group): array
     {
         $query = $this->getFilteredTableQuery();
 

--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -350,7 +350,7 @@ class Group extends Component
         return $query;
     }
 
-    public function scopeQueryByKey(EloquentBuilder $query, string $key): EloquentBuilder
+    public function scopeQueryByKey(EloquentBuilder $query, ?string $key): EloquentBuilder
     {
         $column = $this->getColumn();
 

--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -322,7 +322,7 @@ class Group extends Component
         }
 
         if ($relationshipName = $this->getRelationshipName()) {
-            return $query->orderByPowerJoins("{$relationshipName}.{$this->getRelationshipAttribute()}", $direction); /** @phpstan-ignore method.notFound */
+            return $query->orderByPowerJoins("{$relationshipName}.{$this->getRelationshipAttribute()}", $direction, null, 'leftJoin'); /** @phpstan-ignore method.notFound */
         }
 
         return $query->orderBy($this->getRelationshipAttribute(), $direction);


### PR DESCRIPTION
This fix restores the expected behavior for nullable  in table grouping.
Previously, the grouping relied on an `INNER JOIN`, which excluded rows with `NULL` values.
It now uses a `LEFT JOIN` to correctly include groups with nullable keys.

Previous: #18058
Also fix: #18105 allowing `getGroupedSelectableTableRecordKeys` and `scopeQueryByKey` to have `?string $key`
