### PR TITLE
fix: Select `reorderable()` closure not re-evaluating on live update

### DIFF
--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -189,6 +189,7 @@
                 wire:key="{{ $livewireKey }}.{{
                     substr(md5(serialize([
                         $isDisabled,
+                        $isReorderable,
                     ])), 0, 64)
                 }}"
                 x-on:keydown.esc="select.dropdown.isActive && $event.stopPropagation()"


### PR DESCRIPTION

## Description
### Fixes: #19410

## Visual changes




### Before


https://github.com/user-attachments/assets/4f82a56e-f0dc-499a-8e62-9ce533732fb0

### After

https://github.com/user-attachments/assets/b966ca7c-f2f4-4c05-a526-c4834d6b9787




## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
