### PR TITLE
fix: `mutateDehydratedState` is not called when parent container is hidden

### DIFF
--- a/packages/schemas/src/Concerns/CanBeHidden.php
+++ b/packages/schemas/src/Concerns/CanBeHidden.php
@@ -29,4 +29,13 @@ trait CanBeHidden
     {
         return ! $this->isHidden();
     }
+
+    public function isHiddenAndNotDehydratedWhenHidden(): bool
+    {
+        if (! $this->isHidden()) {
+            return false;
+        }
+
+        return ! $this->getParentComponent()?->isDehydratedWhenHidden();
+    }
 }

--- a/packages/schemas/src/Concerns/HasState.php
+++ b/packages/schemas/src/Concerns/HasState.php
@@ -143,14 +143,14 @@ trait HasState
     public function callBeforeStateDehydrated(array &$state = []): void
     {
         foreach ($this->getComponents(withActions: false, withHidden: true) as $component) {
-            if ($component->isHidden()) {
+            if ($component->isHiddenAndNotDehydratedWhenHidden()) {
                 continue;
             }
 
             $component->callBeforeStateDehydrated($state);
 
-            foreach ($component->getChildSchemas() as $childSchema) {
-                if ($childSchema->isHidden()) {
+            foreach ($component->getChildSchemas(withHidden: true) as $childSchema) {
+                if ($childSchema->isHiddenAndNotDehydratedWhenHidden()) {
                     continue;
                 }
 
@@ -219,8 +219,8 @@ trait HasState
                 continue;
             }
 
-            foreach ($component->getChildSchemas() as $childSchema) {
-                if ($childSchema->isHidden()) {
+            foreach ($component->getChildSchemas(withHidden: true) as $childSchema) {
+                if ($childSchema->isHiddenAndNotDehydratedWhenHidden()) {
                     continue;
                 }
 
@@ -256,8 +256,8 @@ trait HasState
                 continue;
             }
 
-            foreach ($component->getChildSchemas() as $childSchema) {
-                if ($childSchema->isHidden()) {
+            foreach ($component->getChildSchemas(withHidden: true) as $childSchema) {
+                if ($childSchema->isHiddenAndNotDehydratedWhenHidden()) {
                     continue;
                 }
 

--- a/tests/src/Forms/StateTest.php
+++ b/tests/src/Forms/StateTest.php
@@ -816,6 +816,49 @@ test('dehydrated state can be mutated', function (): void {
         ]);
 });
 
+test('dehydrated state can be mutated when component is hidden and dehydrated when hidden', function (): void {
+    $schema = Schema::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            Field::make($statePath = Str::random())
+                ->default($state = Str::random())
+                ->hidden()
+                ->dehydratedWhenHidden()
+                ->mutateDehydratedStateUsing(fn ($state) => strrev($state)),
+        ])
+        ->fill();
+
+    invade($schema->getLivewire())->cacheSchema('form', $schema);
+
+    expect($schema->getState())
+        ->toBe([
+            $statePath => strrev($state),
+        ]);
+});
+
+test('dehydrated state can be mutated when parent schema is hidden and dehydrated when hidden', function (): void {
+    $schema = Schema::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            (new Component)
+                ->hidden()
+                ->dehydratedWhenHidden()
+                ->childComponents([
+                    Field::make($statePath = Str::random())
+                        ->default($state = Str::random())
+                        ->mutateDehydratedStateUsing(fn ($state) => strrev($state)),
+                ]),
+        ])
+        ->fill();
+
+    invade($schema->getLivewire())->cacheSchema('form', $schema);
+
+    expect($schema->getState())
+        ->toBe([
+            $statePath => strrev($state),
+        ]);
+});
+
 test('sibling state can be retrieved relatively from another component', function (): void {
     Schema::make(Livewire::make())
         ->statePath('data')


### PR DESCRIPTION
Fixes #18666.