### PR TITLE
The navigation group won't show in RTL mode

### DIFF
--- a/packages/panels/resources/views/components/sidebar/group.blade.php
+++ b/packages/panels/resources/views/components/sidebar/group.blade.php
@@ -64,7 +64,6 @@
     @if ($hasDropdown)
         <x-filament::dropdown
             :placement="(__('filament-panels::layout.direction') === 'rtl') ? 'left-start' : 'right-start'"
-            teleport
             x-show="! $store.sidebar.isOpen"
         >
             <x-slot name="trigger">

--- a/packages/panels/resources/views/components/sidebar/group.blade.php
+++ b/packages/panels/resources/views/components/sidebar/group.blade.php
@@ -29,13 +29,13 @@
         <div
             @if ($collapsible)
                 x-on:click="$store.sidebar.toggleCollapsedGroup(label)"
-            role="button"
+                role="button"
             @endif
             @if ($sidebarCollapsible)
                 x-show="$store.sidebar.isOpen"
-            x-transition:enter="fi-transition-enter"
-            x-transition:enter-start="fi-transition-enter-start"
-            x-transition:enter-end="fi-transition-enter-end"
+                x-transition:enter="fi-transition-enter"
+                x-transition:enter-start="fi-transition-enter-start"
+                x-transition:enter-end="fi-transition-enter-end"
             @endif
             class="fi-sidebar-group-btn"
         >
@@ -64,7 +64,6 @@
     @if ($hasDropdown)
         <x-filament::dropdown
             :placement="(__('filament-panels::layout.direction') === 'rtl') ? 'left-start' : 'right-start'"
-            :teleport="__('filament-panels::layout.direction') !== 'rtl'"
             x-show="! $store.sidebar.isOpen"
         >
             <x-slot name="trigger">
@@ -155,15 +154,15 @@
         @if (filled($label))
             @if ($sidebarCollapsible)
                 x-show="$store.sidebar.isOpen ? ! $store.sidebar.groupIsCollapsed(label) : ! @js($hasDropdown)"
-        @else
-            x-show="! $store.sidebar.groupIsCollapsed(label)"
-        @endif
-        x-collapse.duration.200ms
+            @else
+                x-show="! $store.sidebar.groupIsCollapsed(label)"
+            @endif
+            x-collapse.duration.200ms
         @endif
         @if ($sidebarCollapsible)
             x-transition:enter="fi-transition-enter"
-        x-transition:enter-start="fi-transition-enter-start"
-        x-transition:enter-end="fi-transition-enter-end"
+            x-transition:enter-start="fi-transition-enter-start"
+            x-transition:enter-end="fi-transition-enter-end"
         @endif
         class="fi-sidebar-group-items"
     >

--- a/packages/panels/resources/views/components/sidebar/group.blade.php
+++ b/packages/panels/resources/views/components/sidebar/group.blade.php
@@ -29,13 +29,13 @@
         <div
             @if ($collapsible)
                 x-on:click="$store.sidebar.toggleCollapsedGroup(label)"
-                role="button"
+            role="button"
             @endif
             @if ($sidebarCollapsible)
                 x-show="$store.sidebar.isOpen"
-                x-transition:enter="fi-transition-enter"
-                x-transition:enter-start="fi-transition-enter-start"
-                x-transition:enter-end="fi-transition-enter-end"
+            x-transition:enter="fi-transition-enter"
+            x-transition:enter-start="fi-transition-enter-start"
+            x-transition:enter-end="fi-transition-enter-end"
             @endif
             class="fi-sidebar-group-btn"
         >
@@ -64,6 +64,7 @@
     @if ($hasDropdown)
         <x-filament::dropdown
             :placement="(__('filament-panels::layout.direction') === 'rtl') ? 'left-start' : 'right-start'"
+            :teleport="__('filament-panels::layout.direction') !== 'rtl'"
             x-show="! $store.sidebar.isOpen"
         >
             <x-slot name="trigger">
@@ -154,15 +155,15 @@
         @if (filled($label))
             @if ($sidebarCollapsible)
                 x-show="$store.sidebar.isOpen ? ! $store.sidebar.groupIsCollapsed(label) : ! @js($hasDropdown)"
-            @else
-                x-show="! $store.sidebar.groupIsCollapsed(label)"
-            @endif
-            x-collapse.duration.200ms
+        @else
+            x-show="! $store.sidebar.groupIsCollapsed(label)"
+        @endif
+        x-collapse.duration.200ms
         @endif
         @if ($sidebarCollapsible)
             x-transition:enter="fi-transition-enter"
-            x-transition:enter-start="fi-transition-enter-start"
-            x-transition:enter-end="fi-transition-enter-end"
+        x-transition:enter-start="fi-transition-enter-start"
+        x-transition:enter-end="fi-transition-enter-end"
         @endif
         class="fi-sidebar-group-items"
     >

--- a/packages/panels/resources/views/livewire/topbar.blade.php
+++ b/packages/panels/resources/views/livewire/topbar.blade.php
@@ -121,7 +121,6 @@
                         @if ($groupLabel)
                             <x-filament::dropdown
                                 placement="bottom-start"
-                                teleport
                                 :attributes="\Filament\Support\prepare_inherited_attributes($groupExtraTopbarAttributeBag)"
                             >
                                 <x-slot name="trigger">


### PR DESCRIPTION
## Description

After upgrading to v4, the navigation group no longer works in RTL mode.

## Visual changes

Before:

[Screencast From 2025-11-08 10-24-44.webm](https://github.com/user-attachments/assets/00275c19-9e2d-4d18-b239-0c4ba3c816d7)

After:

[Screencast From 2025-11-12 16-49-25.webm](https://github.com/user-attachments/assets/7b8cb4d5-1046-4f6c-a5cc-ea1ba538cd14)


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
