### PR TITLE
feat: #18651 Ability to add ActionGroup to ->extraModalFooterActions()

### DIFF
--- a/packages/actions/docs/02-modals.md
+++ b/packages/actions/docs/02-modals.md
@@ -524,6 +524,42 @@ Action::make('edit')
 
 Now, the edit modal will have a "Delete" button in the footer, which will open a confirmation modal when clicked. This action is completely independent of the `edit` action, and will not run the `edit` action when it is clicked.
 
+#### Grouping extra footer actions
+
+You can use `ActionGroup` to group related actions together in the modal footer:
+
+```php
+use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
+
+Action::make('create')
+    ->schema([
+        // ...
+    ])
+    ->extraModalFooterActions([
+        Action::make('createAnother')
+            ->action(function () {
+                // ...
+            }),
+        ActionGroup::make([
+            Action::make('createAndEmail')
+                ->action(function () {
+                    // ...
+                }),
+            Action::make('createAndNotify')
+                ->action(function () {
+                    // ...
+                }),
+            Action::make('createDraft')
+                ->action(function () {
+                    // ...
+                }),
+        ])
+            ->button()
+            ->label('More Options'),
+    ])
+```
+
 In this example though, you probably want to cancel the `edit` action if the `delete` action is run. You can do this using the `cancelParentActions()` method:
 
 ```php

--- a/packages/actions/src/Concerns/CanOpenModal.php
+++ b/packages/actions/src/Concerns/CanOpenModal.php
@@ -5,6 +5,7 @@ namespace Filament\Actions\Concerns;
 use BackedEnum;
 use Closure;
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\View\ActionsIconAlias;
 use Filament\Support\Enums\Alignment;
 use Filament\Support\Enums\Width;
@@ -18,12 +19,12 @@ use Illuminate\Support\Arr;
 trait CanOpenModal
 {
     /**
-     * @var array<string, Action>
+     * @var array<string, Action | ActionGroup>
      */
     protected array $cachedExtraModalFooterActions;
 
     /**
-     * @var array<Action> | Closure
+     * @var array<Action | ActionGroup> | Closure
      */
     protected array | Closure $extraModalFooterActions = [];
 
@@ -46,7 +47,7 @@ trait CanOpenModal
     protected Alignment | string | Closure | null $modalAlignment = null;
 
     /**
-     * @var array<string, Action>
+     * @var array<string, Action | ActionGroup>
      */
     protected array $cachedModalFooterActions;
 
@@ -195,7 +196,7 @@ trait CanOpenModal
     }
 
     /**
-     * @param  array<Action> | Closure  $actions
+     * @param  array<Action | ActionGroup> | Closure  $actions
      *
      *@deprecated Use `extraModalFooterActions()` instead.
      */
@@ -207,7 +208,7 @@ trait CanOpenModal
     }
 
     /**
-     * @param  array<Action> | Closure  $actions
+     * @param  array<Action | ActionGroup> | Closure  $actions
      */
     public function extraModalFooterActions(array | Closure $actions): static
     {
@@ -340,7 +341,7 @@ trait CanOpenModal
     }
 
     /**
-     * @return array<string, Action>
+     * @return array<string, Action | ActionGroup>
      */
     public function getModalFooterActions(): array
     {
@@ -406,7 +407,17 @@ trait CanOpenModal
             return $this->cachedModalActions;
         }
 
-        $actions = $this->getModalFooterActions();
+        $actions = [];
+        
+        foreach ($this->getModalFooterActions() as $key => $action) {
+            if ($action instanceof ActionGroup) {
+                foreach ($action->getFlatActions() as $flatAction) {
+                    $actions[$flatAction->getName()] = $flatAction;
+                }
+            } else {
+                $actions[$key] = $action;
+            }
+        }
 
         foreach ($this->modalActions as $action) {
             foreach (Arr::wrap($this->evaluate($action)) as $modalAction) {
@@ -435,14 +446,33 @@ trait CanOpenModal
             ->table($this->getTable());
     }
 
+    protected function prepareActionGroup(ActionGroup $group): ActionGroup
+    {
+        $group
+            ->schemaContainer($this->getSchemaContainer())
+            ->schemaComponent($this->getSchemaComponent())
+            ->livewire($this->getLivewire())
+            ->when(
+                ! $group->hasRecord(),
+                fn (ActionGroup $group) => $group->record($this->getRecord()),
+            )
+            ->table($this->getTable());
+        
+        foreach ($group->getFlatActions() as $nestedAction) {
+            $this->prepareModalAction($nestedAction);
+        }
+        
+        return $group;
+    }
+
     /**
-     * @return array<Action>
+     * @return array<Action | ActionGroup>
      */
     public function getVisibleModalFooterActions(): array
     {
         return array_filter(
             $this->getModalFooterActions(),
-            fn (Action $action): bool => $action->isVisible(),
+            fn (Action | ActionGroup $action): bool => $action->isVisible(),
         );
     }
 
@@ -489,7 +519,7 @@ trait CanOpenModal
     }
 
     /**
-     * @return array<Action>
+     * @return array<Action | ActionGroup>
      */
     public function getExtraModalFooterActions(): array
     {
@@ -500,7 +530,12 @@ trait CanOpenModal
         $actions = [];
 
         foreach ($this->evaluate($this->extraModalFooterActions) as $action) {
-            $actions[$action->getName()] = $this->prepareModalAction($action);
+            if ($action instanceof ActionGroup) {
+                $key = 'group_' . spl_object_id($action);
+                $actions[$key] = $this->prepareActionGroup($action);
+            } else {
+                $actions[$action->getName()] = $this->prepareModalAction($action);
+            }
         }
 
         return $this->cachedExtraModalFooterActions = $actions;

--- a/tests/src/Actions/ActionTest.php
+++ b/tests/src/Actions/ActionTest.php
@@ -445,3 +445,64 @@ it('will assert that a notification was not sent', function (): void {
         ->callAction('shows-notification-with-id')
         ->assertNotNotified('A notification');
 });
+
+it('can call an action inside an ActionGroup in extraModalFooterActions', function (): void {
+    livewire(Actions::class)
+        ->callAction([
+            'withGroupedExtraActions',
+            TestAction::make('simpleExtra'),
+        ])
+        ->assertDispatched('simple-extra-called');
+});
+
+it('can call an action with data inside an ActionGroup in extraModalFooterActions', function (): void {
+    livewire(Actions::class)
+        ->callAction([
+            'withGroupedExtraActions',
+            TestAction::make('option3'),
+        ], [
+            'value' => $value = Str::random(),
+        ])
+        ->assertHasNoFormErrors()
+        ->assertDispatched('option3-called', value: $value);
+});
+
+it('can mount a parent action with ActionGroup in extraModalFooterActions', function (): void {
+    livewire(Actions::class)
+        ->mountAction('withGroupedExtraActions')
+        ->assertActionMounted('withGroupedExtraActions')
+        ->assertActionDataSet([
+            'content' => null,
+        ]);
+});
+
+it('can call different actions within ActionGroup in extraModalFooterActions', function (): void {
+    livewire(Actions::class)
+        ->callAction([
+            'withGroupedExtraActions',
+            TestAction::make('option1'),
+        ])
+        ->assertDispatched('option1-called');
+
+    livewire(Actions::class)
+        ->callAction([
+            'withGroupedExtraActions',
+            TestAction::make('option2'),
+        ])
+        ->assertDispatched('option2-called');
+});
+
+it('can submit parent action after calling action in ActionGroup in extraModalFooterActions', function (): void {
+    livewire(Actions::class)
+        ->callAction([
+            'withGroupedExtraActions',
+            TestAction::make('option1'),
+        ])
+        ->assertDispatched('option1-called')
+        ->fillForm([
+            'content' => $content = Str::random(),
+        ])
+        ->callMountedAction()
+        ->assertHasNoActionErrors()
+        ->assertDispatched('grouped-extra-actions-called', content: $content);
+});

--- a/tests/src/Actions/ActionTest.php
+++ b/tests/src/Actions/ActionTest.php
@@ -446,7 +446,7 @@ it('will assert that a notification was not sent', function (): void {
         ->assertNotNotified('A notification');
 });
 
-it('can call an action inside an ActionGroup in extraModalFooterActions', function (): void {
+it('can call an action registered alongside an ActionGroup in extraModalFooterActions', function (): void {
     livewire(Actions::class)
         ->callAction([
             'withGroupedExtraActions',
@@ -455,7 +455,7 @@ it('can call an action inside an ActionGroup in extraModalFooterActions', functi
         ->assertDispatched('simple-extra-called');
 });
 
-it('can call an action with data inside an ActionGroup in extraModalFooterActions', function (): void {
+it('can call an action with data registered in an ActionGroup in extraModalFooterActions', function (): void {
     livewire(Actions::class)
         ->callAction([
             'withGroupedExtraActions',
@@ -467,7 +467,7 @@ it('can call an action with data inside an ActionGroup in extraModalFooterAction
         ->assertDispatched('option3-called', value: $value);
 });
 
-it('can open modal for action with ActionGroup in extraModalFooterActions', function (): void {
+it('can mount an action that has an ActionGroup in extraModalFooterActions', function (): void {
     livewire(Actions::class)
         ->mountAction('withGroupedExtraActions')
         ->assertActionMounted('withGroupedExtraActions')
@@ -476,7 +476,7 @@ it('can open modal for action with ActionGroup in extraModalFooterActions', func
         ]);
 });
 
-it('can call different actions within ActionGroup in extraModalFooterActions', function (): void {
+it('can call multiple actions registered in an ActionGroup in extraModalFooterActions', function (): void {
     livewire(Actions::class)
         ->callAction([
             'withGroupedExtraActions',
@@ -492,7 +492,7 @@ it('can call different actions within ActionGroup in extraModalFooterActions', f
         ->assertDispatched('option2-called');
 });
 
-it('can submit parent action after calling action in ActionGroup in extraModalFooterActions', function (): void {
+it('can submit parent action after calling an action registered in an ActionGroup in extraModalFooterActions', function (): void {
     livewire(Actions::class)
         ->callAction([
             'withGroupedExtraActions',

--- a/tests/src/Actions/ActionTest.php
+++ b/tests/src/Actions/ActionTest.php
@@ -467,7 +467,7 @@ it('can call an action with data inside an ActionGroup in extraModalFooterAction
         ->assertDispatched('option3-called', value: $value);
 });
 
-it('can mount a parent action with ActionGroup in extraModalFooterActions', function (): void {
+it('can open modal for action with ActionGroup in extraModalFooterActions', function (): void {
     livewire(Actions::class)
         ->mountAction('withGroupedExtraActions')
         ->assertActionMounted('withGroupedExtraActions')

--- a/tests/src/Actions/ActionTest.php
+++ b/tests/src/Actions/ActionTest.php
@@ -470,10 +470,7 @@ it('can call an action with data registered in an ActionGroup in extraModalFoote
 it('can mount an action that has an ActionGroup in extraModalFooterActions', function (): void {
     livewire(Actions::class)
         ->mountAction('withGroupedExtraActions')
-        ->assertActionMounted('withGroupedExtraActions')
-        ->assertActionDataSet([
-            'content' => null,
-        ]);
+        ->assertActionMounted('withGroupedExtraActions');
 });
 
 it('can call multiple actions registered in an ActionGroup in extraModalFooterActions', function (): void {

--- a/tests/src/Fixtures/Livewire/PostsTable.php
+++ b/tests/src/Fixtures/Livewire/PostsTable.php
@@ -327,6 +327,30 @@ class PostsTable extends Component implements HasActions, HasSchemas, Tables\Con
                                 ->action(fn (array $data, Post $record) => $this->dispatch('nested-called', bar: $data['bar'], recordKey: $record->getKey())),
                         ]),
                 ]),
+                Action::make('withGroupedExtraActions')
+                    ->schema([
+                        TextInput::make('content')
+                            ->required(),
+                    ])
+                    ->action(function (array $data, Post $record): void {
+                        $this->dispatch('grouped-extra-actions-called', content: $data['content'], recordKey: $record->getKey());
+                    })
+                    ->extraModalFooterActions([
+                        Action::make('simpleExtra')
+                            ->action(fn (Post $record) => $this->dispatch('simple-extra-called', recordKey: $record->getKey())),
+                        ActionGroup::make([
+                            Action::make('option1')
+                                ->action(fn (Post $record) => $this->dispatch('option1-called', recordKey: $record->getKey())),
+                            Action::make('option2')
+                                ->action(fn (Post $record) => $this->dispatch('option2-called', recordKey: $record->getKey())),
+                            Action::make('option3')
+                                ->schema([
+                                    TextInput::make('value')
+                                        ->required(),
+                                ])
+                                ->action(fn (array $data, Post $record) => $this->dispatch('option3-called', value: $data['value'], recordKey: $record->getKey())),
+                        ])->button()->label('More Options'),
+                    ]),
             ])
             ->toolbarActions([
                 DeleteBulkAction::make(),

--- a/tests/src/Fixtures/Pages/Actions.php
+++ b/tests/src/Fixtures/Pages/Actions.php
@@ -3,6 +3,7 @@
 namespace Filament\Tests\Fixtures\Pages;
 
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
@@ -121,6 +122,30 @@ class Actions extends Page
 
                     $action->halt();
                 }),
+            Action::make('withGroupedExtraActions')
+                ->schema([
+                    TextInput::make('content')
+                        ->required(),
+                ])
+                ->action(function (array $data): void {
+                    $this->dispatch('grouped-extra-actions-called', content: $data['content']);
+                })
+                ->extraModalFooterActions([
+                    Action::make('simpleExtra')
+                        ->action(fn () => $this->dispatch('simple-extra-called')),
+                    ActionGroup::make([
+                        Action::make('option1')
+                            ->action(fn () => $this->dispatch('option1-called')),
+                        Action::make('option2')
+                            ->action(fn () => $this->dispatch('option2-called')),
+                        Action::make('option3')
+                            ->schema([
+                                TextInput::make('value')
+                                    ->required(),
+                            ])
+                            ->action(fn (array $data) => $this->dispatch('option3-called', value: $data['value'])),
+                    ])->button()->label('More Options'),
+                ]),
             Action::make('visible'),
             Action::make('hidden')
                 ->hidden(),

--- a/tests/src/Tables/Actions/ActionTest.php
+++ b/tests/src/Tables/Actions/ActionTest.php
@@ -410,7 +410,7 @@ it('can replicate a record', function (): void {
     ]);
 });
 
-it('can call an action inside an ActionGroup in extraModalFooterActions', function (): void {
+it('can call an action registered alongside an ActionGroup in extraModalFooterActions', function (): void {
     $post = Post::factory()->create();
 
     livewire(PostsTable::class)
@@ -421,7 +421,7 @@ it('can call an action inside an ActionGroup in extraModalFooterActions', functi
         ->assertDispatched('simple-extra-called', recordKey: $post->getKey());
 });
 
-it('can call an action with data inside an ActionGroup in extraModalFooterActions', function (): void {
+it('can call an action with data registered in an ActionGroup in extraModalFooterActions', function (): void {
     $post = Post::factory()->create();
 
     livewire(PostsTable::class)
@@ -435,7 +435,7 @@ it('can call an action with data inside an ActionGroup in extraModalFooterAction
         ->assertDispatched('option3-called', value: $value, recordKey: $post->getKey());
 });
 
-it('can open modal for action with ActionGroup in extraModalFooterActions', function (): void {
+it('can mount an action that has an ActionGroup in extraModalFooterActions', function (): void {
     $post = Post::factory()->create();
 
     livewire(PostsTable::class)
@@ -443,7 +443,7 @@ it('can open modal for action with ActionGroup in extraModalFooterActions', func
         ->assertTableActionMounted('withGroupedExtraActions');
 });
 
-it('can access record in actions within ActionGroup in extraModalFooterActions', function (): void {
+it('can call multiple actions registered in an ActionGroup in extraModalFooterActions', function (): void {
     $post = Post::factory()->create();
 
     livewire(PostsTable::class)
@@ -461,7 +461,7 @@ it('can access record in actions within ActionGroup in extraModalFooterActions',
         ->assertDispatched('option2-called', recordKey: $post->getKey());
 });
 
-it('can submit parent action after calling action in ActionGroup', function (): void {
+it('can submit parent action after calling an action registered in an ActionGroup in extraModalFooterActions', function (): void {
     $post = Post::factory()->create();
 
     livewire(PostsTable::class)

--- a/tests/src/Tables/Actions/ActionTest.php
+++ b/tests/src/Tables/Actions/ActionTest.php
@@ -409,3 +409,74 @@ it('can replicate a record', function (): void {
         'title' => $post->title . ' (Copy)',
     ]);
 });
+
+it('can call an action inside an ActionGroup in extraModalFooterActions', function (): void {
+    $post = Post::factory()->create();
+
+    livewire(PostsTable::class)
+        ->callAction([
+            TestAction::make('withGroupedExtraActions')->table($post),
+            TestAction::make('simpleExtra'),
+        ])
+        ->assertDispatched('simple-extra-called', recordKey: $post->getKey());
+});
+
+it('can call an action with data inside an ActionGroup in extraModalFooterActions', function (): void {
+    $post = Post::factory()->create();
+
+    livewire(PostsTable::class)
+        ->callAction([
+            TestAction::make('withGroupedExtraActions')->table($post),
+            TestAction::make('option3'),
+        ], [
+            'value' => $value = Str::random(),
+        ])
+        ->assertHasNoFormErrors()
+        ->assertDispatched('option3-called', value: $value, recordKey: $post->getKey());
+});
+
+it('can mount a parent action with ActionGroup in extraModalFooterActions', function (): void {
+    $post = Post::factory()->create();
+
+    livewire(PostsTable::class)
+        ->mountTableAction('withGroupedExtraActions', $post)
+        ->assertTableActionMounted('withGroupedExtraActions')
+        ->assertTableActionDataSet([
+            'content' => null,
+        ]);
+});
+
+it('can access record in actions within ActionGroup in extraModalFooterActions', function (): void {
+    $post = Post::factory()->create();
+
+    livewire(PostsTable::class)
+        ->callAction([
+            TestAction::make('withGroupedExtraActions')->table($post),
+            TestAction::make('option1'),
+        ])
+        ->assertDispatched('option1-called', recordKey: $post->getKey());
+
+    livewire(PostsTable::class)
+        ->callAction([
+            TestAction::make('withGroupedExtraActions')->table($post),
+            TestAction::make('option2'),
+        ])
+        ->assertDispatched('option2-called', recordKey: $post->getKey());
+});
+
+it('can submit parent action after calling action in ActionGroup', function (): void {
+    $post = Post::factory()->create();
+
+    livewire(PostsTable::class)
+        ->callAction([
+            TestAction::make('withGroupedExtraActions')->table($post),
+            TestAction::make('option1'),
+        ])
+        ->assertDispatched('option1-called', recordKey: $post->getKey())
+        ->fillForm([
+            'content' => $content = Str::random(),
+        ])
+        ->callMountedTableAction()
+        ->assertHasNoTableActionErrors()
+        ->assertDispatched('grouped-extra-actions-called', content: $content, recordKey: $post->getKey());
+});

--- a/tests/src/Tables/Actions/ActionTest.php
+++ b/tests/src/Tables/Actions/ActionTest.php
@@ -435,15 +435,12 @@ it('can call an action with data inside an ActionGroup in extraModalFooterAction
         ->assertDispatched('option3-called', value: $value, recordKey: $post->getKey());
 });
 
-it('can mount a parent action with ActionGroup in extraModalFooterActions', function (): void {
+it('can open modal for action with ActionGroup in extraModalFooterActions', function (): void {
     $post = Post::factory()->create();
 
     livewire(PostsTable::class)
         ->mountTableAction('withGroupedExtraActions', $post)
-        ->assertTableActionMounted('withGroupedExtraActions')
-        ->assertTableActionDataSet([
-            'content' => null,
-        ]);
+        ->assertTableActionMounted('withGroupedExtraActions');
 });
 
 it('can access record in actions within ActionGroup in extraModalFooterActions', function (): void {


### PR DESCRIPTION
## Description

Resolves: https://github.com/filamentphp/filament/discussions/18651

Feature to add `ActionGroup` to `extraModalFooterActions`.

## Visual changes

<img width="628" height="82" alt="image" src="https://github.com/user-attachments/assets/e6cce670-905a-4165-b2fa-363bf7e5ff74" />

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
