### PR TITLE
🌐 Update danish label for "Attach" in attach.php

### DIFF
--- a/packages/actions/resources/lang/da/attach.php
+++ b/packages/actions/resources/lang/da/attach.php
@@ -4,7 +4,7 @@ return [
 
     'single' => [
 
-        'label' => 'Attach',
+        'label' => 'Vedhæft',
 
         'modal' => [
 


### PR DESCRIPTION
Update danish translation of the word "Attach" to align with the rest of the translations - currently it's just using the english word.
