### PR TITLE
[4.x] Fix table group/summary cell alignment

### DIFF
--- a/packages/tables/resources/css/cell.css
+++ b/packages/tables/resources/css/cell.css
@@ -70,7 +70,7 @@
     }
 
     &.fi-ta-summary-row-heading-cell {
-        @apply px-3 py-4 text-sm font-medium text-gray-950 dark:text-white;
+        @apply px-3 py-4 text-sm font-medium text-gray-950 sm:first-of-type:ps-6 sm:last-of-type:pe-6 dark:text-white;
     }
 
     &.fi-align-start {

--- a/packages/tables/resources/css/row.css
+++ b/packages/tables/resources/css/row.css
@@ -19,8 +19,12 @@
         }
     }
 
+    & .fi-ta-group-header-cell {
+        @apply px-3 sm:first-of-type:ps-6 sm:last-of-type:pe-6;
+    }
+
     & .fi-ta-group-header {
-        @apply flex w-full items-center gap-x-3 px-3 py-2;
+        @apply flex w-full items-center gap-x-3 py-2;
 
         &.fi-collapsible {
             @apply cursor-pointer;


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Fixed inconsistent padding for table group header cells and summary row heading cells. When using table grouping and summaries without toolbar actions, the first and last cells did not have the proper responsive padding (`sm:ps-6` and `sm:pe-6`) that other table cells have, causing visual misalignment.

## Visual changes

### Before
<img width="1334" height="551" alt="Screenshot 2025-11-14 at 7 49 27 PM" src="https://github.com/user-attachments/assets/4a3cd2fc-cbe5-4d12-a299-17f6e3f0ddd7" />

### After
<img width="1334" height="551" alt="Screenshot 2025-11-14 at 7 49 45 PM" src="https://github.com/user-attachments/assets/6b614130-b7c0-4103-8c6b-8a211e7bb750" />

### With Toolbar actions (still looks good)
<img width="1334" height="551" alt="Screenshot 2025-11-14 at 7 51 45 PM" src="https://github.com/user-attachments/assets/d9377ed9-626e-483f-ac02-5ce91cc5375c" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
