### PR TITLE
Add extraInputAttributeBag to rich editor

### DIFF
--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -1,6 +1,7 @@
 @php
     $customBlocks = $getCustomBlocks();
     $extraAttributeBag = $getExtraAttributeBag();
+    $extraInputAttributeBag = $getExtraInputAttributeBag();
     $fieldWrapperView = $getFieldWrapperView();
     $id = $getId();
     $isDisabled = $isDisabled();
@@ -100,7 +101,9 @@
             <div
                 {{ $getExtraInputAttributeBag()->class(['fi-fo-rich-editor-main']) }}
             >
-                <div class="fi-fo-rich-editor-content fi-prose" x-ref="editor">
+                <div x-ref="editor"
+                    {{ $extraInputAttributeBag->class(['fi-fo-rich-editor-content fi-prose']) }}
+                    >
                     @foreach ($floatingToolbars as $nodeName => $buttons)
                         <div
                             x-ref="floatingToolbar::{{ $nodeName }}"


### PR DESCRIPTION
## Description

Refactored the rich editor's content div to use $extraInputAttributeBag for applying classes. This allows for better extensibility.

Note: Tailwind classes applied via the attribute bag are not currently taking effect, though the editor's styling and functionality remain intact. Further investigation is needed to enable Tailwind utility class application. ex.('class'=>'h-20' is on the dom but not taking effect but 'style'=>'height:200px' is working)


## Functional changes

- [ x ] Code style has been fixed by running the `composer cs` command.
- [ x ] Changes have been tested to not break existing functionality.
- [ x ] Documentation is up-to-date.
