### PR TITLE
fix: Menu items not sorted correctly by their sort value

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -383,7 +383,7 @@ trait HasTenancy
                 fn (Collection $items): Collection => $items->put('register', $this->getTenantRegistrationMenuItem()),
             )
             ->filter(fn (Action $item): bool => $item->isVisible())
-            ->sort(fn (Action $item): int => $item->getSort())
+            ->sortBy(fn (Action $item): int => $item->getSort())
             ->all();
     }
 

--- a/packages/panels/src/Panel/Concerns/HasUserMenu.php
+++ b/packages/panels/src/Panel/Concerns/HasUserMenu.php
@@ -127,7 +127,7 @@ trait HasUserMenu
                 fn (Collection $items): Collection => $items->put('logout', $this->getUserLogoutMenuItem()),
             )
             ->filter(fn (Action $item): bool => $item->isVisible())
-            ->sort(fn (Action $item): int => $item->getSort())
+            ->sortBy(fn (Action $item): int => $item->getSort())
             ->all();
     }
 }


### PR DESCRIPTION
## Description

This PR fixes a bug where user menu items and tenant menu items were not being sorted correctly by their sort values.

### The Problem
The `getUserMenuItems()` and `getTenantMenuItems()` methods were using `Collection::sort()` with a single-parameter callback:

```php
->sort(fn (Action $item): int => $item->getSort())
```

However, `Collection::sort()` expects a comparison callback (that returns -1, 0, or 1), not a value callback. When called with a single-parameter callback that returns a value, it produces unpredictable sorting results.

### The Solution
Changed to use `Collection::sortBy()` which correctly accepts a single-parameter callback that returns a value to sort by:

```php
->sortBy(fn (Action $item): int => $item->getSort())
```

This ensures menu items are consistently ordered by their sort value in ascending order.

### Files Changed
- `packages/panels/src/Panel/Concerns/HasUserMenu.php` - Line 130
- `packages/panels/src/Panel/Concerns/HasTenancy.php` - Line 386

## Visual changes

N/A - This is a bug fix that affects menu item ordering

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.