### PR TITLE
fix: Rich-Editor: Apply disabled styling when disabled

### DIFF
--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -20,6 +20,7 @@
 <x-dynamic-component :component="$fieldWrapperView" :field="$field">
     <x-filament::input.wrapper
         :valid="! $errors->has($statePath)"
+        :disabled="$isDisabled"
         x-cloak
         :attributes="
             \Filament\Support\prepare_inherited_attributes($extraAttributeBag)

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -19,8 +19,8 @@
 
 <x-dynamic-component :component="$fieldWrapperView" :field="$field">
     <x-filament::input.wrapper
-        :valid="! $errors->has($statePath)"
         :disabled="$isDisabled"
+        :valid="! $errors->has($statePath)"
         x-cloak
         :attributes="
             \Filament\Support\prepare_inherited_attributes($extraAttributeBag)


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Disabled RTEs don't appear to be disabled.

## Visual changes

Before:
<img width="675" height="147" alt="image" src="https://github.com/user-attachments/assets/3dddf9cf-a05c-4340-ae27-4f5d822e47ed" />


After:
<img width="671" height="144" alt="image" src="https://github.com/user-attachments/assets/cfa65d50-8697-409f-ac15-4a6b8b590fdb" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
