### PR TITLE
Added Dutch translation for the grid tools

### DIFF
--- a/packages/forms/resources/lang/nl/components.php
+++ b/packages/forms/resources/lang/nl/components.php
@@ -561,6 +561,8 @@ return [
             'h1' => 'Titel',
             'h2' => 'Kop',
             'h3' => 'Subkop',
+            'grid' => 'Raster',
+            'grid_delete' => 'Verwijder raster',
             'highlight' => 'Markeren',
             'horizontal_rule' => 'Horizontale lijn',
             'italic' => 'Cursief',


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Added Dutch translation for the RichEditor grid tools.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
