### PR TITLE
Fix: Update itemLabel type to include Htmlable

### DIFF
--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -60,7 +60,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
 
     protected string | Closure | null $relationship = null;
 
-    protected string | Closure | Htmlable | null $itemLabel = null;
+    protected string | Htmlable | Closure | null $itemLabel = null;
 
     protected bool | Closure $hasItemNumbers = false;
 
@@ -1039,7 +1039,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         $this->rawState($items);
     }
 
-    public function itemLabel(string | Closure | Htmlable | null $label): static
+    public function itemLabel(string | Htmlable | Closure | null $label): static
     {
         $this->itemLabel = $label;
 

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -60,7 +60,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
 
     protected string | Closure | null $relationship = null;
 
-    protected string | Closure | null $itemLabel = null;
+    protected string | Closure | Htmlable | null $itemLabel = null;
 
     protected bool | Closure $hasItemNumbers = false;
 
@@ -1039,7 +1039,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         $this->rawState($items);
     }
 
-    public function itemLabel(string | Closure | null $label): static
+    public function itemLabel(string | Closure | Htmlable | null $label): static
     {
         $this->itemLabel = $label;
 


### PR DESCRIPTION
## Description

The `getItemLabel()` method in the `Repeater` component already declares `string | Htmlable | null` as its return type, indicating that `Htmlable` values are a supported and intended use case. However, the `$itemLabel` property and its corresponding `itemLabel()` setter only accepted `string | Closure | null`. The property's and setter's type signature is updated to align with the getter's existing return type.

## Visual changes

No visual changes. 

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
