### PR TITLE
[4.x] Add missing German form component translations

### DIFF
--- a/packages/forms/resources/lang/de/components.php
+++ b/packages/forms/resources/lang/de/components.php
@@ -11,6 +11,7 @@ return [
             ],
 
             'add' => [
+
                 'label' => 'Zu :label hinzufügen',
 
                 'modal' => [
@@ -30,6 +31,7 @@ return [
             ],
 
             'add_between' => [
+
                 'label' => 'Dazwischen einfügen',
 
                 'modal' => [
@@ -45,6 +47,7 @@ return [
                     ],
 
                 ],
+
             ],
 
             'delete' => [
@@ -281,6 +284,10 @@ return [
 
     'markdown_editor' => [
 
+        'file_attachments_accepted_file_types_message' => 'Hochgeladene Dateien müssen vom Typ :values sein.',
+
+        'file_attachments_max_size_message' => 'Hochgeladene Dateien dürfen nicht größer als :max Kilobytes sein.',
+
         'tools' => [
             'attach_files' => 'Dateien beifügen',
             'blockquote' => 'Zitat',
@@ -416,14 +423,6 @@ return [
 
                     ],
 
-                    'actions' => [
-
-                        'save' => [
-                            'label' => 'Speichern',
-                        ],
-
-                    ],
-
                 ],
 
             ],
@@ -440,6 +439,71 @@ return [
 
                         'save' => [
                             'label' => 'Speichern',
+                        ],
+
+                    ],
+
+                ],
+
+            ],
+
+            'grid' => [
+
+                'label' => 'Raster',
+
+                'modal' => [
+
+                    'heading' => 'Raster',
+
+                    'form' => [
+
+                        'preset' => [
+
+                            'label' => 'Voreinstellung',
+
+                            'placeholder' => 'Keine',
+
+                            'options' => [
+                                'two' => 'Zwei',
+                                'three' => 'Drei',
+                                'four' => 'Vier',
+                                'five' => 'Fünf',
+                                'two_start_third' => 'Zwei (Anfang Drittel)',
+                                'two_end_third' => 'Zwei (Ende Drittel)',
+                                'two_start_fourth' => 'Zwei (Anfang Viertel)',
+                                'two_end_fourth' => 'Zwei (Ende Viertel)',
+                            ],
+                        ],
+
+                        'columns' => [
+                            'label' => 'Spalten',
+                        ],
+
+                        'from_breakpoint' => [
+
+                            'label' => 'Ab Breakpoint',
+
+                            'options' => [
+                                'default' => 'Alle',
+                                'sm' => 'Klein (sm)',
+                                'md' => 'Mittel (md)',
+                                'lg' => 'Groß (lg)',
+                                'xl' => 'Extra groß (xl)',
+                                '2xl' => 'Zweifach extra groß (2xl)',
+                            ],
+
+                        ],
+
+                        'is_asymmetric' => [
+                            'label' => 'Zwei asymmetrische Spalten',
+                        ],
+
+                        'start_span' => [
+                            'label' => 'Spannweite am Anfang',
+                        ],
+
+                        'end_span' => [
+                            'label' => 'Spannweite am Ende',
                         ],
 
                     ],
@@ -472,25 +536,43 @@ return [
 
             ],
 
-        ],
+            'text_color' => [
 
-        'no_merge_tag_search_results_message' => 'Keine Ergebnisse für Merge-Tags.',
+                'label' => 'Textfarbe',
 
-        'dialogs' => [
+                'modal' => [
 
-            'link' => [
+                    'heading' => 'Textfarbe',
 
-                'actions' => [
-                    'link' => 'Verlinken',
-                    'unlink' => 'Verlinkung aufheben',
+                    'form' => [
+
+                        'color' => [
+                            'label' => 'Farbe',
+                        ],
+
+                        'custom_color' => [
+                            'label' => 'Benutzerdefinierte Farbe',
+                        ],
+
+                    ],
+
                 ],
-
-                'label' => 'URL',
-
-                'placeholder' => 'URL eingeben',
 
             ],
 
+        ],
+
+        'file_attachments_accepted_file_types_message' => 'Hochgeladene Dateien müssen vom Typ :values sein.',
+
+        'file_attachments_max_size_message' => 'Hochgeladene Dateien dürfen nicht größer als :max Kilobytes sein.',
+
+        'no_merge_tag_search_results_message' => 'Keine Ergebnisse für Merge-Tags.',
+
+        'mentions' => [
+            'no_options_message' => 'Keine Optionen verfügbar.',
+            'no_search_results_message' => 'Keine Ergebnisse gefunden.',
+            'search_prompt' => 'Beginnen Sie mit der Eingabe, um zu suchen...',
+            'searching_message' => 'Sucht...',
         ],
 
         'tools' => [
@@ -503,12 +585,15 @@ return [
             'bold' => 'Fett',
             'bullet_list' => 'Aufzählungsliste',
             'clear_formatting' => 'Formatierung löschen',
+            'code' => 'Code',
             'code_block' => 'Code Block',
             'custom_blocks' => 'Blöcke',
             'details' => 'Details',
             'h1' => 'Titel',
             'h2' => 'Überschrift',
             'h3' => 'Unterüberschrift',
+            'grid' => 'Raster',
+            'grid_delete' => 'Raster löschen',
             'highlight' => 'Hervorheben',
             'horizontal_rule' => 'Horizontale Linie',
             'italic' => 'Kursiv',
@@ -532,9 +617,13 @@ return [
             'table_merge_cells' => 'Zellen verbinden',
             'table_split_cell' => 'Zelle teilen',
             'table_toggle_header_row' => 'Kopfzeile umschalten',
+            'table_toggle_header_cell' => 'Kopfzelle umschalten',
+            'text_color' => 'Textfarbe',
             'underline' => 'Unterstreichen',
             'undo' => 'Rückgängig',
         ],
+
+        'uploading_file_message' => 'Datei wird hochgeladen...',
 
     ],
 
@@ -597,6 +686,8 @@ return [
 
         'max_items_message' => 'Es können nur :count ausgewählt werden.',
 
+        'no_options_message' => 'Keine Optionen verfügbar.',
+
         'no_search_results_message' => 'Die Suche ergab keine Treffer.',
 
         'placeholder' => 'Wählen Sie eine Option',
@@ -608,12 +699,27 @@ return [
     ],
 
     'tags_input' => [
+
+        'actions' => [
+
+            'delete' => [
+                'label' => 'Löschen',
+            ],
+
+        ],
+
         'placeholder' => 'Neue Kennzeichnung',
+
     ],
 
     'text_input' => [
 
         'actions' => [
+
+            'copy' => [
+                'label' => 'Kopieren',
+                'message' => 'Kopiert',
+            ],
 
             'hide_password' => [
                 'label' => 'Passwort verbergen',


### PR DESCRIPTION
## Description

Adds all the missing German form components translations and deletes some unused. Ensures the German translation file has the same structure as the English does have.

## Visual changes

It affects multiple places, but one example is the mentions plugin in the RichEditor.

Before:
<img width="1614" height="506" alt="CleanShot 2026-01-27 at 06 32 10@2x" src="https://github.com/user-attachments/assets/c46ea2d8-e103-412b-82c3-d7d29cccbfe5" />

After:
<img width="1598" height="538" alt="CleanShot 2026-01-27 at 06 32 42@2x" src="https://github.com/user-attachments/assets/d839dd5a-0279-402d-acf8-9a2e69519efa" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] ~~Documentation is up-to-date.~~ (no change required)
