### PR TITLE
Fix afterStateUpdatedJs not working with Livewire v4

### DIFF
--- a/packages/forms/resources/views/components/repeater/table.blade.php
+++ b/packages/forms/resources/views/components/repeater/table.blade.php
@@ -174,12 +174,12 @@
                                                     containerPath: @js($itemStatePath),
                                                     $wire,
                                                 })"
-                                                @if ($afterStateUpdatedJs = $schemaComponent->getAfterStateUpdatedJs())
-                                                    x-init="{{ implode(';', array_map(
-                                                        fn (string $js): string => '$wire.watch(' . Js::from($schemaComponentStatePath) . ', ($state, $old) => isStateChanged($state, $old) && eval(' . Js::from($js) . '))',
-                                                        $afterStateUpdatedJs,
-                                                    )) }}"
-                                                @endif
+                                @if ($afterStateUpdatedJs = $schemaComponent->getAfterStateUpdatedJs())
+                                    x-init="{{ implode(';', array_map(
+                                        fn (string $js): string => '$wire.$watch(' . Js::from($schemaComponentStatePath) . ', ($state, $old) => isStateChanged($state, $old) && eval(' . Js::from($js) . '))',
+                                        $afterStateUpdatedJs,
+                                    )) }}"
+                                @endif
                                             >
                                                 {{ $schemaComponent }}
                                             </td>

--- a/packages/schemas/resources/views/components/flex.blade.php
+++ b/packages/schemas/resources/views/components/flex.blade.php
@@ -54,7 +54,7 @@
                         })"
                 @if ($afterStateUpdatedJs = $schemaComponent->getAfterStateUpdatedJs())
                     x-init="{!! implode(';', array_map(
-                        fn (string $js): string => '$wire.watch(' . Js::from($componentStatePath) . ', ($state, $old) => isStateChanged($state, $old) && eval(' . Js::from($js) . '))',
+                        fn (string $js): string => '$wire.$watch(' . Js::from($componentStatePath) . ', ($state, $old) => isStateChanged($state, $old) && eval(' . Js::from($js) . '))',
                         $afterStateUpdatedJs,
                     )) !!}"
                 @endif

--- a/packages/schemas/src/Components/Component.php
+++ b/packages/schemas/src/Components/Component.php
@@ -195,7 +195,7 @@ class Component extends ViewComponent
                 })"
                 <?php if ($afterStateUpdatedJs = $this->getAfterStateUpdatedJs()) { ?>
                     x-init="<?= implode(';', array_map(
-                        fn (string $js): string => '$wire.watch(' . Js::from($statePath) . ', ($state, $old) => isStateChanged($state, $old) && eval(' . Js::from($js) . '))',
+                        fn (string $js): string => '$wire.$watch(' . Js::from($statePath) . ', ($state, $old) => isStateChanged($state, $old) && eval(' . Js::from($js) . '))',
                         $afterStateUpdatedJs,
                     )) ?>"
                 <?php } ?>

--- a/tests/src/Forms/Components/AfterStateUpdatedJsTest.php
+++ b/tests/src/Forms/Components/AfterStateUpdatedJsTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Schema;
+use Filament\Tests\TestCase;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Artisan;
+use Livewire\Component;
+
+use function Filament\Tests\livewire;
+
+uses(TestCase::class);
+
+beforeEach(function (): void {
+    Artisan::call('filament:assets');
+});
+
+it('renders afterStateUpdatedJs with correct $wire.$watch syntax', function (): void {
+    $component = livewire(AfterStateUpdatedJsTestComponent::class);
+
+    $html = $component->html();
+
+    expect($html)->toContain('$wire.$watch');
+    expect($html)->not->toContain('$wire.watch(');
+});
+
+it('includes afterStateUpdatedJs in component x-init', function (): void {
+    $component = livewire(AfterStateUpdatedJsTestComponent::class);
+
+    $html = $component->html();
+
+    expect($html)->toContain('x-init');
+    expect($html)->toContain('$set');
+    expect($html)->toContain('volume_weight');
+});
+
+class AfterStateUpdatedJsTestComponent extends Component implements \Filament\Actions\Contracts\HasActions, \Filament\Schemas\Contracts\HasSchemas
+{
+    use \Filament\Actions\Concerns\InteractsWithActions;
+    use \Filament\Schemas\Concerns\InteractsWithSchemas;
+
+    public ?array $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill();
+    }
+
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->schema([
+                TextInput::make('length')
+                    ->numeric()
+                    ->default(0)
+                    ->afterStateUpdatedJs(<<<'JS'
+                        const length = parseFloat($state ?? 0);
+                        const breadth = parseFloat($get('breadth') ?? 0);
+                        const height = parseFloat($get('height') ?? 0);
+                        const weight = (length * breadth * height) / 5000;
+                        $set('volume_weight', Math.round(weight * 100) / 100);
+                    JS),
+
+                TextInput::make('breadth')
+                    ->numeric()
+                    ->default(0)
+                    ->afterStateUpdatedJs(<<<'JS'
+                        const length = parseFloat($get('length') ?? 0);
+                        const breadth = parseFloat($state ?? 0);
+                        const height = parseFloat($get('height') ?? 0);
+                        const weight = (length * breadth * height) / 5000;
+                        $set('volume_weight', Math.round(weight * 100) / 100);
+                    JS),
+
+                TextInput::make('height')
+                    ->numeric()
+                    ->default(0)
+                    ->afterStateUpdatedJs(<<<'JS'
+                        const length = parseFloat($get('length') ?? 0);
+                        const breadth = parseFloat($get('breadth') ?? 0);
+                        const height = parseFloat($state ?? 0);
+                        const weight = (length * breadth * height) / 5000;
+                        $set('volume_weight', Math.round(weight * 100) / 100);
+                    JS),
+
+                TextInput::make('volume_weight')
+                    ->readOnly()
+                    ->default(0),
+            ])
+            ->statePath('data');
+    }
+
+    public function render(): View
+    {
+        return view('livewire.form');
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes issue #19054 where `afterStateUpdatedJs` callbacks were not firing in Filament v5 with Livewire v4.

## Root Cause

Livewire v4 defines the watch method as `$wire.$watch()` (with a `$` prefix). While an alias mapping exists in Livewire ("watch": "$watch"), it's not reliably applied at runtime, causing the watcher callbacks to fail silently.

## Solution

Changed all instances of `$wire.watch()` to `$wire.$watch()` across three files to match the actual Livewire v4 API.

## Files Changed

1. `packages/forms/resources/views/components/repeater/table.blade.php` - Line 179
2. `packages/schemas/resources/views/components/flex.blade.php` - Line 57
3. `packages/schemas/src/Components/Component.php` - Line 198

## Tests Added

Added `tests/src/Forms/Components/AfterStateUpdatedJsTest.php` with two test cases:

- **`it renders afterStateUpdatedJs with correct $wire.$watch syntax`** - Verifies the rendered HTML contains `$wire.$watch` and not the broken `$wire.watch(` syntax
- **`it includes afterStateUpdatedJs in component x-init`** - Verifies the JavaScript code is properly included in the `x-init` directive

```
✓ it renders afterStateUpdatedJs with correct $wire.$watch syntax
✓ it includes afterStateUpdatedJs in component x-init

Tests: 2 passed (5 assertions)
```

## Example Use Case

This fix enables the following code to work correctly:

```php
TextInput::make('length')
    ->afterStateUpdatedJs(<<<'JS'
        const length = parseFloat($state ?? 0);
        const breadth = parseFloat($get('breadth') ?? 0);
        const height = parseFloat($get('height') ?? 0);
        const weight = (length * breadth * height) / 5000;
        
        $set('volume_weight_value', Math.round(weight * 100) / 100);
    JS)
```

Previously, the callback would not fire. After this fix, it will execute as expected.