### PR TITLE
Fix assertHasTableActionErrors() deprecated replacement

### DIFF
--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -161,7 +161,7 @@ namespace Livewire\Features\SupportTesting {
         public function assertTableActionHalted(string | array $name): static {}
 
         /**
-         * @deprecated Use `assertHasTableActionErrors()` instead.
+         * @deprecated Use `assertHasFormErrors()` instead.
          */
         public function assertHasTableActionErrors(array $keys = []): static {}
 


### PR DESCRIPTION
## Description

I noticed this deprecated message had the same method name suggested as its replacement:

```php
/**
 * @deprecated Use `assertHasTableActionErrors()` instead.
 */
public function assertHasTableActionErrors(array $keys = []): static {}
```

I have just corrected this to ```assertHasFormErrors()```

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
