### PR TITLE
fix: ensure main container fills viewport with collapsible si…

### DIFF
--- a/packages/panels/resources/views/components/layout/index.blade.php
+++ b/packages/panels/resources/views/components/layout/index.blade.php
@@ -29,7 +29,7 @@
             @endif
             @class([
                 'fi-main-ctn w-screen flex-1 flex-col',
-                'h-full opacity-0 transition-all' => filament()->isSidebarCollapsibleOnDesktop() || filament()->isSidebarFullyCollapsibleOnDesktop(),
+                'min-h-[calc(100dvh-4rem)] opacity-0 transition-all' => filament()->isSidebarCollapsibleOnDesktop() || filament()->isSidebarFullyCollapsibleOnDesktop(),
                 'opacity-0' => ! (filament()->isSidebarCollapsibleOnDesktop() || filament()->isSidebarFullyCollapsibleOnDesktop() || filament()->hasTopNavigation() || (! filament()->hasNavigation())),
                 'flex' => filament()->hasTopNavigation() || (! filament()->hasNavigation()),
             ])


### PR DESCRIPTION
This pull request aims to address the same issue reported in v4.x here: https://github.com/filamentphp/filament/pull/17646
for reference : https://github.com/Devonab/filament-easy-footer/issues/16#issuecomment-3694732307

## Description

When one sets up their panel using the one of following methods:

```
->sidebarCollapsibleOnDesktop()
->sidebarFullyCollapsibleOnDesktop()
```

The content is no longer at a minimum height of 100%, which can be a bit troublesome when one wishes to place an element in the renderHook PanelsRenderHook::FOOTER.

I replaced the `h-full` present in `packages/filament/packages/panels/resources/views/components/layout/index.blade.php`.

## Visual changes

Before :
<img width="1917" height="913" alt="image" src="https://github.com/user-attachments/assets/fa8a4080-a6b6-4982-a742-c5757f6ed3fa" />

After :
<img width="1910" height="915" alt="image" src="https://github.com/user-attachments/assets/9823ebed-c6a5-4a8b-b54d-1b671da32002" />



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
