### PR TITLE
feat: get item index in itemLabel on Repeater

### DIFF
--- a/packages/forms/resources/views/components/repeater/index.blade.php
+++ b/packages/forms/resources/views/components/repeater/index.blade.php
@@ -91,7 +91,7 @@
             >
                 @foreach ($items as $itemKey => $item)
                     @php
-                        $itemLabel = $getItemLabel($itemKey);
+                        $itemLabel = $getItemLabel($itemKey, $loop->iteration);
                         $visibleExtraItemActions = array_filter(
                             $extraItemActions,
                             fn (Action $action): bool => $action(['item' => $itemKey])->isVisible(),

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -1191,7 +1191,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         ));
     }
 
-    public function getItemLabel(string $key): string | Htmlable | null
+    public function getItemLabel(string $key, ?int $index = null): string | Htmlable | null
     {
         $container = $this->getChildSchema($key);
 
@@ -1202,6 +1202,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
             'schema' => $container,
             'state' => $container->getStateSnapshot(),
             'uuid' => $key,
+            'index' => $index,
         ]);
     }
 


### PR DESCRIPTION
passes the index to `getItemLabel()` so we can do something like this

``` php
Repeater::make()
    ->itemLabel(function (int $index) {
        return match($index) {
            1 => 'Primary',
            default => 'Backup',
        };
    })
```

<img width="804" height="514" alt="image" src="https://github.com/user-attachments/assets/c6d0af7d-1511-45d7-949b-ea681fa825ce" />
