### PR TITLE
Add assertions for extraImgAttributes to TestsColumn

### DIFF
--- a/docs/10-testing/03-testing-tables.md
+++ b/docs/10-testing/03-testing-tables.md
@@ -242,6 +242,20 @@ it('displays author in red', function () {
 });
 ```
 
+When using image columns, the extra image attributes can also be tested to ensure that a column has the correct extra img attributes, you can use the `assertTableColumnHasExtraImgAttributes()` and `assertTableColumnDoesNotHaveExtraImgAttributes()` methods:
+
+```php
+use function Pest\Livewire\livewire;
+
+it('displays author in red', function () {
+    $post = Post::factory()->create();
+
+    livewire(PostsTable::class)
+        ->assertTableColumnHasExtraImgAttributes('author.image.url', ['class' => 'border border-emerald-500'], $post)
+        ->assertTableColumnDoesNotHaveExtraImgAttributes('author.image.url', ['class' => 'border border-red-500'], $post);
+});
+```
+
 ### Testing the options in a `SelectColumn`
 
 If you have a select column, you can ensure it has the correct options with `assertTableSelectColumnHasOptions()` and `assertTableSelectColumnDoesNotHaveOptions()`:

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -39,6 +39,10 @@ namespace Livewire\Features\SupportTesting {
 
         public function assertTableColumnDoesNotHaveExtraAttributes(string $name, array $attributes, $record): static {}
 
+        public function assertTableColumnHasExtraImgAttributes(string $name, array $attributes, $record): static {}
+
+        public function assertTableColumnDoesNotHaveExtraImgAttributes(string $name, array $attributes, $record): static {}
+
         public function assertTableColumnHasDescription(string $name, $description, $record, $position = 'below'): static {}
 
         public function assertTableColumnDoesNotHaveDescription(string $name, $description, $record, $position = 'below'): static {}

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -3,7 +3,9 @@
 namespace Filament\Tables\Testing;
 
 use Closure;
+use Filament\Support\ArrayRecord;
 use Filament\Tables\Columns\Column;
+use Filament\Tables\Columns\ImageColumn;
 use Filament\Tables\Columns\SelectColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Contracts\HasTable;
@@ -359,6 +361,80 @@ class TestsColumns
                 $attributes,
                 $column->getExtraAttributes(),
                 "Failed asserting that a table column with name [{$name}] does not have extra attributes [{$attributesString}] for record [{$record->getKey()}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertTableColumnHasExtraImgAttributes(): Closure
+    {
+        return function (string $name, array $attributes, $record) {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableColumnExists($name);
+
+            $column = $this->instance()->getTable()->getColumn($name);
+
+            if (! ($record instanceof Model)) {
+                /** @phpstan-ignore-next-line */
+                $this->assertTableRecordKeyExists((string) $record);
+                $record = $this->instance()->getTableRecord($record);
+                $recordKey = $record[ArrayRecord::getKeyName()];
+            } else {
+                $recordKey = $record->getKey();
+            }
+
+            $column->record($record);
+
+            $attributesString = print_r($attributes, true);
+
+            $livewireClass = $this->instance()::class;
+
+            if (! $column instanceof ImageColumn) {
+                Assert::fail('Extra Image attributes can only be asserted on columns of type ' . ImageColumn::class);
+            }
+
+            Assert::assertEquals(
+                $attributes,
+                $column->getExtraImgAttributes(),
+                "Failed asserting that a table column with name [{$name}] has extra img attributes [{$attributesString}] for record [{$recordKey}] on the [{$livewireClass}] component.",
+            );
+
+            return $this;
+        };
+    }
+
+    public function assertTableColumnDoesNotHaveExtraImgAttributes(): Closure
+    {
+        return function (string $name, array $attributes, $record) {
+            /** @phpstan-ignore-next-line */
+            $this->assertTableColumnExists($name);
+
+            $column = $this->instance()->getTable()->getColumn($name);
+
+            if (! ($record instanceof Model)) {
+                /** @phpstan-ignore-next-line */
+                $this->assertTableRecordKeyExists((string) $record);
+                $record = $this->instance()->getTableRecord($record);
+                $recordKey = $record[ArrayRecord::getKeyName()];
+            } else {
+                $recordKey = $record->getKey();
+            }
+
+            $column->record($record);
+
+            $attributesString = print_r($attributes, true);
+
+            $livewireClass = $this->instance()::class;
+
+            if (! $column instanceof ImageColumn) {
+                Assert::fail('Extra Image attributes can only be asserted on columns of type ' . ImageColumn::class);
+            }
+
+            Assert::assertNotEquals(
+                $attributes,
+                $column->getExtraImgAttributes(),
+                "Failed asserting that a table column with name [{$name}] does not have extra img attributes [{$attributesString}] for record [{$recordKey}] on the [{$livewireClass}] component.",
             );
 
             return $this;

--- a/tests/src/Fixtures/Livewire/UsersTable.php
+++ b/tests/src/Fixtures/Livewire/UsersTable.php
@@ -52,6 +52,10 @@ class UsersTable extends Component implements HasActions, HasSchemas, Tables\Con
                     ->label('Language')
                     ->sortable()
                     ->searchable(),
+                Tables\Columns\ImageColumn::make('image')
+                    ->state(fn (User $record) => $record->image?->url)
+                    ->extraImgAttributes(['class' => 'border border-emerald-500'])
+                    ->label('Image'),
                 Tables\Columns\TextColumn::make('image.url')
                     ->label('Image URL')
                     ->sortable()

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -457,6 +457,34 @@ it('can state whether a column has extra attributes', function (): void {
         ->assertTableColumnDoesNotHaveExtraAttributes('extra_attributes', ['class' => 'text-primary-500'], $post);
 });
 
+it('can state whether a image column has extra image attributes', function (): void {
+    $post = Post::factory()->create();
+
+    livewire(UsersTable::class)
+        ->assertTableColumnHasExtraImgAttributes('image', ['class' => 'border border-emerald-500'], $post)
+        ->assertTableColumnDoesNotHaveExtraImgAttributes('image', ['class' => 'border border-red-500'], $post);
+});
+
+it('cannot assert for extra image attributes on non image column', function (): void {
+    $post = Post::factory()->create();
+
+    $this->expectException('PHPUnit\Framework\AssertionFailedError');
+    $this->expectExceptionMessage('Extra Image attributes can only be asserted on columns of type Filament\Tables\Columns\ImageColumn');
+
+    livewire(UsersTable::class)
+        ->assertTableColumnHasExtraImgAttributes('image.url', ['class' => 'border border-emerald-500'], $post);
+});
+
+it('cannot assert for not having extra image attributes on non image column', function (): void {
+    $post = Post::factory()->create();
+
+    $this->expectException('PHPUnit\Framework\AssertionFailedError');
+    $this->expectExceptionMessage('Extra Image attributes can only be asserted on columns of type Filament\Tables\Columns\ImageColumn');
+
+    livewire(UsersTable::class)
+        ->assertTableColumnDoesNotHaveExtraImgAttributes('image.url', ['class' => 'border border-emerald-500'], $post);
+});
+
 it('can state whether a column has a description', function (): void {
     $post = Post::factory()->create();
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

Right now it is possible to check for extraAttributes on columns using
- `assertTableColumnHasExtraAttributes()`
- `assertTableColumnDoesNotHaveExtraAttributes()`

However, the same functionality does not exist when using extraImgAttributes on the ImageColumn. I added
- `assertTableColumnHasExtraImgAttributes()`
- `assertTableColumnDoesNotHaveExtraImgAttributes()`

to add that functionality.

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
