### PR TITLE
Feature: use getSeparator instead of hardcoded comma when state of TextColumn is array

### DIFF
--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -251,7 +251,7 @@ class TextColumn extends Column implements HasEmbeddedView
         if (($stateCount > 1) && (! $isListWithLineBreaks) && (! $isBadge)) {
             $state = [
                 implode(
-                    ', ',
+                    $this->getSeparator() ?? ', ',
                     array_map(
                         fn (mixed $stateItem): string => $formatState($stateItem),
                         $state,


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

`TextColumn::separator()` method was ignored when the state of `TextColumn` is array:

```php
TextColumn::make('status')
    ->getStateUsing(fn (): array => [
        '1', '2', '3'
    ])
    ->separator(' | '),
```

This PR introduces usage of `getSeparator()` in `implode()` first argument, instead of hardcoded comma. Because `getSeparator()` can be null and `implode()` function does not handle null as a separator, the fallback to comma is introduced.

## Visual changes

Before:
<img width="120" height="123" alt="image" src="https://github.com/user-attachments/assets/df8435e5-74cc-42b2-bd3e-ee8ea9ec487f" />

After this PR:

<img width="123" height="123" alt="image" src="https://github.com/user-attachments/assets/253a8abb-429d-4798-b4a9-93fbfea585dc" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
