### PR TITLE
Fix method name for disabling notifications

### DIFF
--- a/packages/actions/docs/04-create.md
+++ b/packages/actions/docs/04-create.md
@@ -112,13 +112,13 @@ CreateAction::make()
 
 <UtilityInjection set="actions" version="4.x" extras="Notification;;Filament\Notifications\Notification;;$notification;;The default notification object, which could be a useful starting point for customization.">As well as allowing a static value, the `successNotification()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
-To disable the notification altogether, use the `successNotification(null)` method:
+To disable the notification altogether, use the `successNotificationTitle(null)` method:
 
 ```php
 use Filament\Actions\CreateAction;
 
 CreateAction::make()
-    ->successNotification(null)
+    ->successNotificationTitle(null)
 ```
 
 ## Lifecycle hooks


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

The proposed method for the current code is inaccurate. Unless fixed, the correct method to use is `successNotificationTitle(null)`.

For more context, see: https://github.com/filamentphp/filament/issues/18637