### PR TITLE
Update query column references for table context

### DIFF
--- a/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
@@ -94,10 +94,14 @@ trait InteractsWithTableQuery
                         "%{$nonTranslatableSearch}%",
                     ),
                     fn (EloquentBuilder $query) => $query->{$whereClause}(
-                        generate_search_column_expression((string) str($searchColumn)->replace('.', '->'), $isSearchForcedCaseInsensitive, $databaseConnection),
+                        generate_search_column_expression(
+                            $query->getModel()->getTable() . '.' . (string) str($searchColumn)->replace('.', '->'),
+                            $isSearchForcedCaseInsensitive,
+                            $databaseConnection
+                        ),
                         'like',
                         "%{$nonTranslatableSearch}%",
-                    ),
+                  ),
                 ),
             );
 
@@ -129,7 +133,7 @@ trait InteractsWithTableQuery
                 continue;
             }
 
-            $query->orderBy($sortColumn, $direction);
+            $query->orderBy($query->getModel()->getTable() . '.' . $sortColumn, $direction);
         }
 
         return $query;


### PR DESCRIPTION
## Description

We encountered a bug where if you search in a table, and then you try to sort a column that has another column with the same name (like 'name' and 'property.name'), you will get an exception. This ensures we are prepending the table name for the query.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
