### PR TITLE
Added "Publishing configuration" file section to the installation docs

### DIFF
--- a/docs/01-introduction/02-installation.md
+++ b/docs/01-introduction/02-installation.md
@@ -70,16 +70,6 @@ php artisan make:filament-user
 
 Open `/admin` in your web browser, sign in, and [start building your app](../getting-started)!
 
-### Publishing configuration
-
-Filament ships with a configuration file that allows you to override defaults shared across all packages. Publish it after installing the panel builder so you can review and customize the settings:
-
-```bash
-php artisan vendor:publish --tag=filament-config
-```
-
-This command creates `config/filament.php`, where you can configure options like the default filesystem disk, file generation flags, and UI defaults. Re-run the publish command any time you want to pull in newly added configuration keys before tweaking them to suit your project.
-
 </div>
 
 <div
@@ -290,5 +280,15 @@ The important parts of this are the `@filamentStyles` in the `<head>` of the lay
 </div>
 
 </div>
+
+## Publishing configuration
+
+Filament ships with a configuration file that allows you to override defaults shared across all packages. Publish it after installing the panel builder so you can review and customize the settings:
+
+```bash
+php artisan vendor:publish --tag=filament-config
+```
+
+This command creates `config/filament.php`, where you can configure options like the default filesystem disk, file generation flags, and UI defaults. Re-run the publish command any time you want to pull in newly added configuration keys before tweaking them to suit your project.
 
 </div>

--- a/docs/01-introduction/02-installation.md
+++ b/docs/01-introduction/02-installation.md
@@ -70,10 +70,20 @@ php artisan make:filament-user
 
 Open `/admin` in your web browser, sign in, and [start building your app](../getting-started)!
 
+### Publishing configuration
+
+Filament ships with a configuration file that allows you to override defaults shared across all packages. Publish it after installing the panel builder so you can review and customize the settings:
+
+```bash
+php artisan vendor:publish --tag=filament-config
+```
+
+This command creates `config/filament.php`, where you can configure options like the default filesystem disk, file generation flags, and UI defaults. Re-run the publish command any time you want to pull in newly added configuration keys before tweaking them to suit your project.
+
 </div>
 
 <div
-    x-show="package === 'components'" 
+    x-show="package === 'components'"
     x-data="{ laravelProject: 'new' }"
     x-cloak
 >
@@ -228,7 +238,7 @@ export default defineConfig({
 
 Compile your new CSS and JavaScript assets using `npm run dev`.
 
-### Configuring your layout 
+### Configuring your layout
 
 If you don't have a Blade layout file yet, create it at `resources/views/components/layouts/app.blade.php` by running the following command:
 


### PR DESCRIPTION
## Description
There are 8 occurances in the docs that link to this URL https://filamentphp.com/docs/4.x/introduction/overview#publishing-configuration but there is no `#publishing-configuration` section leading to confusion.

The closest section I found is in the [upgrade guide](https://filamentphp.com/docs/4.x/upgrade-guide#publishing-the-configuration-file) which I was going to update the references to, but it didn't feel right.

So this PR adds a `#publishing-configuration`  to the https://filamentphp.com/docs/4.x/introduction/installation page.

Here are the places that reference this missing section.

- [docs/05-panel-configuration.md#L410](https://github.com/angus-mcritchie/filament/blob/c84f15ae7f2d76d8f2016efa1b1092fe5e7fcb4a/docs/05-panel-configuration.md?plain=1#L410)
- [packages/actions/docs/12-export.md#L423](https://github.com/angus-mcritchie/filament/blob/8e0b87f6a535a77c4a5759a96f3ec459860009c2/packages/actions/docs/12-export.md?plain=1#L423)
- [packages/forms/docs/09-file-upload.md#L26](https://github.com/angus-mcritchie/filament/blob/c6cf3ee11ee54292c7d19f04c338feb6e7d2f9e2/packages/forms/docs/09-file-upload.md?plain=1#L26)
- [packages/infolists/docs/04-image-entry.md#L17](https://github.com/angus-mcritchie/filament/blob/31b1d0764dee25ee7a1446b06afb6db008171644/packages/infolists/docs/04-image-entry.md?plain=1#L17)
- [packages/infolists/docs/04-image-entry.md#L25](https://github.com/angus-mcritchie/filament/blob/31b1d0764dee25ee7a1446b06afb6db008171644/packages/infolists/docs/04-image-entry.md?plain=1#L25)
- [packages/spatie-laravel-media-library-plugin/README.md#L52](https://github.com/angus-mcritchie/filament/blob/99346e610502138f56551a270fa17ad9d5e91e3e/packages/spatie-laravel-media-library-plugin/README.md?plain=1#L52)
- [packages/tables/docs/02-columns/04-image.md#L18](https://github.com/angus-mcritchie/filament/blob/31b1d0764dee25ee7a1446b06afb6db008171644/packages/tables/docs/02-columns/04-image.md?plain=1#L18)
- [packages/tables/docs/02-columns/04-image.md#L26](https://github.com/angus-mcritchie/filament/blob/31b1d0764dee25ee7a1446b06afb6db008171644/packages/tables/docs/02-columns/04-image.md?plain=1#L26)

## Visual changes
Docs only.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
