### PR TITLE
Allow customizing the form component class in table filters

### DIFF
--- a/packages/tables/docs/03-filters/01-overview.md
+++ b/packages/tables/docs/03-filters/01-overview.md
@@ -94,6 +94,20 @@ Filter::make('is_featured')
 
 <UtilityInjection set="tableFilters" version="5.x" extras="Field;;Filament\Forms\Components\Field;;$field;;The field object to modify.">The function passed to `modifyFormFieldUsing()` can inject various utilities as parameters.</UtilityInjection>
 
+### Using a custom form component class
+
+If you want to use your own custom form component class for the filter instead of the built-in ones, you can use the `formComponent()` method:
+
+```php
+use App\Filament\Forms\Components\CustomCheckbox;
+use Filament\Tables\Filters\Filter;
+
+Filter::make('is_featured')
+    ->formComponent(CustomCheckbox::class)
+```
+
+This is useful if you have extended the base [Checkbox](../../forms/checkbox) or [Toggle](../../forms/toggle) component with additional functionality that you want to use in your filter.
+
 ## Applying the filter by default
 
 You may set a filter to be enabled by default, using the `default()` method:

--- a/packages/tables/docs/03-filters/02-select.md
+++ b/packages/tables/docs/03-filters/02-select.md
@@ -170,3 +170,22 @@ SelectFilter::make('status')
 
 <UtilityInjection set="tableFilters" version="5.x">As well as allowing a static value, the `default()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
+## Using a custom select component class
+
+If you want to use your own custom select component class instead of the built-in `Select` component, you can use the `formComponent()` method:
+
+```php
+use App\Filament\Forms\Components\CustomSelect;
+use Filament\Tables\Filters\SelectFilter;
+
+SelectFilter::make('status')
+    ->formComponent(CustomSelect::class)
+    ->options([
+        'draft' => 'Draft',
+        'reviewing' => 'Reviewing',
+        'published' => 'Published',
+    ])
+```
+
+This is useful if you have extended the base [Select](../../forms/select) component with additional functionality, such as custom styling or behavior, that you want to use in your filter. Your custom component must extend `Filament\Forms\Components\Select`.
+

--- a/packages/tables/src/Filters/Filter.php
+++ b/packages/tables/src/Filters/Filter.php
@@ -8,6 +8,9 @@ use Filament\Forms\Components\Toggle;
 
 class Filter extends BaseFilter
 {
+    /**
+     * @var class-string<Field>
+     */
     protected string $formComponent = Checkbox::class;
 
     protected function setUp(): void

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -20,6 +20,11 @@ class SelectFilter extends BaseFilter
     use Concerns\HasPlaceholder;
     use Concerns\HasRelationship;
 
+    /**
+     * @var class-string<Select>
+     */
+    protected string $formComponent = Select::class;
+
     protected string | Closure | null $attribute = null;
 
     protected bool | Closure $isMultiple = false;
@@ -317,9 +322,19 @@ class SelectFilter extends BaseFilter
         return $this->evaluate($this->isSearchForcedCaseInsensitive);
     }
 
+    /**
+     * @param  class-string<Select>  $component
+     */
+    public function formComponent(string $component): static
+    {
+        $this->formComponent = $component;
+
+        return $this;
+    }
+
     public function getFormField(): Select
     {
-        $field = Select::make($this->isMultiple() ? 'values' : 'value')
+        $field = $this->formComponent::make($this->isMultiple() ? 'values' : 'value')
             ->label($this->getLabel())
             ->multiple($this->isMultiple())
             ->placeholder($this->getPlaceholder())

--- a/tests/src/Tables/Filters/SelectFilterTest.php
+++ b/tests/src/Tables/Filters/SelectFilterTest.php
@@ -431,6 +431,17 @@ it('can get `getFormField()` with relationship configuration', function (): void
     expect($formField->isPreloaded())->toBeTrue();
 });
 
+it('can use `formComponent()` to change the component class', function (): void {
+    $filter = Tables\Filters\SelectFilter::make('status')
+        ->formComponent(CustomSelectComponent::class)
+        ->options(['active' => 'Active', 'inactive' => 'Inactive']);
+
+    $formField = $filter->getFormField();
+
+    expect($formField)->toBeInstanceOf(CustomSelectComponent::class);
+    expect($formField->getName())->toBe('value');
+});
+
 it('returns empty options when relationship is searchable without preload via `getFormField()`', function (): void {
     User::factory()->count(3)->create();
 
@@ -597,4 +608,9 @@ class TestTableWithCustomRelationshipLabelFilter extends Component implements Ha
     {
         return view('livewire.table');
     }
+}
+
+class CustomSelectComponent extends Select
+{
+    //
 }


### PR DESCRIPTION
## Summary
- Adds `formComponent()` method to `SelectFilter` to allow using custom `Select` components
- Includes test and documentation

## Changes

This PR adds the ability to customize the form component class used by `SelectFilter` (and by extension `TernaryFilter` which inherits from it), following the same pattern already established in the base `Filter` class.

**Use case:** Users who have extended the base `Select` component with additional functionality (custom styling, behavior, or third-party integrations) can now use their custom component in select filters.

## Usage

```php
use App\Forms\Components\CustomSelect;
use Filament\Tables\Filters\SelectFilter;

SelectFilter::make('status')
    ->formComponent(CustomSelect::class)
    ->options([
        'draft' => 'Draft',
        'reviewing' => 'Reviewing',
        'published' => 'Published',
    ])
```

This also works with `TernaryFilter`.