### PR TITLE
fix: Respect Schema::configureUsing() column configuration in defaultForm/defaultInfolist

### DIFF
--- a/packages/panels/src/Resources/Concerns/InteractsWithRelationshipTable.php
+++ b/packages/panels/src/Resources/Concerns/InteractsWithRelationshipTable.php
@@ -71,7 +71,11 @@ trait InteractsWithRelationshipTable
 
     public function defaultForm(Schema $schema): Schema
     {
-        return $schema->columns(2);
+        if (! $schema->hasConfiguredColumns()) {
+            $schema->columns(2);
+        }
+
+        return $schema;
     }
 
     public function form(Schema $schema): Schema
@@ -85,7 +89,11 @@ trait InteractsWithRelationshipTable
 
     public function defaultInfolist(Schema $schema): Schema
     {
-        return $schema->columns(2);
+        if (! $schema->hasConfiguredColumns()) {
+            $schema->columns(2);
+        }
+
+        return $schema;
     }
 
     public function infolist(Schema $schema): Schema

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -292,8 +292,11 @@ class CreateRecord extends Page
 
     public function defaultForm(Schema $schema): Schema
     {
+        if (! $schema->hasConfiguredColumns()) {
+            $schema->columns($this->hasInlineLabels() ? 1 : 2);
+        }
+
         return $schema
-            ->columns($this->hasInlineLabels() ? 1 : 2)
             ->inlineLabel($this->hasInlineLabels())
             ->model($this->getModel())
             ->operation('create')

--- a/packages/panels/src/Resources/Pages/EditRecord.php
+++ b/packages/panels/src/Resources/Pages/EditRecord.php
@@ -286,9 +286,9 @@ class EditRecord extends Page
     public function getDefaultActionSchemaResolver(Action $action): ?Closure
     {
         return match (true) {
-            $action instanceof CreateAction => fn (Schema $schema): Schema => static::getResource()::form($schema->columns(2)),
+            $action instanceof CreateAction => fn (Schema $schema): Schema => static::getResource()::form($schema->hasConfiguredColumns() ? $schema : $schema->columns(2)),
             $action instanceof EditAction => fn (Schema $schema): Schema => $schema->components([EmbeddedSchema::make('form')]),
-            $action instanceof ViewAction => fn (Schema $schema): Schema => static::getResource()::infolist(static::getResource()::form($schema->columns(2))),
+            $action instanceof ViewAction => fn (Schema $schema): Schema => static::getResource()::infolist(static::getResource()::form($schema->hasConfiguredColumns() ? $schema : $schema->columns(2))),
             default => null,
         };
     }
@@ -352,8 +352,11 @@ class EditRecord extends Page
 
     public function defaultForm(Schema $schema): Schema
     {
+        if (! $schema->hasConfiguredColumns()) {
+            $schema->columns($this->hasInlineLabels() ? 1 : 2);
+        }
+
         return $schema
-            ->columns($this->hasInlineLabels() ? 1 : 2)
             ->inlineLabel($this->hasInlineLabels())
             ->model($this->getRecord())
             ->operation('edit')

--- a/packages/panels/src/Resources/Pages/ListRecords.php
+++ b/packages/panels/src/Resources/Pages/ListRecords.php
@@ -91,8 +91,8 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
     public function getDefaultActionSchemaResolver(Action $action): ?Closure
     {
         return match (true) {
-            $action instanceof CreateAction, $action instanceof EditAction => fn (Schema $schema): Schema => $this->form($schema->columns(2)),
-            $action instanceof ViewAction => fn (Schema $schema): Schema => $this->infolist($this->form($schema->columns(2))),
+            $action instanceof CreateAction, $action instanceof EditAction => fn (Schema $schema): Schema => $this->form($schema->hasConfiguredColumns() ? $schema : $schema->columns(2)),
+            $action instanceof ViewAction => fn (Schema $schema): Schema => $this->infolist($this->form($schema->hasConfiguredColumns() ? $schema : $schema->columns(2))),
             default => null,
         };
     }

--- a/packages/panels/src/Resources/Pages/ViewRecord.php
+++ b/packages/panels/src/Resources/Pages/ViewRecord.php
@@ -133,7 +133,7 @@ class ViewRecord extends Page
     public function getDefaultActionSchemaResolver(Action $action): ?Closure
     {
         return match (true) {
-            $action instanceof CreateAction, $action instanceof EditAction => fn (Schema $schema): Schema => static::getResource()::form($schema->columns(2)),
+            $action instanceof CreateAction, $action instanceof EditAction => fn (Schema $schema): Schema => static::getResource()::form($schema->hasConfiguredColumns() ? $schema : $schema->columns(2)),
             $action instanceof ViewAction => fn (Schema $schema): Schema => $this->hasInfolist() ? $schema->components([EmbeddedSchema::make('infolist')]) : $schema->components([EmbeddedSchema::make('form')]),
             default => null,
         };
@@ -152,8 +152,11 @@ class ViewRecord extends Page
 
     public function defaultForm(Schema $schema): Schema
     {
+        if (! $schema->hasConfiguredColumns()) {
+            $schema->columns($this->hasInlineLabels() ? 1 : 2);
+        }
+
         return $schema
-            ->columns($this->hasInlineLabels() ? 1 : 2)
             ->disabled()
             ->inlineLabel($this->hasInlineLabels())
             ->model($this->getRecord())
@@ -168,8 +171,11 @@ class ViewRecord extends Page
 
     public function defaultInfolist(Schema $schema): Schema
     {
+        if (! $schema->hasConfiguredColumns()) {
+            $schema->columns($this->hasInlineLabels() ? 1 : 2);
+        }
+
         return $schema
-            ->columns($this->hasInlineLabels() ? 1 : 2)
             ->inlineLabel($this->hasInlineLabels())
             ->record($this->getRecord());
     }

--- a/packages/schemas/src/Concerns/HasColumns.php
+++ b/packages/schemas/src/Concerns/HasColumns.php
@@ -37,6 +37,11 @@ trait HasColumns
         return $this;
     }
 
+    public function hasConfiguredColumns(): bool
+    {
+        return $this->columns !== null;
+    }
+
     /**
      * @return array<string, ?int> | int | null
      */


### PR DESCRIPTION
### Problem
When using `Schema::configureUsing()` to globally set columns (e.g., `columns(['lg' => 1])`), the `defaultForm()` and `defaultInfolist()` methods in resource pages unconditionally override this configuration with `columns(2)`, effectively ignoring `configureUsing`.

### Root Cause
Execution order:
1. `Schema::make()` → `configure()` → applies `configureUsing` closures → columns set to `['lg' => 1]`
2. `defaultForm()`/`defaultInfolist()` → calls `columns(2)` unconditionally → **overwrites** to `['lg' => 2]`

The `defaultForm`/`defaultInfolist` methods always force `columns(2)` without checking if columns were already configured via `configureUsing`.

### Solution
Add a `hasConfiguredColumns()` method to the `HasColumns` trait and guard the `columns()` calls in default methods so they only apply when no columns have been previously configured.

### Files to Modify

| # | Package | File | Change |
|---|---------|------|--------|
| 1 | `schemas` | `src/Concerns/HasColumns.php` | Add `hasConfiguredColumns(): bool` method |
| 2 | `panels` | `src/Resources/Pages/ViewRecord.php` | Guard `columns()` in `defaultForm()` and `defaultInfolist()` |
| 3 | `panels` | `src/Resources/Pages/EditRecord.php` | Guard `columns()` in `defaultForm()` |
| 4 | `panels` | `src/Resources/Pages/CreateRecord.php` | Guard `columns()` in `defaultForm()` |
| 5 | `panels` | `src/Resources/Concerns/InteractsWithRelationshipTable.php` | Guard `columns(2)` in `defaultForm()` and `defaultInfolist()` |

Optional (action modals — secondary scope):

| # | Package | File | Change |
|---|---------|------|--------|
| 6 | `panels` | `src/Resources/Pages/ListRecords.php` | Guard `columns(2)` in `getDefaultActionSchemaResolver()` |
| 7 | `panels` | `src/Resources/Pages/EditRecord.php` | Guard `columns(2)` in `getDefaultActionSchemaResolver()` |
| 8 | `panels` | `src/Resources/Pages/ViewRecord.php` | Guard `columns(2)` in `getDefaultActionSchemaResolver()` |

### Files that DON'T need changes (no forced columns)
- `Auth/Pages/Login.php`, `Register.php`, `EditProfile.php`, `RequestPasswordReset.php`
- `Pages/Tenancy/EditTenantProfile.php`, `RegisterTenant.php`

### Fix Pattern

**Before:**
```php
public function defaultForm(Schema $schema): Schema
{
    return $schema
        ->columns($this->hasInlineLabels() ? 1 : 2)
        ->inlineLabel($this->hasInlineLabels())
        // ...
}
```

**After:**
```php
public function defaultForm(Schema $schema): Schema
{
    if (! $schema->hasConfiguredColumns()) {
        $schema->columns($this->hasInlineLabels() ? 1 : 2);
    }

    return $schema
        ->inlineLabel($this->hasInlineLabels())
        // ...
}
```

### New Method in HasColumns

```php
public function hasConfiguredColumns(): bool
{
    return $this->columns !== null;
}
```

### Target Branch
`4.x`

### Backward Compatibility
100% backward compatible — default behavior (without `configureUsing`) remains identical since `$columns` is `null` by default, so the guard falls through and applies `columns(2)` as before. Only fixes the case where `configureUsing` sets columns and was previously being ignored.

### Reproduction Steps
```php
// In AppServiceProvider::boot()
Schemas\Schema::configureUsing(function (Schemas\Schema $schema) {
    return $schema->columns(['lg' => 1]);
});
```
**Expected:** Resource pages render with 1 column layout
**Actual:** Resource pages render with 2 columns (configureUsing ignored)