### PR TITLE
feat: expose table records count

### DIFF
--- a/docs/03-resources/11-widgets.md
+++ b/docs/03-resources/11-widgets.md
@@ -123,6 +123,16 @@ use Filament\Widgets\StatsOverviewWidget\Stat;
 Stat::make('Total Products', $this->getPageTableRecords()->count()),
 ```
 
+## Accessing the total table records count
+
+If you need the total count of all records for the table query without executing additional count query, you can access the `$tableRecordsCount` property:
+
+```php
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+Stat::make('Total Products', $this->tableRecordsCount),
+```
+
 ## Passing properties to widgets on resource pages
 
 When registering a widget on a resource page, you can use the `make()` method to pass an array of [Livewire properties](https://livewire.laravel.com/docs/properties) to it:

--- a/docs/03-resources/11-widgets.md
+++ b/docs/03-resources/11-widgets.md
@@ -125,7 +125,7 @@ Stat::make('Total Products', $this->getPageTableRecords()->count()),
 
 ## Accessing the total table records count
 
-If you need the total count of all records for the table query without executing additional count query, you can access the `$tableRecordsCount` property:
+If you need the total count of all records for the table query without executing an additional count query, you can use the `$tableRecordsCount` property:
 
 ```php
 use Filament\Widgets\StatsOverviewWidget\Stat;

--- a/packages/panels/src/Pages/Concerns/ExposesTableToWidgets.php
+++ b/packages/panels/src/Pages/Concerns/ExposesTableToWidgets.php
@@ -9,6 +9,7 @@ trait ExposesTableToWidgets /** @phpstan-ignore trait.unused */
         return [
             'activeTab' => $this->activeTab,
             'paginators' => $this->paginators,
+            'tableRecordsCount' => $this->getAllTableRecordsCount(),
             'parentRecord' => $this->parentRecord,
             'tableColumnSearches' => $this->tableColumnSearches,
             'tableFilters' => $this->tableFilters,

--- a/packages/panels/src/Pages/Concerns/ExposesTableToWidgets.php
+++ b/packages/panels/src/Pages/Concerns/ExposesTableToWidgets.php
@@ -9,11 +9,11 @@ trait ExposesTableToWidgets /** @phpstan-ignore trait.unused */
         return [
             'activeTab' => $this->activeTab,
             'paginators' => $this->paginators,
-            'tableRecordsCount' => $this->getAllTableRecordsCount(),
             'parentRecord' => $this->parentRecord,
             'tableColumnSearches' => $this->tableColumnSearches,
             'tableFilters' => $this->tableFilters,
             'tableGrouping' => $this->tableGrouping,
+            'tableRecordsCount' => $this->getAllTableRecordsCount(),
             'tableRecordsPerPage' => $this->tableRecordsPerPage,
             'tableSearch' => $this->tableSearch,
             'tableSort' => $this->tableSort,

--- a/packages/panels/src/Widgets/Concerns/InteractsWithPageTable.php
+++ b/packages/panels/src/Widgets/Concerns/InteractsWithPageTable.php
@@ -19,7 +19,6 @@ trait InteractsWithPageTable /** @phpstan-ignore trait.unused */
     #[Reactive]
     public $paginators = [];
 
-    /** @var int | null */
     #[Reactive]
     public ?int $tableRecordsCount = null;
 

--- a/packages/panels/src/Widgets/Concerns/InteractsWithPageTable.php
+++ b/packages/panels/src/Widgets/Concerns/InteractsWithPageTable.php
@@ -88,7 +88,6 @@ trait InteractsWithPageTable /** @phpstan-ignore trait.unused */
             'tableColumnSearches' => $this->tableColumnSearches,
             'tableFilters' => $this->tableFilters,
             'tableGrouping' => $this->tableGrouping,
-            'tableRecordsCount' => $this->tableRecordsCount,
             'tableRecordsPerPage' => $this->tableRecordsPerPage,
             'tableSearch' => $this->tableSearch,
             'tableSort' => $this->tableSort,

--- a/packages/panels/src/Widgets/Concerns/InteractsWithPageTable.php
+++ b/packages/panels/src/Widgets/Concerns/InteractsWithPageTable.php
@@ -19,6 +19,10 @@ trait InteractsWithPageTable /** @phpstan-ignore trait.unused */
     #[Reactive]
     public $paginators = [];
 
+    /** @var int | null */
+    #[Reactive]
+    public ?int $tableRecordsCount = null;
+
     /**
      * @var array<string, string | array<string, string | null> | null>
      */
@@ -81,6 +85,7 @@ trait InteractsWithPageTable /** @phpstan-ignore trait.unused */
         foreach ([
             'activeTab' => $this->activeTab,
             'paginators' => $this->paginators,
+            'tableRecordsCount' => $this->tableRecordsCount,
             'parentRecord' => $this->parentRecord,
             'tableColumnSearches' => $this->tableColumnSearches,
             'tableFilters' => $this->tableFilters,

--- a/packages/panels/src/Widgets/Concerns/InteractsWithPageTable.php
+++ b/packages/panels/src/Widgets/Concerns/InteractsWithPageTable.php
@@ -84,11 +84,11 @@ trait InteractsWithPageTable /** @phpstan-ignore trait.unused */
         foreach ([
             'activeTab' => $this->activeTab,
             'paginators' => $this->paginators,
-            'tableRecordsCount' => $this->tableRecordsCount,
             'parentRecord' => $this->parentRecord,
             'tableColumnSearches' => $this->tableColumnSearches,
             'tableFilters' => $this->tableFilters,
             'tableGrouping' => $this->tableGrouping,
+            'tableRecordsCount' => $this->tableRecordsCount,
             'tableRecordsPerPage' => $this->tableRecordsPerPage,
             'tableSearch' => $this->tableSearch,
             'tableSort' => $this->tableSort,


### PR DESCRIPTION
## Description

This pull request exposes the result of `getAllTableRecordsCount` method to the Widgets. In most applications, there are stat widgets that show the total count of records. When queries are complex and expensive, it adds up to the page performance. Having a clean way to get the table total count from an existing/cached property is helpful and performant and avoids extra Database query.

## Visual changes

No visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
