### PR TITLE
Fix: Scope persisted table filters session key by tenant

### DIFF
--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -221,7 +221,15 @@ trait HasFilters
 
     public function getTableFiltersSessionKey(): string
     {
-        $table = md5($this::class);
+        $tenantKey = filament()->getTenant()?->getKey();
+
+        $namespace = $this::class;
+
+        if ($tenantKey) {
+            $namespace .= '|' . $tenantKey;
+        }
+
+        $table = md5($namespace);
 
         return "tables.{$table}_filters";
     }

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -230,7 +230,7 @@ trait HasFilters
             $tenantKey = Filament::getTenant()?->getKey();
         }
 
-        if ($tenantKey !== null && $tenantKey !== '') {
+        if (filled($tenantKey)) {
             $namespace .= '|' . $tenantKey;
         }
 

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Tables\Concerns;
 
+use Filament\Facades\Filament;
 use Filament\QueryBuilder\Forms\Components\RuleBuilder;
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Schema;
@@ -221,11 +222,15 @@ trait HasFilters
 
     public function getTableFiltersSessionKey(): string
     {
-        $tenantKey = filament()->getTenant()?->getKey();
-
         $namespace = $this::class;
 
-        if ($tenantKey) {
+        $tenantKey = null;
+
+        if (class_exists(Filament::class)) {
+            $tenantKey = Filament::getTenant()?->getKey();
+        }
+
+        if ($tenantKey !== null && $tenantKey !== '') {
             $namespace .= '|' . $tenantKey;
         }
 


### PR DESCRIPTION
Scope persisted table filters session key by tenant

## Description

When persistFiltersInSession() is enabled, table filters are stored in the session using a key derived from the table/component class. In multi-tenant apps, switching tenants within the same session can unintentionally reuse the previous tenant’s persisted filters.

This PR scopes the table filters session key by the current tenant key (when a tenant is active), so persisted filters are isolated per tenant.

If tenant-scoped persistence is not the expected default behavior, this could be exposed as a configuration option on persistFiltersInSession() to allow opting into tenant-aware filter persistence.

- [] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
