### PR TITLE
fix: locale and name in email change notification

### DIFF
--- a/packages/panels/src/Auth/Pages/EditProfile.php
+++ b/packages/panels/src/Auth/Pages/EditProfile.php
@@ -26,6 +26,7 @@ use Filament\Support\Exceptions\Halt;
 use Filament\Support\Facades\FilamentView;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Hash;
@@ -234,21 +235,9 @@ class EditProfile extends Page
             'newEmail' => $newEmail,
         ]));
 
-        if (method_exists($record, 'routeNotificationForMail')) {
-            $newEmailRecipient = $record->routeNotificationForMail($notification);
-            if (is_array($newEmailRecipient) && array_key_exists($record->getAttributeValue('email'), $newEmailRecipient)) {
-                // Add new entry
-                $name = $newEmailRecipient[$record->getAttributeValue('email')];
-                $newEmailRecipient[$newEmail] = $name;
+        $newEmailRecipient = $this->getEmailChangeVerificationRecipientWithNewEmail($record, $notification, $newEmail);
 
-                // Remove old entry
-                unset($newEmailRecipient[$record->getAttributeValue('email')]);
-            }
-        } else {
-            $newEmailRecipient = $record->getAttributeValue('email');
-        }
-
-        if ($record instanceof \Illuminate\Contracts\Translation\HasLocalePreference) {
+        if ($record instanceof HasLocalePreference) {
             $notification->locale($record->preferredLocale());
         }
 
@@ -258,6 +247,28 @@ class EditProfile extends Page
         $this->getEmailChangeVerificationSentNotification($newEmail)?->send();
 
         $this->data['email'] = $record->getAttributeValue('email');
+    }
+
+    /**
+     * @return string | array<string, string>
+     */
+    protected function getEmailChangeVerificationRecipientWithNewEmail(Model $record, VerifyEmailChange $notification, string $newEmail): string | array
+    {
+        if (! method_exists($record, 'routeNotificationForMail')) {
+            return $newEmail;
+        }
+
+        $recipient = $record->routeNotificationForMail($notification);
+        $currentEmail = $record->getAttributeValue('email');
+
+        if (
+            (! is_array($recipient))
+            || (! array_key_exists($currentEmail, $recipient))
+        ) {
+            return $newEmail;
+        }
+
+        return [$newEmail => $recipient[$currentEmail]];
     }
 
     protected function getSavedNotification(): ?FilamentNotification

--- a/packages/panels/src/Auth/Pages/EditProfile.php
+++ b/packages/panels/src/Auth/Pages/EditProfile.php
@@ -234,7 +234,25 @@ class EditProfile extends Page
             'newEmail' => $newEmail,
         ]));
 
-        Notification::route('mail', $newEmail)
+        if (method_exists($record, 'routeNotificationForMail')) {
+            $newEmailRecipient = $record->routeNotificationForMail($notification);
+            if (is_array($newEmailRecipient) && array_key_exists($record->getAttributeValue('email'), $newEmailRecipient)) {
+                // Add new entry
+                $name = $newEmailRecipient[$record->getAttributeValue('email')];
+                $newEmailRecipient[$newEmail] = $name;
+
+                // Remove old entry
+                unset($newEmailRecipient[$record->getAttributeValue('email')]);
+            }
+        } else {
+            $newEmailRecipient = $record->getAttributeValue('email');
+        }
+
+        if ($record instanceof \Illuminate\Contracts\Translation\HasLocalePreference) {
+            $notification->locale($record->preferredLocale());
+        }
+
+        Notification::route('mail', $newEmailRecipient)
             ->notify($notification);
 
         $this->getEmailChangeVerificationSentNotification($newEmail)?->send();


### PR DESCRIPTION
## Description

Fixes #18789 

## Visual changes

_None_

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

Using `preferredLocale` and `routeNotificationForMail` for anonymous notification
