### PR TITLE
[4.x] Feature: Allow UnitEnum in auth helpers

### DIFF
--- a/packages/panels/src/helpers.php
+++ b/packages/panels/src/helpers.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Gate;
 use LogicException;
+use UnitEnum;
 
 if (! function_exists('Filament\authorize')) {
     /**
@@ -16,7 +17,7 @@ if (! function_exists('Filament\authorize')) {
      *
      * @throws AuthorizationException
      */
-    function authorize(string $action, Model | string $model, bool $shouldCheckPolicyExistence = true): Response
+    function authorize(UnitEnum | string $action, Model | string $model, bool $shouldCheckPolicyExistence = true): Response
     {
         return get_authorization_response($action, $model, $shouldCheckPolicyExistence)->authorize();
     }
@@ -26,7 +27,7 @@ if (! function_exists('Filament\get_authorization_response')) {
     /**
      * @param  Model|class-string<Model>  $model
      */
-    function get_authorization_response(string $action, Model | string $model, bool $shouldCheckPolicyExistence = true): Response
+    function get_authorization_response(UnitEnum | string $action, Model | string $model, bool $shouldCheckPolicyExistence = true): Response
     {
         $user = Filament::auth()->user();
 

--- a/packages/panels/src/helpers.php
+++ b/packages/panels/src/helpers.php
@@ -57,7 +57,7 @@ if (! function_exists('Filament\get_authorization_response')) {
 
             throw new LogicException(blank($policyClass)
                 ? "Strict authorization mode is enabled, but no policy was found for [{$model}]."
-                : 'Strict authorization mode is enabled, but no [' . $policyMethod . "()] method was found on [{$policyClass}].");
+                : "Strict authorization mode is enabled, but no [{$policyMethod}()] method was found on [{$policyClass}].");
         }
 
         /** @var bool | Response | null $response */

--- a/packages/panels/src/helpers.php
+++ b/packages/panels/src/helpers.php
@@ -2,6 +2,7 @@
 
 namespace Filament;
 
+use BackedEnum;
 use Filament\Facades\Filament;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Access\Response;
@@ -38,8 +39,8 @@ if (! function_exists('Filament\get_authorization_response')) {
         $policy = Gate::getPolicyFor($model);
 
         $policyMethod = match (true) {
-            $action instanceof \BackedEnum => $action->value,
-            $action instanceof \UnitEnum => $action->name,
+            $action instanceof BackedEnum => $action->value,
+            $action instanceof UnitEnum => $action->name,
             default => $action,
         };
 

--- a/packages/panels/src/helpers.php
+++ b/packages/panels/src/helpers.php
@@ -11,8 +11,6 @@ use Illuminate\Support\Facades\Gate;
 use LogicException;
 use UnitEnum;
 
-use function Illuminate\Support\enum_value;
-
 if (! function_exists('Filament\authorize')) {
     /**
      * @param  Model|class-string<Model>  $model
@@ -39,7 +37,13 @@ if (! function_exists('Filament\get_authorization_response')) {
 
         $policy = Gate::getPolicyFor($model);
 
-        if (filled($policy) && method_exists($policy, enum_value($action))) {
+        $policyMethod = match (true) {
+            $action instanceof \BackedEnum => $action->value,
+            $action instanceof \UnitEnum => $action->name,
+            default => $action,
+        };
+
+        if (filled($policy) && method_exists($policy, $policyMethod)) {
             return Gate::forUser($user)->inspect($action, Arr::wrap($model));
         }
 
@@ -52,7 +56,7 @@ if (! function_exists('Filament\get_authorization_response')) {
 
             throw new LogicException(blank($policyClass)
                 ? "Strict authorization mode is enabled, but no policy was found for [{$model}]."
-                : 'Strict authorization mode is enabled, but no [' . enum_value($action) . "()] method was found on [{$policyClass}].");
+                : 'Strict authorization mode is enabled, but no [' . $policyMethod . "()] method was found on [{$policyClass}].");
         }
 
         /** @var bool | Response | null $response */

--- a/packages/panels/src/helpers.php
+++ b/packages/panels/src/helpers.php
@@ -52,7 +52,7 @@ if (! function_exists('Filament\get_authorization_response')) {
 
             throw new LogicException(blank($policyClass)
                 ? "Strict authorization mode is enabled, but no policy was found for [{$model}]."
-                : 'Strict authorization mode is enabled, but no [' . enum_value($action) . "] method was found on [{$policyClass}].");
+                : 'Strict authorization mode is enabled, but no [' . enum_value($action) . "()] method was found on [{$policyClass}].");
         }
 
         /** @var bool | Response | null $response */

--- a/packages/panels/src/helpers.php
+++ b/packages/panels/src/helpers.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Facades\Gate;
 use LogicException;
 use UnitEnum;
 
+use function Illuminate\Support\enum_value;
+
 if (! function_exists('Filament\authorize')) {
     /**
      * @param  Model|class-string<Model>  $model
@@ -32,12 +34,12 @@ if (! function_exists('Filament\get_authorization_response')) {
         $user = Filament::auth()->user();
 
         if (! $shouldCheckPolicyExistence) {
-            return Gate::forUser($user)->inspect($action, Arr::wrap($model));
+            return Gate::forUser($user)->authorize($action, Arr::wrap($model));
         }
 
         $policy = Gate::getPolicyFor($model);
 
-        if (filled($policy) && method_exists($policy, $action)) {
+        if (filled($policy) && method_exists($policy, enum_value($action))) {
             return Gate::forUser($user)->inspect($action, Arr::wrap($model));
         }
 
@@ -50,7 +52,7 @@ if (! function_exists('Filament\get_authorization_response')) {
 
             throw new LogicException(blank($policyClass)
                 ? "Strict authorization mode is enabled, but no policy was found for [{$model}]."
-                : "Strict authorization mode is enabled, but no [{$action}()] method was found on [{$policyClass}].");
+                : 'Strict authorization mode is enabled, but no [' . enum_value($action) . "] method was found on [{$policyClass}].");
         }
 
         /** @var bool | Response | null $response */

--- a/packages/panels/src/helpers.php
+++ b/packages/panels/src/helpers.php
@@ -34,7 +34,7 @@ if (! function_exists('Filament\get_authorization_response')) {
         $user = Filament::auth()->user();
 
         if (! $shouldCheckPolicyExistence) {
-            return Gate::forUser($user)->authorize($action, Arr::wrap($model));
+            return Gate::forUser($user)->inspect($action, Arr::wrap($model));
         }
 
         $policy = Gate::getPolicyFor($model);


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

According to #18847, this PR allows `UnitEnum` as an `$action` parameter of `authorize` and `get_authorization_response` helper functions. 


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
