### PR TITLE
Update return type of StatsOverviewWidget

### DIFF
--- a/packages/widgets/src/StatsOverviewWidget.php
+++ b/packages/widgets/src/StatsOverviewWidget.php
@@ -87,7 +87,7 @@ class StatsOverviewWidget extends Widget implements HasSchemas
     }
 
     /**
-     * @return array<Stat>
+     * @return array<Component>
      */
     protected function getCachedStats(): array
     {
@@ -97,7 +97,7 @@ class StatsOverviewWidget extends Widget implements HasSchemas
     /**
      * @deprecated Use `getStats()` instead.
      *
-     * @return array<Stat>
+     * @return array<Component>
      */
     protected function getCards(): array
     {
@@ -105,7 +105,7 @@ class StatsOverviewWidget extends Widget implements HasSchemas
     }
 
     /**
-     * @return array<Stat>
+     * @return array<Component>
      */
     protected function getStats(): array
     {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The `getStats` method on the `StatsOverviewWidget` component had a return type of `array<Stat>` however any component can be rendered within the `getStats` array.

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
