### PR TITLE
fix: Action on Table throws `foreach() argument must be of type array|object, null given` when `legacy_model_binding` is set

### DIFF
--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -603,7 +603,6 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
     {
         if (! $this->getOptionLabelsUsing) {
             $state = $this->getState();
-
             $options = $this->getOptions();
 
             $labels = [];

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -603,11 +603,12 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
     {
         if (! $this->getOptionLabelsUsing) {
             $state = $this->getState();
+
             $options = $this->getOptions();
 
             $labels = [];
 
-            foreach ($state as $value) {
+            foreach ($state ?? [] as $value) {
                 if ($value instanceof BackedEnum) {
                     $value = $value->value;
                 }


### PR DESCRIPTION
Fixes #17757