### PR TITLE
[4.x] Fix duplicate orderBy in defaultSort()

### DIFF
--- a/packages/tables/src/Concerns/CanSortRecords.php
+++ b/packages/tables/src/Concerns/CanSortRecords.php
@@ -129,7 +129,6 @@ trait CanSortRecords
 
             if (
                 is_string($order['column'] ?? null) &&
-                str($order['column'] ?? null)->contains('.') &&
                 str($order['column'] ?? null)->afterLast('.')->is(
                     str($qualifiedKeyName)->afterLast('.')
                 )


### PR DESCRIPTION
## Description

Fixes: #19063 

### Problem

defaultSort('id', 'desc') generates duplicate orderBy:


The check str($order['column'])->contains('.') skips id (no dot), so posts.id gets added again.

# before

<img width="1500" height="194" alt="image" src="https://github.com/user-attachments/assets/3ed89a39-1ea4-445d-b525-6b0952307f00" />


# after
<img width="1154" height="236" alt="image" src="https://github.com/user-attachments/assets/f93df730-c851-452b-bb76-904b8ad3c940" />


## Visual changes


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
