### PR TITLE
Fix: dehydrateStateUsing is never called on form fields inside table filter schemas

### DIFF
--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -64,7 +64,7 @@ trait HasFilters
         if ($this->getTable()->persistsFiltersInSession()) {
             session()->put(
                 $this->getTableFiltersSessionKey(),
-                $this->tableFilters,
+                $this->getDehydratedTableFilters(),
             );
         }
 
@@ -209,7 +209,44 @@ trait HasFilters
 
     public function getTableFilterState(string $name): ?array
     {
-        return Arr::get($this->tableFilters, $this->parseTableFilterName($name));
+        $name = $this->parseTableFilterName($name);
+
+        $state = Arr::get($this->tableFilters, $name);
+
+        if ($state === null) {
+            return null;
+        }
+
+        $filter = $this->getTable()->getFilter($name);
+
+        if (! $filter) {
+            return $state;
+        }
+
+        try {
+            return $filter->getSchema()->getStateSnapshot();
+        } catch (\Throwable) {
+            return $state;
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getDehydratedTableFilters(): array
+    {
+        $dehydrated = [];
+
+        foreach ($this->getTable()->getFilters() as $filter) {
+            $name = $filter->getName();
+            $state = $this->getTableFilterState($name);
+
+            if ($state !== null) {
+                $dehydrated[$name] = $state;
+            }
+        }
+
+        return $dehydrated;
     }
 
     public function getTableFilterFormState(string $name): ?array

--- a/packages/tables/src/Concerns/HasFilters.php
+++ b/packages/tables/src/Concerns/HasFilters.php
@@ -235,18 +235,7 @@ trait HasFilters
      */
     protected function getDehydratedTableFilters(): array
     {
-        $dehydrated = [];
-
-        foreach ($this->getTable()->getFilters() as $filter) {
-            $name = $filter->getName();
-            $state = $this->getTableFilterState($name);
-
-            if ($state !== null) {
-                $dehydrated[$name] = $state;
-            }
-        }
-
-        return $dehydrated;
+        return $this->getTableFiltersForm()->getStateSnapshot();
     }
 
     public function getTableFilterFormState(string $name): ?array

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -53,6 +53,18 @@ trait InteractsWithTable
         $this->initTableColumnManager();
 
         if (! $this->shouldMountInteractsWithTable) {
+            // Re-hydrate filter form state from (possibly dehydrated) property
+            // values on subsequent Livewire requests. The dehydrate hook stores
+            // dehydrated values in the wire snapshot, so we must run fill() to
+            // invoke formatStateUsing / afterStateHydrated callbacks.
+            $stateToHydrate = $this->getTable()->hasDeferredFilters()
+                ? $this->tableDeferredFilters
+                : $this->tableFilters;
+
+            if ($stateToHydrate !== null) {
+                $this->getTableFiltersForm()->fill($stateToHydrate);
+            }
+
             return;
         }
 
@@ -85,7 +97,7 @@ trait InteractsWithTable
         if ($shouldPersistFiltersInSession) {
             session()->put(
                 $filtersSessionKey,
-                $this->tableFilters,
+                $this->getDehydratedTableFilters(),
             );
         }
 
@@ -162,6 +174,29 @@ trait InteractsWithTable
     public function mountInteractsWithTable(): void
     {
         $this->shouldMountInteractsWithTable = true;
+    }
+
+    /**
+     * Dehydrate filter state before Livewire serializes it to the URL query
+     * string and wire snapshot. This ensures that `dehydrateStateUsing`
+     * callbacks are applied and `formatStateUsing` does not compound on
+     * every page reload.
+     */
+    public function dehydrateInteractsWithTable(): void
+    {
+        if (! isset($this->table)) {
+            return;
+        }
+
+        $dehydrated = $this->getDehydratedTableFilters();
+
+        if ($dehydrated !== ($this->tableFilters ?? [])) {
+            $this->tableFilters = $dehydrated ?: null;
+        }
+
+        if ($this->getTable()->hasDeferredFilters() && $this->tableDeferredFilters !== null) {
+            $this->tableDeferredFilters = $dehydrated ?: null;
+        }
     }
 
     public function table(Table $table): Table


### PR DESCRIPTION
## Problem

Fixes #19170

When using `dehydrateStateUsing` on form fields inside a table `Filter::make()->schema([...])`, the dehydration callback is never invoked. The raw user input is passed directly to the `query()` callback and persisted in the URL/session as-is.

Since `formatStateUsing` IS applied on every page hydration, but the persisted filter state was never dehydrated, `formatStateUsing` keeps transforming an already-formatted value — causing it to compound on every page reload (e.g. 10 → 1000 → 100000).

## Root Cause

`getTableFilterState()` returns the raw Livewire property value (`$this->tableFilters[$name]`) without running the state through the filter schema's dehydration pipeline. Similarly, `handleTableFilterUpdates()` persists this raw state to the session.

## Solution

- Modified `getTableFilterState()` to dehydrate the filter state through the filter's schema via `getStateSnapshot()` before returning it. This ensures the `query()` callback receives properly dehydrated values.
- Modified `handleTableFilterUpdates()` to persist dehydrated filter state to the session, preventing `formatStateUsing` from compounding on page reloads.
- Added a `getDehydratedTableFilters()` helper method that collects dehydrated state for all filters.
- Wrapped the dehydration call in a try/catch to gracefully fall back to raw state if dehydration fails, ensuring backward compatibility.