### PR TITLE
fix: `ColumnGroup` doesn't accept `HtmlString` as label (#19152)

### DIFF
--- a/packages/tables/src/Table/Concerns/HasColumns.php
+++ b/packages/tables/src/Table/Concerns/HasColumns.php
@@ -62,7 +62,7 @@ trait HasColumns
             if ($component instanceof ColumnGroup) {
                 $this->hasColumnGroups = true;
 
-                $this->columnGroups[$component->getLabel()] = $component;
+                $this->columnGroups[e($component->getLabel())] = $component;
 
                 $this->columns = [
                     ...$this->columns,

--- a/tests/src/Tables/Columns/ColumnGroupTest.php
+++ b/tests/src/Tables/Columns/ColumnGroupTest.php
@@ -11,6 +11,7 @@ use Filament\Tables\Table;
 use Filament\Tests\Fixtures\Models\Post;
 use Filament\Tests\Tables\TestCase;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\HtmlString;
 use Livewire\Component;
 
 use function Filament\Tests\livewire;
@@ -32,6 +33,15 @@ it('can render grouped columns', function (): void {
         ->assertCanRenderTableColumn('author.email');
 });
 
+it('can use `HtmlString` as label', function (): void {
+    Post::factory()->count(5)->create();
+
+    livewire(TestTableWithColumnGroupWithHtmlStringLabel::class)
+        ->assertSuccessful()
+        ->assertCanRenderTableColumn('author.name')
+        ->assertCanRenderTableColumn('author.email');
+});
+
 class TestTableWithColumnGroup extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
 {
     use InteractsWithActions;
@@ -45,6 +55,31 @@ class TestTableWithColumnGroup extends Component implements HasActions, HasSchem
             ->columns([
                 Tables\Columns\TextColumn::make('title'),
                 Tables\Columns\ColumnGroup::make('Author', [
+                    Tables\Columns\TextColumn::make('author.name'),
+                    Tables\Columns\TextColumn::make('author.email'),
+                ]),
+            ]);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.table');
+    }
+}
+
+class TestTableWithColumnGroupWithHtmlStringLabel extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use Tables\Concerns\InteractsWithTable;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(Post::query())
+            ->columns([
+                Tables\Columns\TextColumn::make('title'),
+                Tables\Columns\ColumnGroup::make(new HtmlString('<span>Author</span>'), [
                     Tables\Columns\TextColumn::make('author.name'),
                     Tables\Columns\TextColumn::make('author.email'),
                 ]),


### PR DESCRIPTION
Fixes #19152

## Problem

When using an `HtmlString` as a `ColumnGroup` label (which is allowed by the type signature), PHP throws an error:

```
Cannot access offset of type Illuminate\Support\HtmlString on array
```

This happens because the code was trying to use the `HtmlString` object directly as an array key, but PHP only allows strings or integers as array keys.

## Solution

I used `e()` instead of a `(string)` cast to match the existing pattern in the codebase. In `HasColumnManager::mapTableColumnGroupToArray()`, the same conversion is already done with `e()`:

## Testing

Added a test case that reproduces the bug and verifies the fix. Without the fix, the test fails with the exact error from the issue. With the fix, all tests pass.

```
✓ it can use HtmlString as label
```