### PR TITLE
chore: Add shrink-0 utility to builder item header icon

### DIFF
--- a/packages/forms/resources/css/components/builder.css
+++ b/packages/forms/resources/css/components/builder.css
@@ -72,7 +72,7 @@
     }
 
     & .fi-fo-builder-item-header-icon {
-        @apply text-gray-400 dark:text-gray-500;
+        @apply text-gray-400 dark:text-gray-500 shrink-0;
     }
 
     & .fi-fo-builder-item-header-label {

--- a/packages/forms/resources/css/components/builder.css
+++ b/packages/forms/resources/css/components/builder.css
@@ -72,7 +72,7 @@
     }
 
     & .fi-fo-builder-item-header-icon {
-        @apply text-gray-400 dark:text-gray-500 shrink-0;
+        @apply shrink-0 text-gray-400 dark:text-gray-500;
     }
 
     & .fi-fo-builder-item-header-label {


### PR DESCRIPTION
## Description
Adding utility prevents the unwanted shrinking of the icon when the container resizes.

## Visual changes

**Before**
<img width="804" height="564" alt="BRB-2026-02-20-142421@2x" src="https://github.com/user-attachments/assets/66afa8d4-9109-41bf-8518-481bb730bf00" />

**After**
<img width="804" height="548" alt="BRB-2026-02-20-142433@2x" src="https://github.com/user-attachments/assets/de93a0f6-7c08-495a-a1ff-4166582b6306" />
