### PR TITLE
docs: enhance documentation on JavaScript asset registration

### DIFF
--- a/docs/09-advanced/02-assets.md
+++ b/docs/09-advanced/02-assets.md
@@ -359,10 +359,35 @@ window.filamentData.user.name // 'Dan Harrin'
 If you want to register a JavaScript file from a URL, you may do so. These assets will be loaded on every page as normal, but not copied into the `/public` directory when the `php artisan filament:assets` command is run. This is useful for registering external scripts from a CDN, or scripts that you are already compiling directly into the `/public` directory:
 
 ```php
+use Filament\Support\Facades\FilamentAsset;
 use Filament\Support\Assets\Js;
 
 FilamentAsset::register([
     Js::make('example-external-script', 'https://example.com/external.js'),
     Js::make('example-local-script', asset('js/local.js')),
+]);
+```
+
+### Registering JavaScript files that has import statement
+
+Command `php artisan filament:assets` only copies the selected file to the public directory. However, if you use `import` statement in your JavaScript file, it will not work. Example:
+```js
+import moment from "moment-timezone";
+console.log(moment.tz.guess());
+```
+
+You need to run the Vite build process first:
+```bash
+npm run build
+```
+
+Then use Vite::asset() to get the URL of the compiled asset:
+```php
+use Filament\Support\Facades\FilamentAsset;
+use Filament\Support\Assets\Js;
+use Illuminate\Support\Facades\Vite;
+
+FilamentAsset::register([
+	Js::make('timezone', Vite::asset('resources/js/timezone.js')),
 ]);
 ```

--- a/docs/09-advanced/02-assets.md
+++ b/docs/09-advanced/02-assets.md
@@ -1,6 +1,7 @@
 ---
 title: Registering assets
 ---
+import Aside from "@components/Aside.astro"
 
 ## Introduction
 
@@ -412,5 +413,5 @@ FilamentAsset::register([
 This approach also works for TypeScript files or any other JavaScript that needs a build step. Since `Vite::asset()` returns a URL, the asset will not be copied by `php artisan filament:assets` — it is served directly from Vite's build output.
 
 <Aside variant="info">
-If you need to bundle JavaScript for an [asynchronous Alpine.js component](#asynchronous-alpinejs-components), consider using esbuild instead, as documented in that section.
+    If you need to bundle JavaScript for an [asynchronous Alpine.js component](#asynchronous-alpinejs-components), consider using esbuild instead, as documented in that section.
 </Aside>

--- a/docs/09-advanced/02-assets.md
+++ b/docs/09-advanced/02-assets.md
@@ -368,26 +368,49 @@ FilamentAsset::register([
 ]);
 ```
 
-### Registering JavaScript files that has import statement
+### Using Vite-compiled JavaScript files
 
-Command `php artisan filament:assets` only copies the selected file to the public directory. However, if you use `import` statement in your JavaScript file, it will not work. Example:
+The `php artisan filament:assets` command copies files as-is into the `/public` directory without bundling or resolving dependencies. This means that if your JavaScript file uses `import` statements to pull in npm packages, the browser will not be able to resolve them. To use JavaScript files that require bundling, you should compile them with [Vite](https://vitejs.dev) first, and then register the compiled output as a URL-based asset.
+
+First, add your JavaScript file as an entry point in your `vite.config.js`:
+
 ```js
-import moment from "moment-timezone";
-console.log(moment.tz.guess());
+import { defineConfig } from 'vite'
+import laravel from 'laravel-vite-plugin'
+
+export default defineConfig({
+    plugins: [
+        laravel({
+            input: [
+                'resources/css/app.css',
+                'resources/js/app.js',
+                'resources/js/timezone.js', // Your custom script
+            ],
+        }),
+    ],
+})
 ```
 
-You need to run the Vite build process first:
+Then, compile the assets using Vite:
+
 ```bash
 npm run build
 ```
 
-Then use Vite::asset() to get the URL of the compiled asset:
+Finally, register the compiled asset using `Vite::asset()` to resolve the versioned URL:
+
 ```php
-use Filament\Support\Facades\FilamentAsset;
 use Filament\Support\Assets\Js;
+use Filament\Support\Facades\FilamentAsset;
 use Illuminate\Support\Facades\Vite;
 
 FilamentAsset::register([
-	Js::make('timezone', Vite::asset('resources/js/timezone.js')),
+    Js::make('timezone', Vite::asset('resources/js/timezone.js')),
 ]);
 ```
+
+This approach also works for TypeScript files or any other JavaScript that needs a build step. Since `Vite::asset()` returns a URL, the asset will not be copied by `php artisan filament:assets` — it is served directly from Vite's build output.
+
+<Aside variant="info">
+If you need to bundle JavaScript for an [asynchronous Alpine.js component](#asynchronous-alpinejs-components), consider using esbuild instead, as documented in that section.
+</Aside>


### PR DESCRIPTION
Added instructions for registering JavaScript files with import statements and using Vite for asset compilation. Reference discussion:  https://github.com/filamentphp/filament/discussions/15278