### PR TITLE
Fix sidebar navigation hover cursor

### DIFF
--- a/packages/panels/resources/css/components/sidebar.css
+++ b/packages/panels/resources/css/components/sidebar.css
@@ -284,3 +284,7 @@
 .fi-sidebar-close-sidebar-btn {
     @apply mx-0! lg:hidden;
 }
+
+.fi-sidebar-group.fi-collapsible > .fi-sidebar-group-btn {
+    cursor: pointer;
+}

--- a/packages/panels/resources/css/components/sidebar.css
+++ b/packages/panels/resources/css/components/sidebar.css
@@ -7,6 +7,10 @@
         }
     }
 
+    &.fi-collapsible > .fi-sidebar-group-btn {
+        @apply cursor-pointer;
+    }
+
     &.fi-active {
         & .fi-sidebar-group-dropdown-trigger-btn {
             & .fi-icon {
@@ -283,8 +287,4 @@
 
 .fi-sidebar-close-sidebar-btn {
     @apply mx-0! lg:hidden;
-}
-
-.fi-sidebar-group.fi-collapsible > .fi-sidebar-group-btn {
-    cursor: pointer;
 }


### PR DESCRIPTION
Fixes #18942

Sidebar navigation groups and items only showed a pointer cursor
on the chevron icon. This change applies cursor:pointer to the
entire clickable row so text and whitespace behave correctly.