### PR TITLE
Fix/form novalidate for livewire 4

### DIFF
--- a/packages/schemas/resources/views/components/form.blade.php
+++ b/packages/schemas/resources/views/components/form.blade.php
@@ -3,6 +3,7 @@
         $attributes
             ->merge([
                 'id' => $getId(),
+                'novalidate' => true,
                 'wire:submit' => $getLivewireSubmitHandler(),
             ], escape: false)
             ->merge($getExtraAttributes(), escape: false)

--- a/tests/src/Panels/Resources/Pages/CreateRecordTest.php
+++ b/tests/src/Panels/Resources/Pages/CreateRecordTest.php
@@ -273,3 +273,11 @@ it('does not render page if the policy create returns a denied response', functi
 
     app()->bind(TicketPolicy::class . '::create', fn (): bool => true);
 });
+
+it('displays Filament validation errors when submitting a form with empty required fields in the browser', function (): void {
+    visit(PostResource::getUrl('create'))
+        ->assertSee('Create post')
+        ->click('.fi-sc-form button[type="submit"]')
+        ->waitForText('The title field is required')
+        ->assertSee('The title field is required');
+});


### PR DESCRIPTION
## Description

This PR fixes #18992 

Livewire 4 changed how form submissions interact with native browser HTML5 validation. Without novalidate on the form element, the browser's native validation blocks form submission before Livewire can process it, preventing Filament's validation UI (highlighted fields, custom error messages) from displaying. Users only see the browser's native validation tooltip instead.                                                                                                                

This was confirmed by comparing Filament v4.5.2 and v5.0.0 - the form templates are identical, with the only difference being Livewire ^3.5 → ^4.0.

The fix: Add novalidate attribute to the form element in packages/schemas/resources/views/components/form.blade.php. This is standard practice for JavaScript-driven forms and allows Livewire/Laravel to handle validation server-side with Filament's styled UI.                                                                      
                                                                                                                                                                      
Testing: Added a browser test that verifies Filament validation errors display when submitting a form with empty required fields.

## Visual changes

Screenshot 1 - Current behaviour in Laravel 5 (the server side validation is blocked by browser validation) 
<img width="3008" height="2211" alt="image" src="https://github.com/user-attachments/assets/1a448b78-9205-448d-8241-60b19cfd0b2b" />

Screenshot 2 - After applying novalidate to the form element 
<img width="3008" height="2206" alt="image" src="https://github.com/user-attachments/assets/320e007f-55fb-4dec-8f27-ee541f2c037a" />

Screenshot 2 aligns with existing functionality on filament v4, due to the difference in livewire versions. Although this issue stems from livewire changes, the included change improves the robustness of filament to control this aspect of form validation and the inclusion of the new test will flag any breaking changes. 


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.