### PR TITLE
docs: improve comment clarity in CanGenerateUrls

### DIFF
--- a/packages/panels/src/Resources/Resource/Concerns/CanGenerateUrls.php
+++ b/packages/panels/src/Resources/Resource/Concerns/CanGenerateUrls.php
@@ -34,9 +34,9 @@ trait CanGenerateUrls
                 }
 
                 if (str(original_request()->getUri())->contains('/livewire-unit-test-endpoint/')) {
-                    // In the future, Filament will support generating URLs for nested resources.
-                    // within tests. For now, it is unable to resolve the missing URL parameters
-                    // from the parent records as it does not have access to the original request.
+                    // In the future, Filament will support generating URLs for nested resources within tests.
+                    // For now, it is unable to resolve the missing URL parameters from the parent records
+                    // as it does not have access to the original request.
                     return '';
                 }
 


### PR DESCRIPTION
## Description

Fixed grammar and readability in a comment explaining why URLs cannot be generated for nested resources in test environments. The original comment had a sentence split awkwardly across two lines, making it harder to read.

**File Changed:** `packages/panels/src/Resources/Resource/Concerns/CanGenerateUrls.php`

**Lines:** 34-40

**What was changed:**
- Merged split comment lines (lines 35-37) into coherent sentences
- Improved overall readability and flow of the explanation
- No code logic or behavior changed - comment-only improvement

## Visual changes

N/A - Comment-only change (no visual or functional impact)

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

## Additional Notes

This is a straightforward documentation improvement that enhances code readability without altering any functionality. The change aligns with Filament's commitment to clear, maintainable code.