### PR TITLE
Update Tailwind CSS version in upgrade guide

### DIFF
--- a/docs/14-upgrade-guide.md
+++ b/docs/14-upgrade-guide.md
@@ -14,7 +14,7 @@ import Disclosure from "@components/Disclosure.astro"
 
 - PHP 8.2+
 - Laravel v11.28+
-- Tailwind CSS v4.0+, if you’re currently using Tailwind CSS v3.0 with Filament. This doesn’t apply if you’re just using a Filament panel without a custom theme CSS file.
+- Tailwind CSS v4.1+, if you’re currently using Tailwind CSS v3.0 with Filament. This doesn’t apply if you’re just using a Filament panel without a custom theme CSS file.
 - Filament no longer requires `doctrine/dbal`, but if your application still does, and you don’t have it installed directly, you should add it to your `composer.json` file.
 
 ## Running the automated upgrade script


### PR DESCRIPTION
This PR updates the Filament v4 upgrade guide to require **Tailwind CSS v4.1+** instead of v4.0.
Filament v4 introduces the `wrap-anywhere` utility in `key-value.css` [here](https://github.com/filamentphp/filament/pull/16954/files#diff-a8e87ca324b0247e9c667edd2bc6881885263142efd4fd31b661b5ac0587c944R17), but this utility was only added to Tailwind in **v4.1.0** (see Tailwind [PR #17483](https://github.com/tailwindlabs/tailwindcss/pull/17483/files#diff-036c40df8e1498a5c399fb971238a19fcdab257001b9703661a46a110984b56aL2111-R2084)). Because Tailwind v4.0 does not include this class, projects following the current upgrade guide may encounter missing-utility issues (`Cannot apply unknown utility class: wrap-anywhere`). Updating the requirement ensures theTailwind version matches Filament’s actual usage.
