### PR TITLE
fix: unmount action on halt during mount phase

### DIFF
--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -165,6 +165,8 @@ trait InteractsWithActions
                 $action->callAfterFormFilled();
             }
         } catch (Halt $exception) {
+            $this->unmountAction(canCancelParentActions: false);
+
             return null;
         } catch (Cancel $exception) {
             $this->unmountAction(canCancelParentActions: false);


### PR DESCRIPTION
## Description

### Fixes: #19268 


Fix stale mounted action entry left behind when `halt()` is thrown during the mount phase.

## Visual changes

https://github.com/user-attachments/assets/804530ac-ca97-4ccb-93be-bde2b74fdbf0



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
