### PR TITLE
Refactor widget schema handling in Page.php

### DIFF
--- a/packages/panels/src/Pages/Dashboard.php
+++ b/packages/panels/src/Pages/Dashboard.php
@@ -89,6 +89,6 @@ class Dashboard extends Page
     public function getWidgetsContentComponent(): Component
     {
         return Grid::make($this->getColumns())
-            ->schema($this->getWidgetsSchemaComponents($this->getWidgets()));
+            ->schema(fn (): array => $this->getWidgetsSchemaComponents($this->getWidgets()));
     }
 }

--- a/packages/panels/src/Pages/Page.php
+++ b/packages/panels/src/Pages/Page.php
@@ -58,6 +58,16 @@ abstract class Page extends BasePage
 
     protected static bool $shouldRegisterNavigation = true;
 
+    /**
+     * @var array<Component | Action | ActionGroup>
+     */
+    protected array $cachedHeaderWidgetsSchemaComponents;
+
+    /**
+     * @var array<Component | Action | ActionGroup>
+     */
+    protected array $cachedFooterWidgetsSchemaComponents;
+
     protected string $view = 'filament-panels::pages.page';
 
     public function getLayout(): string
@@ -387,10 +397,10 @@ abstract class Page extends BasePage
             ->components([
                 RenderHook::make(PanelsRenderHook::PAGE_HEADER_WIDGETS_START),
                 Grid::make($this->getHeaderWidgetsColumns())
-                    ->schema(fn (): array => $this->getWidgetsSchemaComponents($this->getHeaderWidgets())),
+                    ->schema(fn (): array => $this->cachedHeaderWidgetsSchemaComponents ??= $this->getWidgetsSchemaComponents($this->getHeaderWidgets())),
                 RenderHook::make(PanelsRenderHook::PAGE_HEADER_WIDGETS_END),
             ])
-            ->hidden(fn (): bool => empty($this->getWidgetsSchemaComponents($this->getHeaderWidgets())));
+            ->hidden(fn (): bool => empty($this->cachedHeaderWidgetsSchemaComponents ??= $this->getWidgetsSchemaComponents($this->getHeaderWidgets())));
     }
 
     public function footerWidgets(Schema $schema): Schema
@@ -399,10 +409,10 @@ abstract class Page extends BasePage
             ->components([
                 RenderHook::make(PanelsRenderHook::PAGE_FOOTER_WIDGETS_START),
                 Grid::make($this->getFooterWidgetsColumns())
-                    ->schema(fn (): array => $this->getWidgetsSchemaComponents($this->getFooterWidgets())),
+                    ->schema(fn (): array => $this->cachedFooterWidgetsSchemaComponents ??= $this->getWidgetsSchemaComponents($this->getFooterWidgets())),
                 RenderHook::make(PanelsRenderHook::PAGE_FOOTER_WIDGETS_END),
             ])
-            ->hidden(fn (): bool => empty($this->getWidgetsSchemaComponents($this->getFooterWidgets())));
+            ->hidden(fn (): bool => empty($this->cachedFooterWidgetsSchemaComponents ??= $this->getWidgetsSchemaComponents($this->getFooterWidgets())));
     }
 
     public function getDefaultTestingSchemaName(): ?string

--- a/packages/panels/src/Pages/Page.php
+++ b/packages/panels/src/Pages/Page.php
@@ -387,10 +387,10 @@ abstract class Page extends BasePage
             ->components([
                 RenderHook::make(PanelsRenderHook::PAGE_HEADER_WIDGETS_START),
                 Grid::make($this->getHeaderWidgetsColumns())
-                    ->schema($widgets = $this->getWidgetsSchemaComponents($this->getHeaderWidgets())),
+                    ->schema(fn (): array => $this->getWidgetsSchemaComponents($this->getHeaderWidgets())),
                 RenderHook::make(PanelsRenderHook::PAGE_HEADER_WIDGETS_END),
             ])
-            ->hidden(empty($widgets));
+            ->hidden(fn (): bool => empty($this->getWidgetsSchemaComponents($this->getHeaderWidgets())));
     }
 
     public function footerWidgets(Schema $schema): Schema
@@ -399,10 +399,10 @@ abstract class Page extends BasePage
             ->components([
                 RenderHook::make(PanelsRenderHook::PAGE_FOOTER_WIDGETS_START),
                 Grid::make($this->getFooterWidgetsColumns())
-                    ->schema($widgets = $this->getWidgetsSchemaComponents($this->getFooterWidgets())),
+                    ->schema(fn (): array => $this->getWidgetsSchemaComponents($this->getFooterWidgets())),
                 RenderHook::make(PanelsRenderHook::PAGE_FOOTER_WIDGETS_END),
             ])
-            ->hidden(empty($widgets));
+            ->hidden(fn (): bool => empty($this->getWidgetsSchemaComponents($this->getFooterWidgets())));
     }
 
     public function getDefaultTestingSchemaName(): ?string


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When trying to access `$this->tableFilters` or other data in the `getHeaderWidgets()` method, it is a request behind. This fixes it.

## Visual changes

N/A

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
