### PR TITLE
fix: check for modalContainer connection before dispatching modal-closed event

### DIFF
--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -71,6 +71,10 @@
         close: function () {
             this.isOpen = false
 
+            if (! this.$refs.modalContainer.isConnected) {
+                return
+            }
+
             this.$refs.modalContainer.dispatchEvent(
                 new CustomEvent('modal-closed', { detail: { id: '{{ $id }}' } }),
             )


### PR DESCRIPTION
## Description
Fixes: #18700
Since Livewire 3.7.0, dispatchEvents is deferred via queueMicrotask. When an action completes, morph replaces the modal element before the close-modal event arrives, causing close() to run on a disconnected element.
This adds a guard to skip dispatching modal-closed when the modal container is no longer in the DOM.

## Visual changes



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
