### PR TITLE
Add table reorder callbacks

### DIFF
--- a/packages/tables/docs/01-overview.md
+++ b/packages/tables/docs/01-overview.md
@@ -434,6 +434,26 @@ public function table(Table $table): Table
 
 <AutoScreenshot name="tables/reordering/custom-trigger-action" alt="Table with reorderable rows and a custom trigger action" version="4.x" />
 
+### Running code before and after reordering
+
+You may run code before or after a record is reordered using the `beforeReordering()` and `afterReordering()` methods. Both methods accept a function that receives the new `$order` array of record keys:
+
+```php
+use Filament\Tables\Table;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->reorderable('sort')
+        ->beforeReordering(function (array $order): void {
+            // Runs before records are reordered in the database.
+        })
+        ->afterReordering(function (array $order): void {
+            // Runs after records are reordered in the database.
+        });
+}
+```
+
 ## Customizing the table header
 
 You can add a heading to a table using the `$table->heading()` method:

--- a/packages/tables/src/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Concerns/CanReorderRecords.php
@@ -20,6 +20,8 @@ trait CanReorderRecords
             return;
         }
 
+        $this->getTable()->callBeforeReorderCallback($order);
+
         $orderColumn = (string) str($this->getTable()->getReorderColumn())->afterLast('.');
 
         DB::transaction(function () use ($order, $orderColumn): void {
@@ -52,6 +54,8 @@ trait CanReorderRecords
                     ),
                 ]);
         });
+
+        $this->getTable()->callAfterReorderCallback($order);
     }
 
     public function toggleTableReordering(): void

--- a/packages/tables/src/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Concerns/CanReorderRecords.php
@@ -20,7 +20,7 @@ trait CanReorderRecords
             return;
         }
 
-        $this->getTable()->callBeforeReorderCallback($order);
+        $this->getTable()->callBeforeReordering($order);
 
         $orderColumn = (string) str($this->getTable()->getReorderColumn())->afterLast('.');
 
@@ -55,7 +55,7 @@ trait CanReorderRecords
                 ]);
         });
 
-        $this->getTable()->callAfterReorderCallback($order);
+        $this->getTable()->callAfterReordering($order);
     }
 
     public function toggleTableReordering(): void

--- a/packages/tables/src/Table/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Table/Concerns/CanReorderRecords.php
@@ -34,7 +34,7 @@ trait CanReorderRecords
         return $this;
     }
 
-    public function reorderable(string | Closure | null $column = null, bool | Closure | null $condition = null, string | Closure | null $direction = null, Closure | null $beforeReorder = null, Closure | null $afterReorder = null): static
+    public function reorderable(string | Closure | null $column = null, bool | Closure | null $condition = null, string | Closure | null $direction = null, ?Closure $beforeReorder = null, ?Closure $afterReorder = null): static
     {
         $this->reorderColumn = $column;
 

--- a/packages/tables/src/Table/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Table/Concerns/CanReorderRecords.php
@@ -23,9 +23,9 @@ trait CanReorderRecords
 
     protected ?Closure $modifyReorderRecordsTriggerActionUsing = null;
 
-    protected ?Closure $beforeReorderCallback = null;
+    protected ?Closure $beforeReorderingCallback = null;
 
-    protected ?Closure $afterReorderCallback = null;
+    protected ?Closure $afterReorderingCallback = null;
 
     public function reorderRecordsTriggerAction(?Closure $callback): static
     {
@@ -34,7 +34,7 @@ trait CanReorderRecords
         return $this;
     }
 
-    public function reorderable(string | Closure | null $column = null, bool | Closure | null $condition = null, string | Closure | null $direction = null, ?Closure $beforeReorder = null, ?Closure $afterReorder = null): static
+    public function reorderable(string | Closure | null $column = null, bool | Closure | null $condition = null, string | Closure | null $direction = null): static
     {
         $this->reorderColumn = $column;
 
@@ -44,8 +44,19 @@ trait CanReorderRecords
 
         $this->reorderDirection = $direction;
 
-        $this->beforeReorderCallback = $beforeReorder;
-        $this->afterReorderCallback = $afterReorder;
+        return $this;
+    }
+
+    public function beforeReordering(?Closure $callback): static
+    {
+        $this->beforeReorderingCallback = $callback;
+
+        return $this;
+    }
+
+    public function afterReordering(?Closure $callback): static
+    {
+        $this->afterReorderingCallback = $callback;
 
         return $this;
     }
@@ -108,20 +119,16 @@ trait CanReorderRecords
     /**
      * @param  array<int | string>  $order
      */
-    public function callBeforeReorderCallback(array $order): void
+    public function callBeforeReordering(array $order): void
     {
-        if ($this->beforeReorderCallback !== null) {
-            $this->evaluate($this->beforeReorderCallback, ['order' => $order]);
-        }
+        $this->evaluate($this->beforeReorderingCallback, ['order' => $order]);
     }
 
     /**
      * @param  array<int | string>  $order
      */
-    public function callAfterReorderCallback(array $order): void
+    public function callAfterReordering(array $order): void
     {
-        if ($this->afterReorderCallback !== null) {
-            $this->evaluate($this->afterReorderCallback, ['order' => $order]);
-        }
+        $this->evaluate($this->afterReorderingCallback, ['order' => $order]);
     }
 }

--- a/packages/tables/src/Table/Concerns/CanReorderRecords.php
+++ b/packages/tables/src/Table/Concerns/CanReorderRecords.php
@@ -23,6 +23,10 @@ trait CanReorderRecords
 
     protected ?Closure $modifyReorderRecordsTriggerActionUsing = null;
 
+    protected ?Closure $beforeReorderCallback = null;
+
+    protected ?Closure $afterReorderCallback = null;
+
     public function reorderRecordsTriggerAction(?Closure $callback): static
     {
         $this->modifyReorderRecordsTriggerActionUsing = $callback;
@@ -30,7 +34,7 @@ trait CanReorderRecords
         return $this;
     }
 
-    public function reorderable(string | Closure | null $column = null, bool | Closure | null $condition = null, string | Closure | null $direction = null): static
+    public function reorderable(string | Closure | null $column = null, bool | Closure | null $condition = null, string | Closure | null $direction = null, Closure | null $beforeReorder = null, Closure | null $afterReorder = null): static
     {
         $this->reorderColumn = $column;
 
@@ -39,6 +43,9 @@ trait CanReorderRecords
         }
 
         $this->reorderDirection = $direction;
+
+        $this->beforeReorderCallback = $beforeReorder;
+        $this->afterReorderCallback = $afterReorder;
 
         return $this;
     }
@@ -96,5 +103,25 @@ trait CanReorderRecords
     public function isReorderAuthorized(): bool
     {
         return (bool) $this->evaluate($this->isReorderAuthorized);
+    }
+
+    /**
+     * @param  array<int | string>  $order
+     */
+    public function callBeforeReorderCallback(array $order): void
+    {
+        if ($this->beforeReorderCallback !== null) {
+            $this->evaluate($this->beforeReorderCallback, ['order' => $order]);
+        }
+    }
+
+    /**
+     * @param  array<int | string>  $order
+     */
+    public function callAfterReorderCallback(array $order): void
+    {
+        if ($this->afterReorderCallback !== null) {
+            $this->evaluate($this->afterReorderCallback, ['order' => $order]);
+        }
     }
 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Since #6208 model events are not triggered anymore when reordering table records. It is a problem when using Laravel Scout for example.
This PR adds a before and after reorder callback.

Same as #15055 because I needed it again for 4.x.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.

I'd need help for the documentation if it is required. English is not my primary language.

## Sample usage
```php
$table->reorderable('sequence', afterReorder: function (array $order): void {
    Item::whereIn('id', $order)->get()->each->searchable();
});
```