### PR TITLE
[4.x] Fixed ColumnTests Assertions with Custom Data Table

### DIFF
--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -63,6 +63,22 @@ class TestsColumns
         };
     }
 
+    public function assertTableRecordKeyExists(): Closure
+    {
+        return function (?string $recordKey): static {
+            $record = $this->instance()->getTableRecord($recordKey);
+
+            $livewireClass = $this->instance()::class;
+
+            Assert::assertNotEmpty(
+                $record,
+                "Failed asserting that a table row with key {$recordKey} exists on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
     public function assertTableColumnExists(): Closure
     {
         return function (string $name, ?Closure $checkColumnUsing = null, $record = null): static {

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -64,7 +64,7 @@ class TestsColumns
         };
     }
 
-    public function assertTableRecordKeyExists(): Closure
+    protected function assertTableRecordKeyExists(): Closure
     {
         return function (?string $recordKey): static {
             $record = $this->instance()->getTableRecord($recordKey);
@@ -200,9 +200,9 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record[ArrayRecord::getKeyName()];
+                $recordKey = $record[ArrayRecord::getKeyName()];
             } else {
-                $key = $record->getKey();
+                $recordKey = $record->getKey();
             }
 
             $column->record($record);
@@ -226,7 +226,7 @@ class TestsColumns
             Assert::assertEquals(
                 $state,
                 $actualState,
-                "Failed asserting that a table column with name [{$name}] has value of [{$displayState}] for record [{$key}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] has value of [{$displayState}] for record [{$recordKey}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -245,9 +245,9 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record[ArrayRecord::getKeyName()];
+                $recordKey = $record[ArrayRecord::getKeyName()];
             } else {
-                $key = $record->getKey();
+                $recordKey = $record->getKey();
             }
 
             $column->record($record);
@@ -271,7 +271,7 @@ class TestsColumns
             Assert::assertNotEquals(
                 $state,
                 $actualState,
-                "Failed asserting that a table column with name [{$name}] does not have a value of [{$displayState}] for record [{$key}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] does not have a value of [{$displayState}] for record [{$recordKey}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -291,9 +291,9 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record[ArrayRecord::getKeyName()];
+                $recordKey = $record[ArrayRecord::getKeyName()];
             } else {
-                $key = $record->getKey();
+                $recordKey = $record->getKey();
             }
 
             $column->record($record);
@@ -305,7 +305,7 @@ class TestsColumns
             Assert::assertEquals(
                 $state,
                 $column->formatState($column->getState()),
-                "Failed asserting that a table column with name [{$name}] has a formatted state of [{$state}] for record [{$key}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] has a formatted state of [{$state}] for record [{$recordKey}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -325,9 +325,9 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record[ArrayRecord::getKeyName()];
+                $recordKey = $record[ArrayRecord::getKeyName()];
             } else {
-                $key = $record->getKey();
+                $recordKey = $record->getKey();
             }
 
             $column->record($record);
@@ -339,7 +339,7 @@ class TestsColumns
             Assert::assertNotEquals(
                 $state,
                 $column->formatState($column->getState()),
-                "Failed asserting that a table column with name [{$name}] does not have a formatted state of [{$state}] for record [{$key}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] does not have a formatted state of [{$state}] for record [{$recordKey}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -358,9 +358,9 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record[ArrayRecord::getKeyName()];
+                $recordKey = $record[ArrayRecord::getKeyName()];
             } else {
-                $key = $record->getKey();
+                $recordKey = $record->getKey();
             }
 
             $column->record($record);
@@ -372,7 +372,7 @@ class TestsColumns
             Assert::assertEquals(
                 $attributes,
                 $column->getExtraAttributes(),
-                "Failed asserting that a table column with name [{$name}] has extra attributes [{$attributesString}] for record [{$key}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] has extra attributes [{$attributesString}] for record [{$recordKey}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -391,9 +391,9 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record[ArrayRecord::getKeyName()];
+                $recordKey = $record[ArrayRecord::getKeyName()];
             } else {
-                $key = $record->getKey();
+                $recordKey = $record->getKey();
             }
 
             $column->record($record);
@@ -405,7 +405,7 @@ class TestsColumns
             Assert::assertNotEquals(
                 $attributes,
                 $column->getExtraAttributes(),
-                "Failed asserting that a table column with name [{$name}] does not have extra attributes [{$attributesString}] for record [{$key}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] does not have extra attributes [{$attributesString}] for record [{$recordKey}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -425,9 +425,9 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record[ArrayRecord::getKeyName()];
+                $recordKey = $record[ArrayRecord::getKeyName()];
             } else {
-                $key = $record->getKey();
+                $recordKey = $record->getKey();
             }
 
             $column->record($record);
@@ -439,7 +439,7 @@ class TestsColumns
             Assert::assertEquals(
                 $description,
                 $actualDescription,
-                "Failed asserting that a table column with name [{$name}] has description [{$description}] for record [{$key}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] has description [{$description}] for record [{$recordKey}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -459,9 +459,9 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record[ArrayRecord::getKeyName()];
+                $recordKey = $record[ArrayRecord::getKeyName()];
             } else {
-                $key = $record->getKey();
+                $recordKey = $record->getKey();
             }
 
             $column->record($record);
@@ -473,7 +473,7 @@ class TestsColumns
             Assert::assertNotEquals(
                 $description,
                 $actualDescription,
-                "Failed asserting that a table column with name [{$name}] does not have description [{$description}] for record [{$key}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] does not have description [{$description}] for record [{$recordKey}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -493,9 +493,9 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record[ArrayRecord::getKeyName()];
+                $recordKey = $record[ArrayRecord::getKeyName()];
             } else {
-                $key = $record->getKey();
+                $recordKey = $record->getKey();
             }
 
             $column->record($record);
@@ -507,7 +507,7 @@ class TestsColumns
             Assert::assertEquals(
                 $options,
                 $column->getOptions(),
-                "Failed asserting that a table column with name [{$name}] has options [{$optionsString}] for record [{$key}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] has options [{$optionsString}] for record [{$recordKey}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -527,9 +527,9 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record[ArrayRecord::getKeyName()];
+                $recordKey = $record[ArrayRecord::getKeyName()];
             } else {
-                $key = $record->getKey();
+                $recordKey = $record->getKey();
             }
 
             $column->record($record);
@@ -541,7 +541,7 @@ class TestsColumns
             Assert::assertNotEquals(
                 $options,
                 $column->getOptions(),
-                "Failed asserting that a table column with name [{$name}] does not have options [{$optionsString}] for record [{$key}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] does not have options [{$optionsString}] for record [{$recordKey}] on the [{$livewireClass}] component.",
             );
 
             return $this;

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -3,6 +3,7 @@
 namespace Filament\Tables\Testing;
 
 use Closure;
+use Filament\Support\ArrayRecord;
 use Filament\Tables\Columns\Column;
 use Filament\Tables\Columns\SelectColumn;
 use Filament\Tables\Columns\TextColumn;
@@ -199,7 +200,7 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record['__key'];
+                $key = $record[ArrayRecord::getKeyName()];
             } else {
                 $key = $record->getKey();
             }
@@ -244,7 +245,7 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record['__key'];
+                $key = $record[ArrayRecord::getKeyName()];
             } else {
                 $key = $record->getKey();
             }
@@ -290,7 +291,7 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record['__key'];
+                $key = $record[ArrayRecord::getKeyName()];
             } else {
                 $key = $record->getKey();
             }
@@ -324,7 +325,7 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record['__key'];
+                $key = $record[ArrayRecord::getKeyName()];
             } else {
                 $key = $record->getKey();
             }
@@ -357,7 +358,7 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record['__key'];
+                $key = $record[ArrayRecord::getKeyName()];
             } else {
                 $key = $record->getKey();
             }
@@ -390,7 +391,7 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record['__key'];
+                $key = $record[ArrayRecord::getKeyName()];
             } else {
                 $key = $record->getKey();
             }
@@ -424,7 +425,7 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record['__key'];
+                $key = $record[ArrayRecord::getKeyName()];
             } else {
                 $key = $record->getKey();
             }
@@ -458,7 +459,7 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record['__key'];
+                $key = $record[ArrayRecord::getKeyName()];
             } else {
                 $key = $record->getKey();
             }
@@ -492,7 +493,7 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record['__key'];
+                $key = $record[ArrayRecord::getKeyName()];
             } else {
                 $key = $record->getKey();
             }
@@ -526,7 +527,7 @@ class TestsColumns
                 /** @phpstan-ignore-next-line */
                 $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
-                $key = $record['__key'];
+                $key = $record[ArrayRecord::getKeyName()];
             } else {
                 $key = $record->getKey();
             }

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -196,7 +196,12 @@ class TestsColumns
             $column = $this->instance()->getTable()->getColumn($name);
 
             if (! ($record instanceof Model)) {
+                /** @phpstan-ignore-next-line */
+                $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
+                $key = $record['__key'];
+            } else {
+                $key = $record->getKey();
             }
 
             $column->record($record);
@@ -220,7 +225,7 @@ class TestsColumns
             Assert::assertEquals(
                 $state,
                 $actualState,
-                "Failed asserting that a table column with name [{$name}] has value of [{$displayState}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] has value of [{$displayState}] for record [{$key}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -236,7 +241,12 @@ class TestsColumns
             $column = $this->instance()->getTable()->getColumn($name);
 
             if (! ($record instanceof Model)) {
+                /** @phpstan-ignore-next-line */
+                $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
+                $key = $record['__key'];
+            } else {
+                $key = $record->getKey();
             }
 
             $column->record($record);
@@ -260,7 +270,7 @@ class TestsColumns
             Assert::assertNotEquals(
                 $state,
                 $actualState,
-                "Failed asserting that a table column with name [{$name}] does not have a value of [{$displayState}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] does not have a value of [{$displayState}] for record [{$key}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -277,7 +287,12 @@ class TestsColumns
             $column = $this->instance()->getTable()->getColumn($name);
 
             if (! ($record instanceof Model)) {
+                /** @phpstan-ignore-next-line */
+                $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
+                $key = $record['__key'];
+            } else {
+                $key = $record->getKey();
             }
 
             $column->record($record);
@@ -289,7 +304,7 @@ class TestsColumns
             Assert::assertEquals(
                 $state,
                 $column->formatState($column->getState()),
-                "Failed asserting that a table column with name [{$name}] has a formatted state of [{$state}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] has a formatted state of [{$state}] for record [{$key}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -306,7 +321,12 @@ class TestsColumns
             $column = $this->instance()->getTable()->getColumn($name);
 
             if (! ($record instanceof Model)) {
+                /** @phpstan-ignore-next-line */
+                $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
+                $key = $record['__key'];
+            } else {
+                $key = $record->getKey();
             }
 
             $column->record($record);
@@ -318,7 +338,7 @@ class TestsColumns
             Assert::assertNotEquals(
                 $state,
                 $column->formatState($column->getState()),
-                "Failed asserting that a table column with name [{$name}] does not have a formatted state of [{$state}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] does not have a formatted state of [{$state}] for record [{$key}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -334,7 +354,12 @@ class TestsColumns
             $column = $this->instance()->getTable()->getColumn($name);
 
             if (! ($record instanceof Model)) {
+                /** @phpstan-ignore-next-line */
+                $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
+                $key = $record['__key'];
+            } else {
+                $key = $record->getKey();
             }
 
             $column->record($record);
@@ -346,7 +371,7 @@ class TestsColumns
             Assert::assertEquals(
                 $attributes,
                 $column->getExtraAttributes(),
-                "Failed asserting that a table column with name [{$name}] has extra attributes [{$attributesString}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] has extra attributes [{$attributesString}] for record [{$key}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -362,7 +387,12 @@ class TestsColumns
             $column = $this->instance()->getTable()->getColumn($name);
 
             if (! ($record instanceof Model)) {
+                /** @phpstan-ignore-next-line */
+                $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
+                $key = $record['__key'];
+            } else {
+                $key = $record->getKey();
             }
 
             $column->record($record);
@@ -374,7 +404,7 @@ class TestsColumns
             Assert::assertNotEquals(
                 $attributes,
                 $column->getExtraAttributes(),
-                "Failed asserting that a table column with name [{$name}] does not have extra attributes [{$attributesString}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] does not have extra attributes [{$attributesString}] for record [{$key}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -391,7 +421,12 @@ class TestsColumns
             $column = $this->instance()->getTable()->getColumn($name);
 
             if (! ($record instanceof Model)) {
+                /** @phpstan-ignore-next-line */
+                $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
+                $key = $record['__key'];
+            } else {
+                $key = $record->getKey();
             }
 
             $column->record($record);
@@ -403,7 +438,7 @@ class TestsColumns
             Assert::assertEquals(
                 $description,
                 $actualDescription,
-                "Failed asserting that a table column with name [{$name}] has description [{$description}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] has description [{$description}] for record [{$key}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -420,7 +455,12 @@ class TestsColumns
             $column = $this->instance()->getTable()->getColumn($name);
 
             if (! ($record instanceof Model)) {
+                /** @phpstan-ignore-next-line */
+                $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
+                $key = $record['__key'];
+            } else {
+                $key = $record->getKey();
             }
 
             $column->record($record);
@@ -432,7 +472,7 @@ class TestsColumns
             Assert::assertNotEquals(
                 $description,
                 $actualDescription,
-                "Failed asserting that a table column with name [{$name}] does not have description [{$description}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] does not have description [{$description}] for record [{$key}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -449,7 +489,12 @@ class TestsColumns
             $column = $this->instance()->getTable()->getColumn($name);
 
             if (! ($record instanceof Model)) {
+                /** @phpstan-ignore-next-line */
+                $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
+                $key = $record['__key'];
+            } else {
+                $key = $record->getKey();
             }
 
             $column->record($record);
@@ -461,7 +506,7 @@ class TestsColumns
             Assert::assertEquals(
                 $options,
                 $column->getOptions(),
-                "Failed asserting that a table column with name [{$name}] has options [{$optionsString}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] has options [{$optionsString}] for record [{$key}] on the [{$livewireClass}] component.",
             );
 
             return $this;
@@ -478,7 +523,12 @@ class TestsColumns
             $column = $this->instance()->getTable()->getColumn($name);
 
             if (! ($record instanceof Model)) {
+                /** @phpstan-ignore-next-line */
+                $this->assertTableRecordKeyExists((string) $record);
                 $record = $this->instance()->getTableRecord($record);
+                $key = $record['__key'];
+            } else {
+                $key = $record->getKey();
             }
 
             $column->record($record);
@@ -490,7 +540,7 @@ class TestsColumns
             Assert::assertNotEquals(
                 $options,
                 $column->getOptions(),
-                "Failed asserting that a table column with name [{$name}] does not have options [{$optionsString}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+                "Failed asserting that a table column with name [{$name}] does not have options [{$optionsString}] for record [{$key}] on the [{$livewireClass}] component.",
             );
 
             return $this;

--- a/tests/src/Fixtures/Livewire/CustomDataTable.php
+++ b/tests/src/Fixtures/Livewire/CustomDataTable.php
@@ -46,11 +46,11 @@ class CustomDataTable extends Component implements HasActions, HasSchemas, Table
                     ->boolean(),
                 TextColumn::make('formatted_state')
                     ->formatStateUsing(fn () => 'formatted state'),
-                Tables\Columns\TextColumn::make('extra_attributes')
+                TextColumn::make('extra_attributes')
                     ->extraAttributes([
                         'class' => 'text-danger-500',
                     ]),
-                Tables\Columns\TextColumn::make('with_description')
+                TextColumn::make('with_description')
                     ->description('description below')
                     ->description('description above', 'above'),
 

--- a/tests/src/Fixtures/Livewire/CustomDataTable.php
+++ b/tests/src/Fixtures/Livewire/CustomDataTable.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Livewire;
+
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Tables;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+
+class CustomDataTable extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use Tables\Concerns\InteractsWithTable;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->records(fn (): array => [
+                1 => [
+                    'title' => 'First item',
+                    'slug' => 'first-item',
+                    'is_featured' => true,
+                ],
+                2 => [
+                    'title' => 'Second item',
+                    'slug' => 'second-item',
+                    'is_featured' => false,
+                ],
+                3 => [
+                    'title' => 'Third item',
+                    'slug' => 'third-item',
+                    'is_featured' => true,
+                ],
+            ])
+            ->columns([
+                TextColumn::make('title'),
+                TextColumn::make('slug'),
+                IconColumn::make('is_featured')
+                    ->boolean(),
+                TextColumn::make('formatted_state')
+                    ->formatStateUsing(fn () => 'formatted state'),
+                Tables\Columns\TextColumn::make('extra_attributes')
+                    ->extraAttributes([
+                        'class' => 'text-danger-500',
+                    ]),
+                Tables\Columns\TextColumn::make('with_description')
+                    ->description('description below')
+                    ->description('description above', 'above'),
+
+                Tables\Columns\SelectColumn::make('with_options')
+                    ->options([
+                        'red' => 'Red',
+                        'blue' => 'Blue',
+                    ]),
+            ]);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.table');
+    }
+}

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -508,17 +508,6 @@ it('can state whether a select column has options with custom data', function ()
         ->assertTableSelectColumnDoesNotHaveOptions('with_options', ['one' => 'One', 'two' => 'Two'], 2);
 });
 
-it('can assert that a key exists in a table with custom data', function (): void {
-    livewire(CustomDataTable::class)
-        ->assertTableRecordKeyExists(1);
-
-    $this->expectException('PHPUnit\Framework\ExpectationFailedException');
-    $this->expectExceptionMessage('Failed asserting that a table row with key 1000 exists on the [' . CustomDataTable::class . '] component');
-
-    livewire(CustomDataTable::class)
-        ->assertTableRecordKeyExists(1000);
-});
-
 it('can assert that a column exists with the given configuration', function (): void {
     $publishedPost = Post::factory()->create([
         'is_published' => true,

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -475,6 +475,17 @@ it('can state whether a select column has options', function (): void {
         ->assertTableSelectColumnDoesNotHaveOptions('with_options', ['one' => 'One', 'two' => 'Two'], $post);
 });
 
+it('can assert that a key exists in a table with custom data', function (): void {
+    livewire(CustomDataTable::class)
+        ->assertTableRecordKeyExists(1);
+
+    $this->expectException('PHPUnit\Framework\ExpectationFailedException');
+    $this->expectExceptionMessage('Failed asserting that a table row with key 1000 exists on the [' . CustomDataTable::class . '] component');
+
+    livewire(CustomDataTable::class)
+        ->assertTableRecordKeyExists(1000);
+});
+
 it('can assert that a column exists with the given configuration', function (): void {
     $publishedPost = Post::factory()->create([
         'is_published' => true,

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -2,6 +2,7 @@
 
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tests\Fixtures\Livewire\CustomDataTable;
 use Filament\Tests\Fixtures\Livewire\PostsTable;
 use Filament\Tests\Fixtures\Livewire\PostsTableWithQualifiedColumns;
 use Filament\Tests\Fixtures\Livewire\PostsTableWithTableSearchableColumns;
@@ -371,7 +372,7 @@ it('can call a column action object', function (): void {
         ->assertDispatched('column-action-object-called');
 });
 
-it('can state whether a column has the correct value', function (): void {
+it('can state whether a column has the correct value with Eloquent records', function (): void {
     $post = Post::factory()->create();
 
     livewire(PostsTable::class)
@@ -379,12 +380,24 @@ it('can state whether a column has the correct value', function (): void {
         ->assertTableColumnStateNotSet('with_state', 'incorrect state', $post);
 });
 
-it('can state whether a column has the correct formatted value', function (): void {
+it('can state whether a column has the correct value with custom data', function (): void {
+    livewire(CustomDataTable::class)
+        ->assertTableColumnStateSet('title', 'Second item', 2)
+        ->assertTableColumnStateNotSet('title', 'incorrect state', 2);
+});
+
+it('can state whether a column has the correct formatted value with Eloquent records', function (): void {
     $post = Post::factory()->create();
 
     livewire(PostsTable::class)
         ->assertTableColumnFormattedStateSet('formatted_state', 'formatted state', $post)
         ->assertTableColumnFormattedStateNotSet('formatted_state', 'incorrect formatted state', $post);
+});
+
+it('can state whether a column has the correct formatted value with custom data', function (): void {
+    livewire(CustomDataTable::class)
+        ->assertTableColumnFormattedStateSet('formatted_state', 'formatted state', 1)
+        ->assertTableColumnFormattedStateNotSet('formatted_state', 'incorrect formatted state', 1);
 });
 
 it('can output JSON values', function (): void {
@@ -449,7 +462,7 @@ it('can output values in a JSON column with a non-relationship accessor method',
         ->assertTableColumnStateSet('config.setting', 'foo', $post);
 });
 
-it('can state whether a column has extra attributes', function (): void {
+it('can state whether a column has extra attributes with Eloquent records', function (): void {
     $post = Post::factory()->create();
 
     livewire(PostsTable::class)
@@ -457,7 +470,13 @@ it('can state whether a column has extra attributes', function (): void {
         ->assertTableColumnDoesNotHaveExtraAttributes('extra_attributes', ['class' => 'text-primary-500'], $post);
 });
 
-it('can state whether a column has a description', function (): void {
+it('can state whether a column has extra attributes with custom data', function (): void {
+    livewire(CustomDataTable::class)
+        ->assertTableColumnHasExtraAttributes('extra_attributes', ['class' => 'text-danger-500'], 1)
+        ->assertTableColumnDoesNotHaveExtraAttributes('extra_attributes', ['class' => 'text-primary-500'], 1);
+});
+
+it('can state whether a column has a description with Eloquent records', function (): void {
     $post = Post::factory()->create();
 
     livewire(PostsTable::class)
@@ -467,12 +486,26 @@ it('can state whether a column has a description', function (): void {
         ->assertTableColumnDoesNotHaveDescription('with_description', 'incorrect description above', $post, 'above');
 });
 
-it('can state whether a select column has options', function (): void {
+it('can state whether a column has a description with custom data', function (): void {
+    livewire(CustomDataTable::class)
+        ->assertTableColumnHasDescription('with_description', 'description below', 1)
+        ->assertTableColumnHasDescription('with_description', 'description above', 1, 'above')
+        ->assertTableColumnDoesNotHaveDescription('with_description', 'incorrect description below', 1)
+        ->assertTableColumnDoesNotHaveDescription('with_description', 'incorrect description above', 1, 'above');
+});
+
+it('can state whether a select column has options with Eloquent records', function (): void {
     $post = Post::factory()->create();
 
     livewire(PostsTable::class)
         ->assertTableSelectColumnHasOptions('with_options', ['red' => 'Red', 'blue' => 'Blue'], $post)
         ->assertTableSelectColumnDoesNotHaveOptions('with_options', ['one' => 'One', 'two' => 'Two'], $post);
+});
+
+it('can state whether a select column has options with custom data', function (): void {
+    livewire(CustomDataTable::class)
+        ->assertTableSelectColumnHasOptions('with_options', ['red' => 'Red', 'blue' => 'Blue'], 2)
+        ->assertTableSelectColumnDoesNotHaveOptions('with_options', ['one' => 'One', 'two' => 'Two'], 2);
 });
 
 it('can assert that a key exists in a table with custom data', function (): void {


### PR DESCRIPTION
## Description

The assertion methods listed below allow passing either an Eloquent Record or the the row index as the `$record` parameter.

The functionality works - but the phpunit messages use `$record->getKey()`  which mean the assertions fail when used with an index instead of an Eloquent Record causing an error.

- `assertTableColumnStateSet`
- `assertTableColumnStateNotSet`
- `assertTableColumnFormattedStateSet`
- `assertTableColumnFormattedStateNotSet`
- `assertTableColumnHasExtraAttributes`
- `assertTableColumnDoesNotHaveExtraAttributes`
- `assertTableColumnHasDescription`
- `assertTableColumnDoesNotHaveDescription`
- `assertTableSelectColumnHasOptions`
- `assertTableSelectColumnDoesNotHaveOptions`

## Visual changes

None

## Functional changes

- [x] Added `assertTableRecordKeyExists` to give a friendly error if an invalid index is passed
- [x] Updated other assertions to use the passed `$record` as the `$key` if it is not an Eloquent Model
- [x] Added a `CustomDataTable` fixture (based on the existing `PostsTable)

## Workaround
In case anyone else needs a workaround before this is merged:

Add this to your TestCase:
```php

namespace Tests;

use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
abstract class TestCase extends BaseTestCase
{
    /**
     * Workaround for this bug: https://github.com/filamentphp/filament/pull/19092
     */
    protected function workaroundFilamentBug(\Closure $closure)
    {
        try {
            $closure();
        } catch(\Error $e) {
            if ($e->getMessage() !== "Call to a member function getKey() on array") {
                throw $e;
            }
        }
    }
}
```

And use it like this:
```php
$page = Livewire::test(MyPage::class);
$this->workaroundFilamentBug(fn() => $page->assertTableColumnStateSet('column_name', 3, 1));
```