### PR TITLE
Add Dutch translation for 'uploading_file_message'

### DIFF
--- a/packages/forms/resources/lang/nl/components.php
+++ b/packages/forms/resources/lang/nl/components.php
@@ -580,6 +580,8 @@ return [
             'undo' => 'Ongedaan maken',
         ],
 
+        'uploading_file_message' => 'Uploading file...',
+
     ],
 
     'select' => [

--- a/packages/forms/resources/lang/nl/components.php
+++ b/packages/forms/resources/lang/nl/components.php
@@ -580,7 +580,7 @@ return [
             'undo' => 'Ongedaan maken',
         ],
 
-        'uploading_file_message' => 'Uploading file...',
+        'uploading_file_message' => 'Het bestand wordt geüpload...',
 
     ],
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Added missing Dutch translation for the file uploading message.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
