### PR TITLE
Fix: Fix AboveContent filters visibility

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -249,6 +249,7 @@
 
                 @if ($hasFiltersAboveContent)
                     <div
+                        x-data="{ areFiltersOpen: @js(! $hasCollapsibleFilters) }"
                         x-bind:class="{ 'fi-open': areFiltersOpen }"
                         @class([
                             'fi-ta-filters-above-content-ctn',

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -249,11 +249,11 @@
 
                 @if ($hasFiltersAboveContent)
                     <div
-                        x-data="{ areFiltersOpen: @js(! $hasCollapsibleFilters) }"
-                        x-bind:class="{ 'fi-open': areFiltersOpen }"
+                        @if ($hasCollapsibleFilters)
+                            x-bind:class="{ 'fi-open': areFiltersOpen }"
+                        @endif
                         @class([
                             'fi-ta-filters-above-content-ctn',
-                            'lg:fi-open' => ! $hasCollapsibleFilters,
                         ])
                     >
                         <x-filament-tables::filters
@@ -261,7 +261,7 @@
                             :form="$filtersForm"
                             :heading-tag="$secondLevelHeadingTag"
                             x-cloak
-                            x-show="areFiltersOpen"
+                            :x-show="$hasCollapsibleFilters ? 'areFiltersOpen' : null"
                         />
 
                         @if ($hasCollapsibleFilters)


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR restores visibility for table filters using `FiltersLayout::AboveContent`.

In [commit #18206](https://github.com/filamentphp/filament/pull/18206),  
the `x-data` binding that controls filter visibility was removed or renamed incorrectly,  
causing filters to remain hidden (`display: none`) even when defined.

The fix restores the correct Alpine binding:
```blade
x-data="{ areFiltersOpen: @js(! $hasCollapsibleFilters) }"
```

instead of:
```blade
x-data="{ areFiltersOpen: @js(! $hasFiltersAboveContentCollapsible) }"
```
which removed in [commit #18206](https://github.com/filamentphp/filament/pull/18206) 

<img width="676" height="252" alt="Screenshot 2025-10-15 at 3 44 49 AM" src="https://github.com/user-attachments/assets/e96f46d2-26d5-4b6d-859c-4053e78f534a" />
