### PR TITLE
Feature: remove separator in title when brandName is blank

### DIFF
--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -33,7 +33,7 @@
 
         <title>
             {{ filled($title) ? $title : null }}
-            {{ filled($brandName) && filled($title) ? " - " : null }}
+            {{ filled($brandName) && filled($title) ? ' - ' : null }}
             {{ filled($brandName) ? $brandName : null }}
         </title>
 

--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -32,7 +32,9 @@
         @endphp
 
         <title>
-            {{ filled($title) ? "{$title} - " : null }} {{ $brandName }}
+            {{ filled($title) ? $title : null }}
+            {{ filled($brandName) && filled($title) ? " - " : null }}
+            {{ filled($brandName) ? $brandName : null }}
         </title>
 
         {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::STYLES_BEFORE, scopes: $renderHookScopes) }}


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR removes separator ` - ` in page title when `brandName` is blank.

Simpler solution for this PR: https://github.com/filamentphp/filament/pull/18747

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
