### PR TITLE
fix: preserve Model instances in action definition arguments

### DIFF
--- a/packages/actions/src/Action.php
+++ b/packages/actions/src/Action.php
@@ -466,7 +466,7 @@ class Action extends ViewComponent implements Arrayable
 
         $argumentsParameter = '';
 
-        if (count($arguments = $this->getArguments())) {
+        if (count($arguments = $this->getInvokedArguments() ?? [])) {
             $argumentsParameter .= ', ';
             $argumentsParameter .= Js::from($arguments);
         }

--- a/packages/actions/src/Concerns/HasMountableArguments.php
+++ b/packages/actions/src/Concerns/HasMountableArguments.php
@@ -5,6 +5,11 @@ namespace Filament\Actions\Concerns;
 trait HasMountableArguments
 {
     /**
+     * @var array<string, mixed>|null
+     */
+    protected ?array $invokedArguments = null;
+
+    /**
      * @param  array<string, mixed>  $arguments
      */
     public function __invoke(array $arguments): static
@@ -15,7 +20,16 @@ trait HasMountableArguments
         $action = clone $this;
 
         $action->arguments($arguments);
+        $action->invokedArguments = $arguments;
 
         return $action;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getInvokedArguments(): ?array
+    {
+        return $this->invokedArguments;
     }
 }


### PR DESCRIPTION
## Description
Fixes: #19328

Only serialize invoked arguments (from `__invoke()`) to JS, keeping definition arguments like `->arguments(['user' => $model])` intact.                                          


## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
