### PR TITLE
docs: Update text column documentation with badge warning

### DIFF
--- a/packages/tables/docs/02-columns/02-text.md
+++ b/packages/tables/docs/02-columns/02-text.md
@@ -100,6 +100,10 @@ TextColumn::make('status')
 
 You may add other things to the badge, like an [icon](#adding-an-icon).
 
+<Aside variant="warning">
+    When using `->badge()` you cannot set `->iconColor()` this is so that we match consistently with the background color, if you want you can override this behavior with the `.fi-icon` and `.fi-color` [CSS Hooks](../../styling/css-hooks)
+</Aside>
+
 Optionally, you may pass a boolean value to control if the text should be in a badge or not:
 
 ```php


### PR DESCRIPTION
Added warning note about using badge with icon color.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

[text.css](https://github.com/filamentphp/filament/blob/4.x/packages/tables/resources/css/columns/text.css#L224-L231) specifically excludes icon from `.fi-color` if its within a badge component.

This is expected behavior to keep with design consistency more easy, all this adds is documentation so this doesn't come as a surprise.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes 

N/A

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
