### PR TITLE
Add panel awareness to MakeUserCommand

### DIFF
--- a/packages/panels/src/Commands/MakeUserCommand.php
+++ b/packages/panels/src/Commands/MakeUserCommand.php
@@ -3,6 +3,7 @@
 namespace Filament\Commands;
 
 use Filament\Facades\Filament;
+use Filament\Support\Commands\Concerns\HasPanel;
 use Illuminate\Auth\EloquentUserProvider;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Auth\Authenticatable;
@@ -22,6 +23,8 @@ use function Laravel\Prompts\text;
 ])]
 class MakeUserCommand extends Command
 {
+    use HasPanel;
+
     protected $description = 'Create a new Filament user';
 
     protected $name = 'make:filament-user';
@@ -58,6 +61,12 @@ class MakeUserCommand extends Command
                 mode: InputOption::VALUE_REQUIRED,
                 description: 'The password for the user (min. 8 characters)',
             ),
+            new InputOption(
+                name: 'panel',
+                shortcut: null,
+                mode: InputOption::VALUE_REQUIRED,
+                description: 'The panel to create the user in',
+            ),
         ];
     }
 
@@ -68,6 +77,8 @@ class MakeUserCommand extends Command
 
     public function handle(): int
     {
+        $this->configurePanel(question: 'Which panel would you like to create this user in?');
+
         $this->options = $this->options();
 
         if (! Filament::getCurrentOrDefaultPanel()) {
@@ -120,14 +131,14 @@ class MakeUserCommand extends Command
 
     protected function sendSuccessMessage(Model & Authenticatable $user): void
     {
-        $loginUrl = Filament::getLoginUrl();
+        $loginUrl = $this->panel->getLoginUrl();
 
         $this->components->info('Success! ' . ($user->getAttribute('email') ?? $user->getAttribute('username') ?? 'You') . " may now log in at {$loginUrl}");
     }
 
     protected function getAuthGuard(): Guard
     {
-        return Filament::auth();
+        return $this->panel->auth();
     }
 
     protected function getUserProvider(): UserProvider


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

In a project I have two panels, each one with a different auth guard (different models), but when I run the MakeUserCommand it always creates the user in the default panel.

This pull request adds panel awareness to the MakeUserCommand, so if you have more than one panel in your project it asks you to select one of them and it resolves the selected panel auth guard and login url for the successful message

I didn't see any tests for the command so I didn't add test for this, tell me if it is needed and I'll add it.

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
