### PR TITLE
fix(imports): use fallback for getLabel() before Str::lcfirst() in ImportColumn

### DIFF
--- a/packages/actions/src/Imports/ImportColumn.php
+++ b/packages/actions/src/Imports/ImportColumn.php
@@ -653,7 +653,7 @@ class ImportColumn extends Component
 
     public function getValidationAttribute(): string
     {
-        return $this->evaluate($this->validationAttribute) ?? Str::lcfirst($this->getLabel());
+        return $this->evaluate($this->validationAttribute) ?? Str::lcfirst($this->getLabel() ?? $this->getName());
     }
 
     public function getLabel(): ?string

--- a/packages/actions/src/Imports/ImportColumn.php
+++ b/packages/actions/src/Imports/ImportColumn.php
@@ -651,9 +651,9 @@ class ImportColumn extends Component
         return $this;
     }
 
-    public function getValidationAttribute(): string
+    public function getValidationAttribute(): ?string
     {
-        return $this->evaluate($this->validationAttribute) ?? Str::lcfirst($this->getLabel() ?? $this->getName());
+        return $this->evaluate($this->validationAttribute) ?? (filled($label = $this->getLabel()) ? Str::lcfirst($label) : null);
     }
 
     public function getLabel(): ?string


### PR DESCRIPTION
## Description

This PR addresses a PHP deprecation warning that occurs when `lcfirst()` receives a `null` argument.

Laravel string functions like `lcfirst` (and the underlying `mb_substr` used by them) no longer accept `null`. Or, the label of an import column may be null, in which case it should default to the column name.

Interestingly, while investigating this, I initially suspected that validation might fail for these keys because the returned attribute was effectively an empty string or null. However, validation appeared to continue working correctly regardless. This change doesn't alter that underlying validation logic; it specifically targets the removal of the deprecation warning to keep logs clean and ensure future PHP compatibility.

Warning message:
```
mb_substr(): Passing null to parameter #1 ($string) of type string is deprecated in ./vendor/laravel/framework/src/Illuminate/Support/Str.php on line 171
```

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
