### PR TITLE
[4.x] Render hook classes

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasRenderHooks.php
+++ b/packages/panels/src/Panel/Concerns/HasRenderHooks.php
@@ -4,6 +4,10 @@ namespace Filament\Panel\Concerns;
 
 use Closure;
 use Filament\Support\Facades\FilamentView;
+use Filament\View\RenderHook;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
+use ReflectionClass;
 
 trait HasRenderHooks
 {
@@ -11,6 +15,11 @@ trait HasRenderHooks
      * @var array<string, array<string, array<Closure>>>
      */
     protected array $renderHooks = [];
+
+    /**
+     * @var array<string, string>
+     */
+    protected array $renderHookDirectories = [];
 
     /**
      * @param  string | array<string> | null  $scopes
@@ -28,8 +37,57 @@ trait HasRenderHooks
         return $this;
     }
 
+    public function discoverRenderHooks(string $in, string $for): static
+    {
+        $this->renderHookDirectories[$in] = $for;
+
+        return $this;
+    }
+
     protected function registerRenderHooks(): void
     {
+        $filesystem = app(Filesystem::class);
+
+        foreach ($this->renderHookDirectories as $in => $for) {
+            if (blank($in) || blank($for)) {
+                continue;
+            }
+
+            if (! $filesystem->exists($in)) {
+                continue;
+            }
+
+            $namespace = str($for);
+
+            foreach ($filesystem->allFiles($in) as $file) {
+                $class = (string) $namespace
+                    ->append('\\', $file->getRelativePathname())
+                    ->replace([DIRECTORY_SEPARATOR, '.php'], ['\\', '']);
+
+                if (! class_exists($class)) {
+                    continue;
+                }
+
+                if ((new ReflectionClass($class))->isAbstract()) {
+                    continue;
+                }
+
+                if (! is_subclass_of($class, RenderHook::class)) {
+                    continue;
+                }
+
+                $hooks = $class::getRenderHooks();
+
+                foreach (Arr::wrap($hooks) as $hook) {
+                    $this->renderHook(
+                        $hook,
+                        fn (array $data, array $scopes) => app()->call([app($class), 'render'], ['data' => $data, 'scopes' => $scopes]),
+                        $class::getScopes(),
+                    );
+                }
+            }
+        }
+
         foreach ($this->renderHooks as $hookName => $scopedHooks) {
             foreach ($scopedHooks as $scope => $hooks) {
                 foreach ($hooks as $hook) {

--- a/packages/panels/src/View/RenderHook.php
+++ b/packages/panels/src/View/RenderHook.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Filament\View;
+
+use Illuminate\Contracts\View\View;
+
+abstract class RenderHook
+{
+    /**
+     * @return non-empty-array<string>|null
+     */
+    public static function getScopes(): ?array
+    {
+        return null;
+    }
+
+    /**
+     * @return string | array<string>
+     */
+    abstract public static function getRenderHooks(): string | array;
+
+    /**
+     * @param array<string> $scopes
+     * @param array<mixed> $data
+     */
+    abstract public function render(array $scopes, array $data): View | string;
+}


### PR DESCRIPTION
## Description

Render hooks are commonly used to customize the Filament experience further, especially inside of panels.

One limitation that I personally find with the `renderHook()` method is that certain views require custom data and placing all of that logic inside of the panel provider or a service provider can become rather messy.

A workaround for this that already exists is creating a class to handle the rendering, but it still requires some manual wiring to work correctly, especially when dependency injection is involved.

This pull request introduces the concept of a `RenderHook` class with support for auto-discovery.

You create a class that extends `Filament\View\RenderHook` and implement the necessary methods. You specify the hook(s) you want to render for and the View or string that should be rendered.

Classes are resolved from the container so dependency injection works as expected and you can pull in service classes for data retrieval etc.

By adding `->discoverRenderHooks()` onto your `Panel` object, specifying the directory and namespace, you get the real benefit of auto-discovered render hooks, removing the need for that superfluous method call.

## Visual changes

N/A

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
