### PR TITLE
[3.x] fix: add missing autofocus attribute to Radio and ToggleButtons

### DIFF
--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -38,6 +38,7 @@
                         :attributes="
                             \Filament\Support\prepare_inherited_attributes($getExtraInputAttributeBag())
                                 ->merge([
+                                    'autofocus' => $isAutofocused() && $loop->first,
                                     'disabled' => $isDisabled || $isOptionDisabled($value, $label),
                                     'id' => $id . '-' . $value,
                                     'name' => $id,

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -38,7 +38,7 @@
                         :attributes="
                             \Filament\Support\prepare_inherited_attributes($getExtraInputAttributeBag())
                                 ->merge([
-                                    'autofocus' => $isAutofocused() && $loop->first,
+                                    'autofocus' => $loop->first && $isAutofocused(),
                                     'disabled' => $isDisabled || $isOptionDisabled($value, $label),
                                     'id' => $id . '-' . $value,
                                     'name' => $id,

--- a/packages/forms/resources/views/components/toggle-buttons/index.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/index.blade.php
@@ -54,6 +54,7 @@
                 ])
             >
                 <input
+                    @if ($isAutofocused() && $loop->first) autofocus @endif
                     @disabled($shouldOptionBeDisabled)
                     id="{{ $inputId }}"
                     @if (! $isMultiple)

--- a/packages/forms/resources/views/components/toggle-buttons/index.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/index.blade.php
@@ -54,7 +54,7 @@
                 ])
             >
                 <input
-                    @if ($isAutofocused() && $loop->first) autofocus @endif
+                    @if ($loop->first && $isAutofocused()) autofocus @endif
                     @disabled($shouldOptionBeDisabled)
                     id="{{ $inputId }}"
                     @if (! $isMultiple)


### PR DESCRIPTION
## Description

`->autofocus()` has no effect on Radio and ToggleButtons because their Blade templates don't render the `autofocus` HTML attribute. Other components like Checkbox and TextInput already do this correctly via `'autofocus' => $isAutofocused()` in their attribute merge.

This adds the missing `autofocus` attribute to the first option's `<input>` element for both components.

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.