### PR TITLE
fix: Apply StateCasts to child components in Repeater for JSON columns

### DIFF
--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -826,13 +826,24 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         $items = [];
 
         foreach ($this->getRawState() ?? [] as $itemKey => $itemData) {
-            $items[$itemKey] = $this
+            $childSchema = $this
                 ->getChildSchema()
                 ->statePath($itemKey)
                 ->constantState(((! ($relationship && $records->has($itemKey))) && is_array($itemData)) ? $itemData : null)
                 ->model($relationship ? $records[$itemKey] ?? $this->getRelatedModel() : null)
                 ->inlineLabel(false)
                 ->getClone();
+
+            // Apply StateCasts to child components for non-relationship repeaters.
+            // This ensures components like FileUpload have properly normalized state
+            // after afterStateHydrated restructures items and clears cached schemas.
+            if (! $relationship) {
+                foreach ($childSchema->getComponents(withActions: false, withHidden: true) as $component) {
+                    $component->castStateAfterLoadingFromRelationships();
+                }
+            }
+
+            $items[$itemKey] = $childSchema;
         }
 
         return $items;


### PR DESCRIPTION
## Summary

Fixes #18726

When `Repeater`'s `afterStateHydrated` restructures items with UUID keys, it calls `rawState()` which triggers `clearCachedDefaultChildSchemas()`. Subsequent calls to `getItems()` create new child schemas that haven't been through `hydrateState()`, so `StateCasts` (like `FileUploadStateCast`) are never applied.

This causes FileUpload components inside non-relationship Repeaters (JSON columns) to fail with:
```
foreach() argument must be of type array|object, string given
```

The error occurs because `FileUpload::getUploadedFiles()` expects UUID-keyed arrays but receives raw strings.

## Solution

Apply `StateCasts` to child components after creating schemas in `getItems()` for non-relationship repeaters. The existing `castStateAfterLoadingFromRelationships()` method handles this perfectly - it recursively processes child schemas and is idempotent.

For relationship-based repeaters, this is already handled via `loadStateFromRelationships(shouldHydrate: true)`.

## Test Plan

- [x] Create a Repeater with FileUpload inside a JSON column (not relationship-based)
- [x] Upload an image and save
- [x] Reload the form - previously crashed, now works correctly