### PR TITLE
Update missing spanish translations

### DIFF
--- a/packages/forms/resources/lang/es/components.php
+++ b/packages/forms/resources/lang/es/components.php
@@ -568,6 +568,13 @@ return [
 
         'no_merge_tag_search_results_message' => 'No se encontraron etiquetas dinámicas.',
 
+        'mentions' => [
+            'no_options_message' => 'No hay opciones disponibles.',
+            'no_search_results_message' => 'No hay resultados que coincidan con su búsqueda.',
+            'search_prompt' => 'Comience a escribir para buscar...',
+            'searching_message' => 'Buscando...',
+        ],
+
         'tools' => [
             'align_center' => 'Alinear al centro',
             'align_end' => 'Alinear al final',
@@ -692,7 +699,17 @@ return [
     ],
 
     'tags_input' => [
+
+        'actions' => [
+
+            'delete' => [
+                'label' => 'Eliminar',
+            ],
+
+        ],
+
         'placeholder' => 'Nueva etiqueta',
+
     ],
 
     'text_input' => [

--- a/packages/widgets/resources/lang/es/chart.php
+++ b/packages/widgets/resources/lang/es/chart.php
@@ -10,4 +10,20 @@ return [
 
     ],
 
+    'filters' => [
+
+        'actions' => [
+
+            'apply' => [
+                'label' => 'Aplicar',
+            ],
+
+            'reset' => [
+                'label' => 'Restablecer',
+            ],
+
+        ],
+
+    ],
+
 ];


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Update missing spanish translations:

[**forms**] `components.php`

| Key                                            | Status  |
|---|---|
| rich_editor.mentions.no_options_message        | Missing |
| rich_editor.mentions.no_search_results_message | Missing |
| rich_editor.mentions.search_prompt             | Missing |
| rich_editor.mentions.searching_message         | Missing |
| tags_input.actions.delete.label                | Missing |


[**widgets**] `chart.php`


| Key                         | Status  |
|---|---|
| filters.actions.apply.label | Missing |
| filters.actions.reset.label | Missing |

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
