### PR TITLE
Add missing SK/CZ translations.

### DIFF
--- a/packages/actions/resources/lang/cs/export.php
+++ b/packages/actions/resources/lang/cs/export.php
@@ -14,6 +14,18 @@ return [
 
                 'label' => 'Sloupce',
 
+                'actions' => [
+
+                    'select_all' => [
+                        'label' => 'Vybrat vše',
+                    ],
+
+                    'deselect_all' => [
+                        'label' => 'Zrušit výběr všeho',
+                    ],
+
+                ],
+
                 'form' => [
 
                     'is_enabled' => [
@@ -63,6 +75,11 @@ return [
         'max_rows' => [
             'title' => 'Export překračuje povolenou velikost',
             'body' => 'Není možné exportovat více než 1 řádek najednou.|Není možné exportovat více než :count řádků najednou.',
+        ],
+
+        'no_columns' => [
+            'title' => 'Nejsou vybrány žádné sloupce',
+            'body' => 'Prosím vyberte alespoň jeden sloupec k exportu.',
         ],
 
         'started' => [

--- a/packages/actions/resources/lang/sk/export.php
+++ b/packages/actions/resources/lang/sk/export.php
@@ -14,6 +14,18 @@ return [
 
                 'label' => 'Stĺpce',
 
+                'actions' => [
+
+                    'select_all' => [
+                        'label' => 'Vybrať všetko',
+                    ],
+
+                    'deselect_all' => [
+                        'label' => 'Zrušiť výber všetkých',
+                    ],
+
+                ],
+
                 'form' => [
 
                     'is_enabled' => [
@@ -63,6 +75,11 @@ return [
         'max_rows' => [
             'title' => 'Export je príliš veľký',
             'body' => 'Naraz nemôžete exportovať viac ako 1 riadok.|Naraz nemôžete exportovať viac ako :count riadkov.',
+        ],
+
+        'no_columns' => [
+            'title' => 'Nie sú vybrané žiadne stĺpce',
+            'body' => 'Prosím vyberte aspoň jeden stĺpec na export.',
         ],
 
         'started' => [

--- a/packages/forms/resources/lang/cs/components.php
+++ b/packages/forms/resources/lang/cs/components.php
@@ -568,6 +568,13 @@ return [
 
         'no_merge_tag_search_results_message' => 'Žádné výsledky pro značky slučování.',
 
+        'mentions' => [
+            'no_options_message' => 'Nejsou dostupné žádné možnosti.',
+            'no_search_results_message' => 'Žádné výsledky neodpovídají vašemu hledání.',
+            'search_prompt' => 'Začněte psát na vyhledávání...',
+            'searching_message' => 'Hledám...',
+        ],
+
         'tools' => [
             'align_center' => 'Zarovnat na střed',
             'align_end' => 'Zarovnat vpravo',
@@ -679,6 +686,8 @@ return [
 
         'max_items_message' => 'Lze vybrat pouze 1 položka.|Lze vybrat pouze :count položky.|Lze vybrat pouze :count položek.',
 
+        'no_options_message' => 'Nejsou dostupné žádné možnosti.',
+
         'no_search_results_message' => 'Vašemu hledání neodpovídají žádné výsledky.',
 
         'placeholder' => 'Zvolte některou z možností',
@@ -690,7 +699,17 @@ return [
     ],
 
     'tags_input' => [
+
+        'actions' => [
+
+            'delete' => [
+                'label' => 'Smazat',
+            ],
+
+        ],
+
         'placeholder' => 'Nový štítek',
+
     ],
 
     'text_input' => [

--- a/packages/forms/resources/lang/sk/components.php
+++ b/packages/forms/resources/lang/sk/components.php
@@ -568,6 +568,13 @@ return [
 
         'no_merge_tag_search_results_message' => 'Nenašli sa žiadne výsledky pre značky zlúčenia.',
 
+        'mentions' => [
+            'no_options_message' => 'Nie sú dostupné žiadne možnosti.',
+            'no_search_results_message' => 'Žiadne výsledky nezodpovedajú vášmu hľadaniu.',
+            'search_prompt' => 'Začnite písať na vyhľadávanie...',
+            'searching_message' => 'Hľadám...',
+        ],
+
         'tools' => [
             'align_center' => 'Zarovnať na stred',
             'align_end' => 'Zarovnať vpravo',
@@ -679,6 +686,8 @@ return [
 
         'max_items_message' => 'Maximálny počet pre výber je: :count.',
 
+        'no_options_message' => 'Nie sú dostupné žiadne možnosti.',
+
         'no_search_results_message' => 'Žiadne možnosti neodpovedajú vášmu hľadaniu.',
 
         'placeholder' => 'Vyberte možnosť',
@@ -690,7 +699,17 @@ return [
     ],
 
     'tags_input' => [
+
+        'actions' => [
+
+            'delete' => [
+                'label' => 'Odstrániť',
+            ],
+
+        ],
+
         'placeholder' => 'Nová značka',
+
     ],
 
     'text_input' => [

--- a/packages/tables/resources/lang/cs/table.php
+++ b/packages/tables/resources/lang/cs/table.php
@@ -30,6 +30,8 @@ return [
 
             'loading_message' => 'Načítává se...',
 
+            'no_options_message' => 'Nejsou dostupné žádné možnosti.',
+
             'no_search_results_message' => 'Žádné možnosti neodpovídají vašemu hledání.',
 
             'placeholder' => 'Vyberte možnost',

--- a/packages/tables/resources/lang/sk/table.php
+++ b/packages/tables/resources/lang/sk/table.php
@@ -30,6 +30,8 @@ return [
 
             'loading_message' => 'Načítava sa...',
 
+            'no_options_message' => 'Nie sú dostupné žiadne možnosti.',
+
             'no_search_results_message' => 'Žiadne možnosti nezodpovedajú vášmu vyhľadávaniu.',
 
             'placeholder' => 'Vyberte možnosť',


### PR DESCRIPTION
## Description

Add missing SK/CZ translations in actions, forms and tables.

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
