### PR TITLE
[4.x] fix - handle Htmlable state in TextEntry/TextColumn toEmbeddedHtml blank check

### DIFF
--- a/packages/infolists/src/Components/TextEntry.php
+++ b/packages/infolists/src/Components/TextEntry.php
@@ -185,7 +185,7 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
                 'fi-in-text',
             ]);
 
-        if (blank($state)) {
+        if (blank($state instanceof Htmlable ? $state->toHtml() : $state)) {
             $attributes = $attributes
                 ->merge([
                     'x-tooltip' => filled($tooltip = $this->getEmptyTooltip())

--- a/packages/tables/src/Columns/TextColumn.php
+++ b/packages/tables/src/Columns/TextColumn.php
@@ -184,7 +184,7 @@ class TextColumn extends Column implements HasEmbeddedView
                 ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : ''),
             ]);
 
-        if (blank($state)) {
+        if (blank($state instanceof Htmlable ? $state->toHtml() : $state)) {
             $attributes = $attributes
                 ->merge([
                     'x-tooltip' => filled($tooltip = $this->getEmptyTooltip())


### PR DESCRIPTION
## Description

When rendering the content of a `Filament\Forms\Components\RichEditor` field using a `Filament\Infolists\Components\TextEntry` when the model is set up with  the `Filament\Forms\Components\RichEditor\Models\Contracts\HasRichContent` contract and `Filament\Forms\Components\RichEditor\Models\Concerns\InteractsWithRichContent` trait, the **placeholder is never rendered**.

This is because the `blank($state)` check does return false because it is given a `Filament\Forms\Components\RichEditor\RichContentAttribute`.

This fix checks if the `$state` implements `Illuminate\Contracts\Support\Htmlable` and uses the rendered html in the blank check instead.

This fixes both `NULL` and `EMPTY` values.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
