### PR TITLE
fix: Wrong method name in documentation

### DIFF
--- a/packages/infolists/docs/01-overview.md
+++ b/packages/infolists/docs/01-overview.md
@@ -437,7 +437,7 @@ use Filament\Schemas\Components\Section;
 
 Section::make('Details')
     ->inlineLabel()
-    ->entries([
+    ->schema([
         TextInput::make('name'),
         TextInput::make('email')
             ->label('Email address'),

--- a/packages/infolists/docs/01-overview.md
+++ b/packages/infolists/docs/01-overview.md
@@ -403,7 +403,7 @@ use Filament\Schemas\Components\Section;
 
 Section::make('Details')
     ->inlineLabel()
-    ->entries([
+    ->schema([
         TextInput::make('name'),
         TextInput::make('email')
             ->label('Email address'),


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Example bug, see https://github.com/filamentphp/filament/discussions/18744

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
