### PR TITLE
fix: fill default state in custom block form of rich editor

### DIFF
--- a/packages/forms/src/Components/RichEditor/Actions/CustomBlockAction.php
+++ b/packages/forms/src/Components/RichEditor/Actions/CustomBlockAction.php
@@ -14,7 +14,7 @@ class CustomBlockAction
     public static function make(): Action
     {
         return Action::make(static::NAME)
-            ->fillForm(fn (array $arguments): array => $arguments['config'] ?? [])
+            ->fillForm(fn (array $arguments): ?array => $arguments['config'] ?? null)
             ->modalHeading(function (array $arguments, RichEditor $component): ?string {
                 $block = $component->getCustomBlock($arguments['id']);
 


### PR DESCRIPTION
## Description
Before this PR, the `->default()` method did not work for field components inside a custom block action form.  

------
- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
