### PR TITLE
feat: uri state cast

### DIFF
--- a/packages/forms/src/Components/TextInput.php
+++ b/packages/forms/src/Components/TextInput.php
@@ -9,6 +9,7 @@ use Filament\Schemas\Components\Concerns\CanTrimState;
 use Filament\Schemas\Components\Contracts\HasAffixActions;
 use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
 use Filament\Schemas\Components\StateCasts\NumberStateCast;
+use Filament\Schemas\Components\StateCasts\UriStateCast;
 use Filament\Support\Concerns\HasExtraAlpineAttributes;
 use Filament\Support\RawJs;
 use LogicException;
@@ -47,6 +48,8 @@ class TextInput extends Field implements CanHaveNumericState, Contracts\CanBeLen
     protected bool | Closure $isCopyable = false;
 
     protected bool | Closure $isTel = false;
+
+    protected bool | Closure $isUri = false;
 
     protected bool | Closure $isUrl = false;
 
@@ -216,6 +219,13 @@ class TextInput extends Field implements CanHaveNumericState, Contracts\CanBeLen
         return $this;
     }
 
+    public function uri(bool | Closure $condition = true): static
+    {
+        $this->isUri = $condition;
+
+        return $this;
+    }
+
     public function url(bool | Closure $condition = true): static
     {
         $this->isUrl = $condition;
@@ -290,6 +300,11 @@ class TextInput extends Field implements CanHaveNumericState, Contracts\CanBeLen
         return (bool) $this->evaluate($this->isTel);
     }
 
+    public function isUri(): bool
+    {
+        return (bool) $this->evaluate($this->isUri);
+    }
+
     public function isUrl(): bool
     {
         return (bool) $this->evaluate($this->isUrl);
@@ -303,6 +318,7 @@ class TextInput extends Field implements CanHaveNumericState, Contracts\CanBeLen
         return [
             ...parent::getDefaultStateCasts(),
             ...($this->isNumeric() ? [app(NumberStateCast::class, ['isNullable' => true])] : []),
+            ...($this->isUri() ? [app(UriStateCast::class, ['isNullable' => true])] : []),
         ];
     }
 

--- a/packages/schemas/src/Components/StateCasts/UriStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/UriStateCast.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Filament\Schemas\Components\StateCasts;
+
+use Filament\Schemas\Components\StateCasts\Contracts\StateCast;
+use Illuminate\Support\Uri;
+
+class UriStateCast implements StateCast
+{
+    public function __construct(
+        protected bool $isNullable = true,
+    ) {}
+
+    /**
+     * @param  string|null  $state
+     */
+    public function get(mixed $state): ?Uri
+    {
+        if ($this->isNullable && blank($state)) {
+            return null;
+        }
+
+        return Uri::of($state);
+    }
+
+    /**
+     * @param  Uri|null  $state
+     */
+    public function set(mixed $state): ?string
+    {
+        if ($this->isNullable && blank($state)) {
+            return null;
+        }
+
+        return $state->__toString();
+    }
+}


### PR DESCRIPTION
## Description

This PR adds the `->uri()` method on the `TextInput` component to cast the state using the `Uri` Laravel helper.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
