### PR TITLE
fix: reinitialize charts when container becomes visible

### DIFF
--- a/packages/widgets/resources/js/components/chart.js
+++ b/packages/widgets/resources/js/components/chart.js
@@ -21,16 +21,47 @@ export default function chart({ cachedData, maxHeight, options, type }) {
             this.initChart()
 
             this.$wire.$on('updateChartData', ({ data }) => {
+                cachedData = data
+
                 const chart = this.getChart()
 
                 if (!chart) {
+                    // Chart may not exist yet if the container was hidden
+                    // when updateChartData fired. It will be initialized
+                    // when the container becomes visible via the
+                    // IntersectionObserver below.
                     return
                 }
 
-                cachedData = data
                 chart.data = data
                 chart.update('resize')
             })
+
+            // Reinitialize the chart when its container becomes visible.
+            // Chart.js cannot render correctly in hidden containers (e.g.
+            // non-active tabs) because the canvas has zero dimensions.
+            this.intersectionObserver = new IntersectionObserver(
+                (entries) => {
+                    for (const entry of entries) {
+                        if (!entry.isIntersecting) {
+                            continue
+                        }
+
+                        const chart = this.getChart()
+
+                        if (chart) {
+                            // Chart exists but may have stale dimensions
+                            chart.resize()
+                        } else {
+                            // Chart was never initialized (container was
+                            // hidden on mount), initialize it now
+                            this.initChart()
+                        }
+                    }
+                },
+                { threshold: 0.1 },
+            )
+            this.intersectionObserver.observe(this.$el)
 
             Alpine.effect(() => {
                 Alpine.store('theme')
@@ -181,6 +212,10 @@ export default function chart({ cachedData, maxHeight, options, type }) {
 
             if (this.resizeObserver) {
                 this.resizeObserver.disconnect()
+            }
+
+            if (this.intersectionObserver) {
+                this.intersectionObserver.disconnect()
             }
 
             this.getChart()?.destroy()


### PR DESCRIPTION
## Problem

Charts placed in non-active tabs or hidden containers do not render correctly. When the tab containing a chart becomes active, the chart is either empty or has incorrect dimensions. Data updates sent while the chart is in a hidden tab are also lost.

## Root Cause

Chart.js relies on the canvas element's computed dimensions to render. When a chart is in a non-active tab (typically `display: none` or zero-height container), the canvas has zero dimensions. This causes:

1. Charts initialized while hidden render with zero width/height
2. `chart.update('resize')` called while hidden has no visible effect
3. When the tab becomes active, the chart is not re-rendered

## Fix

Added an `IntersectionObserver` to the chart Alpine component that:

1. Detects when the chart container enters the viewport (becomes visible)
2. If the chart instance exists but was updated while hidden, calls `chart.resize()` to recalculate dimensions
3. If the chart was never initialized (container was hidden at mount time), calls `initChart()` to create it with correct dimensions

Also updated the `updateChartData` handler to gracefully handle the case where the chart instance doesn't exist yet (deferred initialization), storing the data in `cachedData` so it's available when the chart is eventually initialized.

The observer is cleaned up in the `destroy()` method alongside the existing `ResizeObserver`.

## Steps to Reproduce

1. Place a chart widget inside a non-active tab
2. Load the page
3. Switch to the tab containing the chart
4. Chart is either empty or has wrong dimensions

## After Fix

1. Chart initializes correctly when its tab becomes active
2. Data updates received while the chart is hidden are applied when the tab becomes active

Fixes #16599