### PR TITLE
Fix deprecation description

### DIFF
--- a/docs/10-testing/05-testing-actions.md
+++ b/docs/10-testing/05-testing-actions.md
@@ -314,7 +314,7 @@ it('can only print a sent invoice', function () {
 });
 ```
 
-To ensure sets of actions exist in the correct order, you can use `assertActionsExistInOrder()`:
+To ensure sets of actions exist in the correct order, you can use `assertActionListInOrder()`:
 
 ```php
 use function Pest\Livewire\livewire;
@@ -325,7 +325,7 @@ it('can have actions in order', function () {
     livewire(EditInvoice::class, [
         'invoice' => $invoice,
     ])
-        ->assertActionsExistInOrder(['send', 'export']);
+        ->assertActionListInOrder(['send', 'export']);
 });
 ```
 

--- a/packages/tables/.stubs.php
+++ b/packages/tables/.stubs.php
@@ -206,7 +206,7 @@ namespace Livewire\Features\SupportTesting {
         public function assertTableBulkActionDoesNotExist(string $name): static {}
 
         /**
-         * @deprecated Use `assertActionsExistInOrder()` instead.
+         * @deprecated Use `assertActionListInOrder()` instead.
          */
         public function assertTableBulkActionsExistInOrder(array $names): static {}
 


### PR DESCRIPTION
As far as I am aware, there is no `assertActionsExistInOrder`, however there is an `assertActionListInOrder` function. I don't know whether the function is actually supposed to exist and was merely forgotten, then may this serve as a reminder and the PR can be closed.
