### PR TITLE
Added missing Dutch translations and improved existing translations for form components

### DIFF
--- a/packages/forms/resources/lang/nl/components.php
+++ b/packages/forms/resources/lang/nl/components.php
@@ -32,7 +32,7 @@ return [
 
             'add_between' => [
 
-                'label' => 'Invoegen',
+                'label' => 'Invoegen tussen blokken',
 
                 'modal' => [
 
@@ -232,7 +232,7 @@ return [
                 'label' => 'Beeldverhoudingen',
 
                 'no_fixed' => [
-                    'label' => 'Geen',
+                    'label' => 'Vrij',
                 ],
 
             ],
@@ -301,7 +301,7 @@ return [
             'redo' => 'Opnieuw',
             'strike' => 'Doorhalen',
             'table' => 'Tabel',
-            'undo' => 'Herstellen',
+            'undo' => 'Ongedaan maken',
         ],
 
     ],
@@ -395,11 +395,11 @@ return [
 
             'attach_files' => [
 
-                'label' => 'Bestanden bijvoegen',
+                'label' => 'Bestand uploaden',
 
                 'modal' => [
 
-                    'heading' => 'Bestand bijvoegen',
+                    'heading' => 'Bestand uploaden',
 
                     'form' => [
 
@@ -416,7 +416,7 @@ return [
 
                             'label' => [
                                 'new' => 'Alt tekst',
-                                'existing' => 'Alt tekst veranderen',
+                                'existing' => 'Alt tekst wijzigen',
                             ],
 
                         ],
@@ -514,7 +514,7 @@ return [
 
             'link' => [
 
-                'label' => 'Bewerken',
+                'label' => 'Link',
 
                 'modal' => [
 
@@ -527,7 +527,31 @@ return [
                         ],
 
                         'should_open_in_new_tab' => [
-                            'label' => 'Open in nieuwe tab',
+                            'label' => 'Openen in nieuwe tab',
+                        ],
+
+                    ],
+
+                ],
+
+            ],
+
+            'text_color' => [
+
+                'label' => 'Tekstkleur',
+
+                'modal' => [
+
+                    'heading' => 'Tekstkleur',
+
+                    'form' => [
+
+                        'color' => [
+                            'label' => 'Kleur',
+                        ],
+
+                        'custom_color' => [
+                            'label' => 'Aangepaste kleur',
                         ],
 
                     ],
@@ -543,6 +567,13 @@ return [
         'file_attachments_max_size_message' => 'Geüploade bestanden mogen niet groter zijn dan :max kilobytes.',
 
         'no_merge_tag_search_results_message' => 'Geen merge tags gevonden.',
+
+        'mentions' => [
+            'no_options_message' => 'Geen opties beschikbaar.',
+            'no_search_results_message' => 'Geen resultaten gevonden.',
+            'search_prompt' => 'Begin met typen om te zoeken...',
+            'searching_message' => 'Zoeken...',
+        ],
 
         'tools' => [
             'align_center' => 'Centreren',
@@ -562,7 +593,7 @@ return [
             'h2' => 'Kop',
             'h3' => 'Subkop',
             'grid' => 'Raster',
-            'grid_delete' => 'Verwijder raster',
+            'grid_delete' => 'Raster verwijderen',
             'highlight' => 'Markeren',
             'horizontal_rule' => 'Horizontale lijn',
             'italic' => 'Cursief',
@@ -586,11 +617,13 @@ return [
             'table_merge_cells' => 'Cellen samenvoegen',
             'table_split_cell' => 'Cel splitsen',
             'table_toggle_header_row' => 'Koprij wisselen',
+            'table_toggle_header_cell' => 'Kopcel wisselen',
+            'text_color' => 'Tekstkleur',
             'underline' => 'Onderstrepen',
             'undo' => 'Ongedaan maken',
         ],
 
-        'uploading_file_message' => 'Het bestand wordt geüpload...',
+        'uploading_file_message' => 'Bestand uploaden...',
 
     ],
 
@@ -653,18 +686,30 @@ return [
 
         'max_items_message' => 'Er kunnen maar :count geselecteerd worden.',
 
-        'no_search_results_message' => 'Er zijn geen resultaten voor je zoekopdracht.',
+        'no_options_message' => 'Geen opties beschikbaar.',
+
+        'no_search_results_message' => 'Geen resultaten gevonden.',
 
         'placeholder' => 'Selecteer een optie',
 
         'searching_message' => 'Zoeken...',
 
-        'search_prompt' => 'Start met typen om te zoeken...',
+        'search_prompt' => 'Begin met typen om te zoeken...',
 
     ],
 
     'tags_input' => [
+
+        'actions' => [
+
+            'delete' => [
+                'label' => 'Verwijderen',
+            ],
+
+        ],
+
         'placeholder' => 'Nieuwe tag',
+
     ],
 
     'text_input' => [


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR adds missing Dutch translations for the form components and fixes some existing translations:

### Added missing translations:

- rich_editor.mentions - All mention-related messages (no_options_message, no_search_results_message, search_prompt, searching_message)
- rich_editor.actions.text_color - Text color action modal and form labels
- rich_editor.tools.table_toggle_header_cell - Missing tool label
- rich_editor.tools.text_color - Missing tool label
- tags_input.actions.delete - Missing delete action label
- select.no_options_message - Missing message

### Fixed translations:

- rich_editor.actions.link.label: "Bewerken" → "Link" (to match English)
- rich_editor.actions.attach_files.label: "Bestanden bijvoegen" → "Bestand uploaden" (to match English "Upload file")
- rich_editor.actions.attach_files.modal.heading: "Bestand bijvoegen" → "Bestand uploaden"
- file_upload.editor.aspect_ratios.no_fixed: "Geen" → "Vrij" (to match English "Free")
- Various minor grammar improvements for consistency

## Visual changes

N/A - Translation changes only.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
