### PR TITLE
Fix: `Table::configureUsing()` with `recordUrl(null)` is ignored

### DIFF
--- a/packages/panels/src/Resources/Concerns/InteractsWithRelationshipTable.php
+++ b/packages/panels/src/Resources/Concerns/InteractsWithRelationshipTable.php
@@ -141,8 +141,10 @@ trait InteractsWithRelationshipTable
                 }
 
                 return null;
-            })
-            ->recordUrl(function (Model $record, Table $table): ?string {
+            });
+
+        if (! $table->isRecordUrlCustom()) {
+            $table->recordUrl(function (Model $record, Table $table): ?string {
                 foreach (['view', 'edit'] as $action) {
                     $action = $table->getAction($action);
 
@@ -174,8 +176,10 @@ trait InteractsWithRelationshipTable
                 }
 
                 return null;
-            })
-            ->authorizeReorder(fn (): bool => $this->canReorder());
+            });
+        }
+
+        $table->authorizeReorder(fn (): bool => $this->canReorder());
 
         if ($relatedResource = static::getRelatedResource()) {
             $table->modelLabel($relatedResource::getModelLabel());

--- a/packages/panels/src/Resources/Concerns/InteractsWithRelationshipTable.php
+++ b/packages/panels/src/Resources/Concerns/InteractsWithRelationshipTable.php
@@ -143,7 +143,7 @@ trait InteractsWithRelationshipTable
                 return null;
             });
 
-        if (! $table->isRecordUrlCustom()) {
+        if (! $table->hasCustomRecordUrl()) {
             $table->recordUrl(function (Model $record, Table $table): ?string {
                 foreach (['view', 'edit'] as $action) {
                     $action = $table->getAction($action);

--- a/packages/panels/src/Resources/Pages/ListRecords.php
+++ b/packages/panels/src/Resources/Pages/ListRecords.php
@@ -158,7 +158,7 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
                 return null;
             });
 
-        if (! $table->isRecordUrlCustom()) {
+        if (! $table->hasCustomRecordUrl()) {
             $table->recordUrl(function (Model $record, Table $table): ?string {
                 foreach (['view', 'edit'] as $action) {
                     $action = $table->getAction($action);

--- a/packages/panels/src/Resources/Pages/ListRecords.php
+++ b/packages/panels/src/Resources/Pages/ListRecords.php
@@ -156,8 +156,10 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
                 }
 
                 return null;
-            })
-            ->recordUrl(function (Model $record, Table $table): ?string {
+            });
+
+        if (! $table->isRecordUrlCustom()) {
+            $table->recordUrl(function (Model $record, Table $table): ?string {
                 foreach (['view', 'edit'] as $action) {
                     $action = $table->getAction($action);
 
@@ -206,6 +208,7 @@ class ListRecords extends Page implements Tables\Contracts\HasTable
 
                 return null;
             });
+        }
 
         static::getResource()::configureTable($table);
 

--- a/packages/tables/src/Table/Concerns/HasRecordUrl.php
+++ b/packages/tables/src/Table/Concerns/HasRecordUrl.php
@@ -12,7 +12,7 @@ trait HasRecordUrl
 
     protected string | Closure | null $recordUrl = null;
 
-    protected bool $isRecordUrlCustom = false;
+    protected bool $hasCustomRecordUrl = false;
 
     /**
      * @var array<array<mixed> | Closure>
@@ -33,14 +33,14 @@ trait HasRecordUrl
         }
 
         $this->recordUrl = $url;
-        $this->isRecordUrlCustom = true;
+        $this->hasCustomRecordUrl = true;
 
         return $this;
     }
 
-    public function isRecordUrlCustom(): bool
+    public function hasCustomRecordUrl(): bool
     {
-        return $this->isRecordUrlCustom;
+        return $this->hasCustomRecordUrl;
     }
 
     /**

--- a/packages/tables/src/Table/Concerns/HasRecordUrl.php
+++ b/packages/tables/src/Table/Concerns/HasRecordUrl.php
@@ -12,6 +12,8 @@ trait HasRecordUrl
 
     protected string | Closure | null $recordUrl = null;
 
+    protected bool $isRecordUrlCustom = false;
+
     /**
      * @var array<array<mixed> | Closure>
      */
@@ -31,8 +33,14 @@ trait HasRecordUrl
         }
 
         $this->recordUrl = $url;
+        $this->isRecordUrlCustom = true;
 
         return $this;
+    }
+
+    public function isRecordUrlCustom(): bool
+    {
+        return $this->isRecordUrlCustom;
     }
 
     /**


### PR DESCRIPTION
## Bug Description

When using `Table::configureUsing()` to globally disable clickable row links via `recordUrl(null)`, the configuration has no effect. Table rows continue to render as clickable links pointing to the `view` or `edit` pages.

```php
// AppServiceProvider.php - this does NOT work
Tables\Table::configureUsing(function (Tables\Table $table) {
    return $table->recordUrl(null);
});
```

## Root Cause

In both `ListRecords::makeTable()` and `InteractsWithRelationshipTable::makeTable()`, the `recordUrl()` method is called **unconditionally** in the method chain **after** `makeBaseTable()` (which applies the `configureUsing` callbacks).

Execution order:

```
1. Table::make()          → runs configureUsing (sets recordUrl to null) ✅
2. ->recordUrl(closure)   → overwrites with default closure ❌
3. configureTable()       → runs the Resource's table() method
```

The default closure at step 2 always overrides whatever was set at step 1, making it impossible to configure `recordUrl` globally via `configureUsing`.

### Affected Files

- `vendor/filament/filament/src/Resources/Pages/ListRecords.php` (line ~160)
- `vendor/filament/filament/src/Resources/Concerns/InteractsWithRelationshipTable.php` (line ~145)

## Fix

The fix introduces a `$isRecordUrlCustom` flag in the `HasRecordUrl` trait. When `recordUrl()` is called (by `configureUsing` or any other means), the flag is set to `true`. The `makeTable()` methods then check this flag before applying the default closure.

### 3 files changed

---

### 1. `packages/tables/src/Table/Concerns/HasRecordUrl.php`

Add a boolean flag to track if `recordUrl()` was explicitly called, and a public method to check it.

```diff
 trait HasRecordUrl
 {
     protected bool | Closure $shouldOpenRecordUrlInNewTab = false;

     protected string | Closure | null $recordUrl = null;

+    protected bool $isRecordUrlCustom = false;
+
     /**
      * @var array<array<mixed> | Closure>
      */
     protected array $extraRecordLinkAttributes = [];

     // ...

     public function recordUrl(string | Closure | null $url, bool | Closure | null $shouldOpenInNewTab = null): static
     {
         if ($shouldOpenInNewTab !== null) {
             $this->openRecordUrlInNewTab($shouldOpenInNewTab);
         }

         $this->recordUrl = $url;
+        $this->isRecordUrlCustom = true;

         return $this;
     }

+    public function isRecordUrlCustom(): bool
+    {
+        return $this->isRecordUrlCustom;
+    }
+
     // ...
 }
```

---

### 2. `packages/panels/src/Resources/Pages/ListRecords.php`

Break the chain before `recordUrl()` and wrap it in a conditional check.

```diff
     protected function makeTable(): Table
     {
         $table = $this->makeBaseTable()
             ->query(fn (): Builder => $this->getTableQuery())
             // ...
             ->when($this->getPluralModelLabel(), fn (Table $table, string $pluralModelLabel): Table => $table->pluralModelLabel($pluralModelLabel))
             ->recordAction(function (Model $record, Table $table): ?string {
                 // ... (unchanged)
-            })
-            ->recordUrl(function (Model $record, Table $table): ?string {
-                // ... default closure
             });

+        if (! $table->isRecordUrlCustom()) {
+            $table->recordUrl(function (Model $record, Table $table): ?string {
+                // ... default closure (unchanged)
+            });
+        }
+
         static::getResource()::configureTable($table);

         return $table;
     }
```

---

### 3. `packages/panels/src/Resources/Concerns/InteractsWithRelationshipTable.php`

Same pattern — break the chain and wrap `recordUrl()` in a conditional.

```diff
     protected function makeTable(): Table
     {
         $table = $this->makeBaseTable()
             ->relationship(fn (): Relation | Builder => $this->getRelationship())
             ->modifyQueryUsing($this->modifyQueryWithActiveTab(...))
             ->queryStringIdentifier(Str::lcfirst(class_basename(static::class)))
             ->recordAction(function (Model $record, Table $table): ?string {
                 // ... (unchanged)
-            })
-            ->recordUrl(function (Model $record, Table $table): ?string {
-                // ... default closure
-            })
-            ->authorizeReorder(fn (): bool => $this->canReorder());
+            });
+
+        if (! $table->isRecordUrlCustom()) {
+            $table->recordUrl(function (Model $record, Table $table): ?string {
+                // ... default closure (unchanged)
+            });
+        }
+
+        $table->authorizeReorder(fn (): bool => $this->canReorder());

         // ...
     }
```

---

## How to Reproduce

1. Add this to `AppServiceProvider::boot()`:

```php
use Filament\Tables;

Tables\Table::configureUsing(function (Tables\Table $table) {
    return $table->recordUrl(null);
});
```

2. Navigate to any Resource list page
3. **Expected:** Row links should be disabled (no `<a>` tags wrapping the row content)
4. **Actual:** Rows are still clickable links

## After the Fix

The same `configureUsing` code above correctly disables row links globally. Additionally:

- Setting `recordUrl()` in a Resource's `table()` method still works (takes highest priority)
- Setting `recordUrl()` via `configureUsing` is now respected as the global default
- Not calling `recordUrl()` at all preserves the current default behavior (auto-resolve from view/edit actions)
- Custom closures via `configureUsing` also work:

```php
Tables\Table::configureUsing(function (Tables\Table $table) {
    return $table->recordUrl(fn (Model $record) => route('custom.show', $record));
});
```

## PR Info

- **Title:** `fix: Respect Table::configureUsing() for recordUrl configuration`
- **Packages affected:** `filament/tables`, `filament/filament` (panels)
- **Breaking changes:** None. Default behavior is preserved when `recordUrl()` is not explicitly called.
