### PR TITLE
Add css class to read notifications

### DIFF
--- a/packages/notifications/resources/views/database-notifications.blade.php
+++ b/packages/notifications/resources/views/database-notifications.blade.php
@@ -75,6 +75,7 @@
             @foreach ($notifications as $notification)
                 <div
                     @class([
+                        'fi-no-notification-read-ctn' => ! $notification->unread(),
                         'fi-no-notification-unread-ctn' => $notification->unread(),
                     ])
                 >


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Without jumping through hoops, it's not easily possible to style read database notifications against unread notifications. This adds a simple class to differentiate between them.

## Visual changes
BEFORE: 
<img width="590" height="238" alt="Screenshot 2025-11-01 at 12 46 10" src="https://github.com/user-attachments/assets/762ec450-0aa0-4be4-8c5a-ed6463e4f318" />

AFTER:
<img width="576" height="243" alt="Screenshot 2025-11-01 at 12 45 36" src="https://github.com/user-attachments/assets/c1ef1e1a-e96d-400d-9d8c-0a333971c038" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
