### PR TITLE
Refactor Livewire component registration for simplicity

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasComponents.php
+++ b/packages/panels/src/Panel/Concerns/HasComponents.php
@@ -19,8 +19,8 @@ use Filament\Widgets\WidgetConfiguration;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
 use Livewire\Component;
+use Livewire\Finder\Finder;
 use Livewire\Livewire;
-use Livewire\Mechanisms\ComponentRegistry;
 use ReflectionClass;
 
 trait HasComponents
@@ -593,7 +593,7 @@ trait HasComponents
 
     protected function queueLivewireComponentForRegistration(string $component): void
     {
-        $componentName = app(ComponentRegistry::class)->getName($component);
+        [$namespace, $componentName] = app(Finder::class)->parseNamespaceAndName($component);
 
         $this->livewireComponents[$componentName] = $component;
     }

--- a/tests/src/Tables/TablesServiceProvider.php
+++ b/tests/src/Tables/TablesServiceProvider.php
@@ -4,13 +4,15 @@ namespace Filament\Tests\Tables;
 
 use Filament\Tests\Fixtures\Livewire\PostsTable;
 use Illuminate\Support\ServiceProvider;
+use Livewire\Finder\Finder;
 use Livewire\Livewire;
-use Livewire\Mechanisms\ComponentRegistry;
 
 class TablesServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
-        Livewire::component(app(ComponentRegistry::class)->getName(PostsTable::class), PostsTable::class);
+        [$namespace, $componentName] = app(Finder::class)->parseNamespaceAndName(PostsTable::class);
+
+        Livewire::component($componentName, PostsTable::class);
     }
 }


### PR DESCRIPTION
Simplify Livewire component registration by replacing the use of `ComponentRegistry` with `Finder`. The `Finder`'s `parseNamespaceAndName` method is now utilized, enhancing clarity and streamlining the process.

https://github.com/livewire/livewire/commit/ccc1e88a75c1e0eba71e9520e0e744700800592e

Remove unused ComponentRegistry class in version v4.0.0-beta.3

https://github.com/livewire/livewire/releases/tag/v4.0.0-beta.3