### PR TITLE
Add onErrorUrl() method to Image component for fallback image support

### DIFF
--- a/packages/schemas/docs/07-primes.md
+++ b/packages/schemas/docs/07-primes.md
@@ -414,6 +414,24 @@ Image::make(
 
 <AutoScreenshot name="primes/image/tooltip" alt="Image with a tooltip" version="4.x" />
 
+### Adding a fallback image URL
+
+You may specify a fallback image URL that will be displayed when the primary image fails to load using the `onErrorUrl()` method:
+
+```php
+use Filament\Schemas\Components\Image;
+
+Image::make(
+    url: asset('images/user-avatar.jpg'),
+    alt: 'User avatar',
+)
+    ->onErrorUrl(asset('images/default-avatar.jpg'))
+```
+
+<UtilityInjection set="schemaComponents" version="4.x">As well as allowing a static value, the `onErrorUrl()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+
+When the primary image fails to load, the browser will automatically replace it with the fallback URL specified via `onErrorUrl()`. This is useful for handling broken image links gracefully and providing a better user experience.
+
 ## Unordered list component
 
 Unordered lists can be inserted into a schema using the `UnorderedList` component. The list items, comprising plain text or [text components](#text-component), are passed to the `make()` method:

--- a/packages/schemas/resources/views/components/image.blade.php
+++ b/packages/schemas/resources/views/components/image.blade.php
@@ -5,6 +5,7 @@
     $height = $getImageHeight() ?? '8rem';
     $width = $getImageWidth();
     $tooltip = $getTooltip();
+    $onErrorUrl = $getOnErrorUrl();
 
     if (! $alignment instanceof Alignment) {
         $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
@@ -14,6 +15,10 @@
 <img
     alt="{{ $getAlt() }}"
     src="{{ $getUrl() }}"
+    @if (filled($onErrorUrl))
+        data-error-url="{{ $onErrorUrl }}"
+        onerror="if(this.getAttribute('data-error-url')) this.src=this.getAttribute('data-error-url')"
+    @endif
     @if (filled($tooltip))
         x-tooltip="{ content: @js($tooltip), theme: $store.theme, allowHTML: @js($tooltip instanceof \Illuminate\Contracts\Support\Htmlable) }"
     @endif

--- a/packages/schemas/src/Components/Image.php
+++ b/packages/schemas/src/Components/Image.php
@@ -21,6 +21,8 @@ class Image extends Component
 
     protected int | string | Closure | null $imageWidth = null;
 
+    protected string | Closure | null $onErrorUrl = null;
+
     final public function __construct(string | Closure $url, string | Closure $alt)
     {
         $this->url($url);
@@ -109,5 +111,23 @@ class Image extends Component
         }
 
         return $width;
+    }
+
+    public function onErrorUrl(string | Closure | null $url): static
+    {
+        $this->onErrorUrl = $url;
+
+        return $this;
+    }
+
+    public function getOnErrorUrl(): ?string
+    {
+        $url = $this->evaluate($this->onErrorUrl);
+
+        if ($url === null) {
+            return null;
+        }
+
+        return $url;
     }
 }


### PR DESCRIPTION
## Description

This PR adds an `onErrorUrl()` method to the `Filament\Schemas\Components\Image` component, allowing developers to specify a fallback image URL that will be displayed when the primary image fails to load. This is useful for handling broken image links gracefully and providing a better user experience.

The implementation follows Filament's existing patterns:
- Supports `string | Closure | null` for dynamic URL generation
- Uses `$this->evaluate()` for closure evaluation
- Only adds error handling attributes when an error URL is provided
- Uses standard HTML `onerror` event handler for browser-native fallback functionality

**Usage example:**
Image::make($url, $alt)
    ->onErrorUrl($fallbackUrl)When the primary image fails to load, the browser will automatically replace it with the fallback URL specified via `onErrorUrl()`.

## Visual changes

No visual changes to the UI itself. The feature only affects behavior when an image fails to load - in that case, the fallback image will be displayed instead of a broken image icon.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.