### PR TITLE
fix: markdown editor not clearing after keybinding form submit

### DIFF
--- a/packages/forms/resources/js/components/markdown-editor.js
+++ b/packages/forms/resources/js/components/markdown-editor.js
@@ -211,11 +211,18 @@ export default function markdownEditorFormComponent({
                     return
                 }
 
-                if (this.editor.codemirror.hasFocus()) {
+                const newValue = this.state ?? ''
+
+                // Only update the editor when the value has actually
+                // changed. This prevents cursor jumps during debounced
+                // typing while still allowing external state changes
+                // (e.g. form reset after keybinding submit) to update
+                // the editor content.
+                if (Alpine.raw(this.editor).value() === newValue) {
                     return
                 }
 
-                Alpine.raw(this.editor).value(this.state ?? '')
+                Alpine.raw(this.editor).value(newValue)
             })
 
             if (setUpUsing) {


### PR DESCRIPTION
## Problem

When a form containing a Markdown Editor is submitted via a key binding (e.g. `Ctrl+Enter`), the editor content is not cleared even though Livewire resets the form state. Clicking the submit button works correctly.

## Root Cause

The Markdown Editor component watches the Alpine `state` property for changes and updates the CodeMirror editor content. However, the watcher had a `hasFocus()` guard:

```js
this.$watch('state', () => {
    if (this.editor.codemirror.hasFocus()) {
        return  // <-- short-circuits when editor has focus
    }
    Alpine.raw(this.editor).value(this.state ?? '')
})
```

When submitting via mouse click, the editor loses focus (blur fires first), so the watcher runs normally. When submitting via key binding, the editor retains focus, and the watcher short-circuits. When Livewire resets the form state to empty, the editor content stays unchanged.

## Fix

Replaced the `hasFocus()` check with a value comparison:

```js
const newValue = this.state ?? ''
if (Alpine.raw(this.editor).value() === newValue) {
    return
}
Alpine.raw(this.editor).value(newValue)
```

This allows:
- External state changes (form reset, Livewire updates) to propagate to the editor regardless of focus state
- No cursor jumps during user typing, because the debounced state update sets the same value the editor already contains

## Steps to Reproduce

1. Create a form with a MarkdownEditor field and a key binding submit action
2. Type content into the editor
3. Press the key binding (e.g. `Ctrl+Enter`) to submit
4. Observe: editor content remains (should be cleared)

## After Fix

Editor content clears correctly regardless of whether the form is submitted via mouse click or key binding.

Fixes #12858