### PR TITLE
Support multibyte whitespaces

### DIFF
--- a/packages/panels/src/Resources/Resource/Concerns/HasGlobalSearch.php
+++ b/packages/panels/src/Resources/Resource/Concerns/HasGlobalSearch.php
@@ -175,7 +175,7 @@ trait HasGlobalSearch
         }
 
         $searchWords = array_filter(
-            str_getcsv(preg_replace('/\s+/', ' ', $search), separator: ' ', escape: '\\'),
+            str_getcsv(preg_replace('/(\s|\x{3164}|\x{1160})+/u', ' ', $search), separator: ' ', escape: '\\'),
             fn ($word): bool => filled($word),
         );
 

--- a/packages/tables/src/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Concerns/CanSearchRecords.php
@@ -125,7 +125,7 @@ trait CanSearchRecords
     protected function extractTableSearchWords(string $search): array
     {
         return array_filter(
-            str_getcsv(preg_replace('/\s+/', ' ', $search), separator: ' ', escape: '\\'),
+            str_getcsv(preg_replace('/(\s|\x{3164}|\x{1160})+/u', ' ', $search), separator: ' ', escape: '\\'),
             fn ($word): bool => filled($word),
         );
     }

--- a/tests/src/Tables/Concerns/CanSearchRecordsTest.php
+++ b/tests/src/Tables/Concerns/CanSearchRecordsTest.php
@@ -19,6 +19,7 @@ it('can extract the search into words using whitespace', function (): void {
     assertCount(2, $trait->extractTableSearchWords('testy test'));
     assertCount(2, $trait->extractTableSearchWords('testy   test'));
     assertCount(2, $trait->extractTableSearchWords("testy \t \n \r  test"));
+    assertCount(2, $trait->extractTableSearchWords("testy 　 \u{3164} \u{1160}  test"));
     assertCount(3, $trait->extractTableSearchWords('testy   tasty   test'));
 
     // test count when string contains phrases


### PR DESCRIPTION
## Description

Support normalization of various full-size and other multibyte whitespace chars during search term extraction.

Since the implementation is the same as `Illuminate\Support\Str::squish`, I think it's fine to replace it with `Illuminate\Support\Str`.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
