### PR TITLE
fix: ensure action is unmounted on validation exception。

### DIFF
--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -170,6 +170,10 @@ trait InteractsWithActions
             $this->unmountAction(canCancelParentActions: false);
 
             return null;
+        } catch (ValidationException $exception) {
+            $this->unmountAction(canCancelParentActions: false);
+
+            throw $exception;
         }
 
         if (! $this->mountedActionShouldOpenModal(mountedAction: $action)) {


### PR DESCRIPTION
## Description

fixes: #18687 

fix: Before mounting an action, if a ValidationException is thrown, call `unmountAction` so that form validation errors render correctly.

It requires developers to verify by themselves in `mountUsing`.


Alternative: add a preMountFieldValidation() method to validate form fields before the modal is mounted/opened



```php

Repeater::make('sec')
    ->minItems(1)
    ->defaultItems(1)
    ->required()
    ->columnSpanFull()
    ->extraItemActions([
        Action::make('fields options')
            ->slideOver()
            ->mountUsing(function (Repeater $component, $arguments){
                $component->getChildSchema($arguments['item'])->validate();

                // or auto validate
                // $component->getItemState($arguments['item']);
            })
            ->modalHeading(function(Repeater $component, $arguments) {
                return $component->getItemState($arguments['item'])['title'];
            })
            ->schema([
                Textarea::make('desc')
                    ->nullable(),
            ])
    ])
    ->schema(function () {
        return [
            TextInput::make('title')
                ->required()
        ];
    });

```

## Visual changes

# before

Calling `getItemState` directly within `modalHeading` will result in a `ValidationException`.

https://github.com/user-attachments/assets/c79604c0-13c9-434e-8861-9a25f33dade5



# after


Call the verification in the `mountUsing`.

https://github.com/user-attachments/assets/68ab718c-2734-4bed-bf9f-9d1d52922962




## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
