### PR TITLE
[4.x] Refactor: Add thousands separators on pagination items

### DIFF
--- a/packages/support/resources/views/components/pagination/index.blade.php
+++ b/packages/support/resources/views/components/pagination/index.blade.php
@@ -161,8 +161,8 @@
                     @foreach ($element as $page => $url)
                         <x-filament::pagination.item
                             :active="$page === $paginator->currentPage()"
-                            :aria-label="trans_choice('filament::components/pagination.actions.go_to_page.label', $page, ['page' => $page])"
-                            :label="$page"
+                            :aria-label="trans_choice('filament::components/pagination.actions.go_to_page.label', $page, ['page' => \Illuminate\Support\Number::format($page)])"
+                            :label="\Illuminate\Support\Number::format($page)"
                             :wire:click="'gotoPage(' . $page . ', \'' . $paginator->getPageName() . '\')'"
                             :wire:key="$this->getId() . '.pagination.' . $paginator->getPageName() . '.' . $page"
                         />


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

It adds thousands separators on Filament pagination items using Laravel's Number support class. I just tested it in English. You might want to test it with other locales to ensure it works properly.

## Visual changes

| Before | After |
|-------|-----|
| <img width="439" height="55" alt="Screenshot 2025-10-22 at 20 08 54" src="https://github.com/user-attachments/assets/90d78163-8b8e-49af-a908-f5e25676853f" /> | <img width="447" height="58" alt="Screenshot 2025-10-22 at 20 08 41" src="https://github.com/user-attachments/assets/476ceaed-d148-486d-a9c6-5ab97012889c" /> |

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
