### PR TITLE
Fix undesired margins on <br> in RichEditor and RichContentRenderer

### DIFF
--- a/packages/support/resources/css/utilities.css
+++ b/packages/support/resources/css/utilities.css
@@ -512,6 +512,10 @@
         margin-top: calc(var(--spacing) * 4);
     }
 
+    p br {
+        margin: 0;
+    }
+
     h1:where(:not(.fi-not-prose, .fi-not-prose *)) {
         font-size: var(--text-xl);
         line-height: calc(28 / 18);


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
In `RichEditor` and `RichContentRenderer`, the `<br>` elements have undesired margins applied. This becomes especially noticeable when using Shift+Enter in the content as you can see in the videos below.

## Visual changes

**Before fix:**

https://github.com/user-attachments/assets/fd3a0012-0bce-4324-9987-39b576d6da55

**After fix:**

https://github.com/user-attachments/assets/58ef4fef-fd41-4f5a-9cdb-036525485c3b

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
