### PR TITLE
Update return types for `getTableFilterState` and `getTableFilterFormState`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -136,6 +136,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",
@@ -3309,6 +3310,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.10.1.tgz",
             "integrity": "sha512-YY/u+RsjLVhcUaIn+wv6vjMx8kldO7SzFFnRu0iuC+QW57VrlqUzqz5PR6CenphwJHuqGM5b3SCr4K2ZPjN8jQ==",
             "dev": true,
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -3612,6 +3614,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.10.1.tgz",
             "integrity": "sha512-i18t1wfVHQjJIMlqIB0SCpP78bsoZDTFhhZBOLYDM0Q4KHY+zVkiZADkiY5zA8UFZiBuWC4eviqajCvq4XOvQw==",
             "dev": true,
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -3718,6 +3721,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.10.1.tgz",
             "integrity": "sha512-tZZ1IGIcch4ezuoid3iPSirh0s2GQuSKY6ceWRJCVeZ2gT2LsN3i10tqfidcYrsmyQRMuM7QUfRmH5HOKJZ73Q==",
             "dev": true,
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -3732,6 +3736,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.10.1.tgz",
             "integrity": "sha512-LhTRI+bECLFqitWN821A7faVFVw5OitFGWn45LIIRc/1Jg3lkqsaqx3LcLN1sjXd+f/vfoeXLKSD6VJvv/B/nQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "prosemirror-changeset": "^2.3.0",
                 "prosemirror-collab": "^1.3.1",
@@ -3762,6 +3767,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.10.1.tgz",
             "integrity": "sha512-QpSMsMtpsBSapCDytjdKXLcuPunnd00fGSrYp23C4BDI2Ph7JOYHsgv/wIKgpAYg2fpbJT6DIIbpSHhWluEFyw==",
             "dev": true,
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -4401,6 +4407,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -4425,6 +4432,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -5047,6 +5055,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.8.19",
                 "caniuse-lite": "^1.0.30001751",
@@ -5227,6 +5236,7 @@
             "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
             "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@kurkle/color": "^0.3.0"
             },
@@ -6539,6 +6549,7 @@
             "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
             "dev": true,
             "hasInstallScript": true,
+            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -6983,7 +6994,8 @@
             "version": "4.32.10",
             "resolved": "https://registry.npmjs.org/filepond/-/filepond-4.32.10.tgz",
             "integrity": "sha512-uflpIL+rfAgsYk7HgXugh7ELlHNHLTPtIHfvuq0gv3x2qNfVxdGA6T7RPxMh9Vji8ysXstXkDHVXQ4hY38MPTQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/filepond-plugin-file-validate-size": {
             "version": "2.2.8",
@@ -7917,6 +7929,7 @@
             "resolved": "https://registry.npmjs.org/imagemin/-/imagemin-7.0.1.tgz",
             "integrity": "sha512-33AmZ+xjZhg2JMCe+vDf6a9mzWukE7l+wAtesjE7KyteqqKjzxv7aVQeWnul1Ve26mWvEQqyPwl0OctNBfSR9w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "file-type": "^12.0.0",
                 "globby": "^10.0.0",
@@ -9166,6 +9179,7 @@
             "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
             "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -10274,6 +10288,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -10848,6 +10863,7 @@
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
             "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -11092,6 +11108,7 @@
             "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
             "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "orderedmap": "^2.0.0"
             }
@@ -11121,6 +11138,7 @@
             "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
             "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.0.0",
                 "prosemirror-transform": "^1.0.0",
@@ -11169,6 +11187,7 @@
             "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.3.tgz",
             "integrity": "sha512-SqMiYMUQNNBP9kfPhLO8WXEk/fon47vc52FQsUiJzTBuyjKgEcoAwMyF04eQ4WZ2ArMn7+ReypYL60aKngbACQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.20.0",
                 "prosemirror-state": "^1.0.0",
@@ -12705,6 +12724,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -13239,6 +13259,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.102.1.tgz",
             "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -13287,6 +13308,7 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
             "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^1.2.0",
@@ -13416,6 +13438,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -13528,6 +13551,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -13623,6 +13647,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,7 +136,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",
@@ -3310,7 +3309,6 @@
             "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.10.1.tgz",
             "integrity": "sha512-YY/u+RsjLVhcUaIn+wv6vjMx8kldO7SzFFnRu0iuC+QW57VrlqUzqz5PR6CenphwJHuqGM5b3SCr4K2ZPjN8jQ==",
             "dev": true,
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -3614,7 +3612,6 @@
             "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.10.1.tgz",
             "integrity": "sha512-i18t1wfVHQjJIMlqIB0SCpP78bsoZDTFhhZBOLYDM0Q4KHY+zVkiZADkiY5zA8UFZiBuWC4eviqajCvq4XOvQw==",
             "dev": true,
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -3721,7 +3718,6 @@
             "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.10.1.tgz",
             "integrity": "sha512-tZZ1IGIcch4ezuoid3iPSirh0s2GQuSKY6ceWRJCVeZ2gT2LsN3i10tqfidcYrsmyQRMuM7QUfRmH5HOKJZ73Q==",
             "dev": true,
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -3736,7 +3732,6 @@
             "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.10.1.tgz",
             "integrity": "sha512-LhTRI+bECLFqitWN821A7faVFVw5OitFGWn45LIIRc/1Jg3lkqsaqx3LcLN1sjXd+f/vfoeXLKSD6VJvv/B/nQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "prosemirror-changeset": "^2.3.0",
                 "prosemirror-collab": "^1.3.1",
@@ -3767,7 +3762,6 @@
             "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.10.1.tgz",
             "integrity": "sha512-QpSMsMtpsBSapCDytjdKXLcuPunnd00fGSrYp23C4BDI2Ph7JOYHsgv/wIKgpAYg2fpbJT6DIIbpSHhWluEFyw==",
             "dev": true,
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -4407,7 +4401,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -4432,7 +4425,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -5055,7 +5047,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.8.19",
                 "caniuse-lite": "^1.0.30001751",
@@ -5236,7 +5227,6 @@
             "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
             "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@kurkle/color": "^0.3.0"
             },
@@ -6549,7 +6539,6 @@
             "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
             "dev": true,
             "hasInstallScript": true,
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -6994,8 +6983,7 @@
             "version": "4.32.10",
             "resolved": "https://registry.npmjs.org/filepond/-/filepond-4.32.10.tgz",
             "integrity": "sha512-uflpIL+rfAgsYk7HgXugh7ELlHNHLTPtIHfvuq0gv3x2qNfVxdGA6T7RPxMh9Vji8ysXstXkDHVXQ4hY38MPTQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/filepond-plugin-file-validate-size": {
             "version": "2.2.8",
@@ -7929,7 +7917,6 @@
             "resolved": "https://registry.npmjs.org/imagemin/-/imagemin-7.0.1.tgz",
             "integrity": "sha512-33AmZ+xjZhg2JMCe+vDf6a9mzWukE7l+wAtesjE7KyteqqKjzxv7aVQeWnul1Ve26mWvEQqyPwl0OctNBfSR9w==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "file-type": "^12.0.0",
                 "globby": "^10.0.0",
@@ -9179,7 +9166,6 @@
             "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
             "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -10288,7 +10274,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -10863,7 +10848,6 @@
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
             "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -11108,7 +11092,6 @@
             "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
             "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "orderedmap": "^2.0.0"
             }
@@ -11138,7 +11121,6 @@
             "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
             "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.0.0",
                 "prosemirror-transform": "^1.0.0",
@@ -11187,7 +11169,6 @@
             "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.3.tgz",
             "integrity": "sha512-SqMiYMUQNNBP9kfPhLO8WXEk/fon47vc52FQsUiJzTBuyjKgEcoAwMyF04eQ4WZ2ArMn7+ReypYL60aKngbACQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.20.0",
                 "prosemirror-state": "^1.0.0",
@@ -12724,7 +12705,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -13259,7 +13239,6 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.102.1.tgz",
             "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -13308,7 +13287,6 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
             "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^1.2.0",
@@ -13438,7 +13416,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -13551,7 +13528,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -13647,7 +13623,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -196,12 +196,12 @@ trait HasFilters
         }
     }
 
-    public function getTableFilterState(string $name): ?array
+    public function getTableFilterState(string $name): mixed
     {
         return Arr::get($this->tableFilters, $this->parseTableFilterName($name));
     }
 
-    public function getTableFilterFormState(string $name): ?array
+    public function getTableFilterFormState(string $name): mixed
     {
         return Arr::get($this->getTable()->hasDeferredFilters() ? $this->tableDeferredFilters : $this->tableFilters, $this->parseTableFilterName($name));
     }

--- a/packages/tables/src/Contracts/HasTable.php
+++ b/packages/tables/src/Contracts/HasTable.php
@@ -33,15 +33,9 @@ interface HasTable
 
     public function getAllSelectableTableRecordsCount(): int;
 
-    /**
-     * @return mixed
-     */
     public function getTableFilterState(string $name): mixed;
 
-    /**
-     * @return array<string, mixed> | null
-     */
-    public function getTableFilterFormState(string $name): ?array;
+    public function getTableFilterFormState(string $name): mixed;
 
     public function getSelectedTableRecords(bool $shouldFetchSelectedRecords = true, ?int $chunkSize = null): EloquentCollection | Collection | LazyCollection;
 

--- a/packages/tables/src/Contracts/HasTable.php
+++ b/packages/tables/src/Contracts/HasTable.php
@@ -34,9 +34,9 @@ interface HasTable
     public function getAllSelectableTableRecordsCount(): int;
 
     /**
-     * @return array<string, mixed> | null
+     * @return mixed
      */
-    public function getTableFilterState(string $name): ?array;
+    public function getTableFilterState(string $name): mixed;
 
     /**
      * @return array<string, mixed> | null


### PR DESCRIPTION
## Description

When using `getTableFilterState` and `getTableFilterFormState` methods, the return type can vary beyond just arrays or nulls, especially when custom filter schemas are used. Single-value filters (e.g., select fields) return strings, toggle filters return booleans, and multi-value filters return arrays. The current `?array` return type is too restrictive and causes type errors when filters return non-array values.

## Visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
