### PR TITLE
RichContentRenderer: prioritize PHP extensions from custom plugins

### DIFF
--- a/packages/forms/src/Components/RichEditor/RichContentRenderer.php
+++ b/packages/forms/src/Components/RichEditor/RichContentRenderer.php
@@ -297,6 +297,14 @@ class RichContentRenderer implements Htmlable
     public function getTipTapPhpExtensions(): array
     {
         return [
+            ...array_reduce(
+                $this->getPlugins(),
+                fn (array $carry, RichContentPlugin $plugin): array => [
+                    ...$carry,
+                    ...$plugin->getTipTapPhpExtensions(),
+                ],
+                initial: [],
+            ),
             app(Blockquote::class),
             app(Bold::class),
             app(BulletList::class),
@@ -345,14 +353,6 @@ class RichContentRenderer implements Htmlable
                 ],
             ]),
             app(Underline::class),
-            ...array_reduce(
-                $this->getPlugins(),
-                fn (array $carry, RichContentPlugin $plugin): array => [
-                    ...$carry,
-                    ...$plugin->getTipTapPhpExtensions(),
-                ],
-                initial: [],
-            ),
         ];
     }
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
The Filament documentation states that you can create custom plugins for RichEditor and RichContent. Plugins may also define `->getTipTapPhpExtensions()`. This generally works well, **but currently it is impossible to override default PHP extensions that are already defined in RichContentRenderer.php.**

## Example
For example: in my [demo repo ](https://github.com/thijskuilman/filament-overlapping-floating-toolbar-reproduction/pull/1) I created a `CustomHeading` PHP extensions that is loaded via `CustomHeadingPlugin`. In my PHP extension, I add a red background to the heading:

```php
class CustomHeading extends Heading
{
    #[\Override]
    public function addOptions()
    {
        return [
            'levels' => [1, 2, 3, 4, 5, 6],
            'HTMLAttributes' => [
                // TODO: Let's add a red background for demo purposes...
                'style' => 'background: red!important'
            ],
        ];
    }
}
```

I then render content containing a heading like this:

```php
RichContentRenderer::make($record->bio)
  ->plugins([
      CustomHeadingPlugin::make(),
  ])
  ->toUnsafeHtml()
```

**Expected behavior:** The heading should have a red background.
**Actual behavior:** The red background does not appear because a default `Heading` extension is loaded first in `RichContentRenderer.php`, preventing my custom extension from overriding it.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
