### PR TITLE
docs: correct `$isLazy` example in widget lazy-loading section

### DIFF
--- a/packages/widgets/docs/03-charts.md
+++ b/packages/widgets/docs/03-charts.md
@@ -302,7 +302,7 @@ By default, widgets are lazy-loaded. This means that they will only be loaded wh
 To disable this behavior, you may override the `$isLazy` property on the widget class:
 
 ```php
-protected static bool $isLazy = true;
+protected static bool $isLazy = false;
 ```
 
 ## Making the chart collapsible


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The **Disabling lazy loading** section in **Chart widgets** incorrectly shows `$isLazy = true` in the example. Since the text explains how to disable lazy loading, the example should use `$isLazy = false`.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
