### PR TITLE
Update `pragmarx/google2fa` dependency to `^9.0`

### DIFF
--- a/packages/panels/composer.json
+++ b/packages/panels/composer.json
@@ -18,7 +18,7 @@
         "filament/support": "self.version",
         "filament/tables": "self.version",
         "filament/widgets": "self.version",
-        "pragmarx/google2fa": "^9.0",
+        "pragmarx/google2fa": "^8.0|^9.0",
         "pragmarx/google2fa-qrcode": "^3.0"
     },
     "autoload": {

--- a/packages/panels/composer.json
+++ b/packages/panels/composer.json
@@ -18,7 +18,7 @@
         "filament/support": "self.version",
         "filament/tables": "self.version",
         "filament/widgets": "self.version",
-        "pragmarx/google2fa": "^8.0",
+        "pragmarx/google2fa": "^9.0",
         "pragmarx/google2fa-qrcode": "^3.0"
     },
     "autoload": {

--- a/packages/panels/src/Auth/MultiFactor/App/AppAuthentication.php
+++ b/packages/panels/src/Auth/MultiFactor/App/AppAuthentication.php
@@ -123,9 +123,9 @@ class AppAuthentication implements MultiFactorAuthenticationProvider
         ));
     }
 
-    public function generateSecret(): string
+    public function generateSecret(int $secretLength = 16): string
     {
-        return $this->google2FA->generateSecretKey();
+        return $this->google2FA->generateSecretKey($secretLength);
     }
 
     public function getCurrentCode(HasAppAuthentication $user, ?string $secret = null): string

--- a/packages/panels/src/Auth/MultiFactor/App/AppAuthentication.php
+++ b/packages/panels/src/Auth/MultiFactor/App/AppAuthentication.php
@@ -123,9 +123,9 @@ class AppAuthentication implements MultiFactorAuthenticationProvider
         ));
     }
 
-    public function generateSecret(int $secretLength = 16): string
+    public function generateSecret(): string
     {
-        return $this->google2FA->generateSecretKey($secretLength);
+        return $this->google2FA->generateSecretKey(16);
     }
 
     public function getCurrentCode(HasAppAuthentication $user, ?string $secret = null): string


### PR DESCRIPTION
## Description
Closes #81
Updates `pragmarx/google2fa` dependency to `^9.0` and ensures previous secret key length (16 characters)

## Visual changes
n/a

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
