### PR TITLE
Fix: Moving the `builder` back misplaces the middle add button.

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -83,12 +83,11 @@
                 x-sortable
                 data-sortable-animation-duration="{{ $getReorderAnimationDuration() }}"
                 x-on:end.stop="
-                    $event.oldDraggableIndex !== $event.newDraggableIndex &&
-                        $wire.mountAction(
-                            'reorder',
-                            { items: $event.target.sortable.toArray() },
-                            { schemaComponent: '{{ $key }}' },
-                        )
+                    $wire.mountAction(
+                        'reorder',
+                        { items: $event.target.sortable.toArray() },
+                        { schemaComponent: '{{ $key }}' },
+                    )
                 "
                 class="fi-fo-builder-items"
             >

--- a/packages/forms/resources/views/components/repeater/index.blade.php
+++ b/packages/forms/resources/views/components/repeater/index.blade.php
@@ -84,7 +84,7 @@
                         ->grid($getGridColumns())
                         ->merge([
                             'data-sortable-animation-duration' => $getReorderAnimationDuration(),
-                            'x-on:end.stop' => '$event.oldDraggableIndex !== $event.newDraggableIndex && $wire.mountAction(\'reorder\', { items: $event.target.sortable.toArray() }, { schemaComponent: \'' . $key . '\' })',
+                            'x-on:end.stop' => '$wire.mountAction(\'reorder\', { items: $event.target.sortable.toArray() }, { schemaComponent: \'' . $key . '\' })',
                         ], escape: false)
                         ->class(['fi-fo-repeater-items'])
                 }}

--- a/packages/forms/resources/views/components/repeater/simple.blade.php
+++ b/packages/forms/resources/views/components/repeater/simple.blade.php
@@ -42,7 +42,7 @@
                         ->grid($getGridColumns())
                         ->merge([
                             'data-sortable-animation-duration' => $getReorderAnimationDuration(),
-                            'x-on:end.stop' => '$event.oldDraggableIndex !== $event.newDraggableIndex && $wire.mountAction(\'reorder\', { items: $event.target.sortable.toArray() }, { schemaComponent: \'' . $key . '\' })',
+                            'x-on:end.stop' => '$wire.mountAction(\'reorder\', { items: $event.target.sortable.toArray() }, { schemaComponent: \'' . $key . '\' })',
                         ], escape: false)
                         ->class(['fi-fo-simple-repeater-items'])
                 }}

--- a/packages/forms/resources/views/components/repeater/table.blade.php
+++ b/packages/forms/resources/views/components/repeater/table.blade.php
@@ -38,9 +38,9 @@
         {{ $attributes
                 ->merge($getExtraAttributes(), escape: false)
                 ->class([
-                                'fi-fo-table-repeater',
-                                'fi-compact' => $isCompact,
-                            ]) }}
+                    'fi-fo-table-repeater',
+                    'fi-compact' => $isCompact,
+                ]) }}
     >
         @if (count($items))
             <table>
@@ -86,7 +86,7 @@
                     {{ (new ComponentAttributeBag)
                             ->merge([
                                 'data-sortable-animation-duration' => $getReorderAnimationDuration(),
-                                'x-on:end.stop' => '$event.oldDraggableIndex !== $event.newDraggableIndex && $wire.mountAction(\'reorder\', { items: $event.target.sortable.toArray() }, { schemaComponent: \'' . $key . '\' })',
+                                'x-on:end.stop' => '$wire.mountAction(\'reorder\', { items: $event.target.sortable.toArray() }, { schemaComponent: \'' . $key . '\' })',
                             ], escape: false) }}
                 >
                     @foreach ($items as $itemKey => $item)


### PR DESCRIPTION

## Description

If the `builder` is moved back to its original position, the button added in the middle will be in the wrong position.


## Visual changes

# Before

https://github.com/user-attachments/assets/bbc5aa29-d09d-4258-b8a9-d453e232e8ee


# After


https://github.com/user-attachments/assets/8e2b007a-5697-4317-8888-e20ed549fef0




## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
