### PR TITLE
Rich Editor: remove top margin between adjacent images

### DIFF
--- a/packages/support/resources/css/utilities.css
+++ b/packages/support/resources/css/utilities.css
@@ -507,6 +507,10 @@
     font-size: var(--text-sm);
     line-height: 1.5;
 
+    img + img {
+        margin-top: 0;
+    }
+
     *:where(:not(.fi-not-prose, .fi-not-prose *))
         + *:where(:not(.fi-not-prose, .fi-not-prose *)) {
         margin-top: calc(var(--spacing) * 4);


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description + visual changes

When placing two images next to each other in the Rich Editor, an unintended top margin is applied to the second image:

https://github.com/user-attachments/assets/5db310cb-b2f4-45d5-9180-d2f3f2591bf6

This issue is resolved by adjusting the CSS to remove the top margin between adjacent images:

<img width="352" height="232" alt="image" src="https://github.com/user-attachments/assets/1b33a998-77f5-4178-9a84-6d1f8909073a" />

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
