### PR TITLE
Update defaultSortKey to sort in the same direction as the main sort column

### DIFF
--- a/packages/tables/docs/02-columns/01-overview.md
+++ b/packages/tables/docs/02-columns/01-overview.md
@@ -316,7 +316,7 @@ public function table(Table $table): Table
 
 ## Disabling default primary key sorting
 
-By default, Filament will automatically add a primary key sort to the table query to ensure that the order of records is consistent. If your table doesn't have a primary key, or you wish to disable this behavior, you can use the `defaultKeySort(false)` method:
+By default, Filament will automatically add a primary key sort to the table query to ensure that the order of records is consistent. The primary key will be sorted in the same direction as the other sort column. If your table doesn't have a primary key, or you wish to disable this behavior, you can use the `defaultKeySort(false)` method:
 
 ```php
 use Filament\Tables\Table;

--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -133,7 +133,7 @@ trait CanSortRecords
             }
         }
 
-        return $query->orderBy($qualifiedKeyName);
+        return $query->orderBy($qualifiedKeyName, $sortDirection);
     }
 
     /**


### PR DESCRIPTION
## Description

The new defaultSortKey feature, if not disabled, will always add a sort by default key without specifying an order. For MariaDB, at least, if you are sorting the other key descending, this will prevent the query from hitting indexes. So, always sort the default key by the same direction as the other column. Other databases may not have the same issue, but there are lots of MariaDB Filament users.

If there are concerns that users wouldn't like this behavior, I could also add a ->defaultSortKeyPreserveOrder bool.. but it's just as easy for users to disable this and use a closure to set their own ordering if it matters for them.

Performance difference:
```
MariaDB [court_dev]> explain select * from `court_cases` order by `score` desc, `id` limit 10 offset 0;
+------+-------------+-------------+------+---------------+------+---------+------+---------+----------------+
| id   | select_type | table       | type | possible_keys | key  | key_len | ref  | rows    | Extra          |
+------+-------------+-------------+------+---------------+------+---------+------+---------+----------------+
|    1 | SIMPLE      | court_cases | ALL  | NULL          | NULL | NULL    | NULL | 5213208 | Using filesort |
+------+-------------+-------------+------+---------------+------+---------+------+---------+----------------+
1 row in set (0.000 sec)

MariaDB [court_dev]> explain select * from `court_cases` order by `score` desc, `id` desc limit 10 offset 0;
+------+-------------+-------------+-------+---------------+-----------+---------+------+------+-------+
| id   | select_type | table       | type  | possible_keys | key       | key_len | ref  | rows | Extra |
+------+-------------+-------------+-------+---------------+-----------+---------+------+------+-------+
|    1 | SIMPLE      | court_cases | index | NULL          | idx_score | 5       | NULL | 10   |       |
+------+-------------+-------------+-------+---------------+-----------+---------+------+------+-------+
1 row in set (0.000 sec)
```

## Visual changes

No visual changes, besides records sorting in the other direction.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
