### PR TITLE
fix: always apply filtering regardless of whether shouldDeselectAllRecordsWhenFiltered is enabled

### DIFF
--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -280,9 +280,7 @@ trait HasBulkActions
                 }
             }
 
-            if ($table->shouldDeselectAllRecordsWhenFiltered()) {
-                $this->filterTableQuery($query);
-            }
+            $this->filterTableQuery($query);
 
             return $query;
         }


### PR DESCRIPTION
## Description

fixes: #18693 

I think `deselectAllRecordsWhenFiltered` should control the UI behavior only, should not affect the query result


related pr: #8591

## Visual changes



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
