### PR TITLE
fix: toggle-button requires double-click when modal is initially focused

### DIFF
--- a/packages/forms/resources/views/components/toggle-buttons/grouped.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/grouped.blade.php
@@ -13,6 +13,7 @@
     :component="$fieldWrapperView"
     :field="$field"
     class="fi-fo-toggle-buttons-wrp"
+    tabindex="-1"
 >
     <div
         {{ $getExtraAttributeBag()->class(['fi-fo-toggle-buttons fi-btn-group']) }}

--- a/packages/forms/resources/views/components/toggle-buttons/grouped.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/grouped.blade.php
@@ -12,8 +12,8 @@
 <x-dynamic-component
     :component="$fieldWrapperView"
     :field="$field"
-    class="fi-fo-toggle-buttons-wrp"
     tabindex="-1"
+    class="fi-fo-toggle-buttons-wrp"
 >
     <div
         {{ $getExtraAttributeBag()->class(['fi-fo-toggle-buttons fi-btn-group']) }}

--- a/packages/forms/resources/views/components/toggle-buttons/index.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/index.blade.php
@@ -18,6 +18,7 @@
     :component="$fieldWrapperView"
     :field="$field"
     class="fi-fo-toggle-buttons-wrp"
+    tabindex="-1"
 >
     <div
         {{

--- a/packages/forms/resources/views/components/toggle-buttons/index.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/index.blade.php
@@ -17,8 +17,8 @@
 <x-dynamic-component
     :component="$fieldWrapperView"
     :field="$field"
-    class="fi-fo-toggle-buttons-wrp"
     tabindex="-1"
+    class="fi-fo-toggle-buttons-wrp"
 >
     <div
         {{


### PR DESCRIPTION
## Description

fixes: #18155

Adding `tabindex="-1"` prevents the component from being auto-focused by the browser. This ensures the first click on the toggle-button directly selects it, instead of just focusing, thus solving the double-click issue when the modal is initially focused.  

Already tested, does not affect tab navigation functionality.

## Visual changes

# Before


https://github.com/user-attachments/assets/b4c1f9b9-0cde-4c9a-b352-74ad72b7e789



# After


https://github.com/user-attachments/assets/9bf623f9-75b6-475d-8093-db015d22f303



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
