### PR TITLE
Add missing italian translation folder for widgets

### DIFF
--- a/packages/widgets/resources/lang/it/chart.php
+++ b/packages/widgets/resources/lang/it/chart.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+
+    'actions' => [
+
+        'filter' => [
+            'label' => 'Filtra',
+        ],
+
+    ],
+
+];


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Added the missing Italian translation folder for the widget package.

## Visual changes

No Visual changes :) 

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
