### PR TITLE
Support enums in exports

### DIFF
--- a/packages/actions/src/Exports/Concerns/CanFormatState.php
+++ b/packages/actions/src/Exports/Concerns/CanFormatState.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Actions\Exports\Concerns;
 
+use BackedEnum;
 use Closure;
 use Illuminate\Support\Str;
 
@@ -65,6 +66,10 @@ trait CanFormatState
         $state = $this->evaluate($this->formatStateUsing ?? $state, [
             'state' => $state,
         ]);
+
+        if ($state instanceof BackedEnum) {
+            $state = $state->value;
+        }
 
         if ($characterLimit = $this->getCharacterLimit()) {
             $state = Str::limit($state, $characterLimit, $this->getCharacterLimitEnd());


### PR DESCRIPTION
If an attribute is cast to an enum and then used in a table, exporting that table thrrows a `Filament\Actions\Exports\ExportColumn::getFormattedState(): Return value must be of type ?string, App\Enums\OrderStatus returned`

This adds support for enums by returing the value which can then continue to be formatted by other methods like `->limit()`.

If you thought it would be worth it, I could also include before the enum check:

```php
if ($state instanceof HasLabel) {
    $state = $state->getLabel();
}
```