### PR TITLE
fix: PHPStan errors from misplaced ignore annotations and dead match arms

### DIFF
--- a/packages/schemas/src/Components/Component.php
+++ b/packages/schemas/src/Components/Component.php
@@ -111,9 +111,7 @@ class Component extends ViewComponent
         }
 
         return match ($parameterType) {
-            Get::class => [$this->makeGetUtility()],
             Model::class, $record::class => [$record],
-            Set::class => [$this->makeSetUtility()],
             default => parent::resolveDefaultClosureDependencyForEvaluationByType($parameterType),
         };
     }

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/RichEditor/FileAttachmentProviders/SpatieMediaLibraryFileAttachmentProvider.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/RichEditor/FileAttachmentProviders/SpatieMediaLibraryFileAttachmentProvider.php
@@ -131,8 +131,8 @@ class SpatieMediaLibraryFileAttachmentProvider implements FileAttachmentProvider
 
     public function saveUploadedFileAttachment(TemporaryUploadedFile $file): mixed
     {
-        $media = $this->getExistingModel() /** @phpstan-ignore method.notFound */
-            ->addMediaFromString($file->get())
+        $media = $this->getExistingModel()
+            ->addMediaFromString($file->get()) /** @phpstan-ignore method.notFound */
             ->usingFileName($this->shouldPreserveFilenames() ? $file->getClientOriginalName() : (Str::ulid() . '.' . $file->getClientOriginalExtension()))
             ->usingName($this->getMediaName($file) ?? pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME))
             ->withCustomProperties($this->getCustomProperties())

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -263,9 +263,8 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
         $collection = $this->getCollection() ?? 'default';
 
-        /** @phpstan-ignore-next-line */
         $diskNameFromRegisteredConversions = $model
-            ->getRegisteredMediaCollections()
+            ->getRegisteredMediaCollections() /** @phpstan-ignore method.notFound */
             ->filter(fn (MediaCollection $mediaCollection): bool => $mediaCollection->name === $collection)
             ->first()
             ?->diskName;

--- a/packages/tables/src/Concerns/HasBulkActions.php
+++ b/packages/tables/src/Concerns/HasBulkActions.php
@@ -149,9 +149,8 @@ trait HasBulkActions
                 });
 
             if (! $this->getTable()->checksIfRecordIsSelectable()) {
-                /** @phpstan-ignore-next-line */
                 return $records
-                    ->map(fn (array $record): string => $this->getTableRecordKey($record))
+                    ->map(fn (array $record): string => $this->getTableRecordKey($record)) /** @phpstan-ignore method.notFound */
                     ->values()
                     ->all();
             }
@@ -177,10 +176,9 @@ trait HasBulkActions
 
         if (! $this->getTable()->checksIfRecordIsSelectable()) {
             $records = $this->getTable()->selectsCurrentPageOnly() ?
-                /** @phpstan-ignore-next-line */
                 $this->getTableRecords()
                     ->filter(fn (Model $record): bool => $tableGrouping->getStringKey($record) === $group)
-                    ->pluck($query->getModel()->getKeyName()) :
+                    ->pluck($query->getModel()->getKeyName()) : /** @phpstan-ignore method.notFound */
                 $query->toBase()->pluck($query->getModel()->getQualifiedKeyName());
 
             return $records


### PR DESCRIPTION
## Description

Fix PHPStan errors surfaced by 2.1.40's line number reporting fix,
and drop dead match arms in Component.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
