### PR TITLE
feat: Add afterCreateUsing callback to Repeater for relationship items

### DIFF
--- a/packages/forms/docs/12-repeater.md
+++ b/packages/forms/docs/12-repeater.md
@@ -28,7 +28,7 @@ Repeater::make('members')
     ->columns(2)
 ```
 
-<AutoScreenshot name="forms/fields/repeater/simple" alt="Repeater" version="4.x" />
+<AutoScreenshot name="forms/fields/repeater/simple" alt="Repeater" version="5.x" />
 
 We recommend that you store repeater data with a `JSON` column in your database. Additionally, if you're using Eloquent, make sure that column has an `array` cast.
 
@@ -61,7 +61,7 @@ Repeater::make('members')
     ->defaultItems(3)
 ```
 
-<UtilityInjection set="formFields" version="4.x">As well as allowing a static value, the `defaultItems()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x">As well as allowing a static value, the `defaultItems()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 ## Adding items
 
@@ -81,7 +81,7 @@ Repeater::make('members')
     ->addActionLabel('Add member')
 ```
 
-<UtilityInjection set="formFields" version="4.x">As well as allowing a static value, the `addActionLabel()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x">As well as allowing a static value, the `addActionLabel()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 ### Aligning the add action button
 
@@ -98,7 +98,7 @@ Repeater::make('members')
     ->addActionAlignment(Alignment::Start)
 ```
 
-<UtilityInjection set="formFields" version="4.x">As well as allowing a static value, the `addActionAlignment()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x">As well as allowing a static value, the `addActionAlignment()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 ### Preventing the user from adding items
 
@@ -114,7 +114,7 @@ Repeater::make('members')
     ->addable(false)
 ```
 
-<UtilityInjection set="formFields" version="4.x">As well as allowing a static value, the `addable()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x">As well as allowing a static value, the `addable()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 ## Deleting items
 
@@ -134,7 +134,7 @@ Repeater::make('members')
     ->deletable(false)
 ```
 
-<UtilityInjection set="formFields" version="4.x">As well as allowing a static value, the `deletable()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x">As well as allowing a static value, the `deletable()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 ## Reordering items
 
@@ -154,7 +154,7 @@ Repeater::make('members')
     ->reorderable(false)
 ```
 
-<UtilityInjection set="formFields" version="4.x">As well as allowing a static value, the `reorderable()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x">As well as allowing a static value, the `reorderable()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 ### Reordering items with buttons
 
@@ -170,7 +170,7 @@ Repeater::make('members')
     ->reorderableWithButtons()
 ```
 
-<AutoScreenshot name="forms/fields/repeater/reorderable-with-buttons" alt="Repeater that is reorderable with buttons" version="4.x" />
+<AutoScreenshot name="forms/fields/repeater/reorderable-with-buttons" alt="Repeater that is reorderable with buttons" version="5.x" />
 
 Optionally, you may pass a boolean value to control if the repeater should be ordered with buttons or not:
 
@@ -184,7 +184,7 @@ Repeater::make('members')
     ->reorderableWithButtons(FeatureFlag::active())
 ```
 
-<UtilityInjection set="formFields" version="4.x">As well as allowing a static value, the `reorderableWithButtons()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x">As well as allowing a static value, the `reorderableWithButtons()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 ### Preventing reordering with drag and drop
 
@@ -200,7 +200,7 @@ Repeater::make('members')
     ->reorderableWithDragAndDrop(false)
 ```
 
-<UtilityInjection set="formFields" version="4.x">As well as allowing a static value, the `reorderableWithDragAndDrop()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x">As well as allowing a static value, the `reorderableWithDragAndDrop()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 ## Collapsing items
 
@@ -228,7 +228,7 @@ Repeater::make('qualifications')
     ->collapsed()
 ```
 
-<AutoScreenshot name="forms/fields/repeater/collapsed" alt="Collapsed repeater" version="4.x" />
+<AutoScreenshot name="forms/fields/repeater/collapsed" alt="Collapsed repeater" version="5.x" />
 
 Optionally, the `collapsible()` and `collapsed()` methods accept a boolean value to control if the repeater should be collapsible and collapsed or not:
 
@@ -243,7 +243,7 @@ Repeater::make('qualifications')
     ->collapsed(FeatureFlag::active())
 ```
 
-<UtilityInjection set="formFields" version="4.x">As well as allowing static values, the `collapsible()` and `collapsed()` methods also accept functions to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x">As well as allowing static values, the `collapsible()` and `collapsed()` methods also accept functions to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 ## Cloning items
 
@@ -259,7 +259,7 @@ Repeater::make('qualifications')
     ->cloneable()
 ```
 
-<AutoScreenshot name="forms/fields/repeater/cloneable" alt="Cloneable repeater" version="4.x" />
+<AutoScreenshot name="forms/fields/repeater/cloneable" alt="Cloneable repeater" version="5.x" />
 
 Optionally, the `cloneable()` method accepts a boolean value to control if the repeater should be cloneable or not:
 
@@ -273,7 +273,7 @@ Repeater::make('qualifications')
     ->cloneable(FeatureFlag::active())
 ```
 
-<UtilityInjection set="formFields" version="4.x">As well as allowing a static value, the `cloneable()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x">As well as allowing a static value, the `cloneable()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 ## Integrating with an Eloquent relationship
 
@@ -317,7 +317,7 @@ Repeater::make('qualifications')
     ->orderColumn('order_column')
 ```
 
-<UtilityInjection set="formFields" version="4.x">As well as allowing a static value, the `orderColumn()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x">As well as allowing a static value, the `orderColumn()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 ### Integrating with a `BelongsToMany` Eloquent relationship
 
@@ -395,7 +395,7 @@ Repeater::make('qualifications')
     })
 ```
 
-<UtilityInjection set="formFields" version="4.x" extras="Data;;array<array<string, mixed>>;;$data;;The data that is being filled into the repeater.">You can inject various utilities into the function passed to `mutateRelationshipDataBeforeFillUsing()` as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x" extras="Data;;array<array<string, mixed>>;;$data;;The data that is being filled into the repeater.">You can inject various utilities into the function passed to `mutateRelationshipDataBeforeFillUsing()` as parameters.</UtilityInjection>
 
 ### Mutating related item data before creating
 
@@ -416,7 +416,7 @@ Repeater::make('qualifications')
     })
 ```
 
-<UtilityInjection set="formFields" version="4.x" extras="Data;;array<string, mixed>;;$data;;The data that is being saved by the repeater.">You can inject various utilities into the function passed to `mutateRelationshipDataBeforeCreateUsing()` as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x" extras="Data;;array<string, mixed>;;$data;;The data that is being saved by the repeater.">You can inject various utilities into the function passed to `mutateRelationshipDataBeforeCreateUsing()` as parameters.</UtilityInjection>
 
 ### Mutating related item data before saving
 
@@ -437,7 +437,29 @@ Repeater::make('qualifications')
     })
 ```
 
-<UtilityInjection set="formFields" version="4.x" extras="Data;;array<string, mixed>;;$data;;The data that is being saved by the repeater.">You can inject various utilities into the function passed to `mutateRelationshipDataBeforeSaveUsing()` as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x" extras="Data;;array<string, mixed>;;$data;;The data that is being saved by the repeater.">You can inject various utilities into the function passed to `mutateRelationshipDataBeforeSaveUsing()` as parameters.</UtilityInjection>
+
+### Running code after creating a related item
+
+You may run code after a new related item is created in the database using the `afterCreateUsing()` method. This method accepts a closure that receives the current item's data in a `$data` variable and the newly created record in a `$record` variable. This is useful when you need the record's ID to perform additional operations, such as attaching pivot data:
+
+```php
+use Filament\Forms\Components\Repeater;
+use Illuminate\Database\Eloquent\Model;
+
+Repeater::make('variants')
+    ->relationship()
+    ->schema([
+        // ...
+    ])
+    ->afterCreateUsing(function (array $data, Model $record): void {
+        if (isset($data['attributes'])) {
+            $record->attributes()->attach($data['attributes']);
+        }
+    })
+```
+
+<UtilityInjection set="formFields" version="5.x" extras="Data;;array<string, mixed>;;$data;;The data that was used to create the record.||Record;;Illuminate\Database\Eloquent\Model;;$record;;The newly created record.">You can inject various utilities into the function passed to `afterCreateUsing()` as parameters.</UtilityInjection>
 
 ### Modifying related records after retrieval
 
@@ -455,7 +477,7 @@ Repeater::make('endItems')
     ->relationship(name: 'items', modifyRecordsUsing: fn (Collection $records): Collection => $records->where('group', 'end')),
 ```
 
-<UtilityInjection set="formFields" version="4.x" extras="Records;;Illuminate\Database\Eloquent\Collection;;$records;;The collection of related records.">You can inject various utilities into the function passed to `modifyRecordsUsing` as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x" extras="Records;;Illuminate\Database\Eloquent\Collection;;$records;;The collection of related records.">You can inject various utilities into the function passed to `modifyRecordsUsing` as parameters.</UtilityInjection>
 
 ## Grid layout
 
@@ -471,11 +493,11 @@ Repeater::make('qualifications')
     ->grid(2)
 ```
 
-<AutoScreenshot name="forms/fields/repeater/grid" alt="Repeater with a 2 column grid of items" version="4.x" />
+<AutoScreenshot name="forms/fields/repeater/grid" alt="Repeater with a 2 column grid of items" version="5.x" />
 
 This method accepts the same options as the `columns()` method of the [grid](../schemas/layouts#grid-system). This allows you to responsively customize the number of grid columns at various breakpoints.
 
-<UtilityInjection set="formFields" version="4.x">As well as allowing a static value, the `grid()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x">As well as allowing a static value, the `grid()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 ## Adding a label to repeater items based on their content
 
@@ -507,9 +529,9 @@ Repeater::make('members')
     Any fields that you use from `$state` should be `live()` if you wish to see the item label update live as you use the form.
 </Aside>
 
-<UtilityInjection set="formFields" version="4.x" extras="Item;;Filament\Schemas\Schema;;$item;;The schema object for the current repeater item.||Key;;string;;$key;;The key for the current repeater item.||State;;array<string, mixed>;;$state;;The raw unvalidated data for the current repeater item.">You can inject various utilities into the function passed to `itemLabel()` as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x" extras="Item;;Filament\Schemas\Schema;;$item;;The schema object for the current repeater item.||Key;;string;;$key;;The key for the current repeater item.||State;;array<string, mixed>;;$state;;The raw unvalidated data for the current repeater item.">You can inject various utilities into the function passed to `itemLabel()` as parameters.</UtilityInjection>
 
-<AutoScreenshot name="forms/fields/repeater/labelled" alt="Repeater with item labels" version="4.x" />
+<AutoScreenshot name="forms/fields/repeater/labelled" alt="Repeater with item labels" version="5.x" />
 
 ## Numbering repeater items
 
@@ -541,9 +563,9 @@ Repeater::make('invitations')
     )
 ```
 
-<UtilityInjection set="formFields" version="4.x">As well as allowing a static value, the `simple()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x">As well as allowing a static value, the `simple()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
-<AutoScreenshot name="forms/fields/repeater/simple-one-field" alt="Simple repeater design with only one field" version="4.x" />
+<AutoScreenshot name="forms/fields/repeater/simple-one-field" alt="Simple repeater design with only one field" version="5.x" />
 
 Instead of using a nested array to store data, simple repeaters use a flat array of values. This means that the data structure for the above example could look like this:
 
@@ -614,7 +636,7 @@ Repeater::make('members')
     ])
 ```
 
-<AutoScreenshot name="forms/fields/repeater/table" alt="Repeater with a table layout" version="4.x" />
+<AutoScreenshot name="forms/fields/repeater/table" alt="Repeater with a table layout" version="5.x" />
 
 The labels displayed in the header of the table are passed to the `TableColumn::make()` method. If you want to provide an accessible label for a column but do not wish to display it, you can use the `hiddenHeaderLabel()` method:
 
@@ -694,9 +716,9 @@ Repeater::make('members')
     ])
 ```
 
-<UtilityInjection set="formFields" version="4.x">As well as allowing a static value, the `compact()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x">As well as allowing a static value, the `compact()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
-<AutoScreenshot name="forms/fields/repeater/table-compact" alt="Repeater with a compact table layout" version="4.x" />
+<AutoScreenshot name="forms/fields/repeater/table-compact" alt="Repeater with a compact table layout" version="5.x" />
 
 ## Repeater validation
 
@@ -717,7 +739,7 @@ Repeater::make('members')
     ->maxItems(5)
 ```
 
-<UtilityInjection set="formFields" version="4.x">As well as allowing static values, the `minItems()` and `maxItems()` methods also accept a function to dynamically calculate them. You can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x">As well as allowing static values, the `minItems()` and `maxItems()` methods also accept a function to dynamically calculate them. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 ### Distinct state validation
 
@@ -754,7 +776,7 @@ Checkbox::make('is_correct')
     ->distinct(FeatureFlag::active())
 ```
 
-<UtilityInjection set="formFields" version="4.x">As well as allowing a static value, the `distinct()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x">As well as allowing a static value, the `distinct()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 #### Automatically fixing indistinct state
 
@@ -788,7 +810,7 @@ Checkbox::make('is_correct')
     ->fixIndistinctState(FeatureFlag::active())
 ```
 
-<UtilityInjection set="formFields" version="4.x">As well as allowing a static value, the `fixIndistinctState()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x">As well as allowing a static value, the `fixIndistinctState()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 #### Disabling options when they are already selected in another item
 
@@ -859,7 +881,7 @@ Repeater::make('members')
     )
 ```
 
-<UtilityInjection set="formFields" version="4.x" extras="Action;;Filament\Actions\Action;;$action;;The action object to customize.">The action registration methods can inject various utilities into the function as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="5.x" extras="Action;;Filament\Actions\Action;;$action;;The action object to customize.">The action registration methods can inject various utilities into the function as parameters.</UtilityInjection>
 
 ### Confirming repeater actions with a modal
 

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -40,35 +40,35 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     use HasContainerGridLayout;
     use HasReorderAnimationDuration;
 
-    protected string | Closure | null $addActionLabel = null;
+    protected string|Closure|null $addActionLabel = null;
 
-    protected string | Closure | null $addBetweenActionLabel = null;
+    protected string|Closure|null $addBetweenActionLabel = null;
 
-    protected bool | Closure $isAddable = true;
+    protected bool|Closure $isAddable = true;
 
-    protected bool | Closure $isDeletable = true;
+    protected bool|Closure $isDeletable = true;
 
-    protected bool | Closure $isReorderable = true;
+    protected bool|Closure $isReorderable = true;
 
-    protected bool | Closure $isReorderableWithDragAndDrop = true;
+    protected bool|Closure $isReorderableWithDragAndDrop = true;
 
-    protected bool | Closure $isReorderableWithButtons = false;
+    protected bool|Closure $isReorderableWithButtons = false;
 
     protected ?Collection $cachedExistingRecords = null;
 
-    protected string | Closure | null $orderColumn = null;
+    protected string|Closure|null $orderColumn = null;
 
-    protected string | Closure | null $relationship = null;
+    protected string|Closure|null $relationship = null;
 
-    protected string | Htmlable | Closure | null $itemLabel = null;
+    protected string|Htmlable|Closure|null $itemLabel = null;
 
-    protected bool | Closure $hasItemNumbers = false;
+    protected bool|Closure $hasItemNumbers = false;
 
-    protected bool | Closure $hasItemHeaders = true;
+    protected bool|Closure $hasItemHeaders = true;
 
-    protected Field | Closure | null $simpleField = null;
+    protected Field|Closure|null $simpleField = null;
 
-    protected Alignment | string | Closure | null $addActionAlignment = null;
+    protected Alignment|string|Closure|null $addActionAlignment = null;
 
     protected ?Closure $modifyRelationshipQueryUsing = null;
 
@@ -102,25 +102,27 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
 
     protected ?Closure $mutateRelationshipDataBeforeSaveUsing = null;
 
+    protected ?Closure $afterCreateUsing = null;
+
     /**
      * @var array<string, mixed> | null
      */
     protected ?array $hydratedDefaultState = null;
 
-    protected string | Closure | null $labelBetweenItems = null;
+    protected string|Closure|null $labelBetweenItems = null;
 
-    protected bool | Closure $isItemLabelTruncated = true;
+    protected bool|Closure $isItemLabelTruncated = true;
 
     protected ?Field $cachedSimpleField = null;
 
     /**
      * @var array<TableColumn> | Closure | null
      */
-    protected array | Closure | null $tableColumns = null;
+    protected array|Closure|null $tableColumns = null;
 
     protected bool $shouldMergeHydratedDefaultStateWithItemsStateAfterStateHydrated = true;
 
-    protected bool | Closure $shouldPartiallyRenderAfterActionsCalled = true;
+    protected bool|Closure $shouldPartiallyRenderAfterActionsCalled = true;
 
     protected function setUp(): void
     {
@@ -224,14 +226,14 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return $action;
     }
 
-    public function addActionAlignment(Alignment | string | Closure | null $addActionAlignment): static
+    public function addActionAlignment(Alignment|string|Closure|null $addActionAlignment): static
     {
         $this->addActionAlignment = $addActionAlignment;
 
         return $this;
     }
 
-    public function getAddActionAlignment(): Alignment | string | null
+    public function getAddActionAlignment(): Alignment|string|null
     {
         $alignment = $this->evaluate($this->addActionAlignment);
 
@@ -313,7 +315,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return 'addBetween';
     }
 
-    public function addBetweenActionLabel(string | Closure | null $label): static
+    public function addBetweenActionLabel(string|Closure|null $label): static
     {
         $this->addBetweenActionLabel = $label;
 
@@ -662,7 +664,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return 'expandAll';
     }
 
-    public function addActionLabel(string | Closure | null $label): static
+    public function addActionLabel(string|Closure|null $label): static
     {
         $this->addActionLabel = $label;
 
@@ -672,28 +674,28 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     /**
      * @deprecated Use `addActionLabel()` instead.
      */
-    public function createItemButtonLabel(string | Closure | null $label): static
+    public function createItemButtonLabel(string|Closure|null $label): static
     {
         $this->addActionLabel($label);
 
         return $this;
     }
 
-    public function labelBetweenItems(string | Closure | null $label): static
+    public function labelBetweenItems(string|Closure|null $label): static
     {
         $this->labelBetweenItems = $label;
 
         return $this;
     }
 
-    public function truncateItemLabel(bool | Closure $condition = true): static
+    public function truncateItemLabel(bool|Closure $condition = true): static
     {
         $this->isItemLabelTruncated = $condition;
 
         return $this;
     }
 
-    public function defaultItems(int | Closure $count): static
+    public function defaultItems(int|Closure $count): static
     {
         $this->default(static function (Repeater $component) use ($count): array {
             $count = $component->evaluate($count);
@@ -741,21 +743,21 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return $this;
     }
 
-    public function addable(bool | Closure $condition = true): static
+    public function addable(bool|Closure $condition = true): static
     {
         $this->isAddable = $condition;
 
         return $this;
     }
 
-    public function deletable(bool | Closure $condition = true): static
+    public function deletable(bool|Closure $condition = true): static
     {
         $this->isDeletable = $condition;
 
         return $this;
     }
 
-    public function reorderable(bool | Closure $condition = true): static
+    public function reorderable(bool|Closure $condition = true): static
     {
         $this->isReorderable = $condition;
 
@@ -765,7 +767,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     /**
      * @deprecated Use `addable()` instead.
      */
-    public function disableItemCreation(bool | Closure $condition = true): static
+    public function disableItemCreation(bool|Closure $condition = true): static
     {
         $this->addable(fn (Repeater $component): bool => ! $this->evaluate($condition));
 
@@ -775,7 +777,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     /**
      * @deprecated Use `deletable()` instead.
      */
-    public function disableItemDeletion(bool | Closure $condition = true): static
+    public function disableItemDeletion(bool|Closure $condition = true): static
     {
         $this->deletable(fn (Repeater $component): bool => ! $this->evaluate($condition));
 
@@ -785,21 +787,21 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     /**
      * @deprecated Use `reorderable()` instead.
      */
-    public function disableItemMovement(bool | Closure $condition = true): static
+    public function disableItemMovement(bool|Closure $condition = true): static
     {
         $this->reorderable(fn (Repeater $component): bool => ! $this->evaluate($condition));
 
         return $this;
     }
 
-    public function reorderableWithDragAndDrop(bool | Closure $condition = true): static
+    public function reorderableWithDragAndDrop(bool|Closure $condition = true): static
     {
         $this->isReorderableWithDragAndDrop = $condition;
 
         return $this;
     }
 
-    public function reorderableWithButtons(bool | Closure $condition = true): static
+    public function reorderableWithButtons(bool|Closure $condition = true): static
     {
         $this->isReorderableWithButtons = $condition;
 
@@ -809,7 +811,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     /**
      * @deprecated No longer part of the design system.
      */
-    public function inset(bool | Closure $condition = true): static
+    public function inset(bool|Closure $condition = true): static
     {
         return $this;
     }
@@ -894,7 +896,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return (bool) $this->evaluate($this->isDeletable);
     }
 
-    public function orderColumn(string | Closure | null $column = 'sort'): static
+    public function orderColumn(string|Closure|null $column = 'sort'): static
     {
         $this->orderColumn = $column;
         $this->reorderable($column);
@@ -905,14 +907,14 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     /**
      * @deprecated Use `orderColumn()` instead.
      */
-    public function orderable(string | Closure | null $column = 'sort'): static
+    public function orderable(string|Closure|null $column = 'sort'): static
     {
         $this->orderColumn($column);
 
         return $this;
     }
 
-    public function relationship(string | Closure | null $name = null, ?Closure $modifyQueryUsing = null, ?Closure $modifyRecordsUsing = null): static
+    public function relationship(string|Closure|null $name = null, ?Closure $modifyQueryUsing = null, ?Closure $modifyRecordsUsing = null): static
     {
         $this->relationship = $name ?? $this->getName();
         $this->modifyRelationshipQueryUsing = $modifyQueryUsing;
@@ -1003,6 +1005,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
                 }
 
                 $record = $relationship->save($record);
+                $component->afterCreate($itemData, $record);
                 $item->model($record)->saveRelationships();
                 $existingRecords->push($record);
             }
@@ -1039,21 +1042,21 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         $this->rawState($items);
     }
 
-    public function itemLabel(string | Htmlable | Closure | null $label): static
+    public function itemLabel(string|Htmlable|Closure|null $label): static
     {
         $this->itemLabel = $label;
 
         return $this;
     }
 
-    public function itemNumbers(bool | Closure $condition = true): static
+    public function itemNumbers(bool|Closure $condition = true): static
     {
         $this->hasItemNumbers = $condition;
 
         return $this;
     }
 
-    public function itemHeaders(bool | Closure $condition = true): static
+    public function itemHeaders(bool|Closure $condition = true): static
     {
         $this->hasItemHeaders = $condition;
 
@@ -1089,7 +1092,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
             ->toArray();
     }
 
-    public function getLabel(): string | Htmlable | null
+    public function getLabel(): string|Htmlable|null
     {
         if ($this->label === null && $this->hasRelationship()) {
             $label = (string) str($this->getRelationshipName())
@@ -1109,7 +1112,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return $this->evaluate($this->orderColumn);
     }
 
-    public function getRelationship(): HasOneOrMany | BelongsToMany | null
+    public function getRelationship(): HasOneOrMany|BelongsToMany|null
     {
         if (! $this->hasRelationship()) {
             return null;
@@ -1191,7 +1194,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         ));
     }
 
-    public function getItemLabel(string $key): string | Htmlable | null
+    public function getItemLabel(string $key): string|Htmlable|null
     {
         $container = $this->getChildSchema($key);
 
@@ -1220,7 +1223,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return (bool) $this->evaluate($this->hasItemHeaders);
     }
 
-    public function simple(Field | Closure | null $field): static
+    public function simple(Field|Closure|null $field): static
     {
         $this->simpleField = $field;
         $this->schema(fn (Repeater $component): array => [$component->getSimpleField()]);
@@ -1236,7 +1239,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     /**
      * @param  array<TableColumn> | Closure | null  $columns
      */
-    public function table(array | Closure | null $columns): static
+    public function table(array|Closure|null $columns): static
     {
         $this->tableColumns = $columns;
 
@@ -1353,6 +1356,30 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return $data;
     }
 
+    public function afterCreateUsing(?Closure $callback): static
+    {
+        $this->afterCreateUsing = $callback;
+
+        return $this;
+    }
+
+    public function afterCreate(array $data, Model $record): void
+    {
+        if ($this->afterCreateUsing instanceof Closure) {
+            $this->evaluate(
+                $this->afterCreateUsing,
+                namedInjections: [
+                    'data' => $data,
+                    'record' => $record,
+                ],
+                typedInjections: [
+                    Model::class => $record,
+                    $record::class => $record,
+                ],
+            );
+        }
+    }
+
     public function canConcealComponents(): bool
     {
         return $this->isCollapsible();
@@ -1409,7 +1436,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return 1;
     }
 
-    public function partiallyRenderAfterActionsCalled(bool | Closure $condition = true): static
+    public function partiallyRenderAfterActionsCalled(bool|Closure $condition = true): static
     {
         $this->shouldPartiallyRenderAfterActionsCalled = $condition;
 

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -40,35 +40,35 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     use HasContainerGridLayout;
     use HasReorderAnimationDuration;
 
-    protected string|Closure|null $addActionLabel = null;
+    protected string | Closure | null $addActionLabel = null;
 
-    protected string|Closure|null $addBetweenActionLabel = null;
+    protected string | Closure | null $addBetweenActionLabel = null;
 
-    protected bool|Closure $isAddable = true;
+    protected bool | Closure $isAddable = true;
 
-    protected bool|Closure $isDeletable = true;
+    protected bool | Closure $isDeletable = true;
 
-    protected bool|Closure $isReorderable = true;
+    protected bool | Closure $isReorderable = true;
 
-    protected bool|Closure $isReorderableWithDragAndDrop = true;
+    protected bool | Closure $isReorderableWithDragAndDrop = true;
 
-    protected bool|Closure $isReorderableWithButtons = false;
+    protected bool | Closure $isReorderableWithButtons = false;
 
     protected ?Collection $cachedExistingRecords = null;
 
-    protected string|Closure|null $orderColumn = null;
+    protected string | Closure | null $orderColumn = null;
 
-    protected string|Closure|null $relationship = null;
+    protected string | Closure | null $relationship = null;
 
-    protected string|Htmlable|Closure|null $itemLabel = null;
+    protected string | Htmlable | Closure | null $itemLabel = null;
 
-    protected bool|Closure $hasItemNumbers = false;
+    protected bool | Closure $hasItemNumbers = false;
 
-    protected bool|Closure $hasItemHeaders = true;
+    protected bool | Closure $hasItemHeaders = true;
 
-    protected Field|Closure|null $simpleField = null;
+    protected Field | Closure | null $simpleField = null;
 
-    protected Alignment|string|Closure|null $addActionAlignment = null;
+    protected Alignment | string | Closure | null $addActionAlignment = null;
 
     protected ?Closure $modifyRelationshipQueryUsing = null;
 
@@ -109,20 +109,20 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
      */
     protected ?array $hydratedDefaultState = null;
 
-    protected string|Closure|null $labelBetweenItems = null;
+    protected string | Closure | null $labelBetweenItems = null;
 
-    protected bool|Closure $isItemLabelTruncated = true;
+    protected bool | Closure $isItemLabelTruncated = true;
 
     protected ?Field $cachedSimpleField = null;
 
     /**
      * @var array<TableColumn> | Closure | null
      */
-    protected array|Closure|null $tableColumns = null;
+    protected array | Closure | null $tableColumns = null;
 
     protected bool $shouldMergeHydratedDefaultStateWithItemsStateAfterStateHydrated = true;
 
-    protected bool|Closure $shouldPartiallyRenderAfterActionsCalled = true;
+    protected bool | Closure $shouldPartiallyRenderAfterActionsCalled = true;
 
     protected function setUp(): void
     {
@@ -226,14 +226,14 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return $action;
     }
 
-    public function addActionAlignment(Alignment|string|Closure|null $addActionAlignment): static
+    public function addActionAlignment(Alignment | string | Closure | null $addActionAlignment): static
     {
         $this->addActionAlignment = $addActionAlignment;
 
         return $this;
     }
 
-    public function getAddActionAlignment(): Alignment|string|null
+    public function getAddActionAlignment(): Alignment | string | null
     {
         $alignment = $this->evaluate($this->addActionAlignment);
 
@@ -315,7 +315,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return 'addBetween';
     }
 
-    public function addBetweenActionLabel(string|Closure|null $label): static
+    public function addBetweenActionLabel(string | Closure | null $label): static
     {
         $this->addBetweenActionLabel = $label;
 
@@ -664,7 +664,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return 'expandAll';
     }
 
-    public function addActionLabel(string|Closure|null $label): static
+    public function addActionLabel(string | Closure | null $label): static
     {
         $this->addActionLabel = $label;
 
@@ -674,28 +674,28 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     /**
      * @deprecated Use `addActionLabel()` instead.
      */
-    public function createItemButtonLabel(string|Closure|null $label): static
+    public function createItemButtonLabel(string | Closure | null $label): static
     {
         $this->addActionLabel($label);
 
         return $this;
     }
 
-    public function labelBetweenItems(string|Closure|null $label): static
+    public function labelBetweenItems(string | Closure | null $label): static
     {
         $this->labelBetweenItems = $label;
 
         return $this;
     }
 
-    public function truncateItemLabel(bool|Closure $condition = true): static
+    public function truncateItemLabel(bool | Closure $condition = true): static
     {
         $this->isItemLabelTruncated = $condition;
 
         return $this;
     }
 
-    public function defaultItems(int|Closure $count): static
+    public function defaultItems(int | Closure $count): static
     {
         $this->default(static function (Repeater $component) use ($count): array {
             $count = $component->evaluate($count);
@@ -743,21 +743,21 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return $this;
     }
 
-    public function addable(bool|Closure $condition = true): static
+    public function addable(bool | Closure $condition = true): static
     {
         $this->isAddable = $condition;
 
         return $this;
     }
 
-    public function deletable(bool|Closure $condition = true): static
+    public function deletable(bool | Closure $condition = true): static
     {
         $this->isDeletable = $condition;
 
         return $this;
     }
 
-    public function reorderable(bool|Closure $condition = true): static
+    public function reorderable(bool | Closure $condition = true): static
     {
         $this->isReorderable = $condition;
 
@@ -767,7 +767,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     /**
      * @deprecated Use `addable()` instead.
      */
-    public function disableItemCreation(bool|Closure $condition = true): static
+    public function disableItemCreation(bool | Closure $condition = true): static
     {
         $this->addable(fn (Repeater $component): bool => ! $this->evaluate($condition));
 
@@ -777,7 +777,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     /**
      * @deprecated Use `deletable()` instead.
      */
-    public function disableItemDeletion(bool|Closure $condition = true): static
+    public function disableItemDeletion(bool | Closure $condition = true): static
     {
         $this->deletable(fn (Repeater $component): bool => ! $this->evaluate($condition));
 
@@ -787,21 +787,21 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     /**
      * @deprecated Use `reorderable()` instead.
      */
-    public function disableItemMovement(bool|Closure $condition = true): static
+    public function disableItemMovement(bool | Closure $condition = true): static
     {
         $this->reorderable(fn (Repeater $component): bool => ! $this->evaluate($condition));
 
         return $this;
     }
 
-    public function reorderableWithDragAndDrop(bool|Closure $condition = true): static
+    public function reorderableWithDragAndDrop(bool | Closure $condition = true): static
     {
         $this->isReorderableWithDragAndDrop = $condition;
 
         return $this;
     }
 
-    public function reorderableWithButtons(bool|Closure $condition = true): static
+    public function reorderableWithButtons(bool | Closure $condition = true): static
     {
         $this->isReorderableWithButtons = $condition;
 
@@ -811,7 +811,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     /**
      * @deprecated No longer part of the design system.
      */
-    public function inset(bool|Closure $condition = true): static
+    public function inset(bool | Closure $condition = true): static
     {
         return $this;
     }
@@ -896,7 +896,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return (bool) $this->evaluate($this->isDeletable);
     }
 
-    public function orderColumn(string|Closure|null $column = 'sort'): static
+    public function orderColumn(string | Closure | null $column = 'sort'): static
     {
         $this->orderColumn = $column;
         $this->reorderable($column);
@@ -907,14 +907,14 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     /**
      * @deprecated Use `orderColumn()` instead.
      */
-    public function orderable(string|Closure|null $column = 'sort'): static
+    public function orderable(string | Closure | null $column = 'sort'): static
     {
         $this->orderColumn($column);
 
         return $this;
     }
 
-    public function relationship(string|Closure|null $name = null, ?Closure $modifyQueryUsing = null, ?Closure $modifyRecordsUsing = null): static
+    public function relationship(string | Closure | null $name = null, ?Closure $modifyQueryUsing = null, ?Closure $modifyRecordsUsing = null): static
     {
         $this->relationship = $name ?? $this->getName();
         $this->modifyRelationshipQueryUsing = $modifyQueryUsing;
@@ -1042,21 +1042,21 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         $this->rawState($items);
     }
 
-    public function itemLabel(string|Htmlable|Closure|null $label): static
+    public function itemLabel(string | Htmlable | Closure | null $label): static
     {
         $this->itemLabel = $label;
 
         return $this;
     }
 
-    public function itemNumbers(bool|Closure $condition = true): static
+    public function itemNumbers(bool | Closure $condition = true): static
     {
         $this->hasItemNumbers = $condition;
 
         return $this;
     }
 
-    public function itemHeaders(bool|Closure $condition = true): static
+    public function itemHeaders(bool | Closure $condition = true): static
     {
         $this->hasItemHeaders = $condition;
 
@@ -1092,7 +1092,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
             ->toArray();
     }
 
-    public function getLabel(): string|Htmlable|null
+    public function getLabel(): string | Htmlable | null
     {
         if ($this->label === null && $this->hasRelationship()) {
             $label = (string) str($this->getRelationshipName())
@@ -1112,7 +1112,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return $this->evaluate($this->orderColumn);
     }
 
-    public function getRelationship(): HasOneOrMany|BelongsToMany|null
+    public function getRelationship(): HasOneOrMany | BelongsToMany | null
     {
         if (! $this->hasRelationship()) {
             return null;
@@ -1194,7 +1194,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         ));
     }
 
-    public function getItemLabel(string $key): string|Htmlable|null
+    public function getItemLabel(string $key): string | Htmlable | null
     {
         $container = $this->getChildSchema($key);
 
@@ -1223,7 +1223,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return (bool) $this->evaluate($this->hasItemHeaders);
     }
 
-    public function simple(Field|Closure|null $field): static
+    public function simple(Field | Closure | null $field): static
     {
         $this->simpleField = $field;
         $this->schema(fn (Repeater $component): array => [$component->getSimpleField()]);
@@ -1239,7 +1239,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
     /**
      * @param  array<TableColumn> | Closure | null  $columns
      */
-    public function table(array|Closure|null $columns): static
+    public function table(array | Closure | null $columns): static
     {
         $this->tableColumns = $columns;
 
@@ -1436,7 +1436,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return 1;
     }
 
-    public function partiallyRenderAfterActionsCalled(bool|Closure $condition = true): static
+    public function partiallyRenderAfterActionsCalled(bool | Closure $condition = true): static
     {
         $this->shouldPartiallyRenderAfterActionsCalled = $condition;
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

 This PR adds an `afterCreateUsing()` callback to the Repeater component when used with `->relationship()`.

Currently, the Repeater provides callbacks for mutating data before operations: 
- `mutateRelationshipDataBeforeCreateUsing()` 
- `mutateRelationshipDataBeforeSaveUsing()` 
- `mutateRelationshipDataBeforeFillUsing()`

However, there is no way to execute code after a new relationship record is created and saved. This is needed when the record's ID is required to perform additional operations, such as attaching data via a pivot 
table.

The mutateRelationshipDataBeforeCreateUsing() callback cannot solve this because the record doesn't have an ID yet at that point. 

 **Note:** I also updated the documentation version tags from `4.x` to `5.x` as this appears to have been missed during the v5 release.
 
## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
