### PR TITLE
Fix empty relationship queries on SelectFilter with hasEmptyOption enabled

### DIFF
--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -41,6 +41,8 @@ class SelectFilter extends BaseFilter
 
     protected ?Closure $getOptionLabelFromRecordUsing = null;
 
+    protected static string $emptyRelationshipOptionKey = '__empty';
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -64,7 +66,7 @@ class SelectFilter extends BaseFilter
 
                     if (
                         $filter->hasEmptyRelationshipOption() &&
-                        in_array('__empty', $state['values'])
+                        in_array(self::$emptyRelationshipOptionKey, $state['values'])
                     ) {
                         $labels[] = $filter->getEmptyRelationshipOptionLabel();
                     }
@@ -78,7 +80,7 @@ class SelectFilter extends BaseFilter
                             )
                             ->when(
                                 $filter->getRelationshipKey(),
-                                fn (Builder $query, string $relationshipKey) => $query->whereIn($relationshipKey, $state['values']),
+                                fn (Builder $query, string $relationshipKey) => $query->whereIn($relationshipKey, self::getRelationshipQueryValues($state['values'])),
                                 fn (Builder $query) => $query->whereKey($state['values'])
                             )
                             ->pluck($relationshipQuery->qualifyColumn($filter->getRelationshipTitleAttribute()))
@@ -113,7 +115,7 @@ class SelectFilter extends BaseFilter
             if ($filter->queriesRelationships()) {
                 if (
                     $filter->hasEmptyRelationshipOption() &&
-                    ($state['value'] === '__empty')
+                    ($state['value'] === self::$emptyRelationshipOptionKey)
                 ) {
                     $label = $filter->getEmptyRelationshipOptionLabel();
                 } else {
@@ -204,21 +206,26 @@ class SelectFilter extends BaseFilter
                 if ($relationshipKey = $this->getRelationshipKey($query)) {
                     return $query->{$isMultiple ? 'whereIn' : 'where'}(
                         $relationshipKey,
-                        $values,
+                        self::getRelationshipQueryValues($values),
                     );
                 }
 
-                return $query->whereKey($values);
+                return $query->whereKey(self::getRelationshipQueryValues($values));
             },
         );
 
         if (
             $this->hasEmptyRelationshipOption() &&
-            in_array('__empty', Arr::wrap($values))
+            in_array(self::$emptyRelationshipOptionKey, Arr::wrap($values))
         ) {
-            $query->where(fn (Builder $query) => $query
-                ->where(fn (Builder $query) => $applyRelationshipScope($query))
-                ->orWhereDoesntHave($this->getRelationshipName()));
+            $query->when(
+                self::getRelationshipQueryValues($values),
+                fn (Builder $query) => $query
+                    ->where(fn (Builder $query) => $applyRelationshipScope($query))
+                    ->orWhereDoesntHave($this->getRelationshipName()),
+                fn (Builder $query) => $query
+                    ->whereDoesntHave($this->getRelationshipName()),
+            );
         } else {
             $applyRelationshipScope($query);
         }
@@ -350,7 +357,7 @@ class SelectFilter extends BaseFilter
                         $this->hasEmptyRelationshipOption() &&
                         str($this->getEmptyRelationshipOptionLabel())->lower()->contains(Str::lower($search))
                     ) {
-                        $options['__empty'] = $this->getEmptyRelationshipOptionLabel();
+                        $options[self::$emptyRelationshipOptionKey] = $this->getEmptyRelationshipOptionLabel();
                     }
 
                     $qualifiedRelatedKeyName = $component->getQualifiedRelatedKeyNameForRelationship($relationship);
@@ -416,7 +423,7 @@ class SelectFilter extends BaseFilter
                     $options = [];
 
                     if ($this->hasEmptyRelationshipOption()) {
-                        $options['__empty'] = $this->getEmptyRelationshipOptionLabel();
+                        $options[self::$emptyRelationshipOptionKey] = $this->getEmptyRelationshipOptionLabel();
                     }
 
                     $qualifiedRelatedKeyName = $component->getQualifiedRelatedKeyNameForRelationship($relationship);
@@ -457,7 +464,7 @@ class SelectFilter extends BaseFilter
                 ->getOptionLabelUsing(function (Select $component) {
                     if (
                         $this->hasEmptyRelationshipOption() &&
-                        ($component->getState() === '__empty')
+                        ($component->getState() === self::$emptyRelationshipOptionKey)
                     ) {
                         return $this->getEmptyRelationshipOptionLabel();
                     }
@@ -487,7 +494,7 @@ class SelectFilter extends BaseFilter
 
                     $qualifiedRelatedKeyName = $component->getQualifiedRelatedKeyNameForRelationship($relationship);
 
-                    $relationshipQuery->whereIn($qualifiedRelatedKeyName, $values);
+                    $relationshipQuery->whereIn($qualifiedRelatedKeyName, self::getRelationshipQueryValues($values));
 
                     if ($this->modifyRelationshipQueryUsing) {
                         $relationshipQuery = $component->evaluate($this->modifyRelationshipQueryUsing, [
@@ -500,9 +507,9 @@ class SelectFilter extends BaseFilter
 
                     if (
                         $this->hasEmptyRelationshipOption() &&
-                        in_array('__empty', $values)
+                        in_array(self::$emptyRelationshipOptionKey, $values)
                     ) {
-                        $labels['__empty'] = $this->getEmptyRelationshipOptionLabel();
+                        $labels[self::$emptyRelationshipOptionKey] = $this->getEmptyRelationshipOptionLabel();
                     }
 
                     if ($component->hasOptionLabelFromRecordUsingCallback()) {
@@ -603,5 +610,22 @@ class SelectFilter extends BaseFilter
         $this->getOptionLabelFromRecordUsing = $callback;
 
         return $this;
+    }
+
+    public static function getRelationshipQueryValues(string | array $values): string | array
+    {
+        if (is_string($values)) {
+            if ($values === self::$emptyRelationshipOptionKey) {
+                return '';
+            }
+
+            return $values;
+        }
+
+        if (in_array(self::$emptyRelationshipOptionKey, $values)) {
+            unset($values[array_search(self::$emptyRelationshipOptionKey, $values)]);
+        }
+
+        return $values;
     }
 }

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -41,7 +41,7 @@ class SelectFilter extends BaseFilter
 
     protected ?Closure $getOptionLabelFromRecordUsing = null;
 
-    protected static string $emptyRelationshipOptionKey = '__empty';
+    protected const EMPTY_RELATIONSHIP_OPTION_KEY = '__empty';
 
     protected function setUp(): void
     {
@@ -66,7 +66,7 @@ class SelectFilter extends BaseFilter
 
                     if (
                         $filter->hasEmptyRelationshipOption() &&
-                        in_array(self::$emptyRelationshipOptionKey, $state['values'])
+                        in_array(static::EMPTY_RELATIONSHIP_OPTION_KEY, $state['values'])
                     ) {
                         $labels[] = $filter->getEmptyRelationshipOptionLabel();
                     }
@@ -80,7 +80,7 @@ class SelectFilter extends BaseFilter
                             )
                             ->when(
                                 $filter->getRelationshipKey(),
-                                fn (Builder $query, string $relationshipKey) => $query->whereIn($relationshipKey, self::getRelationshipQueryValues($state['values'])),
+                                fn (Builder $query, string $relationshipKey) => $query->whereIn($relationshipKey, $filter->getRelationshipQueryValues($state['values'])),
                                 fn (Builder $query) => $query->whereKey($state['values'])
                             )
                             ->pluck($relationshipQuery->qualifyColumn($filter->getRelationshipTitleAttribute()))
@@ -115,7 +115,7 @@ class SelectFilter extends BaseFilter
             if ($filter->queriesRelationships()) {
                 if (
                     $filter->hasEmptyRelationshipOption() &&
-                    ($state['value'] === self::$emptyRelationshipOptionKey)
+                    ($state['value'] === static::EMPTY_RELATIONSHIP_OPTION_KEY)
                 ) {
                     $label = $filter->getEmptyRelationshipOptionLabel();
                 } else {
@@ -194,32 +194,44 @@ class SelectFilter extends BaseFilter
             );
         }
 
-        $applyRelationshipScope = fn (Builder $query) => $query->whereHas(
-            $this->getRelationshipName(),
-            function (Builder $query) use ($isMultiple, $values) {
-                if ($this->modifyRelationshipQueryUsing) {
-                    $query = $this->evaluate($this->modifyRelationshipQueryUsing, [
-                        'query' => $query,
-                    ]) ?? $query;
-                }
+        $filteredValues = $this->getRelationshipQueryValues($values);
 
-                if ($relationshipKey = $this->getRelationshipKey($query)) {
-                    return $query->{$isMultiple ? 'whereIn' : 'where'}(
-                        $relationshipKey,
-                        self::getRelationshipQueryValues($values),
-                    );
-                }
+        $applyRelationshipScope = function (Builder $query) use ($isMultiple, $filteredValues): void {
+            if (empty($filteredValues)) {
+                return;
+            }
 
-                return $query->whereKey(self::getRelationshipQueryValues($values));
-            },
-        );
+            $query->whereHas(
+                $this->getRelationshipName(),
+                function (Builder $query) use ($isMultiple, $filteredValues): void {
+                    if ($this->modifyRelationshipQueryUsing) {
+                        $query = $this->evaluate($this->modifyRelationshipQueryUsing, [
+                            'query' => $query,
+                        ]) ?? $query;
+                    }
+
+                    $queryValues = $isMultiple ? $filteredValues : $filteredValues[0];
+
+                    if ($relationshipKey = $this->getRelationshipKey($query)) {
+                        $query->{$isMultiple ? 'whereIn' : 'where'}(
+                            $relationshipKey,
+                            $queryValues,
+                        );
+
+                        return;
+                    }
+
+                    $query->whereKey($queryValues);
+                },
+            );
+        };
 
         if (
             $this->hasEmptyRelationshipOption() &&
-            in_array(self::$emptyRelationshipOptionKey, Arr::wrap($values))
+            in_array(static::EMPTY_RELATIONSHIP_OPTION_KEY, Arr::wrap($values))
         ) {
             $query->when(
-                self::getRelationshipQueryValues($values),
+                $filteredValues,
                 fn (Builder $query) => $query
                     ->where(fn (Builder $query) => $applyRelationshipScope($query))
                     ->orWhereDoesntHave($this->getRelationshipName()),
@@ -357,7 +369,7 @@ class SelectFilter extends BaseFilter
                         $this->hasEmptyRelationshipOption() &&
                         str($this->getEmptyRelationshipOptionLabel())->lower()->contains(Str::lower($search))
                     ) {
-                        $options[self::$emptyRelationshipOptionKey] = $this->getEmptyRelationshipOptionLabel();
+                        $options[static::EMPTY_RELATIONSHIP_OPTION_KEY] = $this->getEmptyRelationshipOptionLabel();
                     }
 
                     $qualifiedRelatedKeyName = $component->getQualifiedRelatedKeyNameForRelationship($relationship);
@@ -423,7 +435,7 @@ class SelectFilter extends BaseFilter
                     $options = [];
 
                     if ($this->hasEmptyRelationshipOption()) {
-                        $options[self::$emptyRelationshipOptionKey] = $this->getEmptyRelationshipOptionLabel();
+                        $options[static::EMPTY_RELATIONSHIP_OPTION_KEY] = $this->getEmptyRelationshipOptionLabel();
                     }
 
                     $qualifiedRelatedKeyName = $component->getQualifiedRelatedKeyNameForRelationship($relationship);
@@ -464,7 +476,7 @@ class SelectFilter extends BaseFilter
                 ->getOptionLabelUsing(function (Select $component) {
                     if (
                         $this->hasEmptyRelationshipOption() &&
-                        ($component->getState() === self::$emptyRelationshipOptionKey)
+                        ($component->getState() === static::EMPTY_RELATIONSHIP_OPTION_KEY)
                     ) {
                         return $this->getEmptyRelationshipOptionLabel();
                     }
@@ -494,7 +506,7 @@ class SelectFilter extends BaseFilter
 
                     $qualifiedRelatedKeyName = $component->getQualifiedRelatedKeyNameForRelationship($relationship);
 
-                    $relationshipQuery->whereIn($qualifiedRelatedKeyName, self::getRelationshipQueryValues($values));
+                    $relationshipQuery->whereIn($qualifiedRelatedKeyName, $this->getRelationshipQueryValues($values));
 
                     if ($this->modifyRelationshipQueryUsing) {
                         $relationshipQuery = $component->evaluate($this->modifyRelationshipQueryUsing, [
@@ -507,9 +519,9 @@ class SelectFilter extends BaseFilter
 
                     if (
                         $this->hasEmptyRelationshipOption() &&
-                        in_array(self::$emptyRelationshipOptionKey, $values)
+                        in_array(static::EMPTY_RELATIONSHIP_OPTION_KEY, $values)
                     ) {
-                        $labels[self::$emptyRelationshipOptionKey] = $this->getEmptyRelationshipOptionLabel();
+                        $labels[static::EMPTY_RELATIONSHIP_OPTION_KEY] = $this->getEmptyRelationshipOptionLabel();
                     }
 
                     if ($component->hasOptionLabelFromRecordUsingCallback()) {
@@ -612,20 +624,15 @@ class SelectFilter extends BaseFilter
         return $this;
     }
 
-    public static function getRelationshipQueryValues(string | array $values): string | array
+    /**
+     * @param  string | array<array-key, string>  $values
+     * @return array<array-key, string>
+     */
+    protected function getRelationshipQueryValues(string | array $values): array
     {
-        if (is_string($values)) {
-            if ($values === self::$emptyRelationshipOptionKey) {
-                return '';
-            }
-
-            return $values;
-        }
-
-        if (in_array(self::$emptyRelationshipOptionKey, $values)) {
-            unset($values[array_search(self::$emptyRelationshipOptionKey, $values)]);
-        }
-
-        return $values;
+        return array_values(array_filter(
+            Arr::wrap($values),
+            fn (string $value): bool => $value !== static::EMPTY_RELATIONSHIP_OPTION_KEY,
+        ));
     }
 }

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -230,14 +230,13 @@ class SelectFilter extends BaseFilter
             $this->hasEmptyRelationshipOption() &&
             in_array(static::EMPTY_RELATIONSHIP_OPTION_KEY, Arr::wrap($values))
         ) {
-            $query->when(
-                $filteredValues,
-                fn (Builder $query) => $query
+            if (filled($filteredValues)) {
+                $query
                     ->where(fn (Builder $query) => $applyRelationshipScope($query))
-                    ->orWhereDoesntHave($this->getRelationshipName()),
-                fn (Builder $query) => $query
-                    ->whereDoesntHave($this->getRelationshipName()),
-            );
+                    ->orWhereDoesntHave($this->getRelationshipName());
+            } else {
+                $query->whereDoesntHave($this->getRelationshipName());
+            }
         } else {
             $applyRelationshipScope($query);
         }
@@ -625,8 +624,8 @@ class SelectFilter extends BaseFilter
     }
 
     /**
-     * @param  string | array<array-key, string>  $values
-     * @return array<array-key, string>
+     * @param  string | array<string>  $values
+     * @return array<string>
      */
     protected function getRelationshipQueryValues(string | array $values): array
     {

--- a/tests/src/Fixtures/Livewire/PostsTableWithEmptyRelationshipFilter.php
+++ b/tests/src/Fixtures/Livewire/PostsTableWithEmptyRelationshipFilter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Livewire;
+
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Tests\Fixtures\Models\Post;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+
+class PostsTableWithEmptyRelationshipFilter extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use Tables\Concerns\InteractsWithTable;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(Post::query())
+            ->columns([
+                Tables\Columns\TextColumn::make('title'),
+                Tables\Columns\TextColumn::make('author.name'),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('author')
+                    ->relationship('author', 'name', hasEmptyOption: true),
+            ]);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.table');
+    }
+}

--- a/tests/src/Fixtures/Livewire/PostsTableWithMultipleEmptyRelationshipFilter.php
+++ b/tests/src/Fixtures/Livewire/PostsTableWithMultipleEmptyRelationshipFilter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Livewire;
+
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Tests\Fixtures\Models\Post;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+
+class PostsTableWithMultipleEmptyRelationshipFilter extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use Tables\Concerns\InteractsWithTable;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(Post::query())
+            ->columns([
+                Tables\Columns\TextColumn::make('title'),
+                Tables\Columns\TextColumn::make('author.name'),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('author')
+                    ->relationship('author', 'name', hasEmptyOption: true)
+                    ->multiple(),
+            ]);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.table');
+    }
+}

--- a/tests/src/Tables/Filters/SelectFilterTest.php
+++ b/tests/src/Tables/Filters/SelectFilterTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use Filament\Tests\Fixtures\Livewire\PostsTableWithEmptyRelationshipFilter;
+use Filament\Tests\Fixtures\Livewire\PostsTableWithMultipleEmptyRelationshipFilter;
+use Filament\Tests\Fixtures\Models\Post;
+use Filament\Tests\Fixtures\Models\User;
+use Filament\Tests\Tables\TestCase;
+
+use function Filament\Tests\livewire;
+
+uses(TestCase::class);
+
+it('can filter records with no relationship using `hasEmptyRelationshipOption`', function (): void {
+    $author = User::factory()->create();
+
+    $postsWithAuthor = Post::factory()->count(3)->create(['author_id' => $author->getKey()]);
+    $postsWithoutAuthor = Post::factory()->count(2)->create(['author_id' => null]);
+
+    livewire(PostsTableWithEmptyRelationshipFilter::class)
+        ->assertCanSeeTableRecords($postsWithAuthor->merge($postsWithoutAuthor))
+        ->filterTable('author', '__empty')
+        ->assertCanSeeTableRecords($postsWithoutAuthor)
+        ->assertCanNotSeeTableRecords($postsWithAuthor);
+});
+
+it('can filter records by specific relationship value using `hasEmptyRelationshipOption`', function (): void {
+    $author1 = User::factory()->create();
+    $author2 = User::factory()->create();
+
+    $postsWithAuthor1 = Post::factory()->count(3)->create(['author_id' => $author1->getKey()]);
+    $postsWithAuthor2 = Post::factory()->count(2)->create(['author_id' => $author2->getKey()]);
+    $postsWithoutAuthor = Post::factory()->count(2)->create(['author_id' => null]);
+
+    livewire(PostsTableWithEmptyRelationshipFilter::class)
+        ->assertCanSeeTableRecords($postsWithAuthor1->merge($postsWithAuthor2)->merge($postsWithoutAuthor))
+        ->filterTable('author', $author1->getKey())
+        ->assertCanSeeTableRecords($postsWithAuthor1)
+        ->assertCanNotSeeTableRecords($postsWithAuthor2)
+        ->assertCanNotSeeTableRecords($postsWithoutAuthor);
+});
+
+it('can filter records with no relationship using `hasEmptyRelationshipOption` with `multiple()`', function (): void {
+    $author = User::factory()->create();
+
+    $postsWithAuthor = Post::factory()->count(3)->create(['author_id' => $author->getKey()]);
+    $postsWithoutAuthor = Post::factory()->count(2)->create(['author_id' => null]);
+
+    livewire(PostsTableWithMultipleEmptyRelationshipFilter::class)
+        ->assertCanSeeTableRecords($postsWithAuthor->merge($postsWithoutAuthor))
+        ->filterTable('author', ['__empty'])
+        ->assertCanSeeTableRecords($postsWithoutAuthor)
+        ->assertCanNotSeeTableRecords($postsWithAuthor);
+});
+
+it('can filter records by specific relationship values using `hasEmptyRelationshipOption` with `multiple()`', function (): void {
+    $author1 = User::factory()->create();
+    $author2 = User::factory()->create();
+    $author3 = User::factory()->create();
+
+    $postsWithAuthor1 = Post::factory()->count(2)->create(['author_id' => $author1->getKey()]);
+    $postsWithAuthor2 = Post::factory()->count(2)->create(['author_id' => $author2->getKey()]);
+    $postsWithAuthor3 = Post::factory()->count(2)->create(['author_id' => $author3->getKey()]);
+    $postsWithoutAuthor = Post::factory()->count(2)->create(['author_id' => null]);
+
+    livewire(PostsTableWithMultipleEmptyRelationshipFilter::class)
+        ->assertCanSeeTableRecords($postsWithAuthor1->merge($postsWithAuthor2)->merge($postsWithAuthor3)->merge($postsWithoutAuthor))
+        ->filterTable('author', [$author1->getKey(), $author2->getKey()])
+        ->assertCanSeeTableRecords($postsWithAuthor1->merge($postsWithAuthor2))
+        ->assertCanNotSeeTableRecords($postsWithAuthor3)
+        ->assertCanNotSeeTableRecords($postsWithoutAuthor);
+});
+
+it('can filter records by relationship values combined with empty option using `hasEmptyRelationshipOption` with `multiple()`', function (): void {
+    $author1 = User::factory()->create();
+    $author2 = User::factory()->create();
+
+    $postsWithAuthor1 = Post::factory()->count(2)->create(['author_id' => $author1->getKey()]);
+    $postsWithAuthor2 = Post::factory()->count(2)->create(['author_id' => $author2->getKey()]);
+    $postsWithoutAuthor = Post::factory()->count(2)->create(['author_id' => null]);
+
+    livewire(PostsTableWithMultipleEmptyRelationshipFilter::class)
+        ->assertCanSeeTableRecords($postsWithAuthor1->merge($postsWithAuthor2)->merge($postsWithoutAuthor))
+        ->filterTable('author', ['__empty', $author1->getKey()])
+        ->assertCanSeeTableRecords($postsWithAuthor1->merge($postsWithoutAuthor))
+        ->assertCanNotSeeTableRecords($postsWithAuthor2);
+});


### PR DESCRIPTION
## Description

The SelectFilter injects an option with the key `__empty` to the top of the options when `hasEmptyOption` is enabled (integrating a relationship).

This causes an "Invalid text representation" error, as `__empty` is an invalid value for columns of type int / bigint (`"id" = __empty`) on pgsql.

In order to fix this I have added a static method `getRelationshipQueryValues`, which filters said `__empty` key from the (state) value string / values array. I've replaced the arrays `$state['values']` and `$values` with this helper method only where a relationship is queried, so custom option arrays remain untouched.

In the `apply` method I have changed the query to check for an empty value / empty values, so the relationship scope would not be applied, as `"id" = ""` would result in yet another error.

For convenience I've also introduced a static property carrying the `$emptyRelationshipOptionKey` (`__empty`).

## Visual changes

There are no visual changes.

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
