### PR TITLE
fix: Coordinate state loading for multiple Group->relationship() components

### DIFF
--- a/packages/schemas/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
+++ b/packages/schemas/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
@@ -40,7 +40,43 @@ trait EntanglesStateWithSingularRelationship
         $this->loadStateFromRelationshipsUsing(static function (Component | CanEntangleWithSingularRelationships $component): void {
             $component->clearCachedExistingRecord();
 
-            $component->fillFromRelationship();
+            // Find all layout components using this same relationship - mirror the save logic coordination.
+            // This prevents state overwrites when multiple Groups access the same HasOne relationship.
+            $componentsWithThisRelationship = [];
+
+            $findComponentsWithThisRelationship = function (Schema $schema) use ($component, &$componentsWithThisRelationship, &$findComponentsWithThisRelationship): void {
+                foreach ($schema->getComponents(withActions: false, withHidden: true) as $childComponent) {
+                    if (
+                        ($childComponent->getModel() === $component->getModel()) &&
+                        ($childComponent->getRecord() === $component->getRecord()) &&
+                        ($childComponent instanceof CanEntangleWithSingularRelationships) &&
+                        ($childComponent->getRelationshipName() === $component->getRelationshipName()) &&
+                        ($childComponent->hasRelationship())
+                    ) {
+                        $componentsWithThisRelationship[] = $childComponent;
+
+                        continue;
+                    }
+
+                    foreach ($childComponent->getChildSchemas() as $schema) {
+                        $findComponentsWithThisRelationship($schema);
+                    }
+                }
+            };
+
+            $findComponentsWithThisRelationship($component->getRootContainer());
+
+            $isFirstComponent = blank($componentsWithThisRelationship) || (Arr::first($componentsWithThisRelationship) === $component);
+
+            if ($isFirstComponent) {
+                // First component fills from relationship (sets raw state + hydrates + applies StateCasts)
+                $component->fillFromRelationship();
+            } else {
+                // State is already set by the first component.
+                // Just hydrate this component's child schema (applies StateCasts automatically).
+                $hydratedDefaultState = null;
+                $component->getChildSchema()->hydrateState($hydratedDefaultState, shouldCallHydrationHooks: false);
+            }
         });
 
         $this->saveRelationshipsBeforeChildrenUsing(static function (Component | CanEntangleWithSingularRelationships $component, LivewireComponent & HasSchemas $livewire): void {

--- a/packages/schemas/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
+++ b/packages/schemas/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
@@ -40,11 +40,7 @@ trait EntanglesStateWithSingularRelationship
         $this->loadStateFromRelationshipsUsing(static function (Component | CanEntangleWithSingularRelationships $component): void {
             $component->clearCachedExistingRecord();
 
-            // Find all layout components using this same relationship - mirror the save logic coordination.
-            // This prevents state overwrites when multiple Groups access the same HasOne relationship.
-            $componentsWithThisRelationship = [];
-
-            $findComponentsWithThisRelationship = function (Schema $schema) use ($component, &$componentsWithThisRelationship, &$findComponentsWithThisRelationship): void {
+            $findFirstComponentWithThisRelationship = function (Schema $schema) use ($component, &$findFirstComponentWithThisRelationship): ?CanEntangleWithSingularRelationships {
                 foreach ($schema->getComponents(withActions: false, withHidden: true) as $childComponent) {
                     if (
                         ($childComponent->getModel() === $component->getModel()) &&
@@ -53,27 +49,32 @@ trait EntanglesStateWithSingularRelationship
                         ($childComponent->getRelationshipName() === $component->getRelationshipName()) &&
                         ($childComponent->hasRelationship())
                     ) {
-                        $componentsWithThisRelationship[] = $childComponent;
-
-                        continue;
+                        return $childComponent;
                     }
 
                     foreach ($childComponent->getChildSchemas() as $schema) {
-                        $findComponentsWithThisRelationship($schema);
+                        $found = $findFirstComponentWithThisRelationship($schema);
+
+                        if ($found) {
+                            return $found;
+                        }
                     }
                 }
+
+                return null;
             };
 
-            $findComponentsWithThisRelationship($component->getRootContainer());
+            $firstComponentWithThisRelationship = $findFirstComponentWithThisRelationship($component->getRootContainer());
 
-            $isFirstComponent = blank($componentsWithThisRelationship) || (Arr::first($componentsWithThisRelationship) === $component);
+            $isFirstComponent = ($firstComponentWithThisRelationship === null) || ($firstComponentWithThisRelationship === $component);
 
             if ($isFirstComponent) {
-                // First component fills from relationship (sets raw state + hydrates + applies StateCasts)
+                // The first layout component using this relationship is the one that will fill the relationship data for all of them,
+                // but it will only hydrate the state correctly for itself.
                 $component->fillFromRelationship();
             } else {
-                // State is already set by the first component.
-                // Just hydrate this component's child schema (applies StateCasts automatically).
+                // If this is not the first layout component using this relationship, the data has already been filled by the first one,
+                // so we just need to hydrate the state without calling any hydration hooks. This ensures that state casts have run.
                 $hydratedDefaultState = null;
                 $component->getChildSchema()->hydrateState($hydratedDefaultState, shouldCallHydrationHooks: false);
             }


### PR DESCRIPTION
## Summary

Fixes state overwrites when multiple `Group::make()->relationship()` components access the same HasOne relationship across different tabs.

## Problem

The `saveRelationshipsBeforeChildrenUsing` callback already coordinates multiple Groups - only the first Group saves, collecting data from all Groups:

```php
// Existing save logic - already coordinated
$findComponentsWithThisRelationship($component->getRootContainer());

if (filled($componentsWithThisRelationship) && (Arr::first($componentsWithThisRelationship) !== $component)) {
    return;  // Skip if not first component
}

// First component saves data from ALL Groups
foreach ($componentsWithThisRelationship as $componentWithThisRelationship) {
    $data = [...$data, ...$componentWithThisRelationship->getChildSchema()->getState(...)];
}
```

However, `loadStateFromRelationshipsUsing` lacks this coordination - it calls `fillFromRelationship()` for **every** Group, causing state overwrites:

```php
// Current load logic - NOT coordinated
$this->loadStateFromRelationshipsUsing(static function ($component): void {
    $component->clearCachedExistingRecord();
    $component->fillFromRelationship();  // Called for EVERY Group - overwrites previous state
});
```

With 3+ Groups:
1. Group 2 fills → hydrates (normalizes FileUpload to UUID-keyed array)
2. Group 3 fills → **overwrites** Group 2's normalized state
3. Group 4 fills → **overwrites** Group 3's normalized state
4. FileUpload has raw string instead of UUID-keyed array → type errors

**Errors:**
- `foreach() argument must be of type array|object, string given` at `BaseFileUpload.php:742`
- `Argument #2 ($rawState) must be of type ?array, string given` at `RichEditor.php:346`

## Solution

Apply the same coordination pattern from `saveRelationshipsBeforeChildrenUsing` to `loadStateFromRelationshipsUsing`:

- **First component**: calls `fillFromRelationship()` (sets raw state + hydrates all)
- **Subsequent components**: only call `hydrateState()` (state already set, applies StateCasts)

## Benefits

- **Mirrors existing pattern** - same coordination logic already used in save operation
- **No method signature changes** - `fillFromRelationship()` unchanged
- **No new helper methods** - uses existing `hydrateState()`
- **Minimal code change** - ~35 lines added

## Testing

Reproduction repo: https://github.com/iotron/filament-bug-reproduction

Verified both errors are fixed after applying this change.

Fixes #18826
Related to #18718, #18727