### PR TITLE
remove uuid-browser from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,6 @@
                 "sortablejs": "^1.15.0",
                 "tailwindcss": "^4.0.0",
                 "tippy.js": "^6.3.7",
-                "uuid-browser": "^3.1.0",
                 "vanilla-colorful": "^0.7.2"
             }
         },
@@ -14149,14 +14148,6 @@
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
-        },
-        "node_modules/uuid-browser": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/uuid-browser/-/uuid-browser-3.1.0.tgz",
-            "integrity": "sha512-dsNgbLaTrd6l3MMxTtouOCFw4CBFc/3a+GgYA2YyrJvyQ1u6q4pcu3ktLoUZ/VN/Aw9WsauazbgsgdfVWgAKQg==",
-            "deprecated": "Package no longer supported and required. Use the uuid package or crypto.randomUUID instead",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
         "sortablejs": "^1.15.0",
         "tailwindcss": "^4.0.0",
         "tippy.js": "^6.3.7",
-        "uuid-browser": "^3.1.0",
         "vanilla-colorful": "^0.7.2"
     }
 }

--- a/packages/notifications/resources/js/Notification.js
+++ b/packages/notifications/resources/js/Notification.js
@@ -1,8 +1,6 @@
-import { v4 as uuid } from 'uuid-browser'
-
 class Notification {
     constructor() {
-        this.id(uuid())
+        this.id(crypto.randomUUID())
 
         return this
     }


### PR DESCRIPTION
The uuid-browser package is deprecated and outdated, and we don't need it anymore. The native crypto API (https://caniuse.com/mdn-api_crypto_randomuuid) works just fine; one less dependency to go.