### PR TITLE
Fix deprecation on CreateXlsxFile

### DIFF
--- a/packages/actions/src/Exports/Jobs/CreateXlsxFile.php
+++ b/packages/actions/src/Exports/Jobs/CreateXlsxFile.php
@@ -53,7 +53,7 @@ class CreateXlsxFile implements ShouldQueue
         $csvDelimiter = $this->exporter::getCsvDelimiter();
 
         $writeRowsFromFile = function (string $file, ?Style $style, ?Closure $makeRow) use ($csvDelimiter, $disk, $writer): void {
-            $csvReader = CsvReader::createFromStream($disk->readStream($file));
+            $csvReader = CsvReader::from($disk->readStream($file));
             $csvReader->setDelimiter($csvDelimiter);
             $csvResults = (new Statement)->process($csvReader);
 


### PR DESCRIPTION
Fix deprecation Method League\Csv\AbstractCsv::createFromFileObject() is deprecated since league/csv:9.27.0, use League\Csv\AbstractCsv::from() instead

As Sentry keep alert me about it

<img width="1936" height="640" alt="CleanShot 2025-10-28 at 12 27 30@2x" src="https://github.com/user-attachments/assets/387ae7bb-7257-4828-aa3f-1a05c9c1b8ec" />


<img width="1752" height="848" alt="CleanShot 2025-10-28 at 12 32 41@2x" src="https://github.com/user-attachments/assets/e879b0bc-1783-42ab-a8cd-05f5dd370e68" />