### PR TITLE
Vasi rus/failsafe for getting notification on null

### DIFF
--- a/packages/notifications/src/Livewire/DatabaseNotifications.php
+++ b/packages/notifications/src/Livewire/DatabaseNotifications.php
@@ -89,8 +89,14 @@ class DatabaseNotifications extends Component implements HasActions, HasSchemas
 
     public function getNotificationsQuery(): Builder | Relation
     {
-        /** @phpstan-ignore-next-line */
-        return $this->getUser()->notifications()->where('data->format', 'filament');
+        $user = $this->getUser();
+
+        if (!$user) {
+            // Return an empty builder to satisfy the return type
+            return DatabaseNotification::query()->limit(0);
+        }
+
+        return $user->notifications()->where('data->format', 'filament');
     }
 
     public function getUnreadNotificationsQuery(): Builder | Relation

--- a/packages/notifications/src/Livewire/DatabaseNotifications.php
+++ b/packages/notifications/src/Livewire/DatabaseNotifications.php
@@ -91,9 +91,8 @@ class DatabaseNotifications extends Component implements HasActions, HasSchemas
     {
         $user = $this->getUser();
 
-        if (!$user) {
-            /** @phpstan-ignore-next-line */
-            return DatabaseNotification::query()->limit(0);
+        if (! $user) {
+            abort(401);
         }
 
         /** @phpstan-ignore-next-line */

--- a/packages/notifications/src/Livewire/DatabaseNotifications.php
+++ b/packages/notifications/src/Livewire/DatabaseNotifications.php
@@ -93,9 +93,11 @@ class DatabaseNotifications extends Component implements HasActions, HasSchemas
 
         if (!$user) {
             // Return an empty builder to satisfy the return type
+            /** @phpstan-ignore-next-line */
             return DatabaseNotification::query()->limit(0);
         }
 
+        /** @phpstan-ignore-next-line */
         return $user->notifications()->where('data->format', 'filament');
     }
 

--- a/packages/notifications/src/Livewire/DatabaseNotifications.php
+++ b/packages/notifications/src/Livewire/DatabaseNotifications.php
@@ -92,7 +92,6 @@ class DatabaseNotifications extends Component implements HasActions, HasSchemas
         $user = $this->getUser();
 
         if (!$user) {
-            // Return an empty builder to satisfy the return type
             /** @phpstan-ignore-next-line */
             return DatabaseNotification::query()->limit(0);
         }


### PR DESCRIPTION
## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

This typically occurs:
• On pages or components that attempt to fetch user notifications, such as the Filament notification dropdown or database notification query, before a user is authenticated.
• In background jobs or console commands that run outside a user context.
• When using a custom auth setup (e.g., multiple guards) and the expected user guard isn’t active.

💡 Root Cause

The code assumes that Filament::auth()->user() always returns a valid user model.
However, when null is returned, calling $user->notifications() immediately throws a fatal error.

<img width="823" height="336" alt="image" src="https://github.com/user-attachments/assets/1f856ad6-6688-45df-bbe9-b36b6a5bd0f2" />

## Functional changes

- [ ] The issue was fixxed by addding a check for user instance.
- [ ] Changes have been tested to not break existing functionality.
