### PR TITLE
Fix getSelectedTableRecordsQuery()

### DIFF
--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -310,7 +310,9 @@ trait HasBulkActions
             }
         }
 
-        return $table->selectPivotDataInQuery($relationship);
+        $relationship = $table->selectPivotDataInQuery($relationship);
+
+        return $relationship->getQuery();
     }
 
     /**


### PR DESCRIPTION
## Description

HasBulkActions::getSelectedTableRecordsQuery() seems to have a type mismatch when using `allowDuplicates()` with BelongsToMany/MorphToMany relationships.

At line 313 in vendor/filament/tables/src/Concerns/HasBulkActions.php:
 ```php
 return $table->selectPivotDataInQuery($relationship);  // Returns Relation, not Builder
```

## Visual changes

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
