### PR TITLE
Add navigationGroup setter to Page and extend navigationGroup setter on Resource to also accept UnitEnum

### DIFF
--- a/packages/panels/src/Pages/Page.php
+++ b/packages/panels/src/Pages/Page.php
@@ -182,14 +182,24 @@ abstract class Page extends BasePage
         return static::$navigationParentItem;
     }
 
-    public static function getActiveNavigationIcon(): string | BackedEnum | Htmlable | null
+    public static function navigationParentItem(?string $item): void
     {
-        return static::$activeNavigationIcon ?? static::getNavigationIcon();
+        static::$navigationParentItem = $item;
     }
 
     public static function getNavigationIcon(): string | BackedEnum | Htmlable | null
     {
         return static::$navigationIcon;
+    }
+
+    public static function navigationIcon(string | BackedEnum $icon): void
+    {
+        static::$navigationIcon = $icon;
+    }
+
+    public static function getActiveNavigationIcon(): string | BackedEnum | Htmlable | null
+    {
+        return static::$activeNavigationIcon ?? static::getNavigationIcon();
     }
 
     public static function getNavigationLabel(): string
@@ -205,6 +215,11 @@ abstract class Page extends BasePage
         return null;
     }
 
+    public static function getNavigationBadgeTooltip(): string | Htmlable | null
+    {
+        return static::$navigationBadgeTooltip;
+    }
+
     /**
      * @return string | array<string> | null
      */
@@ -213,14 +228,19 @@ abstract class Page extends BasePage
         return null;
     }
 
-    public static function getNavigationBadgeTooltip(): string | Htmlable | null
-    {
-        return static::$navigationBadgeTooltip;
-    }
-
     public static function getNavigationSort(): ?int
     {
         return static::$navigationSort;
+    }
+
+    public static function navigationLabel(?string $label): void
+    {
+        static::$navigationLabel = $label;
+    }
+
+    public static function navigationSort(?int $sort): void
+    {
+        static::$navigationSort = $sort;
     }
 
     public static function getNavigationUrl(): string

--- a/packages/panels/src/Pages/Page.php
+++ b/packages/panels/src/Pages/Page.php
@@ -172,6 +172,11 @@ abstract class Page extends BasePage
         return static::$navigationGroup;
     }
 
+    public static function navigationGroup(string | UnitEnum | null $group): void
+    {
+        static::$navigationGroup = $group;
+    }
+
     public static function getNavigationParentItem(): ?string
     {
         return static::$navigationParentItem;

--- a/packages/panels/src/Resources/Resource/Concerns/HasNavigation.php
+++ b/packages/panels/src/Resources/Resource/Concerns/HasNavigation.php
@@ -109,7 +109,7 @@ trait HasNavigation
         return static::$navigationParentItem;
     }
 
-    public static function navigationGroup(?string $group): void
+    public static function navigationGroup(string | UnitEnum | null $group): void
     {
         static::$navigationGroup = $group;
     }


### PR DESCRIPTION
## Description

The `$navigationGroup` property on a resource already accepts an UnitEnum, this has now been added to the setter.
For a page the `navigationGroup()` function has been added.

The setter on the page comes in handy to move the default Dashboard to another group without overriding the whole page + then it also aligns the Resource methods for `$navigationGroup`.

## Visual changes

/ 

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
