### PR TITLE
fix: CI PHPStan type inference for `Arr::wrap()` in StateCasts

### DIFF
--- a/packages/schemas/src/Components/StateCasts/EnumArrayStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/EnumArrayStateCast.php
@@ -28,8 +28,11 @@ class EnumArrayStateCast implements StateCast
             $state = json_decode($state, associative: true);
         }
 
+        /** @var array<mixed> $state */
+        $state = Arr::wrap($state);
+
         return array_reduce(
-            Arr::wrap($state),
+            $state,
             function (array $carry, $stateItem): array {
                 if (blank($stateItem)) {
                     return $carry;
@@ -62,8 +65,11 @@ class EnumArrayStateCast implements StateCast
             $state = json_decode($state, associative: true);
         }
 
+        /** @var array<mixed> $state */
+        $state = Arr::wrap($state);
+
         return array_reduce(
-            Arr::wrap($state),
+            $state,
             function (array $carry, $stateItem): array {
                 if (blank($stateItem)) {
                     return $carry;

--- a/packages/schemas/src/Components/StateCasts/OptionsArrayStateCast.php
+++ b/packages/schemas/src/Components/StateCasts/OptionsArrayStateCast.php
@@ -21,8 +21,11 @@ class OptionsArrayStateCast implements StateCast
             $state = json_decode($state, associative: true);
         }
 
+        /** @var array<mixed> $state */
+        $state = Arr::wrap($state);
+
         return array_reduce(
-            Arr::wrap($state),
+            $state,
             function (array $carry, $stateItem): array {
                 if (blank($stateItem)) {
                     return $carry;
@@ -73,8 +76,11 @@ class OptionsArrayStateCast implements StateCast
             $state = json_decode($state, associative: true);
         }
 
+        /** @var array<mixed> $state */
+        $state = Arr::wrap($state);
+
         return array_reduce(
-            Arr::wrap($state),
+            $state,
             function (array $carry, $stateItem): array {
                 if (blank($stateItem)) {
                     return $carry;


### PR DESCRIPTION

## Description

Laravel v12.51.0 changed the `Arr::wrap()` return type (laravel/framework#58625), causing PHPStan to incorrectly infer closure parameter types in `EnumArrayStateCast` and `OptionsArrayStateCast`.

Added `@var array<mixed>` annotations before `Arr::wrap()` calls, consistent with the existing pattern in `TextColumn` and `TextEntry`.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
