### PR TITLE
Allow symfony/html-sanitizer ^8.0

### DIFF
--- a/packages/support/composer.json
+++ b/packages/support/composer.json
@@ -20,7 +20,7 @@
         "ryangjchandler/blade-capture-directive": "^1.0",
         "spatie/invade": "^2.0",
         "spatie/laravel-package-tools": "^1.9",
-        "symfony/html-sanitizer": "^7.0",
+        "symfony/html-sanitizer": "^7.0|^8.0",
         "symfony/console": "^7.0"
     },
     "autoload": {


### PR DESCRIPTION
## Description

Update composer.json version constraint for symfony/html-sanitizer to also allow ^8.0.

Note: this is my first PR to Filament. I am not sure if this should target 4.x or 5.x branch.

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
