### PR TITLE
Add early returns to methods with `ExposedLivewireMethod` in `BaseFileUpload`

### DIFF
--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -649,6 +649,14 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
     #[Renderless]
     public function removeUploadedFile(string $fileKey): string | TemporaryUploadedFile | null
     {
+        if ($this->isDisabled()) {
+            return null;
+        }
+
+        if (! $this->isDeletable()) {
+            return null;
+        }
+
         $files = $this->getRawState();
         $file = $files[$fileKey] ?? null;
 
@@ -704,7 +712,11 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
     #[Renderless]
     public function reorderUploadedFiles(array $fileKeys): void
     {
-        if (! $this->isReorderable) {
+        if ($this->isDisabled()) {
+            return;
+        }
+
+        if (! $this->isReorderable()) {
             return;
         }
 


### PR DESCRIPTION
## Description
This PR adds extra early returns to methods with `ExposedLivewireMethod` attribute in `BaseFileUpload`. Because these methods can be called from Livewire, it was possible to remove an uploaded file when the file upload component was `->deletable(false)` and save the state.

The absence of a `->isDisabled()` checks didn't have the same implications, I just added them for consistency and so that `callAfterStateUpdated` wouldn't get called.

I looked through other usages of `ExposedLivewireMethod` in other classes and there shouldn't be a similiar problem.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
