### PR TITLE
Support custom styles for toggle colors

### DIFF
--- a/packages/forms/src/Components/Concerns/HasToggleColors.php
+++ b/packages/forms/src/Components/Concerns/HasToggleColors.php
@@ -6,10 +6,20 @@ use Closure;
 
 trait HasToggleColors
 {
+    /**
+     * @var string|array<string, string>|Closure|null
+     */
     protected string | array | Closure | null $offColor = null;
 
+    /**
+     * @var string|array<string, string>|Closure|null
+     */
     protected string | array | Closure | null $onColor = null;
 
+    /**
+     * @param  string|array<string, string>|Closure|null  $color
+     * @return $this
+     */
     public function offColor(string | array | Closure | null $color): static
     {
         $this->offColor = $color;
@@ -17,6 +27,10 @@ trait HasToggleColors
         return $this;
     }
 
+    /**
+     * @param  string|array<string, string>|Closure|null  $color
+     * @return $this
+     */
     public function onColor(string | array | Closure | null $color): static
     {
         $this->onColor = $color;
@@ -24,11 +38,17 @@ trait HasToggleColors
         return $this;
     }
 
+    /**
+     * @return array<string, string>|string|null
+     */
     public function getOffColor(): array | string | null
     {
         return $this->evaluate($this->offColor);
     }
 
+    /**
+     * @return array<string, string>|string|null
+     */
     public function getOnColor(): array | string | null
     {
         return $this->evaluate($this->onColor);

--- a/packages/forms/src/Components/Concerns/HasToggleColors.php
+++ b/packages/forms/src/Components/Concerns/HasToggleColors.php
@@ -6,30 +6,30 @@ use Closure;
 
 trait HasToggleColors
 {
-    protected string | Closure | null $offColor = null;
+    protected string | array | Closure | null $offColor = null;
 
-    protected string | Closure | null $onColor = null;
+    protected string | array | Closure | null $onColor = null;
 
-    public function offColor(string | Closure | null $color): static
+    public function offColor(string | array | Closure | null $color): static
     {
         $this->offColor = $color;
 
         return $this;
     }
 
-    public function onColor(string | Closure | null $color): static
+    public function onColor(string | array | Closure | null $color): static
     {
         $this->onColor = $color;
 
         return $this;
     }
 
-    public function getOffColor(): ?string
+    public function getOffColor(): array | string | null
     {
         return $this->evaluate($this->offColor);
     }
 
-    public function getOnColor(): ?string
+    public function getOnColor(): array | string | null
     {
         return $this->evaluate($this->onColor);
     }

--- a/packages/support/resources/views/components/toggle.blade.php
+++ b/packages/support/resources/views/components/toggle.blade.php
@@ -22,20 +22,14 @@
         $onColorClasses[] = 'fi-color';
         $onColorStyles = \Filament\Support\get_component_custom_styles(ToggleComponent::class, $onColor);
     } else {
-        $onColorClasses = [
-            ...$onColorClasses,
-            ...\Filament\Support\get_component_color_classes(ToggleComponent::class, $onColor),
-        ];
+        $onColorClasses = \Filament\Support\get_component_color_classes(ToggleComponent::class, $onColor);
     }
 
     if (is_array($offColor)) {
         $offColorClasses[] = 'fi-color';
         $offColorStyles = \Filament\Support\get_component_custom_styles(ToggleComponent::class, $offColor);
     } else {
-        $offColorClasses = [
-            ...$offColorClasses,
-            ...\Filament\Support\get_component_color_classes(ToggleComponent::class, $offColor),
-        ];
+        $offColorClasses = \Filament\Support\get_component_color_classes(ToggleComponent::class, $offColor);
     }
 @endphp
 

--- a/packages/support/resources/views/components/toggle.blade.php
+++ b/packages/support/resources/views/components/toggle.blade.php
@@ -11,19 +11,40 @@
     'onIcon' => null,
 ])
 
+@php
+    $onColorClasses = [];
+    $onColorStyles = [];
+
+    $offColorClasses = [];
+    $offColorStyles = [];
+
+    if (is_array($onColor)) {
+        $onColorClasses[] = 'fi-color';
+        $onColorStyles = \Filament\Support\get_component_custom_styles(ToggleComponent::class, $onColor);
+    } else {
+        $onColorClasses = [
+            ...$onColorClasses,
+            ...\Filament\Support\get_component_color_classes(ToggleComponent::class, $onColor),
+        ];
+    }
+
+    if (is_array($offColor)) {
+        $offColorClasses[] = 'fi-color';
+        $offColorStyles = \Filament\Support\get_component_custom_styles(ToggleComponent::class, $offColor);
+    } else {
+        $offColorClasses = [
+            ...$offColorClasses,
+            ...\Filament\Support\get_component_color_classes(ToggleComponent::class, $offColor),
+        ];
+    }
+@endphp
+
 <button
     x-data="{ state: {{ $state }} }"
     x-bind:aria-checked="state?.toString()"
     x-on:click="state = ! state"
-    x-bind:class="
-        state ? @js(Arr::toCssClasses([
-                    'fi-toggle-on',
-                    ...\Filament\Support\get_component_color_classes(ToggleComponent::class, $onColor),
-                ])) : @js(Arr::toCssClasses([
-                            'fi-toggle-off',
-                            ...\Filament\Support\get_component_color_classes(ToggleComponent::class, $offColor),
-                        ]))
-    "
+    x-bind:class="state ? @js(Arr::toCssClasses(['fi-toggle-on', ...$onColorClasses])) : @js(Arr::toCssClasses(['fi-toggle-off', ...$offColorClasses]))"
+    x-bind:style="state ? @js(Arr::toCssStyles($onColorStyles)) : @js(Arr::toCssStyles($offColorStyles))"
     @if ($state)
         x-cloak
     @endif
@@ -53,8 +74,9 @@
         wire:ignore
         @class([
             'fi-toggle fi-toggle-on fi-hidden',
-            ...\Filament\Support\get_component_color_classes(ToggleComponent::class, $onColor),
+            ...$onColorClasses,
         ])
+        @style($onColorStyles)
     >
         <div>
             <div aria-hidden="true"></div>

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -84,6 +84,7 @@ if (! function_exists('Filament\Support\get_component_color_classes')) {
 if (! function_exists('Filament\Support\get_component_custom_styles')) {
     /**
      * @param  class-string<HasColor>  $component
+     * @param  array<string, string>  $color
      * @return array<string>
      */
     function get_component_custom_styles(string | HasColor $component, array $color): array

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -81,6 +81,21 @@ if (! function_exists('Filament\Support\get_component_color_classes')) {
     }
 }
 
+if (! function_exists('Filament\Support\get_component_custom_styles')) {
+    /**
+     * @param  class-string<HasColor>  $component
+     * @return array<string>
+     */
+    function get_component_custom_styles(string | HasColor $component, array $color): array
+    {
+        if (blank($color)) {
+            return [];
+        }
+
+        return FilamentColor::getComponentCustomStyles($component, $color);
+    }
+}
+
 if (! function_exists('Filament\Support\prepare_inherited_attributes')) {
     function prepare_inherited_attributes(ComponentAttributeBag $attributes): ComponentAttributeBag
     {


### PR DESCRIPTION
## Description

Toggle components now accept color arrays for 'on' and 'off' states, enabling custom styles via get_component_custom_styles. Blade and helper updates ensure correct class and style application for both string and array color values.

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
