### PR TITLE
[4.x] Adds closure evaluation to TimezoneManager

### DIFF
--- a/packages/support/src/Facades/FilamentTimezone.php
+++ b/packages/support/src/Facades/FilamentTimezone.php
@@ -2,11 +2,12 @@
 
 namespace Filament\Support\Facades;
 
+use Closure;
 use Filament\Support\TimezoneManager;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static void set(?string $timezone)
+ * @method static void set(string | Closure | null $timezone)
  * @method static string get()
  *
  * @see TimezoneManager

--- a/packages/support/src/TimezoneManager.php
+++ b/packages/support/src/TimezoneManager.php
@@ -2,17 +2,26 @@
 
 namespace Filament\Support;
 
+use Closure;
+use Filament\Support\Concerns\EvaluatesClosures;
+
 class TimezoneManager
 {
-    protected ?string $timezone = null;
+    use EvaluatesClosures;
 
-    public function set(?string $timezone): void
+    protected string | Closure | null $timezone = null;
+
+    public function set(string | Closure | null $timezone = null): void
     {
         $this->timezone = $timezone;
     }
 
     public function get(): string
     {
-        return $this->timezone ?? config('app.timezone');
+        if (is_null($this->timezone)) {
+            return config('app.timezone');
+        }
+
+        return (string) $this->evaluate($this->timezone);
     }
 }

--- a/packages/support/src/TimezoneManager.php
+++ b/packages/support/src/TimezoneManager.php
@@ -18,10 +18,6 @@ class TimezoneManager
 
     public function get(): string
     {
-        if (is_null($this->timezone)) {
-            return config('app.timezone');
-        }
-
-        return (string) $this->evaluate($this->timezone);
+        return $this->evaluate($this->timezone) ?? config('app.timezone');
     }
 }


### PR DESCRIPTION
## Description

When adding `TimezoneManager` to something like an AppServiceProvider, it gets called too early in the application's boot process to access user-specific configuration.  This allows for closure evaluation for callback mechanisms so that the timezone can be evaluated based on user-specific attributes.

## Visual changes

n/a

## Functional changes

- [ x ] Code style has been fixed by running the `composer cs` command.
- [ x ] Changes have been tested to not break existing functionality.
- [ x ] Documentation is up-to-date.
