### PR TITLE
[4.x] Add string target support for when opening in new tabs

### DIFF
--- a/packages/actions/src/Action.php
+++ b/packages/actions/src/Action.php
@@ -706,7 +706,7 @@ class Action extends ViewComponent implements Arrayable
             label: $this->getLabel(),
             size: $this->getSize(),
             tag: $url ? $shouldPostToUrl ? 'form' : 'a' : 'button',
-            target: ($url && $this->shouldOpenUrlInNewTab()) ? '_blank' : null,
+            target: $url ? $this->getUrlTarget() : null,
             tooltip: $this->getTooltip(),
             type: $this->canSubmitForm() ? 'submit' : 'button',
         );
@@ -745,7 +745,7 @@ class Action extends ViewComponent implements Arrayable
             labeledFromBreakpoint: $this->getLabeledFromBreakpoint(),
             size: $this->getSize(),
             tag: $url ? $shouldPostToUrl ? 'form' : 'a' : 'button',
-            target: ($url && $this->shouldOpenUrlInNewTab()) ? '_blank' : null,
+            target: $url ? $this->getUrlTarget() : null,
             tooltip: $this->getTooltip(),
             type: $this->canSubmitForm() ? 'submit' : 'button',
         );
@@ -778,7 +778,7 @@ class Action extends ViewComponent implements Arrayable
             keyBindings: $this->getKeyBindings(),
             label: $this->getLabel(),
             tag: $url ? $shouldPostToUrl ? 'form' : 'a' : 'button',
-            target: ($url && $this->shouldOpenUrlInNewTab()) ? '_blank' : null,
+            target: $url ? $this->getUrlTarget() : null,
             tooltip: $this->getTooltip(),
             type: $this->canSubmitForm() ? 'submit' : 'button',
         );
@@ -813,7 +813,7 @@ class Action extends ViewComponent implements Arrayable
             label: $this->getLabel(),
             size: $this->getSize(),
             tag: $url ? $shouldPostToUrl ? 'form' : 'a' : 'button',
-            target: ($url && $this->shouldOpenUrlInNewTab()) ? '_blank' : null,
+            target: $url ? $this->getUrlTarget() : null,
             tooltip: $this->getTooltip(),
             type: $this->canSubmitForm() ? 'submit' : 'button',
         );
@@ -850,7 +850,7 @@ class Action extends ViewComponent implements Arrayable
             label: $this->getLabel(),
             size: $this->getSize(),
             tag: $url ? $shouldPostToUrl ? 'form' : 'a' : 'button',
-            target: ($url && $this->shouldOpenUrlInNewTab()) ? '_blank' : null,
+            target: $url ? $this->getUrlTarget() : null,
             tooltip: $this->getTooltip(),
             type: $this->canSubmitForm() ? 'submit' : 'button',
         );

--- a/packages/actions/src/Concerns/CanOpenUrl.php
+++ b/packages/actions/src/Concerns/CanOpenUrl.php
@@ -6,20 +6,20 @@ use Closure;
 
 trait CanOpenUrl
 {
-    protected bool | Closure $shouldOpenUrlInNewTab = false;
+    protected bool | string | Closure $shouldOpenUrlInNewTab = false;
 
     protected string | Closure | null $url = null;
 
     protected bool | Closure $shouldPostToUrl = false;
 
-    public function openUrlInNewTab(bool | Closure $condition = true): static
+    public function openUrlInNewTab(bool | string | Closure $condition = true): static
     {
         $this->shouldOpenUrlInNewTab = $condition;
 
         return $this;
     }
 
-    public function url(string | Closure | null $url, bool | Closure $shouldOpenInNewTab = false): static
+    public function url(string | Closure | null $url, bool | string | Closure $shouldOpenInNewTab = false): static
     {
         $this->openUrlInNewTab($shouldOpenInNewTab);
         $this->url = $url;
@@ -42,6 +42,21 @@ trait CanOpenUrl
     public function shouldOpenUrlInNewTab(): bool
     {
         return (bool) $this->evaluate($this->shouldOpenUrlInNewTab);
+    }
+
+    public function getUrlTarget(): ?string
+    {
+        $value = $this->evaluate($this->shouldOpenUrlInNewTab);
+
+        if (is_string($value) && $value !== '') {
+            return $value;
+        }
+
+        if ($value) {
+            return '_blank';
+        }
+
+        return null;
     }
 
     public function shouldPostToUrl(): bool

--- a/packages/schemas/src/Components/Concerns/CanOpenUrl.php
+++ b/packages/schemas/src/Components/Concerns/CanOpenUrl.php
@@ -6,18 +6,18 @@ use Closure;
 
 trait CanOpenUrl
 {
-    protected bool | Closure $shouldOpenUrlInNewTab = false;
+    protected bool | string | Closure $shouldOpenUrlInNewTab = false;
 
     protected string | Closure | null $url = null;
 
-    public function openUrlInNewTab(bool | Closure $condition = true): static
+    public function openUrlInNewTab(bool | string | Closure $condition = true): static
     {
         $this->shouldOpenUrlInNewTab = $condition;
 
         return $this;
     }
 
-    public function url(string | Closure | null $url, bool | Closure $shouldOpenInNewTab = false): static
+    public function url(string | Closure | null $url, bool | string | Closure $shouldOpenInNewTab = false): static
     {
         $this->openUrlInNewTab($shouldOpenInNewTab);
         $this->url = $url;
@@ -40,6 +40,21 @@ trait CanOpenUrl
         }
 
         return $this->evaluate($this->url);
+    }
+
+    public function getUrlTarget(): ?string
+    {
+        $value = $this->evaluate($this->shouldOpenUrlInNewTab);
+
+        if (is_string($value) && $value !== '') {
+            return $value;
+        }
+
+        if ($value) {
+            return '_blank';
+        }
+
+        return null;
     }
 
     public function hasStateBasedUrls(): bool

--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -55,7 +55,7 @@
 
 <{{ $tag }}
     @if (($tag === 'a') && (! ($disabled && $hasTooltip)))
-        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode) }}
+        {{ \Filament\Support\generate_href_html($href, $target, $spaMode) }}
     @endif
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -95,7 +95,7 @@
 
 <{{ $tag }}
     @if (($tag === 'a') && (! ($disabled && $hasTooltip)))
-        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode) }}
+        {{ \Filament\Support\generate_href_html($href, $target, $spaMode) }}
     @endif
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"

--- a/packages/support/resources/views/components/dropdown/list/item.blade.php
+++ b/packages/support/resources/views/components/dropdown/list/item.blade.php
@@ -53,7 +53,7 @@
 
 <{{ ($tag === 'form') ? 'button' : $tag }}
     @if (($tag === 'a') && (! ($disabled && $hasTooltip)))
-        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode) }}
+        {{ \Filament\Support\generate_href_html($href, $target, $spaMode) }}
     @endif
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"

--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -61,7 +61,7 @@
 
 <{{ $tag }}
     @if (($tag === 'a') && (! ($disabled && $hasTooltip)))
-        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode) }}
+        {{ \Filament\Support\generate_href_html($href, $target, $spaMode) }}
     @endif
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"

--- a/packages/support/resources/views/components/link.blade.php
+++ b/packages/support/resources/views/components/link.blade.php
@@ -72,7 +72,7 @@
 
 <{{ $tag }}
     @if (($tag === 'a') && (! ($disabled && $hasTooltip)))
-        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode) }}
+        {{ \Filament\Support\generate_href_html($href, $target, $spaMode) }}
     @endif
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"

--- a/packages/support/resources/views/components/tabs/item.blade.php
+++ b/packages/support/resources/views/components/tabs/item.blade.php
@@ -32,7 +32,7 @@
     @if ($tag === 'button')
         type="{{ $type }}"
     @elseif ($tag === 'a')
-        {{ \Filament\Support\generate_href_html($href, $target === '_blank', $spaMode) }}
+        {{ \Filament\Support\generate_href_html($href, $target, $spaMode) }}
     @endif
     @if ($hasAlpineActiveClasses)
         x-bind:class="{

--- a/packages/support/src/View/Concerns/CanGenerateBadgeHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateBadgeHtml.php
@@ -116,7 +116,7 @@ trait CanGenerateBadgeHtml
 
         <<?= ($tag === 'form') ? 'button' : $tag ?>
             <?php if (($tag === 'a') && (! ($isDisabled && $hasTooltip))) { ?>
-                <?= generate_href_html($href, $target === '_blank', $hasSpaMode)->toHtml() ?>
+                <?= generate_href_html($href, $target, $hasSpaMode)->toHtml() ?>
             <?php } ?>
             <?php if ($keyBindings) { ?>
                 x-bind:id="$id('key-bindings')"

--- a/packages/support/src/View/Concerns/CanGenerateButtonHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateButtonHtml.php
@@ -172,7 +172,7 @@ trait CanGenerateButtonHtml
 
         <<?= ($tag === 'form') ? 'button' : $tag ?>
             <?php if (($tag === 'a') && (! ($isDisabled && $hasTooltip))) { ?>
-                <?= generate_href_html($href, $target === '_blank', $hasSpaMode)->toHtml() ?>
+                <?= generate_href_html($href, $target, $hasSpaMode)->toHtml() ?>
             <?php } ?>
             <?php if ($keyBindings) { ?>
                 x-bind:id="$id('key-bindings')"

--- a/packages/support/src/View/Concerns/CanGenerateDropdownItemHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateDropdownItemHtml.php
@@ -99,7 +99,7 @@ trait CanGenerateDropdownItemHtml
 
         <<?= ($tag === 'form') ? 'button' : $tag ?>
             <?php if (($tag === 'a') && (! ($isDisabled && $hasTooltip))) { ?>
-                <?= generate_href_html($href, $target === '_blank', $hasSpaMode)->toHtml() ?>
+                <?= generate_href_html($href, $target, $hasSpaMode)->toHtml() ?>
             <?php } ?>
             <?php if ($keyBindings) { ?>
                 x-bind:id="$id('key-bindings')"

--- a/packages/support/src/View/Concerns/CanGenerateIconButtonHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateIconButtonHtml.php
@@ -119,7 +119,7 @@ trait CanGenerateIconButtonHtml
 
         <<?= ($tag === 'form') ? 'button' : $tag ?>
             <?php if (($tag === 'a') && (! ($isDisabled && $hasTooltip))) { ?>
-                <?= generate_href_html($href, $target === '_blank', $hasSpaMode)->toHtml() ?>
+                <?= generate_href_html($href, $target, $hasSpaMode)->toHtml() ?>
             <?php } ?>
             <?php if ($keyBindings) { ?>
                 x-bind:id="$id('key-bindings')"

--- a/packages/support/src/View/Concerns/CanGenerateLinkHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateLinkHtml.php
@@ -138,7 +138,7 @@ trait CanGenerateLinkHtml
 
         <<?= ($tag === 'form') ? 'button' : $tag ?>
             <?php if (($tag === 'a') && (! ($isDisabled && $hasTooltip))) { ?>
-                <?= generate_href_html($href, $target === '_blank', $hasSpaMode)->toHtml() ?>
+                <?= generate_href_html($href, $target, $hasSpaMode)->toHtml() ?>
             <?php } ?>
             <?php if ($keyBindings) { ?>
                 x-bind:id="$id('key-bindings')"

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -121,7 +121,7 @@ if (! function_exists('Filament\Support\is_app_url')) {
 }
 
 if (! function_exists('Filament\Support\generate_href_html')) {
-    function generate_href_html(?string $url, bool $shouldOpenInNewTab = false, ?bool $shouldOpenInSpaMode = null, bool $hasNestedClickEventHandler = false): Htmlable
+    function generate_href_html(?string $url, bool | string $shouldOpenInNewTab = false, ?bool $shouldOpenInSpaMode = null, bool $hasNestedClickEventHandler = false): Htmlable
     {
         if (blank($url)) {
             return new HtmlString('');
@@ -129,8 +129,19 @@ if (! function_exists('Filament\Support\generate_href_html')) {
 
         $html = "href=\"{$url}\"";
 
-        if ($shouldOpenInNewTab) {
-            $html .= ' target="_blank"';
+        $target = null;
+        if (is_string($shouldOpenInNewTab) && $shouldOpenInNewTab !== '') {
+            $target = $shouldOpenInNewTab;
+        } elseif ($shouldOpenInNewTab === true) {
+            $target = '_blank';
+        }
+
+        if ($target !== null) {
+            $html .= " target=\"{$target}\"";
+
+            if ($target === '_blank') {
+                $html .= ' rel="noopener noreferrer"';
+            }
         } elseif ($shouldOpenInSpaMode ?? (FilamentView::hasSpaMode($url))) {
             if (FilamentView::hasSpaPrefetching()) {
                 $html .= ' wire:navigate.hover';

--- a/packages/tables/src/Columns/Concerns/CanOpenUrl.php
+++ b/packages/tables/src/Columns/Concerns/CanOpenUrl.php
@@ -6,18 +6,18 @@ use Closure;
 
 trait CanOpenUrl
 {
-    protected bool | Closure $shouldOpenUrlInNewTab = false;
+    protected bool | string | Closure $shouldOpenUrlInNewTab = false;
 
     protected string | Closure | null $url = null;
 
-    public function openUrlInNewTab(bool | Closure $condition = true): static
+    public function openUrlInNewTab(bool | string | Closure $condition = true): static
     {
         $this->shouldOpenUrlInNewTab = $condition;
 
         return $this;
     }
 
-    public function url(string | Closure | null $url, bool | Closure $shouldOpenInNewTab = false): static
+    public function url(string | Closure | null $url, bool | string | Closure $shouldOpenInNewTab = false): static
     {
         $this->openUrlInNewTab($shouldOpenInNewTab);
         $this->url = $url;
@@ -40,6 +40,21 @@ trait CanOpenUrl
         }
 
         return $this->evaluate($this->url);
+    }
+
+    public function getUrlTarget(): ?string
+    {
+        $value = $this->evaluate($this->shouldOpenUrlInNewTab);
+
+        if (is_string($value) && $value !== '') {
+            return $value;
+        }
+
+        if ($value) {
+            return '_blank';
+        }
+
+        return null;
     }
 
     public function hasStateBasedUrls(): bool

--- a/packages/tables/src/Table/Concerns/HasRecordUrl.php
+++ b/packages/tables/src/Table/Concerns/HasRecordUrl.php
@@ -7,18 +7,18 @@ use Illuminate\Database\Eloquent\Model;
 
 trait HasRecordUrl
 {
-    protected bool | Closure $shouldOpenRecordUrlInNewTab = false;
+    protected bool | string | Closure $shouldOpenRecordUrlInNewTab = false;
 
     protected string | Closure | null $recordUrl = null;
 
-    public function openRecordUrlInNewTab(bool | Closure $condition = true): static
+    public function openRecordUrlInNewTab(bool | string | Closure $condition = true): static
     {
         $this->shouldOpenRecordUrlInNewTab = $condition;
 
         return $this;
     }
 
-    public function recordUrl(string | Closure | null $url, bool | Closure $shouldOpenInNewTab = false): static
+    public function recordUrl(string | Closure | null $url, bool | string | Closure $shouldOpenInNewTab = false): static
     {
         $this->openRecordUrlInNewTab($shouldOpenInNewTab);
         $this->recordUrl = $url;
@@ -58,5 +58,29 @@ trait HasRecordUrl
                 $record::class => $record,
             ] : [],
         );
+    }
+
+    public function getRecordUrlTarget(Model | array $record): ?string
+    {
+        $value = $this->evaluate(
+            $this->shouldOpenRecordUrlInNewTab,
+            namedInjections: [
+                'record' => $record,
+            ],
+            typedInjections: ($record instanceof Model) ? [
+                Model::class => $record,
+                $record::class => $record,
+            ] : [],
+        );
+
+        if (is_string($value) && $value !== '') {
+            return $value;
+        }
+
+        if ($value) {
+            return '_blank';
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR extends Filament’s URL-handling logic to support custom window targets (e.g. named tabs) while maintaining full backward compatibility.

**No breaking changes** — all existing code using `true|false` continues to work as before.

## Example usage

```php
public static function table(Table $table): Table
{
    return $table
        // Default behavior (unchanged)
        ->openRecordUrlInNewTab() 
        ->openRecordUrlInNewTab(true) 
        ->recordUrl(fn ($record) => Resource::getUrl('view', ['record' => $record]))
        ->recordUrl(fn ($record) => Resource::getUrl('view', ['record' => $record]), true)

        // New behavior: reuse named tab/window
        ->openRecordUrlInNewTab('record-123')
        ->recordUrl(fn ($record) => Resource::getUrl('view', ['record' => $record]), 'record-123')
    ;
}
```

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
