### PR TITLE
Add scrollbar-gutter property to `fi` class

### DIFF
--- a/packages/panels/resources/css/components/layout.css
+++ b/packages/panels/resources/css/components/layout.css
@@ -1,5 +1,5 @@
 html.fi {
-    @apply min-h-dvh;
+    @apply min-h-dvh [scrollbar-gutter:stable];
 }
 
 .fi-body {


### PR DESCRIPTION
## Description

This PR adds `scrollbar-gutter: stable;` to the `.fi` class on the `<html>` root element. This fixes a layout shift on the whole page (at least on Windows) when switching between pages that have a scrollbar or not.

> stable: This adds a little opinionated behavior by always reserving space for the scrollbar gutter, as long as the overflow property on the same element is set to scroll or auto and we’re dealing with a classic scrollbar — even when if the box is not overflowing. Conversely, **this will have no impact on an overlay scrollbar.**
> — _[CSS-Tricks](https://css-tricks.com/almanac/properties/s/scrollbar-gutter/#aa-values)_

### More information

- [Article on CSS-Tricks](https://css-tricks.com/almanac/properties/s/scrollbar-gutter/)
- [More information on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter)

## Visual changes

### Before

https://github.com/user-attachments/assets/ec05dbdf-457d-4fe6-b269-2b505be66fff

### After

https://github.com/user-attachments/assets/8d36b329-c0ef-4d15-868a-f83927af5b64

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
