### PR TITLE
fix: grid table border not highlighting on hover/select in dark mode

### DIFF
--- a/packages/tables/resources/css/content.css
+++ b/packages/tables/resources/css/content.css
@@ -43,16 +43,16 @@
             & .fi-ta-record {
                 @apply rounded-xl shadow-sm ring-1 ring-gray-950/5 dark:bg-white/5 dark:ring-white/10;
 
+                &:not(.fi-selected) {
+                    @apply bg-white;
+                }
+
                 &.fi-clickable {
-                    @apply dark:hover:bg-white/10 dark:hover:ring-white/20;
+                    @apply hover:bg-gray-50 dark:hover:bg-white/10 dark:hover:ring-white/20;
                 }
 
                 &.fi-selected {
-                    @apply dark:bg-white/10 dark:ring-white/20;
-                }
-
-                &:not(.fi-selected) {
-                    @apply bg-white dark:bg-white/5 dark:ring-white/10;
+                    @apply bg-gray-50 dark:bg-white/10 dark:ring-white/20;
                 }
 
                 &.fi-ta-record-with-content-prefix {


### PR DESCRIPTION
## Problem

Grid table cards in dark mode do not show visual feedback on hover or when selected. The border (ring) and background remain unchanged during interaction, unlike standard table rows.

## Root Cause

In `packages/tables/resources/css/content.css`, the `:not(.fi-selected)` rule was placed after `.fi-clickable` and `.fi-selected` rules in the CSS cascade. Since it had equal or higher specificity and came later, its dark mode values (`dark:bg-white/5` and `dark:ring-white/10`) overrode the hover (`dark:hover:bg-white/10`, `dark:hover:ring-white/20`) and selected (`dark:bg-white/10`, `dark:ring-white/20`) states.

## Fix

1. Moved `:not(.fi-selected)` before the hover and selected rules so it no longer overrides them in the cascade
2. Removed the redundant dark mode values from `:not(.fi-selected)` since the base `.fi-ta-record` rule already sets `dark:bg-white/5` and `dark:ring-white/10`
3. Added light mode hover (`hover:bg-gray-50`) and selected (`bg-gray-50`) states for grid cards, matching the behavior of standard table rows (`.fi-ta-row`)

## Before / After

**Before:** Grid table cards remain visually static in dark mode on hover and select.
**After:** Grid cards show the same visual feedback as standard table rows in both light and dark mode.

Fixes #7784