### PR TITLE
Add support for extra attributes on sidebar `NavigationItem`

### DIFF
--- a/packages/panels/resources/views/components/page/sub-navigation/mobile-menu.blade.php
+++ b/packages/panels/resources/views/components/page/sub-navigation/mobile-menu.blade.php
@@ -53,6 +53,7 @@
                         $navigationItemIcon = $navigationItem->isActive() ? ($navigationItem->getActiveIcon() ?? $navigationItem->getIcon()) : $navigationItem->getIcon();
                         $navigationItemUrl = $navigationItem->getUrl();
                         $shouldNavigationItemOpenUrlInNewTab = $navigationItem->shouldOpenUrlInNewTab();
+                        $navigationItemExtraAttributes = $navigationItemChild->getExtraAttributeBag();
                     @endphp
 
                     <x-filament::dropdown.list.item
@@ -62,6 +63,7 @@
                         :icon="$navigationItemIcon"
                         tag="a"
                         :target="$shouldNavigationItemOpenUrlInNewTab ? '_blank' : null"
+                        :attributes="\Filament\Support\prepare_inherited_attributes($navigationItemExtraAttributes)"
                     >
                         {{ $navigationItemChild->getLabel() }}
                     </x-filament::dropdown.list.item>

--- a/packages/panels/resources/views/components/page/sub-navigation/tabs.blade.php
+++ b/packages/panels/resources/views/components/page/sub-navigation/tabs.blade.php
@@ -31,6 +31,7 @@
                             $navigationItemIcon = $navigationItem->isActive() ? ($navigationItem->getActiveIcon() ?? $navigationItem->getIcon()) : $navigationItem->getIcon();
                             $navigationItemUrl = $navigationItem->getUrl();
                             $shouldNavigationItemOpenUrlInNewTab = $navigationItem->shouldOpenUrlInNewTab();
+                            $navigationItemExtraAttributes = $navigationItem->getExtraAttributeBag();
                         @endphp
 
                         <x-filament::dropdown.list.item
@@ -40,6 +41,7 @@
                             :icon="$navigationItemIcon"
                             tag="a"
                             :target="$shouldNavigationItemOpenUrlInNewTab ? '_blank' : null"
+                            :attributes="\Filament\Support\prepare_inherited_attributes($navigationItemExtraAttributes)"
                         >
                             {{ $navigationItem->getLabel() }}
 
@@ -61,6 +63,7 @@
                     $navigationItemIcon = $navigationItem->isActive() ? ($navigationItem->getActiveIcon() ?? $navigationItem->getIcon()) : $navigationItem->getIcon();
                     $navigationItemUrl = $navigationItem->getUrl();
                     $shouldNavigationItemOpenUrlInNewTab = $navigationItem->shouldOpenUrlInNewTab();
+                    $navigationItemExtraAttributes = $navigationItem->getExtraAttributeBag();
                 @endphp
 
                 <x-filament::tabs.item
@@ -71,6 +74,7 @@
                     :icon="$navigationItemIcon"
                     tag="a"
                     :target="$shouldNavigationItemOpenUrlInNewTab ? '_blank' : null"
+                    :attributes="\Filament\Support\prepare_inherited_attributes($navigationItemExtraAttributes)"
                 >
                     {{ $navigationItem->getLabel() }}
 

--- a/packages/panels/resources/views/components/sidebar/group.blade.php
+++ b/packages/panels/resources/views/components/sidebar/group.blade.php
@@ -129,6 +129,7 @@
                             $itemUrl = $item->getUrl();
                             $itemIcon = $itemIsActive ? ($item->getActiveIcon() ?? $item->getIcon()) : $item->getIcon();
                             $shouldItemOpenUrlInNewTab = $item->shouldOpenUrlInNewTab();
+                            $itemExtraAttributes = $item->getExtraAttributeBag();
                         @endphp
 
                         <x-filament::dropdown.list.item
@@ -140,6 +141,7 @@
                             :icon="$itemIcon"
                             tag="a"
                             :target="$shouldItemOpenUrlInNewTab ? '_blank' : null"
+                            :attributes="\Filament\Support\prepare_inherited_attributes($itemExtraAttributes)"
                         >
                             {{ $item->getLabel() }}
                         </x-filament::dropdown.list.item>

--- a/packages/panels/resources/views/components/sidebar/group.blade.php
+++ b/packages/panels/resources/views/components/sidebar/group.blade.php
@@ -190,7 +190,6 @@
             @endphp
 
             <x-filament-panels::sidebar.item
-                :attributes="\Filament\Support\prepare_inherited_attributes($itemExtraAttributes)"
                 :active="$isItemActive"
                 :active-child-items="$isItemChildItemsActive"
                 :active-icon="$itemActiveIcon"
@@ -206,6 +205,7 @@
                 :sidebar-collapsible="$sidebarCollapsible"
                 :sub-navigation="$subNavigation"
                 :url="$itemUrl"
+                :attributes="\Filament\Support\prepare_inherited_attributes($itemExtraAttributes)"
             >
                 {{ $item->getLabel() }}
 

--- a/packages/panels/resources/views/components/sidebar/group.blade.php
+++ b/packages/panels/resources/views/components/sidebar/group.blade.php
@@ -177,6 +177,7 @@
                 $itemIcon = $item->getIcon();
                 $shouldItemOpenUrlInNewTab = $item->shouldOpenUrlInNewTab();
                 $itemUrl = $item->getUrl();
+                $itemExtraAttributes = $item->getExtraAttributeBag();
 
                 if ($icon) {
                     if ($hasDropdown || (blank($itemIcon) && blank($itemActiveIcon))) {
@@ -189,6 +190,7 @@
             @endphp
 
             <x-filament-panels::sidebar.item
+                :attributes="\Filament\Support\prepare_inherited_attributes($itemExtraAttributes)"
                 :active="$isItemActive"
                 :active-child-items="$isItemChildItemsActive"
                 :active-icon="$itemActiveIcon"

--- a/packages/panels/resources/views/components/sidebar/item.blade.php
+++ b/packages/panels/resources/views/components/sidebar/item.blade.php
@@ -125,6 +125,7 @@
                     $childItemIcon = $childItem->getIcon();
                     $shouldChildItemOpenUrlInNewTab = $childItem->shouldOpenUrlInNewTab();
                     $childItemUrl = $childItem->getUrl();
+                    $childItemExtraAttributes = $childItem->getExtraAttributeBag();
                 @endphp
 
                 <x-filament-panels::sidebar.item
@@ -142,6 +143,7 @@
                     sub-grouped
                     :sub-navigation="$subNavigation"
                     :url="$childItemUrl"
+                    :attributes="\Filament\Support\prepare_inherited_attributes($childItemExtraAttributes)"
                 >
                     {{ $childItem->getLabel() }}
                 </x-filament-panels::sidebar.item>

--- a/packages/panels/resources/views/components/topbar/item.blade.php
+++ b/packages/panels/resources/views/components/topbar/item.blade.php
@@ -13,10 +13,14 @@
     $tag = $url ? 'a' : 'button';
 @endphp
 
-<li @class([
-    'fi-topbar-item',
-    'fi-active' => $active,
-])>
+<li
+    {{
+        $attributes->class([
+            'fi-topbar-item',
+            'fi-active' => $active,
+        ])
+    }}
+>
     <{{ $tag }}
         @if ($url)
             {{ \Filament\Support\generate_href_html($url, $shouldOpenUrlInNewTab) }}

--- a/packages/panels/resources/views/livewire/topbar.blade.php
+++ b/packages/panels/resources/views/livewire/topbar.blade.php
@@ -179,6 +179,7 @@
                                                 $itemUrl = $item->getUrl();
                                                 $itemIcon = $isItemActive ? ($item->getActiveIcon() ?? $item->getIcon()) : $item->getIcon();
                                                 $shouldItemOpenUrlInNewTab = $item->shouldOpenUrlInNewTab();
+                                                $itemExtraAttributes = $item->getExtraAttributeBag();
                                             @endphp
 
                                             <x-filament::dropdown.list.item
@@ -190,6 +191,7 @@
                                                 :icon="$itemIcon"
                                                 tag="a"
                                                 :target="$shouldItemOpenUrlInNewTab ? '_blank' : null"
+                                                :attributes="\Filament\Support\prepare_inherited_attributes($itemExtraAttributes)"
                                             >
                                                 {{ $item->getLabel() }}
                                             </x-filament::dropdown.list.item>
@@ -208,6 +210,7 @@
                                     $itemIcon = $item->getIcon();
                                     $shouldItemOpenUrlInNewTab = $item->shouldOpenUrlInNewTab();
                                     $itemUrl = $item->getUrl();
+                                    $itemExtraAttributes = $item->getExtraAttributeBag();
                                 @endphp
 
                                 <x-filament-panels::topbar.item
@@ -219,6 +222,7 @@
                                     :icon="$itemIcon"
                                     :should-open-url-in-new-tab="$shouldItemOpenUrlInNewTab"
                                     :url="$itemUrl"
+                                    :attributes="\Filament\Support\prepare_inherited_attributes($itemExtraAttributes)"
                                 >
                                     {{ $item->getLabel() }}
                                 </x-filament-panels::topbar.item>

--- a/packages/panels/src/Navigation/NavigationItem.php
+++ b/packages/panels/src/Navigation/NavigationItem.php
@@ -6,6 +6,7 @@ use BackedEnum;
 use Closure;
 use Filament\Support\Components\Component;
 use Filament\Support\Concerns\HasBadgeTooltip;
+use Filament\Support\Concerns\HasExtraAttributes;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Htmlable;
 use LogicException;
@@ -14,6 +15,7 @@ use UnitEnum;
 class NavigationItem extends Component
 {
     use HasBadgeTooltip;
+    use HasExtraAttributes;
 
     protected string | UnitEnum | Closure | null $group = null;
 


### PR DESCRIPTION
## Description

Introduces the HasExtraAttributes trait to NavigationItem and updates the sidebar group Blade view to pass extra attributes to sidebar items. This allows for more flexible customization of sidebar item components while maintaining the same look and responsiveness.

For example:
- opening globally registered modal using `['x-on:click.prevent' => "$wire.dispatch('open-custom-modal')"]`
- add custom classes on demand for targeting with css, for example making primary color of the first navigation item that is made for call to action behavior

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
