### PR TITLE
allow usage of the Operation enum in disabledOn method

### DIFF
--- a/packages/forms/docs/01-overview.md
+++ b/packages/forms/docs/01-overview.md
@@ -197,15 +197,9 @@ You can disable a field based on the current operation by passing an operation t
 
 ```php
 use Filament\Forms\Components\Toggle;
-use Filament\Support\Enums\Operation;
 
 Toggle::make('is_admin')
     ->disabledOn('edit')
-    
-// or
-
-Toggle::make('is_admin')
-    ->disabledOn(Operation::Edit)
 
 // is the same as
 
@@ -217,16 +211,9 @@ You can also pass an array of operations to the `disabledOn()` method, and the f
 
 ```php
 use Filament\Forms\Components\Toggle;
-use Filament\Support\Enums\Operation;
 
 Toggle::make('is_admin')
     ->disabledOn(['edit', 'view'])
-    
-// or 
-
-
-Toggle::make('is_admin')
-    ->disabledOn([Operation::Edit, Operation::View])
     
 // is the same as
 

--- a/packages/forms/docs/01-overview.md
+++ b/packages/forms/docs/01-overview.md
@@ -197,9 +197,15 @@ You can disable a field based on the current operation by passing an operation t
 
 ```php
 use Filament\Forms\Components\Toggle;
+use Filament\Support\Enums\Operation;
 
 Toggle::make('is_admin')
     ->disabledOn('edit')
+    
+// or
+
+Toggle::make('is_admin')
+    ->disabledOn(Operation::Edit)
 
 // is the same as
 
@@ -211,9 +217,16 @@ You can also pass an array of operations to the `disabledOn()` method, and the f
 
 ```php
 use Filament\Forms\Components\Toggle;
+use Filament\Support\Enums\Operation;
 
 Toggle::make('is_admin')
     ->disabledOn(['edit', 'view'])
+    
+// or 
+
+
+Toggle::make('is_admin')
+    ->disabledOn([Operation::Edit, Operation::View])
     
 // is the same as
 

--- a/packages/schemas/src/Components/Concerns/CanBeDisabled.php
+++ b/packages/schemas/src/Components/Concerns/CanBeDisabled.php
@@ -5,6 +5,7 @@ namespace Filament\Schemas\Components\Concerns;
 use Closure;
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Support\Enums\Operation;
 use Illuminate\Support\Arr;
 use Livewire\Component as LivewireComponent;
 
@@ -21,12 +22,16 @@ trait CanBeDisabled
     }
 
     /**
-     * @param  string | array<string>  $operations
+     * @param  string | Operation | array<string | Operation>  $operations
      */
-    public function disabledOn(string | array $operations): static
+    public function disabledOn(string | Operation | array $operations): static
     {
         $this->disabled(static function (LivewireComponent & HasSchemas $livewire, string $operation) use ($operations): bool {
             foreach (Arr::wrap($operations) as $disabledOperation) {
+                if ($operation instanceof Operation) {
+                    $operation = $operation->value;
+                }
+
                 if ($disabledOperation === $operation || $livewire instanceof $disabledOperation) {
                     return true;
                 }

--- a/packages/schemas/src/Components/Concerns/CanBeDisabled.php
+++ b/packages/schemas/src/Components/Concerns/CanBeDisabled.php
@@ -28,8 +28,8 @@ trait CanBeDisabled
     {
         $this->disabled(static function (LivewireComponent & HasSchemas $livewire, string $operation) use ($operations): bool {
             foreach (Arr::wrap($operations) as $disabledOperation) {
-                if ($operation instanceof Operation) {
-                    $operation = $operation->value;
+                if ($disabledOperation instanceof Operation) {
+                    $disabledOperation = $disabledOperation->value;
                 }
 
                 if ($disabledOperation === $operation || $livewire instanceof $disabledOperation) {


### PR DESCRIPTION
## Description

this change allows you to use the Operation enum on the disabledOn methods for components. 

## Visual changes

n/a

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
