### PR TITLE
Fix: disable reorder in relation manager when isReadonly=true

### DIFF
--- a/packages/panels/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManager.php
@@ -56,6 +56,7 @@ class RelationManager extends Component implements HasActions, HasRenderHookScop
     use InteractsWithActions;
     use InteractsWithRelationshipTable {
         InteractsWithRelationshipTable::makeTable as makeBaseRelationshipTable;
+        InteractsWithRelationshipTable::canReorder as baseCanReorder;
     }
     use InteractsWithSchemas;
 
@@ -321,6 +322,11 @@ class RelationManager extends Component implements HasActions, HasRenderHookScop
                 EmbeddedTable::make(),
                 RenderHook::make(PanelsRenderHook::RESOURCE_RELATION_MANAGER_AFTER),
             ]);
+    }
+
+    protected function canReorder(): bool
+    {
+        return $this->isReadOnly() ? false : $this->baseCanReorder();
     }
 
     public function getDefaultActionAuthorizationResponse(Action $action): ?Response


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When `reorderable()` is set on relation manager table, reordering is possible on readOnly page.

<img width="1327" height="623" alt="Image" src="https://github.com/user-attachments/assets/14e50107-f299-4e1b-baca-b5b92350248a" />

This PR fixes the issue by disabling reordering on read-only pages.

## Visual changes

Reorder button is not present anymore:
<img width="1277" height="614" alt="image" src="https://github.com/user-attachments/assets/b790d0f9-e8bf-494a-b926-32e5cba22e6c" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
