### PR TITLE
Missing keys in the Turkish language have been updated.

### DIFF
--- a/packages/forms/resources/lang/tr/components.php
+++ b/packages/forms/resources/lang/tr/components.php
@@ -284,6 +284,10 @@ return [
 
     'markdown_editor' => [
 
+        'file_attachments_accepted_file_types_message' => 'Yüklenen dosyalar şu türlerden olmalıdır: :values.',
+
+        'file_attachments_max_size_message' => 'Yüklenen dosyalar :max kilobayttan büyük olmamalıdır.',
+
         'tools' => [
             'attach_files' => 'Dosya ekle',
             'blockquote' => 'Alıntı',
@@ -443,6 +447,71 @@ return [
 
             ],
 
+            'grid' => [
+
+                'label' => 'Grid',
+
+                'modal' => [
+
+                    'heading' => 'Grid',
+
+                    'form' => [
+
+                        'preset' => [
+
+                            'label' => 'Ön ayar',
+
+                            'placeholder' => 'Yok',
+
+                            'options' => [
+                                'two' => 'İki',
+                                'three' => 'Üç',
+                                'four' => 'Dört',
+                                'five' => 'Beş',
+                                'two_start_third' => 'İki (Başta Üçte Bir)',
+                                'two_end_third' => 'İki (Sonda Üçte Bir)',
+                                'two_start_fourth' => 'İki (Başta Dörtte Bir)',
+                                'two_end_fourth' => 'İki (Sonda Dörtte Bir)',
+                            ],
+                        ],
+
+                        'columns' => [
+                            'label' => 'Sütunlar',
+                        ],
+
+                        'from_breakpoint' => [
+
+                            'label' => 'Kesme noktasından',
+
+                            'options' => [
+                                'default' => 'Tümü',
+                                'sm' => 'Küçük (sm)',
+                                'md' => 'Orta (md)',
+                                'lg' => 'Büyük (lg)',
+                                'xl' => 'Çok büyük (xl)',
+                                '2xl' => 'İki kat büyük (2xl)',
+                            ],
+
+                        ],
+
+                        'is_asymmetric' => [
+                            'label' => 'İki asimetrik sütun',
+                        ],
+
+                        'start_span' => [
+                            'label' => 'Başlangıç aralığı',
+                        ],
+
+                        'end_span' => [
+                            'label' => 'Bitiş aralığı',
+                        ],
+
+                    ],
+
+                ],
+
+            ],
+
             'link' => [
 
                 'label' => 'Düzenle',
@@ -459,6 +528,30 @@ return [
 
                         'should_open_in_new_tab' => [
                             'label' => 'Yeni sekmede aç',
+                        ],
+
+                    ],
+
+                ],
+
+            ],
+
+            'text_color' => [
+
+                'label' => 'Yazı rengi',
+
+                'modal' => [
+
+                    'heading' => 'Yazı rengi',
+
+                    'form' => [
+
+                        'color' => [
+                            'label' => 'Renk',
+                        ],
+
+                        'custom_color' => [
+                            'label' => 'Özel renk',
                         ],
 
                     ],
@@ -488,6 +581,8 @@ return [
             'h1' => 'Başlık',
             'h2' => 'Başlık 2',
             'h3' => 'Alt başlık',
+            'grid' => 'Grid',
+            'grid_delete' => 'Grid\'i sil',
             'highlight' => 'Vurgula',
             'horizontal_rule' => 'Yatay çizgi',
             'italic' => 'Eğik',
@@ -511,6 +606,8 @@ return [
             'table_merge_cells' => 'Hücreleri birleştir',
             'table_split_cell' => 'Hücreyi böl',
             'table_toggle_header_row' => 'Başlık satırını aç/kapat',
+            'table_toggle_header_cell' => 'Başlık hücresini aç/kapat',
+            'text_color' => 'Yazı rengi',
             'underline' => 'Altı çizili',
             'undo' => 'Geri al',
         ],


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
This PR adds missing Turkish translation keys for Filament forms to improve localization consistency and prevent fallback strings from appearing in the UI.

## Visual changes
None
<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [YES] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
