### PR TITLE
fix: prevent XSS vulnerabilities in markdown editor by sanitizing localStorage and preview content

### DIFF
--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -346,7 +346,7 @@ export default function fileUploadFormComponent({
                     // type is uploaded, for example: `File of invalid type: Expects  or image/*`. This is a
                     // hacky workaround to fix the message to be `File of invalid type: Expects image/*`.
                     this.error = `${error.main}: ${error.sub}`.replace(
-                        'Expects  or',
+                        'Expects or',
                         'Expects',
                     )
                 })

--- a/packages/forms/resources/js/components/markdown-editor/EasyMDE.js
+++ b/packages/forms/resources/js/components/markdown-editor/EasyMDE.js
@@ -1137,7 +1137,10 @@ function toggleSideBySide(editor) {
         if (newValue != null) {
             // Sanitize content to prevent XSS
             const sanitizedContent = newValue
-                .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+                .replace(
+                    /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
+                    '',
+                )
                 .replace(/javascript:/gi, '')
                 .replace(/on\w+\s*=/gi, '')
             preview.innerHTML = sanitizedContent
@@ -1153,7 +1156,10 @@ function toggleSideBySide(editor) {
         if (newValue != null) {
             // Sanitize content to prevent XSS
             const sanitizedContent = newValue
-                .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+                .replace(
+                    /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
+                    '',
+                )
                 .replace(/javascript:/gi, '')
                 .replace(/on\w+\s*=/gi, '')
             preview.innerHTML = sanitizedContent
@@ -2750,7 +2756,10 @@ EasyMDE.prototype.autosave = function () {
                 if (savedContent && typeof savedContent === 'string') {
                     // Basic sanitization - remove potential script tags
                     const sanitizedContent = savedContent
-                        .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+                        .replace(
+                            /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
+                            '',
+                        )
                         .replace(/javascript:/gi, '')
                         .replace(/on\w+\s*=/gi, '')
                     this.codemirror.setValue(sanitizedContent)

--- a/packages/forms/resources/js/components/markdown-editor/EasyMDE.js
+++ b/packages/forms/resources/js/components/markdown-editor/EasyMDE.js
@@ -1135,7 +1135,12 @@ function toggleSideBySide(editor) {
     var sideBySideRenderingFunction = function () {
         var newValue = editor.options.previewRender(editor.value(), preview)
         if (newValue != null) {
-            preview.innerHTML = newValue
+            // Sanitize content to prevent XSS
+            const sanitizedContent = newValue
+                .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+                .replace(/javascript:/gi, '')
+                .replace(/on\w+\s*=/gi, '')
+            preview.innerHTML = sanitizedContent
         }
     }
 
@@ -1146,7 +1151,12 @@ function toggleSideBySide(editor) {
     if (useSideBySideListener) {
         var newValue = editor.options.previewRender(editor.value(), preview)
         if (newValue != null) {
-            preview.innerHTML = newValue
+            // Sanitize content to prevent XSS
+            const sanitizedContent = newValue
+                .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+                .replace(/javascript:/gi, '')
+                .replace(/on\w+\s*=/gi, '')
+            preview.innerHTML = sanitizedContent
         }
         cm.on('update', cm.sideBySideRenderingFunction)
     } else {
@@ -1213,7 +1223,12 @@ function togglePreview(editor) {
 
     var preview_result = editor.options.previewRender(editor.value(), preview)
     if (preview_result !== null) {
-        preview.innerHTML = preview_result
+        // Sanitize preview content to prevent XSS
+        const sanitizedContent = preview_result
+            .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+            .replace(/javascript:/gi, '')
+            .replace(/on\w+\s*=/gi, '')
+        preview.innerHTML = sanitizedContent
     }
 }
 
@@ -2728,11 +2743,18 @@ EasyMDE.prototype.autosave = function () {
                     'smde_' + this.options.autosave.uniqueId,
                 ) != ''
             ) {
-                this.codemirror.setValue(
-                    localStorage.getItem(
-                        'smde_' + this.options.autosave.uniqueId,
-                    ),
+                // Sanitize localStorage content before setting
+                const savedContent = localStorage.getItem(
+                    'smde_' + this.options.autosave.uniqueId,
                 )
+                if (savedContent && typeof savedContent === 'string') {
+                    // Basic sanitization - remove potential script tags
+                    const sanitizedContent = savedContent
+                        .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+                        .replace(/javascript:/gi, '')
+                        .replace(/on\w+\s*=/gi, '')
+                    this.codemirror.setValue(sanitizedContent)
+                }
                 this.options.autosave.foundSavedValue = true
             }
 


### PR DESCRIPTION
### XSS Vulnerabilities in Markdown Editor

## Description

- Issue 1: localStorage XSS
- Issue 2: Preview Content XSS
- Spacing on `expect  or` to `expect or` double spacing to single spacing


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
