### PR TITLE
chore: update env var for default disk

### DIFF
--- a/packages/actions/docs/12-export.md
+++ b/packages/actions/docs/12-export.md
@@ -420,7 +420,7 @@ public static function modifyQuery(Builder $query): Builder
 
 ### Customizing the storage disk
 
-By default, exported files will be uploaded to the storage disk defined in the [configuration file](../../installation#publishing-configuration), which is `public` by default. You can set the `FILAMENT_FILESYSTEM_DISK` environment variable to change this.
+By default, exported files will be uploaded to the storage disk defined in the [configuration file](../../installation#publishing-configuration), which is `public` by default. You can set the `FILESYSTEM_DISK` environment variable to change this.
 
 While using the `public` disk a good default for many parts of Filament, using it for exports would result in exported files being stored in a public location. As such, if the default filesystem disk is `public` and a `local` disk exists in your `config/filesystems.php`, Filament will use the `local` disk for exports instead. If you override the disk to be `public` for an `ExportAction` or inside an exporter class, Filament will use that.
 


### PR DESCRIPTION
## Description

Noticed that the listed environment variable for the default filesystem disk is showing the v3 env var, rather than the new v4 variable as per [the upgrade doc here](https://filamentphp.com/docs/4.x/upgrade-guide#publishing-the-configuration-file).

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
