### PR TITLE
Toggle Buttons shouldn't overwrite colors

### DIFF
--- a/packages/forms/src/Components/ToggleButtons.php
+++ b/packages/forms/src/Components/ToggleButtons.php
@@ -50,10 +50,12 @@ class ToggleButtons extends Field implements Contracts\CanDisableOptions
             0 => $falseLabel ?? __('filament-forms::components.toggle_buttons.boolean.false'),
         ]);
 
-        $this->colors([
-            1 => 'success',
-            0 => 'danger',
-        ]);
+        if ($this->colors === null) {
+            $this->colors([
+                1 => 'success',
+                0 => 'danger',
+            ]);
+        }
 
         $this->icons([
             1 => FilamentIcon::resolve(FormsIconAlias::COMPONENTS_TOGGLE_BUTTONS_BOOLEAN_TRUE) ?? Heroicon::Check,


### PR DESCRIPTION
## Description
When we set the ->boolean() after our custom colors it overwrites them.
![toggle-color](https://github.com/user-attachments/assets/b0ba1146-eed2-4f1a-b6aa-1075ad362830)


## Functional changes
Only set the colors if they are still empty

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
