### PR TITLE
[4.x] Fix action submit flickering with live inputs

### DIFF
--- a/packages/actions/src/Action.php
+++ b/packages/actions/src/Action.php
@@ -418,7 +418,7 @@ class Action extends ViewComponent implements Arrayable
             return $this->livewireTarget;
         }
 
-        if (! $this->canAccessSelectedRecords()) {
+        if ($this->getTable() && ! $this->canAccessSelectedRecords()) {
             return null;
         }
 

--- a/packages/forms/resources/js/components/textarea.js
+++ b/packages/forms/resources/js/components/textarea.js
@@ -41,7 +41,9 @@ export default function textareaFormComponent({
             const contentHeight = this.$el.scrollHeight
             this.$el.style.height = previousHeight
 
-            const minHeightPx = parseFloat(initialHeight) * parseFloat(getComputedStyle(document.documentElement).fontSize)
+            const minHeightPx =
+                parseFloat(initialHeight) *
+                parseFloat(getComputedStyle(document.documentElement).fontSize)
             const newHeight = Math.max(contentHeight, minHeightPx) + 'px'
 
             if (this.wrapperEl.style.height === newHeight) {


### PR DESCRIPTION
Closes #18871.

## Description

Honestly not sure if this is the right fix because there are two options here:
* Adding a delay to the `wire:loading` attribute so that for small live updates it doesn't show at all.
* Ensuring that there is a valid target available.

I've gone with the latter because it felt like there was a gap in the `getLivewireTarget()` logic where the target is `null` if the action is unable to access selected records, but that logic should really only apply to actions inside of a `Table` I believe.

This change correctly adds the `wire:target` to the modal action in all cases, preventing that nasty flicker effect.

## Visual changes


https://github.com/user-attachments/assets/0e459877-8179-4a52-8072-27a5a5a91604

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
