### PR TITLE
Fix Action schema doesn't initialize when action is not sticky

### DIFF
--- a/packages/schemas/resources/views/components/actions.blade.php
+++ b/packages/schemas/resources/views/components/actions.blade.php
@@ -13,8 +13,8 @@
 @endphp
 
 <div
+    x-data="filamentActionsSchemaComponent()"
     @if ($isSticky)
-        x-data="filamentActionsSchemaComponent()"
         x-intersect:enter.half="disableSticky"
         x-intersect:leave="enableSticky"
         x-bind:class="{ 'fi-sticky': isSticky }"


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
The x-data is not initialized when action is not sticky and it throws error in console which makes smoke tests fail.
Good thing I had an PEST smoke test that detected it 

## Visual changes
<img width="549" height="294" alt="Screenshot 2025-10-14 at 13 45 22" src="https://github.com/user-attachments/assets/239f120f-3b43-4497-b6cd-aa709fb76c1e" />

## Functional changes
moved the x-data initialization outside of $isSticky check
