### PR TITLE
refactor(mfa): DRY - Extract resend action logic into reusable method (builds on #18208)

### DIFF
--- a/packages/panels/resources/lang/en/auth/multi-factor/email/actions/disable.php
+++ b/packages/panels/resources/lang/en/auth/multi-factor/email/actions/disable.php
@@ -30,6 +30,10 @@ return [
                                 'title' => 'We\'ve sent you a new code by email',
                             ],
 
+                            'rate_limited' => [
+                                'title' => 'Too many resend attempts. Please wait before requesting another code.',
+                            ],
+
                         ],
 
                     ],

--- a/packages/panels/resources/lang/en/auth/multi-factor/email/actions/set-up.php
+++ b/packages/panels/resources/lang/en/auth/multi-factor/email/actions/set-up.php
@@ -30,6 +30,10 @@ return [
                                 'title' => 'We\'ve sent you a new code by email',
                             ],
 
+                            'rate_limited' => [
+                                'title' => 'Too many resend attempts. Please wait before requesting another code.',
+                            ],
+
                         ],
 
                     ],

--- a/packages/panels/resources/lang/en/auth/multi-factor/email/provider.php
+++ b/packages/panels/resources/lang/en/auth/multi-factor/email/provider.php
@@ -41,6 +41,10 @@ return [
                             'title' => 'We\'ve sent you a new code by email',
                         ],
 
+                        'rate_limited' => [
+                            'title' => 'Too many resend attempts. Please wait before requesting another code.',
+                        ],
+
                     ],
 
                 ],

--- a/packages/panels/src/Auth/MultiFactor/Email/Actions/DisableEmailAuthenticationAction.php
+++ b/packages/panels/src/Auth/MultiFactor/Email/Actions/DisableEmailAuthenticationAction.php
@@ -43,7 +43,14 @@ class DisableEmailAuthenticationAction
                             /** @var HasEmailAuthentication $user */
                             $user = Filament::auth()->user();
 
-                            $emailAuthentication->sendCode($user);
+                            if (! $emailAuthentication->sendCode($user)) {
+                                Notification::make()
+                                    ->title(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend.notifications.rate_limited.title'))
+                                    ->warning()
+                                    ->send();
+
+                                return;
+                            }
 
                             Notification::make()
                                 ->title(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend.notifications.resent.title'))

--- a/packages/panels/src/Auth/MultiFactor/Email/Actions/DisableEmailAuthenticationAction.php
+++ b/packages/panels/src/Auth/MultiFactor/Email/Actions/DisableEmailAuthenticationAction.php
@@ -32,42 +32,30 @@ class DisableEmailAuthenticationAction
             ->modalIcon(Heroicon::OutlinedLockOpen)
             ->modalHeading(__('filament-panels::auth/multi-factor/email/actions/disable.modal.heading'))
             ->modalDescription(__('filament-panels::auth/multi-factor/email/actions/disable.modal.description'))
-            ->schema([
-                OneTimeCodeInput::make('code')
-                    ->label(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.label'))
-                    ->validationAttribute(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.validation_attribute'))
-                    ->belowContent(Action::make('resend')
-                        ->label(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend.label'))
-                        ->link()
-                        ->action(function () use ($emailAuthentication): void {
-                            /** @var HasEmailAuthentication $user */
-                            $user = Filament::auth()->user();
+            ->schema(function () use ($emailAuthentication): array {
+                /** @var HasEmailAuthentication $user */
+                $user = Filament::auth()->user();
 
-                            if (! $emailAuthentication->sendCode($user)) {
-                                Notification::make()
-                                    ->title(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend.notifications.rate_limited.title'))
-                                    ->warning()
-                                    ->send();
+                return [
+                    OneTimeCodeInput::make('code')
+                        ->label(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.label'))
+                        ->validationAttribute(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.validation_attribute'))
+                        ->belowContent($emailAuthentication->createResendAction(
+                            $user,
+                            'filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend'
+                        ))
+                        ->required()
+                        ->rule(function () use ($emailAuthentication): Closure {
+                            return function (string $attribute, mixed $value, Closure $fail) use ($emailAuthentication): void {
+                                if (is_string($value) && $emailAuthentication->verifyCode($value)) {
+                                    return;
+                                }
 
-                                return;
-                            }
-
-                            Notification::make()
-                                ->title(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend.notifications.resent.title'))
-                                ->success()
-                                ->send();
-                        }))
-                    ->required()
-                    ->rule(function () use ($emailAuthentication): Closure {
-                        return function (string $attribute, mixed $value, Closure $fail) use ($emailAuthentication): void {
-                            if (is_string($value) && $emailAuthentication->verifyCode($value)) {
-                                return;
-                            }
-
-                            $fail(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.messages.invalid'));
-                        };
-                    }),
-            ])
+                                $fail(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.messages.invalid'));
+                            };
+                        }),
+                ];
+            })
             ->modalSubmitAction(fn (Action $action) => $action
                 ->label(__('filament-panels::auth/multi-factor/email/actions/disable.modal.actions.submit.label')))
             ->action(function (): void {

--- a/packages/panels/src/Auth/MultiFactor/Email/Actions/SetUpEmailAuthenticationAction.php
+++ b/packages/panels/src/Auth/MultiFactor/Email/Actions/SetUpEmailAuthenticationAction.php
@@ -44,7 +44,14 @@ class SetUpEmailAuthenticationAction
                             /** @var HasEmailAuthentication $user */
                             $user = Filament::auth()->user();
 
-                            $emailAuthentication->sendCode($user);
+                            if (! $emailAuthentication->sendCode($user)) {
+                                Notification::make()
+                                    ->title(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend.notifications.rate_limited.title'))
+                                    ->warning()
+                                    ->send();
+
+                                return;
+                            }
 
                             Notification::make()
                                 ->title(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend.notifications.resent.title'))

--- a/packages/panels/src/Auth/MultiFactor/Email/Actions/SetUpEmailAuthenticationAction.php
+++ b/packages/panels/src/Auth/MultiFactor/Email/Actions/SetUpEmailAuthenticationAction.php
@@ -34,42 +34,30 @@ class SetUpEmailAuthenticationAction
             ->modalIconColor('primary')
             ->modalHeading(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.heading'))
             ->modalDescription(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.description'))
-            ->schema([
-                OneTimeCodeInput::make('code')
-                    ->label(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.label'))
-                    ->belowContent(Action::make('resend')
-                        ->label(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend.label'))
-                        ->link()
-                        ->action(function () use ($emailAuthentication): void {
-                            /** @var HasEmailAuthentication $user */
-                            $user = Filament::auth()->user();
+            ->schema(function () use ($emailAuthentication): array {
+                /** @var HasEmailAuthentication $user */
+                $user = Filament::auth()->user();
 
-                            if (! $emailAuthentication->sendCode($user)) {
-                                Notification::make()
-                                    ->title(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend.notifications.rate_limited.title'))
-                                    ->warning()
-                                    ->send();
+                return [
+                    OneTimeCodeInput::make('code')
+                        ->label(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.label'))
+                        ->belowContent($emailAuthentication->createResendAction(
+                            $user,
+                            'filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend'
+                        ))
+                        ->validationAttribute(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.validation_attribute'))
+                        ->required()
+                        ->rule(function () use ($emailAuthentication): Closure {
+                            return function (string $attribute, $value, Closure $fail) use ($emailAuthentication): void {
+                                if ($emailAuthentication->verifyCode($value)) {
+                                    return;
+                                }
 
-                                return;
-                            }
-
-                            Notification::make()
-                                ->title(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend.notifications.resent.title'))
-                                ->success()
-                                ->send();
-                        }))
-                    ->validationAttribute(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.validation_attribute'))
-                    ->required()
-                    ->rule(function () use ($emailAuthentication): Closure {
-                        return function (string $attribute, $value, Closure $fail) use ($emailAuthentication): void {
-                            if ($emailAuthentication->verifyCode($value)) {
-                                return;
-                            }
-
-                            $fail(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.messages.invalid'));
-                        };
-                    }),
-            ])
+                                $fail(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.messages.invalid'));
+                            };
+                        }),
+                ];
+            })
             ->modalSubmitAction(fn (Action $action) => $action
                 ->label(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.actions.submit.label')))
             ->action(function (): void {

--- a/packages/panels/src/Auth/MultiFactor/Email/EmailAuthentication.php
+++ b/packages/panels/src/Auth/MultiFactor/Email/EmailAuthentication.php
@@ -130,6 +130,28 @@ class EmailAuthentication implements HasBeforeChallengeHook, MultiFactorAuthenti
         return true;
     }
 
+    public function createResendAction(HasEmailAuthentication $user, string $translationKeyPrefix): Action
+    {
+        return Action::make('resend')
+            ->label(__("{$translationKeyPrefix}.label"))
+            ->link()
+            ->action(function () use ($user, $translationKeyPrefix): void {
+                if (! $this->sendCode($user)) {
+                    Notification::make()
+                        ->title(__("{$translationKeyPrefix}.notifications.rate_limited.title"))
+                        ->warning()
+                        ->send();
+
+                    return;
+                }
+
+                Notification::make()
+                    ->title(__("{$translationKeyPrefix}.notifications.resent.title"))
+                    ->success()
+                    ->send();
+            });
+    }
+
     /**
      * @return array<Component | Action | ActionGroup>
      */
@@ -195,24 +217,10 @@ class EmailAuthentication implements HasBeforeChallengeHook, MultiFactorAuthenti
             OneTimeCodeInput::make('code')
                 ->label(__('filament-panels::auth/multi-factor/email/provider.login_form.code.label'))
                 ->validationAttribute('code')
-                ->belowContent(Action::make('resend')
-                    ->label(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.label'))
-                    ->link()
-                    ->action(function () use ($user): void {
-                        if (! $this->sendCode($user)) {
-                            Notification::make()
-                                ->title(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.notifications.rate_limited.title'))
-                                ->warning()
-                                ->send();
-
-                            return;
-                        }
-
-                        Notification::make()
-                            ->title(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.notifications.resent.title'))
-                            ->success()
-                            ->send();
-                    }))
+                ->belowContent($this->createResendAction(
+                    $user,
+                    'filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend'
+                ))
                 ->required()
                 ->rule(function (): Closure {
                     return function (string $attribute, $value, Closure $fail): void {

--- a/packages/panels/src/Auth/MultiFactor/Email/EmailAuthentication.php
+++ b/packages/panels/src/Auth/MultiFactor/Email/EmailAuthentication.php
@@ -55,7 +55,7 @@ class EmailAuthentication implements HasBeforeChallengeHook, MultiFactorAuthenti
         return $user->hasEmailAuthentication();
     }
 
-    public function sendCode(HasEmailAuthentication $user): void
+    public function sendCode(HasEmailAuthentication $user): bool
     {
         if (! ($user instanceof Model)) {
             throw new LogicException('The [' . $user::class . '] class must be an instance of [' . Model::class . '] to use email authentication.');
@@ -70,7 +70,7 @@ class EmailAuthentication implements HasBeforeChallengeHook, MultiFactorAuthenti
         $rateLimitingKey = "filament_email_authentication.{$user->getKey()}";
 
         if (RateLimiter::tooManyAttempts($rateLimitingKey, maxAttempts: 2)) {
-            return;
+            return false;
         }
 
         RateLimiter::hit($rateLimitingKey);
@@ -85,6 +85,8 @@ class EmailAuthentication implements HasBeforeChallengeHook, MultiFactorAuthenti
             'code' => $code,
             'codeExpiryMinutes' => $codeExpiryMinutes,
         ]));
+
+        return true;
     }
 
     public function enableEmailAuthentication(HasEmailAuthentication $user): void
@@ -197,7 +199,14 @@ class EmailAuthentication implements HasBeforeChallengeHook, MultiFactorAuthenti
                     ->label(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.label'))
                     ->link()
                     ->action(function () use ($user): void {
-                        $this->sendCode($user);
+                        if (! $this->sendCode($user)) {
+                            Notification::make()
+                                ->title(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.notifications.rate_limited.title'))
+                                ->warning()
+                                ->send();
+
+                            return;
+                        }
 
                         Notification::make()
                             ->title(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.notifications.resent.title'))

--- a/tests/src/Panels/Auth/MultiFactor/Email/DisableEmailAuthenticationActionTest.php
+++ b/tests/src/Panels/Auth/MultiFactor/Email/DisableEmailAuthenticationActionTest.php
@@ -5,6 +5,7 @@ use Filament\Auth\MultiFactor\Email\EmailAuthentication;
 use Filament\Auth\MultiFactor\Email\Notifications\VerifyEmailAuthentication;
 use Filament\Auth\Pages\EditProfile;
 use Filament\Facades\Filament;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Arr;
@@ -70,7 +71,12 @@ it('can resend the code to the user', function (): void {
 
     $livewire
         ->callAction(TestAction::make('resend')
-            ->schemaComponent('code'));
+            ->schemaComponent('code'))
+        ->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend.notifications.resent.title'))
+                ->success()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);
 });
@@ -86,13 +92,23 @@ it('can resend the code to the user more than twice per minute', function (): vo
 
     $livewire
         ->callAction(TestAction::make('resend')
-            ->schemaComponent('code'));
+            ->schemaComponent('code'))
+        ->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend.notifications.resent.title'))
+                ->success()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);
 
     $livewire
         ->callAction(TestAction::make('resend')
-            ->schemaComponent('code'));
+            ->schemaComponent('code'))
+        ->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend.notifications.rate_limited.title'))
+                ->warning()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);
 
@@ -100,7 +116,12 @@ it('can resend the code to the user more than twice per minute', function (): vo
 
     $livewire
         ->callAction(TestAction::make('resend')
-            ->schemaComponent('code'));
+            ->schemaComponent('code'))
+        ->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/actions/disable.modal.form.code.actions.resend.notifications.resent.title'))
+                ->success()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 3);
 });

--- a/tests/src/Panels/Auth/MultiFactor/Email/EmailAuthenticationChallengeTest.php
+++ b/tests/src/Panels/Auth/MultiFactor/Email/EmailAuthenticationChallengeTest.php
@@ -5,6 +5,7 @@ use Filament\Auth\MultiFactor\Email\EmailAuthentication;
 use Filament\Auth\MultiFactor\Email\Notifications\VerifyEmailAuthentication;
 use Filament\Auth\Pages\Login;
 use Filament\Facades\Filament;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Arr;
@@ -108,8 +109,14 @@ it('can resend the code to the user', function (): void {
     $this->travelBack();
 
     $livewire
-        ->callAction(TestAction::make('resend')
-            ->schemaComponent("{$emailAuthentication->getId()}.code", schema: 'multiFactorChallengeForm'));
+        ->callAction(
+            TestAction::make('resend')
+                ->schemaComponent("{$emailAuthentication->getId()}.code", schema: 'multiFactorChallengeForm')
+        )->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.notifications.resent.title'))
+                ->success()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);
 });
@@ -133,22 +140,40 @@ it('can not resend the code to the user more than twice per minute', function ()
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 1);
 
     $livewire
-        ->callAction(TestAction::make('resend')
-            ->schemaComponent("{$emailAuthentication->getId()}.code", schema: 'multiFactorChallengeForm'));
+        ->callAction(
+            TestAction::make('resend')
+                ->schemaComponent("{$emailAuthentication->getId()}.code", schema: 'multiFactorChallengeForm')
+        )->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.notifications.resent.title'))
+                ->success()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);
 
     $livewire
-        ->callAction(TestAction::make('resend')
-            ->schemaComponent("{$emailAuthentication->getId()}.code", schema: 'multiFactorChallengeForm'));
+        ->callAction(
+            TestAction::make('resend')
+                ->schemaComponent("{$emailAuthentication->getId()}.code", schema: 'multiFactorChallengeForm')
+        )->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.notifications.rate_limited.title'))
+                ->warning()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);
 
     $this->travelBack();
 
     $livewire
-        ->callAction(TestAction::make('resend')
-            ->schemaComponent("{$emailAuthentication->getId()}.code", schema: 'multiFactorChallengeForm'));
+        ->callAction(
+            TestAction::make('resend')
+                ->schemaComponent("{$emailAuthentication->getId()}.code", schema: 'multiFactorChallengeForm')
+        )->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/provider.login_form.code.actions.resend.notifications.resent.title'))
+                ->success()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 3);
 });

--- a/tests/src/Panels/Auth/MultiFactor/Email/SetUpEmailAuthenticationActionTest.php
+++ b/tests/src/Panels/Auth/MultiFactor/Email/SetUpEmailAuthenticationActionTest.php
@@ -5,6 +5,7 @@ use Filament\Auth\MultiFactor\Email\EmailAuthentication;
 use Filament\Auth\MultiFactor\Email\Notifications\VerifyEmailAuthentication;
 use Filament\Auth\Pages\EditProfile;
 use Filament\Facades\Filament;
+use Filament\Notifications\Notification as FilamentNotification;
 use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\TestCase;
 use Illuminate\Support\Arr;
@@ -81,7 +82,12 @@ it('can resend the code to the user', function (): void {
 
     $livewire
         ->callAction(TestAction::make('resend')
-            ->schemaComponent('code'));
+            ->schemaComponent('code'))
+        ->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend.notifications.resent.title'))
+                ->success()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);
 });
@@ -97,13 +103,23 @@ it('can resend the code to the user more than twice per minute', function (): vo
 
     $livewire
         ->callAction(TestAction::make('resend')
-            ->schemaComponent('code'));
+            ->schemaComponent('code'))
+        ->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend.notifications.resent.title'))
+                ->success()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);
 
     $livewire
         ->callAction(TestAction::make('resend')
-            ->schemaComponent('code'));
+            ->schemaComponent('code'))
+        ->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend.notifications.rate_limited.title'))
+                ->warning()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 2);
 
@@ -111,7 +127,12 @@ it('can resend the code to the user more than twice per minute', function (): vo
 
     $livewire
         ->callAction(TestAction::make('resend')
-            ->schemaComponent('code'));
+            ->schemaComponent('code'))
+        ->assertNotified(
+            FilamentNotification::make()
+                ->title(__('filament-panels::auth/multi-factor/email/actions/set-up.modal.form.code.actions.resend.notifications.resent.title'))
+                ->success()
+        );
 
     Notification::assertSentTimes(VerifyEmailAuthentication::class, 3);
 });


### PR DESCRIPTION
Eliminates code duplication by extracting resend action logic into a reusable method.

Builds on #18208