### PR TITLE
Extended Table empty state documentation with HtmlString example

### DIFF
--- a/packages/tables/docs/08-empty-state.md
+++ b/packages/tables/docs/08-empty-state.md
@@ -98,6 +98,7 @@ You may also simply pass any `Htmlable`, like an `HtmlString`:
 
 ```php
 use Filament\Tables\Table;
+use Illuminate\Support\HtmlString;
 
 public function table(Table $table): Table
 {

--- a/packages/tables/docs/08-empty-state.md
+++ b/packages/tables/docs/08-empty-state.md
@@ -93,3 +93,15 @@ public function table(Table $table): Table
         ->emptyState(view('tables.posts.empty-state'));
 }
 ```
+
+You may also simply pass any `Htmlable`, like an `HtmlString`:
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->emptyState(new HtmlString("<div class='fi-ta-empty-state'>Empty!</div>"));
+}
+```


### PR DESCRIPTION
## Description

The documentation did not mention `Table::emptyState()` can take any Htmlable, which can be a simpler solution for users looking to customize the empty state than a custom view.

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
