### PR TITLE
fix: missing lithuanian translations

### DIFF
--- a/packages/panels/resources/lang/lt/auth/multi-factor/app/actions/disable.php
+++ b/packages/panels/resources/lang/lt/auth/multi-factor/app/actions/disable.php
@@ -2,33 +2,33 @@
 
 return [
 
-    'label' => 'Turn off',
+    'label' => 'Išjungti',
 
     'modal' => [
 
-        'heading' => 'Disable authenticator app',
+        'heading' => 'Išjungti autentifikavimo programą',
 
-        'description' => 'Are you sure you want to stop using the authenticator app? Disabling this will remove an extra layer of security from your account.',
+        'description' => 'Ar tikrai norite sustabdyti autentifikavimo programos naudojimą? Išjungus šią funkciją, jūsų paskyrai bus pašalintas papildomas saugos lygis.',
 
         'form' => [
 
             'code' => [
 
-                'label' => 'Enter the 6-digit code from the authenticator app',
+                'label' => 'Įveskite 6 skaitmenų kodą iš autentifikavimo programos',
 
                 'validation_attribute' => 'code',
 
                 'actions' => [
 
                     'use_recovery_code' => [
-                        'label' => 'Use a recovery code instead',
+                        'label' => 'Naudoti atsarginį kodą',
                     ],
 
                 ],
 
                 'messages' => [
 
-                    'invalid' => 'The code you entered is invalid.',
+                    'invalid' => 'Įvestas kodas yra neteisingas.',
 
                 ],
 
@@ -36,13 +36,13 @@ return [
 
             'recovery_code' => [
 
-                'label' => 'Or, enter a recovery code',
+                'label' => 'Arba įveskite atsarginį kodą',
 
                 'validation_attribute' => 'recovery code',
 
                 'messages' => [
 
-                    'invalid' => 'The recovery code you entered is invalid.',
+                    'invalid' => 'Įvestas atsarginis kodas yra neteisingas.',
 
                 ],
 
@@ -53,7 +53,7 @@ return [
         'actions' => [
 
             'submit' => [
-                'label' => 'Disable authenticator app',
+                'label' => 'Išjungti autentifikavimo programą',
             ],
 
         ],
@@ -63,7 +63,7 @@ return [
     'notifications' => [
 
         'disabled' => [
-            'title' => 'Authenticator app has been disabled',
+            'title' => 'Autentifikavimo programa išjungta',
         ],
 
     ],

--- a/packages/panels/resources/lang/lt/auth/multi-factor/app/actions/regenerate-recovery-codes.php
+++ b/packages/panels/resources/lang/lt/auth/multi-factor/app/actions/regenerate-recovery-codes.php
@@ -2,25 +2,25 @@
 
 return [
 
-    'label' => 'Regenerate recovery codes',
+    'label' => 'Regeneruoti atsarginius kodus',
 
     'modal' => [
 
-        'heading' => 'Regenerate authenticator app recovery codes',
+        'heading' => 'Regeneruoti autentifikavimo programos atsarginius kodus',
 
-        'description' => 'If you lose your recovery codes, you can regenerate them here. Your old recovery codes will be invalidated immediately.',
+        'description' => 'Jei praradote atsarginius kodus, galite juos regeneruoti čia. Jūsų seni atsarginiai kodai bus nedelsiant panaikinti.',
 
         'form' => [
 
             'code' => [
 
-                'label' => 'Enter the 6-digit code from the authenticator app',
+                'label' => 'Įveskite 6 skaitmenų kodą iš autentifikavimo programos',
 
                 'validation_attribute' => 'code',
 
                 'messages' => [
 
-                    'invalid' => 'The code you entered is invalid.',
+                    'invalid' => 'Įvestas kodas yra neteisingas.',
 
                 ],
 
@@ -28,7 +28,7 @@ return [
 
             'password' => [
 
-                'label' => 'Or, enter your current password',
+                'label' => 'Arba įveskite dabartinį slaptažodį',
 
                 'validation_attribute' => 'password',
 
@@ -39,7 +39,7 @@ return [
         'actions' => [
 
             'submit' => [
-                'label' => 'Regenerate recovery codes',
+                'label' => 'Regeneruoti atsarginius kodus',
             ],
 
         ],
@@ -49,7 +49,7 @@ return [
     'notifications' => [
 
         'regenerated' => [
-            'title' => 'New authenticator app recovery codes have been generated',
+            'title' => 'Nauji autentifikavimo programos atsarginiai kodai buvo sugeneruoti',
         ],
 
     ],
@@ -58,14 +58,14 @@ return [
 
         'modal' => [
 
-            'heading' => 'New recovery codes',
+            'heading' => 'Nauji atsarginiai kodai',
 
-            'description' => 'Please save the following recovery codes in a safe place. They will only be shown once, but you\'ll need them if you lose access to your authenticator app:',
+            'description' => 'Prašome išsaugoti šiuos naujus atsarginius kodus saugioje vietoje. Jie bus rodomi tik vieną kartą, bet jums reikės jų, jei prarasite prieigą prie autentifikavimo programos:',
 
             'actions' => [
 
                 'submit' => [
-                    'label' => 'Close',
+                    'label' => 'Uždaryti',
                 ],
 
             ],

--- a/packages/panels/resources/lang/lt/auth/multi-factor/app/actions/set-up.php
+++ b/packages/panels/resources/lang/lt/auth/multi-factor/app/actions/set-up.php
@@ -2,39 +2,39 @@
 
 return [
 
-    'label' => 'Set up',
+    'label' => 'Įgalinti',
 
     'modal' => [
 
-        'heading' => 'Set up authenticator app',
+        'heading' => 'Įgalinti autentifikavimo programą',
 
         'description' => <<<'BLADE'
-            You'll need an app like Google Authenticator (<x-filament::link href="https://itunes.apple.com/us/app/google-authenticator/id388497605" target="_blank">iOS</x-filament::link>, <x-filament::link href="https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2" target="_blank">Android</x-filament::link>) to complete this process.
+            Jums reikės programos tokios kaip Google Authenticator (<x-filament::link href="https://itunes.apple.com/us/app/google-authenticator/id388497605" target="_blank">iOS</x-filament::link>, <x-filament::link href="https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2" target="_blank">Android</x-filament::link>) norint užbaigti šį procesą.
             BLADE,
 
         'content' => [
 
             'qr_code' => [
 
-                'instruction' => 'Scan this QR code with your authenticator app:',
+                'instruction' => 'Nuskaitykite šį QR kodą naudodami autentifikavimo programą:',
 
-                'alt' => 'QR code to scan with an authenticator app',
+                'alt' => 'QR kodas, kurį reikia nuskaityti naudojant autentifikavimo programą',
 
             ],
 
             'text_code' => [
 
-                'instruction' => 'Or enter this code manually:',
+                'instruction' => 'Arba įveskite šį kodą rankiniu būdu:',
 
                 'messages' => [
-                    'copied' => 'Copied',
+                    'copied' => 'Nukopijuota',
                 ],
 
             ],
 
             'recovery_codes' => [
 
-                'instruction' => 'Please save the following recovery codes in a safe place. They will only be shown once, but you\'ll need them if you lose access to your authenticator app:',
+                'instruction' => 'Prašome išsaugoti šiuos atsarginius kodus saugioje vietoje. Jie bus rodomi tik vieną kartą, bet jums reikės jų, jei prarasite prieigą prie autentifikavimo programos:',
 
             ],
 
@@ -44,15 +44,15 @@ return [
 
             'code' => [
 
-                'label' => 'Enter the 6-digit code from the authenticator app',
+                'label' => 'Įveskite 6 skaitmenų kodą iš autentifikavimo programos',
 
                 'validation_attribute' => 'code',
 
-                'below_content' => 'You will need to enter the 6-digit code from your authenticator app each time you sign in or perform sensitive actions.',
+                'below_content' => 'Jums reikės įvesti 6 skaitmenų kodą iš savo autentifikavimo programos kaskart, kai prisijungsite arba atliksite jautrius veiksmus.',
 
                 'messages' => [
 
-                    'invalid' => 'The code you entered is invalid.',
+                    'invalid' => 'Įvestas kodas yra neteisingas.',
 
                 ],
 
@@ -63,7 +63,7 @@ return [
         'actions' => [
 
             'submit' => [
-                'label' => 'Enable authenticator app',
+                'label' => 'Įgalinti autentifikavimo programą',
             ],
 
         ],
@@ -73,7 +73,7 @@ return [
     'notifications' => [
 
         'enabled' => [
-            'title' => 'Authenticator app has been enabled',
+            'title' => 'Autentifikavimo programa įjungta',
         ],
 
     ],

--- a/packages/panels/resources/lang/lt/auth/multi-factor/app/provider.php
+++ b/packages/panels/resources/lang/lt/auth/multi-factor/app/provider.php
@@ -6,13 +6,13 @@ return [
 
         'actions' => [
 
-            'label' => 'Authenticator app',
+            'label' => 'Autentifikavimo programa',
 
-            'below_content' => 'Use a secure app to generate a temporary code for login verification.',
+            'below_content' => 'Naudokite saugią programą, kad sugeneruotumėte laikiną kodą prisijungimui.',
 
             'messages' => [
-                'enabled' => 'Enabled',
-                'disabled' => 'Disabled',
+                'enabled' => 'Įjungta',
+                'disabled' => 'Išjungta',
             ],
 
         ],
@@ -21,25 +21,25 @@ return [
 
     'login_form' => [
 
-        'label' => 'Use a code from your authenticator app',
+        'label' => 'Naudokite kodą iš savo autentifikavimo programos',
 
         'code' => [
 
-            'label' => 'Enter the 6-digit code from the authenticator app',
+            'label' => 'Įveskite 6 skaitmenų kodą iš autentifikavimo programos',
 
             'validation_attribute' => 'code',
 
             'actions' => [
 
                 'use_recovery_code' => [
-                    'label' => 'Use a recovery code instead',
+                    'label' => 'Arba naudokite atsarginį kodą',
                 ],
 
             ],
 
             'messages' => [
 
-                'invalid' => 'The code you entered is invalid.',
+                'invalid' => 'Įvestas kodas yra neteisingas.',
 
             ],
 
@@ -47,13 +47,13 @@ return [
 
         'recovery_code' => [
 
-            'label' => 'Or, enter a recovery code',
+            'label' => 'Arba įveskite atsarginį kodą',
 
             'validation_attribute' => 'recovery code',
 
             'messages' => [
 
-                'invalid' => 'The recovery code you entered is invalid.',
+                'invalid' => 'Įvestas atsarginis kodas yra neteisingas.',
 
             ],
 

--- a/packages/panels/resources/lang/lt/auth/multi-factor/recovery-codes-modal-content.php
+++ b/packages/panels/resources/lang/lt/auth/multi-factor/recovery-codes-modal-content.php
@@ -4,19 +4,19 @@ return [
 
     'actions' => [
 
-        'Click to' => 'Spustelėkite, kad',
+        '0' => 'Spustelėkite, kad',
 
         'copy' => [
             'label' => 'kopijuoti',
         ],
 
-        'or' => 'arba',
+        '1' => 'arba',
 
         'download' => [
             'label' => 'atsisiųsti',
         ],
 
-        'all the codes at once.' => 'visus kodus iš karto.',
+        '2' => 'visus kodus iš karto.',
 
     ],
 

--- a/packages/widgets/resources/lang/lt/chart.php
+++ b/packages/widgets/resources/lang/lt/chart.php
@@ -10,4 +10,20 @@ return [
 
     ],
 
+    'filters' => [
+
+        'actions' => [
+
+            'apply' => [
+                'label' => 'Taikyti',
+            ],
+
+            'reset' => [
+                'label' => 'Atstatyti',
+            ],
+
+        ],
+
+    ],
+
 ];

--- a/translators.csv
+++ b/translators.csv
@@ -50,4 +50,4 @@ pl;         ;ralphredd;321627563736956929;
 sv;     ;maurelius7390;496175168431849482
 sw;     ;ngaiza_287;817131592350302208
 pl;webard;webard;1387370568445202454
-lt;donatiss
+lt;donatiss;;

--- a/translators.csv
+++ b/translators.csv
@@ -50,4 +50,4 @@ pl;         ;ralphredd;321627563736956929;
 sv;     ;maurelius7390;496175168431849482
 sw;     ;ngaiza_287;817131592350302208
 pl;webard;webard;1387370568445202454
-lt;donatiss;;
+lt;donatiss;donatis07;883253450207543327

--- a/translators.csv
+++ b/translators.csv
@@ -50,3 +50,4 @@ pl;         ;ralphredd;321627563736956929;
 sv;     ;maurelius7390;496175168431849482
 sw;     ;ngaiza_287;817131592350302208
 pl;webard;webard;1387370568445202454
+lt;donatiss


### PR DESCRIPTION
## Description

Added multi-factor authentication (MFA) related translations for enabling, disabling, and regenerating recovery codes.

Added missing widgets chart translations keys.

## Visual changes

no changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date. (no changes)
