### PR TITLE
Feature: Add option to block password managers for text inputs

### DIFF
--- a/packages/forms/docs/02-text-input.md
+++ b/packages/forms/docs/02-text-input.md
@@ -248,6 +248,25 @@ TextInput::make('apiKey')
     This feature only works when SSL is enabled for the app.
 </Aside>
 
+## Block password managers
+
+Some password managers may suggest filling stored credentials or addresses into a field. This often is the case when a field is named something like `name`, `street`, `city` etc.
+
+To explicitly disable this behaviour for a text input  you may use the `blockPasswordManagers()` method:
+
+```php
+use Filament\Forms\Components\TextInput;
+
+TextInput::make('street')
+    ->blockPasswordManagers()
+```
+
+<UtilityInjection set="formFields" version="4.x">As well as allowing static values, the `blockPasswordManagers()` method parameters also accept functions to dynamically calculate them. You can inject various utilities into the function as parameters.</UtilityInjection>
+
+<Aside variant="warning">
+    Currently supported password managers are 1Password, LastPass, BitWarden and Keeper.
+</Aside>
+
 ## Input masking
 
 Input masking is the practice of defining a format that the input value must conform to.

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -23,6 +23,7 @@
     $suffixLabel = $getSuffixLabel();
     $statePath = $getStatePath();
     $placeholder = $getPlaceholder();
+    $blockPasswordManagers = $isBlockPasswordManagers();
 
     if ($isPasswordRevealable) {
         $xData = '{ isPasswordRevealed: false }';
@@ -64,9 +65,13 @@
             $applyStateBindingModifiers('wire:model') => $statePath,
             'x-bind:type' => $isPasswordRevealable ? 'isPasswordRevealed ? \'text\' : \'password\'' : null,
             'x-mask' . ($mask instanceof \Filament\Support\RawJs ? ':dynamic' : '') => filled($mask) ? $mask : null,
+            'data-1p-ignore' => $blockPasswordManagers ? '' : null,
+            'data-lpignore' => $blockPasswordManagers ? 'true' : null,
+            'data-bwignore' => $blockPasswordManagers ? 'true' : null,
         ], escape: false)
         ->class([
             'fi-revealable' => $isPasswordRevealable,
+            'keeper-ignore' => $blockPasswordManagers,
         ]);
 @endphp
 

--- a/packages/forms/src/Components/TextInput.php
+++ b/packages/forms/src/Components/TextInput.php
@@ -44,6 +44,8 @@ class TextInput extends Field implements CanHaveNumericState, Contracts\CanBeLen
 
     protected bool | Closure $isRevealable = false;
 
+    protected bool | Closure $blockPasswordManagers = false;
+
     protected bool | Closure $isCopyable = false;
 
     protected bool | Closure $isTel = false;
@@ -169,6 +171,18 @@ class TextInput extends Field implements CanHaveNumericState, Contracts\CanBeLen
         }
 
         return $this->isPassword() ?: throw new LogicException("The text input [{$this->getStatePath()}] is not a [password()], so it cannot be [revealable()].");
+    }
+
+    public function blockPasswordManagers(bool | Closure $condition = true): static
+    {
+        $this->blockPasswordManagers = $condition;
+
+        return $this;
+    }
+
+    public function isBlockPasswordManagers(): bool
+    {
+        return (bool) $this->evaluate($this->blockPasswordManagers);
     }
 
     public function copyable(

--- a/packages/forms/src/Components/TextInput.php
+++ b/packages/forms/src/Components/TextInput.php
@@ -173,6 +173,10 @@ class TextInput extends Field implements CanHaveNumericState, Contracts\CanBeLen
         return $this->isPassword() ?: throw new LogicException("The text input [{$this->getStatePath()}] is not a [password()], so it cannot be [revealable()].");
     }
 
+    /**
+     * Prevent password managers like 1password or LastPass from injecting
+     * buttons or dropdowns into the field.
+     */
     public function blockPasswordManagers(bool | Closure $condition = true): static
     {
         $this->blockPasswordManagers = $condition;


### PR DESCRIPTION
## Description

Some password managers may suggest filling stored credentials or addresses into a text field. This often is the case when a field is named something like `name`, `street`, `city` etc.

This behaviour can be blocked for some of the most common password managers like Lastpass of 1Password using HTML attributes or classes.

My current usecase is an application with an address database. Using this feature, I can disable the address suggestion when creating or editing addresses in my application.

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
