### PR TITLE
fix: gracefully handle unresolvable actions when record state changes

### DIFF
--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -194,9 +194,15 @@ trait InteractsWithActions
      */
     public function callMountedAction(array $arguments = []): mixed
     {
-        $action = $this->getMountedAction();
+        try {
+            $action = $this->getMountedAction();
+        } catch (ActionNotResolvableException $exception) {
+            $action = null;
+        }
 
         if (! $action) {
+            $this->unmountAction(canCancelParentActions: false);
+
             return null;
         }
 

--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -98,7 +98,9 @@ trait InteractsWithActions
 
         // Boot the InteractsWithTable trait first so the table object is available.
         if (! ($this instanceof HasTable)) {
-            $this->cacheMountedActions($this->mountedActions);
+            if (empty($this->cacheMountedActions($this->mountedActions))) {
+                $this->mountedActions = [];
+            }
         }
     }
 
@@ -483,8 +485,6 @@ trait InteractsWithActions
         try {
             return $this->cachedMountedActions = $this->resolveActions($mountedActions);
         } catch (ActionNotResolvableException) {
-            $this->mountedActions = [];
-
             return $this->cachedMountedActions = [];
         }
     }

--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -197,8 +197,6 @@ trait InteractsWithActions
         $action = $this->getMountedAction();
 
         if (! $action) {
-            $this->unmountAction(canCancelParentActions: false);
-
             return null;
         }
 

--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -194,11 +194,7 @@ trait InteractsWithActions
      */
     public function callMountedAction(array $arguments = []): mixed
     {
-        try {
-            $action = $this->getMountedAction();
-        } catch (ActionNotResolvableException $exception) {
-            $action = null;
-        }
+        $action = $this->getMountedAction();
 
         if (! $action) {
             $this->unmountAction(canCancelParentActions: false);
@@ -486,7 +482,13 @@ trait InteractsWithActions
      */
     protected function cacheMountedActions(array $mountedActions): array
     {
-        return $this->cachedMountedActions = $this->resolveActions($mountedActions);
+        try {
+            return $this->cachedMountedActions = $this->resolveActions($mountedActions);
+        } catch (ActionNotResolvableException) {
+            $this->mountedActions = [];
+
+            return $this->cachedMountedActions = [];
+        }
     }
 
     /**
@@ -597,6 +599,14 @@ trait InteractsWithActions
 
         if ($action['context']['bulk'] ?? false) {
             $resolvedAction = $this->getTable()->getBulkAction($action['name']);
+
+            if ($resolvedAction && ! empty($this->selectedTableRecords) && $this->getTable()->hasQuery()) {
+                $count = $this->getSelectedTableRecordsQuery(shouldFetchSelectedRecords: false)->count();
+
+                if ($count === 0) {
+                    throw new ActionNotResolvableException('The selected records for the bulk action no longer exist.');
+                }
+            }
         }
 
         $resolvedAction ??= $this->getTable()->getAction($action['name']) ?? throw new ActionNotResolvableException("Action [{$action['name']}] not found on table.");

--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -599,9 +599,7 @@ trait InteractsWithActions
             $resolvedAction = $this->getTable()->getBulkAction($action['name']);
 
             if ($resolvedAction && ! empty($this->selectedTableRecords) && $this->getTable()->hasQuery()) {
-                $count = $this->getSelectedTableRecordsQuery(shouldFetchSelectedRecords: false)->count();
-
-                if ($count === 0) {
+                if (! $this->getSelectedTableRecordsQuery(shouldFetchSelectedRecords: false)->exists()) {
                     throw new ActionNotResolvableException('The selected records for the bulk action no longer exist.');
                 }
             }

--- a/packages/actions/src/Concerns/InteractsWithActions.php
+++ b/packages/actions/src/Concerns/InteractsWithActions.php
@@ -597,12 +597,6 @@ trait InteractsWithActions
 
         if ($action['context']['bulk'] ?? false) {
             $resolvedAction = $this->getTable()->getBulkAction($action['name']);
-
-            if ($resolvedAction && ! empty($this->selectedTableRecords) && $this->getTable()->hasQuery()) {
-                if (! $this->getSelectedTableRecordsQuery(shouldFetchSelectedRecords: false)->exists()) {
-                    throw new ActionNotResolvableException('The selected records for the bulk action no longer exist.');
-                }
-            }
         }
 
         $resolvedAction ??= $this->getTable()->getAction($action['name']) ?? throw new ActionNotResolvableException("Action [{$action['name']}] not found on table.");

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -48,7 +48,9 @@ trait InteractsWithTable
 
         $this->cacheSchema('tableFiltersForm', $this->getTableFiltersForm(...));
 
-        $this->cacheMountedActions($this->mountedActions);
+        if (empty($this->cacheMountedActions($this->mountedActions))) {
+            $this->mountedActions = [];
+        }
 
         $this->initTableColumnManager();
 

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Tables\Concerns;
 
+use Filament\Actions\Exceptions\ActionNotResolvableException;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View;
@@ -48,7 +49,12 @@ trait InteractsWithTable
 
         $this->cacheSchema('tableFiltersForm', $this->getTableFiltersForm(...));
 
-        $this->cacheMountedActions($this->mountedActions);
+        try {
+            $this->cacheMountedActions($this->mountedActions);
+        } catch (ActionNotResolvableException) {
+            $this->mountedActions = [];
+            $this->cachedMountedActions = [];
+        }
 
         $this->initTableColumnManager();
 

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Tables\Concerns;
 
-use Filament\Actions\Exceptions\ActionNotResolvableException;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View;
@@ -49,12 +48,7 @@ trait InteractsWithTable
 
         $this->cacheSchema('tableFiltersForm', $this->getTableFiltersForm(...));
 
-        try {
-            $this->cacheMountedActions($this->mountedActions);
-        } catch (ActionNotResolvableException) {
-            $this->mountedActions = [];
-            $this->cachedMountedActions = [];
-        }
+        $this->cacheMountedActions($this->mountedActions);
 
         $this->initTableColumnManager();
 


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When a user clicks on an action whose associated record state has changed (e.g., the record was deleted or modified by another user/process), `cacheMountedActions()` and `getMountedAction()` throw an                      
  `ActionNotResolvableException`, causing an unhandled error. This change gracefully catches the exception in two places:

  - `InteractsWithTable::bootedInteractsWithTable()` — resets the mounted action state instead of crashing during the Livewire boot lifecycle.
  - `InteractsWithActions::callMountedAction()` — unmounts the action and returns `null` instead of throwing, consistent with how `mountAction()` and `unmountAction()` already handle this exception.

## Visual changes
N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
