### PR TITLE
Allow customizing the default loading indicator SVG

### DIFF
--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -206,7 +206,7 @@ if (! function_exists('Filament\Support\generate_loading_indicator_html')) {
             "fi-size-{$size->value}",
         ]);
 
-        return new HtmlString(<<<HTML
+     $defaultSvg = <<<HTML
             <svg
                 fill="none"
                 viewBox="0 0 24 24"
@@ -225,7 +225,15 @@ if (! function_exists('Filament\Support\generate_loading_indicator_html')) {
                     fill="currentColor"
                 ></path>
             </svg>
-            HTML);
+            HTML;
+
+        $svg = config('filament.loading_indicator_svg');
+
+        if (is_callable($svg)) {
+            return new HtmlString($svg($attributes));
+        }
+
+        return new HtmlString($svg ?? $defaultSvg);
     }
 }
 


### PR DESCRIPTION
Refactor loading indicator SVG handling to use a default SVG and allow for custom SVG configuration.

## Description
Currently, `generate_loading_indicator_html()` in `helpers.php` has a hardcoded 
SVG with no way to customize it without modifying vendor files directly.

This PR allows users to provide a custom loading indicator SVG via the 
`filament.loading_indicator_svg` config key.

Accepts:
- A **callable** that receives a `ComponentAttributeBag` and returns a string
  (ensures attributes like CSS classes are correctly applied)

## Visual changes

**Config (default):**
<img width="637" height="769" alt="Screenshot 2026-03-04 180250" src="https://github.com/user-attachments/assets/a1b8292a-84b4-4a0e-b298-060468243096" />

**Svg (default):**
<img width="394" height="55" alt="Screenshot 2026-03-04 180339" src="https://github.com/user-attachments/assets/906fee76-495e-4464-bc3b-795125728f36" />

**Config (Custom svg):**
<img width="621" height="758" alt="Screenshot 2026-03-04 180402" src="https://github.com/user-attachments/assets/e4cbde89-639f-48cf-8d2a-f008f71ada60" />

**Svg(custom Lucide loader):**
<img width="399" height="54" alt="Screenshot 2026-03-04 180421" src="https://github.com/user-attachments/assets/37d756ca-081d-44b4-b21c-64e0b9a24037" />

## Functional changes
- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.