### PR TITLE
Added link to packages site to access Blueprint license info

### DIFF
--- a/docs/01-introduction/03-ai.md
+++ b/docs/01-introduction/03-ai.md
@@ -59,6 +59,10 @@ If you're interested in an example of a plan that Claude Opus 4.5 can write with
 
 Blueprint is compatible with Filament v4 and above.
 
+<Aside variant="info">
+    To access your purchased license, sign in to the [Filament Packages portal](https://packages.filamentphp.com/portal/sign-in) with email address used in your purchase of the Blueprint license.
+</Aside>
+
 Once you have [purchased a license for Blueprint](https://packages.filamentphp.com/portal/blueprint/checkout), install it via Composer:
 
 ```bash

--- a/docs/01-introduction/03-ai.md
+++ b/docs/01-introduction/03-ai.md
@@ -59,10 +59,6 @@ If you're interested in an example of a plan that Claude Opus 4.5 can write with
 
 Blueprint is compatible with Filament v4 and above.
 
-<Aside variant="info">
-    To access your purchased license, sign in to the [Filament Packages portal](https://packages.filamentphp.com/portal/sign-in) with email address used in your purchase of the Blueprint license.
-</Aside>
-
 Once you have [purchased a license for Blueprint](https://packages.filamentphp.com/portal/blueprint/checkout), install it via Composer:
 
 ```bash
@@ -78,6 +74,10 @@ php artisan boost:install
 ```
 
 To verify installation, check your `AGENTS.md`, `CLAUDE.md`, or similar file for a new **Filament Blueprint** section.
+
+<Aside variant="info">
+    To access your purchased license, sign in to [Filament Packages](https://packages.filamentphp.com) with the email address used to purchase your Blueprint license.
+</Aside>
 
 ### Using Blueprint
 


### PR DESCRIPTION
Added instructions for accessing the Blueprint license.

<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
For someone who had purchased the Filament Blueprint license, there were no instructions on how to access it. The link in the receipt/confirmation email that used to work after purchasing, expires.

I added an info box using the `<Aside>` tag which I saw used near the top of the same page, to clarify how and where to access the license.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

Not sure how to build the docs to take a screenshot😅. Hoping it's not needed.

## Functional changes

- [ x ] Code style has been fixed by running the `composer cs` command.
- [ x ] Changes have been tested to not break existing functionality.
- [ x ] Documentation is up-to-date.
