### PR TITLE
[5.x] docs(ai): update installation instructions for Blueprint v2.0

### DIFF
--- a/docs/01-introduction/03-ai.md
+++ b/docs/01-introduction/03-ai.md
@@ -68,8 +68,18 @@ Once you have [purchased a license for Blueprint](https://packages.filamentphp.c
 ```bash
 composer config repositories.filament composer https://packages.filamentphp.com/composer
 composer config --auth http-basic.packages.filamentphp.com "YOUR_EMAIL_ADDRESS" "YOUR_LICENSE_KEY"
-composer require filament/blueprint --dev
+composer require filament/blueprint:"^2.0" --dev
 ```
+
+<Aside variant="warning">
+    When using Windows PowerShell to install Blueprint, you may need to run the command below, since it ignores `^` characters in version constraints:
+
+    ```bash
+    composer config repositories.filament composer https://packages.filamentphp.com/composer
+    composer config --auth http-basic.packages.filamentphp.com "YOUR_EMAIL_ADDRESS" "YOUR_LICENSE_KEY"
+    composer require filament/blueprint:"~2.0" --dev
+    ```
+</Aside>
 
 Then run the Boost installer and select **Filament Blueprint** when prompted:
 


### PR DESCRIPTION
Update composer commands in the documentation to specify the Blueprint version as "^2.0". Add a warning and alternate installation steps for Windows PowerShell users to address version constraint issues with `^`.