### PR TITLE
[4.x] Fix table sorting

### DIFF
--- a/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
@@ -124,7 +124,7 @@ trait InteractsWithTableQuery
             $sortColumn = (string) str($sortColumn)->replace('.', '->');
 
             if ($relationshipName) {
-                $query->orderByPowerJoins("{$relationshipName}.{$sortColumn}", $direction, joinType: 'leftJoin'); /** @phpstan-ignore method.notFound */
+                $query->orderByPowerJoins("{$relationshipName}.{$sortColumn}", $direction, joinType: 'leftJoin', aliases: 'sort'); /** @phpstan-ignore method.notFound */
 
                 continue;
             }

--- a/packages/tables/src/Grouping/Group.php
+++ b/packages/tables/src/Grouping/Group.php
@@ -322,7 +322,7 @@ class Group extends Component
         }
 
         if ($relationshipName = $this->getRelationshipName()) {
-            return $query->orderByPowerJoins("{$relationshipName}.{$this->getRelationshipAttribute()}", $direction, joinType: 'leftJoin'); /** @phpstan-ignore method.notFound */
+            return $query->orderByPowerJoins("{$relationshipName}.{$this->getRelationshipAttribute()}", $direction, joinType: 'leftJoin', aliases: 'group'); /** @phpstan-ignore method.notFound */
         }
 
         return $query->orderBy($this->getRelationshipAttribute(), $direction);


### PR DESCRIPTION
## Description

Fixes duplicate alias error when relation column in same table

result sql goes like

from
```sql
select
  "sites".*
from
  "sites"
  left join "sites" on "sites"."parent_id" = "sites"."id"
order by
  "sites"."name" asc
```
to
```sql
select
  "sites".*
from
  "sites"
  left join "sites" as "sort" on "sites"."parent_id" = "sort"."id"
order by
  "sort"."name" asc
```
