### PR TITLE
Ensure true mime type is passed as a header by default

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -140,7 +140,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             $filename = $component->getUploadedFileNameForStorage($file);
 
             $media = $mediaAdder
-                ->addCustomHeaders($component->getCustomHeaders())
+                ->addCustomHeaders([...['ContentType' => $file->getMimeType()], ...$component->getCustomHeaders()])
                 ->usingFileName($filename)
                 ->usingName($component->getMediaName($file) ?? pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME))
                 ->storingConversionsOnDisk($component->getConversionsDisk() ?? '')

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -140,7 +140,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             $filename = $component->getUploadedFileNameForStorage($file);
 
             $media = $mediaAdder
-                ->addCustomHeaders([...['ContentType' => $file->getMimeType()], ...$component->getCustomHeaders()])
+                ->addCustomHeaders([...['Content-Type' => $file->getMimeType()], ...$component->getCustomHeaders()])
                 ->usingFileName($filename)
                 ->usingName($component->getMediaName($file) ?? pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME))
                 ->storingConversionsOnDisk($component->getConversionsDisk() ?? '')

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -140,7 +140,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             $filename = $component->getUploadedFileNameForStorage($file);
 
             $media = $mediaAdder
-                ->addCustomHeaders([...['Content-Type' => $file->getMimeType()], ...$component->getCustomHeaders()])
+                ->addCustomHeaders([...['ContentType' => $file->getMimeType()], ...$component->getCustomHeaders()])
                 ->usingFileName($filename)
                 ->usingName($component->getMediaName($file) ?? pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME))
                 ->storingConversionsOnDisk($component->getConversionsDisk() ?? '')


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

I have recently discovered an issue where content that has first been downloaded as a stream, such as pdf's, png's, jpg's etc. do not keep their true mime type as the 'Content-Type' header is missing/incorrect. 

Example: 
- I have a pdf file with the mime type `application/pdf`
- I would expect upon upload that this mime type persists with this correct Content-Type header
- Instead the mime type is uploaded as `application/octet-stream` 

This means that after uploading such a file, the content is always streamed because of the way the file was retrieved the first time, which isn't expected behaviour. 

What I would expect: 
- The pdf file has the correct mime type `application/pdf`
- The upload is persisted with this same mime type by setting the correct header
- The file opens in the browser and doesn't download directly to one's device

This PR alleviates that issue by first passing in the correct mime type as a header, but can always be overwritten by the user e.g. 

```php
SpatieMediaLibraryFileUpload::make('attachments')
    ->multiple()
    ->customHeaders(['Content-Type' => 'application/octet-stream'])
```

Example file you can try this with is attached here:
[invoice_123_08_11_2025_test.pdf](https://github.com/user-attachments/files/23431904/invoice_123_08_11_2025_test.pdf)

Upload this file to the latest release of this package. Notice the mime_type in the database is `application/octet-stream`. 

Now install my changes. See the mime_type is correctly `application/pdf`.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
