### PR TITLE
[4.x] Fix logic error in Select dynamic options check

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -1308,7 +1308,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
         }
 
         if ($this->hasRelationship()) {
-            return $this->isPreloaded();
+            return ! $this->isPreloaded();
         }
 
         return $this->options instanceof Closure;


### PR DESCRIPTION
## Description

This PR fixes an error in the logic to determine if a select has dynamic options.

Behavior before:
When a select has a relationship, is searchable and options are preloaded, the options are correctly preloaded into the DOM, but when opening the dropdown, the wrongly implemented check forces the options to reload.

New behavior:
Options are still correctly loaded into the DOM and used when the dropdown opens without reloading.

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] ~~Documentation is up-to-date.~~ No changes required
