### PR TITLE
[4.x] fix: add missing autofocus attribute to Radio and ToggleButtons

### DIFF
--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -27,6 +27,7 @@
             @php
                 $inputAttributes = $extraInputAttributeBag
                     ->merge([
+                        'autofocus' => $isAutofocused() && $loop->first,
                         'disabled' => $isDisabled || $isOptionDisabled($value, $label),
                         'id' => $id . '-' . $value,
                         'name' => $id,

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -27,7 +27,7 @@
             @php
                 $inputAttributes = $extraInputAttributeBag
                     ->merge([
-                        'autofocus' => $isAutofocused() && $loop->first,
+                        'autofocus' => $loop->first && $isAutofocused(),
                         'disabled' => $isDisabled || $isOptionDisabled($value, $label),
                         'id' => $id . '-' . $value,
                         'name' => $id,

--- a/packages/forms/resources/views/components/toggle-buttons/index.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/index.blade.php
@@ -41,7 +41,7 @@
 
             <div class="fi-fo-toggle-buttons-btn-ctn">
                 <input
-                    @if ($isAutofocused() && $loop->first) autofocus @endif
+                    @if ($loop->first && $isAutofocused()) autofocus @endif
                     @disabled($shouldOptionBeDisabled)
                     id="{{ $inputId }}"
                     @if (! $isMultiple)

--- a/packages/forms/resources/views/components/toggle-buttons/index.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/index.blade.php
@@ -41,6 +41,7 @@
 
             <div class="fi-fo-toggle-buttons-btn-ctn">
                 <input
+                    @if ($isAutofocused() && $loop->first) autofocus @endif
                     @disabled($shouldOptionBeDisabled)
                     id="{{ $inputId }}"
                     @if (! $isMultiple)


### PR DESCRIPTION
## Description

`->autofocus()` has no effect on Radio and ToggleButtons because their Blade templates don't render the `autofocus` HTML attribute. Other components like Checkbox and TextInput already do this correctly via `'autofocus' => $isAutofocused()` in their attribute merge.

This adds the missing `autofocus` attribute to the first option's `<input>` element for both components.

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.