### PR TITLE
fix: fix Italian translation in actions/delete.php

### DIFF
--- a/packages/actions/resources/lang/it/delete.php
+++ b/packages/actions/resources/lang/it/delete.php
@@ -54,18 +54,18 @@ return [
                 'title' => 'Eliminati',
             ],
 
-        ],
+            'deleted_partial' => [
+                'title' => 'Eliminati :count di :total',
+                'missing_authorization_failure_message' => 'Non hai il permesso di eliminare :count.',
+                'missing_processing_failure_message' => ':count non possono essere eliminati.',
+            ],
 
-        'deleted_partial' => [
-            'title' => 'Eliminati :count di :total',
-            'missing_authorization_failure_message' => 'Non hai il permesso di eliminare :count.',
-            'missing_processing_failure_message' => ':count non possono essere eliminati.',
-        ],
+            'deleted_none' => [
+                'title' => 'Eliminazione fallita',
+                'missing_authorization_failure_message' => 'Non hai il permesso di eliminare :count.',
+                'missing_processing_failure_message' => ':count non possono essere eliminati.',
+            ],
 
-        'deleted_none' => [
-            'title' => 'Eliminazione fallita',
-            'missing_authorization_failure_message' => 'Non hai il permesso di eliminare :count.',
-            'missing_processing_failure_message' => ':count non possono essere eliminati.',
         ],
 
     ],


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fix Italian translations for actions/delete

## Visual changes

No visual changes

## Functional changes

No functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
