### PR TITLE
[4.x] Fix cross-domain URL detection in multi-domain apps

### DIFF
--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -116,19 +116,13 @@ if (! function_exists('Filament\Support\is_slot_empty')) {
 if (! function_exists('Filament\Support\is_app_url')) {
     function is_app_url(string $url): bool
     {
-        $url = str($url);
-
-        if ($url->startsWith('/') && (! $url->startsWith('//'))) {
+        if (str($url)->startsWith('/') && ! str($url)->startsWith('//')) {
             return true;
         }
 
-        $appUrl = rtrim((string) config('app.url'), '/');
+        $urlHost = parse_url($url, PHP_URL_HOST);
 
-        if (($appUrl !== '') && $url->startsWith($appUrl)) {
-            return true;
-        }
-
-        return $url->startsWith(request()->root());
+        return (! $urlHost) || $urlHost === request()->getHost();
     }
 }
 


### PR DESCRIPTION
## Description

Fixes: #19117

Compare URL host with `request()->getHost()` instead of using `config('app.url')` prefix matching.

## Visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
