### PR TITLE
Update label for open_bulk_actions in German translation

### DIFF
--- a/packages/tables/resources/lang/de/table.php
+++ b/packages/tables/resources/lang/de/table.php
@@ -108,7 +108,7 @@ return [
         ],
 
         'open_bulk_actions' => [
-            'label' => 'Aktionen öffnen',
+            'label' => 'Mehrfachaktionen',
         ],
 
         'column_manager' => [


### PR DESCRIPTION
Current translation is more like "Open actions" instead of the english "Bulk actions" which roughly translates to "Mehrfachaktionen".

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
