### PR TITLE
fix: support `v` prefix in version constraints for v3→v4 upgrade

### DIFF
--- a/packages/upgrade/bin/filament-v4
+++ b/packages/upgrade/bin/filament-v4
@@ -176,7 +176,7 @@ try {
                     if (!str_starts_with($dep, 'filament/')) {
                         continue;
                     }
-                    if (preg_match("/\^\s*4(?:\.|$)|~\s*4(?:\.|$)|>=\s*4(?:\.|$)/", (string) $constraint)) {
+                    if (preg_match("/\^\s*v?4(?:\.|$)|~\s*v?4(?:\.|$)|>=\s*v?4(?:\.|$)/", (string) $constraint)) {
                         $compatibility = [
                             'version' => (string) ($checkingVersion['version'] ?? ''),
                             'isPrerelease' => false,
@@ -197,7 +197,7 @@ try {
                             continue;
                         }
 
-                        if (preg_match("/\^\s*4(?:\.|$)|~\s*4(?:\.|$)|>=\s*4(?:\.|$)/", (string) $constraint)) {
+                        if (preg_match("/\^\s*v?4(?:\.|$)|~\s*v?4(?:\.|$)|>=\s*v?4(?:\.|$)/", (string) $constraint)) {
                             $compatibility = [
                                 'version' => (string) ($checkingVersion['version'] ?? ''),
                                 'isPrerelease' => true,
@@ -228,7 +228,7 @@ try {
                                 continue;
                             }
 
-                            if (preg_match("/\^\s*4(?:\.|$)|~\s*4(?:\.|$)|>=\s*4(?:\.|$)/", (string) $constraint)) {
+                            if (preg_match("/\^\s*v?4(?:\.|$)|~\s*v?4(?:\.|$)|>=\s*v?4(?:\.|$)/", (string) $constraint)) {
                                 $compatibility = [
                                     'version' => (string) ($checkingVersion['version'] ?? ''),
                                     'isPrerelease' => false,
@@ -257,7 +257,7 @@ try {
                                     continue;
                                 }
 
-                                if (preg_match("/\^\s*4(?:\.|$)|~\s*4(?:\.|$)|>=\s*4(?:\.|$)/", (string) $constraint)) {
+                                if (preg_match("/\^\s*v?4(?:\.|$)|~\s*v?4(?:\.|$)|>=\s*v?4(?:\.|$)/", (string) $constraint)) {
                                     $compatibility = [
                                         'version' => (string) ($checkingVersion['version'] ?? ''),
                                         'isPrerelease' => true,

--- a/packages/upgrade/src/check-compatibility.php
+++ b/packages/upgrade/src/check-compatibility.php
@@ -1,7 +1,25 @@
 <?php
 
+use Laravel\Prompts\ConfirmPrompt;
+use Laravel\Prompts\Prompt;
 use function Laravel\Prompts\confirm;
 use function Termwind\render;
+
+Prompt::fallbackWhen(windows_os());
+
+ConfirmPrompt::fallbackUsing(function (ConfirmPrompt $prompt) {
+    $default = $prompt->default ? 'yes' : 'no';
+
+    render("<p class=\"text-cyan\">{$prompt->label} (yes/no) [{$default}]</p>");
+
+    $input = strtolower(trim(fgets(STDIN)));
+
+    if ($input === '') {
+        return $prompt->default;
+    }
+
+    return in_array($input, ['y', 'yes', '1']);
+});
 
 render('<p class="text-blue font-bold">Checking PHP version compatibility with v4...</p>');
 

--- a/packages/upgrade/src/check-compatibility.php
+++ b/packages/upgrade/src/check-compatibility.php
@@ -132,7 +132,7 @@ foreach ($plugins as $plugin) {
                         continue;
                     }
 
-                    if (preg_match("/\^\s*4(?:\.|$)|~\s*4(?:\.|$)|>=\s*4(?:\.|$)/", (string) $constraint)) {
+                    if (preg_match("/\^\s*v?4(?:\.|$)|~\s*v?4(?:\.|$)|>=\s*v?4(?:\.|$)/", (string) $constraint)) {
                         $compatibility = [
                             'version' => $checkingVersion['version'],
                             'isPrerelease' => false,
@@ -168,7 +168,7 @@ foreach ($plugins as $plugin) {
                         continue;
                     }
 
-                    if (preg_match("/\^\s*4(?:\.|$)|~\s*4(?:\.|$)|>=\s*4(?:\.|$)/", (string) $constraint)) {
+                    if (preg_match("/\^\s*v?4(?:\.|$)|~\s*v?4(?:\.|$)|>=\s*v?4(?:\.|$)/", (string) $constraint)) {
                         $compatibility = [
                             'version' => $checkingVersion['version'],
                             'isPrerelease' => true,


### PR DESCRIPTION

## Description

Same fix as #19252, but for the 4.x branch.

## Visual changes


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
