### PR TITLE
fix: Prevent file loss during parallel multi-file uploads

### DIFF
--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -80,6 +80,8 @@ export default function fileUploadFormComponent({
     uploadUsing,
 }) {
     return {
+        activeUploads: 0,
+
         fileKeyIndex: {},
 
         pond: null,
@@ -200,6 +202,7 @@ export default function fileUploadFormComponent({
                         progress,
                         abort,
                     ) => {
+                        this.activeUploads++
                         this.shouldUpdateState = false
 
                         let fileKey = (
@@ -220,16 +223,34 @@ export default function fileUploadFormComponent({
                             fileKey,
                             file,
                             (fileKey) => {
-                                this.shouldUpdateState = true
+                                this.activeUploads--
+
+                                if (this.activeUploads === 0) {
+                                    this.shouldUpdateState = true
+                                }
 
                                 load(fileKey)
                             },
-                            error,
+                            (errorMessage) => {
+                                this.activeUploads--
+
+                                if (this.activeUploads === 0) {
+                                    this.shouldUpdateState = true
+                                }
+
+                                error(errorMessage)
+                            },
                             progress,
                         )
 
                         return {
                             abort: () => {
+                                this.activeUploads--
+
+                                if (this.activeUploads === 0) {
+                                    this.shouldUpdateState = true
+                                }
+
                                 cancelUploadUsing(fileKey)
                                 abort()
                             },

--- a/tests/js/file-upload-active-uploads.test.mjs
+++ b/tests/js/file-upload-active-uploads.test.mjs
@@ -1,0 +1,180 @@
+/**
+ * Regression test for the activeUploads counter fix.
+ * https://github.com/filamentphp/filament/issues/13306
+ *
+ * Tests the counter logic that prevents shouldUpdateState from being set to
+ * true while parallel uploads are still in flight. Run with: node --test tests/js/
+ *
+ * BEFORE the fix, shouldUpdateState was a simple boolean toggle:
+ *   File A starts -> shouldUpdateState = false
+ *   File B starts -> shouldUpdateState = false (no-op)
+ *   File A done   -> shouldUpdateState = true  <-- VULNERABLE
+ *   [poll re-render fires here, state overwrites, File B lost]
+ *
+ * AFTER the fix, an activeUploads counter gates the flag:
+ *   File A starts -> activeUploads=1, shouldUpdateState = false
+ *   File B starts -> activeUploads=2, shouldUpdateState = false
+ *   File A done   -> activeUploads=1, shouldUpdateState stays false
+ *   [poll re-render fires here, state watcher skips -- safe]
+ *   File B done   -> activeUploads=0, shouldUpdateState = true
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+/**
+ * Minimal simulation of the file-upload component's upload tracking logic.
+ * Extracted from packages/forms/resources/js/components/file-upload.js
+ */
+function createUploadTracker() {
+    return {
+        activeUploads: 0,
+        shouldUpdateState: true,
+
+        startUpload() {
+            this.activeUploads++
+            this.shouldUpdateState = false
+        },
+
+        finishUpload() {
+            this.activeUploads--
+            if (this.activeUploads === 0) {
+                this.shouldUpdateState = true
+            }
+        },
+
+        errorUpload() {
+            this.activeUploads--
+            if (this.activeUploads === 0) {
+                this.shouldUpdateState = true
+            }
+        },
+
+        abortUpload() {
+            this.activeUploads--
+            if (this.activeUploads === 0) {
+                this.shouldUpdateState = true
+            }
+        },
+    }
+}
+
+describe('activeUploads counter', () => {
+    it('should block state updates while any upload is in flight', () => {
+        const tracker = createUploadTracker()
+
+        // Two parallel uploads start
+        tracker.startUpload() // File A
+        tracker.startUpload() // File B
+
+        assert.equal(tracker.activeUploads, 2)
+        assert.equal(tracker.shouldUpdateState, false)
+
+        // File A completes -- state should still be locked
+        tracker.finishUpload()
+        assert.equal(tracker.activeUploads, 1)
+        assert.equal(
+            tracker.shouldUpdateState,
+            false,
+            'shouldUpdateState must remain false while File B is still uploading',
+        )
+
+        // File B completes -- now state can update
+        tracker.finishUpload()
+        assert.equal(tracker.activeUploads, 0)
+        assert.equal(tracker.shouldUpdateState, true)
+    })
+
+    it('should handle error during parallel upload without unblocking prematurely', () => {
+        const tracker = createUploadTracker()
+
+        tracker.startUpload() // File A
+        tracker.startUpload() // File B
+        tracker.startUpload() // File C
+
+        // File B errors out
+        tracker.errorUpload()
+        assert.equal(tracker.activeUploads, 2)
+        assert.equal(
+            tracker.shouldUpdateState,
+            false,
+            'shouldUpdateState must remain false -- Files A and C still in flight',
+        )
+
+        // File A completes
+        tracker.finishUpload()
+        assert.equal(tracker.activeUploads, 1)
+        assert.equal(tracker.shouldUpdateState, false)
+
+        // File C completes
+        tracker.finishUpload()
+        assert.equal(tracker.activeUploads, 0)
+        assert.equal(tracker.shouldUpdateState, true)
+    })
+
+    it('should handle abort during parallel upload without unblocking prematurely', () => {
+        const tracker = createUploadTracker()
+
+        tracker.startUpload() // File A
+        tracker.startUpload() // File B
+
+        // File A is aborted by user
+        tracker.abortUpload()
+        assert.equal(tracker.activeUploads, 1)
+        assert.equal(
+            tracker.shouldUpdateState,
+            false,
+            'shouldUpdateState must remain false -- File B still in flight',
+        )
+
+        // File B completes
+        tracker.finishUpload()
+        assert.equal(tracker.activeUploads, 0)
+        assert.equal(tracker.shouldUpdateState, true)
+    })
+
+    it('should allow state updates for single file upload (no regression)', () => {
+        const tracker = createUploadTracker()
+
+        tracker.startUpload()
+        assert.equal(tracker.shouldUpdateState, false)
+
+        tracker.finishUpload()
+        assert.equal(tracker.shouldUpdateState, true)
+    })
+
+    it('should simulate the exact race condition scenario from issue #13306', () => {
+        const tracker = createUploadTracker()
+
+        // User drops 3 files, maxParallelUploads = 2
+        tracker.startUpload() // File A starts
+        tracker.startUpload() // File B starts
+
+        // File A completes
+        tracker.finishUpload()
+
+        // THIS is the race condition window: a Livewire poll fires here.
+        // BEFORE the fix: shouldUpdateState would be true, and the poll
+        // would overwrite FilePond state, dropping File B.
+        // AFTER the fix: shouldUpdateState is still false because
+        // activeUploads > 0.
+        assert.equal(
+            tracker.shouldUpdateState,
+            false,
+            'Poll fires after File A completes but File B is still uploading -- state must NOT update',
+        )
+
+        // File C starts (was queued behind maxParallelUploads)
+        tracker.startUpload()
+        assert.equal(tracker.activeUploads, 2)
+
+        // File B completes
+        tracker.finishUpload()
+        assert.equal(tracker.shouldUpdateState, false)
+
+        // File C completes -- all done
+        tracker.finishUpload()
+        assert.equal(tracker.activeUploads, 0)
+        assert.equal(tracker.shouldUpdateState, true)
+    })
+})

--- a/tests/src/Forms/Components/FileUploadTest.php
+++ b/tests/src/Forms/Components/FileUploadTest.php
@@ -275,6 +275,114 @@ describe('validation', function (): void {
     });
 });
 
+describe('parallel uploads', function (): void {
+    // Regression test for https://github.com/filamentphp/filament/issues/13306
+    //
+    // The core race condition is in the JS Alpine component: when multiple files
+    // upload in parallel with ->poll() active, shouldUpdateState was reset to true
+    // after the first file completed, allowing a poll-triggered re-render to
+    // overwrite FilePond state and drop in-flight uploads.
+    //
+    // The fix introduces an activeUploads counter so shouldUpdateState only becomes
+    // true when ALL uploads finish. These PHP tests validate the server-side contract
+    // that multiple files persist in state. The JS counter logic is tested separately
+    // in tests/js/file-upload-active-uploads.test.mjs.
+
+    it('retains all files when multiple files are uploaded to a multiple() FileUpload', function (): void {
+        try {
+            livewire(TestComponentWithParallelFileUpload::class)
+                ->fillForm([
+                    'attachments' => [
+                        UploadedFile::fake()->image('photo1.jpg'),
+                        UploadedFile::fake()->image('photo2.jpg'),
+                        UploadedFile::fake()->image('photo3.jpg'),
+                    ],
+                ])
+                ->assertSchemaStateSet(function (array $data): void {
+                    expect($data['attachments'])->toHaveCount(3)
+                        ->and($data['attachments'][0])->toBeInstanceOf(TemporaryUploadedFile::class)
+                        ->and($data['attachments'][1])->toBeInstanceOf(TemporaryUploadedFile::class)
+                        ->and($data['attachments'][2])->toBeInstanceOf(TemporaryUploadedFile::class);
+                });
+        } catch (RootTagMissingFromViewException $exception) {
+            // Flaky test
+        }
+    });
+
+    it('retains all files after sequential fillForm calls simulating incremental upload completions', function (): void {
+        try {
+            $component = livewire(TestComponentWithParallelFileUpload::class)
+                ->fillForm([
+                    'attachments' => [
+                        UploadedFile::fake()->image('batch1.jpg'),
+                    ],
+                ]);
+
+            // Simulate a second batch arriving (as if another upload completed)
+            $component->fillForm([
+                'attachments' => [
+                    UploadedFile::fake()->image('batch1.jpg'),
+                    UploadedFile::fake()->image('batch2.jpg'),
+                ],
+            ]);
+
+            $component->assertSchemaStateSet(function (array $data): void {
+                expect($data['attachments'])->toHaveCount(2)
+                    ->and($data['attachments'][0])->toBeInstanceOf(TemporaryUploadedFile::class)
+                    ->and($data['attachments'][1])->toBeInstanceOf(TemporaryUploadedFile::class);
+            });
+        } catch (RootTagMissingFromViewException $exception) {
+            // Flaky test
+        }
+    });
+
+    it('validates and saves all files from a parallel multiple upload', function (): void {
+        livewire(TestComponentWithParallelFileUploadAndSave::class)
+            ->fillForm([
+                'attachments' => [
+                    UploadedFile::fake()->image('save1.jpg'),
+                    UploadedFile::fake()->image('save2.jpg'),
+                    UploadedFile::fake()->image('save3.jpg'),
+                ],
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors(['attachments']);
+    });
+});
+
+class TestComponentWithParallelFileUpload extends Livewire
+{
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->components([
+                FileUpload::make('attachments')
+                    ->multiple()
+                    ->maxParallelUploads(2),
+            ])
+            ->statePath('data');
+    }
+}
+
+class TestComponentWithParallelFileUploadAndSave extends Livewire
+{
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->components([
+                FileUpload::make('attachments')
+                    ->multiple()
+                    ->maxParallelUploads(2),
+            ])
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->form->getState();
+    }
+}
+
 class TestComponentWithFileUpload extends Livewire
 {
     public function form(Schema $form): Schema


### PR DESCRIPTION
## Description

Fixes #13306

When uploading multiple files via `FileUpload::make()->multiple()`, some files go missing. This is a race condition in the `shouldUpdateState` flag management during parallel uploads.

### Root cause

The `shouldUpdateState` flag is set to `false` when a file upload starts, and back to `true` when it completes. With `maxParallelUploads` defaulting to 2, this creates a race condition:

1. File A starts uploading -> `shouldUpdateState = false`
2. File B starts uploading -> `shouldUpdateState` already `false`
3. File A finishes -> `shouldUpdateState = true`
4. A Livewire poll or re-render triggers the `$watch("state")` handler
5. Since `shouldUpdateState` is now `true`, the handler overwrites the FilePond file list with server state
6. File B (still uploading) is lost

This explains why `->maxParallelUploads(1)` was reported as a workaround (serializes uploads, no race), and why `->poll()` on a relation manager exacerbates the issue (more frequent re-renders during the vulnerability window).

### Fix

Introduces an `activeUploads` counter that tracks the number of concurrent in-flight uploads. The `shouldUpdateState` flag is only re-enabled when the counter reaches zero (all uploads complete). This covers success, error, and abort paths.

### Before (race condition)
```
File A start -> shouldUpdateState = false
File B start -> shouldUpdateState = false (no-op)
File A done  -> shouldUpdateState = true  <-- VULNERABLE
[poll fires, state overwrites, File B lost]
File B done  -> shouldUpdateState = true
```

### After (fixed)
```
File A start -> activeUploads = 1, shouldUpdateState = false
File B start -> activeUploads = 2, shouldUpdateState = false
File A done  -> activeUploads = 1, shouldUpdateState stays false
[poll fires, state watcher skips update - safe]
File B done  -> activeUploads = 0, shouldUpdateState = true
```

### Regression tests

**PHP tests** (`tests/src/Forms/Components/FileUploadTest.php`):
- Validates that all files persist in state when uploading multiple files to a `->multiple()` FileUpload
- Tests sequential `fillForm` calls simulating incremental upload completions
- Verifies save works correctly with parallel multiple uploads

**JS tests** (`tests/js/file-upload-active-uploads.test.mjs`):
- Directly tests the `activeUploads` counter logic extracted from the Alpine component
- Validates that `shouldUpdateState` stays `false` while any upload is in flight
- Covers success, error, and abort code paths
- Simulates the exact #13306 scenario: poll fires after first file completes but before second finishes
- Zero dependencies, runs with `node --test tests/js/`

## Visual changes

None.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Regression tests added for the race condition fix.
- [ ] Documentation is up-to-date.
