### PR TITLE
getParentRepeaterItem could be null

### DIFF
--- a/packages/schemas/src/Components/Concerns/CanBeRepeated.php
+++ b/packages/schemas/src/Components/Concerns/CanBeRepeated.php
@@ -13,7 +13,7 @@ trait CanBeRepeated
     {
         $repeater = $this->getParentRepeaterItem()?->getParentComponent();
 
-        assert($repeater instanceof Repeater);
+        assert(($repeater instanceof Repeater) || (! $repeater));
 
         return $repeater;
     }


### PR DESCRIPTION
getParentRepeaterItem could be null

## Description

getParentRepeaterItem() could be null

<img width="1262" height="317" alt="image" src="https://github.com/user-attachments/assets/d5dd43b7-0573-43fe-be6c-441955175969" />
## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
