### PR TITLE
fix: Add bg-transparent to input to fix dark mode with tailwindcss/forms

### DIFF
--- a/packages/support/resources/css/components/input/index.css
+++ b/packages/support/resources/css/components/input/index.css
@@ -1,5 +1,5 @@
 input.fi-input {
-    @apply block w-full appearance-none border-none px-3 py-1.5 text-start text-sm leading-6 text-gray-950 transition duration-75 placeholder:text-gray-400 focus:ring-0 focus:outline-none disabled:text-gray-500 disabled:[-webkit-text-fill-color:var(--color-gray-500)] disabled:placeholder:[-webkit-text-fill-color:var(--color-gray-400)] dark:text-white dark:placeholder:text-gray-500 dark:disabled:text-gray-400 dark:disabled:[-webkit-text-fill-color:var(--color-gray-400)] dark:disabled:placeholder:[-webkit-text-fill-color:var(--color-gray-500)];
+    @apply block w-full appearance-none border-none bg-transparent px-3 py-1.5 text-start text-sm leading-6 text-gray-950 transition duration-75 placeholder:text-gray-400 focus:ring-0 focus:outline-none disabled:text-gray-500 disabled:[-webkit-text-fill-color:var(--color-gray-500)] disabled:placeholder:[-webkit-text-fill-color:var(--color-gray-400)] dark:text-white dark:placeholder:text-gray-500 dark:disabled:text-gray-400 dark:disabled:[-webkit-text-fill-color:var(--color-gray-400)] dark:disabled:placeholder:[-webkit-text-fill-color:var(--color-gray-500)];
 
     /* https://defensivecss.dev/tip/input-zoom-safari */
     @supports (-webkit-touch-callout: none) {


### PR DESCRIPTION
## Summary
- Adds `bg-transparent` to the `input.fi-input` CSS selector to fix dark mode inputs appearing white when using the `@tailwindcss/forms` plugin

## Problem
When using the `@tailwindcss/forms` plugin alongside Filament, text inputs in dark mode display with white backgrounds instead of transparent backgrounds. This is because `@tailwindcss/forms` sets default backgrounds on form elements, and Filament wasn't explicitly overriding this.

## Solution
Add `bg-transparent` to the base `input.fi-input` CSS rule. This ensures inputs inherit their background from their container rather than using the tailwindcss/forms default, regardless of whether the plugin is installed.

## Test plan
- [x] Verify inputs display correctly in dark mode without tailwindcss/forms
- [x] Verify inputs display correctly in dark mode with tailwindcss/forms plugin enabled

Fixes #18874

🤖 Generated with [Claude Code](https://claude.com/claude-code)