### PR TITLE
Hide hamburger icon when not needed

### DIFF
--- a/packages/panels/resources/views/components/layout/index.blade.php
+++ b/packages/panels/resources/views/components/layout/index.blade.php
@@ -32,7 +32,7 @@
         @livewire(filament()->getTopbarLivewireComponent())
 
         {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::TOPBAR_AFTER, scopes: $renderHookScopes) }}
-    @else
+    @elseif ($hasNavigation)
         <div
             @if ($isSidebarFullyCollapsibleOnDesktop)
                 x-data="{}"


### PR DESCRIPTION
When a panel is configured with `->navigation(false)` the sidebar is hidden but the mobile hamburger button still shows (even though there's no sidebar to open). This PR only renders the hamburger button when `$hasNavigation` is true. 