### PR TITLE
Import Event facade used in the 'can save' test.

### DIFF
--- a/tests/src/Panels/Resources/Pages/EditRecordTest.php
+++ b/tests/src/Panels/Resources/Pages/EditRecordTest.php
@@ -21,6 +21,7 @@ use Filament\Tests\Fixtures\Resources\Tickets\TicketResource;
 use Filament\Tests\Panels\Resources\TestCase;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 
 use function Filament\Tests\livewire;


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This was not imported already, but was working okay on most systems due to class aliases.

On systems with the PECL event extension installed this would resolve to the `\Event` class and cause an error since `fake()` doesn't exist on the class from the extension.

## Visual changes

<img width="742" height="379" alt="image" src="https://github.com/user-attachments/assets/0b892123-3011-4141-adb3-ec2ed33d9a5e" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
