### PR TITLE
fix: action modal partial rerender during poll destroying nested component state

### DIFF
--- a/packages/support/src/Livewire/Partials/PartialsComponentHook.php
+++ b/packages/support/src/Livewire/Partials/PartialsComponentHook.php
@@ -92,6 +92,24 @@ class PartialsComponentHook extends ComponentHook
         return $originallyMountedActionIndex === $mountedActionIndex;
     }
 
+    public function shouldSkipMountedActionRerender(): bool
+    {
+        if (! property_exists($this->component, 'mountedActions')) {
+            return false;
+        }
+
+        $mountedActionIndex = array_key_last($this->component->mountedActions);
+
+        if (blank($mountedActionIndex)) {
+            return false;
+        }
+
+        $updatesCount = $this->storeGet('updatesCount') ?? 0;
+        $callsCount = $this->storeGet('callsCount') ?? 0;
+
+        return ($updatesCount + $callsCount) === 0;
+    }
+
     public function shouldRenderMountedActionsOnly(bool $whenActionMounted = true): bool
     {
         if (! property_exists($this->component, 'mountedActions')) {
@@ -110,6 +128,12 @@ class PartialsComponentHook extends ComponentHook
     public function dehydrate(ComponentContext $context): void
     {
         if ($this->shouldForceRender()) {
+            return;
+        }
+
+        // Re-rendering action modal partials during a pure poll would re-mount
+        // nested Livewire components inside the modal, discarding their state.
+        if ($this->shouldSkipMountedActionRerender()) {
             return;
         }
 


### PR DESCRIPTION
## Description
Fixes #18681

When an action modal is open, pure poll requests still trigger shouldRenderMountedActionOnly() in dehydrate(), re-rendering the modal partial on every poll. This re-mounts nested Livewire components inside the modal, losing their state (e.g. search input gets cleared).

shouldSkipMountedActionRerender() skips partial rendering in dehydrate() when there are no calls or updates but an action is already mounted.

## Visual changes

### Before



https://github.com/user-attachments/assets/59cf8577-7e84-421b-84c3-05591128b252




### After


https://github.com/user-attachments/assets/3c8d3591-97d9-48f0-94da-b69807f0e539




## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
