### PR TITLE
feat: adjust deletion logic for repeater group-specific records

### DIFF
--- a/packages/forms/docs/12-repeater.md
+++ b/packages/forms/docs/12-repeater.md
@@ -454,6 +454,31 @@ Repeater::make('qualifications')
 
 <UtilityInjection set="formFields" version="4.x" extras="Data;;array<string, mixed>;;$data;;The data that is being saved by the repeater.">You can inject various utilities into the function passed to `mutateRelationshipDataBeforeSaveUsing()` as parameters.</UtilityInjection>
 
+
+### Modifying related records after retrieval
+
+You may filter or modify the related records of a repeater after they are retrieved from the database using the `modifyRecordsUsing()` method. This method accepts a closure that receives a `Collection` of related records. You should return the modified collection.
+
+This can be particularly useful to restrict records to a specific group or category without triggering additional queries:
+
+```php
+use Filament\Forms\Components\Repeater;
+use Illuminate\Database\Eloquent\Collection;
+
+Repeater::make('children')
+    ->relationship(name: 'children', modifyRecordsUsing: function (Collection $records) {
+        return $records->where('group', 'start_items');
+    }),
+Repeater::make('children')
+    ->relationship(name: 'children', modifyRecordsUsing: function (Collection $records) {
+        return $records->where('group', 'end_items');
+    }),
+```
+
+<Aside variant="info">
+    Unlike `modifyQueryUsing()`, `modifyRecordsUsing()` operates on the already loaded collection, avoiding N+1 query issues. This is ideal for filtering records based on dynamic conditions after eager loading.
+</Aside>
+
 ## Grid layout
 
 You may organize repeater items into columns by using the `grid()` method:

--- a/packages/forms/docs/12-repeater.md
+++ b/packages/forms/docs/12-repeater.md
@@ -454,30 +454,23 @@ Repeater::make('qualifications')
 
 <UtilityInjection set="formFields" version="4.x" extras="Data;;array<string, mixed>;;$data;;The data that is being saved by the repeater.">You can inject various utilities into the function passed to `mutateRelationshipDataBeforeSaveUsing()` as parameters.</UtilityInjection>
 
-
 ### Modifying related records after retrieval
 
-You may filter or modify the related records of a repeater after they are retrieved from the database using the `modifyRecordsUsing()` method. This method accepts a closure that receives a `Collection` of related records. You should return the modified collection.
+You may filter or modify the related records of a repeater after they are retrieved from the database using the `modifyRecordsUsing` argument. This method accepts a function that receives a `Collection` of related records. You should return the modified collection.
 
-This can be particularly useful to restrict records to a specific group or category without triggering additional queries:
+This can be particularly useful to restrict records to a specific group or category without doing this in the database query itself, which would trigger an extra query if the records are already eager loaded:
 
 ```php
 use Filament\Forms\Components\Repeater;
 use Illuminate\Database\Eloquent\Collection;
 
-Repeater::make('children')
-    ->relationship(name: 'children', modifyRecordsUsing: function (Collection $records) {
-        return $records->where('group', 'start_items');
-    }),
-Repeater::make('children')
-    ->relationship(name: 'children', modifyRecordsUsing: function (Collection $records) {
-        return $records->where('group', 'end_items');
-    }),
+Repeater::make('startItems')
+    ->relationship(name: 'items', modifyRecordsUsing: fn (Collection $records): Collection => $records->where('group', 'start')),
+Repeater::make('endItems')
+    ->relationship(name: 'items', modifyRecordsUsing: fn (Collection $records): Collection => $records->where('group', 'end')),
 ```
 
-<Aside variant="info">
-    Unlike `modifyQueryUsing()`, `modifyRecordsUsing()` operates on the already loaded collection, avoiding N+1 query issues. This is ideal for filtering records based on dynamic conditions after eager loading.
-</Aside>
+<UtilityInjection set="formFields" version="4.x" extras="Records;;Illuminate\Database\Eloquent\Collection;;$records;;The collection of related records.">You can inject various utilities into the function passed to `modifyRecordsUsing` as parameters.</UtilityInjection>
 
 ## Grid layout
 

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1131,17 +1131,17 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return $this->evaluate($this->relationship);
     }
 
-    protected function modifyRelationshipRecords(Collection $collection): Collection
+    protected function modifyRelationshipRecords(Collection $records): Collection
     {
-        if (! $this->modifyRelationshipRecordsUsing) {
-            return $collection;
-        }
-
-        return $this->evaluate($this->modifyRelationshipRecordsUsing, [
-            'records' => $collection,
-        ], [
-            Collection::class => $collection,
-        ]);
+        return $this->evaluate(
+            $this->modifyRelationshipRecordsUsing,
+            namedInjections: [
+                'records' => $records,
+            ],
+            typedInjections: [
+                Collection::class => $records,
+            ],
+        ) ?? $records;
     }
 
     public function getCachedExistingRecords(): Collection

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -6,7 +6,6 @@ use Closure;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Repeater\TableColumn;
 use Filament\Forms\View\FormsIconAlias;
-use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Concerns\CanBeCollapsed;
 use Filament\Schemas\Components\Concerns\CanBeCompact;
 use Filament\Schemas\Components\Concerns\HasContainerGridLayout;
@@ -72,6 +71,8 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     protected Alignment | string | Closure | null $addActionAlignment = null;
 
     protected ?Closure $modifyRelationshipQueryUsing = null;
+
+    protected ?Closure $modifyRelationshipRecordsUsing = null;
 
     protected ?Closure $modifyAddActionUsing = null;
 
@@ -911,10 +912,11 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return $this;
     }
 
-    public function relationship(string | Closure | null $name = null, ?Closure $modifyQueryUsing = null): static
+    public function relationship(string | Closure | null $name = null, ?Closure $modifyQueryUsing = null, ?Closure $modifyRecordsUsing = null): static
     {
         $this->relationship = $name ?? $this->getName();
         $this->modifyRelationshipQueryUsing = $modifyQueryUsing;
+        $this->modifyRelationshipRecordsUsing = $modifyRecordsUsing;
 
         $this->afterStateHydrated(static function (Repeater $component): void {
             if (! is_array($component->hydratedDefaultState)) {
@@ -1129,6 +1131,19 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return $this->evaluate($this->relationship);
     }
 
+    protected function modifyRelationshipRecords(Collection $collection): Collection
+    {
+        if (! $this->modifyRelationshipRecordsUsing) {
+            return $collection;
+        }
+
+        return $this->evaluate($this->modifyRelationshipRecordsUsing, [
+            'records' => $collection,
+        ], [
+            Collection::class => $collection,
+        ]);
+    }
+
     public function getCachedExistingRecords(): Collection
     {
         if ($this->cachedExistingRecords) {
@@ -1145,11 +1160,11 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
             $this->getModelInstance()->relationLoaded($relationshipName) &&
             (! $this->modifyRelationshipQueryUsing)
         ) {
-            return $this->cachedExistingRecords = $this->getRecord()->getRelationValue($relationshipName)
+            return $this->cachedExistingRecords = $this->modifyRelationshipRecords($this->getRecord()->getRelationValue($relationshipName)
                 ->when(filled($orderColumn), fn (Collection $records) => $records->sortBy($orderColumn))
                 ->mapWithKeys(
                     fn (Model $item): array => ["record-{$item[$relatedKeyName]}" => $item],
-                );
+                ));
         }
 
         $relationshipQuery = $relationship->getQuery();
@@ -1171,9 +1186,9 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
             $relationshipQuery->orderBy($orderColumn);
         }
 
-        return $this->cachedExistingRecords = $relationshipQuery->get()->mapWithKeys(
+        return $this->cachedExistingRecords = $this->modifyRelationshipRecords($relationshipQuery->get()->mapWithKeys(
             fn (Model $item): array => ["record-{$item[$relatedKeyName]}" => $item],
-        );
+        ));
     }
 
     public function getItemLabel(string $key): string | Htmlable | null


### PR DESCRIPTION
## Description

This PR improves the handling of repeater relationships by restricting record deletion and modification to specific groups. It avoids unintended deletions and reduces N+1 query issues by reusing already eager loaded relationships.

The implementation intercepts the `getCachedExistingRecords` method before returning, which alters the collection. Deletion is already handled through a *diff* on this collection, ensuring that only relevant elements are deleted.

Before, the relationships used `modifyQueryUsing`, which could trigger N+1 queries. After the change, we use `modifyRecordsUsing` to filter the already loaded collection by group.


## Visual changes

No visual changes. The PR affects backend behavior and data integrity only.


## Functional changes

**Before vs After example:**

**Before (N+1 queries possible):**

```php
Repeater::make($childKey)
    ->relationship(name: 'children', modifyQueryUsing: function (Builder $query) {
        return $query->where('group', 'start_items');
    }),
Repeater::make($childKey)
    ->relationship(name: 'children', modifyQueryUsing: function (Builder $query) {
        return $query->where('group', 'end_items');
    }),
```

**After (reuses eager loaded collection):**

```php
Repeater::make($childKey)
    ->relationship(name: 'children', modifyRecordsUsing: function (Collection $records) {
        return $records->where('group', 'start_items');
    }),
Repeater::make($childKey)
    ->relationship(name: 'children', modifyRecordsUsing: function (Collection $records) {
        return $records->where('group', 'end_items');
    }),
```

* [x] Code style has been fixed by running the `composer cs` command.
* [x] Changes have been tested to not break existing functionality.
* [x] Documentation is up-to-date.

