### PR TITLE
[4.x] Robots meta tag to prevent panel pages being indexed

### DIFF
--- a/packages/forms/resources/js/components/textarea.js
+++ b/packages/forms/resources/js/components/textarea.js
@@ -41,7 +41,9 @@ export default function textareaFormComponent({
             const contentHeight = this.$el.scrollHeight
             this.$el.style.height = previousHeight
 
-            const minHeightPx = parseFloat(initialHeight) * parseFloat(getComputedStyle(document.documentElement).fontSize)
+            const minHeightPx =
+                parseFloat(initialHeight) *
+                parseFloat(getComputedStyle(document.documentElement).fontSize)
             const newHeight = Math.max(contentHeight, minHeightPx) + 'px'
 
             if (this.wrapperEl.style.height === newHeight) {

--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -21,6 +21,7 @@
         <meta charset="utf-8" />
         <meta name="csrf-token" content="{{ csrf_token() }}" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="robots" content="noindex,nofollow" />
 
         @if ($favicon = filament()->getFavicon())
             <link rel="icon" href="{{ $favicon }}" />


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Firstly, Happy New Year! Hope you managed to get some time to relax @danharrin !

This is a simple addition to the Filament panels to prevent panel pages from being indexed by search engines. It adds a meta tag telling robots to not index the pages.

Currently, its possible for panel pages to be indexed within Google, exposing locations of Filament login URL's etc.

## Visual changes

NA

## Functional changes

NA
