### PR TITLE
Clarify CLI prompt and output

### DIFF
--- a/packages/support/src/Commands/Concerns/CanAskForRelatedResource.php
+++ b/packages/support/src/Commands/Concerns/CanAskForRelatedResource.php
@@ -15,7 +15,7 @@ trait CanAskForRelatedResource
         info('Filament can link this to an existing resource, which will open the resource\'s pages instead of modals when links are clicked. It will also inherit the resource\'s configuration.');
 
         if (! confirm(
-            label: 'Do you want to do this?',
+            label: 'Do you want to link this to an existing resource?',
             default: false,
         )) {
             return null;

--- a/packages/support/src/Commands/Concerns/CanAskForRelatedResource.php
+++ b/packages/support/src/Commands/Concerns/CanAskForRelatedResource.php
@@ -12,7 +12,7 @@ trait CanAskForRelatedResource
      */
     protected function askForRelatedResource(): ?string
     {
-        info('Filament can link this to an existing resource, which will open the resource\'s pages instead of modals when links are clicked. It will also inherit the resource\'s configuration.');
+        info('Linking to an existing resource will open the resource\'s pages instead of modals when links are clicked. It will also inherit the resource\'s configuration.');
 
         if (! confirm(
             label: 'Do you want to link this to an existing resource?',

--- a/tests/src/Panels/Commands/Legacy/LegacyMakePageCommandTest.php
+++ b/tests/src/Panels/Commands/Legacy/LegacyMakePageCommandTest.php
@@ -349,7 +349,7 @@ $runGenerateManageRelatedRecordsPageCommand = function (TestCase $testCase): Pen
 
 $generateManageRelatedRecordsPageCommandQuestions = [
     'relationship' => 'What is the relationship?',
-    'hasRelatedResource' => 'Do you want to do this?',
+    'hasRelatedResource' => 'Do you want to link this to an existing resource?',
     'relatedResource' => 'Which resource do you want to use?',
     'isGenerated' => 'Should the page be generated from the current database columns?',
     'relatedModel' => 'What is the related model?',

--- a/tests/src/Panels/Commands/MakePageCommandTest.php
+++ b/tests/src/Panels/Commands/MakePageCommandTest.php
@@ -340,7 +340,7 @@ $runGenerateManageRelatedRecordsPageCommand = function (TestCase $testCase): Pen
 
 $generateManageRelatedRecordsPageCommandQuestions = [
     'relationship' => 'What is the relationship?',
-    'hasRelatedResource' => 'Do you want to do this?',
+    'hasRelatedResource' => 'Do you want to link this to an existing resource?',
     'relatedResource' => 'Which resource do you want to use?',
     'hasFormSchemaClass' => 'Should an existing form schema class be used?',
     'isGenerated' => 'Should the page be generated from the current database columns?',


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

`Do you want to do this?` is not a proper question.
The question is actually in the `info(...)` call before the prompt.

<img width="1473" height="312" alt="Capture d’écran, le 2025-12-09 à 10 17 35" src="https://github.com/user-attachments/assets/6db82829-df15-405e-a6ef-a324e46e8684" />

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
Replace `Do you want to do this?` with `Do you want to link this to an existing resource?`

## Visual changes

Not sure how to run the CLI against my local change.
Running a composer install on the `4.x` branch doesn't work.

> » composer install --ignore-platform-req=ext-intl
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Your lock file does not contain a compatible set of packages. Please run composer update.
  Problem 1
    - brianium/paratest is locked to version v7.8.4 and an update of this package was not requested.
    - brianium/paratest v7.8.4 requires php ~8.2.0 || ~8.3.0 || ~8.4.0 -> your php version (8.5.0) does not satisfy that requirement.
  Problem 2
    - pestphp/pest is locked to version v3.8.4 and an update of this package was not requested.
    - brianium/paratest v7.8.4 requires php ~8.2.0 || ~8.3.0 || ~8.4.0 -> your php version (8.5.0) does not satisfy that requirement.
    - pestphp/pest v3.8.4 requires brianium/paratest ^7.8.4 -> satisfiable by brianium/paratest[v7.8.4].

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
