### PR TITLE
Re-fix form field focusing

### DIFF
--- a/packages/schemas/resources/views/components/tabs/tab.blade.php
+++ b/packages/schemas/resources/views/components/tabs/tab.blade.php
@@ -21,7 +21,6 @@
                         'aria-labelledby' => $id,
                         'id' => $id,
                         'role' => 'tabpanel',
-                        'tabindex' => '0',
                         'wire:key' => $getLivewireKey() . '.container',
                     ], escape: false)
                     ->merge($getExtraAttributes(), escape: false)
@@ -38,7 +37,6 @@
                         'aria-labelledby' => $id,
                         'id' => $id,
                         'role' => 'tabpanel',
-                        'tabindex' => '0',
                         'wire:key' => $getLivewireKey() . '.container',
                     ], escape: false)
                     ->merge($getExtraAttributes(), escape: false)


### PR DESCRIPTION
v4 reintroduced this issue: https://github.com/filamentphp/filament/pull/18168

As before, removing `tabIndex` fixes the issue. 

Removing the tabindex in the second div is what solves the issues for relation managers. I'm not entirely sure where the first div comes into play so if you prefer I only remove it from the second I can put the first one back. 