### PR TITLE
fix: Enable native picker for date/time TextInputColumn types

### DIFF
--- a/packages/tables/src/Columns/TextInputColumn.php
+++ b/packages/tables/src/Columns/TextInputColumn.php
@@ -303,7 +303,7 @@ class TextInputColumn extends Column implements Editable, HasEmbeddedView
 
                 <div class="fi-input-wrp-content-ctn">
                     <input
-                        <?php if (in_array($type, ['color'])) { ?>
+                        <?php if (in_array($type, ['color', 'date', 'datetime-local', 'month', 'time', 'week'])) { ?>
                             onclick="if (typeof this.showPicker === 'function') { this.showPicker() }"
                         <?php } ?>
                         x-model.lazy="state"

--- a/tests/src/Tables/Columns/TextInputColumnTest.php
+++ b/tests/src/Tables/Columns/TextInputColumnTest.php
@@ -25,6 +25,14 @@ it('can render', function (): void {
         ->assertCanRenderTableColumn('rating');
 });
 
+it('renders showPicker onclick for date type inputs', function (): void {
+    Post::factory()->count(1)->create();
+
+    livewire(TestTableWithDateTextInputColumn::class)
+        ->assertSuccessful()
+        ->assertSeeHtml('showPicker');
+});
+
 it('can display different values', function (): void {
     Post::factory()->create(['rating' => 1]);
     Post::factory()->create(['rating' => 5]);
@@ -33,6 +41,29 @@ it('can display different values', function (): void {
     livewire(TestTableWithTextInputColumn::class)
         ->assertSuccessful();
 });
+
+class TestTableWithDateTextInputColumn extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use Tables\Concerns\InteractsWithTable;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(Post::query())
+            ->columns([
+                Tables\Columns\TextColumn::make('title'),
+                Tables\Columns\TextInputColumn::make('created_at')
+                    ->type('date'),
+            ]);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.table');
+    }
+}
 
 class TestTableWithTextInputColumn extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
 {


### PR DESCRIPTION
## Description

Fixes #15895

Since PR #15340 added `x-on:click.prevent.stop` to the `TextInputColumn` wrapper div, the native browser datepicker no longer opens for `TextInputColumn::make("field")->type("date")` (and other date/time types). The `.prevent` modifier calls `preventDefault()` which blocks the native picker popup.

### Root cause

PR #15340 changed `x-on:click.stop=""` to `x-on:click.prevent.stop` on the input wrapper to prevent stacked column clicks from triggering the row `<a>` link navigation. The `.stop` (stopPropagation) was already sufficient for preventing event bubbling, but `.prevent` (preventDefault) was added as a belt-and-suspenders measure. Unfortunately, `preventDefault()` also blocks native browser pickers (date, time, etc.) from opening.

### Fix

The codebase already handles `color` type inputs with an explicit `showPicker()` onclick handler. This PR extends that pattern to also cover `date`, `datetime-local`, `month`, `time`, and `week` input types, calling `showPicker()` to programmatically open the native picker despite `preventDefault()`.

### Steps to reproduce (before fix)

1. Add `TextInputColumn::make("some_date")->type("date")` to a Filament table
2. Click the calendar icon or input field
3. The native datepicker does not open

### After fix

The native datepicker opens correctly via `showPicker()`.

### Affected types

- `date`
- `datetime-local`
- `month`
- `time`
- `week`

## Visual changes

None (restores expected browser-native behavior).

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.