### PR TITLE
fix: resolve table record without applying filter query conditions

### DIFF
--- a/packages/tables/docs/03-filters/01-overview.md
+++ b/packages/tables/docs/03-filters/01-overview.md
@@ -200,6 +200,35 @@ TernaryFilter::make('trashed')
     ]))
 ```
 
+## Excluding filters when resolving records
+
+When a user interacts with a table record (e.g., clicking an action button), Filament resolves that record from the database. By default, all active filter conditions are applied, ensuring users cannot access records outside their filter scope.
+
+However, some filters like `TrashedFilter` modify global scopes rather than restricting access. When a record's state changes after the user saw it in the table, you may still want the user to interact with it.
+
+You may mark a filter to be excluded when resolving records using the `excludeWhenResolvingRecord()` method:
+
+```php
+use Filament\Tables\Filters\Filter;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+Filter::make('trashed')
+    ->query(fn (Builder $query) => $query->onlyTrashed())
+    ->baseQuery(fn (Builder $query) => $query->withoutGlobalScopes([
+        SoftDeletingScope::class,
+    ]))
+    ->excludeWhenResolvingRecord()
+```
+
+When `excludeWhenResolvingRecord()` is used:
+- The filter's `query()` callback is not applied when resolving records
+- The filter's `baseQuery()` callback is still applied when resolving records
+
+<Aside variant="danger">
+    Do not use `excludeWhenResolvingRecord()` on filters that enforce authorization rules. For example, if you have a filter that restricts records by tenant or user ownership, those filters should remain enforced to prevent unauthorized access.
+</Aside>
+
 ## Customizing the filters trigger action
 
 To customize the filters trigger buttons, you may use the `filtersTriggerAction()` method, passing a closure that returns an action. All methods that are available to [customize action trigger buttons](../../actions/overview) can be used:

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -197,6 +197,30 @@ trait HasFilters
         }
     }
 
+    protected function applyBaseFiltersToTableQuery(Builder $query): Builder
+    {
+        $table = $this->getTable();
+
+        if ($table->hasDeferredFilters()) {
+            $this->getTableFiltersForm()->statePath('tableFilters')->flushCachedAbsoluteStatePaths();
+        }
+
+        try {
+            foreach ($table->getFilters() as $filter) {
+                $filter->applyToBaseQuery(
+                    $query,
+                    $this->getTableFilterState($filter->getName()) ?? [],
+                );
+            }
+
+            return $query;
+        } finally {
+            if ($table->hasDeferredFilters()) {
+                $this->getTableFiltersForm()->statePath('tableDeferredFilters')->flushCachedAbsoluteStatePaths();
+            }
+        }
+    }
+
     public function getTableFilterState(string $name): ?array
     {
         return Arr::get($this->tableFilters, $this->parseTableFilterName($name));

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -166,7 +166,7 @@ trait HasFilters
         $this->handleTableFilterUpdates();
     }
 
-    protected function applyFiltersToTableQuery(Builder $query): Builder
+    protected function applyFiltersToTableQuery(Builder $query, bool $isResolvingRecord = false): Builder
     {
         $table = $this->getTable();
 
@@ -182,38 +182,18 @@ trait HasFilters
                 );
             }
 
-            return $query->where(function (Builder $query) use ($table): void {
+            return $query->where(function (Builder $query) use ($table, $isResolvingRecord): void {
                 foreach ($table->getFilters() as $filter) {
+                    if ($isResolvingRecord && $filter->shouldExcludeWhenResolvingRecord()) {
+                        continue;
+                    }
+
                     $filter->apply(
                         $query,
                         $this->getTableFilterState($filter->getName()) ?? [],
                     );
                 }
             });
-        } finally {
-            if ($table->hasDeferredFilters()) {
-                $this->getTableFiltersForm()->statePath('tableDeferredFilters')->flushCachedAbsoluteStatePaths();
-            }
-        }
-    }
-
-    protected function applyBaseFiltersToTableQuery(Builder $query): Builder
-    {
-        $table = $this->getTable();
-
-        if ($table->hasDeferredFilters()) {
-            $this->getTableFiltersForm()->statePath('tableFilters')->flushCachedAbsoluteStatePaths();
-        }
-
-        try {
-            foreach ($table->getFilters() as $filter) {
-                $filter->applyToBaseQuery(
-                    $query,
-                    $this->getTableFilterState($filter->getName()) ?? [],
-                );
-            }
-
-            return $query;
         } finally {
             if ($table->hasDeferredFilters()) {
                 $this->getTableFiltersForm()->statePath('tableDeferredFilters')->flushCachedAbsoluteStatePaths();

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -192,7 +192,9 @@ trait HasRecords
         }
 
         if (! ($this->getTable()->getRelationship() instanceof BelongsToMany)) {
-            return $this->getFilteredTableQuery()->find($key);
+            return $this->applyBaseFiltersToTableQuery(
+                $this->getTable()->getQuery(),
+            )->find($key);
         }
 
         /** @var BelongsToMany $relationship */
@@ -203,7 +205,7 @@ trait HasRecords
 
         $table = $this->getTable();
 
-        $this->applyFiltersToTableQuery($relationship->getQuery());
+        $this->applyBaseFiltersToTableQuery($relationship->getQuery());
 
         $query = $table->allowsDuplicates() ?
             $relationship->wherePivot($pivotKeyName, $key) :

--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -192,8 +192,9 @@ trait HasRecords
         }
 
         if (! ($this->getTable()->getRelationship() instanceof BelongsToMany)) {
-            return $this->applyBaseFiltersToTableQuery(
+            return $this->applyFiltersToTableQuery(
                 $this->getTable()->getQuery(),
+                isResolvingRecord: true,
             )->find($key);
         }
 
@@ -205,7 +206,7 @@ trait HasRecords
 
         $table = $this->getTable();
 
-        $this->applyBaseFiltersToTableQuery($relationship->getQuery());
+        $this->applyFiltersToTableQuery($relationship->getQuery(), isResolvingRecord: true);
 
         $query = $table->allowsDuplicates() ?
             $relationship->wherePivot($pivotKeyName, $key) :

--- a/packages/tables/src/Filters/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Filters/Concerns/InteractsWithTableQuery.php
@@ -11,6 +11,8 @@ trait InteractsWithTableQuery
 
     protected ?Closure $modifyBaseQueryUsing = null;
 
+    protected bool | Closure $shouldExcludeWhenResolvingRecord = false;
+
     /**
      * @param  array<string, mixed>  $data
      */
@@ -99,5 +101,17 @@ trait InteractsWithTableQuery
     protected function hasBaseQueryModificationCallback(): bool
     {
         return $this->modifyBaseQueryUsing instanceof Closure;
+    }
+
+    public function excludeWhenResolvingRecord(bool | Closure $condition = true): static
+    {
+        $this->shouldExcludeWhenResolvingRecord = $condition;
+
+        return $this;
+    }
+
+    public function shouldExcludeWhenResolvingRecord(): bool
+    {
+        return (bool) $this->evaluate($this->shouldExcludeWhenResolvingRecord);
     }
 }

--- a/packages/tables/src/Filters/TrashedFilter.php
+++ b/packages/tables/src/Filters/TrashedFilter.php
@@ -34,6 +34,8 @@ class TrashedFilter extends TernaryFilter
             SoftDeletingScope::class,
         ]));
 
+        $this->excludeWhenResolvingRecord();
+
         $this->indicateUsing(function (array $state): array {
             if ($state['value'] ?? null) {
                 return [Indicator::make($this->getTrueLabel())];

--- a/tests/src/Panels/Resources/RelationManagerTest.php
+++ b/tests/src/Panels/Resources/RelationManagerTest.php
@@ -253,7 +253,7 @@ it('can attach records when some are already related', function (): void {
     expect($ticket->departments()->count())->toBe(2);
 });
 
-it('can access record for action after record no longer matches filter in BelongsToMany relation manager', function (): void {
+it('can access record for action after record no longer matches `TrashedFilter` in BelongsToMany relation manager', function (): void {
     $ticket = Ticket::factory()->create();
     $department = Department::factory()->create();
     $ticket->departments()->attach($department);

--- a/tests/src/Panels/Resources/RelationManagerTest.php
+++ b/tests/src/Panels/Resources/RelationManagerTest.php
@@ -253,7 +253,7 @@ it('can attach records when some are already related', function (): void {
     expect($ticket->departments()->count())->toBe(2);
 });
 
-it('can access record for action after record no longer matches `TrashedFilter` in BelongsToMany relation manager', function (): void {
+it('can access record for action after record no longer matches `TrashedFilter` in `BelongsToMany` relation manager', function (): void {
     $ticket = Ticket::factory()->create();
     $department = Department::factory()->create();
     $ticket->departments()->attach($department);

--- a/tests/src/Panels/Resources/RelationManagerTest.php
+++ b/tests/src/Panels/Resources/RelationManagerTest.php
@@ -252,3 +252,22 @@ it('can attach records when some are already related', function (): void {
     // Verify total count is now 2
     expect($ticket->departments()->count())->toBe(2);
 });
+
+it('can access record for action after record no longer matches filter in BelongsToMany relation manager', function (): void {
+    $ticket = Ticket::factory()->create();
+    $department = Department::factory()->create();
+    $ticket->departments()->attach($department);
+
+    $department->delete();
+
+    livewire(DepartmentsRelationManager::class, [
+        'ownerRecord' => $ticket,
+        'pageClass' => EditTicket::class,
+    ])
+        ->filterTable('trashed', false)
+        ->assertCanSeeTableRecords([$department])
+        ->tap(fn () => $department->restore())
+        ->callAction(TestAction::make(DeleteAction::class)->table($department));
+
+    expect($department->fresh()->trashed())->toBeTrue();
+});

--- a/tests/src/Tables/Filters/TrashedFilterTest.php
+++ b/tests/src/Tables/Filters/TrashedFilterTest.php
@@ -3,6 +3,7 @@
 use Filament\Actions\DeleteAction;
 use Filament\Actions\ForceDeleteAction;
 use Filament\Actions\RestoreAction;
+use Filament\Actions\Testing\TestAction;
 use Filament\Tables\Filters\TrashedFilter;
 use Filament\Tests\Fixtures\Livewire\PostsTable;
 use Filament\Tests\Fixtures\Models\Post;
@@ -102,4 +103,16 @@ it('can restore records that are already deleted', function (): void {
 
     assertModelExists($trashedPost);
     assertNotSoftDeleted($trashedPost);
+});
+
+it('can access record for action after record no longer matches filter', function (): void {
+    $post = Post::factory()->create(['is_published' => true]);
+
+    livewire(PostsTable::class)
+        ->filterTable('is_published')
+        ->assertCanSeeTableRecords([$post])
+        ->tap(fn () => $post->update(['is_published' => false]))
+        ->callAction(TestAction::make(DeleteAction::class)->table($post));
+
+    assertSoftDeleted($post);
 });

--- a/tests/src/Tables/Filters/TrashedFilterTest.php
+++ b/tests/src/Tables/Filters/TrashedFilterTest.php
@@ -105,14 +105,28 @@ it('can restore records that are already deleted', function (): void {
     assertNotSoftDeleted($trashedPost);
 });
 
-it('can access record for action after record no longer matches filter', function (): void {
+it('can access record for action after record no longer matches `TrashedFilter`', function (): void {
+    $post = Post::factory()->create();
+
+    livewire(PostsTable::class)
+        ->filterTable(TrashedFilter::class, null)
+        ->assertCanSeeTableRecords([$post])
+        ->tap(fn () => $post->delete())
+        ->callAction(TestAction::make(RestoreAction::class)->table($post));
+
+    assertNotSoftDeleted($post);
+});
+
+it('cannot access record for action after record no longer matches non-excluded filter', function (): void {
     $post = Post::factory()->create(['is_published' => true]);
 
     livewire(PostsTable::class)
         ->filterTable('is_published')
         ->assertCanSeeTableRecords([$post])
-        ->tap(fn () => $post->update(['is_published' => false]))
-        ->callAction(TestAction::make(DeleteAction::class)->table($post));
+        ->tap(fn () => $post->update(['is_published' => false]));
 
-    assertSoftDeleted($post);
+    expect(fn () => livewire(PostsTable::class)
+        ->filterTable('is_published')
+        ->mountTableAction(DeleteAction::class, $post)
+    )->toThrow(TypeError::class);
 });

--- a/tests/src/Tables/Filters/TrashedFilterTest.php
+++ b/tests/src/Tables/Filters/TrashedFilterTest.php
@@ -125,8 +125,9 @@ it('cannot access record for action after record no longer matches non-excluded 
         ->assertCanSeeTableRecords([$post])
         ->tap(fn () => $post->update(['is_published' => false]));
 
-    expect(fn () => livewire(PostsTable::class)
-        ->filterTable('is_published')
-        ->mountTableAction(DeleteAction::class, $post)
+    expect(
+        fn () => livewire(PostsTable::class)
+            ->filterTable('is_published')
+            ->mountTableAction(DeleteAction::class, $post)
     )->toThrow(TypeError::class);
 });


### PR DESCRIPTION
## Description

### Fixes: #19026 

### Problem: 

Actions fail when a record's state changes and no longer matches the active filter (e.g., restoring a trashed record while filtering "only trashed").

### Solution: 

resolveTableRecord() now only applies baseQuery() modifications (like removing SoftDeletingScope), not query() filter conditions.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
