### PR TITLE
fix: Column testing helpers with aggregation

### DIFF
--- a/packages/tables/src/Concerns/HasRecords.php
+++ b/packages/tables/src/Concerns/HasRecords.php
@@ -192,10 +192,16 @@ trait HasRecords
         }
 
         if (! ($this->getTable()->getRelationship() instanceof BelongsToMany)) {
-            return $this->applyFiltersToTableQuery(
+            $query = $this->applyFiltersToTableQuery(
                 $this->getTable()->getQuery(isResolvingRecord: true),
                 isResolvingRecord: true,
-            )->find($key);
+            );
+
+            foreach ($this->getTable()->getVisibleColumns() as $column) {
+                $column->applyRelationshipAggregates($query);
+            }
+
+            return $query->find($key);
         }
 
         /** @var BelongsToMany $relationship */
@@ -213,6 +219,10 @@ trait HasRecords
         $query = $table->allowsDuplicates() ?
             $relationship->wherePivot($pivotKeyName, $key) :
             $relationship->where($relationship->getQualifiedRelatedKeyName(), $key);
+
+        foreach ($table->getVisibleColumns() as $column) {
+            $column->applyRelationshipAggregates($query);
+        }
 
         $record = $table->selectPivotDataInQuery($query)->first();
 

--- a/packages/tables/src/Testing/TestsColumns.php
+++ b/packages/tables/src/Testing/TestsColumns.php
@@ -94,9 +94,15 @@ class TestsColumns
             );
 
             if ($record) {
-                if (! ($record instanceof Model)) {
-                    $record = $this->instance()->getTableRecord($record);
+                if ($record instanceof Model) {
+                    $recordKey = (string) $record->getKey();
+                } elseif (is_array($record)) {
+                    $recordKey = (string) $record[ArrayRecord::getKeyName()];
+                } else {
+                    $recordKey = (string) $record;
                 }
+
+                $record = $this->instance()->getTableRecord($recordKey);
 
                 $column->record($record);
             }
@@ -126,9 +132,15 @@ class TestsColumns
             }
 
             if ($record) {
-                if (! ($record instanceof Model)) {
-                    $record = $this->instance()->getTableRecord($record);
+                if ($record instanceof Model) {
+                    $recordKey = (string) $record->getKey();
+                } elseif (is_array($record)) {
+                    $recordKey = (string) $record[ArrayRecord::getKeyName()];
+                } else {
+                    $recordKey = (string) $record;
                 }
+
+                $record = $this->instance()->getTableRecord($recordKey);
 
                 $column->record($record);
             }
@@ -196,14 +208,18 @@ class TestsColumns
 
             $column = $this->instance()->getTable()->getColumn($name);
 
-            if (! ($record instanceof Model)) {
-                /** @phpstan-ignore-next-line */
-                $this->assertTableRecordKeyExists((string) $record);
-                $record = $this->instance()->getTableRecord($record);
-                $recordKey = $record[ArrayRecord::getKeyName()];
+            if ($record instanceof Model) {
+                $recordKey = (string) $record->getKey();
+            } elseif (is_array($record)) {
+                $recordKey = (string) $record[ArrayRecord::getKeyName()];
             } else {
-                $recordKey = $record->getKey();
+                $recordKey = (string) $record;
             }
+
+            /** @phpstan-ignore-next-line */
+            $this->assertTableRecordKeyExists($recordKey);
+
+            $record = $this->instance()->getTableRecord($recordKey);
 
             $column->record($record);
 
@@ -241,14 +257,18 @@ class TestsColumns
 
             $column = $this->instance()->getTable()->getColumn($name);
 
-            if (! ($record instanceof Model)) {
-                /** @phpstan-ignore-next-line */
-                $this->assertTableRecordKeyExists((string) $record);
-                $record = $this->instance()->getTableRecord($record);
-                $recordKey = $record[ArrayRecord::getKeyName()];
+            if ($record instanceof Model) {
+                $recordKey = (string) $record->getKey();
+            } elseif (is_array($record)) {
+                $recordKey = (string) $record[ArrayRecord::getKeyName()];
             } else {
-                $recordKey = $record->getKey();
+                $recordKey = (string) $record;
             }
+
+            /** @phpstan-ignore-next-line */
+            $this->assertTableRecordKeyExists($recordKey);
+
+            $record = $this->instance()->getTableRecord($recordKey);
 
             $column->record($record);
 
@@ -287,14 +307,18 @@ class TestsColumns
             /** @var TextColumn $column */
             $column = $this->instance()->getTable()->getColumn($name);
 
-            if (! ($record instanceof Model)) {
-                /** @phpstan-ignore-next-line */
-                $this->assertTableRecordKeyExists((string) $record);
-                $record = $this->instance()->getTableRecord($record);
-                $recordKey = $record[ArrayRecord::getKeyName()];
+            if ($record instanceof Model) {
+                $recordKey = (string) $record->getKey();
+            } elseif (is_array($record)) {
+                $recordKey = (string) $record[ArrayRecord::getKeyName()];
             } else {
-                $recordKey = $record->getKey();
+                $recordKey = (string) $record;
             }
+
+            /** @phpstan-ignore-next-line */
+            $this->assertTableRecordKeyExists($recordKey);
+
+            $record = $this->instance()->getTableRecord($recordKey);
 
             $column->record($record);
 
@@ -321,14 +345,18 @@ class TestsColumns
             /** @var TextColumn $column */
             $column = $this->instance()->getTable()->getColumn($name);
 
-            if (! ($record instanceof Model)) {
-                /** @phpstan-ignore-next-line */
-                $this->assertTableRecordKeyExists((string) $record);
-                $record = $this->instance()->getTableRecord($record);
-                $recordKey = $record[ArrayRecord::getKeyName()];
+            if ($record instanceof Model) {
+                $recordKey = (string) $record->getKey();
+            } elseif (is_array($record)) {
+                $recordKey = (string) $record[ArrayRecord::getKeyName()];
             } else {
-                $recordKey = $record->getKey();
+                $recordKey = (string) $record;
             }
+
+            /** @phpstan-ignore-next-line */
+            $this->assertTableRecordKeyExists($recordKey);
+
+            $record = $this->instance()->getTableRecord($recordKey);
 
             $column->record($record);
 
@@ -354,14 +382,18 @@ class TestsColumns
 
             $column = $this->instance()->getTable()->getColumn($name);
 
-            if (! ($record instanceof Model)) {
-                /** @phpstan-ignore-next-line */
-                $this->assertTableRecordKeyExists((string) $record);
-                $record = $this->instance()->getTableRecord($record);
-                $recordKey = $record[ArrayRecord::getKeyName()];
+            if ($record instanceof Model) {
+                $recordKey = (string) $record->getKey();
+            } elseif (is_array($record)) {
+                $recordKey = (string) $record[ArrayRecord::getKeyName()];
             } else {
-                $recordKey = $record->getKey();
+                $recordKey = (string) $record;
             }
+
+            /** @phpstan-ignore-next-line */
+            $this->assertTableRecordKeyExists($recordKey);
+
+            $record = $this->instance()->getTableRecord($recordKey);
 
             $column->record($record);
 
@@ -387,14 +419,18 @@ class TestsColumns
 
             $column = $this->instance()->getTable()->getColumn($name);
 
-            if (! ($record instanceof Model)) {
-                /** @phpstan-ignore-next-line */
-                $this->assertTableRecordKeyExists((string) $record);
-                $record = $this->instance()->getTableRecord($record);
-                $recordKey = $record[ArrayRecord::getKeyName()];
+            if ($record instanceof Model) {
+                $recordKey = (string) $record->getKey();
+            } elseif (is_array($record)) {
+                $recordKey = (string) $record[ArrayRecord::getKeyName()];
             } else {
-                $recordKey = $record->getKey();
+                $recordKey = (string) $record;
             }
+
+            /** @phpstan-ignore-next-line */
+            $this->assertTableRecordKeyExists($recordKey);
+
+            $record = $this->instance()->getTableRecord($recordKey);
 
             $column->record($record);
 
@@ -421,14 +457,18 @@ class TestsColumns
             /** @var TextColumn $column */
             $column = $this->instance()->getTable()->getColumn($name);
 
-            if (! ($record instanceof Model)) {
-                /** @phpstan-ignore-next-line */
-                $this->assertTableRecordKeyExists((string) $record);
-                $record = $this->instance()->getTableRecord($record);
-                $recordKey = $record[ArrayRecord::getKeyName()];
+            if ($record instanceof Model) {
+                $recordKey = (string) $record->getKey();
+            } elseif (is_array($record)) {
+                $recordKey = (string) $record[ArrayRecord::getKeyName()];
             } else {
-                $recordKey = $record->getKey();
+                $recordKey = (string) $record;
             }
+
+            /** @phpstan-ignore-next-line */
+            $this->assertTableRecordKeyExists($recordKey);
+
+            $record = $this->instance()->getTableRecord($recordKey);
 
             $column->record($record);
 
@@ -455,14 +495,18 @@ class TestsColumns
             /** @var TextColumn $column */
             $column = $this->instance()->getTable()->getColumn($name);
 
-            if (! ($record instanceof Model)) {
-                /** @phpstan-ignore-next-line */
-                $this->assertTableRecordKeyExists((string) $record);
-                $record = $this->instance()->getTableRecord($record);
-                $recordKey = $record[ArrayRecord::getKeyName()];
+            if ($record instanceof Model) {
+                $recordKey = (string) $record->getKey();
+            } elseif (is_array($record)) {
+                $recordKey = (string) $record[ArrayRecord::getKeyName()];
             } else {
-                $recordKey = $record->getKey();
+                $recordKey = (string) $record;
             }
+
+            /** @phpstan-ignore-next-line */
+            $this->assertTableRecordKeyExists($recordKey);
+
+            $record = $this->instance()->getTableRecord($recordKey);
 
             $column->record($record);
 
@@ -489,14 +533,18 @@ class TestsColumns
             /** @var SelectColumn $column */
             $column = $this->instance()->getTable()->getColumn($name);
 
-            if (! ($record instanceof Model)) {
-                /** @phpstan-ignore-next-line */
-                $this->assertTableRecordKeyExists((string) $record);
-                $record = $this->instance()->getTableRecord($record);
-                $recordKey = $record[ArrayRecord::getKeyName()];
+            if ($record instanceof Model) {
+                $recordKey = (string) $record->getKey();
+            } elseif (is_array($record)) {
+                $recordKey = (string) $record[ArrayRecord::getKeyName()];
             } else {
-                $recordKey = $record->getKey();
+                $recordKey = (string) $record;
             }
+
+            /** @phpstan-ignore-next-line */
+            $this->assertTableRecordKeyExists($recordKey);
+
+            $record = $this->instance()->getTableRecord($recordKey);
 
             $column->record($record);
 
@@ -523,14 +571,18 @@ class TestsColumns
             /** @var SelectColumn $column */
             $column = $this->instance()->getTable()->getColumn($name);
 
-            if (! ($record instanceof Model)) {
-                /** @phpstan-ignore-next-line */
-                $this->assertTableRecordKeyExists((string) $record);
-                $record = $this->instance()->getTableRecord($record);
-                $recordKey = $record[ArrayRecord::getKeyName()];
+            if ($record instanceof Model) {
+                $recordKey = (string) $record->getKey();
+            } elseif (is_array($record)) {
+                $recordKey = (string) $record[ArrayRecord::getKeyName()];
             } else {
-                $recordKey = $record->getKey();
+                $recordKey = (string) $record;
             }
+
+            /** @phpstan-ignore-next-line */
+            $this->assertTableRecordKeyExists($recordKey);
+
+            $record = $this->instance()->getTableRecord($recordKey);
 
             $column->record($record);
 

--- a/tests/src/Fixtures/Livewire/UsersTable.php
+++ b/tests/src/Fixtures/Livewire/UsersTable.php
@@ -64,6 +64,8 @@ class UsersTable extends Component implements HasActions, HasSchemas, Tables\Con
                     ->label('Setting Language (HasOneThrough)')
                     ->sortable()
                     ->searchable(),
+                Tables\Columns\TextColumn::make('posts_count')
+                    ->counts('posts'),
             ]);
     }
 

--- a/tests/src/Tables/ColumnTest.php
+++ b/tests/src/Tables/ColumnTest.php
@@ -386,6 +386,16 @@ it('can state whether a column has the correct value with custom data', function
         ->assertTableColumnStateNotSet('title', 'incorrect state', 2);
 });
 
+it('can state whether a column with `counts()` has the correct value', function (): void {
+    $user = User::factory()
+        ->has(Post::factory()->count(3))
+        ->create();
+
+    livewire(UsersTable::class)
+        ->assertTableColumnStateSet('posts_count', 3, $user)
+        ->assertTableColumnStateNotSet('posts_count', 0, $user);
+});
+
 it('can state whether a column has the correct formatted value with Eloquent records', function (): void {
     $post = Post::factory()->create();
 


### PR DESCRIPTION
Instead of using the exact model instance that the user passes in, the key is extracted from the model instance, and the model instance is re-fetched using the table query, so that aggregations etc can run.

This shouldn't break tests that have been written correctly (the table record passed exists in the table), but it could reveal issues with tests that used to pass without the table actually containing that record.