### PR TITLE
[4.x] Add `unsaved-changes-alert-setup` component for better reuse outside of panel

### DIFF
--- a/packages/panels/resources/views/components/page/index.blade.php
+++ b/packages/panels/resources/views/components/page/index.blade.php
@@ -147,25 +147,7 @@
 
     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_END, scopes: $this->getRenderHookScopes()) }}
 
-    @if (method_exists($this, 'hasUnsavedDataChangesAlert') && $this->hasUnsavedDataChangesAlert())
-        @if (\Filament\Support\Facades\FilamentView::hasSpaMode())
-            @script
-                <script>
-                    setUpSpaModeUnsavedDataChangesAlert({
-                        body: @js(__('filament-panels::unsaved-changes-alert.body')),
-                        resolveLivewireComponentUsing: () => @this,
-                        $wire,
-                    })
-                </script>
-            @endscript
-        @else
-            @script
-                <script>
-                    setUpUnsavedDataChangesAlert({ $wire })
-                </script>
-            @endscript
-        @endif
-    @endif
+    <x-filament-panels::unsaved-changes-alert-setup />
 
     @if ((! app()->hasDebugModeEnabled()) && $this->hasErrorNotifications())
         @script

--- a/packages/panels/resources/views/components/unsaved-changes-alert-setup.blade.php
+++ b/packages/panels/resources/views/components/unsaved-changes-alert-setup.blade.php
@@ -1,0 +1,19 @@
+@if (method_exists($this, 'hasUnsavedDataChangesAlert') && $this->hasUnsavedDataChangesAlert())
+    @if (\Filament\Support\Facades\FilamentView::hasSpaMode())
+        @script
+        <script>
+            setUpSpaModeUnsavedDataChangesAlert({
+                body: @js(__('filament-panels::unsaved-changes-alert.body')),
+                resolveLivewireComponentUsing: () => @this,
+                $wire
+            })
+        </script>
+        @endscript
+    @else
+        @script
+        <script>
+            setUpUnsavedDataChangesAlert({ $wire })
+        </script>
+        @endscript
+    @endif
+@endif


### PR DESCRIPTION
## Description

This PR adds a new `<x-filament-panels::unsaved-changes-alert-setup />` Blade component, which contains the setup code for the [Unsaved Changes Alerts](https://filamentphp.com/docs/4.x/panel-configuration#unsaved-changes-alerts) feature.

We use the "Unsaved Changes Alerts" in our admin panel, but also use Filament Forms in our frontend and would like to bring the feature to our users as we think it's very convenient.

By extracting the logic into a component, we can simply add the new Blade component into our views and use the feature immediately.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
