### PR TITLE
fix: cast `CodeEntry` state to array for collections

### DIFF
--- a/packages/infolists/src/Components/CodeEntry.php
+++ b/packages/infolists/src/Components/CodeEntry.php
@@ -5,6 +5,7 @@ namespace Filament\Infolists\Components;
 use Closure;
 use Filament\Support\Components\Contracts\HasEmbeddedView;
 use Filament\Support\Concerns\CanBeCopied;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Js;
 use Phiki\Grammar\Grammar;
 use Phiki\Phiki;
@@ -59,6 +60,10 @@ class CodeEntry extends Entry implements HasEmbeddedView
     public function toEmbeddedHtml(): string
     {
         $state = $this->getState();
+
+        if ($state instanceof Collection) {
+            $state = $state->all();
+        }
 
         $attributes = $this->getExtraAttributeBag()
             ->class([


### PR DESCRIPTION
## Description

Convert the state of the CodeEntry component to an array when it is a collection to ensure proper display of collections.

## Visual changes

# Before

<img width="1645" height="440" alt="image" src="https://github.com/user-attachments/assets/f67d8a5a-2115-44fa-903e-1b63774af8f2" />

# After

<img width="1596" height="444" alt="image" src="https://github.com/user-attachments/assets/d2c51017-02b5-4276-947d-486bd5c5fa96" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
