### PR TITLE
Update 08-text-input.md

### DIFF
--- a/packages/tables/docs/02-columns/08-text-input.md
+++ b/packages/tables/docs/02-columns/08-text-input.md
@@ -37,15 +37,29 @@ use Filament\Tables\Columns\TextInputColumn;
 TextInputColumn::make('background_color')->type('color')
 ```
 
-For numeric fields (e.g. quantity, price), use `type('number')`. You can combine it with `inputMode('decimal')` and `step('any')` for decimal values, or `step(1)` for integers:
+## Setting the HTML input mode
+
+You may use the `inputMode()` method to set the [HTML inputmode attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode), which hints at the type of keyboard to show on mobile. For numeric inputs, use `inputMode('decimal')` for decimal values or `inputMode('numeric')` for integers:
 
 ```php
+use Filament\Tables\Columns\TextInputColumn;
+
 TextInputColumn::make('quantity')
-    ->label('Quantity')
+    ->type('number')
+    ->inputMode('decimal')
+```
+
+## Setting the numeric step
+
+When using `type('number')`, you may use the `step()` method to set the [HTML step attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#step). Use `step('any')` for decimal values or `step('1')` for integers:
+
+```php
+use Filament\Tables\Columns\TextInputColumn;
+
+TextInputColumn::make('quantity')
     ->type('number')
     ->inputMode('decimal')
     ->step('1')
-    ->rules(['required', 'numeric', 'min:1'])
 ```
 
 ## Lifecycle hooks

--- a/packages/tables/docs/02-columns/08-text-input.md
+++ b/packages/tables/docs/02-columns/08-text-input.md
@@ -37,6 +37,17 @@ use Filament\Tables\Columns\TextInputColumn;
 TextInputColumn::make('background_color')->type('color')
 ```
 
+For numeric fields (e.g. quantity, price), use `type('number')`. You can combine it with `inputMode('decimal')` and `step('any')` for decimal values, or `step(1)` for integers:
+
+```php
+TextInputColumn::make('quantity')
+    ->label('Quantity')
+    ->type('number')
+    ->inputMode('decimal')
+    ->step('1')
+    ->rules(['required', 'numeric', 'min:1'])
+```
+
 ## Lifecycle hooks
 
 Hooks may be used to execute code at various points within the input's lifecycle:


### PR DESCRIPTION
## Description

The TextInputColumn documentation feels incomplete. For example, there is no mention that you can use `type('number')` for numeric fields (quantity, price, etc.), nor how to combine it with `inputMode('decimal')` and `step('any')` for decimal inputs. This PR adds a short section and example for `type('number')` so that users don’t have to dig into the vendor code to discover this.

## Visual changes

None (documentation only).

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.