### PR TITLE
Improve API of "counts" text columns

### DIFF
--- a/packages/support/src/Concerns/CanAggregateRelatedModels.php
+++ b/packages/support/src/Concerns/CanAggregateRelatedModels.php
@@ -14,9 +14,9 @@ trait CanAggregateRelatedModels
     protected string | array | Closure | null $relationshipToAvg = null;
 
     /**
-     * @var string | array<int | string, string | Closure> | Closure | null
+     * @var bool | string | array<int | string, string | Closure> | Closure | null
      */
-    protected string | array | Closure | null $relationshipsToCount = null;
+    protected bool | string | array | Closure | null $relationshipsToCount = null;
 
     /**
      * @var string | array<int | string, string | Closure> | Closure | null
@@ -56,11 +56,15 @@ trait CanAggregateRelatedModels
     }
 
     /**
-     * @param  string | array<int | string, string | Closure> | Closure | null  $relationships
+     * @param  bool | string | array<int | string, string | Closure> | Closure | null  $relationships
      */
-    public function counts(string | array | Closure | null $relationships): static
+    public function counts(bool | string | array | Closure | null $relationships = true): static
     {
         $this->relationshipsToCount = $relationships;
+
+        if ($relationships === true) {
+            $this->attribute("{$this->getName()}_count");
+        }
 
         return $this;
     }
@@ -126,7 +130,17 @@ trait CanAggregateRelatedModels
      */
     public function getRelationshipsToCount(): string | array | null
     {
-        return $this->evaluate($this->relationshipsToCount);
+        $relationshipsToCount = $this->evaluate($this->relationshipsToCount);
+
+        if ($relationshipsToCount === true) {
+            return $this->getName();
+        }
+
+        if ($relationshipsToCount === false) {
+            return null;
+        }
+
+        return $relationshipsToCount;
     }
 
     /**

--- a/packages/support/src/Concerns/HasCellState.php
+++ b/packages/support/src/Concerns/HasCellState.php
@@ -28,6 +28,8 @@ trait HasCellState
 
     protected ?string $inverseRelationshipName = null;
 
+    protected string | Closure | null $attribute = null;
+
     /**
      * @var array<string, mixed>
      */
@@ -72,6 +74,13 @@ trait HasCellState
         return $this;
     }
 
+    public function attribute(string | Closure | null $name): static
+    {
+        $this->attribute = $name;
+
+        return $this;
+    }
+
     public function isDistinctList(): bool
     {
         return (bool) $this->evaluate($this->isDistinctList);
@@ -80,6 +89,11 @@ trait HasCellState
     public function getDefaultState(): mixed
     {
         return $this->evaluate($this->defaultState);
+    }
+
+    public function getAttribute(): string
+    {
+        return $this->evaluate($this->attribute) ?? $this->getName();
     }
 
     public function getState(): mixed
@@ -149,7 +163,7 @@ trait HasCellState
             }
         }
 
-        $name = $this->getName();
+        $name = $this->getAttribute();
 
         if (
             ($record instanceof HasRichContent) &&
@@ -327,7 +341,7 @@ trait HasCellState
 
     public function getAttributeName(Model $record): string
     {
-        $name = $this->getName();
+        $name = $this->getAttribute();
 
         if (! str($name)->contains('.')) {
             return $name;
@@ -354,7 +368,7 @@ trait HasCellState
 
     public function getFullAttributeName(Model $record): string
     {
-        $name = $this->getName();
+        $name = $this->getAttribute();
 
         if (! str($name)->contains('.')) {
             return $name;

--- a/packages/tables/docs/02-columns/01-overview.md
+++ b/packages/tables/docs/02-columns/01-overview.md
@@ -115,10 +115,10 @@ If you wish to count the number of related records in a column, you may use the 
 ```php
 use Filament\Tables\Columns\TextColumn;
 
-TextColumn::make('users_count')->counts('users')
+TextColumn::make('users')->counts()
 ```
 
-In this example, `users` is the name of the relationship to count from. The name of the column must be `users_count`, as this is the convention that [Laravel uses](https://laravel.com/docs/eloquent-relationships#counting-related-models) for storing the result.
+In this example, `users` is the name of the relationship to count from.
 
 If you'd like to scope the relationship before counting, you can pass an array to the method, where the key is the relationship name and the value is the function to scope the Eloquent query with:
 
@@ -130,6 +130,8 @@ TextColumn::make('users_count')->counts([
     'users' => fn (Builder $query) => $query->where('is_active', true),
 ])
 ```
+
+When the relationship is defined explicitly, the name of the column must be `users_count`, as this is the convention that [Laravel uses](https://laravel.com/docs/eloquent-relationships#counting-related-models) for storing the result.
 
 #### Determining relationship existence
 

--- a/packages/tables/src/Concerns/CanSummarizeRecords.php
+++ b/packages/tables/src/Concerns/CanSummarizeRecords.php
@@ -46,7 +46,7 @@ trait CanSummarizeRecords
                 continue;
             }
 
-            $qualifiedAttribute = $query->getModel()->qualifyColumn($column->getName());
+            $qualifiedAttribute = $query->getModel()->qualifyColumn($column->getAttribute());
 
             foreach ($summarizers as $summarizer) {
                 if ($summarizer->hasQueryModification()) {

--- a/tests/src/Fixtures/Resources/Users/UserResource.php
+++ b/tests/src/Fixtures/Resources/Users/UserResource.php
@@ -44,8 +44,8 @@ class UserResource extends Resource
                 Tables\Columns\TextColumn::make('posts_exists')
                     ->exists('posts')
                     ->label('Has Posts'),
-                Tables\Columns\TextColumn::make('posts_count')
-                    ->counts('posts')
+                Tables\Columns\TextColumn::make('posts')
+                    ->counts()
                     ->label('# Posts'),
                 Tables\Columns\TextColumn::make('posts_avg_rating')
                     ->avg('posts', 'rating')

--- a/tests/src/Panels/Resources/Pages/ListRecordsTest.php
+++ b/tests/src/Panels/Resources/Pages/ListRecordsTest.php
@@ -22,9 +22,11 @@ use Filament\Tests\Fixtures\Resources\Posts\PostResource;
 use Filament\Tests\Fixtures\Resources\TicketMessages\TicketMessageResource;
 use Filament\Tests\Fixtures\Resources\Tickets\Pages\ListTickets;
 use Filament\Tests\Fixtures\Resources\Tickets\TicketResource;
+use Filament\Tests\Fixtures\Resources\Users\Pages\ListUsers;
 use Filament\Tests\Fixtures\Resources\Users\UserResource;
 use Filament\Tests\Panels\Resources\TestCase;
 use Illuminate\Auth\Access\Response;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
 
 use function Filament\Tests\livewire;
@@ -64,12 +66,12 @@ it('can render post authors', function (): void {
 });
 
 it('can render post count', function (): void {
-    /** @var \Illuminate\Database\Eloquent\Collection<int, User> $users */
+    /** @var Collection<int, User> $users */
     $users = User::factory()->count(10)
         ->afterCreating(fn (User $author) => Post::factory()->count($author->getKey())->for($author, 'author')->create())
         ->create();
 
-    $table = livewire(\Filament\Tests\Fixtures\Resources\Users\Pages\ListUsers::class)
+    $table = livewire(ListUsers::class)
         ->assertCanRenderTableColumn('posts');
 
     foreach ($users as $user) {

--- a/tests/src/Panels/Resources/Pages/ListRecordsTest.php
+++ b/tests/src/Panels/Resources/Pages/ListRecordsTest.php
@@ -63,6 +63,20 @@ it('can render post authors', function (): void {
         ->assertCanRenderTableColumn('author.name');
 });
 
+it('can render post count', function (): void {
+    /** @var \Illuminate\Database\Eloquent\Collection<int, User> $users */
+    $users = User::factory()->count(10)
+        ->afterCreating(fn (User $author) => Post::factory()->count($author->getKey())->for($author, 'author')->create())
+        ->create();
+
+    $table = livewire(\Filament\Tests\Fixtures\Resources\Users\Pages\ListUsers::class)
+        ->assertCanRenderTableColumn('posts');
+
+    foreach ($users as $user) {
+        $table->assertTableColumnStateSet('posts', $user->posts()->count(), $user->getKey());
+    }
+});
+
 it('can sort posts by title', function (): void {
     Post::factory()->count(10)->create();
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Allow the "relationshipToCount" to have boolean values. If this value is set to true, then infer the relationship based on column-name.

Introduce a new field called "attribute" which decouples the filament column's name, from the database column/model attribute. Default means original behavior.

Instead of:
```php
TextColumn('posts_count')->counts('posts');
```

You can now do:
```php
TextColumn('posts')->counts();
```

## Visual changes

No visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
