### PR TITLE
Prevent null reference errors when key bindings trigger after element removal

### DIFF
--- a/packages/panels/resources/views/livewire/global-search.blade.php
+++ b/packages/panels/resources/views/livewire/global-search.blade.php
@@ -33,7 +33,7 @@
                     x-bind:id="$id('input')"
                     x-on:keydown.down.prevent.stop="$dispatch('focus-first-global-search-result')"
                     wire:model.live.debounce.{{ $debounce }}="search"
-                    x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($id('input')).focus()"
+                    x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($id('input'))?.focus()"
                     class="fi-input fi-input-has-inline-prefix"
                 />
             </x-filament::input.wrapper>

--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -59,7 +59,7 @@
     @endif
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"
-        x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id).click()"
+        x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id)?.click()"
     @endif
     @if ($hasTooltip)
         x-tooltip="{

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -99,7 +99,7 @@
     @endif
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"
-        x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id).click()"
+        x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id)?.click()"
     @endif
     @if ($hasTooltip)
         x-tooltip="{

--- a/packages/support/resources/views/components/dropdown/list/item.blade.php
+++ b/packages/support/resources/views/components/dropdown/list/item.blade.php
@@ -57,7 +57,7 @@
     @endif
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"
-        x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id).click()"
+        x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id)?.click()"
     @endif
     @if ($hasTooltip)
         x-tooltip="{

--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -65,7 +65,7 @@
     @endif
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"
-        x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id).click()"
+        x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id)?.click()"
     @endif
     @if ($hasTooltip)
         x-tooltip="{

--- a/packages/support/resources/views/components/link.blade.php
+++ b/packages/support/resources/views/components/link.blade.php
@@ -76,7 +76,7 @@
     @endif
     @if ($keyBindings)
         x-bind:id="$id('key-bindings')"
-        x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id).click()"
+        x-mousetrap.global.{{ collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') }}="document.getElementById($el.id)?.click()"
     @endif
     @if ($hasTooltip)
         x-tooltip="{

--- a/packages/support/src/View/Concerns/CanGenerateBadgeHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateBadgeHtml.php
@@ -120,7 +120,7 @@ trait CanGenerateBadgeHtml
             <?php } ?>
             <?php if ($keyBindings) { ?>
                 x-bind:id="$id('key-bindings')"
-                x-mousetrap.global.<?= collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') ?>="document.getElementById($el.id).click()"
+                x-mousetrap.global.<?= collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') ?>="document.getElementById($el.id)?.click()"
             <?php } ?>
             <?php if ($hasTooltip) { ?>
                 x-tooltip="{

--- a/packages/support/src/View/Concerns/CanGenerateButtonHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateButtonHtml.php
@@ -176,7 +176,7 @@ trait CanGenerateButtonHtml
             <?php } ?>
             <?php if ($keyBindings) { ?>
                 x-bind:id="$id('key-bindings')"
-                x-mousetrap.global.<?= collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') ?>="document.getElementById($el.id).click()"
+                x-mousetrap.global.<?= collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') ?>="document.getElementById($el.id)?.click()"
             <?php } ?>
             <?php if ($hasTooltip) { ?>
                 x-tooltip="{

--- a/packages/support/src/View/Concerns/CanGenerateDropdownItemHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateDropdownItemHtml.php
@@ -103,7 +103,7 @@ trait CanGenerateDropdownItemHtml
             <?php } ?>
             <?php if ($keyBindings) { ?>
                 x-bind:id="$id('key-bindings')"
-                x-mousetrap.global.<?= collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') ?>="document.getElementById($el.id).click()"
+                x-mousetrap.global.<?= collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') ?>="document.getElementById($el.id)?.click()"
             <?php } ?>
             <?php if ($hasTooltip) { ?>
                 x-tooltip="{

--- a/packages/support/src/View/Concerns/CanGenerateIconButtonHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateIconButtonHtml.php
@@ -123,7 +123,7 @@ trait CanGenerateIconButtonHtml
             <?php } ?>
             <?php if ($keyBindings) { ?>
                 x-bind:id="$id('key-bindings')"
-                x-mousetrap.global.<?= collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') ?>="document.getElementById($el.id).click()"
+                x-mousetrap.global.<?= collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') ?>="document.getElementById($el.id)?.click()"
             <?php } ?>
             <?php if ($hasTooltip) { ?>
                 x-tooltip="{

--- a/packages/support/src/View/Concerns/CanGenerateLinkHtml.php
+++ b/packages/support/src/View/Concerns/CanGenerateLinkHtml.php
@@ -142,7 +142,7 @@ trait CanGenerateLinkHtml
             <?php } ?>
             <?php if ($keyBindings) { ?>
                 x-bind:id="$id('key-bindings')"
-                x-mousetrap.global.<?= collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') ?>="document.getElementById($el.id).click()"
+                x-mousetrap.global.<?= collect($keyBindings)->map(fn (string $keyBinding): string => str_replace('+', '-', $keyBinding))->implode('.') ?>="document.getElementById($el.id)?.click()"
             <?php } ?>
             <?php if ($hasTooltip) { ?>
                 x-tooltip="{


### PR DESCRIPTION
When an action using a key binding is hidden, the element gets removed from the DOM but the mousetrap global key binding persists. Pressing the same key again causes a null reference error:

<img width="1150" height="377" alt="image" src="https://github.com/user-attachments/assets/1034fe16-48c8-4608-8b9d-93b0fd2b917d" />

This PR adds optional chaining to all mousetrap key binding handlers to fix this.