### PR TITLE
fix: handle session sort retrieval to avoid array assignment

### DIFF
--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -143,7 +143,8 @@ trait InteractsWithTable
             $shouldPersistSortInSession &&
             session()->has($sortSessionKey)
         ) {
-            $this->tableSort = session()->get($sortSessionKey);
+            $sessionSort = session()->get($sortSessionKey);
+            $this->tableSort = is_string($sessionSort) ? $sessionSort : null;
         }
 
         if ($shouldPersistSortInSession) {


### PR DESCRIPTION
## Description

fixes: #18691

This pull request makes a small adjustment to how table sort state is restored from the session. Now, the sort value is only set if the session value is a string, preventing potential issues if the session contains unexpected data types.

- Only assigns `tableSort` from the session if the session value is a string, improving type safety in `InteractsWithTable.php`.
## Visual changes
## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
