### PR TITLE
feature/action-can-be-defined-as-closure

### DIFF
--- a/packages/tables/docs/04-actions.md
+++ b/packages/tables/docs/04-actions.md
@@ -46,6 +46,22 @@ All methods on the action accept callback functions, where you can access the cu
 
 <AutoScreenshot name="tables/actions/simple" alt="Table with actions" version="4.x" />
 
+You can also provide a callback that returns an action
+
+```php
+use Filament\Tables\Enums\RecordActionsPosition;
+use Filament\Tables\Table;
+use App\Services\PdfRenderService;
+
+public function table(Table $table): Table
+{
+    return $table
+        ->recordActions([
+            fn($record) => app(PdfRenderService::class,['document' => $record])->downloadAction()
+        ]);
+}
+```
+
 ### Positioning record actions before columns
 
 By default, the record actions in your table are rendered in the final cell of each row. You may move them before the columns by using the `position` argument:

--- a/packages/tables/src/Table/Concerns/HasRecordActions.php
+++ b/packages/tables/src/Table/Concerns/HasRecordActions.php
@@ -47,6 +47,9 @@ trait HasRecordActions
     public function pushRecordActions(array | ActionGroup $actions): static
     {
         foreach (Arr::wrap($actions) as $action) {
+            if($action instanceof Closure) {
+                $action = $this->evaluate($action);
+            }
             $action->table($this);
 
             if ($action instanceof ActionGroup) {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

I have some specialised service classes, that I would like to be able to also return a Filament Action. I know this can be done by creating an Action class that calls the service classes, but for small projects this increases my number of classes :)
So if possible, I would like to add the feature that you can also specify an action by calling a closure that returns an action.

In that way I can do: 
```
public function table(Table $table): Table
{
    return $table
        ->recordActions([
            fn($record) => app(PdfRenderService::class,['document' => $record])->downloadAction()
        ]);
```
Where the dowloadAction method returns an Action.

## Visual changes

none

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
