### PR TITLE
fix: remove duplicate applySortingToTableQuery call in HasBulkActions

### DIFF
--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -308,7 +308,13 @@ trait HasBulkActions
 
         $relationship = $table->selectPivotDataInQuery($relationship);
 
-        return $relationship->getQuery();
+        $query = $relationship->getQuery();
+
+        if (! $chunkSize) {
+            $this->applySortingToTableQuery($query);
+        }
+
+        return $query;
     }
 
     /**

--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -231,10 +231,6 @@ trait HasBulkActions
 
         $query = $this->getSelectedTableRecordsQuery($shouldFetchSelectedRecords, $chunkSize);
 
-        if (! $chunkSize) {
-            $this->applySortingToTableQuery($query);
-        }
-
         if (! $shouldFetchSelectedRecords) {
             return $this->cachedSelectedTableRecords = $query->toBase()->pluck($query->getModel()->getQualifiedKeyName());
         }


### PR DESCRIPTION
## Summary

This PR fixes a bug where `applySortingToTableQuery()` was being called twice when executing bulk actions, causing SQL errors on SQL Server.

### The Problem

When executing a bulk action, the `applySortingToTableQuery()` method was called twice on the same query object:
1. First in `getSelectedTableRecordsQuery()` at line 273
2. Then again in `getSelectedTableRecords()` at line 235

This resulted in duplicate ORDER BY clauses, which causes SQL Server (and likely other databases that enforce unique columns in ORDER BY) to throw an error:

```
SQLSTATE[42000]: A column has been specified more than once in the order by list.
Columns in the order by list must be unique.
```

### The Fix

Remove the redundant `applySortingToTableQuery()` call from `getSelectedTableRecords()` since it's already being called within `getSelectedTableRecordsQuery()`.

Fixes #18991

## Test plan

- [x] Verified the duplicate call is removed
- [ ] Test bulk actions on SQL Server with sorted columns
- [ ] Test bulk actions on other databases to ensure no regression

🤖 Generated with [Claude Code](https://claude.ai/code)