### PR TITLE
Fix SPA mode URL detection for Octane & alternative runtimes (FrankenPHP, Swoole, containers)

### DIFF
--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -116,7 +116,14 @@ if (! function_exists('Filament\Support\is_slot_empty')) {
 if (! function_exists('Filament\Support\is_app_url')) {
     function is_app_url(string $url): bool
     {
-        return str($url)->startsWith(request()->root());
+        if (str($url)->startsWith('/') && ! str($url)->startsWith('//')) {
+            return true;
+        }
+
+        $appUrl = rtrim((string) config('app.url'), '/');
+
+        return ($appUrl !== '' && str($url)->startsWith($appUrl))
+            || rescue(fn () => str($url)->startsWith(request()->root()), false);
     }
 }
 

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -116,14 +116,19 @@ if (! function_exists('Filament\Support\is_slot_empty')) {
 if (! function_exists('Filament\Support\is_app_url')) {
     function is_app_url(string $url): bool
     {
-        if (str($url)->startsWith('/') && ! str($url)->startsWith('//')) {
+        $url = str($url);
+
+        if ($url->startsWith('/') && (! $url->startsWith('//'))) {
             return true;
         }
 
         $appUrl = rtrim((string) config('app.url'), '/');
 
-        return ($appUrl !== '' && str($url)->startsWith($appUrl))
-            || rescue(fn () => str($url)->startsWith(request()->root()), false);
+        if (($appUrl !== '') && $url->startsWith($appUrl)) {
+            return true;
+        }
+
+        return $url->startsWith(request()->root());
     }
 }
 


### PR DESCRIPTION
## Fixes an issue where **Filament SPA mode fails when running on non PHP-FPM runtimes** such as Laravel Octane (FrankenPHP, Swoole) and in containerized or load-balanced environments.

---

### Issue

SPA mode relies on `is_app_url()` to determine whether a URL belongs to the application.
The previous implementation depended solely on `request()->root()`, which is **not reliable** in:

* Octane runtimes (FrankenPHP / Swoole)
* Reverse proxies and load balancers
* Containers where the public app URL differs from the internal request root

This causes Filament to incorrectly treat internal URLs as external, breaking SPA navigation.

---

### Change

Update `is_app_url()` to:

* Prefer `config('app.url')` as the canonical application URL
* Correctly handle relative URLs
* Retain `request()->root()` as a safe fallback for backward compatibility

```php
function is_app_url(string $url): bool
{
    if (str($url)->startsWith('/') && ! str($url)->startsWith('//')) {
        return true;
    }

    $appUrl = rtrim((string) config('app.url'), '/');

    return ($appUrl !== '' && str($url)->startsWith($appUrl))
        || rescue(fn () => str($url)->startsWith(request()->root()), false);
}
```

---

### Impact

* ✅ Fixes SPA mode on Octane (FrankenPHP, Swoole)
* ✅ Works correctly behind proxies and in containers
* ✅ No breaking changes
* ✅ More predictable behavior across all runtimes