### PR TITLE
[v4] docs: fixed various typos in docs

### DIFF
--- a/docs/01-introduction/01-overview.md
+++ b/docs/01-introduction/01-overview.md
@@ -42,7 +42,7 @@ Filament is designed to be highly extensible, allowing you to add your own UI co
 The vast majority of plugins in the ecosystem are open-source and free to use. Some premium plugins are available for purchase, often offering enhanced customer support and quality.
 
 <Aside variant="warning">
-    Plugins not maintained by Filament team are created and managed by independent authors. While these plugins can enhance your experience, Filament cannot guarantee their quality, security, compatibility, or maintenance. We recommend reviewing the plugin's code, documentation, and user feedback before installation.
+    Plugins not maintained by the Filament team are created and managed by independent authors. While these plugins can enhance your experience, Filament cannot guarantee their quality, security, compatibility, or maintenance. We recommend reviewing the plugin's code, documentation, and user feedback before installation.
 </Aside>
 
 You can browse an extensive list of official and community plugins on the [Filament website](/plugins).

--- a/docs/03-resources/01-overview.md
+++ b/docs/03-resources/01-overview.md
@@ -443,7 +443,7 @@ public static function getNavigationParentItem(): ?string
 
 ## Generating URLs to resource pages
 
-Filament provides `getUrl()` static method on resource classes to generate URLs to resources and specific pages within them. Traditionally, you would need to construct the URL by hand or by using Laravel's `route()` helper, but these methods depend on knowledge of the resource's slug or route naming conventions.
+Filament provides a `getUrl()` static method on resource classes to generate URLs to resources and specific pages within them. Traditionally, you would need to construct the URL by hand or by using Laravel's `route()` helper, but these methods depend on knowledge of the resource's slug or route naming conventions.
 
 The `getUrl()` method, without any arguments, will generate a URL to the resource's [List page](listing-records):
 

--- a/docs/06-navigation/01-overview.md
+++ b/docs/06-navigation/01-overview.md
@@ -250,7 +250,7 @@ enum NavigationGroup
 }
 ```
 
-To order that the cases are defined in will control the order of the navigation groups.
+The order that the cases are defined in will control the order of the navigation groups.
 
 To use an enum navigation group for a resource or custom page, you can set the `$navigationGroup` property to the enum case:
 

--- a/docs/07-users/01-overview.md
+++ b/docs/07-users/01-overview.md
@@ -331,7 +331,7 @@ public function panel(Panel $panel): Panel
 
 ### Disabling revealable password inputs
 
-By default, all password inputs in authentication forms are [`revealable()`](../forms/text-input#revealable-password-inputs). This allows the user can see a plain text version of the password they're typing by clicking a button. To disable this feature, you can pass `false` to the `revealablePasswords()` [configuration](../panel-configuration) method:
+By default, all password inputs in authentication forms are [`revealable()`](../forms/text-input#revealable-password-inputs). This allows the user to see a plain text version of the password they're typing by clicking a button. To disable this feature, you can pass `false` to the `revealablePasswords()` [configuration](../panel-configuration) method:
 
 ```php
 use Filament\Panel;

--- a/docs/07-users/03-tenancy.md
+++ b/docs/07-users/03-tenancy.md
@@ -485,7 +485,7 @@ However, this is a sign that Filament's tenancy feature is not suitable for your
 
 ## Setting up avatars
 
-Out of the box, Filament uses [ui-avatars.com](https://ui-avatars.com) to generate avatars based on a user's name. However, if you user model has an `avatar_url` attribute, that will be used instead. To customize how Filament gets a user's avatar URL, you can implement the `HasAvatar` contract:
+Out of the box, Filament uses [ui-avatars.com](https://ui-avatars.com) to generate avatars based on a user's name. However, if your user model has an `avatar_url` attribute, that will be used instead. To customize how Filament gets a user's avatar URL, you can implement the `HasAvatar` contract:
 
 ```php
 <?php

--- a/docs/10-testing/01-overview.md
+++ b/docs/10-testing/01-overview.md
@@ -12,7 +12,7 @@ Since all Filament components are mounted to a Livewire component, we're just us
 
 Looking for a full example on how to test a panel resource? Check out the [Testing resources](testing-resources) section.
 
-If you could like to learn the different methods available to test tables, check out the [Testing tables](testing-tables) section.
+If you would like to learn the different methods available to test tables, check out the [Testing tables](testing-tables) section.
 
 If you need to test a schema, which encompasses both forms and infolists, check out the [Testing schemas](testing-schemas) section.
 

--- a/docs/10-testing/03-testing-tables.md
+++ b/docs/10-testing/03-testing-tables.md
@@ -178,7 +178,7 @@ it('has an author column', function () {
 });
 ```
 
-You may pass a function as an additional argument to assert that a column passes a given "truth test". This is useful for asserting that a column has a specific configuration. You can also pass in a record as the third parameter, which is useful if your check is dependant on which table row is being rendered:
+You may pass a function as an additional argument to assert that a column passes a given "truth test". This is useful for asserting that a column has a specific configuration. You can also pass in a record as the third parameter, which is useful if your check is dependent on which table row is being rendered:
 
 ```php
 use function Pest\Livewire\livewire;
@@ -385,7 +385,7 @@ You may pass a function as an additional argument to assert that a filter passes
 use function Pest\Livewire\livewire;
 use Filament\Tables\Filters\SelectFilter;
 
-it('has an author filter', function () {    
+it('has an author filter', function () {
     livewire(PostResource\Pages\ListPosts::class)
         ->assertTableFilterExists('author', function (SelectFilter $column): bool {
             return $column->getLabel() === 'Select author';
@@ -464,7 +464,7 @@ By default, only columns that are toggled on by default in the table will be ren
 ```php
 use function Pest\Livewire\livewire;
 
-it('can toggle all columns', function () {    
+it('can toggle all columns', function () {
     livewire(PostResource\Pages\ListPosts::class)
         ->toggleAllTableColumns();
 });
@@ -475,7 +475,7 @@ You can also toggle all columns off using `toggleAllTableColumns(false)`:
 ```php
 use function Pest\Livewire\livewire;
 
-it('can toggle all columns off', function () {    
+it('can toggle all columns off', function () {
     livewire(PostResource\Pages\ListPosts::class)
         ->toggleAllTableColumns(false);
 });

--- a/docs/11-plugins/03-building-a-panel-plugin.md
+++ b/docs/11-plugins/03-building-a-panel-plugin.md
@@ -136,7 +136,7 @@ class ClockWidget extends Widget
 }
 ```
 
-Next, we'll need to create the view for our widget. Create a new file at `resources/views/widget.blade.php` and add the following code. We'll make use of Filament's blade components to save time on writing the html for the widget.
+Next, we'll need to create the view for our widget. Create a new file at `resources/views/widget.blade.php` and add the following code. We'll make use of Filament's Blade components to save time on writing the HTML for the widget.
 
 We are using async Alpine to load our Alpine component, so we'll need to add the `x-load` attribute to the div to tell Alpine to load our component. You can learn more about this in the [Core Concepts](../advanced/assets#asynchronous-alpinejs-components) section of the docs.
 

--- a/docs/11-plugins/04-building-a-standalone-plugin.md
+++ b/docs/11-plugins/04-building-a-standalone-plugin.md
@@ -89,7 +89,7 @@ You may also remove the testing directories and files, but we'll leave them in f
 
 Now that we have our plugin cleaned up, we can start adding our code. The boilerplate in the `src/HeadingsServiceProvider.php` file has a lot going on so, let's delete everything and start from scratch.
 
-We need to be able to register our stylesheet with the Filament Asset Manager so that we can load it on demand in our blade view. To do this, we'll need to add the following to the `packageBooted` method in our service provider.
+We need to be able to register our stylesheet with the Filament Asset Manager so that we can load it on demand in our Blade view. To do this, we'll need to add the following to the `packageBooted` method in our service provider.
 
 ***Note the `loadedOnRequest()` method. This is important, because it tells Filament to only load the stylesheet when it's needed.***
 

--- a/docs/12-components/03-empty-state.md
+++ b/docs/12-components/03-empty-state.md
@@ -86,7 +86,7 @@ By default, the size of the empty state icon is "large". You can change it to be
 
 ## Adding footer actions to the empty state
 
-You can add actions below the description by using the `footer` slot. This is useful for placing buttons, like the `[<x-filament::button>`](button) component:
+You can add actions below the description by using the `footer` slot. This is useful for placing buttons, like the [`<x-filament::button>`](button) component:
 
 ```blade
 <x-filament::empty-state>

--- a/docs/13-deployment.md
+++ b/docs/13-deployment.md
@@ -29,7 +29,7 @@ To optimize Filament for production, you should run the following command in you
 php artisan filament:optimize
 ```
 
-This command will [cache the Filament components](#caching-filament-components) and additionally the [Blade icons](#caching-blade-icons), which can significantly improve the performance of your Filament panels. This command is a shorthand for the commands `php artisan filament:cache-components` and `php artisan icons:cache`.
+This command will [cache the Filament components](#caching-filament-components) and additionally the [Blade Icons](#caching-blade-icons), which can significantly improve the performance of your Filament panels. This command is a shorthand for the commands `php artisan filament:cache-components` and `php artisan icons:cache`.
 
 To clear the caches at once, you can run:
 

--- a/docs/14-upgrade-guide.md
+++ b/docs/14-upgrade-guide.md
@@ -24,7 +24,7 @@ import Disclosure from "@components/Disclosure.astro"
 </Aside>
 
 <Aside variant="info">
-    Some plugins you're using may not be available in v4 just yet. You could temporarily remove them from your `composer.json` file until they've been upgraded, replace them with a similar plugins that are v4-compatible, wait for the plugins to be upgraded before upgrading your app, or even write PRs to help the authors upgrade them.
+    Some plugins you're using may not be available in v4 just yet. You could temporarily remove them from your `composer.json` file until they've been upgraded, replace them with similar plugins that are v4-compatible, wait for the plugins to be upgraded before upgrading your app, or even write PRs to help the authors upgrade them.
 </Aside>
 
 The first step to upgrade your Filament app is to run the automated upgrade script. This script will automatically upgrade your application to the latest version of Filament and make changes to your code, which handles most breaking changes:
@@ -717,7 +717,7 @@ public function table(Table $table): Table
 <Disclosure x-show="packages.includes('panels')">
 <span slot="summary">Overriding the `can*()` authorization methods on a `Resource`, `RelationManager` or `ManageRelatedRecords` class</span>
 
-Although these methods, such as `canCreate()`, `canViewAny()` and `canDelete()`weren’t documented, if you’re overriding those to provide custom authorization logic in v3, you should be aware that they aren’t always called in v4. The authorization logic has been improved to properly support [policy response objects](https://laravel.com/docs/authorization#policy-responses), and these methods were too simple as they are just able to return booleans.
+Although these methods, such as `canCreate()`, `canViewAny()` and `canDelete()` weren't documented, if you're overriding those to provide custom authorization logic in v3, you should be aware that they aren't always called in v4. The authorization logic has been improved to properly support [policy response objects](https://laravel.com/docs/authorization#policy-responses), and these methods were too simple as they are just able to return booleans.
 
 If you can make the authorization customization inside the policy of the model instead, you should do that. If you need to customize the authorization logic in the resource or relation manager class, you should override the `get*AuthorizationResponse()` methods instead, such as `getCreateAuthorizationResponse()`, `getViewAnyAuthorizationResponse()` and `getDeleteAuthorizationResponse()`. These methods are called when the authorization logic is executed, and they return a [policy response object](https://laravel.com/docs/authorization#policy-responses). If you remove the override for the `can*()` methods, the `get*AuthorizationResponse()` methods will be used to determine the authorization response boolean, so you don't have to maintain the logic twice.
 </Disclosure>

--- a/packages/actions/docs/12-export.md
+++ b/packages/actions/docs/12-export.md
@@ -298,7 +298,7 @@ ExportColumn::make('users_exists')
 
 In this example, `users` is the name of the relationship to check for existence. The name of the column must be `users_exists`, as this is the convention that [Laravel uses](https://laravel.com/docs/eloquent-relationships#other-aggregate-functions) for storing the result.
 
-If you'd like to scope the relationship before checking existance, you can pass an array to the method, where the key is the relationship name and the value is the function to scope the Eloquent query with:
+If you'd like to scope the relationship before checking existence, you can pass an array to the method, where the key is the relationship name and the value is the function to scope the Eloquent query with:
 
 ```php
 use Filament\Actions\Exports\ExportColumn;

--- a/packages/tables/docs/02-columns/01-overview.md
+++ b/packages/tables/docs/02-columns/01-overview.md
@@ -143,7 +143,7 @@ TextColumn::make('users_exists')->exists('users')
 
 In this example, `users` is the name of the relationship to check for existence. The name of the column must be `users_exists`, as this is the convention that [Laravel uses](https://laravel.com/docs/eloquent-relationships#other-aggregate-functions) for storing the result.
 
-If you'd like to scope the relationship before checking existance, you can pass an array to the method, where the key is the relationship name and the value is the function to scope the Eloquent query with:
+If you'd like to scope the relationship before checking existence, you can pass an array to the method, where the key is the relationship name and the value is the function to scope the Eloquent query with:
 
 ```php
 use Filament\Tables\Columns\TextColumn;


### PR DESCRIPTION
## Description
Fixed various typos discovered by multiple LLMs and carefully reviewed by me to ensure they are all real.

## Visual changes
Just doc typo fixes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
