### PR TITLE
Fix: keep parent modal open when child action modal opens

### DIFF
--- a/packages/actions/resources/js/components/modals.js
+++ b/packages/actions/resources/js/components/modals.js
@@ -20,7 +20,12 @@ export default ({ livewireId }) => ({
             return
         }
 
-        if (this.actionNestingIndex !== null) {
+        const isNestingIncrease =
+            this.actionNestingIndex !== null &&
+            newActionNestingIndex !== null &&
+            newActionNestingIndex > this.actionNestingIndex
+
+        if (this.actionNestingIndex !== null && !isNestingIncrease) {
             this.closeModal()
         }
 

--- a/packages/support/resources/css/components/modal.css
+++ b/packages/support/resources/css/components/modal.css
@@ -100,6 +100,17 @@
         @apply fixed inset-0 z-40 bg-gray-950/50 dark:bg-gray-950/75;
     }
 
+    &.fi-modal-open ~ .fi-modal.fi-modal-open {
+        & > .fi-modal-close-overlay,
+        & > .fi-modal-window-ctn {
+            @apply z-50;
+        }
+
+        & > .fi-modal-close-overlay {
+            @apply bg-gray-950/25 dark:bg-gray-950/50;
+        }
+    }
+
     & > .fi-modal-window-ctn {
         @apply fixed inset-0 z-40 grid min-h-full grid-rows-[1fr_auto_1fr] justify-items-center sm:grid-rows-[1fr_auto_3fr];
 


### PR DESCRIPTION
## Summary

- When a nested action (e.g. repeater delete confirmation) opens inside a slide-over, the parent modal closes first — making it feel like the user lost their work
- This skips the parent close when action nesting depth is **increasing**, so the parent stays visible and the child renders on top
- CSS raises stacked child modals to `z-50` (above parent's `z-40`) with a lighter backdrop to avoid double-darkness

<img width="2408" height="1842" alt="image" src="https://github.com/user-attachments/assets/2f3f069f-0aee-4cfc-9cb3-bd2c952d8215" />

## Changes

**`packages/actions/resources/js/components/modals.js`** — 5 lines added

When `syncActionModals` detects nesting is increasing (parent → child), it no longer calls `closeModal()` on the parent. On nesting decrease (child dismissed), the parent is already open and the existing `(! isOpen)` guard in `open-modal` prevents a redundant reopen.

**`packages/support/resources/css/components/modal.css`** — 11 lines added

Sibling `.fi-modal-open` elements get `z-50` on their overlay and window container, plus a lighter backdrop (`bg-gray-950/25` / `dark:bg-gray-950/50`).

## Test plan

- [ ] Open any Create/Edit slide-over with a repeater
- [ ] Click delete on a repeater item → confirmation should stack ON TOP of the slide-over
- [ ] Cancel confirmation → slide-over stays with all form data intact
- [ ] Confirm delete → action executes, slide-over stays, item removed
- [ ] Close slide-over entirely → everything cleans up
- [ ] Test escape key and click-away on the confirmation modal
- [ ] Test with non-slide-over modals (standard centered modals with nested actions)
- [ ] Test deeper nesting (3+ levels) if applicable