### PR TITLE
[3.x] Add Htmlable to getDescription method in HasDescription contract

### DIFF
--- a/packages/support/src/Contracts/HasDescription.php
+++ b/packages/support/src/Contracts/HasDescription.php
@@ -2,7 +2,9 @@
 
 namespace Filament\Support\Contracts;
 
+use Illuminate\Contracts\Support\Htmlable;
+
 interface HasDescription
 {
-    public function getDescription(): ?string;
+    public function getDescription(): string | Htmlable | null;
 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Adding Htmlable to the return type for the getDescription method in the HasDescriptions contract, to allow returning HtmlString from enum descriptions.

This should not cause any BC issues, as existing concrete getDescription methods using ?string as the return type would be covariant (more specific), which PHP is happy with.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
