### PR TITLE
Fallback to existing mention label if provider does not return a label

### DIFF
--- a/packages/forms/src/Components/RichEditor/RichContentRenderer.php
+++ b/packages/forms/src/Components/RichEditor/RichContentRenderer.php
@@ -294,10 +294,6 @@ class RichContentRenderer implements Htmlable
                 return;
             }
 
-            if (filled($node->attrs->label ?? null)) {
-                return;
-            }
-
             $char = $node->attrs->char ?? '@';
             $mentionsByChar[$char][] = (string) $id;
         });
@@ -330,7 +326,7 @@ class RichContentRenderer implements Htmlable
                 return;
             }
 
-            $label = $node->attrs->label ?? $labelsByChar[$char][(string) $id] ?? (string) $id;
+            $label = $labelsByChar[$char][(string) $id] ?? $node->attrs->label ?? (string) $id;
             $node->attrs->label = $label;
 
             $url = $provider->getUrl((string) $id, $label);

--- a/packages/forms/src/Components/RichEditor/StateCasts/RichEditorStateCast.php
+++ b/packages/forms/src/Components/RichEditor/StateCasts/RichEditorStateCast.php
@@ -59,6 +59,10 @@ class RichEditorStateCast implements StateCast
                     return;
                 }
 
+                if (isset($node->attrs->label) && $node->attrs->label) {
+                    return;
+                }
+
                 unset($node->attrs->label);
             });
         }

--- a/packages/forms/src/Components/RichEditor/StateCasts/RichEditorStateCast.php
+++ b/packages/forms/src/Components/RichEditor/StateCasts/RichEditorStateCast.php
@@ -53,20 +53,6 @@ class RichEditorStateCast implements StateCast
             });
         }
 
-        if ($this->richEditor->getMentionProviders()) {
-            $editor->descendants(function (object &$node): void {
-                if ($node->type !== 'mention') {
-                    return;
-                }
-
-                if (isset($node->attrs->label) && $node->attrs->label) {
-                    return;
-                }
-
-                unset($node->attrs->label);
-            });
-        }
-
         return $editor->{$this->richEditor->isJson() ? 'getDocument' : 'getHtml'}();
     }
 

--- a/tests/src/Forms/Components/RichEditor/RichContentRendererTest.php
+++ b/tests/src/Forms/Components/RichEditor/RichContentRendererTest.php
@@ -631,9 +631,7 @@ it('handles multiple mention providers with different chars', function (): void 
     expect($html)->toContain('#issue-123');
 });
 
-it('preserves existing labels and does not refetch them', function (): void {
-    $fetchCount = 0;
-
+it('falls back to existing label when provider returns no label', function (): void {
     $renderer = RichContentRenderer::make([
         'type' => 'doc',
         'content' => [
@@ -643,9 +641,9 @@ it('preserves existing labels and does not refetch them', function (): void {
                     [
                         'type' => 'mention',
                         'attrs' => [
-                            'id' => '1',
-                            'label' => 'Existing Label',
+                            'id' => '999',
                             'char' => '@',
+                            'label' => 'Existing Label',
                         ],
                     ],
                 ],
@@ -655,21 +653,15 @@ it('preserves existing labels and does not refetch them', function (): void {
 
     $renderer->mentions([
         MentionProvider::make('@')
-            ->getLabelsUsing(function (array $ids) use (&$fetchCount): array {
-                $fetchCount++;
-
-                return ['1' => 'New Label'];
-            }),
+            ->getLabelsUsing(fn (array $ids): array => []),
     ]);
 
     $html = $renderer->toUnsafeHtml();
 
-    expect($fetchCount)->toBe(0);
     expect($html)->toContain('@Existing Label');
-    expect($html)->not->toContain('New Label');
 });
 
-it('falls back to id as label when provider returns no label', function (): void {
+it('falls back to id as label when provider returns no label and no label is set', function (): void {
     $renderer = RichContentRenderer::make([
         'type' => 'doc',
         'content' => [


### PR DESCRIPTION
## Description

This PR changes the mention rendering to fallback to the stored label in the database according to the discussion here: https://github.com/filamentphp/filament/discussions/18984

In addition the label gets persisted to the database even if a `MentionProvider` is available (otherwise there is nothing to fall back to).

## Visual changes

Before (when user is not available anymore):
<img width="368" height="74" alt="CleanShot 2026-01-18 at 12 08 01@2x" src="https://github.com/user-attachments/assets/feac9c54-633e-457e-926c-fbde14d494d5" />

After:
<img width="430" height="66" alt="CleanShot 2026-01-18 at 12 10 23@2x" src="https://github.com/user-attachments/assets/902674e7-c3c7-40b2-8a6d-d70afe754894" />


_When the provider returns a label (in my case, the user still exists), there is no visual change._


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] ~~Documentation is up-to-date.~~(no change required)
