### PR TITLE
fix: hide parent ActionGroup when all nested actions are hidden

### DIFF
--- a/packages/actions/src/Concerns/CanBeHidden.php
+++ b/packages/actions/src/Concerns/CanBeHidden.php
@@ -45,7 +45,13 @@ trait CanBeHidden
         }
 
         if ($this instanceof ActionGroup) {
-            return false;
+            foreach ($this->getActions() as $action) {
+                if (! $action->isHiddenInGroup()) {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         return ! $this->isAuthorizedOrNotHiddenWhenUnauthorized();


### PR DESCRIPTION
## Description

fixes: #19015

## Visual changes

# before

<img width="1064" height="446" alt="image" src="https://github.com/user-attachments/assets/011b9c13-0978-4eed-8a71-ccd2f9ea0929" />
<img width="622" height="336" alt="image" src="https://github.com/user-attachments/assets/59c6fd5a-618e-4eb9-b20e-1a53abe4085a" />


# after
<img width="620" height="414" alt="image" src="https://github.com/user-attachments/assets/c25d8400-316c-4b0d-9c69-0d36c159258e" />

<img width="576" height="402" alt="image" src="https://github.com/user-attachments/assets/231fc708-59c6-4f8f-8a62-07e2e4aabcb8" />




## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
