### PR TITLE
[v4 Docs] Replace 'size' with 'iconSize' in icon-button examples

### DIFF
--- a/docs/12-components/03-icon-button.md
+++ b/docs/12-components/03-icon-button.md
@@ -34,25 +34,25 @@ By default, the size of an icon button is "medium". You can make it "extra small
 ```blade
 <x-filament::icon-button
     icon="heroicon-m-plus"
-    size="xs"
+    iconSize="xs"
     label="New label"
 />
 
 <x-filament::icon-button
     icon="heroicon-m-plus"
-    size="sm"
+    iconSize="sm"
     label="New label"
 />
 
 <x-filament::icon-button
     icon="heroicon-s-plus"
-    size="lg"
+    iconSize="lg"
     label="New label"
 />
 
 <x-filament::icon-button
     icon="heroicon-s-plus"
-    size="xl"
+    iconSize="xl"
     label="New label"
 />
 ```

--- a/docs/12-components/03-icon-button.md
+++ b/docs/12-components/03-icon-button.md
@@ -29,7 +29,7 @@ By default, an icon button's underlying HTML tag is `<button>`. You can change i
 
 ## Setting the size of an icon button
 
-By default, the size of an icon button is "medium". You can make it "extra small", "small", "large" or "extra large" by using the `size` attribute:
+By default, the size of an icon button is "medium". You can make it "extra small", "small", "large" or "extra large" by using the `iconSize` attribute:
 
 ```blade
 <x-filament::icon-button


### PR DESCRIPTION
## Description
Documentation changes only!

size is not used in icon buttons... so to change the actual size of the icon button you need to set iconSize

## Functional changes

- [x] Documentation is up-to-date.
