### PR TITLE
Add abbreviate() method for number formatting 

### DIFF
--- a/packages/infolists/docs/02-text-entry.md
+++ b/packages/infolists/docs/02-text-entry.md
@@ -316,6 +316,28 @@ TextEntry::make('stock')
 
 <UtilityInjection set="infolistEntries" version="4.x">As well as allowing static values, the `locale` argument also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
+### Number abbreviation
+
+Instead of passing a function to `formatStateUsing()`, you can use the `abbreviate()` method to format the number in a human-readable way with abbreviated units:
+
+```php
+use Filament\Infolists\Components\TextEntry;
+
+TextEntry::make('views')
+    ->abbreviate()
+```
+
+By default, the abbreviation uses one decimal place. You can customize the number of decimal places by passing an integer to the `precision` argument:
+
+```php
+use Filament\Infolists\Components\TextEntry;
+
+TextEntry::make('views')
+    ->abbreviate(precision: 2)
+```
+
+<UtilityInjection set="infolistEntries" version="4.x">As well as allowing static values, the `precision` argument also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+
 ### Money formatting
 
 Instead of passing a function to `formatStateUsing()`, you can use the `money()` method to easily format amounts of money, in any currency:

--- a/packages/infolists/src/Components/Concerns/CanFormatState.php
+++ b/packages/infolists/src/Components/Concerns/CanFormatState.php
@@ -286,6 +286,27 @@ trait CanFormatState
         return $this;
     }
 
+    public function abbreviate(int | Closure $precision = 0): static
+    {
+        $this->isNumeric = true;
+
+        $this->formatStateUsing(static function (TextEntry $component, $state) use ($precision): ?string {
+            if (blank($state)) {
+                return null;
+            }
+
+            if (! is_numeric($state)) {
+                return $state;
+            }
+
+            $precision = $component->evaluate($precision);
+
+            return Number::abbreviate($state, $precision);
+        });
+
+        return $this;
+    }
+
     public function time(string | Closure | null $format = null, string | Closure | null $timezone = null): static
     {
         $this->isTime = true;

--- a/packages/tables/docs/02-columns/02-text.md
+++ b/packages/tables/docs/02-columns/02-text.md
@@ -316,6 +316,28 @@ TextColumn::make('stock')
 
 <UtilityInjection set="tableColumns" version="4.x">As well as allowing static values, the `locale` argument also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
+### Number abbreviation
+
+Instead of passing a function to `formatStateUsing()`, you can use the `abbreviate()` method to format the number in a human-readable way with abbreviated units:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('views')
+    ->abbreviate()
+```
+
+By default, the abbreviation uses one decimal place. You can customize the number of decimal places by passing an integer to the `precision` argument:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('views')
+    ->abbreviate(precision: 2)
+```
+
+<UtilityInjection set="tableColumns" version="4.x">As well as allowing static values, the `precision` argument also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+
 ### Money formatting
 
 Instead of passing a function to `formatStateUsing()`, you can use the `money()` method to easily format amounts of money, in any currency:

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -286,6 +286,27 @@ trait CanFormatState
         return $this;
     }
 
+    public function abbreviate(int | Closure $precision = 0): static
+    {
+        $this->isNumeric = true;
+
+        $this->formatStateUsing(static function (TextColumn $column, $state) use ($precision): ?string {
+            if (blank($state)) {
+                return null;
+            }
+
+            if (! is_numeric($state)) {
+                return $state;
+            }
+
+            $precision = $column->evaluate($precision);
+
+            return Number::abbreviate($state, $precision);
+        });
+
+        return $this;
+    }
+
     public function time(string | Closure | null $format = null, string | Closure | null $timezone = null): static
     {
         $this->isTime = true;


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR introduces a new `abbreviate()` method for [TextColumn](https://filamentphp.com/docs/4.x/tables/columns/text) and [TextEntry](https://filamentphp.com/docs/4.x/infolists/text-entry), allowing numerical values to be displayed in a human-readable, abbreviated format (_e.g. 1.2K, 3.5M_).

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
