### PR TITLE
fix: Support Closure in `columns()` for Wizard Step and Tab

### DIFF
--- a/packages/schemas/src/Components/Tabs/Tab.php
+++ b/packages/schemas/src/Components/Tabs/Tab.php
@@ -68,7 +68,11 @@ class Tab extends Component implements CanConcealComponents
      */
     public function getAllColumns(): array
     {
-        return $this->columns ?? $this->getContainer()->getAllColumns();
+        if ($this->columns === null) {
+            return $this->getContainer()->getAllColumns();
+        }
+
+        return parent::getAllColumns();
     }
 
     public function canConcealComponents(): bool

--- a/packages/schemas/src/Components/Wizard/Step.php
+++ b/packages/schemas/src/Components/Wizard/Step.php
@@ -131,7 +131,11 @@ class Step extends Component implements CanConcealComponents
      */
     public function getAllColumns(): array
     {
-        return $this->columns ?? $this->getContainer()->getAllColumns();
+        if ($this->columns === null) {
+            return $this->getContainer()->getAllColumns();
+        }
+
+        return parent::getAllColumns();
     }
 
     public function canConcealComponents(): bool


### PR DESCRIPTION

## Description

Fixes #19175

`Step::getAllColumns()` and `Tab::getAllColumns()` were returning `$this->columns` directly without evaluating Closures, causing a TypeError when using `->columns(fn () => ...)`.

Now they delegate to `parent::getAllColumns()` which properly handles Closure evaluation.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
