### PR TITLE
[4.x] docs(ai): update installation instructions for Blueprint v1.0

### DIFF
--- a/docs/01-introduction/03-ai.md
+++ b/docs/01-introduction/03-ai.md
@@ -68,8 +68,19 @@ Once you have [purchased a license for Blueprint](https://packages.filamentphp.c
 ```bash
 composer config repositories.filament composer https://packages.filamentphp.com/composer
 composer config --auth http-basic.packages.filamentphp.com "YOUR_EMAIL_ADDRESS" "YOUR_LICENSE_KEY"
-composer require filament/blueprint --dev
+composer require filament/blueprint:"^1.0" --dev
 ```
+
+<Aside variant="warning">
+    When using Windows PowerShell to install Blueprint, you may need to run the command below, since it ignores `^` characters in version constraints:
+
+    ```bash
+    composer config repositories.filament composer https://packages.filamentphp.com/composer
+    composer config --auth http-basic.packages.filamentphp.com "YOUR_EMAIL_ADDRESS" "YOUR_LICENSE_KEY"
+    composer require filament/blueprint:"~1.0" --dev
+    ```
+</Aside>
+
 
 Then run the Boost installer and select **Filament Blueprint** when prompted:
 


### PR DESCRIPTION
Updated the installation instructions for Blueprint to clarify the use of version constraints in Composer, particularly for Windows PowerShell users. Highlighted the need to use `~1.0` instead of `^1.0` for proper compatibility.