### PR TITLE
fix: Select all when not deselecting records between filters

### DIFF
--- a/packages/tables/src/Table/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Table/Concerns/HasBulkActions.php
@@ -164,6 +164,10 @@ trait HasBulkActions
 
     public function canTrackDeselectedRecords(): bool
     {
+        if (! $this->shouldDeselectAllRecordsWhenFiltered()) {
+            return false;
+        }
+
         return (bool) $this->evaluate($this->canTrackDeselectedRecords);
     }
 


### PR DESCRIPTION
Fixes #18693.