### PR TITLE
fix: TextInputColumn with date type

### DIFF
--- a/packages/tables/src/Columns/TextInputColumn.php
+++ b/packages/tables/src/Columns/TextInputColumn.php
@@ -303,7 +303,7 @@ class TextInputColumn extends Column implements Editable, HasEmbeddedView
 
                 <div class="fi-input-wrp-content-ctn">
                     <input
-                        <?php if (in_array($type, ['color'])) { ?>
+                        <?php if (in_array($type, ['color', 'date', 'datetime-local', 'time', 'week', 'month'])) { ?>
                             onclick="if (typeof this.showPicker === 'function') { this.showPicker() }"
                         <?php } ?>
                         x-model.lazy="state"


### PR DESCRIPTION
## Description

Fixes #15895

When using `TextInputColumn` with date type, clicking the input did not open the native browser picker.
eg:

```php
TextInputColumn::make('date')
    ->type('date'),

TextInputColumn::make('datetime-local')
    ->type('datetime-local'),

TextInputColumn::make('time')
    ->type('time'),

TextInputColumn::make('week')
    ->type('week'),

TextInputColumn::make('month')
    ->type('month'),
```

The `onclick` handler calling `showPicker()` was only applied to `color` type, leaving `date`, `datetime-local`, `time`, `week` and `month` without it.

## Visual changes

**Before:**


https://github.com/user-attachments/assets/7a527c4a-344a-412f-b177-eed4d310e861



**After:**


https://github.com/user-attachments/assets/ff9317a4-4593-4375-b961-5e340684855f



## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
