### PR TITLE
fix: Add missing named 'attributes'-parameter on builder blade

### DIFF
--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -171,7 +171,7 @@
                                 @endphp
 
                                 @if ($hasBlockIcons && filled($blockIcon))
-                                    {{ \Filament\Support\generate_icon_html($blockIcon, (new \Illuminate\View\ComponentAttributeBag)->class(['fi-fo-builder-item-header-icon'])) }}
+                                    {{ \Filament\Support\generate_icon_html($blockIcon, attributes: (new \Illuminate\View\ComponentAttributeBag)->class(['fi-fo-builder-item-header-icon'])) }}
                                 @endif
 
                                 @if ($hasBlockLabels)


### PR DESCRIPTION
## Description
The block icon class (`fi-fo-builder-item-header-icon`) in the Builder component was not being applied because the attributes parameter is missing from the `generate_icon_html` call.

### Before
<img width="1228" height="252" alt="BRB-2026-02-26-163738@2x" src="https://github.com/user-attachments/assets/515427fd-3590-4c1b-af5e-542aa8b1cb02" />

### After
<img width="1262" height="306" alt="BRB-2026-02-26-163809@2x" src="https://github.com/user-attachments/assets/ec88266c-7b0b-447a-8e95-b468f5e74f50" />
