### PR TITLE
Fix Postgres error when using searchable in tables

### DIFF
--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -272,11 +272,11 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
 
         $isSearchForcedCaseInsensitive ??= match ($driverName) {
             'pgsql' => true,
-            default => str($column)->contains('json_extract('),
+            default => str($column)->contains('json_extract(') || str($column)->contains('->'),
         };
 
         if ($isSearchForcedCaseInsensitive) {
-            if (in_array($driverName, ['mysql', 'mariadb'], true) && str($column)->contains('->') && ! str($column)->startsWith('json_extract(')) {
+            if (in_array($driverName, ['mysql', 'mariadb', 'sqlite'], true) && str($column)->contains('->') && ! str($column)->startsWith('json_extract(')) {
                 [$field, $path] = invade($databaseConnection->getQueryGrammar())->wrapJsonFieldAndPath($column); /** @phpstan-ignore-line */
                 $column = "json_extract({$field}{$path})";
             }
@@ -300,12 +300,7 @@ if (! function_exists('Filament\Support\generate_search_term_expression')) {
      */
     function generate_search_term_expression(string $search, ?bool $isSearchForcedCaseInsensitive, Connection $databaseConnection): string
     {
-        $isSearchForcedCaseInsensitive ??= match ($databaseConnection->getDriverName()) {
-            'pgsql' => true,
-            default => false,
-        };
-
-        if (! $isSearchForcedCaseInsensitive) {
+        if ($isSearchForcedCaseInsensitive === false) {
             return $search;
         }
 

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -227,7 +227,7 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
     /**
      * @internal This function is only to be used internally by Filament and is subject to change at any time. Please do not use this function in your own code.
      */
-    function generate_search_column_expression(string $column, ?bool $isSearchForcedCaseInsensitive, Connection $databaseConnection): string | Expression
+    function generate_search_column_expression(string $column, ?bool $isSearchForcedCaseInsensitive, Connection $databaseConnection): Expression
     {
         $driverName = $databaseConnection->getDriverName();
 
@@ -290,14 +290,7 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
             $column = "{$column} collate {$collation}";
         }
 
-        if (
-            str($column)->contains('(') || // This checks if the column name probably contains a raw expression like `lower()` or `json_extract()`.
-            filled($collation)
-        ) {
-            return new Expression($column);
-        }
-
-        return $column;
+        return new Expression($column);
     }
 }
 

--- a/packages/tables/src/Table/Concerns/CanSearchRecords.php
+++ b/packages/tables/src/Table/Concerns/CanSearchRecords.php
@@ -35,6 +35,8 @@ trait CanSearchRecords
 
     protected ?Closure $searchUsing = null;
 
+    protected bool | Closure | null $isSearchForcedCaseInsensitive = null;
+
     public function persistSearchInSession(bool | Closure $condition = true): static
     {
         $this->persistsSearchInSession = $condition;
@@ -205,29 +207,31 @@ trait CanSearchRecords
 
             $model = $query->getModel();
 
-            $nonTranslatableSearch = generate_search_term_expression($search, isSearchForcedCaseInsensitive: false, databaseConnection: $databaseConnection);
+            $isSearchForcedCaseInsensitive = $this->isSearchForcedCaseInsensitive();
+
+            $nonTranslatableSearch = generate_search_term_expression($search, isSearchForcedCaseInsensitive: $isSearchForcedCaseInsensitive, databaseConnection: $databaseConnection);
 
             $translatableContentDriver = $this->getLivewire()->makeFilamentTranslatableContentDriver();
 
             $query->when(
                 $translatableContentDriver?->isAttributeTranslatable($model::class, attribute: $column),
-                fn (Builder $query): Builder => $translatableContentDriver->applySearchConstraintToQuery($query, $column, $search, $whereClause, isSearchForcedCaseInsensitive: false),
+                fn (Builder $query): Builder => $translatableContentDriver->applySearchConstraintToQuery($query, $column, $search, $whereClause, isSearchForcedCaseInsensitive: $isSearchForcedCaseInsensitive),
                 fn (Builder $query) => $query->when(
                     $this->getExtraSearchableColumnRelationship($column, $query->getModel()),
                     fn (Builder $query): Builder => $query->{"{$whereClause}Relation"}(
                         (string) str($column)->beforeLast('.'),
-                        generate_search_column_expression((string) str($column)->afterLast('.'), isSearchForcedCaseInsensitive: false, databaseConnection: $databaseConnection),
+                        generate_search_column_expression((string) str($column)->afterLast('.'), isSearchForcedCaseInsensitive: $isSearchForcedCaseInsensitive, databaseConnection: $databaseConnection),
                         'like',
                         "%{$nonTranslatableSearch}%",
                     ),
-                    function (Builder $query) use ($databaseConnection, $nonTranslatableSearch, $column, $whereClause): Builder {
+                    function (Builder $query) use ($databaseConnection, $nonTranslatableSearch, $column, $whereClause, $isSearchForcedCaseInsensitive): Builder {
                         // Treat the missing "relationship" as a JSON column if dot notation is used in the column name.
                         if (str($column)->contains('.')) {
                             $column = (string) str($column)->replace('.', '->');
                         }
 
                         return $query->{$whereClause}(
-                            generate_search_column_expression($column, isSearchForcedCaseInsensitive: false, databaseConnection: $databaseConnection),
+                            generate_search_column_expression($column, isSearchForcedCaseInsensitive: $isSearchForcedCaseInsensitive, databaseConnection: $databaseConnection),
                             'like',
                             "%{$nonTranslatableSearch}%",
                         );
@@ -297,5 +301,17 @@ trait CanSearchRecords
             'query' => $query,
             'search' => $search,
         ]);
+    }
+
+    public function forceSearchCaseInsensitive(bool | Closure | null $condition = true): static
+    {
+        $this->isSearchForcedCaseInsensitive = $condition;
+
+        return $this;
+    }
+
+    public function isSearchForcedCaseInsensitive(): ?bool
+    {
+        return $this->evaluate($this->isSearchForcedCaseInsensitive);
     }
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/filamentphp/filament/issues/18467

Fixes a `undefined column` error from Postgres when using table search. Also fixes a bug where table search would always force the search term to be lowercase by adding `forceSearchCaseInsensitive()` to `Table` (same implementation as in `Column`).

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
