### PR TITLE
Add translateLabel to ExportColumn

### DIFF
--- a/packages/actions/src/Exports/ExportColumn.php
+++ b/packages/actions/src/Exports/ExportColumn.php
@@ -21,6 +21,8 @@ class ExportColumn extends Component
 
     protected string | Closure | null $label = null;
 
+    protected bool $shouldTranslateLabel = false;
+
     protected ?Exporter $exporter = null;
 
     protected bool | Closure $isEnabledByDefault = true;
@@ -101,14 +103,25 @@ class ExportColumn extends Component
         return $this->getExporter()?->getRecord();
     }
 
+    public function translateLabel(bool $shouldTranslateLabel = true): static
+    {
+        $this->shouldTranslateLabel = $shouldTranslateLabel;
+
+        return $this;
+    }
+
     public function getLabel(): ?string
     {
-        return $this->evaluate($this->label) ?? (string) str($this->getName())
+        $label = $this->evaluate($this->label) ?? (string) str($this->getName())
             ->beforeLast('.')
             ->afterLast('.')
             ->kebab()
             ->replace(['-', '_'], ' ')
             ->ucfirst();
+
+        return is_string($label) && $this->shouldTranslateLabel
+            ? __($label)
+            : $label;
     }
 
     public function applyRelationshipAggregates(EloquentBuilder $query): EloquentBuilder


### PR DESCRIPTION
## Description

The ExportColumn does not have a `translateLabel` method. It simply adds that to translate column names

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date. - I can add to the label example if approved
