### PR TITLE
fix: bulk action receives non-selectable records when using "Select all"

### DIFF
--- a/packages/tables/src/Table/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Table/Concerns/HasBulkActions.php
@@ -168,6 +168,10 @@ trait HasBulkActions
             return false;
         }
 
+        if ($this->checksIfRecordIsSelectable()) {
+            return false;
+        }
+
         return (bool) $this->evaluate($this->canTrackDeselectedRecords);
     }
 


### PR DESCRIPTION

## Description

Fixes #19219

Disable deselected record tracking when the table has a `checkIfRecordIsSelectableUsing()` check, so "Select all" falls back to `getAllSelectableTableRecordKeys()` which correctly filters non-selectable records.

## Visual changes

### before
<img width="2350" height="958" alt="image" src="https://github.com/user-attachments/assets/85da3c2a-ecec-4aab-aebc-bff26903b291" />


### after

<img width="2370" height="1052" alt="image" src="https://github.com/user-attachments/assets/2fe38d30-ab60-4926-83b5-4e1065ed7e45" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
