### PR TITLE
Fix hint evaluation

### DIFF
--- a/packages/forms/src/Components/Concerns/HasHint.php
+++ b/packages/forms/src/Components/Concerns/HasHint.php
@@ -51,7 +51,7 @@ trait HasHint
                         /** @var self $parentComponent */
                         $parentComponent = $component->getContainer()->getParentComponent();
 
-                        return filled($parentComponent->hasHint());
+                        return filled($parentComponent->getHint());
                     });
             }
 

--- a/packages/infolists/src/Components/Concerns/HasHint.php
+++ b/packages/infolists/src/Components/Concerns/HasHint.php
@@ -50,7 +50,7 @@ trait HasHint
                         /** @var self $parentComponent */
                         $parentComponent = $component->getContainer()->getParentComponent();
 
-                        return filled($parentComponent->hasHint());
+                        return filled($parentComponent->getHint());
                     });
             }
 


### PR DESCRIPTION
## Description

When evaluating a field hint with a closure it appears that it renders the container div even if the result of the closure is null or false. That creates an additional space above the field.

## Visual changes

<img width="659" height="371" alt="Screenshot 2025-10-20 at 5 01 41 PM" src="https://github.com/user-attachments/assets/bd2a8b2e-f431-4680-b120-b9ff681e8748" />
<img width="685" height="355" alt="Screenshot 2025-10-20 at 5 01 52 PM" src="https://github.com/user-attachments/assets/ab3bbb46-e56a-47fd-881b-fbd066e75ecc" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
