### PR TITLE
Revert "Hide attach files toolbar button when file attachments are disabled"

### DIFF
--- a/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
+++ b/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
@@ -168,9 +168,4 @@ trait InteractsWithToolbarButtons
 
         return false;
     }
-
-    public function hasCustomToolbarButtons(): bool
-    {
-        return $this->evaluate($this->toolbarButtons) !== null;
-    }
 }

--- a/packages/forms/src/Components/MarkdownEditor.php
+++ b/packages/forms/src/Components/MarkdownEditor.php
@@ -32,10 +32,7 @@ class MarkdownEditor extends Field implements Contracts\CanBeLengthConstrained
             ['bold', 'italic', 'strike', 'link'],
             ['heading'],
             ['blockquote', 'codeBlock', 'bulletList', 'orderedList'],
-            [
-                'table',
-                ...($this->hasFileAttachments() ? ['attachFiles'] : []),
-            ],
+            ['table', 'attachFiles'],
             ['undo', 'redo'],
         ];
     }
@@ -65,6 +62,6 @@ class MarkdownEditor extends Field implements Contracts\CanBeLengthConstrained
 
     public function hasFileAttachmentsByDefault(): bool
     {
-        return (! $this->hasCustomToolbarButtons()) || $this->hasToolbarButton('attachFiles');
+        return $this->hasToolbarButton('attachFiles');
     }
 }

--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -704,7 +704,7 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
             ['blockquote', 'codeBlock', 'bulletList', 'orderedList'],
             [
                 'table',
-                ...($this->hasFileAttachments() ? ['attachFiles'] : []),
+                'attachFiles',
                 ...(filled($this->getCustomBlocks()) ? ['customBlocks'] : []),
                 ...(filled($this->getMergeTags()) ? ['mergeTags'] : []),
             ],
@@ -1020,6 +1020,6 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
 
     public function hasFileAttachmentsByDefault(): bool
     {
-        return (! $this->hasCustomToolbarButtons()) || $this->hasToolbarButton('attachFiles');
+        return $this->hasToolbarButton('attachFiles');
     }
 }


### PR DESCRIPTION
Reverts filamentphp/filament#18298


Resolves https://github.com/filamentphp/filament/issues/18414 

Verified the loop disappears when reverting line 35 of forms/src/Components/MarkdownEditor.php. Not sure what a proper fix would be to also hide the button when attachments are disabled.