### PR TITLE
Hide attach files toolbar button when file attachments are disabled

### DIFF
--- a/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
+++ b/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
@@ -168,4 +168,9 @@ trait InteractsWithToolbarButtons
 
         return false;
     }
+
+    public function hasCustomToolbarButtons(): bool
+    {
+        return $this->evaluate($this->toolbarButtons) !== null;
+    }
 }

--- a/packages/forms/src/Components/MarkdownEditor.php
+++ b/packages/forms/src/Components/MarkdownEditor.php
@@ -65,6 +65,6 @@ class MarkdownEditor extends Field implements Contracts\CanBeLengthConstrained
 
     public function hasFileAttachmentsByDefault(): bool
     {
-        return $this->evaluate($this->toolbarButtons) === null || $this->hasToolbarButton('attachFiles');
+        return (! $this->hasCustomToolbarButtons()) || $this->hasToolbarButton('attachFiles');
     }
 }

--- a/packages/forms/src/Components/MarkdownEditor.php
+++ b/packages/forms/src/Components/MarkdownEditor.php
@@ -65,6 +65,6 @@ class MarkdownEditor extends Field implements Contracts\CanBeLengthConstrained
 
     public function hasFileAttachmentsByDefault(): bool
     {
-        return $this->hasToolbarButton('attachFiles');
+        return $this->evaluate($this->toolbarButtons) === null || $this->hasToolbarButton('attachFiles');
     }
 }

--- a/packages/forms/src/Components/MarkdownEditor.php
+++ b/packages/forms/src/Components/MarkdownEditor.php
@@ -32,7 +32,10 @@ class MarkdownEditor extends Field implements Contracts\CanBeLengthConstrained
             ['bold', 'italic', 'strike', 'link'],
             ['heading'],
             ['blockquote', 'codeBlock', 'bulletList', 'orderedList'],
-            ['table', 'attachFiles'],
+            [
+                'table',
+                ...($this->hasFileAttachments() ? ['attachFiles'] : []),
+            ],
             ['undo', 'redo'],
         ];
     }

--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -701,7 +701,7 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
             ['blockquote', 'codeBlock', 'bulletList', 'orderedList'],
             [
                 'table',
-                'attachFiles',
+                ...($this->hasFileAttachments() ? ['attachFiles'] : []),
                 ...(filled($this->getCustomBlocks()) ? ['customBlocks'] : []),
                 ...(filled($this->getMergeTags()) ? ['mergeTags'] : []),
             ],

--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -1017,6 +1017,6 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
 
     public function hasFileAttachmentsByDefault(): bool
     {
-        return $this->evaluate($this->toolbarButtons) === null || $this->hasToolbarButton('attachFiles');
+        return (! $this->hasCustomToolbarButtons()) || $this->hasToolbarButton('attachFiles');
     }
 }

--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -1017,6 +1017,6 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
 
     public function hasFileAttachmentsByDefault(): bool
     {
-        return $this->hasToolbarButton('attachFiles');
+        return $this->evaluate($this->toolbarButtons) === null || $this->hasToolbarButton('attachFiles');
     }
 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
Extends #18274 to hide the attachFiles toolbar button when file attachments are disabled.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

*Before*

<img width="902" height="283" alt="{7A75080B-447B-4571-9182-E54D0B23F76C}" src="https://github.com/user-attachments/assets/f0072b19-c8b2-437c-9c6f-c2d98574544a" />

*After*

<img width="906" height="296" alt="{2EA0CF7A-31F4-45C5-96AC-CC16CE11D27D}" src="https://github.com/user-attachments/assets/b253288a-3060-442a-aaca-5afa1f2e2860" />

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
