### PR TITLE
fix: improve integer handling in OptionsArrayStateCast and OptionStat…

### DIFF
--- a/packages/schemas/src/Components/StateCasts/OptionStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/OptionStateCast.php
@@ -29,6 +29,14 @@ class OptionStateCast implements StateCast
                 && (($state === '0') || (! str($state)->startsWith('0')))
             )
         ) {
+            $max = (string) PHP_INT_MAX;
+            if (
+                strlen($state) > strlen($max) ||
+                (strlen($state) === strlen($max) && strcmp($state, $max) > 0)
+            ) {
+                return strval($state);
+            }
+
             return intval($state);
         }
 

--- a/packages/schemas/src/Components/StateCasts/OptionStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/OptionStateCast.php
@@ -30,9 +30,10 @@ class OptionStateCast implements StateCast
             )
         ) {
             $max = (string) PHP_INT_MAX;
+
             if (
-                strlen($state) > strlen($max) ||
-                (strlen($state) === strlen($max) && strcmp($state, $max) > 0)
+                (strlen($state) > strlen($max)) ||
+                ((strlen($state) === strlen($max)) && (strcmp($state, $max) > 0))
             ) {
                 return strval($state);
             }

--- a/packages/schemas/src/Components/StateCasts/OptionsArrayStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/OptionsArrayStateCast.php
@@ -40,7 +40,16 @@ class OptionsArrayStateCast implements StateCast
                         && (($stateItem === '0') || (! str($stateItem)->startsWith('0')))
                     )
                 ) {
-                    $carry[] = intval($stateItem);
+                    $max = (string) PHP_INT_MAX;
+
+                    if (
+                        strlen($stateItem) > strlen($max) ||
+                        (strlen($stateItem) === strlen($max) && strcmp($stateItem, $max) > 0)
+                    ) {
+                        $carry[] = strval($stateItem);
+                    } else {
+                        $carry[] = intval($stateItem);
+                    }
                 } else {
                     $carry[] = strval($stateItem);
                 }

--- a/packages/schemas/src/Components/StateCasts/OptionsArrayStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/OptionsArrayStateCast.php
@@ -43,8 +43,8 @@ class OptionsArrayStateCast implements StateCast
                     $max = (string) PHP_INT_MAX;
 
                     if (
-                        strlen($stateItem) > strlen($max) ||
-                        (strlen($stateItem) === strlen($max) && strcmp($stateItem, $max) > 0)
+                        (strlen($stateItem) > strlen($max)) ||
+                        ((strlen($stateItem) === strlen($max)) && (strcmp($stateItem, $max) > 0))
                     ) {
                         $carry[] = strval($stateItem);
                     } else {


### PR DESCRIPTION
fixes: #18134

## Description

If it exceeds PHP's int limit, keep it as a string.

## Visual changes
## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
