### PR TITLE
[4.x] Remove fieldset top-padding, when unlabeled and uncontained

### DIFF
--- a/packages/support/resources/css/components/fieldset.css
+++ b/packages/support/resources/css/components/fieldset.css
@@ -20,4 +20,8 @@
     &.fi-fieldset-not-contained {
         @apply pt-6;
     }
+
+    &.fi-fieldset-not-contained.fi-fieldset-label-hidden {
+        @apply pt-0;
+    }
 }


### PR DESCRIPTION
## Description
The `fieldset` component is super-handy for _(a number of reasons, one of which is)_ controlling visibility for an entire set of fields. The only downside—if the `fieldset` is solely for that purpose and you have `hiddenLabel()` & `contained(false)`—is that you get some unnecessary top-padding applied (`pt-6`, from the `.fi-fieldset-not-contained`). 

This PR fixes that style issue and takes the `pt` one step further, by removing it entirely when both `.fi-fieldset-not-contained` and `.fi-fieldset-label-hidden` are present on the fieldset wrapper.

## Visual changes
### Before:
<img width="1044" height="518" alt="image" src="https://github.com/user-attachments/assets/376e6f2a-eb05-4877-8f53-e628c3b22f59" />

### After:
<img width="1038" height="466" alt="image" src="https://github.com/user-attachments/assets/b1a48901-65a8-4b75-afd9-e169bef5eb3c" />

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality. _(lmk if we need to add screenshot tests)_
- [X] Documentation is up-to-date. _(lmk if you'd like an example of this, in Schema docs or Forms reactive cookbook)_
