### PR TITLE
Fix return type mismatches for HasLabel, HasIcon, and HasDescription in documentation

### DIFF
--- a/docs/09-advanced/03-enums.md
+++ b/docs/09-advanced/03-enums.md
@@ -19,6 +19,7 @@ The `HasLabel` interface transforms an enum instance into a textual label. This 
 
 ```php
 use Filament\Support\Contracts\HasLabel;
+use Illuminate\Contracts\Support\Htmlable;
 
 enum Status: string implements HasLabel
 {
@@ -27,7 +28,7 @@ enum Status: string implements HasLabel
     case Published = 'published';
     case Rejected = 'rejected';
     
-    public function getLabel(): ?string
+    public function getLabel(): string | Htmlable | null
     {
         return $this->name;
         
@@ -136,7 +137,9 @@ If you use a [`ToggleButtons`](../forms/toggle-buttons) form field, and it is se
 The `HasIcon` interface transforms an enum instance into an [icon](../styling/icons). This is useful for displaying icons alongside enum values in your UI.
 
 ```php
+use BackedEnum;
 use Filament\Support\Contracts\HasIcon;
+use Illuminate\Contracts\Support\Htmlable;
 
 enum Status: string implements HasIcon
 {
@@ -145,7 +148,7 @@ enum Status: string implements HasIcon
     case Published = 'published';
     case Rejected = 'rejected';
     
-    public function getIcon(): ?string
+    public function getIcon(): string | BackedEnum | Htmlable | null
     {
         return match ($this) {
             self::Draft => 'heroicon-m-pencil',
@@ -176,6 +179,7 @@ The `HasDescription` interface transforms an enum instance into a textual descri
 ```php
 use Filament\Support\Contracts\HasDescription;
 use Filament\Support\Contracts\HasLabel;
+use Illuminate\Contracts\Support\Htmlable;
 
 enum Status: string implements HasLabel, HasDescription
 {
@@ -184,12 +188,12 @@ enum Status: string implements HasLabel, HasDescription
     case Published = 'published';
     case Rejected = 'rejected';
     
-    public function getLabel(): ?string
+    public function getLabel(): string | Htmlable | null
     {
         return $this->name;
     }
     
-    public function getDescription(): ?string
+    public function getDescription(): string | Htmlable | null
     {
         return match ($this) {
             self::Draft => 'This has not finished being written yet.',


### PR DESCRIPTION
The `Status` enum implements Filament support contracts whose method signatures allow returning `string | Htmlable | null`. However, the documented/example implementations were using narrower return types, which caused a mismatch with the actual contracts.

This change updates the return types of the `getLabel()`, `getIcon()` & `getDescription` methods to accurately reflect the supported return values, ensuring consistency with the Filament API and preventing confusion for developers implementing these contracts.

## Visual changes

No visual changes.
This is a documentation / type-signature consistency update only.

## Functional changes

* [x] Code style has been fixed by running the `composer cs` command.
* [x] Changes have been tested to not break existing functionality.
* [x] Documentation is up-to-date.