### PR TITLE
Fix RichEditor type error when saving form without editing the field

### DIFF
--- a/packages/forms/src/Components/RichEditor.php
+++ b/packages/forms/src/Components/RichEditor.php
@@ -997,6 +997,24 @@ class RichEditor extends Field implements Contracts\CanBeLengthConstrained
         return parent::callAfterStateUpdated($shouldBubbleToParents);
     }
 
+    public function callBeforeStateDehydrated(array &$state = []): static
+    {
+        $rawState = $this->getRawState();
+
+        // https://github.com/filamentphp/filament/issues/17472
+        // The beforeStateDehydrated callback expects ?array but getRawState() returns
+        // string when RichEditor is in HTML mode and the field wasn't edited.
+        if (! is_array($rawState)) {
+            foreach ($this->getStateCasts() as $stateCast) {
+                $rawState = $stateCast->set($rawState);
+            }
+
+            $this->rawState($rawState);
+        }
+
+        return parent::callBeforeStateDehydrated($state);
+    }
+
     /**
      * @param  array<string, string | TextColor> | Closure | null  $colors
      */


### PR DESCRIPTION
## Summary

This PR fixes the `TypeError: Argument #2 ($rawState) must be of type ?array, string given` error that occurs when saving a form that contains a RichEditor field in HTML mode (not using `->json()`) without editing that field.

**Related issues:**
- https://github.com/filamentphp/filament/issues/17472
- https://github.com/filamentphp/filament/issues/18017

## Problem

When a RichEditor stores content as HTML (the default mode), the `beforeStateDehydrated` callback registered in `setUp()` expects `?array $rawState`. However, when the form is saved without editing the RichEditor field:

1. `callAfterStateUpdated()` is NOT called (since the field wasn't updated)
2. `callBeforeStateDehydrated()` IS called (as part of the form save process)
3. `getRawState()` returns the HTML string from the database
4. The callback receives a string instead of an array, causing the type error

The existing fix in PR #17762 added state normalization to `callAfterStateUpdated()`, which only runs when the RichEditor field itself is edited. This doesn't cover the case where other fields are edited but the RichEditor is left untouched.

## Solution

Add the same state normalization logic to `callBeforeStateDehydrated()`, which runs during every form save regardless of which fields were edited. This ensures the raw state is converted to the expected array format before the `beforeStateDehydrated` callback is invoked.

## Test Case

1. Create a model with a RichEditor field storing HTML (not using `->json()` mode)
2. Save some HTML content to the field
3. Edit ANY other field in the form (not the RichEditor)
4. Save the form
5. Without this fix: `TypeError` is thrown
6. With this fix: Form saves successfully