### PR TITLE
Add padding to actions in fused group

### DIFF
--- a/packages/schemas/resources/css/components/fused-group.css
+++ b/packages/schemas/resources/css/components/fused-group.css
@@ -16,6 +16,10 @@
             & .fi-input {
                 @apply min-h-full;
             }
+
+            & .fi-sc-actions {
+                @apply p-2.5;
+            }
         }
 
         & > :first-child .fi-input-wrp {

--- a/packages/schemas/resources/css/components/fused-group.css
+++ b/packages/schemas/resources/css/components/fused-group.css
@@ -18,7 +18,7 @@
             }
 
             & .fi-sc-actions {
-                @apply p-2.5;
+                @apply px-3 py-2;
             }
         }
 


### PR DESCRIPTION
## Description

This PR automatically pads `Actions` component when it's inside `FusedGroup` https://github.com/filamentphp/filament/discussions/18820#discussioncomment-15391674

## Visual changes
Before
<img width="507" height="96" alt="image" src="https://github.com/user-attachments/assets/792b1960-5e67-457d-8435-07b1e56f9bfa" />


After
<img width="517" height="112" alt="image" src="https://github.com/user-attachments/assets/e2c11185-57cc-47c3-842e-9efbf4cdcc98" />

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
