### PR TITLE
fix: prevent `array_key_exists()` null key deprecation on PHP 8.5

### DIFF
--- a/packages/panels/src/Auth/Pages/EditProfile.php
+++ b/packages/panels/src/Auth/Pages/EditProfile.php
@@ -263,8 +263,7 @@ class EditProfile extends Page
 
         if (
             (! is_array($recipient))
-            || ($currentEmail === null)
-            || (! array_key_exists($currentEmail, $recipient))
+            || (! array_key_exists($currentEmail ?? '', $recipient))
         ) {
             return $newEmail;
         }

--- a/packages/panels/src/Auth/Pages/EditProfile.php
+++ b/packages/panels/src/Auth/Pages/EditProfile.php
@@ -263,6 +263,7 @@ class EditProfile extends Page
 
         if (
             (! is_array($recipient))
+            || ($currentEmail === null)
             || (! array_key_exists($currentEmail, $recipient))
         ) {
             return $newEmail;

--- a/packages/panels/src/Pages/Concerns/HasSubNavigation.php
+++ b/packages/panels/src/Pages/Concerns/HasSubNavigation.php
@@ -82,7 +82,7 @@ trait HasSubNavigation
                     $itemGroupKey = $itemGroup->name;
                 }
 
-                if (array_key_exists($itemGroupKey, $navigationGroups)) {
+                if (($itemGroupKey !== null) && array_key_exists($itemGroupKey, $navigationGroups)) {
                     $navigationGroups[$itemGroupKey]->items([
                         ...$navigationGroups[$itemGroupKey]->getItems(),
                         $item,

--- a/packages/panels/src/Pages/Concerns/HasSubNavigation.php
+++ b/packages/panels/src/Pages/Concerns/HasSubNavigation.php
@@ -82,7 +82,7 @@ trait HasSubNavigation
                     $itemGroupKey = $itemGroup->name;
                 }
 
-                if (($itemGroupKey !== null) && array_key_exists($itemGroupKey, $navigationGroups)) {
+                if (array_key_exists($itemGroupKey ?? '', $navigationGroups)) {
                     $navigationGroups[$itemGroupKey]->items([
                         ...$navigationGroups[$itemGroupKey]->getItems(),
                         $item,

--- a/packages/panels/src/Resources/Concerns/HasTabs.php
+++ b/packages/panels/src/Resources/Concerns/HasTabs.php
@@ -66,7 +66,7 @@ trait HasTabs
 
     protected function modifyQueryWithActiveTab(Builder $query, bool $isResolvingRecord = false): Builder
     {
-        if (blank(filled($this->activeTab))) {
+        if (blank($this->activeTab)) {
             return $query;
         }
 

--- a/packages/panels/src/Resources/Pages/Concerns/HasRelationManagers.php
+++ b/packages/panels/src/Resources/Pages/Concerns/HasRelationManagers.php
@@ -69,7 +69,7 @@ trait HasRelationManagers
     {
         $managers = $this->getRelationManagers();
 
-        if (array_key_exists($this->activeRelationManager, $managers)) {
+        if (($this->activeRelationManager !== null) && array_key_exists($this->activeRelationManager, $managers)) {
             return;
         }
 

--- a/packages/panels/src/Resources/Pages/Concerns/HasRelationManagers.php
+++ b/packages/panels/src/Resources/Pages/Concerns/HasRelationManagers.php
@@ -69,7 +69,7 @@ trait HasRelationManagers
     {
         $managers = $this->getRelationManagers();
 
-        if (($this->activeRelationManager !== null) && array_key_exists($this->activeRelationManager, $managers)) {
+        if (array_key_exists($this->activeRelationManager ?? '', $managers)) {
             return;
         }
 

--- a/packages/tables/src/Columns/Summarizers/Average.php
+++ b/packages/tables/src/Columns/Summarizers/Average.php
@@ -35,7 +35,7 @@ class Average extends Summarizer
 
     public function getSelectedState(): int | float | null
     {
-        if (! array_key_exists($this->selectAlias, $this->selectedState)) {
+        if ($this->selectAlias === null || ! array_key_exists($this->selectAlias, $this->selectedState)) {
             return null;
         }
 

--- a/packages/tables/src/Columns/Summarizers/Average.php
+++ b/packages/tables/src/Columns/Summarizers/Average.php
@@ -35,7 +35,7 @@ class Average extends Summarizer
 
     public function getSelectedState(): int | float | null
     {
-        if ($this->selectAlias === null || ! array_key_exists($this->selectAlias, $this->selectedState)) {
+        if (! array_key_exists($this->selectAlias ?? '', $this->selectedState)) {
             return null;
         }
 

--- a/packages/tables/src/Columns/Summarizers/Count.php
+++ b/packages/tables/src/Columns/Summarizers/Count.php
@@ -78,7 +78,7 @@ class Count extends Summarizer
 
     public function getSelectedState(): int | float | null
     {
-        if (! array_key_exists($this->selectAlias, $this->selectedState)) {
+        if ($this->selectAlias === null || ! array_key_exists($this->selectAlias, $this->selectedState)) {
             return null;
         }
 

--- a/packages/tables/src/Columns/Summarizers/Count.php
+++ b/packages/tables/src/Columns/Summarizers/Count.php
@@ -78,7 +78,7 @@ class Count extends Summarizer
 
     public function getSelectedState(): int | float | null
     {
-        if ($this->selectAlias === null || ! array_key_exists($this->selectAlias, $this->selectedState)) {
+        if (! array_key_exists($this->selectAlias ?? '', $this->selectedState)) {
             return null;
         }
 

--- a/packages/tables/src/Columns/Summarizers/Sum.php
+++ b/packages/tables/src/Columns/Summarizers/Sum.php
@@ -35,7 +35,7 @@ class Sum extends Summarizer
 
     public function getSelectedState(): int | float | null
     {
-        if ($this->selectAlias === null || ! array_key_exists($this->selectAlias, $this->selectedState)) {
+        if (! array_key_exists($this->selectAlias ?? '', $this->selectedState)) {
             return null;
         }
 

--- a/packages/tables/src/Columns/Summarizers/Sum.php
+++ b/packages/tables/src/Columns/Summarizers/Sum.php
@@ -35,7 +35,7 @@ class Sum extends Summarizer
 
     public function getSelectedState(): int | float | null
     {
-        if (! array_key_exists($this->selectAlias, $this->selectedState)) {
+        if ($this->selectAlias === null || ! array_key_exists($this->selectAlias, $this->selectedState)) {
             return null;
         }
 


### PR DESCRIPTION

## Description

Fixes #19284 

guard array_key_exists() calls against null keys to avoid the PHP 8.5 deprecation warning, and fix a latent blank(filled()) typo in HasTabs.

## Visual changes


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
