### PR TITLE
Allow Illuminate\Contracts\Database\Query\Expression for aggregate column arguments

### DIFF
--- a/packages/infolists/src/Components/TextEntry.php
+++ b/packages/infolists/src/Components/TextEntry.php
@@ -21,6 +21,7 @@ use Filament\Support\Enums\IconPosition;
 use Filament\Support\Enums\IconSize;
 use Filament\Support\Enums\TextSize;
 use Filament\Support\View\Components\BadgeComponent;
+use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
@@ -554,7 +555,7 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
     /**
      * @param  string | array<int | string, string | Closure> | Closure | null  $relationship
      */
-    public function avg(string | array | Closure | null $relationship, string | Closure | null $column): static
+    public function avg(string | array | Closure | null $relationship, string | Expression | Closure | null $column): static
     {
         $this->state(function (TextEntry $entry, ?Model $record) use ($relationship, $column): int | float | null {
             if (blank($record)) {
@@ -595,7 +596,7 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
     /**
      * @param  string | array<int | string, string | Closure> | Closure | null  $relationship
      */
-    public function max(string | array | Closure | null $relationship, string | Closure | null $column): static
+    public function max(string | array | Closure | null $relationship, string | Expression | Closure | null $column): static
     {
         $this->state(function (TextEntry $entry, ?Model $record) use ($relationship, $column): int | float | null {
             if (blank($record)) {
@@ -616,7 +617,7 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
     /**
      * @param  string | array<int | string, string | Closure> | Closure | null  $relationship
      */
-    public function min(string | array | Closure | null $relationship, string | Closure | null $column): static
+    public function min(string | array | Closure | null $relationship, string | Expression | Closure | null $column): static
     {
         $this->state(function (TextEntry $entry, ?Model $record) use ($relationship, $column): int | float | null {
             if (blank($record)) {
@@ -637,7 +638,7 @@ class TextEntry extends Entry implements HasAffixActions, HasEmbeddedView
     /**
      * @param  string | array<int | string, string | Closure> | Closure | null  $relationship
      */
-    public function sum(string | array | Closure | null $relationship, string | Closure | null $column): static
+    public function sum(string | array | Closure | null $relationship, string | Expression | Closure | null $column): static
     {
         $this->state(function (TextEntry $entry, ?Model $record) use ($relationship, $column): int | float | null {
             if (blank($record)) {

--- a/packages/support/src/Concerns/CanAggregateRelatedModels.php
+++ b/packages/support/src/Concerns/CanAggregateRelatedModels.php
@@ -3,10 +3,11 @@
 namespace Filament\Support\Concerns;
 
 use Closure;
+use Illuminate\Contracts\Database\Query\Expression;
 
 trait CanAggregateRelatedModels
 {
-    protected string | Closure | null $columnToAvg = null;
+    protected string | Expression | Closure | null $columnToAvg = null;
 
     /**
      * @var string | array<int | string, string | Closure> | Closure | null
@@ -23,21 +24,21 @@ trait CanAggregateRelatedModels
      */
     protected string | array | Closure | null $relationshipsToExistenceCheck = null;
 
-    protected string | Closure | null $columnToMax = null;
+    protected string | Expression | Closure | null $columnToMax = null;
 
     /**
      * @var string | array<int | string, string | Closure> | Closure | null
      */
     protected string | array | Closure | null $relationshipToMax = null;
 
-    protected string | Closure | null $columnToMin = null;
+    protected string | Expression | Closure | null $columnToMin = null;
 
     /**
      * @var string | array<int | string, string | Closure> | Closure | null
      */
     protected string | array | Closure | null $relationshipToMin = null;
 
-    protected string | Closure | null $columnToSum = null;
+    protected string | Expression | Closure | null $columnToSum = null;
 
     /**
      * @var string | array<int | string, string | Closure> | Closure | null
@@ -47,7 +48,7 @@ trait CanAggregateRelatedModels
     /**
      * @param  string | array<int | string, string | Closure> | Closure | null  $relationship
      */
-    public function avg(string | array | Closure | null $relationship, string | Closure | null $column): static
+    public function avg(string | array | Closure | null $relationship, string | Expression | Closure | null $column): static
     {
         $this->columnToAvg = $column;
         $this->relationshipToAvg = $relationship;
@@ -78,7 +79,7 @@ trait CanAggregateRelatedModels
     /**
      * @param  string | array<int | string, string | Closure> | Closure | null  $relationship
      */
-    public function max(string | array | Closure | null $relationship, string | Closure | null $column): static
+    public function max(string | array | Closure | null $relationship, string | Expression | Closure | null $column): static
     {
         $this->columnToMax = $column;
         $this->relationshipToMax = $relationship;
@@ -89,7 +90,7 @@ trait CanAggregateRelatedModels
     /**
      * @param  string | array<int | string, string | Closure> | Closure | null  $relationship
      */
-    public function min(string | array | Closure | null $relationship, string | Closure | null $column): static
+    public function min(string | array | Closure | null $relationship, string | Expression | Closure | null $column): static
     {
         $this->columnToMin = $column;
         $this->relationshipToMin = $relationship;
@@ -100,7 +101,7 @@ trait CanAggregateRelatedModels
     /**
      * @param  string | array<int | string, string | Closure> | Closure | null  $relationship
      */
-    public function sum(string | array | Closure | null $relationship, string | Closure | null $column): static
+    public function sum(string | array | Closure | null $relationship, string | Expression | Closure | null $column): static
     {
         $this->columnToSum = $column;
         $this->relationshipToSum = $relationship;
@@ -108,7 +109,7 @@ trait CanAggregateRelatedModels
         return $this;
     }
 
-    public function getColumnToAvg(): ?string
+    public function getColumnToAvg(): string | Expression | null
     {
         return $this->evaluate($this->columnToAvg);
     }
@@ -137,7 +138,7 @@ trait CanAggregateRelatedModels
         return $this->evaluate($this->relationshipsToExistenceCheck);
     }
 
-    public function getColumnToMax(): ?string
+    public function getColumnToMax(): string | Expression | null
     {
         return $this->evaluate($this->columnToMax);
     }
@@ -150,7 +151,7 @@ trait CanAggregateRelatedModels
         return $this->evaluate($this->relationshipToMax);
     }
 
-    public function getColumnToMin(): ?string
+    public function getColumnToMin(): string | Expression | null
     {
         return $this->evaluate($this->columnToMin);
     }
@@ -163,7 +164,7 @@ trait CanAggregateRelatedModels
         return $this->evaluate($this->relationshipToMin);
     }
 
-    public function getColumnToSum(): ?string
+    public function getColumnToSum(): string | Expression | null
     {
         return $this->evaluate($this->columnToSum);
     }


### PR DESCRIPTION
## Description
Allow Expression instances to be passed. Because Laravel's relationship aggregate functions can accept [expressions for columns](https://github.com/laravel/framework/blob/3ef5c8a85b4c598d5ffaf98afd72f6a5d6a0be2c/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php#L726-L772]). This change enables callers to pass DB::raw(...) or other Expression objects for computed aggregates

```php
TextColumn::make('purchase_items_total_price')
    ->sum('purchaseItems as purchase_items_total_price', DB::raw('price * quantity')),
```

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
