### PR TITLE
[5.x] Fix `afterStateUpdatedJs` broken with Livewire

### DIFF
--- a/packages/forms/resources/views/components/repeater/table.blade.php
+++ b/packages/forms/resources/views/components/repeater/table.blade.php
@@ -176,7 +176,7 @@
                                                 })"
                                                 @if ($afterStateUpdatedJs = $schemaComponent->getAfterStateUpdatedJs())
                                                     x-init="{{ implode(';', array_map(
-                                                        fn (string $js): string => '$wire.watch(' . Js::from($schemaComponentStatePath) . ', ($state, $old) => isStateChanged($state, $old) && eval(' . Js::from($js) . '))',
+                                                        fn (string $js): string => '$wire; $wire.watch(' . Js::from($schemaComponentStatePath) . ', ($state, $old) => isStateChanged($state, $old) && eval(' . Js::from($js) . '))',
                                                         $afterStateUpdatedJs,
                                                     )) }}"
                                                 @endif

--- a/packages/schemas/resources/views/components/flex.blade.php
+++ b/packages/schemas/resources/views/components/flex.blade.php
@@ -54,7 +54,7 @@
                         })"
                 @if ($afterStateUpdatedJs = $schemaComponent->getAfterStateUpdatedJs())
                     x-init="{!! implode(';', array_map(
-                        fn (string $js): string => '$wire.watch(' . Js::from($componentStatePath) . ', ($state, $old) => isStateChanged($state, $old) && eval(' . Js::from($js) . '))',
+                        fn (string $js): string => '$wire; $wire.watch(' . Js::from($componentStatePath) . ', ($state, $old) => isStateChanged($state, $old) && eval(' . Js::from($js) . '))',
                         $afterStateUpdatedJs,
                     )) !!}"
                 @endif

--- a/packages/schemas/src/Components/Component.php
+++ b/packages/schemas/src/Components/Component.php
@@ -195,7 +195,7 @@ class Component extends ViewComponent
                 })"
                 <?php if ($afterStateUpdatedJs = $this->getAfterStateUpdatedJs()) { ?>
                     x-init="<?= implode(';', array_map(
-                        fn (string $js): string => '$wire.watch(' . Js::from($statePath) . ', ($state, $old) => isStateChanged($state, $old) && eval(' . Js::from($js) . '))',
+                        fn (string $js): string => '$wire; $wire.watch(' . Js::from($statePath) . ', ($state, $old) => isStateChanged($state, $old) && eval(' . Js::from($js) . '))',
                         $afterStateUpdatedJs,
                     )) ?>"
                 <?php } ?>

--- a/tests/resources/views/pages/after-state-updated-js-test.blade.php
+++ b/tests/resources/views/pages/after-state-updated-js-test.blade.php
@@ -1,0 +1,7 @@
+<x-filament-panels::page>
+    <form wire:submit="save">
+        {{ $this->form }}
+
+        <x-filament::button type="submit">Save</x-filament::button>
+    </form>
+</x-filament-panels::page>

--- a/tests/src/Fixtures/Pages/AfterStateUpdatedJsTest.php
+++ b/tests/src/Fixtures/Pages/AfterStateUpdatedJsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Pages;
+
+use BackedEnum;
+use Filament\Forms\Components\TextInput;
+use Filament\Pages\Page;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+
+class AfterStateUpdatedJsTest extends Page
+{
+    protected string $view = 'pages.after-state-updated-js-test';
+
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedDocumentText;
+
+    protected static ?int $navigationSort = 10;
+
+    public ?array $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill();
+    }
+
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->schema([
+                TextInput::make('name')
+                    ->label('Name')
+                    ->extraAttributes(['data-testid' => 'name-input'])
+                    ->afterStateUpdatedJs(<<<'JS'
+                        $set('email', ($state ?? '').replaceAll(' ', '.').toLowerCase() + '@example.com')
+                    JS),
+                TextInput::make('email')
+                    ->label('Email')
+                    ->extraAttributes(['data-testid' => 'email-input']),
+            ])
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->form->getState();
+    }
+}

--- a/tests/src/Fixtures/Providers/AdminPanelProvider.php
+++ b/tests/src/Fixtures/Providers/AdminPanelProvider.php
@@ -16,6 +16,7 @@ use Filament\Tests\Fixtures\Clusters\UserManagement\Pages\ManageStaff;
 use Filament\Tests\Fixtures\Clusters\WithoutSubNavigationCluster;
 use Filament\Tests\Fixtures\Clusters\WithoutSubNavigationCluster\Pages\ClusteredPageWithoutSubNavigation;
 use Filament\Tests\Fixtures\Pages\Actions;
+use Filament\Tests\Fixtures\Pages\AfterStateUpdatedJsTest;
 use Filament\Tests\Fixtures\Pages\BuilderTest;
 use Filament\Tests\Fixtures\Pages\KeyValueTest;
 use Filament\Tests\Fixtures\Pages\RepeaterTest;
@@ -68,6 +69,7 @@ class AdminPanelProvider extends PanelProvider
             ->pages([
                 Pages\Dashboard::class,
                 Actions::class,
+                AfterStateUpdatedJsTest::class,
                 BuilderTest::class,
                 KeyValueTest::class,
                 RepeaterTest::class,

--- a/tests/src/Forms/AfterStateUpdatedJsTest.php
+++ b/tests/src/Forms/AfterStateUpdatedJsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Filament\Tests\Forms;
+
+use Filament\Tests\Fixtures\Models\User;
+use Filament\Tests\TestCase;
+use Illuminate\Support\Facades\Artisan;
+
+uses(TestCase::class);
+
+beforeEach(function (): void {
+    Artisan::call('filament:assets');
+});
+
+it('can use `$set()` in `afterStateUpdatedJs()` to set another field value', function (): void {
+    $this->actingAs(User::factory()->create());
+
+    visit('/after-state-updated-js-test')
+        ->assertSee('Name')
+        ->assertSee('Email')
+        ->fill('#form\.name', 'John Doe')
+        ->wait(1)
+        ->assertValue('#form\.email', 'john.doe@example.com')
+        ->fill('#form\.name', 'Jane Smith')
+        ->wait(1)
+        ->assertValue('#form\.email', 'jane.smith@example.com')
+        ->assertNoSmoke()
+        ->assertNoAccessibilityIssues();
+
+    visit('/after-state-updated-js-test')
+        ->inDarkMode()
+        ->assertNoAccessibilityIssues();
+});


### PR DESCRIPTION

## Description

Fixes #19054

### Root cause
[Livewire PR #9519](https://github.com/livewire/livewire/pull/9519) made `$wire.watch()` return an `unwatch` function. Alpine runs the **return value** of `x-init` as init, so that returned `unwatch` was executed immediately and the watch was cancelled.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
