### PR TITLE
Add note about multiple paginators with custom tables

### DIFF
--- a/packages/tables/docs/09-custom-data.md
+++ b/packages/tables/docs/09-custom-data.md
@@ -329,6 +329,10 @@ In this example, the `forPage()` method is used to paginate the data. This proba
     It might seem like Filament should paginate the data for you, but in many cases, it's better to let your data source—like a custom query or API call—handle the pagination instead.
 </Aside>
 
+<Aside variant="info">
+    If you have multiple custom tables on a page and are using the `queryStringIdentifier('yourname')` method to distinguish them, you will need to add an options argument to the LengthAwarePaginator with the pageName, like `options: ['pageName' => 'yournamePage']` (note the Page suffix to yourname).
+</Aside>
+
 ## Actions
 
 [Actions](actions) in the table work similarly to how they do when using [Eloquent models](https://laravel.com/docs/eloquent). The only difference is that the `$record` parameter in the action's callback function will be an `array` instead of a `Model`.

--- a/packages/tables/docs/09-custom-data.md
+++ b/packages/tables/docs/09-custom-data.md
@@ -329,8 +329,8 @@ In this example, the `forPage()` method is used to paginate the data. This proba
     It might seem like Filament should paginate the data for you, but in many cases, it's better to let your data source—like a custom query or API call—handle the pagination instead.
 </Aside>
 
-<Aside variant="info">
-    If you have multiple custom tables on a page and are using the `queryStringIdentifier('yourname')` method to distinguish them, you will need to add an options argument to the LengthAwarePaginator with the pageName, like `options: ['pageName' => 'yournamePage']` (note the Page suffix to yourname).
+<Aside variant="warning">
+    If you have multiple custom tables on a page and are using the `queryStringIdentifier('customIdentifier')` method to distinguish them, you will need to add an `options` argument to the `LengthAwarePaginator` with the `pageName`, like `options: ['pageName' => 'customIdentifierPage']`. Note that adding the `Page` suffix to your custom identifier is required here.
 </Aside>
 
 ## Actions

--- a/packages/upgrade/src/check-compatibility.php
+++ b/packages/upgrade/src/check-compatibility.php
@@ -2,6 +2,7 @@
 
 use Laravel\Prompts\ConfirmPrompt;
 use Laravel\Prompts\Prompt;
+
 use function Laravel\Prompts\confirm;
 use function Termwind\render;
 

--- a/tests/src/Tables/GroupingTest.php
+++ b/tests/src/Tables/GroupingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Filament\Tables;
+use Filament\Tables\Grouping\Group;
 use Filament\Tests\Fixtures\Livewire\GroupedCustomDataTable;
 use Filament\Tests\Fixtures\Livewire\PostsTable;
 use Filament\Tests\Fixtures\Livewire\UsersTable;
@@ -44,7 +44,7 @@ it('can group a table', function (): void {
             $table = $livewire->getTable();
 
             expect($table)
-                ->getGrouping()->toBeInstanceOf(Tables\Grouping\Group::class)
+                ->getGrouping()->toBeInstanceOf(Group::class)
                 ->and($table->getGrouping())
                 ->getLabel()->toBe('Dynamic label');
         });
@@ -506,7 +506,7 @@ it('can group records with nullable `BelongsTo` -> `HasOneThrough` relationship'
 
 it('can handle array records in `getKey()`', function (): void {
     $livewire = livewire(PostsTable::class)->instance();
-    $group = \Filament\Tables\Grouping\Group::make('status')->table($livewire->getTable());
+    $group = Group::make('status')->table($livewire->getTable());
 
     $arrayRecord = ['__key' => '1', 'name' => 'John', 'status' => 'active'];
 
@@ -515,7 +515,7 @@ it('can handle array records in `getKey()`', function (): void {
 
 it('can handle array records in `getStringKey()`', function (): void {
     $livewire = livewire(PostsTable::class)->instance();
-    $group = \Filament\Tables\Grouping\Group::make('status')->table($livewire->getTable());
+    $group = Group::make('status')->table($livewire->getTable());
 
     $arrayRecord = ['__key' => '1', 'name' => 'John', 'status' => 'active'];
 
@@ -524,7 +524,7 @@ it('can handle array records in `getStringKey()`', function (): void {
 
 it('can handle array records in `getTitle()`', function (): void {
     $livewire = livewire(PostsTable::class)->instance();
-    $group = \Filament\Tables\Grouping\Group::make('status')->table($livewire->getTable());
+    $group = Group::make('status')->table($livewire->getTable());
 
     $arrayRecord = ['__key' => '1', 'name' => 'John', 'status' => 'active'];
 
@@ -533,7 +533,7 @@ it('can handle array records in `getTitle()`', function (): void {
 
 it('can handle array records in `getDescription()`', function (): void {
     $livewire = livewire(PostsTable::class)->instance();
-    $group = \Filament\Tables\Grouping\Group::make('status')
+    $group = Group::make('status')
         ->getDescriptionFromRecordUsing(fn (array $record): string => 'User: ' . $record['name'])
         ->table($livewire->getTable());
 
@@ -544,7 +544,7 @@ it('can handle array records in `getDescription()`', function (): void {
 
 it('can use custom `getKeyFromRecordUsing()` with array records', function (): void {
     $livewire = livewire(PostsTable::class)->instance();
-    $group = \Filament\Tables\Grouping\Group::make('status')
+    $group = Group::make('status')
         ->getKeyFromRecordUsing(fn (array $record): string => strtoupper($record['status']))
         ->table($livewire->getTable());
 
@@ -556,7 +556,7 @@ it('can use custom `getKeyFromRecordUsing()` with array records', function (): v
 
 it('can use custom `getTitleFromRecordUsing()` with array records', function (): void {
     $livewire = livewire(PostsTable::class)->instance();
-    $group = \Filament\Tables\Grouping\Group::make('status')
+    $group = Group::make('status')
         ->getTitleFromRecordUsing(fn (array $record): string => 'Status: ' . ucfirst($record['status']))
         ->table($livewire->getTable());
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Adding a note to the documentation Pagination section for custom tables, describing how to handle having multiple custom tables on a page, as this is not obvious and took me a while to figure out.  Thought this might save the next person some time.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
