### PR TITLE
feat: allow tenant switching to be disabled

### DIFF
--- a/docs/07-users/03-tenancy.md
+++ b/docs/07-users/03-tenancy.md
@@ -466,6 +466,23 @@ Action::make('lockSession')
     ->postToUrl()
 ```
 
+### Disabling the tenant switcher
+
+By default, users can switch between tenants using the tenant menu. If you want to keep the tenant menu visible but prevent users from switching tenants, you can use the `tenantSwitcher()` method in the [configuration](../panel-configuration):
+
+```php
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->tenantSwitcher(false);
+}
+```
+
+This keeps the tenant menu visible, showing the current tenant name and any custom menu items, but hides the list of other tenants. This is useful when you want to display tenant information without allowing switching, or when switching should be controlled through other means.
+
 ### Hiding the tenant menu
 
 You can hide the tenant menu by using the `tenantMenu(false)`

--- a/packages/panels/resources/views/components/tenant-menu.blade.php
+++ b/packages/panels/resources/views/components/tenant-menu.blade.php
@@ -11,12 +11,12 @@
 
     $items = $this->getTenantMenuItems();
 
-    $canSwitchTenants = count($tenants = array_filter(
+    $canSwitchTenants = filament()->canSwitchTenants() && filled($tenants = array_filter(
         filament()->getUserTenants(filament()->auth()->user()),
         fn (\Illuminate\Database\Eloquent\Model $tenant): bool => ! $tenant->is($currentTenant),
     ));
 
-    $isSearchable = filled($canSwitchTenants) ? (filament()->isTenantMenuSearchable() ?? (count($tenants) >= 10)) : false;
+    $isSearchable = $canSwitchTenants && (filament()->isTenantMenuSearchable() ?? (count($tenants) >= 10));
 
     $itemsBeforeAndAfterTenantSwitcher = collect($items)
         ->groupBy(fn (Action $item): bool => $canSwitchTenants && ($item->getSort() < 0), preserveKeys: true)

--- a/packages/panels/resources/views/components/tenant-menu.blade.php
+++ b/packages/panels/resources/views/components/tenant-menu.blade.php
@@ -11,7 +11,7 @@
 
     $items = $this->getTenantMenuItems();
 
-    $canSwitchTenants = filament()->canSwitchTenants() && filled($tenants = array_filter(
+    $canSwitchTenants = filament()->hasTenantSwitcher() && filled($tenants = array_filter(
         filament()->getUserTenants(filament()->auth()->user()),
         fn (\Illuminate\Database\Eloquent\Model $tenant): bool => ! $tenant->is($currentTenant),
     ));

--- a/packages/panels/src/Facades/Filament.php
+++ b/packages/panels/src/Facades/Filament.php
@@ -158,6 +158,7 @@ use Livewire\Component;
  * @method static bool isServing()
  * @method static bool isSidebarCollapsibleOnDesktop()
  * @method static bool isSidebarFullyCollapsibleOnDesktop()
+ * @method static bool canSwitchTenants()
  * @method static ?bool isTenantMenuSearchable()
  * @method static void serving(Closure $callback)
  * @method static void setCurrentPanel(Panel | string | null $panel = null)

--- a/packages/panels/src/Facades/Filament.php
+++ b/packages/panels/src/Facades/Filament.php
@@ -159,7 +159,7 @@ use Livewire\Component;
  * @method static bool isServing()
  * @method static bool isSidebarCollapsibleOnDesktop()
  * @method static bool isSidebarFullyCollapsibleOnDesktop()
- * @method static bool canSwitchTenants()
+ * @method static bool hasTenantSwitcher()
  * @method static ?bool isTenantMenuSearchable()
  * @method static void serving(Closure $callback)
  * @method static void setCurrentPanel(Panel | string | null $panel = null)

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -480,9 +480,9 @@ class FilamentManager
         return $this->getCurrentOrDefaultPanel()->getTenantMenuItems();
     }
 
-    public function canSwitchTenants(): bool
+    public function hasTenantSwitcher(): bool
     {
-        return $this->getCurrentOrDefaultPanel()->canSwitchTenants();
+        return $this->getCurrentOrDefaultPanel()->hasTenantSwitcher();
     }
 
     public function isTenantMenuSearchable(): ?bool

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -480,6 +480,11 @@ class FilamentManager
         return $this->getCurrentOrDefaultPanel()->getTenantMenuItems();
     }
 
+    public function canSwitchTenants(): bool
+    {
+        return $this->getCurrentOrDefaultPanel()->canSwitchTenants();
+    }
+
     public function isTenantMenuSearchable(): ?bool
     {
         return $this->getCurrentOrDefaultPanel()->isTenantMenuSearchable();

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -23,7 +23,7 @@ trait HasTenancy
 
     protected bool | Closure $hasTenantMenu = true;
 
-    protected bool | Closure $canSwitchTenants = true;
+    protected bool | Closure $hasTenantSwitcher = true;
 
     protected bool | Closure | null $isTenantMenuSearchable = null;
 
@@ -73,9 +73,9 @@ trait HasTenancy
         return $this;
     }
 
-    public function switchableTenants(bool | Closure $condition = true): static
+    public function tenantSwitcher(bool | Closure $condition = true): static
     {
-        $this->canSwitchTenants = $condition;
+        $this->hasTenantSwitcher = $condition;
 
         return $this;
     }
@@ -358,9 +358,9 @@ trait HasTenancy
         ]) ?? $action;
     }
 
-    public function canSwitchTenants(): bool
+    public function hasTenantSwitcher(): bool
     {
-        return (bool) $this->evaluate($this->canSwitchTenants);
+        return (bool) $this->evaluate($this->hasTenantSwitcher);
     }
 
     public function isTenantMenuSearchable(): ?bool

--- a/packages/panels/src/Panel/Concerns/HasTenancy.php
+++ b/packages/panels/src/Panel/Concerns/HasTenancy.php
@@ -23,6 +23,8 @@ trait HasTenancy
 
     protected bool | Closure $hasTenantMenu = true;
 
+    protected bool | Closure $canSwitchTenants = true;
+
     protected bool | Closure | null $isTenantMenuSearchable = null;
 
     protected ?string $tenantRoutePrefix = null;
@@ -67,6 +69,13 @@ trait HasTenancy
             ...$this->tenantMenuItems,
             ...$items,
         ];
+
+        return $this;
+    }
+
+    public function switchableTenants(bool | Closure $condition = true): static
+    {
+        $this->canSwitchTenants = $condition;
 
         return $this;
     }
@@ -347,6 +356,11 @@ trait HasTenancy
         return $this->evaluate($item, [
             'action' => $action,
         ]) ?? $action;
+    }
+
+    public function canSwitchTenants(): bool
+    {
+        return (bool) $this->evaluate($this->canSwitchTenants);
     }
 
     public function isTenantMenuSearchable(): ?bool


### PR DESCRIPTION
## Description
This PR adds a `switchableTenants()` configuration method to the Panel builder, allowing developers to disable the tenant switcher, while keeping the tenant menu.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
