### PR TITLE
Add current password field with validation message

### DIFF
--- a/packages/panels/resources/lang/zh_CN/auth/pages/edit-profile.php
+++ b/packages/panels/resources/lang/zh_CN/auth/pages/edit-profile.php
@@ -22,6 +22,12 @@ return [
             'label' => '确认新密码',
         ],
 
+        'current_password' => [
+            'label' => '当前密码',
+            'below_content' => '出于安全原因，请确认您的密码以继续。',
+            'validation_attribute' => '当前密码',
+        ],
+
         'actions' => [
 
             'save' => [


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Fix an issue where, in the admin panel’s personal profile page, the “Current Password” field was not correctly displayed in Chinese under the Chinese locale.

## Visual changes

before:
<img width="1265" height="490" alt="image" src="https://github.com/user-attachments/assets/930c0d17-a04f-482b-bdfc-aaf1b3449899" />

after:
<img width="1256" height="499" alt="image" src="https://github.com/user-attachments/assets/9f222a2f-28cd-41d7-af02-99177c8480dd" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
