### PR TITLE
fix(concern): ensure state path matches in relationship entanglement

### DIFF
--- a/packages/schemas/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
+++ b/packages/schemas/src/Components/Concerns/EntanglesStateWithSingularRelationship.php
@@ -43,6 +43,7 @@ trait EntanglesStateWithSingularRelationship
             $findFirstComponentWithThisRelationship = function (Schema $schema) use ($component, &$findFirstComponentWithThisRelationship): ?CanEntangleWithSingularRelationships {
                 foreach ($schema->getComponents(withActions: false, withHidden: true) as $childComponent) {
                     if (
+                        ($childComponent->getStatePath() === $component->getStatePath()) &&
                         ($childComponent->getModel() === $component->getModel()) &&
                         ($childComponent->getRecord() === $component->getRecord()) &&
                         ($childComponent instanceof CanEntangleWithSingularRelationships) &&


### PR DESCRIPTION
## Description

Prevents coordinated relationship loading when multiple ComponentX::make()->relationship() components reference the same HasOne relationship but use different state paths.

Coordination is now applied only if the components share an identical state path.

Related Issue and Mergerequest:
https://github.com/filamentphp/filament/issues/18826
https://github.com/filamentphp/filament/pull/18827

### Problem
The coordination logic assumes that components pointing to the same relationship should always share state. However, there are valid scenarios where multiple components intentionally use different state paths while referencing the same relationship.

In these cases, forcing coordinated loading causes one component to override another component’s state, leading to unexpected behavior.

### Solution
Before applying the coordinated loading behavior, this PR compares the state paths of all components referencing the relationship.

## Visual changes
None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
