### PR TITLE
[4.x] Bug: Nested JSON fields break with same-name helper/accessor method on model

### DIFF
--- a/docs-assets/app/app/Models/Post.php
+++ b/docs-assets/app/app/Models/Post.php
@@ -24,9 +24,4 @@ class Post extends Model
     {
         return $this->belongsTo(User::class, 'author_id');
     }
-
-    public function config($key)
-    {
-        return $this->config->$key ?? null;
-    }
 }

--- a/docs-assets/app/app/Models/Post.php
+++ b/docs-assets/app/app/Models/Post.php
@@ -24,4 +24,9 @@ class Post extends Model
     {
         return $this->belongsTo(User::class, 'author_id');
     }
+
+    public function config($key)
+    {
+        return $this->config->$key ?? null;
+    }
 }

--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -298,7 +298,7 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
 
         $record = $this->getModelInstance();
 
-        if (! $record->isRelation($name)) {
+        if ($record->hasAttribute($name) || (! $record->isRelation($name))) {
             throw new LogicException("The relationship [{$name}] does not exist on the model [{$this->getModel()}].");
         }
 

--- a/packages/forms/src/Components/ModalTableSelect.php
+++ b/packages/forms/src/Components/ModalTableSelect.php
@@ -568,6 +568,12 @@ class ModalTableSelect extends Field
         $relationshipName = $this->getRelationshipName();
 
         foreach (explode('.', $relationshipName) as $nestedRelationshipName) {
+            if ($record->hasAttribute($nestedRelationshipName)) {
+                $relationship = null;
+
+                break;
+            }
+
             if (! $record->isRelation($nestedRelationshipName)) {
                 $relationship = null;
 

--- a/packages/forms/src/Components/MorphToSelect.php
+++ b/packages/forms/src/Components/MorphToSelect.php
@@ -203,7 +203,7 @@ class MorphToSelect extends Component
 
         $relationshipName = $this->getName();
 
-        if (! $record->isRelation($relationshipName)) {
+        if ($record->hasAttribute($relationshipName) || (! $record->isRelation($relationshipName))) {
             throw new LogicException("The relationship [{$relationshipName}] does not exist on the model [{$this->getModel()}].");
         }
 

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1119,7 +1119,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
 
         $relationshipName = $this->getRelationshipName();
 
-        if (! $record->isRelation($relationshipName)) {
+        if ($record->hasAttribute($relationshipName) || (! $record->isRelation($relationshipName))) {
             throw new LogicException("The relationship [{$relationshipName}] does not exist on the model [{$this->getModel()}].");
         }
 

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -1255,6 +1255,12 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
         $relationshipName = $this->getRelationshipName();
 
         foreach (explode('.', $relationshipName) as $nestedRelationshipName) {
+            if ($record->hasAttribute($nestedRelationshipName)) {
+                $relationship = null;
+
+                break;
+            }
+
             if (! $record->isRelation($nestedRelationshipName)) {
                 $relationship = null;
 

--- a/packages/forms/src/Components/TableSelect.php
+++ b/packages/forms/src/Components/TableSelect.php
@@ -253,6 +253,12 @@ class TableSelect extends Field
         $relationshipName = $this->getRelationshipName();
 
         foreach (explode('.', $relationshipName) as $nestedRelationshipName) {
+            if ($record->hasAttribute($nestedRelationshipName)) {
+                $relationship = null;
+
+                break;
+            }
+
             if (! $record->isRelation($nestedRelationshipName)) {
                 $relationship = null;
 

--- a/packages/panels/src/Resources/Resource/Concerns/BelongsToTenant.php
+++ b/packages/panels/src/Resources/Resource/Concerns/BelongsToTenant.php
@@ -71,7 +71,7 @@ trait BelongsToTenant
     {
         $relationshipName = static::getTenantOwnershipRelationshipName();
 
-        if (! $record->isRelation($relationshipName)) {
+        if ($record->hasAttribute($relationshipName) || (! $record->isRelation($relationshipName))) {
             $resourceClass = static::class;
             $recordClass = $record::class;
 
@@ -93,7 +93,7 @@ trait BelongsToTenant
     {
         $relationshipName = static::getTenantRelationshipName();
 
-        if (! $tenant->isRelation($relationshipName)) {
+        if ($tenant->hasAttribute($relationshipName) || (! $tenant->isRelation($relationshipName))) {
             $resourceClass = static::class;
             $tenantClass = $tenant::class;
 

--- a/packages/schemas/src/Components/Concerns/CanGetStateFromRelationships.php
+++ b/packages/schemas/src/Components/Concerns/CanGetStateFromRelationships.php
@@ -30,6 +30,12 @@ trait CanGetStateFromRelationships
         $relationship = null;
 
         foreach (explode('.', $statePath ?? $this->getStateRelationshipName()) as $nestedRelationshipName) {
+            if ($record->hasAttribute($nestedRelationshipName)) {
+                $relationship = null;
+
+                break;
+            }
+
             if (! $record->isRelation($nestedRelationshipName)) {
                 $relationship = null;
 

--- a/packages/support/src/Concerns/HasCellState.php
+++ b/packages/support/src/Concerns/HasCellState.php
@@ -218,6 +218,10 @@ trait HasCellState
             array_pop($nameParts);
         }
 
+        if($record->hasAttribute($nameParts[0])) {
+            return null;
+        }
+
         $relationship = null;
 
         foreach ($nameParts as $namePart) {

--- a/packages/support/src/Concerns/HasCellState.php
+++ b/packages/support/src/Concerns/HasCellState.php
@@ -188,6 +188,10 @@ trait HasCellState
             return false;
         }
 
+        if ($record->hasAttribute((string) str($name)->before('.'))) {
+            return false;
+        }
+
         return $record->isRelation((string) str($name)->before('.'));
     }
 
@@ -333,6 +337,10 @@ trait HasCellState
         $lastPart = array_pop($nameParts);
 
         foreach ($nameParts as $namePart) {
+            if ($record->hasAttribute($namePart)) {
+                break;
+            }
+
             if (! $record->isRelation($namePart)) {
                 break;
             }
@@ -356,6 +364,10 @@ trait HasCellState
         $lastPart = array_pop($nameParts);
 
         foreach ($nameParts as $namePart) {
+            if ($record->hasAttribute($namePart)) {
+                break;
+            }
+
             if (! $record->isRelation($namePart)) {
                 break;
             }
@@ -379,6 +391,10 @@ trait HasCellState
         $inverseRelationshipParts = [];
 
         foreach ($nameParts as $namePart) {
+            if ($record->hasAttribute($namePart)) {
+                break;
+            }
+
             if (! $record->isRelation($namePart)) {
                 break;
             }
@@ -395,11 +411,11 @@ trait HasCellState
                 )
                 ->camel();
 
-            if (! $record->isRelation($inverseNestedRelationshipName)) {
+            if ($record->hasAttribute($inverseNestedRelationshipName) || (! $record->isRelation($inverseNestedRelationshipName))) {
                 // The conventional relationship doesn't exist, but we can
                 // attempt to use the original relationship name instead.
 
-                if (! $record->isRelation($namePart)) {
+                if ($record->hasAttribute($namePart) || (! $record->isRelation($namePart))) {
                     $recordClass = $record::class;
 
                     throw new LogicException("When trying to guess the inverse relationship for column [{$this->getName()}], relationship [{$inverseNestedRelationshipName}] was not found on model [{$recordClass}]. Please define a custom [inverseRelationship()] for this column.");
@@ -428,6 +444,10 @@ trait HasCellState
         $relationshipParts = [];
 
         foreach ($nameParts as $namePart) {
+            if ($record->hasAttribute($namePart)) {
+                break;
+            }
+
             if (! $record->isRelation($namePart)) {
                 break;
             }

--- a/packages/support/src/Concerns/HasCellState.php
+++ b/packages/support/src/Concerns/HasCellState.php
@@ -218,13 +218,13 @@ trait HasCellState
             array_pop($nameParts);
         }
 
-        if($record->hasAttribute($nameParts[0])) {
-            return null;
-        }
-
         $relationship = null;
 
         foreach ($nameParts as $namePart) {
+            if ($record->hasAttribute($namePart)) {
+                break;
+            }
+
             if (! $record->isRelation($namePart)) {
                 break;
             }

--- a/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
-
+use Illuminate\Support\Str;
 use function Filament\Support\generate_search_column_expression;
 use function Filament\Support\generate_search_term_expression;
 
@@ -37,7 +37,7 @@ trait InteractsWithTableQuery
 
     public function applyEagerLoading(EloquentBuilder | Relation $query): EloquentBuilder | Relation
     {
-        if (! $this->hasRelationship($query->getModel())) {
+        if (! $this->hasRelationship($query->getModel()) || $query->getModel()->hasAttribute(Str::before($this->name, '.'))) {
             return $query;
         }
 

--- a/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
+
 use function Filament\Support\generate_search_column_expression;
 use function Filament\Support\generate_search_term_expression;
 
@@ -37,7 +37,7 @@ trait InteractsWithTableQuery
 
     public function applyEagerLoading(EloquentBuilder | Relation $query): EloquentBuilder | Relation
     {
-        if (! $this->hasRelationship($query->getModel()) || $query->getModel()->hasAttribute(Str::before($this->name, '.'))) {
+        if (! $this->hasRelationship($query->getModel())) {
             return $query;
         }
 

--- a/packages/tables/src/Columns/SelectColumn.php
+++ b/packages/tables/src/Columns/SelectColumn.php
@@ -786,6 +786,12 @@ class SelectColumn extends Column implements Editable, HasEmbeddedView
         $relationshipName = $this->getOptionsRelationshipName();
 
         foreach (explode('.', $relationshipName) as $nestedRelationshipName) {
+            if ($record->hasAttribute($nestedRelationshipName)) {
+                $relationship = null;
+
+                break;
+            }
+
             if (! $record->isRelation($nestedRelationshipName)) {
                 $relationship = null;
 

--- a/packages/tables/src/Filters/Concerns/HasRelationship.php
+++ b/packages/tables/src/Filters/Concerns/HasRelationship.php
@@ -64,6 +64,12 @@ trait HasRelationship
         $relationshipName = $this->getRelationshipName();
 
         foreach (explode('.', $relationshipName) as $nestedRelationshipName) {
+            if ($record->hasAttribute($nestedRelationshipName)) {
+                $relationship = null;
+
+                break;
+            }
+
             if (! $record->isRelation($nestedRelationshipName)) {
                 $relationship = null;
 

--- a/packages/tables/src/Filters/QueryBuilder/Constraints/RelationshipConstraint/Operators/IsRelatedToOperator.php
+++ b/packages/tables/src/Filters/QueryBuilder/Constraints/RelationshipConstraint/Operators/IsRelatedToOperator.php
@@ -232,6 +232,12 @@ class IsRelatedToOperator extends Operator
         $relationship = null;
 
         foreach (explode('.', $constraint->getRelationshipName()) as $nestedRelationshipName) {
+            if ($record->hasAttribute($nestedRelationshipName)) {
+                $relationship = null;
+
+                break;
+            }
+
             if (! $record->isRelation($nestedRelationshipName)) {
                 $relationship = null;
 

--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -393,6 +393,12 @@ class Group extends Component
         $relationship = null;
 
         foreach (explode('.', $name ?? $this->getRelationshipName()) as $nestedRelationshipName) {
+            if ($record->hasAttribute($nestedRelationshipName)) {
+                $relationship = null;
+
+                break;
+            }
+
             if (! $record->isRelation($nestedRelationshipName)) {
                 $relationship = null;
 

--- a/packages/tables/src/Table/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSearchRecords.php
@@ -248,6 +248,12 @@ trait CanSearchRecords
         $relationship = null;
 
         foreach (str($name)->beforeLast('.')->explode('.')->all() as $nestedRelationshipName) {
+            if ($record->hasAttribute($nestedRelationshipName)) {
+                $relationship = null;
+
+                break;
+            }
+
             if (! $record->isRelation($nestedRelationshipName)) {
                 $relationship = null;
 

--- a/tests/.pest/snapshots/src/Forms/Commands/MakeFormCommandTest/it_can_generate_a_form_schema_class_for_a_model.snap
+++ b/tests/.pest/snapshots/src/Forms/Commands/MakeFormCommandTest/it_can_generate_a_form_schema_class_for_a_model.snap
@@ -31,6 +31,8 @@ class PostForm
                     ->columnSpanFull(),
                 TextInput::make('title')
                     ->required(),
+                Textarea::make('config')
+                    ->columnSpanFull(),
                 Textarea::make('json')
                     ->columnSpanFull(),
                 Textarea::make('json_array_of_objects')

--- a/tests/.pest/snapshots/src/Forms/Commands/MakeLivewireFormCommandTest/it_can_generate_a_livewire_form_component_with_generated_fields.snap
+++ b/tests/.pest/snapshots/src/Forms/Commands/MakeLivewireFormCommandTest/it_can_generate_a_livewire_form_component_with_generated_fields.snap
@@ -47,6 +47,8 @@ class CreatePostWithFields extends Component implements HasActions, HasSchemas
                     ->columnSpanFull(),
                 TextInput::make('title')
                     ->required(),
+                Textarea::make('config')
+                    ->columnSpanFull(),
                 Textarea::make('json')
                     ->columnSpanFull(),
                 Textarea::make('json_array_of_objects')

--- a/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeResourceCommandTest/it_can_generate_the_form_and_table_of_a_resource_class.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeResourceCommandTest/it_can_generate_the_form_and_table_of_a_resource_class.snap
@@ -39,6 +39,8 @@ class PostResource extends Resource
                     ->columnSpanFull(),
                 Forms\Components\TextInput::make('title')
                     ->required(),
+                Forms\Components\Textarea::make('config')
+                    ->columnSpanFull(),
                 Forms\Components\Textarea::make('json')
                     ->columnSpanFull(),
                 Forms\Components\Textarea::make('json_array_of_objects')

--- a/tests/.pest/snapshots/src/Panels/Commands/MakeResourceCommandTest/it_can_generate_the_form__infolist__and_table_content_embedded_in_a_resource_class.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/MakeResourceCommandTest/it_can_generate_the_form__infolist__and_table_content_embedded_in_a_resource_class.snap
@@ -51,6 +51,8 @@ class PostResource extends Resource
                     ->columnSpanFull(),
                 TextInput::make('title')
                     ->required(),
+                Textarea::make('config')
+                    ->columnSpanFull(),
                 Textarea::make('json')
                     ->columnSpanFull(),
                 Textarea::make('json_array_of_objects')
@@ -77,6 +79,9 @@ class PostResource extends Resource
                     ->placeholder('-')
                     ->columnSpanFull(),
                 TextEntry::make('title'),
+                TextEntry::make('config')
+                    ->placeholder('-')
+                    ->columnSpanFull(),
                 TextEntry::make('json')
                     ->placeholder('-')
                     ->columnSpanFull(),

--- a/tests/.pest/snapshots/src/Panels/Commands/MakeResourceCommandTest/it_can_generate_the_resource_form_content.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/MakeResourceCommandTest/it_can_generate_the_resource_form_content.snap
@@ -30,6 +30,8 @@ class PostForm
                     ->columnSpanFull(),
                 TextInput::make('title')
                     ->required(),
+                Textarea::make('config')
+                    ->columnSpanFull(),
                 Textarea::make('json')
                     ->columnSpanFull(),
                 Textarea::make('json_array_of_objects')

--- a/tests/.pest/snapshots/src/Panels/Commands/MakeResourceCommandTest/it_can_generate_the_resource_infolist_content.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/MakeResourceCommandTest/it_can_generate_the_resource_infolist_content.snap
@@ -26,6 +26,9 @@ class PostInfolist
                     ->placeholder('-')
                     ->columnSpanFull(),
                 TextEntry::make('title'),
+                TextEntry::make('config')
+                    ->placeholder('-')
+                    ->columnSpanFull(),
                 TextEntry::make('json')
                     ->placeholder('-')
                     ->columnSpanFull(),

--- a/tests/database/migrations/create_posts_table.php
+++ b/tests/database/migrations/create_posts_table.php
@@ -16,6 +16,7 @@ return new class extends Migration
             $table->unsignedTinyInteger('rating')->default(0);
             $table->json('tags')->nullable();
             $table->string('title');
+            $table->json('config')->nullable();
             $table->json('json')->nullable();
             $table->json('json_array_of_objects')->nullable();
             $table->string('string_backed_enum')->nullable();

--- a/tests/src/Fixtures/Livewire/PostsTable.php
+++ b/tests/src/Fixtures/Livewire/PostsTable.php
@@ -97,6 +97,7 @@ class PostsTable extends Component implements HasActions, HasSchemas, Tables\Con
                     ->searchable()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('json_array_of_objects.*.value'),
+                Tables\Columns\TextColumn::make('config.setting'),
                 Tables\Columns\TextColumn::make('author.json.foo')
                     ->searchable()
                     ->sortable(),

--- a/tests/src/Fixtures/Models/Post.php
+++ b/tests/src/Fixtures/Models/Post.php
@@ -25,6 +25,7 @@ class Post extends Model
             'tags' => 'array',
             'json' => 'array',
             'json_array_of_objects' => 'array',
+            'config' => 'array',
         ];
     }
 
@@ -33,6 +34,11 @@ class Post extends Model
     public function author(): BelongsTo
     {
         return $this->belongsTo(User::class, 'author_id');
+    }
+
+    public function config($key)
+    {
+        return $this->config->$key ?? null;
     }
 
     protected static function newFactory()

--- a/tests/src/Fixtures/Models/Post.php
+++ b/tests/src/Fixtures/Models/Post.php
@@ -36,9 +36,9 @@ class Post extends Model
         return $this->belongsTo(User::class, 'author_id');
     }
 
-    public function config($key)
+    public function config(string $key): mixed
     {
-        return $this->config->$key ?? null;
+        return $this->config[$key] ?? null;
     }
 
     protected static function newFactory()

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -320,6 +320,15 @@ it('can output values in a JSON array column of objects', function (): void {
         ->assertTableColumnStateSet('json_array_of_objects.*.value', ['foo', 'bar', 'baz'], $post);
 });
 
+it('can output values in a JSON column with a non-relationship accessor method', function (): void {
+    $post = Post::factory()->create([
+        'config' => ['setting' => 'foo'],
+    ]);
+
+    livewire(PostsTable::class)
+        ->assertTableColumnStateSet('config.setting', 'foo', $post);
+});
+
 it('can state whether a column has extra attributes', function (): void {
     $post = Post::factory()->create();
 


### PR DESCRIPTION
## Description

Fixes #18124 by building in a workaround for Laravel's false positives on `hasRelationship`, as outlined in https://github.com/laravel/framework/issues/51592. Tests added, but very open to suggestions or related requests—I wasn't 100% sure about the best way to fix this within Filament itself. Let me know if there's anything else I can do to help, here!

## Visual changes

N/A - just fixes an error being thrown for non-existent relationships on the table/index view.

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- ☝ _Note: might need `text=auto` in `.gitattributes` or something...had (and discarded) several thousand changes on Windows_
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date. _(N/A)_