### PR TITLE
Allow chart widgets to have a defined height

### DIFF
--- a/packages/widgets/docs/03-charts.md
+++ b/packages/widgets/docs/03-charts.md
@@ -226,6 +226,14 @@ Alternatively, you may disable polling altogether:
 protected ?string $pollingInterval = null;
 ```
 
+## Setting a chart height
+
+To control the chart size, you can set a fixed height using the `$height`:
+
+```php
+protected ?string $height = '400px';
+```
+
 ## Setting a maximum chart height
 
 You may place a maximum height on the chart to ensure that it doesn't get too big, using the `$maxHeight` property:

--- a/packages/widgets/resources/views/chart-widget.blade.php
+++ b/packages/widgets/resources/views/chart-widget.blade.php
@@ -79,6 +79,7 @@
                             'fi-wi-chart-canvas-ctn-no-aspect-ratio' => filled($maxHeight = $this->getMaxHeight()),
                         ])
                         ->style([
+                            'height: ' . $this->getHeight() => filled($this->getHeight()),
                             'max-height: ' . $maxHeight => filled($maxHeight),
                         ])
                 }}

--- a/packages/widgets/src/ChartWidget.php
+++ b/packages/widgets/src/ChartWidget.php
@@ -29,6 +29,8 @@ abstract class ChartWidget extends Widget implements HasSchemas
 
     protected ?string $description = null;
 
+    protected ?string $height = null;    
+
     protected ?string $maxHeight = null;
 
     /**
@@ -92,6 +94,11 @@ abstract class ChartWidget extends Widget implements HasSchemas
     {
         return $this->description;
     }
+
+    protected function getHeight(): ?string
+    {
+        return $this->height;
+    }    
 
     protected function getMaxHeight(): ?string
     {

--- a/packages/widgets/src/ChartWidget.php
+++ b/packages/widgets/src/ChartWidget.php
@@ -29,7 +29,7 @@ abstract class ChartWidget extends Widget implements HasSchemas
 
     protected ?string $description = null;
 
-    protected ?string $height = null;    
+    protected ?string $height = null;
 
     protected ?string $maxHeight = null;
 

--- a/packages/widgets/src/ChartWidget.php
+++ b/packages/widgets/src/ChartWidget.php
@@ -98,7 +98,7 @@ abstract class ChartWidget extends Widget implements HasSchemas
     protected function getHeight(): ?string
     {
         return $this->height;
-    }    
+    }
 
     protected function getMaxHeight(): ?string
     {


### PR DESCRIPTION
## Description

Add height control for chart widgets

In V3, full-width widgets displayed correctly by filling the entire screen. In V4, they are too slim and barely readable.

Adding a `height` property would allow proper control over widget display and ensure readability.

## Visual changes

V3 

<img width="2191" height="526" alt="image" src="https://github.com/user-attachments/assets/39e68829-e865-4127-a236-98985c8ea504" />

V4

<img width="2191" height="286" alt="image" src="https://github.com/user-attachments/assets/067cbd4b-7bad-4597-be57-5032cdac51f3" />

V4 + Height

<img width="2192" height="535" alt="image" src="https://github.com/user-attachments/assets/23a679fc-d35c-4f17-a207-ca3d9e2a5255" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
