### PR TITLE
[4.x] Fix to handle Block class in CanBeRepeated trait

### DIFF
--- a/packages/schemas/src/Components/Concerns/CanBeRepeated.php
+++ b/packages/schemas/src/Components/Concerns/CanBeRepeated.php
@@ -2,19 +2,19 @@
 
 namespace Filament\Schemas\Components\Concerns;
 
-use Filament\Forms\Components\Builder\Block;
+use Filament\Forms\Components\Builder;
 use Filament\Forms\Components\Repeater;
 use Filament\Schemas\Schema;
 
 trait CanBeRepeated
 {
-    protected Schema | bool | null $cachedParentRepeaterItem = null;
+    protected Schema|bool|null $cachedParentRepeaterItem = null;
 
-    public function getParentRepeater(): null | Repeater | Block
+    public function getParentRepeater(): null|Repeater|Builder
     {
         $repeater = $this->getParentRepeaterItem()?->getParentComponent();
 
-        assert(($repeater instanceof Repeater) || ($repeater instanceof Block) || (! $repeater));
+        assert(($repeater instanceof Repeater) || ($repeater instanceof Builder) || (!$repeater));
 
         return $repeater;
     }
@@ -29,9 +29,9 @@ trait CanBeRepeated
 
         $parentComponent = $container->getParentComponent();
 
-        if (! $parentComponent) {
+        if (!$parentComponent) {
             $this->cachedParentRepeaterItem = false;
-        } elseif ($parentComponent instanceof Repeater || $parentComponent instanceof Block) {
+        } elseif ($parentComponent instanceof Repeater || $parentComponent instanceof Builder) {
             $this->cachedParentRepeaterItem = $container;
         } else {
             $this->cachedParentRepeaterItem = $parentComponent->getParentRepeaterItem();
@@ -44,7 +44,7 @@ trait CanBeRepeated
     {
         $item = $this->getParentRepeaterItem();
 
-        if (! $item) {
+        if (!$item) {
             return 0;
         }
 

--- a/packages/schemas/src/Components/Concerns/CanBeRepeated.php
+++ b/packages/schemas/src/Components/Concerns/CanBeRepeated.php
@@ -14,7 +14,7 @@ trait CanBeRepeated
     {
         $repeater = $this->getParentRepeaterItem()?->getParentComponent();
 
-        assert($repeater instanceof Repeater || $repeater instanceof Block);
+        assert(($repeater instanceof Repeater) || ($repeater instanceof Block) || (! $repeater));
 
         return $repeater;
     }

--- a/packages/schemas/src/Components/Concerns/CanBeRepeated.php
+++ b/packages/schemas/src/Components/Concerns/CanBeRepeated.php
@@ -8,13 +8,13 @@ use Filament\Schemas\Schema;
 
 trait CanBeRepeated
 {
-    protected Schema|bool|null $cachedParentRepeaterItem = null;
+    protected Schema | bool | null $cachedParentRepeaterItem = null;
 
-    public function getParentRepeater(): null|Repeater|Builder
+    public function getParentRepeater(): Repeater | Builder | null
     {
         $repeater = $this->getParentRepeaterItem()?->getParentComponent();
 
-        assert(($repeater instanceof Repeater) || ($repeater instanceof Builder) || (!$repeater));
+        assert(($repeater instanceof Repeater) || ($repeater instanceof Builder) || (! $repeater));
 
         return $repeater;
     }
@@ -29,9 +29,9 @@ trait CanBeRepeated
 
         $parentComponent = $container->getParentComponent();
 
-        if (!$parentComponent) {
+        if (! $parentComponent) {
             $this->cachedParentRepeaterItem = false;
-        } elseif ($parentComponent instanceof Repeater || $parentComponent instanceof Builder) {
+        } elseif (($parentComponent instanceof Repeater) || ($parentComponent instanceof Builder)) {
             $this->cachedParentRepeaterItem = $container;
         } else {
             $this->cachedParentRepeaterItem = $parentComponent->getParentRepeaterItem();
@@ -44,7 +44,7 @@ trait CanBeRepeated
     {
         $item = $this->getParentRepeaterItem();
 
-        if (!$item) {
+        if (! $item) {
             return 0;
         }
 

--- a/packages/schemas/src/Components/Concerns/CanBeRepeated.php
+++ b/packages/schemas/src/Components/Concerns/CanBeRepeated.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Schemas\Components\Concerns;
 
+use Filament\Forms\Components\Builder\Block;
 use Filament\Forms\Components\Repeater;
 use Filament\Schemas\Schema;
 
@@ -9,11 +10,11 @@ trait CanBeRepeated
 {
     protected Schema | bool | null $cachedParentRepeaterItem = null;
 
-    public function getParentRepeater(): ?Repeater
+    public function getParentRepeater(): null | Repeater | Block
     {
         $repeater = $this->getParentRepeaterItem()?->getParentComponent();
 
-        assert(($repeater instanceof Repeater) || (! $repeater));
+        assert($repeater instanceof Repeater || $repeater instanceof Block);
 
         return $repeater;
     }
@@ -30,7 +31,7 @@ trait CanBeRepeated
 
         if (! $parentComponent) {
             $this->cachedParentRepeaterItem = false;
-        } elseif ($parentComponent instanceof Repeater) {
+        } elseif ($parentComponent instanceof Repeater || $parentComponent instanceof Block) {
             $this->cachedParentRepeaterItem = $container;
         } else {
             $this->cachedParentRepeaterItem = $parentComponent->getParentRepeaterItem();

--- a/tests/src/Forms/Components/BuilderTest.php
+++ b/tests/src/Forms/Components/BuilderTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Filament\Forms\Components\Builder;
+use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Schema;
 use Filament\Tests\Fixtures\Livewire\Livewire;
@@ -28,6 +29,149 @@ it('displays blocks in builder', function (): void {
         ->assertSchemaStateSet($data);
 });
 
+it('can validate distinct fields in blocks in a builder with errors', function (): void {
+    $data = [
+        'builder' => [
+            [
+                'type' => 'one',
+                'data' => [
+                    'foo' => 'test 1',
+                ],
+            ],
+            [
+                'type' => 'one',
+                'data' => [
+                    'foo' => 'test 1',
+                ],
+            ],
+        ],
+    ];
+
+    livewire(TestComponentWithBuilder::class)
+        ->assertSuccessful()
+        ->fillForm($data)
+        ->assertSchemaStateSet($data)
+        ->call('save')
+        ->assertHasFormErrors(['builder.0.data.foo' => ['The foo field has a duplicate value.'], 'builder.1.data.foo' => ['The foo field has a duplicate value.']]);
+});
+
+it('can validate distinct fields in blocks in a builder with no errors', function (): void {
+    $data = [
+        'builder' => [
+            [
+                'type' => 'one',
+                'data' => [
+                    'foo' => 'test 1',
+                ],
+            ],
+            [
+                'type' => 'one',
+                'data' => [
+                    'foo' => 'test 2',
+                ],
+            ],
+        ],
+    ];
+
+    livewire(TestComponentWithBuilder::class)
+        ->assertSuccessful()
+        ->fillForm($data)
+        ->assertSchemaStateSet($data)
+        ->call('save')
+        ->assertHasNoFormErrors();
+});
+
+it('can validate distinct fields in a repeater in a builder block with errors', function (): void {
+    $data = [
+        'builder' => [
+            [
+                'type' => 'one',
+                'data' => [
+                    'foo' => 'test 1',
+                    'repeater' => [
+                        [
+                            'bar' => 'test 1',
+                        ],
+                        [
+                            'bar' => 'test 1',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type' => 'one',
+                'data' => [
+                    'foo' => 'test 1',
+                    'repeater' => [
+                        [
+                            'bar' => 'test 1',
+                        ],
+                        [
+                            'bar' => 'test 1',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    livewire(TestComponentWithBuilderAndRepeater::class)
+        ->assertSuccessful()
+        ->fillForm($data)
+        ->assertSchemaStateSet($data)
+        ->call('save')
+        ->assertHasFormErrors([
+            'builder.0.data.foo' => ['The foo field has a duplicate value.'],
+            'builder.0.data.repeater.0.bar' => ['The bar field has a duplicate value.'],
+            'builder.0.data.repeater.1.bar' => ['The bar field has a duplicate value.'],
+            'builder.1.data.foo' => ['The foo field has a duplicate value.'],
+            'builder.1.data.repeater.0.bar' => ['The bar field has a duplicate value.'],
+            'builder.1.data.repeater.1.bar' => ['The bar field has a duplicate value.'],
+        ]);
+});
+
+it('can validate distinct fields in a repeater in a builder block with no errors', function (): void {
+    $data = [
+        'builder' => [
+            [
+                'type' => 'one',
+                'data' => [
+                    'foo' => 'test 1',
+                    'repeater' => [
+                        [
+                            'bar' => 'test 1',
+                        ],
+                        [
+                            'bar' => 'test 2',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type' => 'one',
+                'data' => [
+                    'foo' => 'test 2',
+                    'repeater' => [
+                        [
+                            'bar' => 'test 1',
+                        ],
+                        [
+                            'bar' => 'test 2',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    livewire(TestComponentWithBuilderAndRepeater::class)
+        ->assertSuccessful()
+        ->fillForm($data)
+        ->assertSchemaStateSet($data)
+        ->call('save')
+        ->assertHasNoFormErrors();
+});
+
 class TestComponentWithBuilder extends Livewire
 {
     public function form(Schema $form): Schema
@@ -38,10 +182,45 @@ class TestComponentWithBuilder extends Livewire
                     ->blocks([
                         Builder\Block::make('one')
                             ->schema([
-                                TextInput::make('foo'),
+                                TextInput::make('foo')
+                                    ->distinct(),
                             ]),
                     ]),
             ])
             ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->form->getState();
+    }
+}
+
+class TestComponentWithBuilderAndRepeater extends Livewire
+{
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->components([
+                Builder::make('builder')
+                    ->blocks([
+                        Builder\Block::make('one')
+                            ->schema([
+                                TextInput::make('foo')
+                                    ->distinct(),
+                                Repeater::make('repeater')
+                                    ->schema([
+                                        TextInput::make('bar')
+                                            ->distinct(),
+                                    ]),
+                            ]),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->form->getState();
     }
 }

--- a/tests/src/Forms/Components/RepeaterTest.php
+++ b/tests/src/Forms/Components/RepeaterTest.php
@@ -2,6 +2,7 @@
 
 use Filament\Actions\Action;
 use Filament\Actions\Testing\TestAction;
+use Filament\Forms\Components\Builder;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -533,4 +534,144 @@ enum TestLetterEnum: string
     case A = 'A';
     case B = 'B';
     case C = 'C';
+}
+
+it('can validate distinct fields in a builder block in a repeater with errors', function (): void {
+    $undoRepeaterFake = Repeater::fake();
+
+    $data = [
+        'repeater' => [
+            [
+                'bar' => 'test 1',
+                'builder' => [
+                    [
+                        'type' => 'one',
+                        'data' => [
+                            'foo' => 'test 1',
+                        ],
+                    ],
+                    [
+                        'type' => 'one',
+                        'data' => [
+                            'foo' => 'test 1',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'bar' => 'test 1',
+                'builder' => [
+                    [
+                        'type' => 'one',
+                        'data' => [
+                            'foo' => 'test 1',
+                        ],
+                    ],
+                    [
+                        'type' => 'one',
+                        'data' => [
+                            'foo' => 'test 1',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    livewire(TestComponentWithRepeaterAndBuilder::class)
+        ->assertSuccessful()
+        ->fillForm($data)
+        ->assertFormSet($data)
+        ->call('save')
+        ->assertHasFormErrors([
+            'repeater.0.bar' => ['The bar field has a duplicate value.'],
+            'repeater.0.builder.0.data.foo' => ['The foo field has a duplicate value.'],
+            'repeater.0.builder.1.data.foo' => ['The foo field has a duplicate value.'],
+            'repeater.1.bar' => ['The bar field has a duplicate value.'],
+            'repeater.1.builder.0.data.foo' => ['The foo field has a duplicate value.'],
+            'repeater.1.builder.1.data.foo' => ['The foo field has a duplicate value.'],
+        ]);
+
+    $undoRepeaterFake();
+});
+
+it('can validate distinct fields in a builder block in a repeater with no errors', function (): void {
+    $undoRepeaterFake = Repeater::fake();
+
+    $data = [
+        'repeater' => [
+            [
+                'bar' => 'test 1',
+                'builder' => [
+                    [
+                        'type' => 'one',
+                        'data' => [
+                            'foo' => 'test 1',
+                        ],
+                    ],
+                    [
+                        'type' => 'one',
+                        'data' => [
+                            'foo' => 'test 2',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'bar' => 'test 2',
+                'builder' => [
+                    [
+                        'type' => 'one',
+                        'data' => [
+                            'foo' => 'test 1',
+                        ],
+                    ],
+                    [
+                        'type' => 'one',
+                        'data' => [
+                            'foo' => 'test 2',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    livewire(TestComponentWithRepeaterAndBuilder::class)
+        ->assertSuccessful()
+        ->fillForm($data)
+        ->assertFormSet($data)
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $undoRepeaterFake();
+});
+
+class TestComponentWithRepeaterAndBuilder extends Livewire
+{
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->components([
+                Repeater::make('repeater')
+                    ->schema([
+                        TextInput::make('bar')
+                            ->distinct(),
+                        Builder::make('builder')
+                            ->blocks([
+                                Builder\Block::make('one')
+                                    ->schema([
+                                        TextInput::make('foo')
+                                            ->distinct(),
+                                    ]),
+                            ]),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->form->getState();
+    }
 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The CanBeRepeated trait was not handling the Block class, so (for example) having a 'distinct' validation in a Block would blow up, because getParentRepeaterItem() couldn't find the parent repeating component.

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
