### PR TITLE
Add getOptionDescriptionFromRecordUsing() to CheckboxList

### DIFF
--- a/packages/forms/docs/06-checkbox-list.md
+++ b/packages/forms/docs/06-checkbox-list.md
@@ -270,10 +270,10 @@ CheckboxList::make('technologies')
 
 <Aside variant="warning">
     When using `disabled()` with `relationship()`, ensure that `disabled()` is called before `relationship()`. This ensures that the `dehydrated()` call from within `relationship()` is not overridden by the call from `disabled()`:
-    
+
     ```php
     use Filament\Forms\Components\CheckboxList;
-    
+
     CheckboxList::make('technologies')
         ->disabled()
         ->relationship(titleAttribute: 'name')
@@ -327,6 +327,25 @@ CheckboxList::make('authors')
 ```
 
 <UtilityInjection set="formFields" version="4.x" extras="Eloquent record;;Illuminate\Database\Eloquent\Model;;$record;;The Eloquent record to get the option label for.">The `getOptionLabelFromRecordUsing()` method can inject various utilities into the function as parameters.</UtilityInjection>
+
+### Customizing the relationship option descriptions
+
+If you'd like to customize the description of each option, you can use the `getOptionDescriptionFromRecordUsing()` method to transform an option's Eloquent model into a description:
+
+```php
+use Filament\Forms\Components\CheckboxList;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+CheckboxList::make('authors')
+    ->relationship(
+        modifyQueryUsing: fn (Builder $query) => $query->orderBy('first_name')->orderBy('last_name'),
+    )
+    ->getOptionDescriptionFromRecordUsing(fn (Model $record) => $record->notes)
+```
+
+<UtilityInjection set="formFields" version="4.x" extras="Eloquent record;;Illuminate\Database\Eloquent\Model;;$record;;The Eloquent record to get the option description for.">The `getOptionDescriptionFromRecordUsing()` method can inject various utilities into the function as parameters.</UtilityInjection>
+
 
 ### Saving pivot data to the relationship
 

--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -43,6 +43,8 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
 
     protected ?Closure $getOptionLabelFromRecordUsing = null;
 
+    protected ?Closure $getOptionDescriptionFromRecordUsing = null;
+
     protected string | Closure | null $relationship = null;
 
     protected bool | Closure $isBulkToggleable = false;

--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -141,24 +141,24 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
 
             if ($component->hasOptionLabelFromRecordUsingCallback() || $component->hasOptionDescriptionFromRecordUsingCallback()) {
                 $records = $relationshipQuery->get();
-            }
 
-            if ($component->hasOptionDescriptionFromRecordUsingCallback()) {
-                $descriptions = $records
-                    ->mapWithKeys(static fn (Model $record) => [
-                        $record->{Str::afterLast($relationship->getQualifiedRelatedKeyName(), '.')} => $component->getOptionDescriptionFromRecord($record),
-                    ])
-                    ->toArray();
+                if ($component->hasOptionDescriptionFromRecordUsingCallback()) {
+                    $descriptions = $records
+                        ->mapWithKeys(static fn (Model $record) => [
+                            $record->{Str::afterLast($relationship->getQualifiedRelatedKeyName(), '.')} => $component->getOptionDescriptionFromRecord($record),
+                        ])
+                        ->toArray();
 
-                $component->descriptions($descriptions);
-            }
+                    $component->descriptions($descriptions);
+                }
 
-            if ($component->hasOptionLabelFromRecordUsingCallback()) {
-                return $records
-                    ->mapWithKeys(static fn (Model $record) => [
-                        $record->{Str::afterLast($relationship->getQualifiedRelatedKeyName(), '.')} => $component->getOptionLabelFromRecord($record),
-                    ])
-                    ->toArray();
+                if ($component->hasOptionLabelFromRecordUsingCallback()) {
+                    return $records
+                        ->mapWithKeys(static fn (Model $record) => [
+                            $record->{Str::afterLast($relationship->getQualifiedRelatedKeyName(), '.')} => $component->getOptionLabelFromRecord($record),
+                        ])
+                        ->toArray();
+                }
             }
 
             $relationshipTitleAttribute = $component->getRelationshipTitleAttribute();

--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -139,9 +139,22 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
                 ]) ?? $relationshipQuery;
             }
 
+            if ($component->hasOptionLabelFromRecordUsingCallback() || $component->hasOptionDescriptionFromRecordUsingCallback()) {
+                $records = $relationshipQuery->get();
+            }
+
+            if ($component->hasOptionDescriptionFromRecordUsingCallback()) {
+                $descriptions = $records
+                    ->mapWithKeys(static fn (Model $record) => [
+                        $record->{Str::afterLast($relationship->getQualifiedRelatedKeyName(), '.')} => $component->getOptionDescriptionFromRecord($record),
+                    ])
+                    ->toArray();
+
+                $component->descriptions($descriptions);
+            }
+
             if ($component->hasOptionLabelFromRecordUsingCallback()) {
-                return $relationshipQuery
-                    ->get()
+                return $records
                     ->mapWithKeys(static fn (Model $record) => [
                         $record->{Str::afterLast($relationship->getQualifiedRelatedKeyName(), '.')} => $component->getOptionLabelFromRecord($record),
                     ])

--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -270,6 +270,32 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
         );
     }
 
+    public function getOptionDescriptionFromRecordUsing(?Closure $callback): static
+    {
+        $this->getOptionDescriptionFromRecordUsing = $callback;
+
+        return $this;
+    }
+
+    public function hasOptionDescriptionFromRecordUsingCallback(): bool
+    {
+        return $this->getOptionDescriptionFromRecordUsing !== null;
+    }
+
+    public function getOptionDescriptionFromRecord(Model $record): string | Htmlable
+    {
+        return $this->evaluate(
+            $this->getOptionDescriptionFromRecordUsing,
+            namedInjections: [
+                'record' => $record,
+            ],
+            typedInjections: [
+                Model::class => $record,
+                $record::class => $record,
+            ],
+        );
+    }
+
     public function getRelationshipTitleAttribute(): ?string
     {
         return $this->evaluate($this->relationshipTitleAttribute);


### PR DESCRIPTION
## Description

Currently it is only possible to modify a records label using `getOptionLabelFromRecordUsing()`. I propose adding a `getOptionDescriptionFromRecordUsing()` to also be able to set a records description from an option’s Eloquent model.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
