### PR TITLE
Fix: `afterStateUpdatedJs` in flex components

### DIFF
--- a/packages/schemas/resources/views/components/flex.blade.php
+++ b/packages/schemas/resources/views/components/flex.blade.php
@@ -52,7 +52,7 @@
                             containerPath: @js($statePath),
                             $wire,
                         })"
-                @if ($afterStateUpdatedJs = $schemaComponent->getAfterStateUpdatedJs())
+                @if ($afterStateUpdatedJs = $component->getAfterStateUpdatedJs())
                     x-init="{!! implode(';', array_map(
                         fn (string $js): string => '$wire; $wire.watch(' . Js::from($componentStatePath) . ', ($state, $old) => isStateChanged($state, $old) && eval(' . Js::from($js) . '))',
                         $afterStateUpdatedJs,

--- a/tests/src/Fixtures/Pages/AfterStateUpdatedJsTest.php
+++ b/tests/src/Fixtures/Pages/AfterStateUpdatedJsTest.php
@@ -5,6 +5,7 @@ namespace Filament\Tests\Fixtures\Pages;
 use BackedEnum;
 use Filament\Forms\Components\TextInput;
 use Filament\Pages\Page;
+use Filament\Schemas\Components\Flex;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 
@@ -36,6 +37,18 @@ class AfterStateUpdatedJsTest extends Page
                 TextInput::make('email')
                     ->label('Email')
                     ->extraAttributes(['data-testid' => 'email-input']),
+                Flex::make([
+                    TextInput::make('flex_name')
+                        ->label('Name')
+                        ->extraAttributes(['data-testid' => 'flex-name-input'])
+                        ->afterStateUpdatedJs(<<<'JS'
+                                const parts = ($state ?? '').split(' ');
+                                $set('flex_email', ($state ?? '').replaceAll(' ', '.').toLowerCase() + '@example.com')
+                            JS),
+                    TextInput::make('flex_email')
+                        ->label('Email')
+                        ->extraAttributes(['data-testid' => 'flex-email-input']),
+                ]),
             ])
             ->statePath('data');
     }

--- a/tests/src/Fixtures/Pages/AfterStateUpdatedJsTest.php
+++ b/tests/src/Fixtures/Pages/AfterStateUpdatedJsTest.php
@@ -42,7 +42,6 @@ class AfterStateUpdatedJsTest extends Page
                         ->label('Name')
                         ->extraAttributes(['data-testid' => 'flex-name-input'])
                         ->afterStateUpdatedJs(<<<'JS'
-                                const parts = ($state ?? '').split(' ');
                                 $set('flex_email', ($state ?? '').replaceAll(' ', '.').toLowerCase() + '@example.com')
                             JS),
                     TextInput::make('flex_email')

--- a/tests/src/Forms/AfterStateUpdatedJsTest.php
+++ b/tests/src/Forms/AfterStateUpdatedJsTest.php
@@ -24,6 +24,12 @@ it('can use `$set()` in `afterStateUpdatedJs()` to set another field value', fun
         ->fill('#form\.name', 'Jane Smith')
         ->wait(1)
         ->assertValue('#form\.email', 'jane.smith@example.com')
+        ->fill('#form\.flex_name', 'Jane Doe')
+        ->wait(1)
+        ->assertValue('#form\.flex_email', 'jane.doe@example.com')
+        ->fill('#form\.flex_name', 'John Smith')
+        ->wait(1)
+        ->assertValue('#form\.flex_email', 'john.smith@example.com')
         ->assertNoSmoke()
         ->assertNoAccessibilityIssues();
 


### PR DESCRIPTION
Components within a Flex schema are not being rendered with the correct `afterStateUpdatedJs`.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
When using a `Filament\Schemas\Components\Flex` within a form schema any child form components' `afterStateUpdatedJs` are not being applied.

e.g.
```php
                Flex::make([
                    TextInput::make('flex_name')
                        ->label('Name')
                        ->extraAttributes(['data-testid' => 'flex-name-input'])
                        ->afterStateUpdatedJs(<<<'JS'
                                $set('flex_email', ($state ?? '').replaceAll(' ', '.').toLowerCase() + '@example.com')
                            JS),
                    TextInput::make('flex_email')
                        ->label('Email')
                        ->extraAttributes(['data-testid' => 'flex-email-input']),
                ]),
```

The blade file is trying to render the  `afterStateUpdatedJs` from a different variable, seemingly the wrong one, not the child component being rendered.

This change fixes this issue. 

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
