### PR TITLE
[3.x] fix: `fillForm()` merges list state into existing repeater record keys

### DIFF
--- a/packages/forms/src/Concerns/InteractsWithForms.php
+++ b/packages/forms/src/Concerns/InteractsWithForms.php
@@ -90,7 +90,7 @@ trait InteractsWithForms
     protected function unsetMissingNumericArrayKeys(array &$target, array $state): void
     {
         foreach ($target as $key => $value) {
-            if (is_numeric($key) && (! array_key_exists($key, $state))) {
+            if ((is_numeric($key) || array_is_list($state)) && (! array_key_exists($key, $state))) {
                 unset($target[$key]);
 
                 continue;


### PR DESCRIPTION
## Description

When `fillForm()` is called with list-style arrays (numeric keys `0, 1, 2…`) on a Repeater that has loaded existing relationship records (`record-{id}` keys), `unsetMissingNumericArrayKeys()` only removes orphaned **numeric** keys but leaves the old `record-{id}` keys intact. This causes both key sets to coexist, leading to data duplication on save.

Adding `array_is_list($state)` to the condition ensures that when the new state is a sequential list, **all** non-matching keys are removed — including `record-{id}` keys — giving `fillForm()` proper replacement semantics for list arrays.

### Steps to reproduce

```php
// Given: a Repeater with ->relationship() on existing records (record-1, record-2)
Livewire::test(MyForm::class, ['record' => $record])
    ->fillForm([
        'members' => [
            ['name' => 'John'],  // key 0
            ['name' => 'Jane'],  // key 1
        ],
    ])
    ->call('save');

// Expected: 2 records
// Actual: 4+ records (record-1, record-2, 0, 1 all coexist)
```

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.