### PR TITLE
[4.x] Support custom JSON flags with `CodeEntry`

### DIFF
--- a/packages/forms/resources/js/components/textarea.js
+++ b/packages/forms/resources/js/components/textarea.js
@@ -41,7 +41,9 @@ export default function textareaFormComponent({
             const contentHeight = this.$el.scrollHeight
             this.$el.style.height = previousHeight
 
-            const minHeightPx = parseFloat(initialHeight) * parseFloat(getComputedStyle(document.documentElement).fontSize)
+            const minHeightPx =
+                parseFloat(initialHeight) *
+                parseFloat(getComputedStyle(document.documentElement).fontSize)
             const newHeight = Math.max(contentHeight, minHeightPx) + 'px'
 
             if (this.wrapperEl.style.height === newHeight) {

--- a/packages/infolists/docs/06-code-entry.md
+++ b/packages/infolists/docs/06-code-entry.md
@@ -40,7 +40,7 @@ CodeEntry::make('code')
 <UtilityInjection set="infolistEntries" version="4.x">As well as allowing a static value, the `grammar()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 <Aside variant="tip">
-    If your code entry's content is a PHP array, it will automatically be converted to a JSON string, and the grammar will be set to `Grammar::Json`.
+    If your code entry's content is a PHP array, it will automatically be converted to a JSON string, and the grammar will be set to `Grammar::Json`. You can customize the `JSON_` flags used during conversion with the `jsonFlags()` method.
 </Aside>
 
 ## Changing the code's theme (highlighting)

--- a/packages/infolists/src/Components/CodeEntry.php
+++ b/packages/infolists/src/Components/CodeEntry.php
@@ -22,6 +22,8 @@ class CodeEntry extends Entry implements HasEmbeddedView
 
     protected string | Theme | Closure | null $darkTheme = null;
 
+    protected int | Closure $jsonFlags = JSON_PRETTY_PRINT;
+
     public function grammar(string | Grammar | Closure | null $grammar): static
     {
         $this->grammar = $grammar;
@@ -56,6 +58,18 @@ class CodeEntry extends Entry implements HasEmbeddedView
     public function getDarkTheme(): string | Theme | null
     {
         return $this->evaluate($this->darkTheme);
+    }
+
+    public function jsonFlags(int | Closure $flags): static
+    {
+        $this->jsonFlags = $flags;
+
+        return $this;
+    }
+
+    public function getJsonFlags(): int
+    {
+        return $this->evaluate($this->jsonFlags);
     }
 
     public function toEmbeddedHtml(): string
@@ -104,7 +118,7 @@ class CodeEntry extends Entry implements HasEmbeddedView
         $darkTheme = $this->getDarkTheme();
 
         if (is_array($state)) {
-            $state = json_encode($state, flags: JSON_PRETTY_PRINT);
+            $state = json_encode($state, flags: $this->getJsonFlags());
             $grammar ??= Grammar::Json;
         }
 


### PR DESCRIPTION
## Description

`CodeEntry` currently has some magic internally for `array` state values where it automatically runs it through `json_encode()` with the `JSON_PRETTY_PRINT` flag.

This is a solid default but if you want to customize the flags used, e.g. add `JSON_UNESCAPED_UNICODE`, you would need to provide a custom state formatter instead so that it's a string before `CodeEntry` tries to format it.

This is rather bothersome so I've added a `jsonFlags()` method which you can use to pass a new set of flags through, e.g. `jsonFlags(JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)`.

Happy to change the name to something more explicit but this felt clear enough.

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
