### PR TITLE
Fix column manager polling and reordering

### DIFF
--- a/packages/tables/src/Concerns/HasColumnManager.php
+++ b/packages/tables/src/Concerns/HasColumnManager.php
@@ -69,13 +69,13 @@ trait HasColumnManager
     /**
      * @param  array<int, array{type: string, name: string, label: string, isHidden: bool, isToggled: bool, isToggleable: bool, isToggledHiddenByDefault: ?bool, columns?: array<int, array{type: string, name: string, label: string, isHidden: bool, isToggled: bool, isToggleable: bool, isToggledHiddenByDefault: ?bool}>}>|null  $state
      */
-    public function applyTableColumnManager(?array $state = null): void
+    public function applyTableColumnManager(?array $state = null, bool $wasReordered = false): void
     {
         if (filled($state)) {
             $this->tableColumns = $state;
 
             if ($this->hasReorderableTableColumns()) {
-                $this->persistHasReorderedTableColumns();
+                $this->persistHasReorderedTableColumns($wasReordered);
             }
         }
 
@@ -158,11 +158,11 @@ trait HasColumnManager
         );
     }
 
-    protected function persistHasReorderedTableColumns(): void
+    protected function persistHasReorderedTableColumns(bool $wasReordered = false): void
     {
         session()->put(
             $this->getHasReorderedTableColumnsSessionKey(),
-            $this->hasReorderedTableColumns()
+            $wasReordered || $this->hasReorderedTableColumns()
         );
     }
 


### PR DESCRIPTION
Fixes #18328 

I also noticed while fixing polling that reordering a column back to it's original location would not work as expected. This is due to the `hasReorderedTableColumns()` method returning false since the state is the same which is then persisted in the session to avoid calling the heavier `syncReorderableColumnsFromDefaultTableColumnState()`. 

However, when manually reordering columns `hasReorderedTableColumns` needs to be forced to return true so that when reordering back to the original order it is correctly applied.