### PR TITLE
Pass uploaded file to custom properties

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/README.md
+++ b/packages/spatie-laravel-media-library-plugin/README.md
@@ -90,6 +90,25 @@ SpatieMediaLibraryFileUpload::make('attachments')
     ->customProperties(['zip_filename_prefix' => 'folder/subfolder/'])
 ```
 
+Or you may use a closure to dynamically generate the properties:
+
+```php
+use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+use Spatie\Image\Image;
+
+SpatieMediaLibraryFileUpload::make('image')
+    ->image()
+    ->customProperties(function (TemporaryUploadedFile $file): array  {
+        $image = Image::load($file->getRealPath());
+
+        return [
+            'width' => $image->getWidth(),
+            'height' => $image->getHeight(),
+        ];
+    })
+```
+
 ### Adding custom headers
 
 You may pass in custom headers when uploading files using the `customHeaders()` method:

--- a/packages/spatie-laravel-media-library-plugin/README.md
+++ b/packages/spatie-laravel-media-library-plugin/README.md
@@ -90,7 +90,7 @@ SpatieMediaLibraryFileUpload::make('attachments')
     ->customProperties(['zip_filename_prefix' => 'folder/subfolder/'])
 ```
 
-Or you may use a closure to dynamically generate the properties:
+You may use a function to dynamically set the properties based on the uploaded file:
 
 ```php
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
@@ -99,12 +99,12 @@ use Spatie\Image\Image;
 
 SpatieMediaLibraryFileUpload::make('image')
     ->image()
-    ->customProperties(function (TemporaryUploadedFile $file): array  {
+    ->customProperties(function (TemporaryUploadedFile $file): array {
         $image = Image::load($file->getRealPath());
 
         return [
-            'width' => $image->getWidth(),
             'height' => $image->getHeight(),
+            'width' => $image->getWidth(),
         ];
     })
 ```

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -144,7 +144,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
                 ->usingFileName($filename)
                 ->usingName($component->getMediaName($file) ?? pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME))
                 ->storingConversionsOnDisk($component->getConversionsDisk() ?? '')
-                ->withCustomProperties($component->getCustomProperties())
+                ->withCustomProperties($component->getCustomProperties($file))
                 ->withManipulations($component->getManipulations())
                 ->withResponsiveImagesIf($component->hasResponsiveImages())
                 ->withProperties($component->getProperties())
@@ -319,9 +319,11 @@ class SpatieMediaLibraryFileUpload extends FileUpload
     /**
      * @return array<string, mixed>
      */
-    public function getCustomProperties(): array
+    public function getCustomProperties(TemporaryUploadedFile $file): array
     {
-        return $this->evaluate($this->customProperties) ?? [];
+        return $this->evaluate($this->customProperties, [
+            'file' => $file,
+        ]) ?? [];
     }
 
     /**


### PR DESCRIPTION
## Description

Pass the uploaded file to `customProperties`.

Useful if you need to store extra information e.g image dimensions:
```php
use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
use Spatie\Image\Image;

SpatieMediaLibraryFileUpload::make('image')
    ->image()
    ->customProperties(function (TemporaryUploadedFile $file): array  {
        $image = Image::load($file->getRealPath());

        return [
            'width' => $image->getWidth(),
            'height' => $image->getHeight(),
        ];
    })
```

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
