### PR TITLE
[v4 Docs] Update namespace for schema Overview first Example. 

### DIFF
--- a/packages/schemas/docs/01-overview.md
+++ b/packages/schemas/docs/01-overview.md
@@ -90,6 +90,7 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Grid;
 
 $schema
     ->components([

--- a/packages/schemas/docs/01-overview.md
+++ b/packages/schemas/docs/01-overview.md
@@ -89,8 +89,8 @@ use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Infolists\Components\TextEntry;
-use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Section;
 
 $schema
     ->components([


### PR DESCRIPTION
Going by the documentation example used, the Grid namespace was not imported. So this update, addresses that.



## Description

Going by the documentation example used, the `Grid` namespace was not imported. So this doc update updates the namespace import.

## Visual changes

Before:
<img width="1073" height="393" alt="Screenshot 2025-11-10 at 12 08 25" src="https://github.com/user-attachments/assets/4454f632-0a31-452f-8b77-1e23fc78bdae" />

After:
<img width="1043" height="441" alt="Screenshot 2025-11-10 at 12 08 55" src="https://github.com/user-attachments/assets/cf7dcde3-6db8-412e-b801-138012941811" />



## Functional changes

- [x] Documentation is up-to-date.
