### PR TITLE
Add "shouldTranslate" to notification title and body

### DIFF
--- a/packages/notifications/src/Concerns/HasBody.php
+++ b/packages/notifications/src/Concerns/HasBody.php
@@ -8,6 +8,8 @@ trait HasBody
 {
     protected string | Closure | null $body = null;
 
+    protected bool $shouldTranslateBody = false;
+
     public function body(string | Closure | null $body): static
     {
         $this->body = $body;
@@ -15,8 +17,19 @@ trait HasBody
         return $this;
     }
 
+    public function translateBody(bool $shouldTranslateBody = true): static
+    {
+        $this->shouldTranslateBody = $shouldTranslateBody;
+
+        return $this;
+    }
+
     public function getBody(): ?string
     {
-        return $this->evaluate($this->body);
+        $body = $this->evaluate($this->body);
+
+        return is_string($body) && $this->shouldTranslateBody
+            ? __($body)
+            : $body;
     }
 }

--- a/packages/notifications/src/Concerns/HasTitle.php
+++ b/packages/notifications/src/Concerns/HasTitle.php
@@ -8,6 +8,8 @@ trait HasTitle
 {
     protected string | Closure | null $title = null;
 
+    protected bool $shouldTranslateTitle = false;
+
     public function title(string | Closure | null $title): static
     {
         $this->title = $title;
@@ -15,8 +17,19 @@ trait HasTitle
         return $this;
     }
 
+    public function translateTitle(bool $shouldTranslateTitle = true): static
+    {
+        $this->shouldTranslateTitle = $shouldTranslateTitle;
+
+        return $this;
+    }
+
     public function getTitle(): ?string
     {
-        return $this->evaluate($this->title);
+        $title = $this->evaluate($this->title);
+
+        return is_string($title) && $this->shouldTranslateTitle
+            ? __($title)
+            : $title;
     }
 }


### PR DESCRIPTION
## Description

Allows to use translation keys for notification title and body, similar to labels.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
