### PR TITLE
feat: ActionGroup in HeaderAction

### DIFF
--- a/packages/schemas/src/Components/Concerns/HasActions.php
+++ b/packages/schemas/src/Components/Concerns/HasActions.php
@@ -4,6 +4,7 @@ namespace Filament\Schemas\Components\Concerns;
 
 use Closure;
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Schemas\Components\Contracts\HasAffixActions;
 use Filament\Schemas\Components\Contracts\HasExtraItemActions;
 use Illuminate\Database\Eloquent\Model;
@@ -146,7 +147,7 @@ trait HasActions
         return [];
     }
 
-    public function prepareAction(Action $action): Action
+    public function prepareAction(Action|ActionGroup $action): Action|ActionGroup
     {
         return $action->schemaComponent($this);
     }

--- a/packages/schemas/src/Components/Concerns/HasHeaderActions.php
+++ b/packages/schemas/src/Components/Concerns/HasHeaderActions.php
@@ -4,17 +4,18 @@ namespace Filament\Schemas\Components\Concerns;
 
 use Closure;
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Illuminate\Support\Arr;
 
 trait HasHeaderActions
 {
     /**
-     * @var array<Action | Closure>
+     * @var array<Action | ActionGroup | Closure>
      */
     protected array $headerActions = [];
 
     /**
-     * @param  array<Action | Closure>  $actions
+     * @param  array<Action | ActionGroup | Closure>  $actions
      */
     public function headerActions(array $actions): static
     {
@@ -27,7 +28,7 @@ trait HasHeaderActions
     }
 
     /**
-     * @return array<Action>
+     * @return array<Action | ActionGroup>
      */
     public function getHeaderActions(): array
     {


### PR DESCRIPTION
Update php type from `Action` to `Action | ActionGroup` on the `prepareAction` method


This allows us to pass ActionGroup objects as Actions
<br>
UseCase:
```php
Section::make()
    ->headerActions([
        ActionGroup::make([
            SomeAction::make(),
        ]),
    ])
```
