### PR TITLE
[4.x] Remove wire:ignore from sub-navigation sidebar

### DIFF
--- a/packages/panels/resources/views/components/page/sub-navigation/sidebar.blade.php
+++ b/packages/panels/resources/views/components/page/sub-navigation/sidebar.blade.php
@@ -7,7 +7,7 @@
 >
     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_SUB_NAVIGATION_SIDEBAR_BEFORE, scopes: $this->getRenderHookScopes()) }}
 
-    <ul wire:ignore class="fi-page-sub-navigation-sidebar">
+    <ul class="fi-page-sub-navigation-sidebar">
         @foreach ($navigation as $navigationGroup)
             @php
                 $isNavigationGroupActive = $navigationGroup->isActive();

--- a/packages/panels/resources/views/components/page/sub-navigation/tabs.blade.php
+++ b/packages/panels/resources/views/components/page/sub-navigation/tabs.blade.php
@@ -3,11 +3,7 @@
 ])
 
 <x-filament::tabs
-    wire:ignore
-    :attributes="
-        \Filament\Support\prepare_inherited_attributes($attributes)
-            ->class(['fi-page-sub-navigation-tabs'])
-    "
+    :attributes="\Filament\Support\prepare_inherited_attributes($attributes)->class(['fi-page-sub-navigation-tabs'])"
 >
     @foreach ($navigation as $navigationGroup)
         @php


### PR DESCRIPTION
## Description
The `wire:ignore` attribute on the sub-navigation sidebar `<ul>` element prevents Livewire from updating the sidebar content when dispatching `$refresh` or other reactive updates. This blocks legitimate use cases where sidebar content needs to update dynamically based on page changes.

The `wire:ignore` was likely added for performance optimization and to prevent potential Alpine/Livewire conflicts. However, it prevents legitimate use cases where sidebar content needs to update dynamically. Given Filament's reactive nature and developers' frequent use of dynamic updates throughout their applications, I think the sidebar should support this pattern as well.

Since the collapse state is managed by Alpine's `$persist()` in the sidebar store (localStorage), removing `wire:ignore` doesn't break existing functionality while enabling reactive content updates.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
