### PR TITLE
un-deprecate mountTableAction

### DIFF
--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -77,14 +77,8 @@ namespace Livewire\Features\SupportTesting {
 
         public function loadTable(): static {}
 
-        /**
-         * @deprecated Use `mountAction()` instead.
-         */
         public function mountTableAction(string | array $name, $record = null): static {}
 
-        /**
-         * @deprecated Use `unmountAction()` instead.
-         */
         public function unmountTableAction(): static {}
 
         /**


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
This removes the `@deprecation` on the [testing stubs for `mountTableAction`](https://github.com/filamentphp/filament/blob/d7b51314c6c3000b7879ccc11a33185fca1edf15/packages/tables/.stubs.php#L83). It proposes to use the alternative `mountAction` however with that one it's not possible to pass the required context `['table' => true]` making it not a suitable alternative. I opted to remove the deprecation as I suspect this might be incorrect as the [underlying implementation](https://github.com/filamentphp/filament/blob/d7b51314c6c3000b7879ccc11a33185fca1edf15/packages/tables/src/Testing/TestsActions.php#L22) on `TestsActions` is not deprecated.

Appreciate this might not be the correct direction, happy to update `mountAction` to support passing context if the deprecation was intended.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

N/A

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
