### PR TITLE
Bring back support for Htmlable icons

### DIFF
--- a/packages/actions/src/ActionGroup.php
+++ b/packages/actions/src/ActionGroup.php
@@ -263,7 +263,7 @@ class ActionGroup extends ViewComponent implements Arrayable, HasEmbeddedView
         return false;
     }
 
-    public function getIcon(): string | BackedEnum
+    public function getIcon(): string | BackedEnum | Htmlable
     {
         return $this->getBaseIcon() ?? FilamentIcon::resolve(ActionsIconAlias::ACTION_GROUP) ?? Heroicon::EllipsisVertical;
     }

--- a/packages/infolists/src/Components/IconEntry.php
+++ b/packages/infolists/src/Components/IconEntry.php
@@ -37,14 +37,14 @@ class IconEntry extends Entry implements HasEmbeddedView
      */
     protected string | array | Closure | null $falseColor = null;
 
-    protected string | BackedEnum | Closure | false | null $falseIcon = null;
+    protected string | BackedEnum | Htmlable | Closure | false | null $falseIcon = null;
 
     /**
      * @var string | array<string> | Closure | null
      */
     protected string | array | Closure | null $trueColor = null;
 
-    protected string | BackedEnum | Closure | false | null $trueIcon = null;
+    protected string | BackedEnum | Htmlable | Closure | false | null $trueIcon = null;
 
     protected IconSize | string | Closure | null $size = null;
 
@@ -60,7 +60,7 @@ class IconEntry extends Entry implements HasEmbeddedView
     /**
      * @param  string | array<int | string, string | int> | Closure | null  $color
      */
-    public function false(string | BackedEnum | Closure | false | null $icon = null, string | array | Closure | null $color = null): static
+    public function false(string | BackedEnum | Htmlable | Closure | false | null $icon = null, string | array | Closure | null $color = null): static
     {
         $this->falseIcon($icon);
         $this->falseColor($color);
@@ -79,7 +79,7 @@ class IconEntry extends Entry implements HasEmbeddedView
         return $this;
     }
 
-    public function falseIcon(string | BackedEnum | Closure | false | null $icon): static
+    public function falseIcon(string | BackedEnum | Htmlable | Closure | false | null $icon): static
     {
         $this->boolean();
         $this->falseIcon = $icon;
@@ -90,7 +90,7 @@ class IconEntry extends Entry implements HasEmbeddedView
     /**
      * @param  string | array<int | string, string | int> | Closure | null  $color
      */
-    public function true(string | BackedEnum | Closure | false | null $icon = null, string | array | Closure | null $color = null): static
+    public function true(string | BackedEnum | Htmlable | Closure | false | null $icon = null, string | array | Closure | null $color = null): static
     {
         $this->trueIcon($icon);
         $this->trueColor($color);
@@ -109,7 +109,7 @@ class IconEntry extends Entry implements HasEmbeddedView
         return $this;
     }
 
-    public function trueIcon(string | BackedEnum | Closure | false | null $icon): static
+    public function trueIcon(string | BackedEnum | Htmlable | Closure | false | null $icon): static
     {
         $this->boolean();
         $this->trueIcon = $icon;
@@ -131,7 +131,7 @@ class IconEntry extends Entry implements HasEmbeddedView
         ]);
     }
 
-    public function getIcon(mixed $state): string | BackedEnum | null
+    public function getIcon(mixed $state): string | BackedEnum | Htmlable | null
     {
         if (filled($icon = $this->getBaseIcon($state))) {
             return $icon;
@@ -176,7 +176,7 @@ class IconEntry extends Entry implements HasEmbeddedView
         return $this->evaluate($this->falseColor) ?? 'danger';
     }
 
-    public function getFalseIcon(): string | BackedEnum | null
+    public function getFalseIcon(): string | BackedEnum | Htmlable | null
     {
         $icon = $this->evaluate($this->falseIcon);
 
@@ -197,7 +197,7 @@ class IconEntry extends Entry implements HasEmbeddedView
         return $this->evaluate($this->trueColor) ?? 'success';
     }
 
-    public function getTrueIcon(): string | BackedEnum | null
+    public function getTrueIcon(): string | BackedEnum | Htmlable | null
     {
         $icon = $this->evaluate($this->trueIcon);
 

--- a/packages/notifications/src/Concerns/HasIcon.php
+++ b/packages/notifications/src/Concerns/HasIcon.php
@@ -7,6 +7,7 @@ use Filament\Notifications\View\NotificationsIconAlias;
 use Filament\Support\Concerns\HasIcon as BaseTrait;
 use Filament\Support\Facades\FilamentIcon;
 use Filament\Support\Icons\Heroicon;
+use Illuminate\Contracts\Support\Htmlable;
 
 trait HasIcon
 {
@@ -14,7 +15,7 @@ trait HasIcon
         getIcon as getBaseIcon;
     }
 
-    public function getIcon(): string | BackedEnum | null
+    public function getIcon(): string | BackedEnum | Htmlable | null
     {
         return $this->getBaseIcon() ?? match ($this->getStatus()) {
             'danger' => FilamentIcon::resolve(NotificationsIconAlias::NOTIFICATION_DANGER) ?? Heroicon::OutlinedXCircle,

--- a/packages/support/src/Contracts/HasIcon.php
+++ b/packages/support/src/Contracts/HasIcon.php
@@ -3,8 +3,9 @@
 namespace Filament\Support\Contracts;
 
 use BackedEnum;
+use Illuminate\Contracts\Support\Htmlable;
 
 interface HasIcon
 {
-    public function getIcon(): string | BackedEnum | null;
+    public function getIcon(): string | BackedEnum | Htmlable | null;
 }

--- a/packages/tables/src/Columns/Concerns/HasIcon.php
+++ b/packages/tables/src/Columns/Concerns/HasIcon.php
@@ -7,14 +7,15 @@ use Closure;
 use Filament\Support\Contracts\HasIcon as IconInterface;
 use Filament\Support\Enums\IconPosition;
 use Filament\Tables\Columns\Column;
+use Illuminate\Contracts\Support\Htmlable;
 
 trait HasIcon
 {
-    protected string | BackedEnum | bool | Closure | null $icon = null;
+    protected string | BackedEnum | Htmlable | bool | Closure | null $icon = null;
 
     protected IconPosition | string | Closure | null $iconPosition = null;
 
-    public function icon(string | BackedEnum | bool | Closure | null $icon): static
+    public function icon(string | BackedEnum | Htmlable | bool | Closure | null $icon): static
     {
         $this->icon = $icon;
 
@@ -54,7 +55,7 @@ trait HasIcon
         return $this;
     }
 
-    public function getIcon(mixed $state): string | BackedEnum | null
+    public function getIcon(mixed $state): string | BackedEnum | Htmlable | null
     {
         $icon = $this->evaluate($this->icon, [
             'state' => $state,

--- a/packages/tables/src/Columns/IconColumn.php
+++ b/packages/tables/src/Columns/IconColumn.php
@@ -68,7 +68,7 @@ class IconColumn extends Column implements HasEmbeddedView
     /**
      * @param  string | array<int | string, string | int> | Closure | null  $color
      */
-    public function false(string | BackedEnum | Closure | false | null $icon = null, string | array | Closure | null $color = null): static
+    public function false(string | BackedEnum | Htmlable | Closure | false | null $icon = null, string | array | Closure | null $color = null): static
     {
         $this->falseIcon($icon);
         $this->falseColor($color);
@@ -87,7 +87,7 @@ class IconColumn extends Column implements HasEmbeddedView
         return $this;
     }
 
-    public function falseIcon(string | BackedEnum | Closure | false | null $icon): static
+    public function falseIcon(string | BackedEnum | Htmlable | Closure | false | null $icon): static
     {
         $this->boolean();
         $this->falseIcon = $icon;
@@ -98,7 +98,7 @@ class IconColumn extends Column implements HasEmbeddedView
     /**
      * @param  string | array<int | string, string | int> | Closure | null  $color
      */
-    public function true(string | BackedEnum | Closure | false | null $icon = null, string | array | Closure | null $color = null): static
+    public function true(string | BackedEnum | Htmlable | Closure | false | null $icon = null, string | array | Closure | null $color = null): static
     {
         $this->trueIcon($icon);
         $this->trueColor($color);
@@ -117,7 +117,7 @@ class IconColumn extends Column implements HasEmbeddedView
         return $this;
     }
 
-    public function trueIcon(string | BackedEnum | Closure | false | null $icon): static
+    public function trueIcon(string | BackedEnum | Htmlable | Closure | false | null $icon): static
     {
         $this->boolean();
         $this->trueIcon = $icon;
@@ -165,7 +165,7 @@ class IconColumn extends Column implements HasEmbeddedView
         return $size;
     }
 
-    public function getIcon(mixed $state): string | BackedEnum | null
+    public function getIcon(mixed $state): string | BackedEnum | Htmlable | null
     {
         if (filled($icon = $this->getBaseIcon($state))) {
             return $icon;
@@ -210,7 +210,7 @@ class IconColumn extends Column implements HasEmbeddedView
         return $this->evaluate($this->falseColor) ?? 'danger';
     }
 
-    public function getFalseIcon(): string | BackedEnum | null
+    public function getFalseIcon(): string | BackedEnum | Htmlable | null
     {
         $icon = $this->evaluate($this->falseIcon);
 
@@ -231,7 +231,7 @@ class IconColumn extends Column implements HasEmbeddedView
         return $this->evaluate($this->trueColor) ?? 'success';
     }
 
-    public function getTrueIcon(): string | BackedEnum | null
+    public function getTrueIcon(): string | BackedEnum | Htmlable | null
     {
         $icon = $this->evaluate($this->trueIcon);
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Previously you could use Htmlable instances as icons. It seems like this is currently still partially supported but got lost somewhere along the way. This PR brings back full support for using Htmlable for icons.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
