### PR TITLE
[4.x] Document testing for multi-tenant panels

### DIFF
--- a/docs/10-testing/02-testing-resources.md
+++ b/docs/10-testing/02-testing-resources.md
@@ -445,7 +445,5 @@ $team = Team::factory()->create();
 
 Filament::setTenant($this->team);
 
-$panel = Filament::getCurrentOrDefaultPanel();
-TenantScopedResource::observeTenancyModelCreation($panel);
-TenantScopedResource::registerTenancyModelGlobalScope($panel);
+Filament::bootCurrentPanel();
 ```

--- a/docs/10-testing/02-testing-resources.md
+++ b/docs/10-testing/02-testing-resources.md
@@ -433,3 +433,19 @@ use Filament\Facades\Filament;
 
 Filament::setCurrentPanel('app'); // Where `app` is the ID of the panel you want to test.
 ```
+
+## Testing multi-tenant panels
+
+When testing resources in multi-tenant panels you may need to utilize the following methods in order for the resources to have the tenant scopes applied
+
+```php
+use Filament\Facades\Filament;
+
+$team = Team::factory()->create();
+
+Filament::setTenant($this->team);
+
+$panel = Filament::getCurrentOrDefaultPanel();
+TenantScopedResource::observeTenancyModelCreation($panel);
+TenantScopedResource::registerTenancyModelGlobalScope($this);
+```

--- a/docs/10-testing/02-testing-resources.md
+++ b/docs/10-testing/02-testing-resources.md
@@ -447,5 +447,5 @@ Filament::setTenant($this->team);
 
 $panel = Filament::getCurrentOrDefaultPanel();
 TenantScopedResource::observeTenancyModelCreation($panel);
-TenantScopedResource::registerTenancyModelGlobalScope($this);
+TenantScopedResource::registerTenancyModelGlobalScope($panel);
 ```

--- a/docs/10-testing/02-testing-resources.md
+++ b/docs/10-testing/02-testing-resources.md
@@ -436,7 +436,7 @@ Filament::setCurrentPanel('app'); // Where `app` is the ID of the panel you want
 
 ## Testing multi-tenant panels
 
-When testing resources in multi-tenant panels you may need to utilize the following methods in order for the resources to have the tenant scopes applied
+When testing resources in multi-tenant panels, you may need to call `Filament::bootCurrentPanel()` after setting the tenant in order to apply tenant scopes and model event listeners:
 
 ```php
 use Filament\Facades\Filament;
@@ -444,6 +444,5 @@ use Filament\Facades\Filament;
 $team = Team::factory()->create();
 
 Filament::setTenant($this->team);
-
 Filament::bootCurrentPanel();
 ```


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

This test fails when run in a multi-tenant panel unless the newly documented code is included. (Assume that the `Post` model has a constrained `team_id` column and that `Team` is the tenant model

Fails:
```php
livewire(ListPosts::class)
   ->callAction('create', data: [
      name' => 'My New Post',
   ])
   ->assertHasNoFormErrors();
```

Succeeds:
```php
Filament::setTenant($this->team);

$panel = Filament::getCurrentOrDefaultPanel();
PostResource::observeTenancyModelCreation($panel);
PostResource::registerTenancyModelGlobalScope($panel);

livewire(ListPosts::class)
   ->callAction('create', data: [
      name' => 'My New Post',
   ])
   ->assertHasNoFormErrors();
```

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
