### PR TITLE
fix: handle state type check to allow array in SpatieTagsColumn

### DIFF
--- a/packages/spatie-laravel-tags-plugin/src/Tables/Columns/SpatieTagsColumn.php
+++ b/packages/spatie-laravel-tags-plugin/src/Tables/Columns/SpatieTagsColumn.php
@@ -31,7 +31,7 @@ class SpatieTagsColumn extends TextColumn
         return $this->cacheState(function (): array {
             $state = parent::getState();
 
-            if ($state && (! $state instanceof Collection)) {
+            if ($state && (! $state instanceof Collection) && ! is_array($state)) {
                 return $state;
             }
 

--- a/packages/spatie-laravel-tags-plugin/src/Tables/Columns/SpatieTagsColumn.php
+++ b/packages/spatie-laravel-tags-plugin/src/Tables/Columns/SpatieTagsColumn.php
@@ -31,7 +31,7 @@ class SpatieTagsColumn extends TextColumn
         return $this->cacheState(function (): array {
             $state = parent::getState();
 
-            if ($state && (! $state instanceof Collection) && ! is_array($state)) {
+            if ($state && (! $state instanceof Collection) && (! is_array($state))) {
                 return $state;
             }
 


### PR DESCRIPTION

## Description

fixes: #18149 

The association relationship is returned as an array, which results in no subsequent code being executed


## Visual changes

<img width="1770" height="1139" alt="image" src="https://github.com/user-attachments/assets/b4dca4f1-a372-43e8-9abc-b9dde59a99bc" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
