### PR TITLE
Docs: add Group overview to Schemas > Layouts

### DIFF
--- a/packages/schemas/docs/02-layouts.md
+++ b/packages/schemas/docs/02-layouts.md
@@ -200,6 +200,21 @@ Grid::make([
     ])
 ```
 
+### Group component
+
+The `Group` component allows you to organize a collection of fields into a logical group. This is useful, for example, when you need to place fields within a subgrid or control their visibility without calling `hidden` on each individual field:
+
+```php
+Group::make([
+    TextInput::make('title'),
+    TextInput::make('subtitle'),
+])
+    ->columns(2)
+    ->hidden(fn (string $operation) => $operation === 'create')
+```
+
+You can also leverage a `Group` or other layout components to [save data on a related model](../forms/overview#saving-data-to-relationships).
+
 ### Flex component
 
 The `Flex` component allows you to define layouts with flexible widths, using flexbox. This component does not use Filament's [grid system](#grid-system).

--- a/packages/schemas/docs/02-layouts.md
+++ b/packages/schemas/docs/02-layouts.md
@@ -248,7 +248,7 @@ The `from()` method is used to control the [Tailwind breakpoint](https://tailwin
 
 ### Fieldset component
 
-You may want to group fields into a Fieldset. Each fieldset has a label, a border, and a two-column grid by default:
+Similar to the `Group` component, you may use a `Fieldset` to group a collection of fields inside a visual wrapper. Each fieldset has a label, a border, and a two-column grid by default:
 
 ```php
 use Filament\Schemas\Components\Fieldset;


### PR DESCRIPTION
## Description

Adds some documentation for `Group` component, under **Schema > Layouts**. Loosely related: #18239 

## Visual changes
N/A

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
