### PR TITLE
Allow configuring default grid breakpoint

### DIFF
--- a/packages/schemas/docs/02-layouts.md
+++ b/packages/schemas/docs/02-layouts.md
@@ -23,7 +23,7 @@ You may also [create your own custom layout components](custom-components#custom
 
 All layout components have a `columns()` method that you can use in a couple of different ways:
 
-- You can pass an integer like `columns(2)`. This integer is the number of columns used on the `lg` breakpoint and higher. All smaller devices will have just 1 column.
+- You can pass an integer like `columns(2)`. This integer is the number of columns used on the [default grid breakpoint](#changing-the-default-grid-breakpoint) (`lg` by default) and higher. All smaller devices will have just 1 column.
 - You can pass an array, where the key is the breakpoint and the value is the number of columns. For example, `columns(['md' => 2, 'xl' => 4])` will create a 2 column layout on medium devices, and a 4 column layout on extra large devices. The default breakpoint for smaller devices uses 1 column, unless you use a `default` array key.
 
 Breakpoints (`sm`, `md`, `lg`, `xl`, `2xl`) are defined by Tailwind, and can be found in the [Tailwind documentation](https://tailwindcss.com/docs/responsive-design#overview).
@@ -34,9 +34,9 @@ Breakpoints (`sm`, `md`, `lg`, `xl`, `2xl`) are defined by Tailwind, and can be 
 
 In addition to specifying how many columns a layout component should have, you may also specify how many columns a component should fill within the parent grid, using the `columnSpan()` method. This method accepts an integer or an array of breakpoints and column spans:
 
-- You can pass an integer like `columnSpan(2)`. This integer is the number of columns that are consumed on the `lg` breakpoint and higher. All smaller devices span just 1 column.
+- You can pass an integer like `columnSpan(2)`. This integer is the number of columns that are consumed on the [default grid breakpoint](#changing-the-default-grid-breakpoint) (`lg` by default) and higher. All smaller devices span just 1 column.
 - `columnSpan(['md' => 2, 'xl' => 4])` will make the component fill up to 2 columns on medium devices, and up to 4 columns on extra large devices. The default breakpoint for smaller devices uses 1 column, unless you use a `default` array key.
-- `columnSpan('full')` will make the component fill the full width of the parent grid on the `lg` breakpoint and higher, regardless of how many columns there are. All smaller devices span just 1 column.
+- `columnSpan('full')` will make the component fill the full width of the parent grid on the [default grid breakpoint](#changing-the-default-grid-breakpoint) (`lg` by default) and higher, regardless of how many columns there are. All smaller devices span just 1 column.
 - `columnSpanFull()` will make the component fill the full width of the parent grid on all devices, regardless of how many columns it has.
 
 <UtilityInjection set="schemaComponents" version="5.x">As well as allowing a static value, the `columnSpan()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
@@ -45,7 +45,7 @@ In addition to specifying how many columns a layout component should have, you m
 
 If you want to start a component in a grid at a specific column, you can use the `columnStart()` method. This method accepts an integer, or an array of breakpoints and which column the component should start at:
 
-- You can pass an integer like `columnStart(2)`. This integer is column that the component will start on for the `lg` breakpoint and higher. All smaller devices start the component on the first column.
+- You can pass an integer like `columnStart(2)`. This integer is column that the component will start on for the [default grid breakpoint](#changing-the-default-grid-breakpoint) (`lg` by default) and higher. All smaller devices start the component on the first column.
 - `columnStart(['md' => 2, 'xl' => 4])` will make the component start at column 2 on medium devices, and at column 4 on extra large devices. The default breakpoint for smaller devices uses 1 column, unless you use a `default` array key.
 
 ```php
@@ -77,7 +77,7 @@ In this example, the grid has 3 columns on small devices, 6 columns on extra lar
 
 If you want to control the visual order of components in a grid without changing their position in the markup, you can use the `columnOrder()` method. This method accepts an integer, a closure, or an array of breakpoints and order values:
 
-- You can pass an integer like `columnOrder(2)`. This integer is the order that the component will appear in for the `lg` breakpoint and higher. All smaller devices use the default order, unless you use a `default` array key.
+- You can pass an integer like `columnOrder(2)`. This integer is the order that the component will appear in for the [default grid breakpoint](#changing-the-default-grid-breakpoint) (`lg` by default) and higher. All smaller devices use the default order, unless you use a `default` array key.
 - `columnOrder(['md' => 2, 'xl' => 4])` will set the component's order to 2 on medium devices, and to 4 on extra large devices. The default breakpoint for smaller devices uses the default order, unless you use a `default` array key.
 - `columnOrder(fn () => 1)` will dynamically calculate the order using a closure.
 
@@ -177,6 +177,24 @@ Section::make()
 ```
 
 In this example, on screens smaller than the `xl` breakpoint, the email field will appear first followed by the name field. On screens larger than the `xl` breakpoint, the order is reversed with the name field appearing first followed by the email field.
+
+### Changing the default grid breakpoint
+
+By default, when you pass a simple integer to `columns()`, `columnSpan()`, `columnStart()`, or `columnOrder()`, the value is applied at the `lg` breakpoint and higher. You can change this default breakpoint globally in your `config/filament.php` configuration file:
+
+```php
+'default_grid_breakpoint' => '2xl',
+```
+
+Alternatively, you can set the default breakpoint programmatically at runtime, typically in a service provider:
+
+```php
+use Filament\Support\Facades\FilamentGrid;
+
+FilamentGrid::defaultBreakpoint('xl');
+```
+
+After changing the default breakpoint, all integer values passed to grid methods will be applied at your configured breakpoint instead of `lg`. For example, with `'default_grid_breakpoint' => '2xl'`, calling `columns(3)` will apply 3 columns at the `2xl` breakpoint and higher.
 
 ## Basic layout components
 

--- a/packages/schemas/src/Components/Concerns/HasContainerGridLayout.php
+++ b/packages/schemas/src/Components/Concerns/HasContainerGridLayout.php
@@ -3,6 +3,7 @@
 namespace Filament\Schemas\Components\Concerns;
 
 use Closure;
+use Filament\Support\Facades\FilamentGrid;
 
 trait HasContainerGridLayout
 {
@@ -24,7 +25,7 @@ trait HasContainerGridLayout
 
         if (! is_array($columns)) {
             $columns = [
-                'lg' => $columns,
+                FilamentGrid::getDefaultBreakpoint() => $columns,
             ];
         }
 
@@ -71,7 +72,7 @@ trait HasContainerGridLayout
             }
 
             if (! is_string($gridColumnBreakpoint)) {
-                $columns['lg'] = $gridColumn;
+                $columns[FilamentGrid::getDefaultBreakpoint()] = $gridColumn;
 
                 unset($columns[$gridColumnBreakpoint]);
 

--- a/packages/schemas/src/Concerns/HasColumns.php
+++ b/packages/schemas/src/Concerns/HasColumns.php
@@ -4,6 +4,7 @@ namespace Filament\Schemas\Concerns;
 
 use Closure;
 use Filament\Schemas\Schema;
+use Filament\Support\Facades\FilamentGrid;
 
 trait HasColumns
 {
@@ -25,7 +26,7 @@ trait HasColumns
 
         if (! is_array($columns)) {
             $columns = [
-                'lg' => $columns,
+                FilamentGrid::getDefaultBreakpoint() => $columns,
             ];
         }
 
@@ -90,7 +91,7 @@ trait HasColumns
             }
 
             if (! is_string($columnBreakpoint)) {
-                $columns['lg'] = $column;
+                $columns[FilamentGrid::getDefaultBreakpoint()] = $column;
 
                 unset($columns[$columnBreakpoint]);
 

--- a/packages/support/config/filament.php
+++ b/packages/support/config/filament.php
@@ -117,4 +117,20 @@ return [
 
     'system_route_prefix' => 'filament',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Default Grid Breakpoint
+    |--------------------------------------------------------------------------
+    |
+    | When using the grid system with a simple integer value (e.g.,
+    | `columns(2)` or `columnSpan(2)`), the value will be applied at this
+    | breakpoint and higher. On smaller devices, components will use their
+    | default responsive behavior (e.g., 1 column).
+    |
+    | Supported values: 'sm', 'md', 'lg', 'xl', '2xl'
+    |
+    */
+
+    'default_grid_breakpoint' => 'lg',
+
 ];

--- a/packages/support/src/Concerns/CanOrderColumns.php
+++ b/packages/support/src/Concerns/CanOrderColumns.php
@@ -3,6 +3,7 @@
 namespace Filament\Support\Concerns;
 
 use Closure;
+use Filament\Support\Facades\FilamentGrid;
 
 trait CanOrderColumns
 {
@@ -24,7 +25,7 @@ trait CanOrderColumns
 
         if (! is_array($order)) {
             $order = [
-                'lg' => $order,
+                FilamentGrid::getDefaultBreakpoint() => $order,
             ];
         }
 

--- a/packages/support/src/Concerns/CanSpanColumns.php
+++ b/packages/support/src/Concerns/CanSpanColumns.php
@@ -3,6 +3,7 @@
 namespace Filament\Support\Concerns;
 
 use Closure;
+use Filament\Support\Facades\FilamentGrid;
 
 trait CanSpanColumns
 {
@@ -30,7 +31,7 @@ trait CanSpanColumns
         if (! is_array($span)) {
             $span = [
                 'default' => 1,
-                'lg' => $span,
+                FilamentGrid::getDefaultBreakpoint() => $span,
             ];
         }
 
@@ -62,7 +63,7 @@ trait CanSpanColumns
 
         if (! is_array($start)) {
             $start = [
-                'lg' => $start,
+                FilamentGrid::getDefaultBreakpoint() => $start,
             ];
         }
 

--- a/packages/support/src/Facades/FilamentGrid.php
+++ b/packages/support/src/Facades/FilamentGrid.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Filament\Support\Facades;
+
+use Closure;
+use Filament\Support\Grid\GridManager;
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static void defaultBreakpoint(string | Closure | null $breakpoint)
+ * @method static string getDefaultBreakpoint()
+ *
+ * @see GridManager
+ */
+class FilamentGrid extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return GridManager::class;
+    }
+}

--- a/packages/support/src/Grid/GridManager.php
+++ b/packages/support/src/Grid/GridManager.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Filament\Support\Grid;
+
+use Closure;
+use Filament\Support\Concerns\EvaluatesClosures;
+
+class GridManager
+{
+    use EvaluatesClosures;
+
+    protected string | Closure | null $defaultBreakpoint = null;
+
+    public function defaultBreakpoint(string | Closure | null $breakpoint = null): void
+    {
+        $this->defaultBreakpoint = $breakpoint;
+    }
+
+    public function getDefaultBreakpoint(): string
+    {
+        return $this->evaluate($this->defaultBreakpoint) ?? config('filament.default_grid_breakpoint', 'lg');
+    }
+}

--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -21,6 +21,8 @@ use Filament\Support\Components\Contracts\ScopedComponentManager;
 use Filament\Support\Enums\GridDirection;
 use Filament\Support\Facades\FilamentAsset;
 use Filament\Support\Facades\FilamentColor;
+use Filament\Support\Facades\FilamentGrid;
+use Filament\Support\Grid\GridManager;
 use Filament\Support\Icons\IconManager;
 use Filament\Support\Livewire\Partials\DataStoreOverride;
 use Filament\Support\Livewire\Partials\PartialsComponentHook;
@@ -86,6 +88,11 @@ class SupportServiceProvider extends PackageServiceProvider
         $this->app->scoped(
             ColorManager::class,
             fn () => new ColorManager,
+        );
+
+        $this->app->scoped(
+            GridManager::class,
+            fn () => new GridManager,
         );
 
         $this->app->scoped(
@@ -181,7 +188,7 @@ class SupportServiceProvider extends PackageServiceProvider
 
         ComponentAttributeBag::macro('grid', function (array | int | null $columns = [], GridDirection $direction = GridDirection::Row): ComponentAttributeBag {
             if (! is_array($columns)) {
-                $columns = ['lg' => $columns];
+                $columns = [FilamentGrid::getDefaultBreakpoint() => $columns];
             }
 
             $columns = array_filter($columns);
@@ -212,15 +219,15 @@ class SupportServiceProvider extends PackageServiceProvider
 
         ComponentAttributeBag::macro('gridColumn', function (array | int | string | null $span = [], array | int | null $start = [], array | int | string | null $order = [], bool $isHidden = false): ComponentAttributeBag {
             if (! is_array($span)) {
-                $span = ['lg' => $span];
+                $span = [FilamentGrid::getDefaultBreakpoint() => $span];
             }
 
             if (! is_array($start)) {
-                $start = ['lg' => $start];
+                $start = [FilamentGrid::getDefaultBreakpoint() => $start];
             }
 
             if (! is_array($order)) {
-                $order = ['lg' => $order];
+                $order = [FilamentGrid::getDefaultBreakpoint() => $order];
             }
 
             $span = array_filter($span);

--- a/tests/src/Forms/GridTest.php
+++ b/tests/src/Forms/GridTest.php
@@ -2,6 +2,7 @@
 
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Schema;
+use Filament\Support\Facades\FilamentGrid;
 use Filament\Tests\Fixtures\Livewire\Livewire;
 use Filament\Tests\TestCase;
 
@@ -59,12 +60,12 @@ test('can get number of container columns from parent component', function (): v
         ->toHaveKey('2xl', $columnsAt2xl);
 });
 
-test('can set number of container columns at `lg` breakpoint', function (): void {
+test('can set number of container columns at default breakpoint', function (): void {
     $schema = Schema::make(Livewire::make())
-        ->columns($columnsAtLg = rand(1, 12));
+        ->columns($columnsAtDefaultBreakpoint = rand(1, 12));
 
     expect($schema)
-        ->getColumns('lg')->toBe($columnsAtLg);
+        ->getColumns(FilamentGrid::getDefaultBreakpoint())->toBe($columnsAtDefaultBreakpoint);
 });
 
 test('can get component column span at all breakpoints', function (): void {
@@ -100,13 +101,13 @@ test('can get component column span at one breakpoint', function (): void {
         ->getColumnSpan('2xl')->toBe($spanAt2xl);
 });
 
-test('can set component column span at `lg` breakpoint', function (): void {
+test('can set component column span at default breakpoint', function (): void {
     $component = (new Component)
         ->container(Schema::make(Livewire::make()))
-        ->columnSpan($spanAtLg = rand(1, 12));
+        ->columnSpan($spanAtDefaultBreakpoint = rand(1, 12));
 
     expect($component)
-        ->getColumnSpan('lg')->toBe($spanAtLg);
+        ->getColumnSpan(FilamentGrid::getDefaultBreakpoint())->toBe($spanAtDefaultBreakpoint);
 });
 
 test('can get component column order at all breakpoints', function (): void {
@@ -142,13 +143,13 @@ test('can get component column order at one breakpoint', function (): void {
         ->getColumnOrder('2xl')->toBe($orderAt2xl);
 });
 
-test('can set component column order at `lg` breakpoint', function (): void {
+test('can set component column order at default breakpoint', function (): void {
     $component = (new Component)
         ->container(Schema::make(Livewire::make()))
-        ->columnOrder($defaultOrder = rand(1, 12));
+        ->columnOrder($orderAtDefaultBreakpoint = rand(1, 12));
 
     expect($component)
-        ->getColumnOrder('lg')->toBe($defaultOrder);
+        ->getColumnOrder(FilamentGrid::getDefaultBreakpoint())->toBe($orderAtDefaultBreakpoint);
 });
 
 test('can get component column order with null default values', function (): void {
@@ -163,4 +164,25 @@ test('can get component column order with null default values', function (): voi
         ->toHaveKey('lg', null)
         ->toHaveKey('xl', null)
         ->toHaveKey('2xl', null);
+});
+
+test('can configure default grid breakpoint via config', function (): void {
+    config()->set('filament.default_grid_breakpoint', '2xl');
+
+    $schema = Schema::make(Livewire::make())
+        ->columns($columnsAt2xl = rand(1, 12));
+
+    expect($schema)
+        ->getColumns('2xl')->toBe($columnsAt2xl);
+});
+
+test('can configure default grid breakpoint via `FilamentGrid::defaultBreakpoint()` method', function (): void {
+    FilamentGrid::defaultBreakpoint('xl');
+
+    $component = (new Component)
+        ->container(Schema::make(Livewire::make()))
+        ->columnSpan($spanAtXl = rand(1, 12));
+
+    expect($component)
+        ->getColumnSpan('xl')->toBe($spanAtXl);
 });


### PR DESCRIPTION
## Summary

This PR adds the ability to configure the default grid breakpoint used when passing integers to grid methods like `columns(2)`, `columnSpan(3)`, `columnStart(2)`, `columnOrder(1)`, and `grid(3)`.

Previously, the breakpoint was hardcoded to `'lg'`. Now users can:

1. **Configure via `config/filament.php`:**
   ```php
   'default_grid_breakpoint' => '2xl',
   ```

2. **Set programmatically (e.g., in a service provider):**
   ```php
   use Filament\Support\Facades\FilamentGrid;

   FilamentGrid::defaultBreakpoint('xl');
   ```

## Changes

- Added `GridManager` class to manage the default breakpoint
- Added `FilamentGrid` facade for easy access
- Updated all grid-related methods to use the configurable breakpoint
- Added config option with documentation
- Added tests for both config and programmatic approaches
- Updated layouts documentation

## Why?

Some applications need consistent grid behavior across different breakpoints. For example, an app optimized for large displays may want `'2xl'` as the default instead of `'lg'`.

This is fully backward compatible - the default remains `'lg'`.