### PR TITLE
fix: add null check

### DIFF
--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -598,6 +598,10 @@ trait InteractsWithActions
         if (filled($action['context']['recordKey'] ?? null)) {
             $record = $this->getTableRecord($action['context']['recordKey']);
 
+            if (! $record) {
+                throw new ActionNotResolvableException("Record [{$action['context']['recordKey']}] no longer exists.");
+            }
+
             $resolvedAction->getRootGroup()?->record($record) ?? $resolvedAction->record($record);
         }
 

--- a/tests/src/Panels/Resources/Pages/ListRecordsTest.php
+++ b/tests/src/Panels/Resources/Pages/ListRecordsTest.php
@@ -347,10 +347,9 @@ it('cannot access record for action after record no longer matches tab without `
         ->assertCanSeeTableRecords([$post])
         ->tap(fn () => $post->update(['is_published' => false]));
 
-    expect(
-        fn () => livewire(ListPostsWithTabs::class)
-            ->set('shouldExcludeTabQueryWhenResolvingRecord', false)
-            ->set('activeTab', 'published')
-            ->mountTableAction(DeleteAction::class, $post)
-    )->toThrow(TypeError::class);
+    livewire(ListPostsWithTabs::class)
+        ->set('shouldExcludeTabQueryWhenResolvingRecord', false)
+        ->set('activeTab', 'published')
+        ->mountTableAction(DeleteAction::class, $post)
+        ->assertTableActionNotMounted(DeleteAction::class);
 });

--- a/tests/src/Panels/Resources/RelationManagerTest.php
+++ b/tests/src/Panels/Resources/RelationManagerTest.php
@@ -304,13 +304,12 @@ it('cannot access record for action after record no longer matches tab without `
         ->assertCanSeeTableRecords([$department])
         ->tap(fn () => $department->update(['name' => 'Billing']));
 
-    expect(
-        fn () => livewire(DepartmentsRelationManagerWithTabs::class, [
-            'ownerRecord' => $ticket,
-            'pageClass' => EditTicket::class,
-        ])
-            ->set('shouldExcludeTabQueryWhenResolvingRecord', false)
-            ->set('activeTab', 'a_names')
-            ->mountTableAction(DeleteAction::class, $department)
-    )->toThrow(TypeError::class);
+    livewire(DepartmentsRelationManagerWithTabs::class, [
+        'ownerRecord' => $ticket,
+        'pageClass' => EditTicket::class,
+    ])
+        ->set('shouldExcludeTabQueryWhenResolvingRecord', false)
+        ->set('activeTab', 'a_names')
+        ->mountTableAction(DeleteAction::class, $department)
+        ->assertTableActionNotMounted(DeleteAction::class);
 });

--- a/tests/src/Tables/Filters/TrashedFilterTest.php
+++ b/tests/src/Tables/Filters/TrashedFilterTest.php
@@ -125,9 +125,8 @@ it('cannot access record for action after record no longer matches non-excluded 
         ->assertCanSeeTableRecords([$post])
         ->tap(fn () => $post->update(['is_published' => false]));
 
-    expect(
-        fn () => livewire(PostsTable::class)
-            ->filterTable('is_published')
-            ->mountTableAction(DeleteAction::class, $post)
-    )->toThrow(TypeError::class);
+    livewire(PostsTable::class)
+        ->filterTable('is_published')
+        ->mountTableAction(DeleteAction::class, $post)
+        ->assertTableActionNotMounted(DeleteAction::class);
 });


### PR DESCRIPTION
## Description
User A deletes a record via relation manager. User B tries to delete the same record via relation manger:

```
TypeError
filament/packages/actions/src/DeleteAction.php:43
Filament\Actions\DeleteAction::{closure:Filament\Actions\DeleteAction::setUp():43}(): Argument #1 ($record) must be of type Illuminate\Database\Eloquent\Model, null given, called in /Users/martin/Projects/filament-v4/filament/packages/support/src/Concerns/EvaluatesClosures.php on line 36
```

[https://pastebin.com/jpz8S5RP](https://pastebin.com/jpz8S5RP)

## Visual changes

n/a

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

## Reproduction repo
[https://github.com/martin-ro/filament-null-check](https://github.com/martin-ro/filament-null-check)