### PR TITLE
[3.x] fix: respect `deletable(false)` in repeater relationship save logic

### DIFF
--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -909,21 +909,23 @@ class Repeater extends Field implements Contracts\CanConcealComponents, Contract
 
             $existingRecords = $component->getCachedExistingRecords();
 
-            $recordsToDelete = [];
+            if ($component->isDeletable()) {
+                $recordsToDelete = [];
 
-            foreach ($existingRecords->pluck($relationship->getRelated()->getKeyName()) as $keyToCheckForDeletion) {
-                if (array_key_exists("record-{$keyToCheckForDeletion}", $state)) {
-                    continue;
+                foreach ($existingRecords->pluck($relationship->getRelated()->getKeyName()) as $keyToCheckForDeletion) {
+                    if (array_key_exists("record-{$keyToCheckForDeletion}", $state)) {
+                        continue;
+                    }
+
+                    $recordsToDelete[] = $keyToCheckForDeletion;
+                    $existingRecords->forget("record-{$keyToCheckForDeletion}");
                 }
 
-                $recordsToDelete[] = $keyToCheckForDeletion;
-                $existingRecords->forget("record-{$keyToCheckForDeletion}");
+                $relationship
+                    ->whereKey($recordsToDelete)
+                    ->get()
+                    ->each(static fn (Model $record) => $record->delete());
             }
-
-            $relationship
-                ->whereKey($recordsToDelete)
-                ->get()
-                ->each(static fn (Model $record) => $record->delete());
 
             $childComponentContainers = $component->getChildComponentContainers(
                 withHidden: $component->shouldSaveRelationshipsWhenHidden(),


### PR DESCRIPTION
## Description

When a Repeater uses `->relationship()` and `->deletable(false)`, the `deletable(false)` only hides the delete button in the UI. However, the `saveRelationshipsUsing` callback still deletes related records that are missing from the repeater's current state.

This is unexpected — if a repeater is explicitly marked as non-deletable, it should not delete related records during save either.

### Steps to reproduce

```php
Repeater::make('members')
    ->relationship('members')
    ->deletable(false)  // UI: no delete button
    ->schema([...]);

// If a record exists in DB but is missing from the repeater state
// (e.g., added by another component), it gets deleted on save
// even though deletable(false) was set.
```

### Use case

This is common in Wizard forms where two repeaters reference the same relationship with different field schemas (e.g., Step A: personal data, Step B: income data). Step B uses `->deletable(false)` because only Step A should manage adding/removing records. Without this fix, Step B's save deletes records it doesn't have in its state.

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.