### PR TITLE
Trim invisible characters

### DIFF
--- a/packages/tables/src/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Concerns/CanSearchRecords.php
@@ -5,6 +5,7 @@ namespace Filament\Tables\Concerns;
 use Filament\Tables\Filters\Indicator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
 
@@ -199,7 +200,7 @@ trait CanSearchRecords
 
     public function getTableSearch(): ?string
     {
-        return filled($this->tableSearch) ? trim(strval($this->tableSearch)) : null;
+        return filled($this->tableSearch) ? Str::trim(strval($this->tableSearch)) : null;
     }
 
     public function hasTableSearch(): bool

--- a/tests/src/Tables/Concerns/CanSearchRecordsTest.php
+++ b/tests/src/Tables/Concerns/CanSearchRecordsTest.php
@@ -62,4 +62,13 @@ it('can trim the search query', function (): void {
 
     $trait->tableSearch = '  testy "test phrase" ';
     $this->assertSame('testy "test phrase"', $trait->getTableSearch());
+
+    $trait->tableSearch = '　　　test　　　';
+    $this->assertSame('test', $trait->getTableSearch());
+
+    $trait->tableSearch = "\u{3164}\u{3164}test\u{3164}\u{3164}";
+    $this->assertSame('test', $trait->getTableSearch());
+
+    $trait->tableSearch = "\u{1160}\u{1160}test\u{1160}\u{1160}";
+    $this->assertSame('test', $trait->getTableSearch());
 });


### PR DESCRIPTION
## Description

Multibyte characters contain numerous invisible characters. Removing them prevents unintended searches.

Since invisible characters are countless, we switched from custom implementation to using Laravel's helper.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
