### PR TITLE
Chore: PHPDoc for Actions component

### DIFF
--- a/packages/schemas/src/Components/Actions.php
+++ b/packages/schemas/src/Components/Actions.php
@@ -33,7 +33,7 @@ class Actions extends Component
     const BELOW_CONTENT_SCHEMA_KEY = 'below_content';
 
     /**
-     * @param  array<Action | ActionGroup> | Closure  $actions
+     * @param  array<Component | Action | ActionGroup | string | Htmlable> | Closure  $actions
      */
     final public function __construct(array | Closure $actions)
     {
@@ -41,7 +41,7 @@ class Actions extends Component
     }
 
     /**
-     * @param  array<Action | ActionGroup> | Closure  $actions
+     * @param  array<Component | Action | ActionGroup | string | Htmlable> | Closure  $actions
      */
     public static function make(array | Closure $actions): static
     {
@@ -52,7 +52,7 @@ class Actions extends Component
     }
 
     /**
-     * @param  array<Action | ActionGroup> | Closure  $actions
+     * @param  array<Component | Action | ActionGroup | string | Htmlable> | Closure  $actions
      */
     public function actions(array | Closure $actions): static
     {


### PR DESCRIPTION
## Description

`Actions` component can contain any `Component`, however, PHPStan currently reports an error when a developer uses anything other than `Action` or `ActionGroup`.

Example:
```php
Actions::make([
    Flex::make([
        Action::make('attach')
            ->iconButton()
            ->icon(Phosphor::Paperclip),

        Action::make('emoji')
            ->iconButton()
            ->icon(Phosphor::Smiley),
    ]),

    Flex::make([
        Action::make('record')
            ->iconButton()
            ->icon(Phosphor::MicrophoneFill)
            ->color(Color::Red),

        Action::make('send')
            ->iconButton()
            ->icon(Phosphor::PaperPlaneRightFill),
    ]),
])
    ->alignBetween()
```

New PHPDoc is taken from `Flex` component.

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
