### PR TITLE
Fix stat widget height

### DIFF
--- a/packages/widgets/resources/css/stats-overview-widget.css
+++ b/packages/widgets/resources/css/stats-overview-widget.css
@@ -1,5 +1,5 @@
 .fi-wi-stats-overview-stat {
-    @apply relative block rounded-xl bg-white p-6 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10;
+    @apply relative block h-full rounded-xl bg-white p-6 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10;
 
     & .fi-icon {
         @apply shrink-0 text-gray-400 dark:text-gray-500;


### PR DESCRIPTION
Fixes stat heights when some use descriptions and others do not:

Before
<img width="1023" height="180" alt="Screenshot 2025-11-07 at 2 36 37 PM" src="https://github.com/user-attachments/assets/395e5d09-d7d0-4193-a0d3-3d1b425ae390" />

After
<img width="1030" height="193" alt="Screenshot 2025-11-07 at 2 36 31 PM" src="https://github.com/user-attachments/assets/dbe8dcfc-c110-4fe3-aa00-595ef4984166" />
