### PR TITLE
[4.x] Table of Contents for the Rich Editor

### DIFF
--- a/packages/forms/docs/10-rich-editor.md
+++ b/packages/forms/docs/10-rich-editor.md
@@ -51,6 +51,19 @@ class Post extends Model
 }
 ```
 
+### Output to Array
+Rather than working with the HTML string that we provide, you can also output to an array representation of the content by using the `toArray()` method:
+
+```php
+use Filament\Forms\Components\RichEditor\RichContentRenderer;
+
+$content = RichContentRenderer::make($record->content)->toArray()
+```
+
+You can then iterate through the `$content['content']` array to access the individual nodes.
+
+This can be useful if you want to manipulate the content in some way before rendering it, or if you want to output it in a different format (e.g., JSON for an API).
+
 ## Customizing the toolbar buttons
 
 You may set the toolbar buttons for the editor using the `toolbarButtons()` method. The options shown here are the defaults:
@@ -276,6 +289,30 @@ However, some features, such as the grid layout and text colors, require additio
     {!! \Filament\Forms\Components\RichEditor\RichContentRenderer::make($record->content) !!}
 </div>
 ```
+
+
+### Table of Contents
+
+The rich editor supports generating a table of contents (ToC) based on the headings in the content. You can generate a ToC using the `getTableOfContents()` method on the `RichContentRenderer`:
+It has an optional parameter `maxDepth`, which controls how deep the ToC should go (e.g., h2, h3, etc.). You should use an integer to define the depth.
+
+```php
+$tableOfContents = \Filament\Forms\Components\RichEditor\RichContentRenderer::make($article->raw_content)->toTableOfContents(maxDepth: 3)
+
+// Example Output
+array:4 [▼
+  0 => array:3 [▼
+    "id" => "heading-1-test"
+    "text" => "Heading 1 Test"
+    "depth" => 2
+  ]
+  1 => array:3 [▶]
+  2 => array:4 [▶]
+  3 => array:3 [▶]
+]
+```
+You can then iterate through this array to create your own table of contents.
+
 
 ## Security
 

--- a/packages/forms/src/Components/RichEditor/RichContentRenderer.php
+++ b/packages/forms/src/Components/RichEditor/RichContentRenderer.php
@@ -431,6 +431,150 @@ class RichContentRenderer implements Htmlable
     }
 
     /**
+     * Generate a hierarchical Table of Contents for the current editor content.
+     *
+     * @param  int  $maxDepth  Maximum heading level (1..6) to include.
+     * @return array<int, array{id:string, text:string, depth:int, subs?:array}>
+     */
+    public function toTableOfContents(int $maxDepth = 3): array
+    {
+        if (empty($this->content)) {
+            return [];
+        }
+
+        $document = $this->toArray();
+
+        if (empty($document['content'])) {
+            return [];
+        }
+
+        $idCounts = [];
+        $headings = $this->parseTOCHeadings($document['content'], $maxDepth, $idCounts);
+
+        if ($headings === []) {
+            return [];
+        }
+
+        return $this->generateTOCArray($headings);
+    }
+
+    /**
+     * Recursively extract heading nodes from a list of Tiptap nodes.
+     *
+     * @param  array<int, array<string, mixed>>  $nodes
+     * @param  array<string, int>  $idCounts  Used internally to ensure unique ids (slug => counter).
+     * @return array<int, array{level:int, id:string, text:string}>
+     */
+    private function parseTOCHeadings(array $nodes, int $maxDepth = 3, array &$idCounts = []): array
+    {
+        $headings = [];
+
+        foreach ($nodes as $node) {
+            if (! is_array($node) || ! isset($node['type'])) {
+                continue;
+            }
+
+            if ($node['type'] === 'heading' && isset($node['attrs']['level']) && $node['attrs']['level'] <= $maxDepth) {
+                $text = $this->extractPlainTextFromNode($node['content'] ?? []);
+                $text = trim($text);
+
+                // Derive / normalize id.
+                $id = $node['attrs']['id'] ?? Str::slug($text) ?: 'heading';
+
+                // Ensure uniqueness.
+                if (isset($idCounts[$id])) {
+                    $idCounts[$id]++;
+                    $id = $id . '-' . $idCounts[$id];
+                } else {
+                    $idCounts[$id] = 0;
+                }
+
+                $headings[] = [
+                    'level' => (int) $node['attrs']['level'],
+                    'id' => $id,
+                    'text' => $text,
+                ];
+            }
+
+            // Recurse into child content.
+            if (isset($node['content']) && is_array($node['content'])) {
+                $headings = [
+                    ...$headings,
+                    ...$this->parseTOCHeadings($node['content'], $maxDepth, $idCounts),
+                ];
+            }
+        }
+
+        return $headings;
+    }
+
+    /**
+     * Build a nested TOC tree from a flat, ordered heading list.
+     *
+     * Consumes the $headings array (by reference) as it assembles hierarchy.
+     *
+     * @param  array<int, array{level:int, id:string, text:string}>  $headings
+     * @return array<int, array{id:string, text:string, depth:int, subs?:array}>
+     */
+    private function generateTOCArray(array &$headings, int $parentLevel = 0): array
+    {
+        $result = [];
+
+        while ($headings !== []) {
+            $current = $headings[0];
+            $currentLevel = $current['level'];
+
+            if ($parentLevel >= $currentLevel) {
+                break;
+            }
+
+            array_shift($headings);
+
+            $nextLevel = $headings[0]['level'] ?? 0;
+
+            $entry = [
+                'id' => $current['id'],
+                'text' => $current['text'],
+                'depth' => $currentLevel,
+            ];
+
+            if ($nextLevel > $currentLevel) {
+                $entry['subs'] = $this->generateTOCArray($headings, $currentLevel);
+            }
+
+            $result[] = $entry;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Extract plain text recursively from a node content array.
+     *
+     * @param  array<int, array<string, mixed>>  $nodes
+     */
+    private function extractPlainTextFromNode(array $nodes): string
+    {
+        $buffer = '';
+
+        foreach ($nodes as $n) {
+            if (! is_array($n)) {
+                continue;
+            }
+
+            if (isset($n['text']) && is_string($n['text'])) {
+                $buffer .= $n['text'] . ' ';
+            }
+
+            if (isset($n['content']) && is_array($n['content'])) {
+                $buffer .= $this->extractPlainTextFromNode($n['content']) . ' ';
+            }
+        }
+
+        return trim(preg_replace('/\s+/', ' ', $buffer) ?? '');
+    }
+
+    /**
      * @param  ?array<string, mixed>  $tags
      */
     public function mergeTags(?array $tags): static

--- a/packages/forms/src/Components/RichEditor/RichContentRenderer.php
+++ b/packages/forms/src/Components/RichEditor/RichContentRenderer.php
@@ -478,23 +478,21 @@ class RichContentRenderer implements Htmlable
             }
 
             if ($node['type'] === 'heading' && isset($node['attrs']['level']) && $node['attrs']['level'] <= $maxDepth) {
-                $text = $this->extractPlainTextFromNode($node['content'] ?? []);
-                $text = trim($text);
+                $text = trim($this->extractPlainTextFromNode($node['content']));
 
-                // Derive / normalize id.
-                $id = $node['attrs']['id'] ?? Str::slug($text) ?: 'heading';
+                $baseId = empty($text) ? 'heading' : Str::slug($text);
 
-                // Ensure uniqueness.
-                if (isset($idCounts[$id])) {
-                    $idCounts[$id]++;
-                    $id = $id . '-' . $idCounts[$id];
+                if (isset($idCounts[$baseId])) {
+                    $idCounts[$baseId]++;
+                    $uniqueId = $baseId . '-' . $idCounts[$baseId];
                 } else {
-                    $idCounts[$id] = 0;
+                    $idCounts[$baseId] = 0;
+                    $uniqueId = $baseId;
                 }
 
                 $headings[] = [
                     'level' => (int) $node['attrs']['level'],
-                    'id' => $id,
+                    'id' => $uniqueId,
                     'text' => $text,
                 ];
             }
@@ -579,13 +577,13 @@ class RichContentRenderer implements Htmlable
 
     /**
      * @return void
-     * Wherever you have headings, this will inject ids into the heading attributes
-     * (if they don't already exist)
-     * This allows you to have a table of contents on your page that actually goes to the content.
+     * Assign unique IDs to heading nodes so you can jump to that section of the content.
      */
     protected function processHeaderIds($editor, int $maxDepth = 3): void
     {
-        $editor->descendants(function (&$node) use ($maxDepth) {
+        $idCounts = [];
+
+        $editor->descendants(function (&$node) use ($maxDepth, &$idCounts) {
             if ($node->type !== 'heading') {
                 return;
             }
@@ -594,11 +592,23 @@ class RichContentRenderer implements Htmlable
                 return;
             }
 
-            if (! property_exists($node->attrs, 'id') || $node->attrs->id === null) {
-                $node->attrs->id = str(collect($node->content)->map(function ($node) {
-                    return $node?->text ?? null;
-                })->implode(' '))->slug()->toString();
+            $baseId = str(collect($node->content)->map(function ($child) {
+                return $child?->text ?? null;
+            })->implode(' '))->slug()->toString();
+
+            if ($baseId === '') {
+                $baseId = 'heading';
             }
+
+            if (isset($idCounts[$baseId])) {
+                $idCounts[$baseId]++;
+                $uniqueId = $baseId . '-' . $idCounts[$baseId];
+            } else {
+                $idCounts[$baseId] = 0;
+                $uniqueId = $baseId;
+            }
+
+            $node->attrs->id = $uniqueId;
         });
     }
 

--- a/packages/forms/src/Components/RichEditor/RichContentRenderer.php
+++ b/packages/forms/src/Components/RichEditor/RichContentRenderer.php
@@ -437,7 +437,7 @@ class RichContentRenderer implements Htmlable
      * Generate a hierarchical Table of Contents for the current editor content.
      *
      * @param  int  $maxDepth  Maximum heading level (1..6) to include.
-     * @return array<int, array{id:string, text:string, depth:int, subs?:array}>
+     * @return array<int, array{id:string, text:string, depth:int, subs?:array<int, array<string, mixed>>}>
      */
     public function toTableOfContents(int $maxDepth = 3): array
     {
@@ -473,7 +473,7 @@ class RichContentRenderer implements Htmlable
         $headings = [];
 
         foreach ($nodes as $node) {
-            if (! is_array($node) || ! isset($node['type'])) {
+            if (! isset($node['type'])) {
                 continue;
             }
 
@@ -515,7 +515,7 @@ class RichContentRenderer implements Htmlable
      * Consumes the $headings array (by reference) as it assembles hierarchy.
      *
      * @param  array<int, array{level:int, id:string, text:string}>  $headings
-     * @return array<int, array{id:string, text:string, depth:int, subs?:array}>
+     * @return array<int, array{id:string, text:string, depth:int, subs?:array<int, array<string, mixed>>}>
      */
     private function generateTOCArray(array &$headings, int $parentLevel = 0): array
     {
@@ -559,10 +559,6 @@ class RichContentRenderer implements Htmlable
         $buffer = '';
 
         foreach ($nodes as $n) {
-            if (! is_array($n)) {
-                continue;
-            }
-
             if (isset($n['text']) && is_string($n['text'])) {
                 $buffer .= $n['text'] . ' ';
             }
@@ -579,7 +575,7 @@ class RichContentRenderer implements Htmlable
      * @return void
      *              Assign unique IDs to heading nodes so you can jump to that section of the content.
      */
-    protected function processHeaderIds($editor, int $maxDepth = 3): void
+    protected function processHeaderIds(Editor $editor, int $maxDepth = 3): void
     {
         $idCounts = [];
 
@@ -593,7 +589,7 @@ class RichContentRenderer implements Htmlable
             }
 
             $baseId = str(collect($node->content)->map(function ($child) {
-                return $child?->text ?? null;
+                return $child->text ?? null;
             })->implode(' '))->slug()->toString();
 
             if ($baseId === '') {

--- a/packages/forms/src/Components/RichEditor/RichContentRenderer.php
+++ b/packages/forms/src/Components/RichEditor/RichContentRenderer.php
@@ -11,6 +11,7 @@ use Filament\Forms\Components\RichEditor\TipTapExtensions\DetailsExtension;
 use Filament\Forms\Components\RichEditor\TipTapExtensions\DetailsSummaryExtension;
 use Filament\Forms\Components\RichEditor\TipTapExtensions\GridColumnExtension;
 use Filament\Forms\Components\RichEditor\TipTapExtensions\GridExtension;
+use Filament\Forms\Components\RichEditor\TipTapExtensions\IdExtension;
 use Filament\Forms\Components\RichEditor\TipTapExtensions\ImageExtension;
 use Filament\Forms\Components\RichEditor\TipTapExtensions\LeadExtension;
 use Filament\Forms\Components\RichEditor\TipTapExtensions\MergeTagExtension;
@@ -308,6 +309,7 @@ class RichContentRenderer implements Htmlable
             app(DetailsSummaryExtension::class),
             app(Document::class),
             app(GridColumnExtension::class),
+            app(IdExtension::class),
             app(GridExtension::class),
             app(HardBreak::class),
             app(Heading::class),
@@ -397,6 +399,7 @@ class RichContentRenderer implements Htmlable
         $this->processFileAttachments($editor);
         $this->processMergeTags($editor);
         $this->processNodes($editor);
+        $this->processHeaderIds($editor);
 
         return $editor->getHTML();
     }
@@ -572,6 +575,31 @@ class RichContentRenderer implements Htmlable
         }
 
         return trim(preg_replace('/\s+/', ' ', $buffer) ?? '');
+    }
+
+    /**
+     * @return void
+     * Wherever you have headings, this will inject ids into the heading attributes
+     * (if they don't already exist)
+     * This allows you to have a table of contents on your page that actually goes to the content.
+     */
+    protected function processHeaderIds($editor, int $maxDepth = 3): void
+    {
+        $editor->descendants(function (&$node) use ($maxDepth) {
+            if ($node->type !== 'heading') {
+                return;
+            }
+
+            if ($node->attrs->level > $maxDepth) {
+                return;
+            }
+
+            if (! property_exists($node->attrs, 'id') || $node->attrs->id === null) {
+                $node->attrs->id = str(collect($node->content)->map(function ($node) {
+                    return $node?->text ?? null;
+                })->implode(' '))->slug()->toString();
+            }
+        });
     }
 
     /**

--- a/packages/forms/src/Components/RichEditor/RichContentRenderer.php
+++ b/packages/forms/src/Components/RichEditor/RichContentRenderer.php
@@ -577,13 +577,13 @@ class RichContentRenderer implements Htmlable
 
     /**
      * @return void
-     * Assign unique IDs to heading nodes so you can jump to that section of the content.
+     *              Assign unique IDs to heading nodes so you can jump to that section of the content.
      */
     protected function processHeaderIds($editor, int $maxDepth = 3): void
     {
         $idCounts = [];
 
-        $editor->descendants(function (&$node) use ($maxDepth, &$idCounts) {
+        $editor->descendants(function (&$node) use ($maxDepth, &$idCounts): void {
             if ($node->type !== 'heading') {
                 return;
             }

--- a/packages/forms/src/Components/RichEditor/TipTapExtensions/IdExtension.php
+++ b/packages/forms/src/Components/RichEditor/TipTapExtensions/IdExtension.php
@@ -9,8 +9,14 @@ use Tiptap\Core\Node;
  */
 class IdExtension extends Node
 {
+    /**
+     * @var string
+     */
     public static $name = 'id';
 
+    /**
+     * @return array<array<string, mixed>>
+     */
     public function addGlobalAttributes(): array
     {
         return [

--- a/packages/forms/src/Components/RichEditor/TipTapExtensions/IdExtension.php
+++ b/packages/forms/src/Components/RichEditor/TipTapExtensions/IdExtension.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Filament\Forms\Components\RichEditor\TipTapExtensions;
+
+use Tiptap\Core\Node;
+
+/**
+ * This extension adds support for the `id` attribute on headings and links.
+ */
+class IdExtension extends Node
+{
+    public static $name = 'id';
+
+    public function addGlobalAttributes(): array
+    {
+        return [
+            [
+                'types' => [
+                    'heading',
+                    'link',
+                ],
+                'attributes' => [
+                    'id' => [
+                        'default' => null,
+                        'parseHTML' => function ($DOMNode) {
+                            return $DOMNode->hasAttribute('id') ? $DOMNode->getAttribute('id') : null;
+                        },
+                        'renderHTML' => function ($attributes) {
+                            if (! property_exists($attributes, 'id')) {
+                                return null;
+                            }
+
+                            return [
+                                'id' => $attributes->id,
+                            ];
+                        },
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/src/Forms/Components/RichEditor/RichContentRendererTest.php
+++ b/tests/src/Forms/Components/RichEditor/RichContentRendererTest.php
@@ -526,7 +526,6 @@ it('handles duplicate heading texts with unique IDs and proper nesting', functio
     expect($tableOfContents[1]['subs'][0]['id'])->toBe('child');
 });
 
-
 it('will inject ids into heading nodes', function (): void {
     $renderer = RichContentRenderer::make([
         'type' => 'doc',

--- a/tests/src/Forms/Components/RichEditor/RichContentRendererTest.php
+++ b/tests/src/Forms/Components/RichEditor/RichContentRendererTest.php
@@ -525,3 +525,22 @@ it('handles duplicate heading texts with unique IDs and proper nesting', functio
     expect($tableOfContents[1]['subs'][0]['text'])->toBe('Child');
     expect($tableOfContents[1]['subs'][0]['id'])->toBe('child');
 });
+
+
+it('will inject ids into heading nodes', function (): void {
+    $renderer = RichContentRenderer::make([
+        'type' => 'doc',
+        'content' => [
+            ['type' => 'heading', 'attrs' => ['level' => 2], 'content' => [['type' => 'text', 'text' => 'Duplicate']]],
+            ['type' => 'heading', 'attrs' => ['level' => 2], 'content' => [['type' => 'text', 'text' => 'Duplicate']]],
+            ['type' => 'heading', 'attrs' => ['level' => 3], 'content' => [['type' => 'text', 'text' => 'Child']]],
+        ],
+    ]);
+
+    $content = $renderer->toHtml();
+
+    expect($content)->toBeString();
+    expect($content)->toContain('id="duplicate"');
+    expect($content)->toContain('id="duplicate-1"');
+    expect($content)->toContain('id="child"');
+});

--- a/tests/src/Forms/Components/RichEditor/RichContentRendererTest.php
+++ b/tests/src/Forms/Components/RichEditor/RichContentRendererTest.php
@@ -446,3 +446,82 @@ it('handles dynamic merge tag values', function (): void {
 
     expect($html)->toContain('computed value');
 });
+
+it('extracts the table of contents from content', function (): void {
+    $renderer = RichContentRenderer::make([
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'John Doe',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'heading',
+                'attrs' => ['level' => 2],
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'Section 1',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'heading',
+                'attrs' => ['level' => 3],
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'Section 2',
+                    ],
+                ],
+            ],
+
+        ],
+    ]);
+
+    $tableOfContents = $renderer->toTableOfContents();
+
+    expect($tableOfContents)->toEqual([
+        [
+            'depth' => 2,
+            'text' => 'Section 1',
+            'id' => 'section-1',
+            'subs' => [
+                [
+                    'depth' => 3,
+                    'text' => 'Section 2',
+                    'id' => 'section-2',
+                ],
+            ],
+        ],
+    ]);
+});
+
+it('handles duplicate heading texts with unique IDs and proper nesting', function (): void {
+    $renderer = RichContentRenderer::make([
+        'type' => 'doc',
+        'content' => [
+            ['type' => 'heading', 'attrs' => ['level' => 2], 'content' => [['type' => 'text', 'text' => 'Duplicate']]],
+            ['type' => 'heading', 'attrs' => ['level' => 2], 'content' => [['type' => 'text', 'text' => 'Duplicate']]],
+            ['type' => 'heading', 'attrs' => ['level' => 3], 'content' => [['type' => 'text', 'text' => 'Child']]],
+        ],
+    ]);
+
+    $tableOfContents = $renderer->toTableOfContents();
+
+    expect($tableOfContents)->toHaveCount(2);
+    expect($tableOfContents[0]['text'])->toBe('Duplicate');
+    expect($tableOfContents[0]['id'])->toBe('duplicate');
+    expect($tableOfContents[0])->not->toHaveKey('subs');
+
+    expect($tableOfContents[1]['text'])->toBe('Duplicate');
+    expect($tableOfContents[1]['id'])->toBe('duplicate-1');
+    expect($tableOfContents[1]['subs'])->toBeArray();
+    expect($tableOfContents[1]['subs'][0]['text'])->toBe('Child');
+    expect($tableOfContents[1]['subs'][0]['id'])->toBe('child');
+});


### PR DESCRIPTION
## Description

As this is replacing awcodes tiptapeditor, there are a few extra functions which it did. I believe these would be best placed being brought over. We require them in our workflow, so figured it's easier to add to this than try my own frankenstein dom searching maneuvers.

When you generate the HTML content you don't really have any way of chaining to get additional output, same as it worked on awcodes version, so largely this works the same with a couple of changes. You can call the Table of Contents method and you will get an ARRAY back only, it's up to you to style and implement. Previously he would provide the html, we're not doing that here. Similar to my previous work on the toArray.

In essence, all this does is add the Id Extension so we can automatically add id's to H2's, H3's etc. This allows them to then be anchored, put in a link and referenced on a page. I had a version working that added a # beside the Header so you could quick link to it - but I removed that as I figured that's heavily opinionated. 

This allows you to implement your own table of contents at the top of the page, that quick links to other sections. It's pretty neat! You can develop your own self referencing Table of Contents blocks separately to this functionality to actually insert it into the content

For content heavy pages, a table of contents is critical. I was adding a unique prefix to the headers, but I feel like that might cause issues maybe in regards to on-page SEO. So I've just left it as the header text. Happy to implement whatever works though.

I've also updated the docs to have this in it, and and the toArray functionality so people know it's here.

Any recommendations please let me know! 

## Visual changes

Example Implementation:
<img width="874" height="407" alt="Screenshot 2025-11-25 at 12 38 30" src="https://github.com/user-attachments/assets/a73d5085-0e9c-4530-bcf0-9d9e06a519f3" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
