### PR TITLE
The `shouldRegisterNavigation` setting is not being respected in the cluster

### DIFF
--- a/packages/panels/src/Clusters/Cluster.php
+++ b/packages/panels/src/Clusters/Cluster.php
@@ -32,11 +32,7 @@ class Cluster extends Page
 
     public static function shouldRegisterNavigation(): bool
     {
-        if (! static::$shouldRegisterNavigation) {
-            return false;
-        }
-
-        return static::canAccessClusteredComponents();
+        return parent::shouldRegisterNavigation() && static::canAccessClusteredComponents();
     }
 
     public function mount(): void

--- a/packages/panels/src/Clusters/Cluster.php
+++ b/packages/panels/src/Clusters/Cluster.php
@@ -32,6 +32,10 @@ class Cluster extends Page
 
     public static function shouldRegisterNavigation(): bool
     {
+        if (! static::$shouldRegisterNavigation) {
+            return false;
+        }
+
         return static::canAccessClusteredComponents();
     }
 


### PR DESCRIPTION

The PR corrected the `$shouldRegisterNavigation` method to make cluster navigation visible.

When setting the configuration in `protected static bool $shouldRegisterNavigation = false;` within a cluster, it was not respecting the configuration used, only overriding the `shouldRegisterNavigation` function and returning `false`.