### PR TITLE
[4.x] Fix databaseNotifications livewireComponent parameter being ignored

### DIFF
--- a/packages/panels/resources/views/components/layout/simple.blade.php
+++ b/packages/panels/resources/views/components/layout/simple.blade.php
@@ -24,7 +24,7 @@
         @if (($hasTopbar ?? true) && filament()->auth()->check())
             <div class="fi-simple-layout-header">
                 @if (filament()->hasDatabaseNotifications())
-                    @livewire(Filament\Livewire\DatabaseNotifications::class, [
+                    @livewire(filament()->getDatabaseNotificationsLivewireComponent(), [
                         'lazy' => filament()->hasLazyLoadedDatabaseNotifications(),
                         'position' => \Filament\Enums\DatabaseNotificationsPosition::Topbar,
                     ])

--- a/packages/panels/resources/views/livewire/sidebar.blade.php
+++ b/packages/panels/resources/views/livewire/sidebar.blade.php
@@ -179,7 +179,7 @@
         @if ($shouldRenderFooter)
             <div class="fi-sidebar-footer">
                 @if ($hasDatabaseNotificationsInSidebar)
-                    @livewire(Filament\Livewire\DatabaseNotifications::class, [
+                    @livewire(filament()->getDatabaseNotificationsLivewireComponent(), [
                         'lazy' => filament()->hasLazyLoadedDatabaseNotifications(),
                     ])
                 @endif

--- a/packages/panels/resources/views/livewire/topbar.blade.php
+++ b/packages/panels/resources/views/livewire/topbar.blade.php
@@ -251,7 +251,7 @@
 
             @if (filament()->auth()->check())
                 @if (filament()->hasDatabaseNotifications() && filament()->getDatabaseNotificationsPosition() === \Filament\Enums\DatabaseNotificationsPosition::Topbar)
-                    @livewire(Filament\Livewire\DatabaseNotifications::class, [
+                    @livewire(filament()->getDatabaseNotificationsLivewireComponent(), [
                         'lazy' => filament()->hasLazyLoadedDatabaseNotifications(),
                     ])
                 @endif

--- a/packages/panels/src/Facades/Filament.php
+++ b/packages/panels/src/Facades/Filament.php
@@ -48,6 +48,7 @@ use Livewire\Component;
  * @method static Panel | null getCurrentPanel()
  * @method static Panel | null getCurrentOrDefaultPanel()
  * @method static string | Htmlable | null getDarkModeBrandLogo()
+ * @method static class-string<Component> getDatabaseNotificationsLivewireComponent()
  * @method static string | null getDatabaseNotificationsPollingInterval()
  * @method static DatabaseNotificationsPosition getDatabaseNotificationsPosition()
  * @method static string getDefaultAvatarProvider()

--- a/packages/panels/src/FilamentManager.php
+++ b/packages/panels/src/FilamentManager.php
@@ -790,6 +790,14 @@ class FilamentManager
         return $this->getCurrentOrDefaultPanel()->getDatabaseNotificationsPosition();
     }
 
+    /**
+     * @return class-string<Component>
+     */
+    public function getDatabaseNotificationsLivewireComponent(): string
+    {
+        return $this->getCurrentOrDefaultPanel()->getDatabaseNotificationsLivewireComponent();
+    }
+
     public function hasTopNavigation(): bool
     {
         return $this->getCurrentOrDefaultPanel()->hasTopNavigation();


### PR DESCRIPTION
## Description
Fixes #19116

The `livewireComponent` parameter in `databaseNotifications()` was stored but never used - views hardcoded `DatabaseNotifications::class` instead of reading the configured component.

## Visual changes

### Before

<img width="1166" height="536" alt="image" src="https://github.com/user-attachments/assets/e3dd7951-8a08-4975-9eab-0ab292cbb26d" />


### After

<img width="1146" height="556" alt="image" src="https://github.com/user-attachments/assets/0c2c42d4-2284-4a3c-8b1c-2678bd451c6e" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
