### PR TITLE
Update docs: Add support for pagination links in custom widget and fix current-page-option-property initialization

### DIFF
--- a/.phpactor.json
+++ b/.phpactor.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "/phpactor.schema.json",
+    "language_server_phpstan.enabled": true
+}

--- a/.phpactor.json
+++ b/.phpactor.json
@@ -1,4 +1,0 @@
-{
-    "$schema": "/phpactor.schema.json",
-    "language_server_phpstan.enabled": true
-}

--- a/docs/12-components/03-pagination.md
+++ b/docs/12-components/03-pagination.md
@@ -24,32 +24,6 @@ class ListUsers extends Component
 }
 ```
 
-Additionally, you can also add paginated links to your custom Filament widget by moving the `$view` variable into a `render()` method and using the `WithPagination` trait:
-
-```php
-use App\Models\User;
-use Filament\Widgets\Widget;
-use Illuminate\Contracts\View\View;
-use Livewire\WithPagination;
-
-class CustomWidget extends Widget
-{
-    use WithPagination;
-    
-    // protected string $view = 'livewire.custom-widget';
-
-    public function render(): View
-    {
-        return view('livewire.custom-widget', [
-            'users' => User::query()->paginate(10),
-        ]);
-    }
-}
-
-```
-
-Then, in your Blade view, you can use the Filament pagination component to display the pagination links:
-
 ```blade
 <x-filament::pagination :paginator="$users" />
 ```
@@ -91,7 +65,7 @@ class ListUsers extends Component
 <x-filament::pagination
     :paginator="$users"
     :page-options="[5, 10, 20, 50, 100, 'all']"
-    current-page-option-property="perPage"
+    :current-page-option-property="perPage"
 />
 ```
 

--- a/docs/12-components/03-pagination.md
+++ b/docs/12-components/03-pagination.md
@@ -24,6 +24,32 @@ class ListUsers extends Component
 }
 ```
 
+Additionally, you can also add paginated links to your custom Filament widget by moving the `$view` variable into a `render()` method and using the `WithPagination` trait:
+
+```php
+use App\Models\User;
+use Filament\Widgets\Widget;
+use Illuminate\Contracts\View\View;
+use Livewire\WithPagination;
+
+class CustomWidget extends Widget
+{
+    use WithPagination;
+    
+    // protected string $view = 'livewire.custom-widget';
+
+    public function render(): View
+    {
+        return view('livewire.custom-widget', [
+            'users' => User::query()->paginate(10),
+        ]);
+    }
+}
+
+```
+
+Then, in your Blade view, you can use the Filament pagination component to display the pagination links:
+
 ```blade
 <x-filament::pagination :paginator="$users" />
 ```
@@ -65,7 +91,7 @@ class ListUsers extends Component
 <x-filament::pagination
     :paginator="$users"
     :page-options="[5, 10, 20, 50, 100, 'all']"
-    :current-page-option-property="perPage"
+    current-page-option-property="perPage"
 />
 ```
 


### PR DESCRIPTION
## Description

I worked around to figure out how to add pagination links to my custom widget without using a Filament table. Eventually, I found that pagination can be implemented in a custom widget by adding the WithPagination trait and moving the view variable into the render() method. So I think this new implementation should help other developers implement pagination in their custom widgets.

I also discovered that the initialization of the current-page-option-property may be incorrect. In the documentation, it uses :current-page-option-property but passes a string value, which causes an error because the perPage value is treated as a constant. Therefore, the colon should be removed.

## Visual changes

No visual changes.

## Functional changes

No functional changes.
