### PR TITLE
Add globalSearchSort property to control resource order in global search

### DIFF
--- a/docs/03-resources/10-global-search.md
+++ b/docs/03-resources/10-global-search.md
@@ -144,27 +144,16 @@ public function panel(Panel $panel): Panel
         ->globalSearch(position: GlobalSearchPosition::Sidebar);
 }
 ```
+
 ## Sorting global search results
 
 By default, global search results are ordered alphabetically by resource name. You can customize this order by setting the `$globalSearchSort` property on your resource:
 
 ```php
-protected static ?int $globalSearchSort = 10;
-```
-Resources with a lower sort value will appear before resources with a higher sort value. Resources without a sort value will be treated as having a sort value of 0.
-
-For example, if you want users to appear first in search results, posts second, and comments third:
-
-```php
-// UserResource.php
-protected static ?int $globalSearchSort = 1;
-
-// PostResource.php
-protected static ?int $globalSearchSort = 2;
-
-// CommentResource.php
 protected static ?int $globalSearchSort = 3;
 ```
+
+Now, navigation items with a lower sort value will appear before those with a higher sort value - the order is ascending.
 
 ## Disabling global search
 

--- a/docs/03-resources/10-global-search.md
+++ b/docs/03-resources/10-global-search.md
@@ -144,6 +144,27 @@ public function panel(Panel $panel): Panel
         ->globalSearch(position: GlobalSearchPosition::Sidebar);
 }
 ```
+## Sorting global search results
+
+By default, global search results are ordered alphabetically by resource name. You can customize this order by setting the `$globalSearchSort` property on your resource:
+
+```php
+protected static ?int $globalSearchSort = 10;
+```
+Resources with a lower sort value will appear before resources with a higher sort value. Resources without a sort value will be treated as having a sort value of 0.
+
+For example, if you want users to appear first in search results, posts second, and comments third:
+
+```php
+// UserResource.php
+protected static ?int $globalSearchSort = 1;
+
+// PostResource.php
+protected static ?int $globalSearchSort = 2;
+
+// CommentResource.php
+protected static ?int $globalSearchSort = 3;
+```
 
 ## Disabling global search
 

--- a/packages/panels/src/GlobalSearch/Providers/DefaultGlobalSearchProvider.php
+++ b/packages/panels/src/GlobalSearch/Providers/DefaultGlobalSearchProvider.php
@@ -11,8 +11,12 @@ class DefaultGlobalSearchProvider implements Contracts\GlobalSearchProvider
     {
         $builder = GlobalSearchResults::make();
 
-        $resources = collect(Filament::getResources())
-            ->sortBy(fn (string $resource): int => $resource::getGlobalSearchSort() ?? 0);
+        $resources = Filament::getResources();
+
+        $resources = usort(
+            $resources,
+            fn (string $a, string $b): int => ($a::getGlobalSearchSort() ?? 0) <=> ($b::getGlobalSearchSort() ?? 0),
+        );
 
         foreach ($resources as $resource) {
             if (! $resource::canGloballySearch()) {

--- a/packages/panels/src/GlobalSearch/Providers/DefaultGlobalSearchProvider.php
+++ b/packages/panels/src/GlobalSearch/Providers/DefaultGlobalSearchProvider.php
@@ -11,7 +11,10 @@ class DefaultGlobalSearchProvider implements Contracts\GlobalSearchProvider
     {
         $builder = GlobalSearchResults::make();
 
-        foreach (Filament::getResources() as $resource) {
+        $resources = collect(Filament::getResources())
+            ->sortBy(fn (string $resource): int => $resource::getGlobalSearchSort() ?? 0);
+
+        foreach ($resources as $resource) {
             if (! $resource::canGloballySearch()) {
                 continue;
             }

--- a/packages/panels/src/GlobalSearch/Providers/DefaultGlobalSearchProvider.php
+++ b/packages/panels/src/GlobalSearch/Providers/DefaultGlobalSearchProvider.php
@@ -13,7 +13,7 @@ class DefaultGlobalSearchProvider implements Contracts\GlobalSearchProvider
 
         $resources = Filament::getResources();
 
-        $resources = usort(
+        usort(
             $resources,
             fn (string $a, string $b): int => ($a::getGlobalSearchSort() ?? 0) <=> ($b::getGlobalSearchSort() ?? 0),
         );

--- a/packages/panels/src/Resources/Resource/Concerns/HasGlobalSearch.php
+++ b/packages/panels/src/Resources/Resource/Concerns/HasGlobalSearch.php
@@ -24,6 +24,8 @@ trait HasGlobalSearch
 
     protected static bool $isGloballySearchable = true;
 
+    protected static ?int $globalSearchSort = null;
+
     public static function canGloballySearch(): bool
     {
         return static::$isGloballySearchable && count(static::getGloballySearchableAttributes()) && static::canAccess();
@@ -234,5 +236,14 @@ trait HasGlobalSearch
     public static function getGlobalSearchEloquentQuery(): Builder
     {
         return static::getEloquentQuery();
+    }
+
+    public static function getGlobalSearchSort(): ?int
+    {
+        return static::$globalSearchSort;
+    }
+    public static function globalSearchSort(?int $sort): void
+    {
+        static::$globalSearchSort = $sort;
     }
 }

--- a/packages/panels/src/Resources/Resource/Concerns/HasGlobalSearch.php
+++ b/packages/panels/src/Resources/Resource/Concerns/HasGlobalSearch.php
@@ -242,6 +242,7 @@ trait HasGlobalSearch
     {
         return static::$globalSearchSort;
     }
+
     public static function globalSearchSort(?int $sort): void
     {
         static::$globalSearchSort = $sort;

--- a/tests/src/Fixtures/Resources/Posts/PostResource.php
+++ b/tests/src/Fixtures/Resources/Posts/PostResource.php
@@ -33,6 +33,8 @@ class PostResource extends Resource
 
     protected static int $globalSearchResultsLimit = 3;
 
+    protected static ?int $globalSearchSort = 10;
+
     public static function form(Schema $form): Schema
     {
         return $form

--- a/tests/src/Fixtures/Resources/Users/UserResource.php
+++ b/tests/src/Fixtures/Resources/Users/UserResource.php
@@ -24,6 +24,8 @@ class UserResource extends Resource
 
     protected static ?string $recordTitleAttribute = 'name';
 
+    protected static ?int $globalSearchSort = 5;
+
     public static function form(Schema $form): Schema
     {
         return $form

--- a/tests/src/Panels/GlobalSearch/GlobalSearchTest.php
+++ b/tests/src/Panels/GlobalSearch/GlobalSearchTest.php
@@ -59,23 +59,20 @@ it('can retrieve results via custom search provider', function (): void {
         ->assertDispatched('open-global-search-results')
         ->assertSee(['foo', 'bar', 'baz']);
 });
-it('orders global search results by globalSearchSort', function (): void {
-    // Posts has $globalSearchSort = 10
-    // Users has $globalSearchSort = 5
-    // So Users should appear first (lower number = first)
 
+it('orders resource global search results by `$globalSearchSort`', function (): void {
     User::factory()->create([
-        'name' => 'Search Term Test',
+        'name' => 'Test',
     ]);
 
     Post::factory()->create([
-        'title' => 'Search Term Test',
+        'title' => 'Test',
     ]);
 
     $provider = Filament::getCurrentOrDefaultPanel()->getGlobalSearchProvider();
-    $results = $provider->getResults('Search Term Test');
+    $results = $provider->getResults('Test');
 
-    $categories = $results->getCategories()->keys()->toArray();
+    $categories = $results->getCategories()->keys()->all();
 
     expect($categories[0])->toBe('users');
     expect($categories[1])->toBe('posts');

--- a/tests/src/Panels/GlobalSearch/GlobalSearchTest.php
+++ b/tests/src/Panels/GlobalSearch/GlobalSearchTest.php
@@ -6,6 +6,7 @@ use Filament\GlobalSearch\GlobalSearchResults;
 use Filament\GlobalSearch\Providers\Contracts\GlobalSearchProvider;
 use Filament\Livewire\GlobalSearch;
 use Filament\Tests\Fixtures\Models\Post;
+use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\Panels\GlobalSearch\TestCase;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Support\Str;
@@ -57,6 +58,27 @@ it('can retrieve results via custom search provider', function (): void {
         ->set('search', 'foo')
         ->assertDispatched('open-global-search-results')
         ->assertSee(['foo', 'bar', 'baz']);
+});
+it('orders global search results by globalSearchSort', function (): void {
+    // Posts has $globalSearchSort = 10
+    // Users has $globalSearchSort = 5
+    // So Users should appear first (lower number = first)
+
+    User::factory()->create([
+        'name' => 'Search Term Test',
+    ]);
+
+    Post::factory()->create([
+        'title' => 'Search Term Test',
+    ]);
+
+    $provider = Filament::getCurrentOrDefaultPanel()->getGlobalSearchProvider();
+    $results = $provider->getResults('Search Term Test');
+
+    $categories = $results->getCategories()->keys()->toArray();
+
+    expect($categories[0])->toBe('users');
+    expect($categories[1])->toBe('posts');
 });
 
 class CustomSearchProvider implements GlobalSearchProvider


### PR DESCRIPTION
## Description

This adds support for an additional attribute on resources : $globalSearchSort. Changing this value allows to change the ordering of resources when displayed in the global search results. 

This has been discussed in #12954

## Visual changes

<img width="410" height="407" alt="image" src="https://github.com/user-attachments/assets/927b09ac-c0bf-4e18-91c1-c3ad7b001538" />


## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
