### PR TITLE
Fix deprecation in Writer::createFromFileObject

### DIFF
--- a/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
+++ b/packages/actions/src/Exports/Jobs/PrepareCsvExport.php
@@ -52,7 +52,7 @@ class PrepareCsvExport implements ShouldQueue
 
     public function handle(): void
     {
-        $csv = Writer::createFromFileObject(new SplTempFileObject);
+        $csv = Writer::from(new SplTempFileObject);
         $csv->setOutputBOM(Bom::Utf8);
         $csv->setDelimiter($this->exporter::getCsvDelimiter());
         $csv->insertOne(array_values($this->columnMap));


### PR DESCRIPTION
Sentry giving me alerts on this deprecation

<img width="1582" height="502" alt="CleanShot 2025-10-28 at 12 31 52@2x" src="https://github.com/user-attachments/assets/cebbc039-9165-4183-961d-ff4b28f9eb06" />

<img width="1752" height="848" alt="CleanShot 2025-10-28 at 12 32 41@2x" src="https://github.com/user-attachments/assets/1933c0df-5330-4cac-8e95-5e583310c3ac" />
