### PR TITLE
fix: default create-action URL getting targeted when model doesn't match

### DIFF
--- a/packages/panels/src/Resources/Pages/ManageRelatedRecords.php
+++ b/packages/panels/src/Resources/Pages/ManageRelatedRecords.php
@@ -300,23 +300,28 @@ class ManageRelatedRecords extends Page implements Tables\Contracts\HasTable
             return null;
         }
 
+        $actionModel = $action->getModel();
+
         if (
             ($action instanceof CreateAction) &&
-            ($relatedResource::hasPage('create'))
+            ($relatedResource::hasPage('create')) &&
+            ((blank($actionModel)) || ($actionModel === $relatedResource::getModel()))
         ) {
             return $relatedResource::getUrl('create', shouldGuessMissingParameters: true);
         }
 
         if (
             ($action instanceof EditAction) &&
-            ($relatedResource::hasPage('edit'))
+            ($relatedResource::hasPage('edit')) &&
+            ((blank($actionModel)) || ($actionModel === $relatedResource::getModel()))
         ) {
             return $relatedResource::getUrl('edit', ['record' => $action->getRecord()], shouldGuessMissingParameters: true);
         }
 
         if (
             ($action instanceof ViewAction) &&
-            ($relatedResource::hasPage('view'))
+            ($relatedResource::hasPage('view')) &&
+            ((blank($actionModel)) || ($actionModel === $relatedResource::getModel()))
         ) {
             return $relatedResource::getUrl('view', ['record' => $action->getRecord()], shouldGuessMissingParameters: true);
         }

--- a/packages/panels/src/Resources/Pages/ManageRelatedRecords.php
+++ b/packages/panels/src/Resources/Pages/ManageRelatedRecords.php
@@ -305,7 +305,7 @@ class ManageRelatedRecords extends Page implements Tables\Contracts\HasTable
         if (
             ($action instanceof CreateAction) &&
             ($relatedResource::hasPage('create')) &&
-            ((blank($actionModel)) || ($actionModel === $relatedResource::getModel()))
+            (blank($actionModel) || ($actionModel === $relatedResource::getModel()))
         ) {
             return $relatedResource::getUrl('create', shouldGuessMissingParameters: true);
         }
@@ -313,7 +313,7 @@ class ManageRelatedRecords extends Page implements Tables\Contracts\HasTable
         if (
             ($action instanceof EditAction) &&
             ($relatedResource::hasPage('edit')) &&
-            ((blank($actionModel)) || ($actionModel === $relatedResource::getModel()))
+            (blank($actionModel) || ($actionModel === $relatedResource::getModel()))
         ) {
             return $relatedResource::getUrl('edit', ['record' => $action->getRecord()], shouldGuessMissingParameters: true);
         }
@@ -321,7 +321,7 @@ class ManageRelatedRecords extends Page implements Tables\Contracts\HasTable
         if (
             ($action instanceof ViewAction) &&
             ($relatedResource::hasPage('view')) &&
-            ((blank($actionModel)) || ($actionModel === $relatedResource::getModel()))
+            (blank($actionModel) || ($actionModel === $relatedResource::getModel()))
         ) {
             return $relatedResource::getUrl('view', ['record' => $action->getRecord()], shouldGuessMissingParameters: true);
         }

--- a/packages/panels/src/Resources/Pages/Page.php
+++ b/packages/panels/src/Resources/Pages/Page.php
@@ -354,7 +354,7 @@ abstract class Page extends BasePage
         if (
             ($action instanceof CreateAction) &&
             (static::getResource()::hasPage('create')) &&
-            ((blank($actionModel)) || ($actionModel === static::getResource()::getModel()))
+            (blank($actionModel) || ($actionModel === static::getResource()::getModel()))
         ) {
             return $this->getResourceUrl('create');
         }
@@ -363,7 +363,7 @@ abstract class Page extends BasePage
             ($action instanceof EditAction) &&
             (static::getResource()::hasPage('edit')) &&
             (! $this instanceof EditRecord) &&
-            ((blank($actionModel)) || ($actionModel === static::getResource()::getModel()))
+            (blank($actionModel) || ($actionModel === static::getResource()::getModel()))
         ) {
             return $this->getResourceUrl('edit', ['record' => $action->getRecord()]);
         }
@@ -372,7 +372,7 @@ abstract class Page extends BasePage
             ($action instanceof ViewAction) &&
             (static::getResource()::hasPage('view')) &&
             (! $this instanceof ViewRecord) &&
-            ((blank($actionModel)) || ($actionModel === static::getResource()::getModel()))
+            (blank($actionModel) || ($actionModel === static::getResource()::getModel()))
         ) {
             return $this->getResourceUrl('view', ['record' => $action->getRecord()]);
         }

--- a/packages/panels/src/Resources/Pages/Page.php
+++ b/packages/panels/src/Resources/Pages/Page.php
@@ -349,9 +349,12 @@ abstract class Page extends BasePage
 
     public function getDefaultActionUrl(Action $action): ?string
     {
+        $actionModel = $action->getModel();
+
         if (
             ($action instanceof CreateAction) &&
-            (static::getResource()::hasPage('create'))
+            (static::getResource()::hasPage('create')) &&
+            ((blank($actionModel)) || ($actionModel === static::getResource()::getModel()))
         ) {
             return $this->getResourceUrl('create');
         }
@@ -359,7 +362,8 @@ abstract class Page extends BasePage
         if (
             ($action instanceof EditAction) &&
             (static::getResource()::hasPage('edit')) &&
-            (! $this instanceof EditRecord)
+            (! $this instanceof EditRecord) &&
+            ((blank($actionModel)) || ($actionModel === static::getResource()::getModel()))
         ) {
             return $this->getResourceUrl('edit', ['record' => $action->getRecord()]);
         }
@@ -367,7 +371,8 @@ abstract class Page extends BasePage
         if (
             ($action instanceof ViewAction) &&
             (static::getResource()::hasPage('view')) &&
-            (! $this instanceof ViewRecord)
+            (! $this instanceof ViewRecord) &&
+            ((blank($actionModel)) || ($actionModel === static::getResource()::getModel()))
         ) {
             return $this->getResourceUrl('view', ['record' => $action->getRecord()]);
         }

--- a/packages/panels/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManager.php
@@ -377,23 +377,28 @@ class RelationManager extends Component implements HasActions, HasRenderHookScop
             return null;
         }
 
+        $actionModel = $action->getModel();
+
         if (
             ($action instanceof CreateAction) &&
-            ($relatedResource::hasPage('create'))
+            ($relatedResource::hasPage('create')) &&
+            ((blank($actionModel)) || $actionModel === $relatedResource::getModel())
         ) {
             return $relatedResource::getUrl('create', shouldGuessMissingParameters: true);
         }
 
         if (
             ($action instanceof EditAction) &&
-            ($relatedResource::hasPage('edit'))
+            ($relatedResource::hasPage('edit')) &&
+            ((blank($actionModel)) || $actionModel === $relatedResource::getModel())
         ) {
             return $relatedResource::getUrl('edit', ['record' => $action->getRecord()], shouldGuessMissingParameters: true);
         }
 
         if (
             ($action instanceof ViewAction) &&
-            ($relatedResource::hasPage('view'))
+            ($relatedResource::hasPage('view')) &&
+            ((blank($actionModel)) || $actionModel === $relatedResource::getModel())
         ) {
             return $relatedResource::getUrl('view', ['record' => $action->getRecord()], shouldGuessMissingParameters: true);
         }

--- a/packages/panels/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManager.php
@@ -382,7 +382,7 @@ class RelationManager extends Component implements HasActions, HasRenderHookScop
         if (
             ($action instanceof CreateAction) &&
             ($relatedResource::hasPage('create')) &&
-            ((blank($actionModel)) || $actionModel === $relatedResource::getModel())
+            (blank($actionModel) || ($actionModel === $relatedResource::getModel()))
         ) {
             return $relatedResource::getUrl('create', shouldGuessMissingParameters: true);
         }
@@ -390,7 +390,7 @@ class RelationManager extends Component implements HasActions, HasRenderHookScop
         if (
             ($action instanceof EditAction) &&
             ($relatedResource::hasPage('edit')) &&
-            ((blank($actionModel)) || $actionModel === $relatedResource::getModel())
+            (blank($actionModel) || ($actionModel === $relatedResource::getModel()))
         ) {
             return $relatedResource::getUrl('edit', ['record' => $action->getRecord()], shouldGuessMissingParameters: true);
         }
@@ -398,7 +398,7 @@ class RelationManager extends Component implements HasActions, HasRenderHookScop
         if (
             ($action instanceof ViewAction) &&
             ($relatedResource::hasPage('view')) &&
-            ((blank($actionModel)) || $actionModel === $relatedResource::getModel())
+            (blank($actionModel) || ($actionModel === $relatedResource::getModel()))
         ) {
             return $relatedResource::getUrl('view', ['record' => $action->getRecord()], shouldGuessMissingParameters: true);
         }


### PR DESCRIPTION
When upgrading a Filament V4 project, I encountered a situation where there was a custom page in a resource that had a table on it for a different model. This custom page had a `CreateAction` on top with a `->model(OtherModel::class)` set. However, instead the action now redirected to the `create` page of the resource, rather than open a modal with the schema. 

This PR fixes it by modifying the `getDefaultActionUrl()` to only return a URL if the `$action->getModel()` matches the associated resource model.

Thanks!