### PR TITLE
[5.x] chore: bump tiptap-php to v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "staudenmeir/belongs-to-through": "^2.5",
         "staudenmeir/eloquent-has-many-deep": "^1.7",
         "symplify/monorepo-builder": "^11.0",
-        "ueberdosis/tiptap-php": "^1.4"
+        "ueberdosis/tiptap-php": "^2.0"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
This patch bumps the ueberdosis/tiptap-php to v2.
It looks like aprevious PR https://github.com/filamentphp/filament/pull/16818 for this was merged in v4, but never made it to v5

## Visual changes

<!-- Add screenshots/recordings of before and after. -->
NA

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
