### PR TITLE
fix: avoid null array offset in ViewManager

### DIFF
--- a/packages/support/src/View/ViewManager.php
+++ b/packages/support/src/View/ViewManager.php
@@ -30,6 +30,10 @@ class ViewManager
      */
     public function registerRenderHook(string $name, Closure $hook, string | array | null $scopes = null): void
     {
+        if ($scopes === null) {
+            $scopes = [''];
+        }
+
         if (! is_array($scopes)) {
             $scopes = [$scopes];
         }


### PR DESCRIPTION
## Description

This change addresses a PHP 8.5 deprecation warning where using `null` as an array offset is no longer allowed. In `registerRenderHook`, when no scopes are provided, `$scopes` could remain `null`, leading to `null` being used as an array key when registering render hooks.

To ensure forward compatibility with PHP 8.5, `null` scopes are now explicitly normalized to an empty string (`''`), which preserves the existing behavior while avoiding the deprecated usage. This prevents runtime deprecation notices and ensures consistent hook registration across supported PHP versions.

Similar changes have already been made in other parts of the file, such as these:

https://github.com/filamentphp/filament/blob/0b5b56a3b5139eef03edeceb0811b6479dc7c33c/packages/support/src/View/ViewManager.php#L51

https://github.com/filamentphp/filament/blob/0b5b56a3b5139eef03edeceb0811b6479dc7c33c/packages/support/src/View/ViewManager.php#L92

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
