### PR TITLE
Action support single table inheritance record

### DIFF
--- a/packages/actions/src/Action.php
+++ b/packages/actions/src/Action.php
@@ -473,7 +473,7 @@ class Action extends ViewComponent implements Arrayable
             (! $table)
             || (! $record instanceof Model)
             || blank($table->getModel())
-            || ($record::class === $table->getModel())
+            || is_a($record::class, $table->getModel(), true)
         ) && filled($recordKey = $this->resolveRecordKey($record))) {
             $context['recordKey'] = $recordKey;
         }


### PR DESCRIPTION
## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
I have a model that uses [single table inheritance](https://github.com/tighten/parental).
This can lead to different models being rendered by executing a query on the parent one, example:

```php
class Admin extends User {
 // ...
}

$users = User::all();

assert($users[0] instanceof \App\Models\User);
assert($users[1] instanceof \App\Models\Admin);
```

Let's say I have a filament resource to display all users (mixed models) and run some actions that are common to both models. Then I have lost the ability to customize the fields of the action because the `recordKey` is not being sent in front-end (via the click handler) so later is not being sent back to the back-end.
That is because the condition `$record::class === $table->getModel()` will return false when (as per the example above) the record is Admin because the table model (parent model) is User. I changed the condition in order to accommodate the previous functionality (as much as I can understand) and support my use case.

The condition I changed was implemented in https://github.com/filamentphp/filament/pull/17786, but I do not understand how it solved that related issue. The filament resource and its actions were working correctly until that update.

In case my implementation is not accepted, can you please suggest a workaround in order to continue my use case?

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
