### PR TITLE
Add compact() method to Table for denser row layout

### DIFF
--- a/packages/tables/resources/css/row.css
+++ b/packages/tables/resources/css/row.css
@@ -9,6 +9,26 @@
         @apply bg-gray-50 dark:bg-white/5;
     }
 
+    &.fi-compact {
+        & .fi-ta-text:not(.fi-inline) {
+            @apply py-2;
+        }
+
+        & .fi-ta-cell {
+            &:has(.fi-ta-actions) {
+                @apply py-2;
+            }
+
+            &:has(.fi-ta-record-checkbox) {
+                @apply py-2;
+            }
+
+            &.fi-ta-selection-cell {
+                @apply py-2;
+            }
+        }
+    }
+
     &.fi-collapsed {
         @apply hidden;
     }

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -100,6 +100,7 @@
     $selectsGroupsOnly = $selectsGroupsOnly();
     $recordCheckboxPosition = $getRecordCheckboxPosition();
     $isStriped = $isStriped();
+    $isCompact = $isCompact();
     $isStackedOnMobile = $isStackedOnMobile();
     $isLoaded = $isLoaded();
     $hasFilters = $isFilterable();
@@ -2125,6 +2126,7 @@
                                                         'fi-ta-row',
                                                         'fi-clickable' => $recordAction || $recordUrl,
                                                         'fi-striped' => $isStriped && $isRecordRowStriped,
+                                                        'fi-compact' => $isCompact,
                                                         ...$getRecordClasses($record),
                                                     ])
                                                 >

--- a/packages/tables/src/Table.php
+++ b/packages/tables/src/Table.php
@@ -12,6 +12,7 @@ class Table extends ViewComponent
     use HasDefaultDataFormattingSettings;
     use HasExtraAttributes;
     use Table\Concerns\BelongsToLivewire;
+    use Table\Concerns\CanBeCompact;
     use Table\Concerns\CanBeStackedOnMobile;
     use Table\Concerns\CanBeStriped;
     use Table\Concerns\CanDeferLoading;

--- a/packages/tables/src/Table/Concerns/CanBeCompact.php
+++ b/packages/tables/src/Table/Concerns/CanBeCompact.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Filament\Tables\Table\Concerns;
+
+use Closure;
+
+trait CanBeCompact
+{
+    protected bool | Closure $isCompact = false;
+
+    public function compact(bool | Closure $condition = true): static
+    {
+        $this->isCompact = $condition;
+
+        return $this;
+    }
+
+    public function isCompact(): bool
+    {
+        return (bool) $this->evaluate($this->isCompact);
+    }
+}

--- a/tests/src/Tables/Concerns/CanBeCompactTest.php
+++ b/tests/src/Tables/Concerns/CanBeCompactTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Filament\Tests\Fixtures\Livewire\PostsTable;
+use Filament\Tests\Tables\TestCase;
+
+use function Filament\Tests\livewire;
+
+uses(TestCase::class);
+
+it('returns `false` for `isCompact()` by default', function (): void {
+    $table = livewire(PostsTable::class)->instance()->getTable();
+
+    expect($table->isCompact())->toBeFalse();
+});
+
+it('can use `compact()` to enable compact mode', function (): void {
+    $table = livewire(PostsTable::class)->instance()->getTable();
+    $table->compact();
+
+    expect($table->isCompact())->toBeTrue();
+});
+
+it('can use `compact(false)` to disable compact mode', function (): void {
+    $table = livewire(PostsTable::class)->instance()->getTable();
+    $table->compact();
+    $table->compact(false);
+
+    expect($table->isCompact())->toBeFalse();
+});
+
+it('can use `compact()` with a `Closure`', function (): void {
+    $table = livewire(PostsTable::class)->instance()->getTable();
+    $table->compact(fn (): bool => true);
+
+    expect($table->isCompact())->toBeTrue();
+});
+
+it('can use `compact()` with a `Closure` that returns `false`', function (): void {
+    $table = livewire(PostsTable::class)->instance()->getTable();
+    $table->compact(fn (): bool => false);
+
+    expect($table->isCompact())->toBeFalse();
+});


### PR DESCRIPTION
Description
Problem

Filament tables currently have a fixed row height based on default cell padding. There was no built-in way to reduce the visual density of a table,
making it difficult to display large amounts of data in a compact, scannable format without resorting to custom CSS overrides.

Solution

Introduces a compact() fluent method on the Table class that reduces the vertical padding of table rows, producing a denser layout suitable for
data-heavy interfaces.

What was added

CanBeCompact trait (packages/tables/src/Table/Concerns/CanBeCompact.php): follows the standard Filament boolean concern pattern — $isCompact property
defaults to false, a compact(bool | Closure $condition = true) setter, and an isCompact(): bool getter that resolves Closure values via evaluate().
Table.php: registers the new CanBeCompact trait alongside the existing concerns.
row.css: adds the .fi-compact hook class that applies py-2 padding to text cells, action cells, checkbox cells, and the selection cell — reducing row
height without affecting other layout properties.
index.blade.php: resolves $isCompact from the table and conditionally applies the fi-compact CSS class to each row.
CanBeCompactTest.php: unit tests covering the default state, enabling via compact(), disabling via compact(false), and both truthy and falsy Closure
variants.
Usage

Tables\Table::make()
->compact()
Or conditionally:

->compact(fn (): bool => $this->isCompactView)

<img width="1280" height="439" alt="image" src="https://github.com/user-attachments/assets/ebc59e90-1b81-4efa-ac66-e0948e93e47b" />
