### PR TITLE
Allow pragmarx/google2fa ^9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "phiki/phiki": "^2.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^2.1",
-        "pragmarx/google2fa": "^8.0",
+        "pragmarx/google2fa": "^8.0|^9.0",
         "pragmarx/google2fa-qrcode": "^3.0",
         "rector/rector": "^2.0",
         "spatie/laravel-medialibrary": "^11.0",


### PR DESCRIPTION
Reference:

https://github.com/antonioribeiro/google2fa/releases/tag/v9.0.0