### PR TITLE
fix: correct grammar errors in Spatie plugin README files

### DIFF
--- a/packages/spatie-laravel-media-library-plugin/README.md
+++ b/packages/spatie-laravel-media-library-plugin/README.md
@@ -38,7 +38,7 @@ The media library file upload supports all the customization options of the [ori
 
 ### Passing a collection
 
-Optionally, you may pass a [`collection()`](https://spatie.be/docs/laravel-medialibrary/working-with-media-collections/simple-media-collections) allows you to group files into categories:
+Optionally, you may pass a [`collection()`](https://spatie.be/docs/laravel-medialibrary/working-with-media-collections/simple-media-collections) that allows you to group files into categories:
 
 ```php
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;

--- a/packages/spatie-laravel-tags-plugin/README.md
+++ b/packages/spatie-laravel-tags-plugin/README.md
@@ -26,7 +26,7 @@ You must also [prepare your Eloquent model](https://spatie.be/docs/laravel-tags/
 
 ## Form component
 
-This guide assumes that you've already set up your model attach tags as per [Spatie's documentation](https://spatie.be/docs/laravel-tags/basic-usage/using-tags).
+This guide assumes that you've already set up your model to attach tags as per [Spatie's documentation](https://spatie.be/docs/laravel-tags/basic-usage/using-tags).
 
 You may use the field in the same way as the [original tags input](https://filamentphp.com/docs/forms/tags-input) field:
 
@@ -36,7 +36,7 @@ use Filament\Forms\Components\SpatieTagsInput;
 SpatieTagsInput::make('tags')
 ```
 
-Optionally, you may pass a [`type()`](https://spatie.be/docs/laravel-tags/advanced-usage/using-types) allows you to group tags into collections:
+Optionally, you may pass a [`type()`](https://spatie.be/docs/laravel-tags/advanced-usage/using-types) that allows you to group tags into collections:
 
 ```php
 use Filament\Forms\Components\SpatieTagsInput;

--- a/packages/widgets/docs/03-charts.md
+++ b/packages/widgets/docs/03-charts.md
@@ -338,7 +338,7 @@ window.filamentChartJsPlugins.push(ChartDataLabels)
 
 This is equivalent to including the plugins "inline" via `new Chart(..., { plugins: [...] })` when instantiating a Chart.js chart.
 
-It's important to initialise the array if it has not been already, before pushing onto it. This ensures that mutliple JavaScript files (especially those from Filament plugins) that register Chart.js plugins do not overwrite each other, regardless of the order they are booted in.
+It's important to initialise the array if it has not been already, before pushing onto it. This ensures that multiple JavaScript files (especially those from Filament plugins) that register Chart.js plugins do not overwrite each other, regardless of the order they are booted in.
 
 You can push as many plugins to the array as you would like to install, you do not need a separate file to import each plugin.
 


### PR DESCRIPTION
- Improve sentence structure for better readability

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
