### PR TITLE
Add export italian translations

### DIFF
--- a/packages/actions/resources/lang/it/export.php
+++ b/packages/actions/resources/lang/it/export.php
@@ -14,6 +14,18 @@ return [
 
                 'label' => 'Colonne',
 
+                'actions' => [
+
+                    'select_all' => [
+                        'label' => 'Seleziona tutte',
+                    ],
+
+                    'deselect_all' => [
+                        'label' => 'Deseleziona tutte',
+                    ],
+
+                ],
+
                 'form' => [
 
                     'is_enabled' => [
@@ -63,6 +75,11 @@ return [
         'max_rows' => [
             'title' => 'L\'esportazione è troppo grande',
             'body' => 'Non puoi esportare più di 1 riga alla volta.|Non puoi esportare più di :count righe alla volta.',
+        ],
+
+        'no_columns' => [
+            'title' => 'Nessuna colonna selezionata',
+            'body' => 'Per favore seleziona almeno una colonna da esportare.',
         ],
 
         'started' => [


### PR DESCRIPTION
## Description

Added the missing Italian translations for the export labels.

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
