### PR TITLE
[4.x] Support enum cases in validation rule parameters

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -1005,9 +1005,15 @@ trait CanBeValidated
             }
 
             if (is_array($stateValues)) {
+                $stateValues = array_map(
+                    static fn ($value) => $value instanceof BackedEnum ? $value->value : $value,
+                    $stateValues
+                );
                 $stateValues = implode(',', $stateValues);
             } elseif (is_bool($stateValues)) {
                 $stateValues = $stateValues ? 'true' : 'false';
+            } elseif ($stateValues instanceof BackedEnum) {
+                $stateValues = $stateValues->value;
             }
 
             return "{$rule}:{$statePath},{$stateValues}";

--- a/tests/src/Forms/ValidationTest.php
+++ b/tests/src/Forms/ValidationTest.php
@@ -983,7 +983,7 @@ test('conditional validation rules support enum instances', function (string $ru
     ['requiredIf', IntegerBackedEnum::One, [IntegerBackedEnum::One, IntegerBackedEnum::Two]],
 ]);
 
-test('in/notIn validation rules support enum instances', function (string $rule, string $value): void {
+test('in/notIn validation rules support enum instances', function (string $rule, BackedEnum $value): void {
     $rules = [];
 
     try {
@@ -1000,6 +1000,6 @@ test('in/notIn validation rules support enum instances', function (string $rule,
 
     expect($rules)->not->toBeEmpty();
 })->with([
-    ['notIn', 'one'],
-    ['in', 'three'],
+    ['notIn', StringBackedEnum::One],
+    ['in', StringBackedEnum::Three],
 ]);

--- a/tests/src/Forms/ValidationTest.php
+++ b/tests/src/Forms/ValidationTest.php
@@ -2,6 +2,8 @@
 
 use Filament\Forms\Components\Field;
 use Filament\Schemas\Schema;
+use Filament\Tests\Fixtures\Enums\IntegerBackedEnum;
+use Filament\Tests\Fixtures\Enums\StringBackedEnum;
 use Filament\Tests\Fixtures\Livewire\Livewire;
 use Filament\Tests\TestCase;
 use Illuminate\Contracts\Support\Arrayable;
@@ -952,3 +954,52 @@ test('the `doesntEndWith()` rule can be conditionally validated', function (): v
     expect($fails)
         ->toBeEmpty();
 });
+
+test('conditional validation rules support enum instances', function (string $rule, BackedEnum $defaultValue, BackedEnum | array $enumValue): void {
+    $rules = [];
+
+    try {
+        Schema::make(Livewire::make())
+            ->statePath('data')
+            ->components([
+                (new Field('status'))
+                    ->default($defaultValue),
+                $field = (new Field('description'))
+                    ->{$rule}('status', $enumValue),
+            ])
+            ->fill()
+            ->validate();
+    } catch (ValidationException $exception) {
+        $rules = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    expect($rules)->not->toBeEmpty();
+})->with([
+    ['requiredIf', StringBackedEnum::One, StringBackedEnum::One],
+    ['requiredIf', StringBackedEnum::One, [StringBackedEnum::One, StringBackedEnum::Two]],
+    ['requiredUnless', StringBackedEnum::Two, StringBackedEnum::One],
+    ['requiredUnless', StringBackedEnum::Three, [StringBackedEnum::One, StringBackedEnum::Two]],
+    ['requiredIf', IntegerBackedEnum::One, IntegerBackedEnum::One],
+    ['requiredIf', IntegerBackedEnum::One, [IntegerBackedEnum::One, IntegerBackedEnum::Two]],
+]);
+
+test('in/notIn validation rules support enum instances', function (string $rule, string $value): void {
+    $rules = [];
+
+    try {
+        Schema::make(Livewire::make()->data(['status' => $value]))
+            ->statePath('data')
+            ->components([
+                $field = (new Field('status'))
+                    ->{$rule}([StringBackedEnum::One, StringBackedEnum::Two]),
+            ])
+            ->validate();
+    } catch (ValidationException $exception) {
+        $rules = array_keys($exception->validator->failed()[$field->getStatePath()]);
+    }
+
+    expect($rules)->not->toBeEmpty();
+})->with([
+    ['notIn', 'one'],
+    ['in', 'three'],
+]);


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Added support for `BackedEnum` cases in validation rule parameters, following the same convention as `$get()` and field defaults which already support enum cases. This ensures consistency across the API.

**Before:**
```php
->requiredIf('status', Status::Active->value)
->requiredIf('role', [Role::Admin->value, Role::Editor->value])
```

**After:**
```php
->requiredIf('status', Status::Active)
->requiredIf('role', [Role::Admin, Role::Editor])
```

This works with both string-backed and integer-backed enums for the following methods:
- requiredIf() / requiredUnless()
- prohibitedIf() / prohibitedUnless()
- in() / notIn() (This is already handled fine by Laravel's Rule class)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
