### PR TITLE
fix(mfa): fix notification on email MFA resend

### DIFF
--- a/packages/actions/src/Testing/TestsActions.php
+++ b/packages/actions/src/Testing/TestsActions.php
@@ -768,7 +768,7 @@ class TestsActions
             if (array_key_exists($partialName, $partials)) {
                 return $partials[$partialName];
             }
-            
+
             $nestingIndex = count($this->instance()->mountedActions) - 1;
             $partialName = "{$partialName}.{$nestingIndex}";
 

--- a/packages/panels/resources/lang/en/auth/multi-factor/email/actions/disable.php
+++ b/packages/panels/resources/lang/en/auth/multi-factor/email/actions/disable.php
@@ -30,7 +30,7 @@ return [
                                 'title' => 'We\'ve sent you a new code by email',
                             ],
 
-                            'rate_limited' => [
+                            'throttled' => [
                                 'title' => 'Too many resend attempts. Please wait before requesting another code.',
                             ],
 

--- a/packages/panels/resources/lang/en/auth/multi-factor/email/actions/disable.php
+++ b/packages/panels/resources/lang/en/auth/multi-factor/email/actions/disable.php
@@ -30,6 +30,10 @@ return [
                                 'title' => 'We\'ve sent you a new code by email',
                             ],
 
+                            'rate_limited' => [
+                                'title' => 'Too many resend attempts. Please wait before requesting another code.',
+                            ],
+
                         ],
 
                     ],

--- a/packages/panels/resources/lang/en/auth/multi-factor/email/actions/set-up.php
+++ b/packages/panels/resources/lang/en/auth/multi-factor/email/actions/set-up.php
@@ -30,7 +30,7 @@ return [
                                 'title' => 'We\'ve sent you a new code by email',
                             ],
 
-                            'rate_limited' => [
+                            'throttled' => [
                                 'title' => 'Too many resend attempts. Please wait before requesting another code.',
                             ],
 

--- a/packages/panels/resources/lang/en/auth/multi-factor/email/actions/set-up.php
+++ b/packages/panels/resources/lang/en/auth/multi-factor/email/actions/set-up.php
@@ -30,6 +30,10 @@ return [
                                 'title' => 'We\'ve sent you a new code by email',
                             ],
 
+                            'rate_limited' => [
+                                'title' => 'Too many resend attempts. Please wait before requesting another code.',
+                            ],
+
                         ],
 
                     ],

--- a/packages/panels/resources/lang/en/auth/multi-factor/email/provider.php
+++ b/packages/panels/resources/lang/en/auth/multi-factor/email/provider.php
@@ -41,7 +41,7 @@ return [
                             'title' => 'We\'ve sent you a new code by email',
                         ],
 
-                        'rate_limited' => [
+                        'throttled' => [
                             'title' => 'Too many resend attempts. Please wait before requesting another code.',
                         ],
 

--- a/packages/panels/resources/lang/en/auth/multi-factor/email/provider.php
+++ b/packages/panels/resources/lang/en/auth/multi-factor/email/provider.php
@@ -41,6 +41,10 @@ return [
                             'title' => 'We\'ve sent you a new code by email',
                         ],
 
+                        'rate_limited' => [
+                            'title' => 'Too many resend attempts. Please wait before requesting another code.',
+                        ],
+
                     ],
 
                 ],

--- a/packages/panels/src/Auth/MultiFactor/Email/Actions/DisableEmailAuthenticationAction.php
+++ b/packages/panels/src/Auth/MultiFactor/Email/Actions/DisableEmailAuthenticationAction.php
@@ -45,8 +45,8 @@ class DisableEmailAuthenticationAction
 
                             if (! $emailAuthentication->sendCode($user)) {
                                 Notification::make()
-                                    ->title(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend.notifications.rate_limited.title'))
-                                    ->warning()
+                                    ->title(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend.notifications.throttled.title'))
+                                    ->danger()
                                     ->send();
 
                                 return;

--- a/packages/panels/src/Auth/MultiFactor/Email/Actions/DisableEmailAuthenticationAction.php
+++ b/packages/panels/src/Auth/MultiFactor/Email/Actions/DisableEmailAuthenticationAction.php
@@ -43,7 +43,14 @@ class DisableEmailAuthenticationAction
                             /** @var HasEmailAuthentication $user */
                             $user = Filament::auth()->user();
 
-                            $emailAuthentication->sendCode($user);
+                            if (! $emailAuthentication->sendCode($user)) {
+                                Notification::make()
+                                    ->title(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend.notifications.rate_limited.title'))
+                                    ->warning()
+                                    ->send();
+
+                                return;
+                            }
 
                             Notification::make()
                                 ->title(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend.notifications.resent.title'))

--- a/packages/panels/src/Auth/MultiFactor/Email/Actions/SetUpEmailAuthenticationAction.php
+++ b/packages/panels/src/Auth/MultiFactor/Email/Actions/SetUpEmailAuthenticationAction.php
@@ -46,8 +46,8 @@ class SetUpEmailAuthenticationAction
 
                             if (! $emailAuthentication->sendCode($user)) {
                                 Notification::make()
-                                    ->title(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend.notifications.rate_limited.title'))
-                                    ->warning()
+                                    ->title(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend.notifications.throttled.title'))
+                                    ->danger()
                                     ->send();
 
                                 return;

--- a/packages/panels/src/Auth/MultiFactor/Email/Actions/SetUpEmailAuthenticationAction.php
+++ b/packages/panels/src/Auth/MultiFactor/Email/Actions/SetUpEmailAuthenticationAction.php
@@ -44,7 +44,14 @@ class SetUpEmailAuthenticationAction
                             /** @var HasEmailAuthentication $user */
                             $user = Filament::auth()->user();
 
-                            $emailAuthentication->sendCode($user);
+                            if (! $emailAuthentication->sendCode($user)) {
+                                Notification::make()
+                                    ->title(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend.notifications.rate_limited.title'))
+                                    ->warning()
+                                    ->send();
+
+                                return;
+                            }
 
                             Notification::make()
                                 ->title(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend.notifications.resent.title'))

--- a/packages/panels/src/Auth/MultiFactor/Email/EmailAuthentication.php
+++ b/packages/panels/src/Auth/MultiFactor/Email/EmailAuthentication.php
@@ -201,8 +201,8 @@ class EmailAuthentication implements HasBeforeChallengeHook, MultiFactorAuthenti
                     ->action(function () use ($user): void {
                         if (! $this->sendCode($user)) {
                             Notification::make()
-                                ->title(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.notifications.rate_limited.title'))
-                                ->warning()
+                                ->title(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.notifications.throttled.title'))
+                                ->danger()
                                 ->send();
 
                             return;

--- a/packages/panels/src/Auth/MultiFactor/Email/EmailAuthentication.php
+++ b/packages/panels/src/Auth/MultiFactor/Email/EmailAuthentication.php
@@ -55,7 +55,7 @@ class EmailAuthentication implements HasBeforeChallengeHook, MultiFactorAuthenti
         return $user->hasEmailAuthentication();
     }
 
-    public function sendCode(HasEmailAuthentication $user): void
+    public function sendCode(HasEmailAuthentication $user): bool
     {
         if (! ($user instanceof Model)) {
             throw new LogicException('The [' . $user::class . '] class must be an instance of [' . Model::class . '] to use email authentication.');
@@ -70,7 +70,7 @@ class EmailAuthentication implements HasBeforeChallengeHook, MultiFactorAuthenti
         $rateLimitingKey = "filament_email_authentication.{$user->getKey()}";
 
         if (RateLimiter::tooManyAttempts($rateLimitingKey, maxAttempts: 2)) {
-            return;
+            return false;
         }
 
         RateLimiter::hit($rateLimitingKey);
@@ -85,6 +85,8 @@ class EmailAuthentication implements HasBeforeChallengeHook, MultiFactorAuthenti
             'code' => $code,
             'codeExpiryMinutes' => $codeExpiryMinutes,
         ]));
+
+        return true;
     }
 
     public function enableEmailAuthentication(HasEmailAuthentication $user): void
@@ -197,7 +199,14 @@ class EmailAuthentication implements HasBeforeChallengeHook, MultiFactorAuthenti
                     ->label(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.label'))
                     ->link()
                     ->action(function () use ($user): void {
-                        $this->sendCode($user);
+                        if (! $this->sendCode($user)) {
+                            Notification::make()
+                                ->title(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.notifications.rate_limited.title'))
+                                ->warning()
+                                ->send();
+
+                            return;
+                        }
 
                         Notification::make()
                             ->title(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.notifications.resent.title'))

--- a/tests/src/Panels/Auth/MultiFactor/Email/DisableEmailAuthenticationActionTest.php
+++ b/tests/src/Panels/Auth/MultiFactor/Email/DisableEmailAuthenticationActionTest.php
@@ -106,8 +106,8 @@ it('can resend the code to the user more than twice per minute', function (): vo
             ->schemaComponent('code'))
         ->assertNotified(
             FilamentNotification::make()
-                ->title(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend.notifications.rate_limited.title'))
-                ->warning()
+                ->title(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend.notifications.throttled.title'))
+                ->danger()
         );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);

--- a/tests/src/Panels/Auth/MultiFactor/Email/DisableEmailAuthenticationActionTest.php
+++ b/tests/src/Panels/Auth/MultiFactor/Email/DisableEmailAuthenticationActionTest.php
@@ -5,6 +5,7 @@ use Filament\Auth\MultiFactor\Email\EmailAuthentication;
 use Filament\Auth\MultiFactor\Email\Notifications\VerifyEmailAuthentication;
 use Filament\Auth\Pages\EditProfile;
 use Filament\Facades\Filament;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Arr;
@@ -70,7 +71,12 @@ it('can resend the code to the user', function (): void {
 
     $livewire
         ->callAction(TestAction::make('resend')
-            ->schemaComponent('code'));
+            ->schemaComponent('code'))
+        ->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend.notifications.resent.title'))
+                ->success()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);
 });
@@ -86,13 +92,23 @@ it('can resend the code to the user more than twice per minute', function (): vo
 
     $livewire
         ->callAction(TestAction::make('resend')
-            ->schemaComponent('code'));
+            ->schemaComponent('code'))
+        ->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend.notifications.resent.title'))
+                ->success()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);
 
     $livewire
         ->callAction(TestAction::make('resend')
-            ->schemaComponent('code'));
+            ->schemaComponent('code'))
+        ->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend.notifications.rate_limited.title'))
+                ->warning()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);
 
@@ -100,7 +116,12 @@ it('can resend the code to the user more than twice per minute', function (): vo
 
     $livewire
         ->callAction(TestAction::make('resend')
-            ->schemaComponent('code'));
+            ->schemaComponent('code'))
+        ->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend.notifications.resent.title'))
+                ->success()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 3);
 });

--- a/tests/src/Panels/Auth/MultiFactor/Email/EmailAuthenticationChallengeTest.php
+++ b/tests/src/Panels/Auth/MultiFactor/Email/EmailAuthenticationChallengeTest.php
@@ -5,6 +5,7 @@ use Filament\Auth\MultiFactor\Email\EmailAuthentication;
 use Filament\Auth\MultiFactor\Email\Notifications\VerifyEmailAuthentication;
 use Filament\Auth\Pages\Login;
 use Filament\Facades\Filament;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Arr;
@@ -108,8 +109,14 @@ it('can resend the code to the user', function (): void {
     $this->travelBack();
 
     $livewire
-        ->callAction(TestAction::make('resend')
-            ->schemaComponent("{$emailAuthentication->getId()}.code", schema: 'multiFactorChallengeForm'));
+        ->callAction(
+            TestAction::make('resend')
+                ->schemaComponent("{$emailAuthentication->getId()}.code", schema: 'multiFactorChallengeForm')
+        )->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.notifications.resent.title'))
+                ->success()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);
 });
@@ -133,22 +140,40 @@ it('can not resend the code to the user more than twice per minute', function ()
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 1);
 
     $livewire
-        ->callAction(TestAction::make('resend')
-            ->schemaComponent("{$emailAuthentication->getId()}.code", schema: 'multiFactorChallengeForm'));
+        ->callAction(
+            TestAction::make('resend')
+                ->schemaComponent("{$emailAuthentication->getId()}.code", schema: 'multiFactorChallengeForm')
+        )->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.notifications.resent.title'))
+                ->success()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);
 
     $livewire
-        ->callAction(TestAction::make('resend')
-            ->schemaComponent("{$emailAuthentication->getId()}.code", schema: 'multiFactorChallengeForm'));
+        ->callAction(
+            TestAction::make('resend')
+                ->schemaComponent("{$emailAuthentication->getId()}.code", schema: 'multiFactorChallengeForm')
+        )->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.notifications.rate_limited.title'))
+                ->warning()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);
 
     $this->travelBack();
 
     $livewire
-        ->callAction(TestAction::make('resend')
-            ->schemaComponent("{$emailAuthentication->getId()}.code", schema: 'multiFactorChallengeForm'));
+        ->callAction(
+            TestAction::make('resend')
+                ->schemaComponent("{$emailAuthentication->getId()}.code", schema: 'multiFactorChallengeForm')
+        )->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.notifications.resent.title'))
+                ->success()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 3);
 });

--- a/tests/src/Panels/Auth/MultiFactor/Email/EmailAuthenticationChallengeTest.php
+++ b/tests/src/Panels/Auth/MultiFactor/Email/EmailAuthenticationChallengeTest.php
@@ -157,8 +157,8 @@ it('can not resend the code to the user more than twice per minute', function ()
                 ->schemaComponent("{$emailAuthentication->getId()}.code", schema: 'multiFactorChallengeForm')
         )->assertNotified(
             FilamentNotification::make()
-                ->title(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.notifications.rate_limited.title'))
-                ->warning()
+                ->title(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.notifications.throttled.title'))
+                ->danger()
         );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);

--- a/tests/src/Panels/Auth/MultiFactor/Email/SetUpEmailAuthenticationActionTest.php
+++ b/tests/src/Panels/Auth/MultiFactor/Email/SetUpEmailAuthenticationActionTest.php
@@ -5,6 +5,7 @@ use Filament\Auth\MultiFactor\Email\EmailAuthentication;
 use Filament\Auth\MultiFactor\Email\Notifications\VerifyEmailAuthentication;
 use Filament\Auth\Pages\EditProfile;
 use Filament\Facades\Filament;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Arr;
@@ -81,7 +82,12 @@ it('can resend the code to the user', function (): void {
 
     $livewire
         ->callAction(TestAction::make('resend')
-            ->schemaComponent('code'));
+            ->schemaComponent('code'))
+        ->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend.notifications.resent.title'))
+                ->success()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);
 });
@@ -97,13 +103,23 @@ it('can resend the code to the user more than twice per minute', function (): vo
 
     $livewire
         ->callAction(TestAction::make('resend')
-            ->schemaComponent('code'));
+            ->schemaComponent('code'))
+        ->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend.notifications.resent.title'))
+                ->success()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);
 
     $livewire
         ->callAction(TestAction::make('resend')
-            ->schemaComponent('code'));
+            ->schemaComponent('code'))
+        ->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend.notifications.rate_limited.title'))
+                ->warning()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);
 
@@ -111,7 +127,12 @@ it('can resend the code to the user more than twice per minute', function (): vo
 
     $livewire
         ->callAction(TestAction::make('resend')
-            ->schemaComponent('code'));
+            ->schemaComponent('code'))
+        ->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend.notifications.resent.title'))
+                ->success()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 3);
 });

--- a/tests/src/Panels/Auth/MultiFactor/Email/SetUpEmailAuthenticationActionTest.php
+++ b/tests/src/Panels/Auth/MultiFactor/Email/SetUpEmailAuthenticationActionTest.php
@@ -117,8 +117,8 @@ it('can resend the code to the user more than twice per minute', function (): vo
             ->schemaComponent('code'))
         ->assertNotified(
             FilamentNotification::make()
-                ->title(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend.notifications.rate_limited.title'))
-                ->warning()
+                ->title(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend.notifications.throttled.title'))
+                ->danger()
         );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);


### PR DESCRIPTION
## Description

Fixes a UX issue where the email authentication resend action always displayed a success notification, even when blocked by rate limiting.

### The Problem
When users attempted to resend their email authentication code more than twice within a minute, the rate limiter prevented the email from being sent, but the UI still showed "We've sent you a new code by email."

### The Solution
Modified `sendCode()` to return a boolean indicating success/failure. Resend actions now check this return value and display the appropriate notification:

- **Success** (not rate limited): "We've sent you a new code by email"
- **Rate limited**: "Too many resend attempts. Please wait before requesting another code."

Applied consistently across all three email MFA flows: login challenge, setup, and disable.

### Changes
- Modified `EmailAuthentication::sendCode()` to return `bool` instead of `void`
- Updated resend actions to check return value before showing notifications
- Added translation keys for rate-limited warnings
- Enhanced tests to verify UI notifications match actual behavior

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.