### PR TITLE
bugfix: Allow getOptionDescriptionFromRecord to return null

### DIFF
--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -295,7 +295,7 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
         return $this->getOptionDescriptionFromRecordUsing !== null;
     }
 
-    public function getOptionDescriptionFromRecord(Model $record): string | Htmlable
+    public function getOptionDescriptionFromRecord(Model $record): string | Htmlable | null
     {
         return $this->evaluate(
             $this->getOptionDescriptionFromRecordUsing,


### PR DESCRIPTION
## Description

The `getOptionDescriptionFromRecordUsing()` does not support an Callable which returns null. In some cases an option might have an description and should thus be null.

Fixes bug introduced in #18443.

## Visual changes

Not relevant.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
