### PR TITLE
feat: add RichEditorDropdownTool for grouping toolbar tools

### DIFF
--- a/packages/forms/docs/10-rich-editor.md
+++ b/packages/forms/docs/10-rich-editor.md
@@ -949,6 +949,133 @@ RichContentRenderer::make($record->content)
     ])
 ```
 
+### Grouping toolbar tools into dropdowns
+
+If your toolbar has many related tools (like headings, text alignment, or table operations), you can group them into a single dropdown button using `RichEditorDropdownTool`. This keeps the toolbar compact while still providing access to all options.
+
+`RichEditorDropdownTool` extends `RichEditorTool`, so it can be returned from `getEditorTools()` in a plugin and referenced by name in `toolbarButtons()`.
+
+#### Icon mode (default)
+
+In icon mode, the dropdown trigger displays the currently active option's icon. When the user clicks the trigger, a horizontal row of icon buttons appears:
+
+```php
+use Filament\Forms\Components\RichEditor\RichEditorDropdownTool;
+use Filament\Forms\Components\RichEditor\RichEditorTool;
+
+RichEditorDropdownTool::make('alignDropdown')
+    ->label('Text alignment')
+    ->icon('fi-o-align-start')
+    ->options([
+        RichEditorTool::make('alignStart')
+            ->icon('fi-o-align-start')
+            ->label('Align left')
+            ->jsHandler("\$getEditor()?.chain().focus().setTextAlign('start').run()")
+            ->activeJsExpression("!\$getEditor()?.isActive({ textAlign: 'center' }) && !\$getEditor()?.isActive({ textAlign: 'end' }) && !\$getEditor()?.isActive({ textAlign: 'justify' })"),
+        RichEditorTool::make('alignCenter')
+            ->icon('fi-o-align-center')
+            ->label('Align center')
+            ->jsHandler("\$getEditor()?.chain().focus().setTextAlign('center').run()")
+            ->activeJsExpression("\$getEditor()?.isActive({ textAlign: 'center' })"),
+        RichEditorTool::make('alignEnd')
+            ->icon('fi-o-align-end')
+            ->label('Align right')
+            ->jsHandler("\$getEditor()?.chain().focus().setTextAlign('end').run()")
+            ->activeJsExpression("\$getEditor()?.isActive({ textAlign: 'end' })"),
+        RichEditorTool::make('alignJustify')
+            ->icon('fi-o-align-justify')
+            ->label('Justify')
+            ->jsHandler("\$getEditor()?.chain().focus().setTextAlign('justify').run()")
+            ->activeJsExpression("\$getEditor()?.isActive({ textAlign: 'justify' })"),
+    ])
+```
+
+The icon passed to the dropdown itself (via `->icon()`) is used as the default trigger icon when no option is active.
+
+#### Select mode
+
+In select mode, the dropdown trigger displays the currently active option's text label, similar to a `<select>` element. The menu appears as a vertical list of text options:
+
+```php
+use Filament\Forms\Components\RichEditor\RichEditorDropdownTool;
+use Filament\Forms\Components\RichEditor\RichEditorTool;
+use Filament\Support\Icons\Heroicon;
+
+RichEditorDropdownTool::make('headingDropdown')
+    ->label('Text style')
+    ->icon(Heroicon::Bars3BottomLeft)
+    ->selectMode()
+    ->options([
+        RichEditorTool::make('paragraph')
+            ->icon(Heroicon::Bars3BottomLeft)
+            ->label('Paragraph')
+            ->jsHandler('$getEditor()?.chain().focus().setParagraph().run()')
+            ->activeKey('paragraph'),
+        RichEditorTool::make('heading1')
+            ->icon(Heroicon::H1)
+            ->label('Heading 1')
+            ->jsHandler('$getEditor()?.chain().focus().toggleHeading({ level: 1 }).run()')
+            ->activeKey('heading')
+            ->activeOptions(['level' => 1]),
+        RichEditorTool::make('heading2')
+            ->icon(Heroicon::H2)
+            ->label('Heading 2')
+            ->jsHandler('$getEditor()?.chain().focus().toggleHeading({ level: 2 }).run()')
+            ->activeKey('heading')
+            ->activeOptions(['level' => 2]),
+        RichEditorTool::make('heading3')
+            ->icon(Heroicon::H3)
+            ->label('Heading 3')
+            ->jsHandler('$getEditor()?.chain().focus().toggleHeading({ level: 3 }).run()')
+            ->activeKey('heading')
+            ->activeOptions(['level' => 3]),
+    ])
+```
+
+#### Registering dropdown tools in a plugin
+
+Return `RichEditorDropdownTool` instances from `getEditorTools()`, then reference them by name in `toolbarButtons()`:
+
+```php
+use Filament\Forms\Components\RichEditor\Plugins\Contracts\RichContentPlugin;
+use Filament\Forms\Components\RichEditor\RichEditorDropdownTool;
+use Filament\Forms\Components\RichEditor\RichEditorTool;
+
+class MyPlugin implements RichContentPlugin
+{
+    // ...
+
+    public function getEditorTools(): array
+    {
+        return [
+            RichEditorDropdownTool::make('headingDropdown')
+                ->label('Text style')
+                ->icon(Heroicon::Bars3BottomLeft)
+                ->selectMode()
+                ->options([/* ... */]),
+            RichEditorDropdownTool::make('alignDropdown')
+                ->label('Text alignment')
+                ->icon('fi-o-align-start')
+                ->options([/* ... */]),
+        ];
+    }
+}
+```
+
+```php
+use Filament\Forms\Components\RichEditor;
+
+RichEditor::make('content')
+    ->toolbarButtons([
+        ['bold', 'italic', 'underline'],
+        ['headingDropdown', 'alignDropdown'],
+        ['bulletList', 'orderedList'],
+    ])
+    ->plugins([MyPlugin::make()])
+```
+
+Each option in the dropdown is a regular `RichEditorTool` instance, so all existing tool features work — including `jsHandler()`, `activeKey()`, `activeOptions()`, `activeJsExpression()`, and `action()`.
+
 ### Setting up a TipTap JavaScript extension
 
 Filament is able to asynchronously load JavaScript extensions for TipTap. To do this, you need to create a JavaScript file that contains the extension, and register it in the `getTipTapJsExtensions()` method of your [plugin](#extending-the-rich-editor).

--- a/packages/forms/resources/css/components/rich-editor.css
+++ b/packages/forms/resources/css/components/rich-editor.css
@@ -36,7 +36,7 @@
     }
 
     & .fi-fo-rich-editor-dropdown-tool-trigger {
-        @apply flex h-8 cursor-pointer items-center justify-center gap-0.5 rounded-lg border-none bg-transparent px-1 text-sm font-semibold text-gray-700 outline-none transition duration-75 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-white/5;
+        @apply flex h-8 cursor-pointer items-center justify-center gap-0.5 rounded-lg border-none bg-transparent px-1 text-sm font-semibold text-gray-700 transition duration-75 outline-none hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-white/5;
     }
 
     & .fi-fo-rich-editor-dropdown-tool-chevron {
@@ -48,7 +48,7 @@
     }
 
     & .fi-fo-rich-editor-dropdown-tool-option {
-        @apply flex h-8 min-w-8 cursor-pointer items-center justify-center rounded-lg border-none bg-transparent p-0 text-sm font-semibold text-gray-700 outline-none transition duration-75 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-white/5;
+        @apply flex h-8 min-w-8 cursor-pointer items-center justify-center rounded-lg border-none bg-transparent p-0 text-sm font-semibold text-gray-700 transition duration-75 outline-none hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-white/5;
 
         &.fi-active {
             @apply text-primary-600 dark:text-primary-400 bg-gray-50 dark:bg-white/5;
@@ -65,7 +65,7 @@
         }
 
         & .fi-fo-rich-editor-dropdown-tool-option {
-            @apply min-w-0 justify-start whitespace-nowrap px-2 py-1 text-[0.8125rem] font-normal;
+            @apply min-w-0 justify-start px-2 py-1 text-[0.8125rem] font-normal whitespace-nowrap;
         }
     }
 

--- a/packages/forms/resources/css/components/rich-editor.css
+++ b/packages/forms/resources/css/components/rich-editor.css
@@ -31,6 +31,44 @@
         }
     }
 
+    & .fi-fo-rich-editor-dropdown-tool {
+        @apply relative inline-flex;
+    }
+
+    & .fi-fo-rich-editor-dropdown-tool-trigger {
+        @apply flex h-8 cursor-pointer items-center justify-center gap-0.5 rounded-lg border-none bg-transparent px-1 text-sm font-semibold text-gray-700 outline-none transition duration-75 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-white/5;
+    }
+
+    & .fi-fo-rich-editor-dropdown-tool-chevron {
+        @apply h-3 w-3 text-gray-400 dark:text-gray-500;
+    }
+
+    & .fi-fo-rich-editor-dropdown-tool-menu {
+        @apply absolute top-[calc(100%+0.25rem)] left-0 z-30 flex gap-1 rounded-lg border border-gray-300 bg-white p-1 shadow-lg dark:border-gray-600 dark:bg-gray-800;
+    }
+
+    & .fi-fo-rich-editor-dropdown-tool-option {
+        @apply flex h-8 min-w-8 cursor-pointer items-center justify-center rounded-lg border-none bg-transparent p-0 text-sm font-semibold text-gray-700 outline-none transition duration-75 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-white/5;
+
+        &.fi-active {
+            @apply text-primary-600 dark:text-primary-400 bg-gray-50 dark:bg-white/5;
+        }
+    }
+
+    & .fi-fo-rich-editor-dropdown-tool-select {
+        & .fi-fo-rich-editor-dropdown-tool-trigger {
+            @apply min-w-26 justify-between px-1.5 text-[0.8125rem] font-normal;
+        }
+
+        & .fi-fo-rich-editor-dropdown-tool-menu {
+            @apply min-w-32 flex-col;
+        }
+
+        & .fi-fo-rich-editor-dropdown-tool-option {
+            @apply min-w-0 justify-start whitespace-nowrap px-2 py-1 text-[0.8125rem] font-normal;
+        }
+    }
+
     & .fi-fo-rich-editor-uploading-file-message {
         @apply flex items-center gap-x-3 border-b border-gray-200 bg-gray-50 px-5 py-1.5 text-sm leading-6 font-medium text-gray-700 dark:border-white/10 dark:bg-white/5 dark:text-gray-200;
 

--- a/packages/forms/src/Components/RichEditor/RichEditorDropdownTool.php
+++ b/packages/forms/src/Components/RichEditor/RichEditorDropdownTool.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Filament\Forms\Components\RichEditor;
+
+use Closure;
+use Filament\Forms\Components\RichEditor;
+use Illuminate\Support\Js;
+
+use function Filament\Support\generate_icon_html;
+
+class RichEditorDropdownTool extends RichEditorTool
+{
+    /**
+     * @var array<RichEditorTool> | Closure
+     */
+    protected array | Closure $options = [];
+
+    protected bool $isSelectMode = false;
+
+    /**
+     * @param  array<RichEditorTool> | Closure  $options
+     */
+    public function options(array | Closure $options): static
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
+    /**
+     * @return array<RichEditorTool>
+     */
+    public function getOptions(): array
+    {
+        return $this->evaluate($this->options);
+    }
+
+    public function selectMode(bool $selectMode = true): static
+    {
+        $this->isSelectMode = $selectMode;
+
+        return $this;
+    }
+
+    public function editor(RichEditor $editor): static
+    {
+        parent::editor($editor);
+
+        foreach ($this->getOptions() as $option) {
+            $option->editor($editor);
+        }
+
+        return $this;
+    }
+
+    public function toEmbeddedHtml(): string
+    {
+        return $this->isSelectMode
+            ? $this->toSelectHtml()
+            : $this->toIconDropdownHtml();
+    }
+
+    private function toIconDropdownHtml(): string
+    {
+        $options = $this->getOptions();
+        $label = $this->getLabel();
+        $defaultIconHtml = generate_icon_html($this->getIcon(), alias: $this->getIconAlias())->toHtml();
+
+        $effectJs = $this->buildTriggerIconEffect($options, $defaultIconHtml);
+        $optionsHtml = $this->buildIconOptionsHtml($options);
+        $chevronSvg = $this->chevronSvg();
+
+        $xData = e('{ open: false, triggerIconHtml: ' . Js::from($defaultIconHtml)->toHtml() . ' }');
+        $xEffect = e($effectJs);
+        $xTooltip = e('{ content: ' . Js::from($label)->toHtml() . ', theme: $store.theme }');
+
+        ob_start(); ?>
+
+        <div x-data="<?= $xData ?>"
+             x-effect="<?= $xEffect ?>"
+             x-on:click.outside="open = false"
+             x-on:keydown.escape.window="open = false"
+             class="fi-fo-rich-editor-dropdown-tool">
+
+            <button type="button" tabindex="-1"
+                    x-on:click="open = !open"
+                    class="fi-fo-rich-editor-dropdown-tool-trigger"
+                    aria-haspopup="listbox"
+                    x-bind:aria-expanded="open"
+                    x-tooltip="<?= $xTooltip ?>">
+                <span x-html="triggerIconHtml"><?= $defaultIconHtml ?></span>
+                <?= $chevronSvg ?>
+            </button>
+
+            <div x-show="open" x-cloak x-transition
+                 class="fi-fo-rich-editor-dropdown-tool-menu"
+                 role="listbox">
+                <?= $optionsHtml ?>
+            </div>
+        </div>
+
+        <?php return ob_get_clean();
+    }
+
+    private function toSelectHtml(): string
+    {
+        $options = $this->getOptions();
+        $label = $this->getLabel();
+        $defaultLabel = $options[0]?->getLabel() ?? $label;
+
+        $effectJs = $this->buildTriggerLabelEffect($options, $defaultLabel);
+        $optionsHtml = $this->buildSelectOptionsHtml($options);
+        $chevronSvg = $this->chevronSvg();
+
+        $xData = e('{ open: false, triggerLabel: ' . Js::from($defaultLabel)->toHtml() . ' }');
+        $xEffect = e($effectJs);
+
+        ob_start(); ?>
+
+        <div x-data="<?= $xData ?>"
+             x-effect="<?= $xEffect ?>"
+             x-on:click.outside="open = false"
+             x-on:keydown.escape.window="open = false"
+             class="fi-fo-rich-editor-dropdown-tool fi-fo-rich-editor-dropdown-tool-select">
+
+            <button type="button" tabindex="-1"
+                    x-on:click="open = !open"
+                    class="fi-fo-rich-editor-dropdown-tool-trigger"
+                    aria-haspopup="listbox"
+                    x-bind:aria-expanded="open">
+                <span x-text="triggerLabel"><?= e($defaultLabel) ?></span>
+                <?= $chevronSvg ?>
+            </button>
+
+            <div x-show="open" x-cloak x-transition
+                 class="fi-fo-rich-editor-dropdown-tool-menu"
+                 role="listbox">
+                <?= $optionsHtml ?>
+            </div>
+        </div>
+
+        <?php return ob_get_clean();
+    }
+
+    private function chevronSvg(): string
+    {
+        return '<svg class="fi-fo-rich-editor-dropdown-tool-chevron" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M3 4.5 6 7.5l3-3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+    }
+
+    /**
+     * @param  array<RichEditorTool>  $options
+     */
+    private function buildTriggerIconEffect(array $options, string $defaultIconHtml): string
+    {
+        $parts = [];
+
+        foreach ($options as $option) {
+            $parts[] = 'if (' . $this->buildActiveExpression($option) . ') return ' . Js::from(
+                generate_icon_html($option->getIcon(), alias: $option->getIconAlias())->toHtml()
+            )->toHtml() . ';';
+        }
+
+        return 'triggerIconHtml = (() => { ' . implode(' ', $parts) . ' return ' . Js::from($defaultIconHtml)->toHtml() . '; })()';
+    }
+
+    /**
+     * @param  array<RichEditorTool>  $options
+     */
+    private function buildTriggerLabelEffect(array $options, string $defaultLabel): string
+    {
+        $parts = [];
+
+        foreach ($options as $option) {
+            $parts[] = 'if (' . $this->buildActiveExpression($option) . ') return ' . Js::from($option->getLabel())->toHtml() . ';';
+        }
+
+        return 'triggerLabel = (() => { ' . implode(' ', $parts) . ' return ' . Js::from($defaultLabel)->toHtml() . '; })()';
+    }
+
+    /**
+     * @param  array<RichEditorTool>  $options
+     */
+    private function buildIconOptionsHtml(array $options): string
+    {
+        $html = '';
+
+        foreach ($options as $option) {
+            $activeExpr = $this->buildActiveExpression($option);
+            $iconHtml = generate_icon_html($option->getIcon(), alias: $option->getIconAlias())->toHtml();
+            $optionLabel = $option->getLabel();
+            $jsHandler = $option->getJsHandler();
+
+            $html .= '<button type="button" tabindex="-1" role="option"'
+                . ' x-on:click="' . e($jsHandler . '; open = false') . '"'
+                . ' x-bind:class="' . e("{ 'fi-active': " . $activeExpr . ' }') . '"'
+                . ' x-tooltip="' . e('{ content: ' . Js::from($optionLabel)->toHtml() . ', theme: $store.theme }') . '"'
+                . ' class="fi-fo-rich-editor-dropdown-tool-option"'
+                . '>' . $iconHtml . '</button>';
+        }
+
+        return $html;
+    }
+
+    /**
+     * @param  array<RichEditorTool>  $options
+     */
+    private function buildSelectOptionsHtml(array $options): string
+    {
+        $html = '';
+
+        foreach ($options as $option) {
+            $activeExpr = $this->buildActiveExpression($option);
+            $jsHandler = $option->getJsHandler();
+
+            $html .= '<button type="button" tabindex="-1" role="option"'
+                . ' x-on:click="' . e($jsHandler . '; open = false') . '"'
+                . ' x-bind:class="' . e("{ 'fi-active': " . $activeExpr . ' }') . '"'
+                . ' class="fi-fo-rich-editor-dropdown-tool-option"'
+                . '>' . e($option->getLabel()) . '</button>';
+        }
+
+        return $html;
+    }
+
+    private function buildActiveExpression(RichEditorTool $option): string
+    {
+        $activeJsExpression = $option->getActiveJsExpression();
+
+        if (filled($activeJsExpression)) {
+            return "editorUpdatedAt && ({$activeJsExpression})";
+        }
+
+        return 'editorUpdatedAt && $getEditor()?.isActive('
+            . Js::from($option->getActiveKey())->toHtml()
+            . ', '
+            . Js::from($option->getActiveOptions())->toHtml()
+            . ')';
+    }
+}

--- a/packages/upgrade/src/check-compatibility.php
+++ b/packages/upgrade/src/check-compatibility.php
@@ -2,6 +2,7 @@
 
 use Laravel\Prompts\ConfirmPrompt;
 use Laravel\Prompts\Prompt;
+
 use function Laravel\Prompts\confirm;
 use function Termwind\render;
 

--- a/tests/src/Tables/GroupingTest.php
+++ b/tests/src/Tables/GroupingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Filament\Tables;
+use Filament\Tables\Grouping\Group;
 use Filament\Tests\Fixtures\Livewire\GroupedCustomDataTable;
 use Filament\Tests\Fixtures\Livewire\PostsTable;
 use Filament\Tests\Fixtures\Livewire\UsersTable;
@@ -44,7 +44,7 @@ it('can group a table', function (): void {
             $table = $livewire->getTable();
 
             expect($table)
-                ->getGrouping()->toBeInstanceOf(Tables\Grouping\Group::class)
+                ->getGrouping()->toBeInstanceOf(Group::class)
                 ->and($table->getGrouping())
                 ->getLabel()->toBe('Dynamic label');
         });
@@ -506,7 +506,7 @@ it('can group records with nullable `BelongsTo` -> `HasOneThrough` relationship'
 
 it('can handle array records in `getKey()`', function (): void {
     $livewire = livewire(PostsTable::class)->instance();
-    $group = \Filament\Tables\Grouping\Group::make('status')->table($livewire->getTable());
+    $group = Group::make('status')->table($livewire->getTable());
 
     $arrayRecord = ['__key' => '1', 'name' => 'John', 'status' => 'active'];
 
@@ -515,7 +515,7 @@ it('can handle array records in `getKey()`', function (): void {
 
 it('can handle array records in `getStringKey()`', function (): void {
     $livewire = livewire(PostsTable::class)->instance();
-    $group = \Filament\Tables\Grouping\Group::make('status')->table($livewire->getTable());
+    $group = Group::make('status')->table($livewire->getTable());
 
     $arrayRecord = ['__key' => '1', 'name' => 'John', 'status' => 'active'];
 
@@ -524,7 +524,7 @@ it('can handle array records in `getStringKey()`', function (): void {
 
 it('can handle array records in `getTitle()`', function (): void {
     $livewire = livewire(PostsTable::class)->instance();
-    $group = \Filament\Tables\Grouping\Group::make('status')->table($livewire->getTable());
+    $group = Group::make('status')->table($livewire->getTable());
 
     $arrayRecord = ['__key' => '1', 'name' => 'John', 'status' => 'active'];
 
@@ -533,7 +533,7 @@ it('can handle array records in `getTitle()`', function (): void {
 
 it('can handle array records in `getDescription()`', function (): void {
     $livewire = livewire(PostsTable::class)->instance();
-    $group = \Filament\Tables\Grouping\Group::make('status')
+    $group = Group::make('status')
         ->getDescriptionFromRecordUsing(fn (array $record): string => 'User: ' . $record['name'])
         ->table($livewire->getTable());
 
@@ -544,7 +544,7 @@ it('can handle array records in `getDescription()`', function (): void {
 
 it('can use custom `getKeyFromRecordUsing()` with array records', function (): void {
     $livewire = livewire(PostsTable::class)->instance();
-    $group = \Filament\Tables\Grouping\Group::make('status')
+    $group = Group::make('status')
         ->getKeyFromRecordUsing(fn (array $record): string => strtoupper($record['status']))
         ->table($livewire->getTable());
 
@@ -556,7 +556,7 @@ it('can use custom `getKeyFromRecordUsing()` with array records', function (): v
 
 it('can use custom `getTitleFromRecordUsing()` with array records', function (): void {
     $livewire = livewire(PostsTable::class)->instance();
-    $group = \Filament\Tables\Grouping\Group::make('status')
+    $group = Group::make('status')
         ->getTitleFromRecordUsing(fn (array $record): string => 'Status: ' . ucfirst($record['status']))
         ->table($livewire->getTable());
 


### PR DESCRIPTION
## Summary

Adds a new `RichEditorDropdownTool` component that groups multiple `RichEditorTool` instances into a single dropdown button in the rich editor toolbar.

This is useful for toolbar groups like headings (Paragraph / H1 / H2 / H3), text alignment (left / center / right / justify), or table operations (column add/delete, row add/delete, cell merge/split) — where showing every option as a separate toolbar button creates clutter.

<img width="1038" height="212" alt="image" src="https://github.com/user-attachments/assets/64ac1afb-3964-411f-8e48-944913583418" />

### Two display modes

**Icon mode** (default) — trigger shows the currently active option's icon, menu shows icon buttons horizontally:

```php
RichEditorDropdownTool::make('alignDropdown')
    ->label('Text alignment')
    ->icon('fi-o-align-start')
    ->options([
        RichEditorTool::make('alignStart')
            ->icon('fi-o-align-start')
            ->label('Align left')
            ->jsHandler("\$getEditor()?.chain().focus().setTextAlign('start').run()")
            ->activeJsExpression("!\$getEditor()?.isActive({ textAlign: 'center' }) && !\$getEditor()?.isActive({ textAlign: 'end' })"),
        RichEditorTool::make('alignCenter')
            ->icon('fi-o-align-center')
            ->label('Align center')
            ->jsHandler("\$getEditor()?.chain().focus().setTextAlign('center').run()")
            ->activeJsExpression("\$getEditor()?.isActive({ textAlign: 'center' })"),
        // ...
    ])
```

**Select mode** — trigger shows the active option's text label (like a `<select>`), menu shows text options vertically:

```php
RichEditorDropdownTool::make('headingDropdown')
    ->label('Text style')
    ->icon(Heroicon::Bars3BottomLeft)
    ->selectMode()
    ->options([
        RichEditorTool::make('paragraph')
            ->icon(Heroicon::Bars3BottomLeft)
            ->label('Paragraph')
            ->jsHandler('$getEditor()?.chain().focus().setParagraph().run()')
            ->activeKey('paragraph'),
        RichEditorTool::make('heading1')
            ->icon(Heroicon::H1)
            ->label('Heading 1')
            ->jsHandler('$getEditor()?.chain().focus().toggleHeading({ level: 1 }).run()')
            ->activeKey('heading')
            ->activeOptions(['level' => 1]),
        // ...
    ])
```

### How it works

- Extends `RichEditorTool` so it works anywhere a tool is expected (registered via plugins, referenced in `toolbarButtons` by name)
- Options are regular `RichEditorTool` instances — reuses existing icon, label, jsHandler, activeKey/Options APIs
- Trigger icon/label reactively updates via Alpine `x-effect` when the active option changes
- `editor()` is propagated to child options so `->action()` (Livewire modals) works on options
- Dropdown closes on click-outside and Escape
- CSS follows existing `.fi-fo-rich-editor-tool` patterns with proper dark mode support

### Usage with plugins

```php
class MyPlugin implements RichContentPlugin
{
    public function getEditorTools(): array
    {
        return [
            RichEditorDropdownTool::make('headingDropdown')
                ->label('Text style')
                ->icon(Heroicon::Bars3BottomLeft)
                ->selectMode()
                ->options([/* ... */]),
        ];
    }
}
```

Then reference by name in `toolbarButtons`:

```php
RichEditor::make('content')
    ->toolbarButtons([
        ['bold', 'italic', 'underline'],
        ['headingDropdown', 'alignDropdown'],
    ])
    ->plugins([MyPlugin::make()])
```

## Changes

- **New**: `packages/forms/src/Components/RichEditor/RichEditorDropdownTool.php`
- **Modified**: `packages/forms/resources/css/components/rich-editor.css` (dropdown styles)

Additive only — no breaking changes to existing APIs.