### PR TITLE
[4.x] Fix prevent filter dropdown position misalignment on small screens

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -185,6 +185,7 @@
     >
         @if ($hasFiltersBeforeContent)
             <div
+                wire:ignore.self
                 x-ref="filtersContentContainer"
                 x-transition:enter-start="fi-opacity-0"
                 x-transition:leave-end="fi-opacity-0"
@@ -2244,6 +2245,7 @@
 
         @if ($hasFiltersAfterContent)
             <div
+                wire:ignore.self
                 x-ref="filtersContentContainer"
                 x-transition:enter-start="fi-opacity-0"
                 x-transition:leave-end="fi-opacity-0"


### PR DESCRIPTION
## Description

### Fixes: #19080 

Tried using Livewire's `morph.updated` hook which also works, but went with `wire:ignore.self` to stay consistent with the `dropdown` component.


Thanks @martins-vanags for the detailed bug report and fix suggestion!

## Visual changes

### Before:

https://github.com/user-attachments/assets/18efb48a-91f6-4359-84d6-edc88a4f86fc

### After:

https://github.com/user-attachments/assets/730efbc3-1ec3-472f-8cfb-e506bf0c9ea9



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
