### PR TITLE
Fix: base64_decode deprecation notice in CustomBlockExtension

### DIFF
--- a/packages/forms/src/Components/RichEditor/TipTapExtensions/CustomBlockExtension.php
+++ b/packages/forms/src/Components/RichEditor/TipTapExtensions/CustomBlockExtension.php
@@ -51,7 +51,7 @@ class CustomBlockExtension extends Node
                 'rendered' => false,
             ],
             'preview' => [
-                'parseHTML' => fn ($DOMNode) => base64_decode($DOMNode->getAttribute('data-preview') ?: null),
+                'parseHTML' => fn ($DOMNode) => base64_decode($DOMNode->getAttribute('data-preview') ?: ''),
                 'rendered' => false,
             ],
         ];


### PR DESCRIPTION
## Description

Fixes an issue in the CustomBlockExtension.php where passing `null` to `base64_decode` is deprecated.

<img width="1158" height="81" alt="Screenshot 2026-01-03 at 10 56 36 AM" src="https://github.com/user-attachments/assets/fe336187-bf25-4026-a74d-d38d0ae089e1" />

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
