### PR TITLE
Improve visual separation of select optgroup headers

### DIFF
--- a/packages/support/resources/css/components/input/select.css
+++ b/packages/support/resources/css/components/input/select.css
@@ -69,6 +69,10 @@ select.fi-select-input {
 
     & .fi-select-input-option-group {
         @apply divide-y divide-gray-100 dark:divide-white/5;
+
+        & .fi-dropdown-header {
+            @apply font-semibold text-gray-400 dark:text-gray-500;
+        }
     }
 
     & .fi-select-input-search-ctn {

--- a/packages/support/resources/css/components/input/select.css
+++ b/packages/support/resources/css/components/input/select.css
@@ -71,7 +71,7 @@ select.fi-select-input {
         @apply divide-y divide-gray-100 dark:divide-white/5;
 
         & .fi-dropdown-header {
-            @apply font-semibold text-gray-400 dark:text-gray-500;
+            @apply font-medium text-gray-500 dark:text-gray-400;
         }
     }
 


### PR DESCRIPTION
## Description

When using optgroups with selects the headers look too much like clickable options causing confusion for users. This PR uses darker text to indicate they are not clickabled, but also semibold to indicate it's not just a disabled option.

`.fi-dropdown-header` was targeted from the select.css class instead of directly in`header.css` because `.fi-dropdown-header` is also used for the dropdown blade component and those styles shouldn't be affected.

## Visual changes

<img width="437" height="207" alt="Screenshot 2025-10-31 at 12 27 19 PM" src="https://github.com/user-attachments/assets/d028c192-79b3-4980-b409-e00c866322dc" />

<img width="446" height="208" alt="Screenshot 2025-10-31 at 12 26 51 PM" src="https://github.com/user-attachments/assets/b542941f-dbe9-4d23-bc4b-993818bdf641" />

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
