### PR TITLE
Update fa/infolist.php with corrected translations

### DIFF
--- a/packages/infolists/resources/lang/fa/components.php
+++ b/packages/infolists/resources/lang/fa/components.php
@@ -7,8 +7,8 @@ return [
         'text' => [
 
             'actions' => [
-                'collapse_list' => 'نمایش :count کمتر',
-                'expand_list' => 'نمایش :count بیشتر',
+                'collapse_list' => 'نمایش :count مورد کمتر',
+                'expand_list' => 'نمایش :count مورد بیشتر',
             ],
 
             'more_list_items' => 'و :count مورد دیگر',

--- a/packages/infolists/resources/lang/fa/components.php
+++ b/packages/infolists/resources/lang/fa/components.php
@@ -2,8 +2,36 @@
 
 return [
 
-    'text_entry' => [
-        'more_list_items' => 'و :count عدد دیگر',
-    ],
+    'entries' => [
 
+        'text' => [
+
+            'actions' => [
+                'collapse_list' => 'نمایش :count کمتر',
+                'expand_list' => 'نمایش :count بیشتر',
+            ],
+
+            'more_list_items' => 'و :count مورد دیگر',
+
+        ],
+
+        'key_value' => [
+
+            'columns' => [
+
+                'key' => [
+                    'label' => 'کلید',
+                ],
+
+                'value' => [
+                    'label' => 'مقدار',
+                ],
+
+            ],
+
+            'placeholder' => 'بدون ورودی',
+
+        ],
+
+    ],
 ];


### PR DESCRIPTION
## Description
This PR corrects the Persian (Farsi) translation for the infolist component language file.
The changes ensure that Persian-speaking users have a more natural and accurate language experience.
@ariaieboy 

## Visual changes
Before:
<img width="552" height="392" alt="image" src="https://github.com/user-attachments/assets/c122e687-36ad-4f4a-9216-1b1903bbd831" />

After:
<img width="529" height="369" alt="image" src="https://github.com/user-attachments/assets/552ab22a-f25a-40d2-8473-453d964a5ca2" />

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
