### PR TITLE
Optimize `IdentifyTenant` to reuse existing tenant if set

### DIFF
--- a/packages/panels/src/Http/Middleware/IdentifyTenant.php
+++ b/packages/panels/src/Http/Middleware/IdentifyTenant.php
@@ -29,7 +29,7 @@ class IdentifyTenant
             abort(404);
         }
 
-        $tenant = $panel->resolveTenantForRequest($request->route()->parameter('tenant'));
+        $tenant = $panel->getTenant($request->route()->parameter('tenant'));
 
         if (! $user->canAccessTenant($tenant)) {
             abort(404);

--- a/packages/panels/src/Http/Middleware/IdentifyTenant.php
+++ b/packages/panels/src/Http/Middleware/IdentifyTenant.php
@@ -29,18 +29,18 @@ class IdentifyTenant
             abort(404);
         }
 
-        $tenantRouteKey = $request->route()->parameter('tenant');
-        $slugAttribute = $panel->getTenantSlugAttribute();
+        $tenantRouteParameter = $request->route()->parameter('tenant');
+        $tenantSlugAttribute = $panel->getTenantSlugAttribute();
         $currentTenant = Filament::getTenant();
 
-        $currentTenantKey = filled($slugAttribute)
-            ? $currentTenant?->getAttribute($slugAttribute)
+        $currentTenantIdentifier = filled($tenantSlugAttribute)
+            ? $currentTenant?->getAttribute($tenantSlugAttribute)
             : $currentTenant?->getRouteKey();
 
-        if ($currentTenant && $currentTenantKey === $tenantRouteKey) {
+        if ($currentTenant && $currentTenantIdentifier === $tenantRouteParameter) {
             $tenant = $currentTenant;
         } else {
-            $tenant = $panel->getTenant($tenantRouteKey);
+            $tenant = $panel->getTenant($tenantRouteParameter);
             Filament::setTenant($tenant);
         }
 

--- a/packages/panels/src/Http/Middleware/IdentifyTenant.php
+++ b/packages/panels/src/Http/Middleware/IdentifyTenant.php
@@ -29,24 +29,13 @@ class IdentifyTenant
             abort(404);
         }
 
-        $tenantRouteParameter = $request->route()->parameter('tenant');
-        $tenantSlugAttribute = $panel->getTenantSlugAttribute();
-        $currentTenant = Filament::getTenant();
-
-        $currentTenantIdentifier = filled($tenantSlugAttribute)
-            ? $currentTenant?->getAttribute($tenantSlugAttribute)
-            : $currentTenant?->getRouteKey();
-
-        if ($currentTenant && $currentTenantIdentifier === $tenantRouteParameter) {
-            $tenant = $currentTenant;
-        } else {
-            $tenant = $panel->getTenant($tenantRouteParameter);
-            Filament::setTenant($tenant);
-        }
+        $tenant = $panel->resolveTenantForRequest($request->route()->parameter('tenant'));
 
         if (! $user->canAccessTenant($tenant)) {
             abort(404);
         }
+
+        Filament::setTenant($tenant);
 
         return $next($request);
     }

--- a/packages/panels/src/Http/Middleware/IdentifyTenant.php
+++ b/packages/panels/src/Http/Middleware/IdentifyTenant.php
@@ -29,10 +29,15 @@ class IdentifyTenant
             abort(404);
         }
 
-        $tenantRouteKey = $request->route()->parameter('tenant');
         $currentTenant = Filament::getTenant();
+        $slugAttribute = $panel->getTenantSlugAttribute();
+        $tenantRouteKey = $request->route()->parameter('tenant');
 
-        if ($currentTenant && $currentTenant->getRouteKey() === $tenantRouteKey) {
+        $currentTenantKey = filled($slugAttribute)
+            ? $currentTenant?->getAttribute($slugAttribute)
+            : $currentTenant?->getRouteKey();
+
+        if ($currentTenant && $currentTenantKey === $tenantRouteKey) {
             $tenant = $currentTenant;
         } else {
             $tenant = $panel->getTenant($tenantRouteKey);

--- a/packages/panels/src/Http/Middleware/IdentifyTenant.php
+++ b/packages/panels/src/Http/Middleware/IdentifyTenant.php
@@ -29,13 +29,19 @@ class IdentifyTenant
             abort(404);
         }
 
-        $tenant = $panel->getTenant($request->route()->parameter('tenant'));
+        $tenantRouteKey = $request->route()->parameter('tenant');
+        $currentTenant = Filament::getTenant();
+
+        if ($currentTenant && $currentTenant->getRouteKey() === $tenantRouteKey) {
+            $tenant = $currentTenant;
+        } else {
+            $tenant = $panel->getTenant($tenantRouteKey);
+            Filament::setTenant($tenant);
+        }
 
         if (! $user->canAccessTenant($tenant)) {
             abort(404);
         }
-
-        Filament::setTenant($tenant);
 
         return $next($request);
     }

--- a/packages/panels/src/Http/Middleware/IdentifyTenant.php
+++ b/packages/panels/src/Http/Middleware/IdentifyTenant.php
@@ -29,9 +29,9 @@ class IdentifyTenant
             abort(404);
         }
 
-        $currentTenant = Filament::getTenant();
-        $slugAttribute = $panel->getTenantSlugAttribute();
         $tenantRouteKey = $request->route()->parameter('tenant');
+        $slugAttribute = $panel->getTenantSlugAttribute();
+        $currentTenant = Filament::getTenant();
 
         $currentTenantKey = filled($slugAttribute)
             ? $currentTenant?->getAttribute($slugAttribute)

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -42,6 +42,8 @@ trait HasTenancy
 
     protected ?string $tenantOwnershipRelationshipName = null;
 
+    protected ?Closure $tenantIdentifier = null;
+
     /**
      * @var array<Action | Closure | MenuItem>
      */
@@ -137,6 +139,13 @@ trait HasTenancy
         return $this;
     }
 
+    public function identifyTenant(?Closure $callback): static
+    {
+        $this->tenantIdentifier = $callback;
+
+        return $this;
+    }
+
     public function hasTenancy(): bool
     {
         return filled($this->getTenantModel());
@@ -200,6 +209,17 @@ trait HasTenancy
     public function getTenantRegistrationPage(): ?string
     {
         return $this->tenantRegistrationPage;
+    }
+
+    public function resolveTenantForRequest(string $key): Model
+    {
+        if ($this->tenantIdentifier) {
+            return $this->evaluate($this->tenantIdentifier, [
+                'key' => $key,
+            ]);
+        }
+
+        return $this->getTenant($key);
     }
 
     public function getTenant(string $key): Model

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -42,7 +42,7 @@ trait HasTenancy
 
     protected ?string $tenantOwnershipRelationshipName = null;
 
-    protected ?Closure $tenantIdentifier = null;
+    protected ?Closure $resolveTenantUsing = null;
 
     /**
      * @var array<Action | Closure | MenuItem>
@@ -139,9 +139,9 @@ trait HasTenancy
         return $this;
     }
 
-    public function identifyTenant(?Closure $callback): static
+    public function resolveTenantUsing(?Closure $callback): static
     {
-        $this->tenantIdentifier = $callback;
+        $this->resolveTenantUsing = $callback;
 
         return $this;
     }
@@ -211,19 +211,14 @@ trait HasTenancy
         return $this->tenantRegistrationPage;
     }
 
-    public function resolveTenantForRequest(string $key): Model
+    public function getTenant(string $key): Model
     {
-        if ($this->tenantIdentifier) {
-            return $this->evaluate($this->tenantIdentifier, [
+        if ($this->resolveTenantUsing) {
+            return $this->evaluate($this->resolveTenantUsing, [
                 'key' => $key,
             ]);
         }
 
-        return $this->getTenant($key);
-    }
-
-    public function getTenant(string $key): Model
-    {
         $tenantModel = $this->getTenantModel();
 
         $record = app($tenantModel)


### PR DESCRIPTION
Applications that resolve tenants via custom middleware currently can't avoid Filament re-querying the same tenant from the db.

This PR checks if a tenant has already been set and matches the expected tenant id. If yes, the existing tenant is used. This allows using `Filament::setTenant()` in custom upstream tenant resolution middleware to set the Filament tenant using an already resolved model.

Benefits:
- Allows custom tenant resolution middleware to be reused by Filament
- Saves 1 db query per request if tenant has already been resolved upstream
- Maintains all existing security checks (canAccessTenant, route validation)
- Backward compatible - no impact when tenant isn't pre-set