### PR TITLE
Added Support for TextSize Enum based on docs

### DIFF
--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -358,7 +358,7 @@ class ImageColumn extends Column implements HasEmbeddedView
         return $this->evaluate($this->limit);
     }
 
-    public function limitedRemainingText(bool | Closure $condition = true, string | Closure | null $size = null): static
+    public function limitedRemainingText(bool | Closure $condition = true, TextSize | string | Closure | null $size = null): static
     {
         $this->hasLimitedRemainingText = $condition;
         $this->limitedRemainingTextSize($size);


### PR DESCRIPTION
Docs: https://filamentphp.com/docs/4.x/tables/columns/image#customizing-the-limited-remaining-text-size

Enum Type is currently not accepted, now it is.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
