### PR TITLE
Dont show colum manager for blank columns without column groups

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanBeToggled.php
+++ b/packages/tables/src/Columns/Concerns/CanBeToggled.php
@@ -3,6 +3,7 @@
 namespace Filament\Tables\Columns\Concerns;
 
 use Closure;
+use Filament\Tables\Columns\ColumnGroup;
 
 trait CanBeToggled
 {
@@ -38,7 +39,7 @@ trait CanBeToggled
 
         // When a column label is blank, it must be toggleable so that
         // column groups can be collectively toggled on/off.
-        if (blank($this->getLabel())) {
+        if ($this->getGroup() instanceof ColumnGroup && blank($this->getLabel())) {
             return true;
         }
 


### PR DESCRIPTION
Background: When column lables are blank and inside a column group, `isToggleable()` needs to evaluate to true for that column so that, even though the label is hidden in the manager, when the column group is toggled off the column is toggled off as well. 

However, the unintended side effect of this was columns that weren't in a group that had a blank label would show the column manager toggle button  even if no columns were actually toggleable. 

This PR ensures that the blank condition only applies to columns that are part of a group.