### PR TITLE
feature: `saved()` control for schema components

### DIFF
--- a/docs/11-plugins/04-building-a-standalone-plugin.md
+++ b/docs/11-plugins/04-building-a-standalone-plugin.md
@@ -152,13 +152,6 @@ class Heading extends Component
         return app(static::class, ['level' => $level]);
     }
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->dehydrated(false);
-    }
-
     public function content(string | Closure $content): static
     {
         $this->content = $content;

--- a/packages/forms/docs/01-overview.md
+++ b/packages/forms/docs/01-overview.md
@@ -163,31 +163,31 @@ Toggle::make('is_admin')
 
 <UtilityInjection set="formFields" version="4.x">As well as allowing a static value, the `disabled()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
-Disabling a field will prevent it from being saved. If you'd like it to be saved, but still not editable, use the `dehydrated()` method:
+Disabling a field will prevent it from being saved. If you'd like it to be saved, but still not editable, use the `saved()` method:
 
 ```php
 use Filament\Forms\Components\Toggle;
 
 Toggle::make('is_admin')
     ->disabled()
-    ->dehydrated()
+    ->saved()
 ```
 
 <Aside variant="danger">
-    If you choose to dehydrate the field, a skilled user could still edit the field's value by manipulating Livewire's JavaScript.
+    If you choose to save the field when disabled, a skilled user could still edit the field's value by manipulating Livewire's JavaScript.
 </Aside>
 
-Optionally, you may pass a boolean value to control if the field should be dehydrated or not:
+Optionally, you may pass a boolean value to control if the field should be saved or not:
 
 ```php
 use Filament\Forms\Components\Toggle;
 
 Toggle::make('is_admin')
     ->disabled()
-    ->dehydrated(FeatureFlag::active())
+    ->saved(FeatureFlag::active())
 ```
 
-<UtilityInjection set="formFields" version="4.x">As well as allowing a static value, the `dehydrated()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="4.x">As well as allowing a static value, the `saved()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 ### Disabling a field based on the current operation
 
@@ -1283,22 +1283,22 @@ TextInput::make('name')
     ->dehydrateStateUsing(fn (string $state): string => ucwords($state))
 ```
 
-#### Preventing a field from being dehydrated
+#### Preventing a field from being saved
 
-You may also prevent a field from being dehydrated altogether using `dehydrated(false)`. In this example, the field will not be present in the array returned from `getState()`:
+You may prevent a field from being saved altogether using `saved(false)`. In this example, the field will not be present in the array returned from `getState()`, and any relationships associated with the field will not be saved either:
 
 ```php
 use Filament\Forms\Components\TextInput;
 
 TextInput::make('password_confirmation')
     ->password()
-    ->dehydrated(false)
+    ->saved(false)
 ```
 
 If your schema auto-saves data to the database, like in a [resource](../resources), this is useful to prevent a field from being saved to the database if it is purely used for presentational purposes.
 
 <Aside variant="info">
-    Even when a field is not dehydrated, it is still validated. To learn more about this behavior, see the [validation](validation#disabling-validation-when-fields-are-not-dehydrated) section.
+    Even when a field is not saved, it is still validated. To learn more about this behavior, see the [validation](validation#disabling-validation-when-fields-are-not-saved) section.
 </Aside>
 
 ### Field rendering
@@ -1602,7 +1602,7 @@ TextInput::make('password')
     ->dehydrateStateUsing(fn (string $state): string => Hash::make($state))
 ```
 
-But if your schema is used to change an existing password, you don't want to overwrite the existing password if the field is empty. You can [prevent the field from being dehydrated](#preventing-a-field-from-being-dehydrated) if the field is null or an empty string (using the `filled()` helper):
+But if your schema is used to change an existing password, you don't want to overwrite the existing password if the field is empty. You can [prevent the field from being saved](#preventing-a-field-from-being-saved) if the field is null or an empty string (using the `filled()` helper):
 
 ```php
 use Filament\Forms\Components\TextInput;
@@ -1611,7 +1611,7 @@ use Illuminate\Support\Facades\Hash;
 TextInput::make('password')
     ->password()
     ->dehydrateStateUsing(fn (string $state): string => Hash::make($state))
-    ->dehydrated(fn (?string $state): bool => filled($state))
+    ->saved(fn (?string $state): bool => filled($state))
 ```
 
 However, you want to require the password to be filled when the user is being created, by [injecting the `$operation` utility](#injecting-the-current-operation), and then [conditionally making the field required](#conditionally-making-a-field-required):
@@ -1623,7 +1623,7 @@ use Illuminate\Support\Facades\Hash;
 TextInput::make('password')
     ->password()
     ->dehydrateStateUsing(fn (string $state): string => Hash::make($state))
-    ->dehydrated(fn (?string $state): bool => filled($state))
+    ->saved(fn (?string $state): bool => filled($state))
     ->required(fn (string $operation): bool => $operation === 'create')
 ```
 

--- a/packages/forms/docs/02-text-input.md
+++ b/packages/forms/docs/02-text-input.md
@@ -324,7 +324,7 @@ TextInput::make('name')
 
 There are a few differences, compared to [`disabled()`](overview#disabling-a-field):
 
-- When using `readOnly()`, the field will still be sent to the server when the form is submitted. It can be mutated with the browser console, or via JavaScript. You can use [`dehydrated(false)`](overview#preventing-a-field-from-being-dehydrated) to prevent this.
+- When using `readOnly()`, the field will still be sent to the server when the form is submitted. It can be mutated with the browser console, or via JavaScript. You can use [`saved(false)`](overview#preventing-a-field-from-being-saved) to prevent this.
 - There are no styling changes, such as less opacity, when using `readOnly()`.
 - The field is still focusable when using `readOnly()`.
 

--- a/packages/forms/docs/03-select.md
+++ b/packages/forms/docs/03-select.md
@@ -337,11 +337,11 @@ Select::make('technologies')
 ```
 
 <Aside variant="warning">
-    When using `disabled()` with `multiple()` and `relationship()`, ensure that `disabled()` is called before `relationship()`. This ensures that the `dehydrated()` call from within `relationship()` is not overridden by the call from `disabled()`:
-    
+    When using `disabled()` with `multiple()` and `relationship()`, ensure that `disabled()` is called before `relationship()`. This ensures that the `saved()` call from `disabled()` is not applied after the `relationship()` configuration:
+
     ```php
     use Filament\Forms\Components\Select;
-    
+
     Select::make('technologies')
         ->multiple()
         ->disabled()

--- a/packages/forms/docs/06-checkbox-list.md
+++ b/packages/forms/docs/06-checkbox-list.md
@@ -269,7 +269,7 @@ CheckboxList::make('technologies')
 ```
 
 <Aside variant="warning">
-    When using `disabled()` with `relationship()`, ensure that `disabled()` is called before `relationship()`. This ensures that the `dehydrated()` call from within `relationship()` is not overridden by the call from `disabled()`:
+    When using `disabled()` with `relationship()`, ensure that `disabled()` is called before `relationship()`. This ensures that the `saved()` call from `disabled()` is not applied after the `relationship()` configuration:
 
     ```php
     use Filament\Forms\Components\CheckboxList;

--- a/packages/forms/docs/08-date-time-picker.md
+++ b/packages/forms/docs/08-date-time-picker.md
@@ -315,7 +315,7 @@ Please note that this setting is only enforced on native date pickers. If you're
 
 There are a few differences, compared to [`disabled()`](overview#disabling-a-field):
 
-- When using `readOnly()`, the field will still be sent to the server when the form is submitted. It can be mutated with the browser console, or via JavaScript. You can use [`dehydrated(false)`](overview#preventing-a-field-from-being-dehydrated) to prevent this.
+- When using `readOnly()`, the field will still be sent to the server when the form is submitted. It can be mutated with the browser console, or via JavaScript. You can use [`saved(false)`](overview#preventing-a-field-from-being-saved) to prevent this.
 - There are no styling changes, such as less opacity, when using `readOnly()`.
 - The field is still focusable when using `readOnly()`.
 

--- a/packages/forms/docs/12-repeater.md
+++ b/packages/forms/docs/12-repeater.md
@@ -289,21 +289,6 @@ Repeater::make('qualifications')
     ])
 ```
 
-<Aside variant="warning">
-    When using `disabled()` with `relationship()`, ensure that `disabled()` is called before `relationship()`. This ensures that the `dehydrated()` call from within `relationship()` is not overridden by the call from `disabled()`:
-    
-    ```php
-    use Filament\Forms\Components\Repeater;
-    
-    Repeater::make('qualifications')
-        ->disabled()
-        ->relationship()
-        ->schema([
-            // ...
-        ])
-    ```
-</Aside>
-
 ### Reordering items in a relationship
 
 By default, [reordering](#reordering-items) relationship repeater items is disabled. This is because your related model needs a `sort` column to store the order of related records. To enable reordering, you may use the `orderColumn()` method, passing in a name of the column on your related model to store the order in:

--- a/packages/forms/docs/15-textarea.md
+++ b/packages/forms/docs/15-textarea.md
@@ -65,7 +65,7 @@ Textarea::make('description')
 
 There are a few differences, compared to [`disabled()`](overview#disabling-a-field):
 
-- When using `readOnly()`, the field will still be sent to the server when the form is submitted. It can be mutated with the browser console, or via JavaScript. You can use [`dehydrated(false)`](overview#preventing-a-field-from-being-dehydrated) to prevent this.
+- When using `readOnly()`, the field will still be sent to the server when the form is submitted. It can be mutated with the browser console, or via JavaScript. You can use [`saved(false)`](overview#preventing-a-field-from-being-saved) to prevent this.
 - There are no styling changes, such as less opacity, when using `readOnly()`.
 - The field is still focusable when using `readOnly()`.
 

--- a/packages/forms/docs/23-validation.md
+++ b/packages/forms/docs/23-validation.md
@@ -673,16 +673,16 @@ TextInput::make('password')
 
 Be aware that you will need to ensure that the HTML in all validation messages is safe to render, otherwise your application will be vulnerable to XSS attacks.
 
-## Disabling validation when fields are not dehydrated
+## Disabling validation when fields are not saved
 
-When a field is [not dehydrated](overview#preventing-a-field-from-being-dehydrated), it is still validated. To disable validation for fields that are not dehydrated, use the `validatedWhenNotDehydrated()` method:
+When a field is [not saved](overview#preventing-a-field-from-being-saved), it is still validated. To disable validation for fields that are not saved, use the `validatedWhenNotDehydrated()` method:
 
 ```php
 use Filament\Forms\Components\TextInput;
 
 TextInput::make('name')
     ->required()
-    ->dehydrated(false)
+    ->saved(false)
     ->validatedWhenNotDehydrated(false)
 ```
 

--- a/packages/forms/src/Components/ModalTableSelect.php
+++ b/packages/forms/src/Components/ModalTableSelect.php
@@ -504,7 +504,7 @@ class ModalTableSelect extends Field
             $relationship->syncWithPivotValues($state, $pivotData, detaching: false);
         });
 
-        $this->dehydrated(fn (ModalTableSelect $component): bool => ! $component->isMultiple());
+        $this->dehydrated(fn (ModalTableSelect $component): bool => (! $component->isMultiple()) && $component->isSaved());
 
         return $this;
     }

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -1177,7 +1177,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
             $schema->getRecord()?->update($data);
         });
 
-        $this->dehydrated(fn (Select $component): bool => ! $component->isMultiple());
+        $this->dehydrated(fn (Select $component): bool => (! $component->isMultiple()) && $component->isSaved());
 
         return $this;
     }

--- a/packages/forms/src/Components/TableSelect.php
+++ b/packages/forms/src/Components/TableSelect.php
@@ -242,7 +242,7 @@ class TableSelect extends Field
             $relationship->syncWithPivotValues($state, $pivotData, detaching: false);
         });
 
-        $this->dehydrated(fn (TableSelect $component): bool => ! $component->isMultiple());
+        $this->dehydrated(fn (TableSelect $component): bool => (! $component->isMultiple()) && $component->isSaved());
 
         return $this;
     }

--- a/packages/schemas/src/Components/Concerns/BelongsToModel.php
+++ b/packages/schemas/src/Components/Concerns/BelongsToModel.php
@@ -40,6 +40,10 @@ trait BelongsToModel
             return;
         }
 
+        if (! $this->isSaved()) {
+            return;
+        }
+
         if (! ($this->getRecord()?->exists)) {
             return;
         }
@@ -60,6 +64,10 @@ trait BelongsToModel
         $callback = $this->saveRelationshipsBeforeChildrenUsing;
 
         if (! $callback) {
+            return;
+        }
+
+        if (! $this->isSaved()) {
             return;
         }
 

--- a/packages/schemas/src/Components/Concerns/CanBeDisabled.php
+++ b/packages/schemas/src/Components/Concerns/CanBeDisabled.php
@@ -15,7 +15,7 @@ trait CanBeDisabled
     public function disabled(bool | Closure $condition = true): static
     {
         $this->isDisabled = $condition;
-        $this->dehydrated(fn (Component $component): bool => ! $component->evaluate($condition));
+        $this->saved(fn (Component $component): bool => ! $component->evaluate($condition));
 
         return $this;
     }

--- a/packages/schemas/src/Components/Concerns/HasState.php
+++ b/packages/schemas/src/Components/Concerns/HasState.php
@@ -50,9 +50,11 @@ trait HasState
 
     protected bool $hasDefaultState = false;
 
-    protected bool | Closure $isDehydrated = true;
+    protected bool | Closure | null $isDehydrated = null;
 
     protected bool | Closure $isDehydratedWhenHidden = false;
+
+    protected bool | Closure $isSaved = true;
 
     protected bool | Closure $isValidatedWhenNotDehydrated = true;
 
@@ -258,6 +260,13 @@ trait HasState
     public function dehydratedWhenHidden(bool | Closure $condition = true): static
     {
         $this->isDehydratedWhenHidden = $condition;
+
+        return $this;
+    }
+
+    public function saved(bool | Closure $condition = true): static
+    {
+        $this->isSaved = $condition;
 
         return $this;
     }
@@ -665,7 +674,9 @@ trait HasState
 
     public function isDehydrated(): bool
     {
-        if (! $this->evaluate($this->isDehydrated)) {
+        $isDehydrated = $this->evaluate($this->isDehydrated) ?? $this->isSaved();
+
+        if (! $isDehydrated) {
             return false;
         }
 
@@ -675,6 +686,11 @@ trait HasState
     public function isDehydratedWhenHidden(): bool
     {
         return (bool) $this->evaluate($this->isDehydratedWhenHidden);
+    }
+
+    public function isSaved(): bool
+    {
+        return (bool) $this->evaluate($this->isSaved);
     }
 
     public function isValidatedWhenNotDehydrated(): bool

--- a/tests/src/Forms/RelationshipsTest.php
+++ b/tests/src/Forms/RelationshipsTest.php
@@ -89,3 +89,115 @@ test('hidden fields can save relationships when requested', function (): void {
     expect($numberOfRelationshipsSaved)
         ->toBe(2);
 });
+
+test('fields with saved(false) do not save relationships', function (): void {
+    $numberOfRelationshipsSaved = 0;
+    $isSaved = true;
+
+    $saveRelationshipsUsing = function () use (&$numberOfRelationshipsSaved): void {
+        $numberOfRelationshipsSaved++;
+    };
+
+    $schema = Schema::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            (new Field(Str::random()))
+                ->saveRelationshipsUsing($saveRelationshipsUsing)
+                ->saved(function () use (&$isSaved) {
+                    return $isSaved;
+                }),
+        ])
+        ->model(Post::factory()->create());
+
+    $schema
+        ->saveRelationships();
+
+    expect($numberOfRelationshipsSaved)
+        ->toBe(1);
+
+    $schema
+        ->saveRelationships();
+
+    expect($numberOfRelationshipsSaved)
+        ->toBe(2);
+
+    $isSaved = false;
+
+    $schema
+        ->saveRelationships();
+
+    expect($numberOfRelationshipsSaved)
+        ->toBe(2);
+});
+
+test('saved(false) prevents relationship saving regardless of dehydrated() setting', function (): void {
+    $numberOfRelationshipsSaved = 0;
+
+    $saveRelationshipsUsing = function () use (&$numberOfRelationshipsSaved): void {
+        $numberOfRelationshipsSaved++;
+    };
+
+    $schema = Schema::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            (new Field(Str::random()))
+                ->saveRelationshipsUsing($saveRelationshipsUsing)
+                ->dehydrated(true)
+                ->saved(false),
+        ])
+        ->model(Post::factory()->create());
+
+    $schema
+        ->saveRelationships();
+
+    expect($numberOfRelationshipsSaved)
+        ->toBe(0);
+});
+
+test('disabled fields do not save relationships', function (): void {
+    $numberOfRelationshipsSaved = 0;
+
+    $saveRelationshipsUsing = function () use (&$numberOfRelationshipsSaved): void {
+        $numberOfRelationshipsSaved++;
+    };
+
+    $schema = Schema::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            (new Field(Str::random()))
+                ->saveRelationshipsUsing($saveRelationshipsUsing)
+                ->disabled(),
+        ])
+        ->model(Post::factory()->create());
+
+    $schema
+        ->saveRelationships();
+
+    expect($numberOfRelationshipsSaved)
+        ->toBe(0);
+});
+
+test('disabled fields can save relationships when saveRelationshipsWhenDisabled is called', function (): void {
+    $numberOfRelationshipsSaved = 0;
+
+    $saveRelationshipsUsing = function () use (&$numberOfRelationshipsSaved): void {
+        $numberOfRelationshipsSaved++;
+    };
+
+    $schema = Schema::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            (new Field(Str::random()))
+                ->saveRelationshipsUsing($saveRelationshipsUsing)
+                ->disabled()
+                ->saved()
+                ->saveRelationshipsWhenDisabled(),
+        ])
+        ->model(Post::factory()->create());
+
+    $schema
+        ->saveRelationships();
+
+    expect($numberOfRelationshipsSaved)
+        ->toBe(1);
+});

--- a/tests/src/Forms/RelationshipsTest.php
+++ b/tests/src/Forms/RelationshipsTest.php
@@ -90,7 +90,7 @@ test('hidden fields can save relationships when requested', function (): void {
         ->toBe(2);
 });
 
-test('fields with saved(false) do not save relationships', function (): void {
+test('fields with `saved(false)` do not save relationships', function (): void {
     $numberOfRelationshipsSaved = 0;
     $isSaved = true;
 
@@ -130,7 +130,7 @@ test('fields with saved(false) do not save relationships', function (): void {
         ->toBe(2);
 });
 
-test('saved(false) prevents relationship saving regardless of dehydrated() setting', function (): void {
+test('`saved(false)` prevents relationship saving regardless of `dehydrated()` setting', function (): void {
     $numberOfRelationshipsSaved = 0;
 
     $saveRelationshipsUsing = function () use (&$numberOfRelationshipsSaved): void {

--- a/tests/src/Forms/StateTest.php
+++ b/tests/src/Forms/StateTest.php
@@ -1100,3 +1100,136 @@ test('components can inject their old state after it is updated', function (): v
             'foo' => $state,
         ]);
 });
+
+test('components can be excluded from state dehydration using saved(false)', function (): void {
+    $schema = Schema::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            Field::make(Str::random())
+                ->default(Str::random())
+                ->saved(false),
+        ])
+        ->fill();
+
+    invade($schema->getLivewire())->cacheSchema('form', $schema);
+
+    expect($schema)
+        ->getState()->toBe([]);
+});
+
+test('components can be excluded from state dehydration if their parent component uses saved(false)', function (): void {
+    $schema = Schema::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            (new Component)
+                ->saved(false)
+                ->schema([
+                    Field::make(Str::random())
+                        ->default(Str::random()),
+                ]),
+        ])
+        ->fill();
+
+    invade($schema->getLivewire())->cacheSchema('form', $schema);
+
+    expect($schema)
+        ->getState()->toBe([]);
+});
+
+test('explicit dehydrated(true) takes precedence over saved(false) for dehydration', function (): void {
+    $schema = Schema::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            Field::make($statePath = Str::random())
+                ->default($state = Str::random())
+                ->dehydrated(true)
+                ->saved(false),
+        ])
+        ->fill();
+
+    invade($schema->getLivewire())->cacheSchema('form', $schema);
+
+    // dehydrated(true) explicitly set, so state is dehydrated despite saved(false)
+    expect($schema)
+        ->getState()->toBe([$statePath => $state]);
+});
+
+test('saved(false) prevents dehydration when dehydrated() is not explicitly set', function (): void {
+    $schema = Schema::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            Field::make(Str::random())
+                ->default(Str::random())
+                ->saved(false),
+        ])
+        ->fill();
+
+    invade($schema->getLivewire())->cacheSchema('form', $schema);
+
+    expect($schema)
+        ->getState()->toBe([]);
+});
+
+test('saved() can accept a closure', function (): void {
+    $savedSchema = Schema::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            Field::make($savedStatePath = Str::random())
+                ->default($savedState = Str::random())
+                ->saved(fn (): bool => true),
+        ])
+        ->fill();
+
+    invade($savedSchema->getLivewire())->cacheSchema('form', $savedSchema);
+
+    expect($savedSchema)
+        ->getState()->toBe([$savedStatePath => $savedState]);
+
+    $notSavedSchema = Schema::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            Field::make(Str::random())
+                ->default(Str::random())
+                ->saved(fn (): bool => false),
+        ])
+        ->fill();
+
+    invade($notSavedSchema->getLivewire())->cacheSchema('form', $notSavedSchema);
+
+    expect($notSavedSchema)
+        ->getState()->toBe([]);
+});
+
+test('disabled components can be dehydrated when dehydrated() is called after disabled()', function (): void {
+    $schema = Schema::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            Field::make($statePath = Str::random())
+                ->default($state = Str::random())
+                ->disabled()
+                ->dehydrated(),
+        ])
+        ->fill();
+
+    invade($schema->getLivewire())->cacheSchema('form', $schema);
+
+    expect($schema)
+        ->getState()->toBe([$statePath => $state]);
+});
+
+test('disabled components can be saved when saved() is called after disabled()', function (): void {
+    $schema = Schema::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            Field::make($statePath = Str::random())
+                ->default($state = Str::random())
+                ->disabled()
+                ->saved(),
+        ])
+        ->fill();
+
+    invade($schema->getLivewire())->cacheSchema('form', $schema);
+
+    expect($schema)
+        ->getState()->toBe([$statePath => $state]);
+});

--- a/tests/src/Forms/StateTest.php
+++ b/tests/src/Forms/StateTest.php
@@ -1101,7 +1101,7 @@ test('components can inject their old state after it is updated', function (): v
         ]);
 });
 
-test('components can be excluded from state dehydration using saved(false)', function (): void {
+test('components can be excluded from state dehydration using `saved(false)`', function (): void {
     $schema = Schema::make(Livewire::make())
         ->statePath('data')
         ->components([
@@ -1117,7 +1117,7 @@ test('components can be excluded from state dehydration using saved(false)', fun
         ->getState()->toBe([]);
 });
 
-test('components can be excluded from state dehydration if their parent component uses saved(false)', function (): void {
+test('components can be excluded from state dehydration if their parent component uses `saved(false)`', function (): void {
     $schema = Schema::make(Livewire::make())
         ->statePath('data')
         ->components([
@@ -1136,7 +1136,7 @@ test('components can be excluded from state dehydration if their parent componen
         ->getState()->toBe([]);
 });
 
-test('explicit dehydrated(true) takes precedence over saved(false) for dehydration', function (): void {
+test('explicit `dehydrated(true)` takes precedence over `saved(false)` for dehydration', function (): void {
     $schema = Schema::make(Livewire::make())
         ->statePath('data')
         ->components([
@@ -1154,7 +1154,7 @@ test('explicit dehydrated(true) takes precedence over saved(false) for dehydrati
         ->getState()->toBe([$statePath => $state]);
 });
 
-test('saved(false) prevents dehydration when dehydrated() is not explicitly set', function (): void {
+test('`saved(false)` prevents dehydration when `dehydrated()` is not explicitly set', function (): void {
     $schema = Schema::make(Livewire::make())
         ->statePath('data')
         ->components([
@@ -1170,7 +1170,7 @@ test('saved(false) prevents dehydration when dehydrated() is not explicitly set'
         ->getState()->toBe([]);
 });
 
-test('saved() can accept a closure', function (): void {
+test('`saved()` can accept a closure', function (): void {
     $savedSchema = Schema::make(Livewire::make())
         ->statePath('data')
         ->components([
@@ -1200,7 +1200,7 @@ test('saved() can accept a closure', function (): void {
         ->getState()->toBe([]);
 });
 
-test('disabled components can be dehydrated when dehydrated() is called after disabled()', function (): void {
+test('disabled components can be dehydrated when `dehydrated()` is called after `disabled()`', function (): void {
     $schema = Schema::make(Livewire::make())
         ->statePath('data')
         ->components([
@@ -1217,7 +1217,7 @@ test('disabled components can be dehydrated when dehydrated() is called after di
         ->getState()->toBe([$statePath => $state]);
 });
 
-test('disabled components can be saved when saved() is called after disabled()', function (): void {
+test('disabled components can be saved when `saved()` is called after `disabled()`', function (): void {
     $schema = Schema::make(Livewire::make())
         ->statePath('data')
         ->components([


### PR DESCRIPTION
Closes #17778.