### PR TITLE
Fix incompatible types for brand logo

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasBrandLogo.php
+++ b/packages/panels/src/Panel/Concerns/HasBrandLogo.php
@@ -4,15 +4,14 @@ namespace Filament\Panel\Concerns;
 
 use Closure;
 use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Support\HtmlString;
 
 trait HasBrandLogo
 {
-    protected string | HtmlString | Closure | null $brandLogo = null;
+    protected string | Htmlable | Closure | null $brandLogo = null;
 
     protected string | Closure | null $brandLogoHeight = null;
 
-    protected string | HtmlString | Closure | null $darkModeBrandLogo = null;
+    protected string | Htmlable | Closure | null $darkModeBrandLogo = null;
 
     public function brandLogo(string | Htmlable | Closure | null $logo): static
     {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
This PR fixes following problem:

The type of `$brandLogo` is narrower than that of its getter and setter. While `->brandLogo(...)` accepts any implementation of `Htmlable`, it throws a `TypeError` if anything other than an instance of `HtmlString` is provided.

Example of when it breaks:

```php
$panel
    ->brandLogo(new class implements Htmlable
    {
        public function toHtml()
        {
            // May be useful for lazily evaluating some HTML at render time
            return 'hello world';
        }
    });
```

This introduces a minor breaking change, since `$brandLogo` is protected and might be accessed directly by child panels (classes extending Panel) that expect it to be an instance of `HtmlString`. However, since the getter `->getBrandLogo()` returns an `Htmlable` and is likely used instead of directly accessing the property (I found no direct property usages except in the getter and setter), the impact should be very minimal.

## Visual changes

no visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
