### PR TITLE
feat(header): allow hiding title and show only breadcrumbs

### DIFF
--- a/packages/panels/resources/views/components/header/index.blade.php
+++ b/packages/panels/resources/views/components/header/index.blade.php
@@ -3,6 +3,7 @@
     'actionsAlignment' => null,
     'breadcrumbs' => [],
     'heading',
+    'isHeadingHidden' => false,
     'subheading' => null,
 ])
 
@@ -19,14 +20,16 @@
             <x-filament::breadcrumbs :breadcrumbs="$breadcrumbs" />
         @endif
 
-        <h1 class="fi-header-heading">
-            {{ $heading }}
-        </h1>
+        @if (! $isHeadingHidden)
+            <h1 class="fi-header-heading">
+                {{ $heading }}
+            </h1>
 
-        @if ($subheading)
-            <p class="fi-header-subheading">
-                {{ $subheading }}
-            </p>
+            @if ($subheading)
+                <p class="fi-header-subheading">
+                    {{ $subheading }}
+                </p>
+            @endif
         @endif
     </div>
 

--- a/packages/panels/resources/views/components/page/index.blade.php
+++ b/packages/panels/resources/views/components/page/index.blade.php
@@ -49,6 +49,7 @@
                 $headerActions = $this->getCachedHeaderActions();
                 $headerActionsAlignment = $this->getHeaderActionsAlignment();
                 $breadcrumbs = filament()->hasBreadcrumbs() ? $this->getBreadcrumbs() : [];
+                $isHeadingHidden = $this->isHeadingHidden();
                 $subheading = $this->getSubheading();
             @endphp
 
@@ -57,6 +58,7 @@
                 :actions-alignment="$headerActionsAlignment"
                 :breadcrumbs="$breadcrumbs"
                 :heading="$heading"
+                :is-heading-hidden="$isHeadingHidden"
                 :subheading="$subheading"
             >
                 @if ($heading instanceof \Illuminate\Contracts\Support\Htmlable)

--- a/packages/panels/src/Pages/BasePage.php
+++ b/packages/panels/src/Pages/BasePage.php
@@ -30,6 +30,8 @@ abstract class BasePage extends Component implements HasActions, HasRenderHookSc
 
     protected ?string $subheading = null;
 
+    protected bool $isHeadingHidden = false;
+
     protected string $view;
 
     public static ?Closure $reportValidationErrorUsing = null;
@@ -78,6 +80,11 @@ abstract class BasePage extends Component implements HasActions, HasRenderHookSc
     public function getSubheading(): string | Htmlable | null
     {
         return $this->subheading;
+    }
+
+    public function isHeadingHidden(): bool
+    {
+        return $this->isHeadingHidden;
     }
 
     public function getTitle(): string | Htmlable


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This pull request addresses the inability to hide the page heading while keeping the breadcrumbs visible.

It introduces a new `isHeadingHidden` property on the `BasePage` class. When this property is set to `true` on a page, it will hide the heading and subheading, but the breadcrumbs will remain visible. This provides more flexibility for customizing the page header.

### Example usage:

 ```
class MyPage extends Page
  {
      protected bool $isHeadingHidden = true;
      // ...
  }
```


## Visual changes

**Before:**
![before](https://github.com/user-attachments/assets/aad845ba-d575-4420-ae4f-45c171468749)

**After:**
![after](https://github.com/user-attachments/assets/3282b15e-0ddb-4aa7-b721-f8fc76918a78)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
