### PR TITLE
feat: Add selectAllActionLabel & deselectAllActionLabel methods to CheckboxList component

### DIFF
--- a/packages/forms/docs/06-checkbox-list.md
+++ b/packages/forms/docs/06-checkbox-list.md
@@ -417,4 +417,8 @@ CheckboxList::make('technologies')
     )
 ```
 
+<Aside variant="tip">
+    To customize the bulk toggling button labels, the `selectAllActionLabel()` and `deselectAllActionLabel()` methods can be used instead of passing a function to `selectAllAction()` and `deselectAllAction()`, if you don't require any further customizations.
+</Aside>
+
 <UtilityInjection set="formFields" version="4.x" extras="Action;;Filament\Actions\Action;;$action;;The action object to customize.">The action registration methods can inject various utilities into the function as parameters.</UtilityInjection>

--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -51,6 +51,10 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
 
     protected ?Closure $modifyDeselectAllActionUsing = null;
 
+    protected string | Closure | null $selectAllActionLabel = null;
+
+    protected string | Closure | null $deselectAllActionLabel = null;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -63,10 +67,24 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
         ]);
     }
 
+    public function selectAllActionLabel(string | Closure | null $label = null): static
+    {
+        $this->selectAllActionLabel = $label;
+
+        return $this;
+    }
+
+    public function deselectAllActionLabel(string | Closure | null $label = null): static
+    {
+        $this->deselectAllActionLabel = $label;
+
+        return $this;
+    }
+
     public function getSelectAllAction(): Action
     {
         $action = Action::make($this->getSelectAllActionName())
-            ->label(__('filament-forms::components.checkbox_list.actions.select_all.label'))
+            ->label($this->getSelectAllActionLabel())
             ->livewireClickHandlerEnabled(false)
             ->link()
             ->size(Size::Small);
@@ -92,10 +110,15 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
         return 'selectAll';
     }
 
+    public function getSelectAllActionLabel(): string
+    {
+        return $this->evaluate($this->selectAllActionLabel) ?? __('filament-forms::components.checkbox_list.actions.deselect_all.label');
+    }
+
     public function getDeselectAllAction(): Action
     {
         $action = Action::make($this->getDeselectAllActionName())
-            ->label(__('filament-forms::components.checkbox_list.actions.deselect_all.label'))
+            ->label($this->getDeselectAllActionLabel())
             ->livewireClickHandlerEnabled(false)
             ->link()
             ->size(Size::Small);
@@ -119,6 +142,11 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
     public function getDeselectAllActionName(): string
     {
         return 'deselectAll';
+    }
+
+    public function getDeselectAllActionLabel(): string
+    {
+        return $this->evaluate($this->deselectAllActionLabel) ?? __('filament-forms::components.checkbox_list.actions.select_all.label');
     }
 
     public function relationship(string | Closure | null $name = null, string | Closure | null $titleAttribute = null, ?Closure $modifyQueryUsing = null): static


### PR DESCRIPTION
Like modalSubmitActionLabel() & modalCancelActionLabel() for modal, I add 2 methods to customize label of bulk toggling buttons of checkbox list.

```php
CheckboxList::make('technologies')
    ->options([
        // ...
    ])
    ->bulkToggleable()
     // ...
    ->selectAllActionLabel('Select all technologies')
    ->deselectAllActionLabel('Deselect all technologies'),
```
Documentation updated too

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
