### PR TITLE
fix: Change $activeNavigationIcon type in the documentation to include BackedEnum

### DIFF
--- a/docs/06-navigation/01-overview.md
+++ b/docs/06-navigation/01-overview.md
@@ -46,7 +46,9 @@ If you set `$navigationIcon = null` on all items within the same navigation grou
 You may assign a navigation [icon](../styling/icons) which will only be used for active items using the `$activeNavigationIcon` property:
 
 ```php
-protected static ?string $activeNavigationIcon = 'heroicon-o-document-text';
+use BackedEnum;
+
+protected static string | BackedEnum | null $activeNavigationIcon = 'heroicon-o-document-text';
 ```
 
 <AutoScreenshot name="panels/navigation/active-icon" alt="Different navigation item icon when active" version="3.x" />


### PR DESCRIPTION
### Summary 
This pull request updates the documentation to clarify the accepted types for the `$activeNavigationIcon` property in navigation items. The main change is to show that `$activeNavigationIcon` can now be a `string`, a `BackedEnum`, or `null`.

Documentation update:

* Updated the code example in `docs/06-navigation/01-overview.md` to indicate that `$activeNavigationIcon` supports `string`, `BackedEnum`, or `null` types, and added the necessary `use BackedEnum;` statement.


<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
While reviewing the Filament v4 Navigation documentation, I found an inconsistency between the documented types for ` $navigationIcon` and ` $activeNavigationIcon`.

The docs correctly show:
> ### Customizing a navigation item’s icon
> To customize a navigation item’s [icon](https://filamentphp.com/docs/4.x/styling/icons), you may override the $navigationIcon property on the [resource](https://filamentphp.com/docs/4.x/navigation/resources) or [page](https://filamentphp.com/docs/4.x/navigation/pages) class:

```php
use BackedEnum;

protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-document-text';
```

But the `$activeNavigationIcon` example only showed a string type: `protected static ?string $activeNavigationIcon = 'heroicon-o-document-text';`

> ### Switching navigation item icon when it is active
> You may assign a navigation [icon](https://filamentphp.com/docs/4.x/styling/icons) which will only be used for active items using the $activeNavigationIcon property:

```php
protected static ?string $activeNavigationIcon = 'heroicon-o-document-text';
```

---

The implementation referenced in `HasNavigation.php` supports `BackedEnum` as well, so the documentation should match. See the source for reference: https://github.com/filamentphp/filament/blob/ee05680b3942783e01a1ad07eb977a84aae1ea04/packages/panels/src/Resources/Resource/Concerns/HasNavigation.php#L30

This update brings the docs and examples into alignment.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
