### PR TITLE
fix: update cachedData on chart data update

### DIFF
--- a/packages/widgets/resources/js/components/chart.js
+++ b/packages/widgets/resources/js/components/chart.js
@@ -21,6 +21,7 @@ export default function chart({ cachedData, options, type }) {
             this.initChart()
 
             this.$wire.$on('updateChartData', ({ data }) => {
+                cachedData = data
                 chart = this.getChart()
                 chart.data = data
                 chart.update('resize')


### PR DESCRIPTION
## Description

Hi!
I have chart widget with a filter. When I change filter and resize window OR change theme, the chart data is reset to initial data regardless of the filter value.

I have look at `packages/widgets/resources/js/components/chart.js` source code and found a reason. On resize and on theme change chart got destroyed and created again:

```js
this.resizeHandler = Alpine.debounce(() => {
	this.getChart().destroy()
	this.initChart()
}, 250)
```

But it's always created with initial set of data `cachedData`, because it's not updated on `updateChartData` event when filter value changes. And updated data is lost on chart recreation:

```js
this.$wire.$on('updateChartData', ({ data }) => {
	chart = this.getChart()
	chart.data = data
	chart.update('resize')
})
```

So I propose update of the `cachedData` on `updateChartData` event. Then everything works and chart stay with an actual data on window resize or theme changing.

## Visual changes

https://github.com/user-attachments/assets/7ed0a4dc-8355-4863-aa34-73e2e7493010

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
