### PR TITLE
[4.x] Enhance text component to support icons

### DIFF
--- a/packages/schemas/resources/views/components/text.blade.php
+++ b/packages/schemas/resources/views/components/text.blade.php
@@ -17,8 +17,8 @@
     $weight = $getWeight();
     $fontFamily = $getFontFamily();
 
-    if (!$iconSize && $size instanceof TextSize) {
-        $iconSize = match($size) {
+    if (! $iconSize && $size instanceof TextSize) {
+        $iconSize = match ($size) {
             TextSize::ExtraSmall => IconSize::ExtraSmall,
             TextSize::Small => IconSize::Small,
             TextSize::Medium => IconSize::Medium,
@@ -87,7 +87,7 @@
                 ->merge($getExtraAttributes(), escape: false)
         }}
     >
-        @if ($icon && (!$iconPosition || $iconPosition === IconPosition::Before))
+        @if ($icon && (! $iconPosition || $iconPosition === IconPosition::Before))
             {{ \Filament\Support\generate_icon_html($icon, attributes: new \Illuminate\View\ComponentAttributeBag, size: $iconSize ?? \Filament\Support\Enums\IconSize::Small) }}
         @endif
 

--- a/packages/schemas/resources/views/components/text.blade.php
+++ b/packages/schemas/resources/views/components/text.blade.php
@@ -2,6 +2,9 @@
     use Filament\Schemas\View\Components\TextComponent;
     use Filament\Support\Enums\FontFamily;
     use Filament\Support\Enums\FontWeight;
+    use Filament\Support\Enums\IconPosition;
+    use Filament\Support\Enums\IconSize;
+    use Filament\Support\Enums\TextSize;
     use Filament\Support\RawJs;
 
     $color = $getColor();
@@ -13,6 +16,16 @@
     $tooltip = $getTooltip();
     $weight = $getWeight();
     $fontFamily = $getFontFamily();
+
+    if (!$iconSize && $size instanceof TextSize) {
+        $iconSize = match($size) {
+            TextSize::ExtraSmall => IconSize::ExtraSmall,
+            TextSize::Small => IconSize::Small,
+            TextSize::Medium => IconSize::Medium,
+            TextSize::Large => IconSize::Large,
+            default => IconSize::Small,
+        };
+    }
 
     $copyableState = $getCopyableState($content) ?? $content;
     $copyMessage = $getCopyMessage($copyableState);
@@ -66,6 +79,7 @@
                 ->class([
                     'fi-sc-text',
                     'fi-copyable' => $isCopyable,
+                    'inline-flex items-center gap-1.5' => filled($icon),
                     ($size instanceof \BackedEnum) ? "fi-size-{$size->value}" : $size,
                     ($weight instanceof FontWeight) ? "fi-font-{$weight->value}" : $weight,
                     ($fontFamily instanceof FontFamily) ? "fi-font-{$fontFamily->value}" : $fontFamily,
@@ -73,6 +87,14 @@
                 ->merge($getExtraAttributes(), escape: false)
         }}
     >
+        @if ($icon && (!$iconPosition || $iconPosition === IconPosition::Before))
+            {{ \Filament\Support\generate_icon_html($icon, attributes: new \Illuminate\View\ComponentAttributeBag, size: $iconSize ?? \Filament\Support\Enums\IconSize::Small) }}
+        @endif
+
         {{ $content }}
+
+        @if ($icon && $iconPosition === IconPosition::After)
+            {{ \Filament\Support\generate_icon_html($icon, attributes: new \Illuminate\View\ComponentAttributeBag, size: $iconSize ?? \Filament\Support\Enums\IconSize::Small) }}
+        @endif
     </span>
 @endif


### PR DESCRIPTION
## Description

Adds icon support for `Text` components in normal (non-badge) mode.

## Visual changes

Before: Icons only worked with `->badge()`  
After: Icons work in all modes

```php
Text::make('Label')
    ->icon('heroicon-m-star')
    ->size(TextSize::Large) // Icon scales automatically
```

<img width="1197" height="342" alt="image" src="https://github.com/user-attachments/assets/5073b625-cddc-4948-a7cc-b0227189e204" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.