### PR TITLE
Fix Nested Modals For Schema Components

### DIFF
--- a/packages/actions/src/Action.php
+++ b/packages/actions/src/Action.php
@@ -121,6 +121,8 @@ class Action extends ViewComponent implements Arrayable
 
     protected ?ActionStatus $status = null;
 
+    protected ?Action $parentAction = null;
+
     final public function __construct(?string $name)
     {
         $this->name($name);
@@ -463,10 +465,6 @@ class Action extends ViewComponent implements Arrayable
 
         $table = $this->getTable();
 
-        if ($table) {
-            $context['table'] = true;
-        }
-
         $record = $this->getRecord();
 
         if ($record && (
@@ -476,6 +474,14 @@ class Action extends ViewComponent implements Arrayable
             || is_a($record::class, $table->getModel(), true)
         ) && filled($recordKey = $this->resolveRecordKey($record))) {
             $context['recordKey'] = $recordKey;
+        }
+
+        if ($this->getParentAction()) {
+            return $context;
+        }
+
+        if ($table) {
+            $context['table'] = true;
         }
 
         if ($table && $this->isBulk()) {
@@ -859,5 +865,17 @@ class Action extends ViewComponent implements Arrayable
     public function getClone(): static
     {
         return clone $this;
+    }
+
+    public function parentAction(?Action $action): static
+    {
+        $this->parentAction = $action;
+
+        return $this;
+    }
+
+    public function getParentAction(): ?Action
+    {
+        return $this->parentAction;
     }
 }

--- a/packages/actions/src/Concerns/CanOpenModal.php
+++ b/packages/actions/src/Concerns/CanOpenModal.php
@@ -425,6 +425,7 @@ trait CanOpenModal
     public function prepareModalAction(Action $action): Action
     {
         return $action
+            ->parentAction($this)
             ->schemaContainer($this->getSchemaContainer())
             ->schemaComponent($this->getSchemaComponent())
             ->livewire($this->getLivewire())

--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -605,9 +605,11 @@ trait InteractsWithActions
     {
         if (count($parentActions)) {
             $parentAction = Arr::last($parentActions);
-            $resolvedAction = $parentAction->getModalAction($action['name']) ?? throw new ActionNotResolvableException("Action [{$action['name']}] was not found for action [{$parentAction->getName()}].");
+            $resolvedAction = $parentAction->getModalAction($action['name']);
 
-            return $resolvedAction;
+            if ($resolvedAction) {
+                return $resolvedAction;
+            }
         }
 
         if (! $this instanceof HasSchemas) {

--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -575,18 +575,11 @@ trait InteractsWithActions
             throw new ActionNotResolvableException('Failed to resolve table action for Livewire component without the [' . HasTable::class . '] trait.');
         }
 
-        $resolvedAction = null;
-
-        if (count($parentActions)) {
-            $parentAction = Arr::last($parentActions);
-            $resolvedAction = $parentAction->getModalAction($action['name']) ?? throw new ActionNotResolvableException("Action [{$action['name']}] was not found for action [{$parentAction->getName()}].");
-        } else {
-            if ($action['context']['bulk'] ?? false) {
-                $resolvedAction = $this->getTable()->getBulkAction($action['name']);
-            }
-
-            $resolvedAction ??= $this->getTable()->getAction($action['name']) ?? throw new ActionNotResolvableException("Action [{$action['name']}] not found on table.");
+        if ($action['context']['bulk'] ?? false) {
+            $resolvedAction = $this->getTable()->getBulkAction($action['name']);
         }
+
+        $resolvedAction ??= $this->getTable()->getAction($action['name']) ?? throw new ActionNotResolvableException("Action [{$action['name']}] not found on table.");
 
         if (filled($action['context']['recordKey'] ?? null)) {
             $record = $this->getTableRecord($action['context']['recordKey']);
@@ -603,15 +596,6 @@ trait InteractsWithActions
      */
     protected function resolveSchemaComponentAction(array $action, array $parentActions): Action
     {
-        if (count($parentActions)) {
-            $parentAction = Arr::last($parentActions);
-            $resolvedAction = $parentAction->getModalAction($action['name']);
-
-            if ($resolvedAction) {
-                return $resolvedAction;
-            }
-        }
-
         if (! $this instanceof HasSchemas) {
             throw new ActionNotResolvableException('Failed to resolve action schema for Livewire component without the [' . InteractsWithSchemas::class . '] trait.');
         }

--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -603,6 +603,13 @@ trait InteractsWithActions
      */
     protected function resolveSchemaComponentAction(array $action, array $parentActions): Action
     {
+        if (count($parentActions)) {
+            $parentAction = Arr::last($parentActions);
+            $resolvedAction = $parentAction->getModalAction($action['name']) ?? throw new ActionNotResolvableException("Action [{$action['name']}] was not found for action [{$parentAction->getName()}].");
+
+            return $resolvedAction;
+        }
+
         if (! $this instanceof HasSchemas) {
             throw new ActionNotResolvableException('Failed to resolve action schema for Livewire component without the [' . InteractsWithSchemas::class . '] trait.');
         }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

My company upgraded from v3 to v4 of Filament today and noticed that our nested modals weren't working (spinner and then nothing). I was able to reproduce the issue on the issue template. I looked around and noticed issues #18320 and #18488 appeared to be the same as my issue. Furthermore, I also found issue #16674 and the associated fix #16710. Using the fix PR as a starting point of where to look, I found that the `$parentActions` was unused in `resolveSchemaComponentAction`. Adding handling of the `$parentActions` imitating the nested table action fix did appear to resolve the issue.

As for how I tested this, I used the long parent chain example [from the docs](https://filamentphp.com/docs/4.x/actions/modals#opening-another-modal-from-an-extra-footer-action). Handling the parent actions made it work as expected. I further confirmed that my application's issue is also resolved with this change.

## Visual changes

https://github.com/user-attachments/assets/8530c16c-2322-4b57-b8ab-5ead57c6f075

https://github.com/user-attachments/assets/92cfa67e-5614-41b5-8702-1b2de9715531

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
