### PR TITLE
Add shouldDispatchNotificationEvent method to exporter

### DIFF
--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -242,4 +242,9 @@ abstract class Exporter
     {
         return $query;
     }
+
+    public static function shouldDispatchNotificationEvent(Export $export): bool
+    {
+        return true;
+    }
 }

--- a/packages/actions/src/Exports/Jobs/ExportCompletion.php
+++ b/packages/actions/src/Exports/Jobs/ExportCompletion.php
@@ -52,6 +52,7 @@ class ExportCompletion implements ShouldQueue
         }
 
         $failedRowsCount = $this->export->getFailedRowsCount();
+        $shouldDispatchNotificationEvent = $this->exporter->shouldDispatchNotificationEvent($this->export);
 
         Notification::make()
             ->title($this->exporter::getCompletedNotificationTitle($this->export))
@@ -81,7 +82,7 @@ class ExportCompletion implements ShouldQueue
                 fn (Notification $notification) => $notification
                     ->persistent()
                     ->send(),
-                fn (Notification $notification) => $notification->sendToDatabase($this->export->user, isEventDispatched: true),
+                fn (Notification $notification) => $notification->sendToDatabase($this->export->user, isEventDispatched: $shouldDispatchNotificationEvent),
             );
     }
 }

--- a/packages/actions/src/Exports/Jobs/ExportCompletion.php
+++ b/packages/actions/src/Exports/Jobs/ExportCompletion.php
@@ -52,7 +52,7 @@ class ExportCompletion implements ShouldQueue
         }
 
         $failedRowsCount = $this->export->getFailedRowsCount();
-        $shouldDispatchNotificationEvent = $this->exporter->shouldDispatchNotificationEvent($this->export);
+        $shouldDispatchNotificationEvent = $this->exporter::shouldDispatchNotificationEvent($this->export);
 
         Notification::make()
             ->title($this->exporter::getCompletedNotificationTitle($this->export))


### PR DESCRIPTION
## Description

When an export is completed it sends a notification to the user and writes a line on the log. While it can be useful, when using external channels for the logs it can be strange or bothersome to receive a message when an user completes an export (even more when there are a lot of them)
With this it can be controlled from the exporter if the notification should dispatch the DatabaseNotificationSent event.
Default is true to not change previous behaviour

## Visual changes

//

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date. - Can add to the documentation if and when approved
