### PR TITLE
fix: Clone Schema instances in cloneChildComponents()

### DIFF
--- a/packages/schemas/src/Components/Concerns/HasChildComponents.php
+++ b/packages/schemas/src/Components/Concerns/HasChildComponents.php
@@ -194,7 +194,8 @@ trait HasChildComponents
             } elseif (
                 ($childComponents instanceof Component) ||
                 ($childComponents instanceof Action) ||
-                ($childComponents instanceof ActionGroup)
+                ($childComponents instanceof ActionGroup) ||
+                ($childComponents instanceof Schema)
             ) {
                 $this->childComponents[$key] = $childComponents->getClone();
             }


### PR DESCRIPTION
## Description

When a `Schema` instance (e.g. from `Schema::start()`, `Schema::end()`, or `Schema::between()`) is passed to a field slot like `afterLabel()`, it is stored directly in the `childComponents` array. However, `cloneChildComponents()` only cloned `Component`, `Action`, and `ActionGroup` instances — `Schema` was silently skipped.

This caused stale `cachedAbsoluteStatePath` values to persist when `Builder` cloned block item schemas via `getItems()` → `getClone()`. The Schema's state path, computed with sequential integer keys before Builder's `afterStateHydrated` converted them to UUIDs, was never flushed. This led to phantom state entries that caused silent `ValidationException` failures on save.

### Steps to reproduce

1. Create a form with a `Builder` component
2. Inside a block, add any field with `afterLabel(Schema::start([...]))`:
   ```php
   TextInput::make('content')
       ->afterLabel(Schema::start([
           Icon::make('heroicon-o-information-circle')
               ->tooltip('Test tooltip'),
       ]))
   ```
3. Create a record with one or more blocks
4. Edit the record and save — a `ValidationException` is thrown: `data.schema.0.type field is required`

## Visual changes

N/A — no visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.