### PR TITLE
[4.x] Wizard programmatic step navigation without query string

### DIFF
--- a/packages/schemas/resources/js/components/wizard.js
+++ b/packages/schemas/resources/js/components/wizard.js
@@ -48,6 +48,23 @@ export default function wizardSchemaComponent({
             this.scroll()
         },
 
+        goToStep(stepKey) {
+            const stepIndex = this.getStepIndex(stepKey)
+
+            if (stepIndex <= -1) {
+                return
+            }
+
+            if (!isSkippable && stepIndex > this.getStepIndex(this.step)) {
+                return
+            }
+
+            this.step = stepKey
+
+            this.autofocusFields()
+            this.scroll()
+        },
+
         scroll() {
             this.$nextTick(() => {
                 this.$refs.header?.children[

--- a/packages/schemas/resources/views/components/wizard.blade.php
+++ b/packages/schemas/resources/views/components/wizard.blade.php
@@ -18,7 +18,7 @@
                 stepQueryStringKey: @js($getStepQueryStringKey()),
             })"
     x-on:next-wizard-step.window="if ($event.detail.key === @js($key)) goToNextStep()"
-    x-on:wizard-go-to-step.window="($event.detail.key === @js($key)) && goToStep($event.detail.step)"
+    x-on:go-to-wizard-step.window="($event.detail.key === @js($key)) && goToStep($event.detail.step)"
     wire:ignore.self
     {{
         $attributes

--- a/packages/schemas/resources/views/components/wizard.blade.php
+++ b/packages/schemas/resources/views/components/wizard.blade.php
@@ -18,6 +18,7 @@
                 stepQueryStringKey: @js($getStepQueryStringKey()),
             })"
     x-on:next-wizard-step.window="if ($event.detail.key === @js($key)) goToNextStep()"
+    x-on:wizard-go-to-step.window="($event.detail.key === @js($key)) && goToStep($event.detail.step)"
     wire:ignore.self
     {{
         $attributes

--- a/packages/schemas/src/Components/Wizard.php
+++ b/packages/schemas/src/Components/Wizard.php
@@ -140,7 +140,7 @@ class Wizard extends Component
                 continue;
             }
 
-            if (! $this->isSkippable() && $index > $this->getCurrentStepIndex()) {
+            if ((! $this->isSkippable()) && ($index > $this->getCurrentStepIndex())) {
                 return;
             }
 
@@ -150,7 +150,7 @@ class Wizard extends Component
             $livewire = $this->getLivewire();
 
             $livewire->dispatch(
-                'wizard-go-to-step',
+                'go-to-wizard-step',
                 key: $this->getKey(),
                 step: $step,
             );

--- a/packages/schemas/src/Components/Wizard.php
+++ b/packages/schemas/src/Components/Wizard.php
@@ -128,7 +128,6 @@ class Wizard extends Component
         $this->currentStepIndex($currentStepIndex - 1);
     }
 
-    #[ExposedLivewireMethod]
     public function goToStep(string $step): void
     {
         $steps = array_values(

--- a/packages/schemas/src/Components/Wizard.php
+++ b/packages/schemas/src/Components/Wizard.php
@@ -128,6 +128,37 @@ class Wizard extends Component
         $this->currentStepIndex($currentStepIndex - 1);
     }
 
+    #[ExposedLivewireMethod]
+    public function goToStep(string $step): void
+    {
+        $steps = array_values(
+            $this->getChildSchema()->getComponents()
+        );
+
+        foreach ($steps as $index => $wizardStep) {
+            if ($wizardStep->getKey() !== $step) {
+                continue;
+            }
+
+            if (! $this->isSkippable() && $index > $this->getCurrentStepIndex()) {
+                return;
+            }
+
+            $this->currentStepIndex($index);
+
+            /** @var HasSchemas&LivewireComponent $livewire */
+            $livewire = $this->getLivewire();
+
+            $livewire->dispatch(
+                'wizard-go-to-step',
+                key: $this->getKey(),
+                step: $step,
+            );
+
+            return;
+        }
+    }
+
     public function getNextAction(): Action
     {
         $action = Action::make($this->getNextActionName())


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The Wizard component currently only supports programmatic forward navigation via the `nextStep()` method, which emits a browser event handled by Alpine. There is no native way to programmatically navigate to a specific step or move backwards without relying on query strings or directly mutating Alpine state.

This pull request introduces a new exposed Livewire method that allows navigating to a specific wizard step in a controlled and event-driven way. The implementation follows the existing Wizard architecture and event conventions, keeping the Wizard as the single source of truth for step state.

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
