### PR TITLE
Feature: allow null brand name

### DIFF
--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -32,7 +32,7 @@
         @endphp
 
         <title>
-            {{ filled($title) ? "{$title} - " : null }} {{ $brandName }}
+            {{ filled($title) ? $title : '' }}{{ filled($brandName) && filled($title) ? " - " : '' }}{{ filled($brandName) ? $brandName : '' }}
         </title>
 
         {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::STYLES_BEFORE, scopes: $renderHookScopes) }}

--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -32,7 +32,7 @@
         @endphp
 
         <title>
-            {{ filled($title) ? $title : '' }}{{ filled($brandName) && filled($title) ? " - " : '' }}{{ filled($brandName) ? $brandName : '' }}
+            {{ filled($title) ? $title : '' }}{{ filled($brandName) && filled($title) ? ' - ' : '' }}{{ filled($brandName) ? $brandName : '' }}
         </title>
 
         {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::STYLES_BEFORE, scopes: $renderHookScopes) }}

--- a/packages/panels/src/Auth/MultiFactor/App/AppAuthentication.php
+++ b/packages/panels/src/Auth/MultiFactor/App/AppAuthentication.php
@@ -139,7 +139,7 @@ class AppAuthentication implements MultiFactorAuthenticationProvider
         $user = Filament::auth()->user();
 
         $inlineQrCode = $this->google2FA->getQRCodeInline(
-            $this->getBrandName(),
+            $this->getBrandName() ?? config('app.name'),
             $this->getHolderName($user),
             $secret,
         );
@@ -264,7 +264,7 @@ class AppAuthentication implements MultiFactorAuthenticationProvider
         return $this;
     }
 
-    public function getBrandName(): string
+    public function getBrandName(): string | null
     {
         return $this->brandName ?? strip_tags(Filament::getBrandName());
     }

--- a/packages/panels/src/Auth/MultiFactor/App/AppAuthentication.php
+++ b/packages/panels/src/Auth/MultiFactor/App/AppAuthentication.php
@@ -264,7 +264,7 @@ class AppAuthentication implements MultiFactorAuthenticationProvider
         return $this;
     }
 
-    public function getBrandName(): string | null
+    public function getBrandName(): ?string
     {
         return $this->brandName ?? strip_tags(Filament::getBrandName());
     }

--- a/packages/panels/src/Commands/FileGenerators/PanelProviderClassGenerator.php
+++ b/packages/panels/src/Commands/FileGenerators/PanelProviderClassGenerator.php
@@ -118,6 +118,7 @@ class PanelProviderClassGenerator extends ClassGenerator
             <<<PHP
                 return \$panel{$defaultOutput}
                     ->id(?)
+                    ->brandName(config('app.name'))
                     ->path(?){$loginOutput}
                     ->colors([
                         'primary' => {$this->simplifyFqn(Color::class)}::Amber,

--- a/packages/panels/src/Facades/Filament.php
+++ b/packages/panels/src/Facades/Filament.php
@@ -39,7 +39,7 @@ use Livewire\Component;
  * @method static void currentDomain(?string $domain)
  * @method static string getAuthGuard()
  * @method static string | null getAuthPasswordBroker()
- * @method static string | Htmlable getBrandName()
+ * @method static string | Htmlable | null getBrandName()
  * @method static string | Htmlable | null getBrandLogo()
  * @method static string | null getBrandLogoHeight()
  * @method static array<string | int, array<class-string> | class-string> getClusteredComponents(?string $cluster = null)

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -85,7 +85,7 @@ class FilamentManager
         return $this->getCurrentOrDefaultPanel()->getAuthPasswordBroker();
     }
 
-    public function getBrandName(): string | Htmlable
+    public function getBrandName(): string | Htmlable | null
     {
         return $this->getCurrentOrDefaultPanel()->getBrandName();
     }

--- a/packages/panels/src/Panel/Concerns/HasBrandName.php
+++ b/packages/panels/src/Panel/Concerns/HasBrandName.php
@@ -16,8 +16,8 @@ trait HasBrandName
         return $this;
     }
 
-    public function getBrandName(): string | Htmlable
+    public function getBrandName(): string | Htmlable | null
     {
-        return $this->evaluate($this->brandName) ?? config('app.name');
+        return $this->evaluate($this->brandName);
     }
 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR allows  `brandName()` to be nullable. When `brandName` is null, there is no logo and no suffix in page title.

Of course you can set empty string as brandName, but currently the ` - ` suffix is added to title, when brandName is empty, what looks bad.

This allows to use `PanelsRenderHook::TOPBAR_LOGO_BEFORE` to prepare own logo, in my case it is a dynamic logo that changes when you enter to other cluster of the panel.

This PR can be addressed to v5, because of breaking change that adds `->brandName(config('app.name'))` to generated service provider, to restore previous behavior.

Maybe good option will be separate method to set suffix in title, like `->titleSuffix()`? I can add this.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
