### PR TITLE
[4.x] Support hiddenOn and visibleOn for summarizers

### DIFF
--- a/packages/tables/src/Columns/Summarizers/Concerns/CanBeHidden.php
+++ b/packages/tables/src/Columns/Summarizers/Concerns/CanBeHidden.php
@@ -3,6 +3,8 @@
 namespace Filament\Tables\Columns\Summarizers\Concerns;
 
 use Closure;
+use Filament\Tables\Contracts\HasTable;
+use Illuminate\Support\Arr;
 
 trait CanBeHidden
 {
@@ -22,9 +24,45 @@ trait CanBeHidden
         return $this;
     }
 
+    /**
+     * @param  string | array<string>  $livewireComponents
+     */
+    public function hiddenOn(string | array $livewireComponents): static
+    {
+        $this->hidden(static function (HasTable $livewire) use ($livewireComponents): bool {
+            foreach (Arr::wrap($livewireComponents) as $livewireComponent) {
+                if ($livewire instanceof $livewireComponent) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
+
+        return $this;
+    }
+
     public function visible(bool | Closure $condition = true): static
     {
         $this->isVisible = $condition;
+
+        return $this;
+    }
+
+    /**
+     * @param  string | array<string>  $livewireComponents
+     */
+    public function visibleOn(string | array $livewireComponents): static
+    {
+        $this->visible(static function (HasTable $livewire) use ($livewireComponents): bool {
+            foreach (Arr::wrap($livewireComponents) as $livewireComponent) {
+                if ($livewire instanceof $livewireComponent) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
 
         return $this;
     }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Adds `hiddenOn()` and `visibleOn()` methods to table column summarizers

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
