### PR TITLE
Added loading indicator SVG configuration

### DIFF
--- a/packages/support/config/filament.php
+++ b/packages/support/config/filament.php
@@ -117,4 +117,16 @@ return [
 
     'system_route_prefix' => 'filament',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Loading Indicator SVG
+    |--------------------------------------------------------------------------
+    | Customize the loading indicator SVG by providing a string or a callable
+    | that receives a ComponentAttributeBag and returns an SVG string.
+    |
+    */
+    
+    // 'loading_indicator_svg' => function (ComponentAttributeBag $attributes): string {
+    //     return "<svg {$attributes->toHtml()} ...</svg>";
+    // },
 ];


### PR DESCRIPTION
## Description
Added a commented-out `loading_indicator_svg` config option to `filament.php` 
so users know the customization option exists.

## Visual changes
No visual changes.

## Functional changes
- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.