### PR TITLE
fix undefined isSticky

### DIFF
--- a/packages/forms/resources/lang/pl/components.php
+++ b/packages/forms/resources/lang/pl/components.php
@@ -447,7 +447,7 @@ return [
 
             ],
 
-             'grid' => [
+            'grid' => [
 
                 'label' => 'Siatka',
 

--- a/packages/schemas/resources/views/components/actions.blade.php
+++ b/packages/schemas/resources/views/components/actions.blade.php
@@ -4,6 +4,7 @@
     $actions = $getChildSchema()->getComponents();
     $alignment = $getAlignment();
     $isFullWidth = $isFullWidth();
+    $isSticky = $isSticky();
     $verticalAlignment = $getVerticalAlignment();
 
     if (! $verticalAlignment instanceof VerticalAlignment) {
@@ -12,7 +13,7 @@
 @endphp
 
 <div
-    @if ($isSticky())
+    @if ($isSticky)
         x-data="filamentActionsSchemaComponent()"
         x-intersect:enter.half="disableSticky"
         x-intersect:leave="enableSticky"
@@ -50,7 +51,7 @@
         :actions="$actions"
         :alignment="$alignment"
         :full-width="$isFullWidth"
-        :x-bind:style="$isSticky() ? 'isSticky ? `width: ${width}px;` : \'\'' : null"
+        :x-bind:style="$isSticky ? 'isSticky ? `width: ${width}px;` : \'\'' : null"
     />
 
     @if ($belowContentContainer = $getChildSchema($schemaComponent::BELOW_CONTENT_SCHEMA_KEY)?->toHtmlString())

--- a/packages/schemas/resources/views/components/actions.blade.php
+++ b/packages/schemas/resources/views/components/actions.blade.php
@@ -50,7 +50,7 @@
         :actions="$actions"
         :alignment="$alignment"
         :full-width="$isFullWidth"
-        x-bind:style="isSticky ? `width: ${width}px;` : ''"
+        :x-bind:style="$isSticky() ? 'isSticky ? `width: ${width}px;` : \'\'' : null"
     />
 
     @if ($belowContentContainer = $getChildSchema($schemaComponent::BELOW_CONTENT_SCHEMA_KEY)?->toHtmlString())

--- a/packages/tables/resources/lang/pl/table.php
+++ b/packages/tables/resources/lang/pl/table.php
@@ -26,7 +26,7 @@ return [
             'label' => 'Akcja|Akcje',
         ],
 
-         'select' => [
+        'select' => [
 
             'loading_message' => 'Ładowanie...',
 


### PR DESCRIPTION
Fix js error when sticky is not enabled:
> Alpine Expression Error: isSticky is not defined
> Expression: "isSticky ? `width: ${width}px;` : ''"

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
