### PR TITLE
[4.x] Add `helperText()` to `FusedGroup`

### DIFF
--- a/packages/forms/resources/js/components/textarea.js
+++ b/packages/forms/resources/js/components/textarea.js
@@ -41,7 +41,9 @@ export default function textareaFormComponent({
             const contentHeight = this.$el.scrollHeight
             this.$el.style.height = previousHeight
 
-            const minHeightPx = parseFloat(initialHeight) * parseFloat(getComputedStyle(document.documentElement).fontSize)
+            const minHeightPx =
+                parseFloat(initialHeight) *
+                parseFloat(getComputedStyle(document.documentElement).fontSize)
             const newHeight = Math.max(contentHeight, minHeightPx) + 'px'
 
             if (this.wrapperEl.style.height === newHeight) {

--- a/packages/schemas/src/Components/FusedGroup.php
+++ b/packages/schemas/src/Components/FusedGroup.php
@@ -7,6 +7,7 @@ use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Forms\Components\Concerns\CanBeMarkedAsRequired;
 use Filament\Forms\Components\Concerns\HasExtraFieldWrapperAttributes;
+use Filament\Forms\Components\Concerns\HasHelperText;
 use Filament\Forms\Components\Field;
 use Filament\Schemas\Components\Concerns\EntanglesStateWithSingularRelationship;
 use Filament\Schemas\Components\Concerns\HasLabel;
@@ -20,6 +21,7 @@ class FusedGroup extends Component implements CanEntangleWithSingularRelationshi
     use CanBeMarkedAsRequired;
     use EntanglesStateWithSingularRelationship;
     use HasExtraFieldWrapperAttributes;
+    use HasHelperText;
     use HasLabel;
 
     /**


### PR DESCRIPTION
## Description

Given the familiarity most people will have with `helperText()`, it makes sense to add it to the `FusedGroup` component instead of requiring users to call `->belowContent()` with a `Text` object, etc.

## Visual changes

<img width="1004" height="382" alt="CleanShot 2026-01-06 at 23 53 17@2x" src="https://github.com/user-attachments/assets/458344b7-ff1c-48a8-b8a3-76076479fb1d" />

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
