### PR TITLE
Fix Infolist entries namespace in boost guidelines

### DIFF
--- a/packages/panels/resources/boost/guidelines/core.blade.php
+++ b/packages/panels/resources/boost/guidelines/core.blade.php
@@ -122,7 +122,7 @@ Authenticate before testing panel functionality. Filament uses Livewire, so use 
 
 **Commonly Incorrect Namespaces:**
 - Form fields (TextInput, Select, etc.): `Filament\Forms\Components\`
-- Infolist entries (for read-only views) (TextEntry, IconEntry, etc.): `Filament\Forms\Components\`
+- Infolist entries (for read-only views) (TextEntry, IconEntry, etc.): `Filament\Infolists\Components\`
 - Layout components (Grid, Section, Fieldset, Tabs, Wizard, etc.): `Filament\Schemas\Components\`
 - Schema utilities (Get, Set, etc.): `Filament\Schemas\Components\Utilities\`
 - Actions: `Filament\Actions\` (no `Filament\Tables\Actions\` etc.)


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

The boost guidelines incorrectly reference `Filament\Forms\Components\` for Infolist entries. The correct namespace is
  `Filament\Infolists\Components\`.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
