### PR TITLE
Adding details about notifications and export format

### DIFF
--- a/packages/actions/docs/12-export.md
+++ b/packages/actions/docs/12-export.md
@@ -6,9 +6,7 @@ import UtilityInjection from "@components/UtilityInjection.astro"
 
 ## Introduction
 
-Filament includes an action that is able to export rows to a CSV or XLSX file. When the trigger button is clicked, a modal asks for the columns that they want to export, and what they should be labeled. This feature uses [job batches](https://laravel.com/docs/queues#job-batching) and [database notifications](../../notifications/database-notifications), so you need to publish those migrations from Laravel. 
-If you’d like to receive notifications in a panel, you can enable them in the [panel configuration](../../notifications/database-notifications#enabling-database-notifications-in-a-panel).
-Also, you need to publish the migrations for tables that Filament uses to store information about exports:
+Filament includes an action that is able to export rows to a CSV or XLSX file. When the trigger button is clicked, a modal asks for the columns that they want to export, and what they should be labeled. This feature uses [job batches](https://laravel.com/docs/queues#job-batching) and [database notifications](../../notifications/database-notifications), so you need to publish those migrations from Laravel. Also, you need to publish the migrations for tables that Filament uses to store information about exports:
 
 ```bash
 php artisan make:queue-batches-table
@@ -16,6 +14,8 @@ php artisan make:notifications-table
 php artisan vendor:publish --tag=filament-actions-migrations
 php artisan migrate
 ```
+
+If you’d like to receive export notifications in a panel, you can enable them in the [panel configuration](../../notifications/database-notifications#enabling-database-notifications-in-a-panel).
 
 <Aside variant="info">
     If you're using PostgreSQL, make sure that the `data` column in the notifications migration is using `json()`: `$table->json('data')`.

--- a/packages/actions/docs/12-export.md
+++ b/packages/actions/docs/12-export.md
@@ -6,7 +6,9 @@ import UtilityInjection from "@components/UtilityInjection.astro"
 
 ## Introduction
 
-Filament includes an action that is able to export rows to a CSV or XLSX file. When the trigger button is clicked, a modal asks for the columns that they want to export, and what they should be labeled. This feature uses [job batches](https://laravel.com/docs/queues#job-batching) and [database notifications](../../notifications/database-notifications), so you need to publish those migrations from Laravel. Also, you need to publish the migrations for tables that Filament uses to store information about exports:
+Filament includes an action that is able to export rows to a CSV or XLSX file. When the trigger button is clicked, a modal asks for the columns that they want to export, and what they should be labeled. This feature uses [job batches](https://laravel.com/docs/queues#job-batching) and [database notifications](../../notifications/database-notifications), so you need to publish those migrations from Laravel. 
+If you’d like to receive notifications in a panel, you can enable them in the [panel configuration](../../notifications/database-notifications#enabling-database-notifications-in-a-panel).
+Also, you need to publish the migrations for tables that Filament uses to store information about exports:
 
 ```bash
 php artisan make:queue-batches-table
@@ -337,7 +339,7 @@ ExportColumn::make('users_avg_age')
 
 ## Configuring the export formats
 
-By default, the export action will allow the user to choose between both CSV and XLSX formats. You can use the `ExportFormat` enum to customize this, by passing an array of formats to the `formats()` method on the action:
+By default, the export action will generate both CSV and XLSX formats and allow user to choose between it in the notification. You can use the `ExportFormat` enum to customize this, by passing an array of formats to the `formats()` method on the action:
 
 ```php
 use App\Filament\Exports\ProductExporter;

--- a/packages/actions/docs/12-export.md
+++ b/packages/actions/docs/12-export.md
@@ -339,7 +339,7 @@ ExportColumn::make('users_avg_age')
 
 ## Configuring the export formats
 
-By default, the export action will generate both CSV and XLSX formats and allow user to choose between it in the notification. You can use the `ExportFormat` enum to customize this, by passing an array of formats to the `formats()` method on the action:
+By default, the export action will generate both CSV and XLSX formats and allow user to choose between them in the notification. You can use the `ExportFormat` enum to customize this, by passing an array of formats to the `formats()` method on the action:
 
 ```php
 use App\Filament\Exports\ProductExporter;


### PR DESCRIPTION
## Description

This PR updates the actions/export documentation page :

- Filament export requires notifications to be setup in a panel to be visible in common cases
- All formats are generated when none is provided, then it can be unexpected on big dataset

