### PR TITLE
[5.x] Feature: Strict authorization in CanAuthorizeAccess

### DIFF
--- a/packages/panels/src/Pages/Concerns/CanAuthorizeAccess.php
+++ b/packages/panels/src/Pages/Concerns/CanAuthorizeAccess.php
@@ -2,6 +2,9 @@
 
 namespace Filament\Pages\Concerns;
 
+use Filament\Facades\Filament;
+use LogicException;
+
 trait CanAuthorizeAccess
 {
     public function mountCanAuthorizeAccess(): void
@@ -11,6 +14,8 @@ trait CanAuthorizeAccess
 
     public static function canAccess(): bool
     {
-        return true;
+        return Filament::isAuthorizationStrict()
+        ? throw new LogicException(sprintf('Strict authorization mode is enabled, but [canAccess()] method in [%s] class is not defined.', static::class))
+        : true;
     }
 }


### PR DESCRIPTION
## Description

Actually, this is just an idea to make authorization stricter in v5. While developing the authorization flow in my app, I noticed that many custom pages and dashboards are accessible even when a user has zero permissions, even if `strictAuthorization()` is enabled.

As a developer, I would expect the system to notify me when some permissions are not defined, instead of silently allowing uncontrolled access to resources.

I'm not sure whether modifying `CanAuthorizeAccess` wouldn't be too broad. I also considered adding `canAccess` directly to `Page` or even to the `Dashboard` page to prevent too many breaking changes, I will be grateful for your opinion here.


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
