### PR TITLE
feat: isolate dark mode preference per panel using prefixed localStorage key

### DIFF
--- a/packages/panels/resources/js/dark-mode.js
+++ b/packages/panels/resources/js/dark-mode.js
@@ -1,5 +1,13 @@
 document.addEventListener('alpine:init', () => {
+    const panelId = getComputedStyle(document.documentElement)
+        .getPropertyValue('--panel-id')
+        .trim()
+        .replace(/['"]/g, '')
+
+    const storageKey = panelId ? `theme-${panelId}` : 'theme'
+
     const theme =
+        localStorage.getItem(storageKey) ??
         localStorage.getItem('theme') ??
         getComputedStyle(document.documentElement).getPropertyValue(
             '--default-theme-mode',
@@ -17,7 +25,7 @@ document.addEventListener('alpine:init', () => {
     window.addEventListener('theme-changed', (event) => {
         let theme = event.detail
 
-        localStorage.setItem('theme', theme)
+        localStorage.setItem(storageKey, theme)
 
         if (theme === 'system') {
             theme = window.matchMedia('(prefers-color-scheme: dark)').matches
@@ -31,7 +39,7 @@ document.addEventListener('alpine:init', () => {
     window
         .matchMedia('(prefers-color-scheme: dark)')
         .addEventListener('change', (event) => {
-            if (localStorage.getItem('theme') === 'system') {
+            if (localStorage.getItem(storageKey) === 'system') {
                 window.Alpine.store('theme', event.matches ? 'dark' : 'light')
             }
         })

--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -81,6 +81,7 @@
                 --sidebar-width: {{ filament()->getSidebarWidth() }};
                 --collapsed-sidebar-width: {{ filament()->getCollapsedSidebarWidth() }};
                 --default-theme-mode: {{ filament()->getDefaultThemeMode()->value }};
+                --panel-id: '{{ filament()->getId() }}';
             }
         </style>
 
@@ -90,16 +91,16 @@
 
         @if (! filament()->hasDarkMode())
             <script>
-                localStorage.setItem('theme', 'light')
+                localStorage.setItem('theme-{{ filament()->getId() }}', 'light')
             </script>
         @elseif (filament()->hasDarkModeForced())
             <script>
-                localStorage.setItem('theme', 'dark')
+                localStorage.setItem('theme-{{ filament()->getId() }}', 'dark')
             </script>
         @else
             <script>
                 const loadDarkMode = () => {
-                    window.theme = localStorage.getItem('theme') ?? @js(filament()->getDefaultThemeMode()->value)
+                    window.theme = localStorage.getItem('theme-{{ filament()->getId() }}') ?? localStorage.getItem('theme') ?? @js(filament()->getDefaultThemeMode()->value)
 
                     if (
                         window.theme === 'dark' ||

--- a/packages/panels/resources/views/components/theme-switcher/index.blade.php
+++ b/packages/panels/resources/views/components/theme-switcher/index.blade.php
@@ -1,11 +1,11 @@
 <div
-    x-data="{ theme: null }"
+    x-data="{ theme: null, storageKey: 'theme-{{ filament()->getId() }}' }"
     x-init="
         $watch('theme', () => {
             $dispatch('theme-changed', theme)
         })
 
-        theme = localStorage.getItem('theme') || @js(filament()->getDefaultThemeMode()->value)
+        theme = localStorage.getItem(storageKey) || localStorage.getItem('theme') || @js(filament()->getDefaultThemeMode()->value)
     "
     class="fi-theme-switcher"
 >


### PR DESCRIPTION
### Summary                                                   
																																																								 
- Prefix the localStorage theme key with the panel ID (theme-{panelId}) so each panel stores its dark mode preference independently
- When a project has multiple panels (e.g. admin and app) with different dark mode settings, changing the theme in one panel no longer overwrites the other
- Backwards compatible: reads from the legacy theme key as fallback, so existing users keep their preference after updating

### Problem

When a Laravel project has multiple Filament panels (e.g. admin with dark mode enabled and app with dark mode disabled), they all share a single localStorage key 'theme'. Navigating between panels causes one to overwrite the
other's preference, resulting in a broken dark mode experience.

### Solution

Each panel now uses theme-{panelId} as its localStorage key (e.g. theme-admin, theme-app). This is implemented across three files:

- base.blade.php: Exposes the panel ID via a --panel-id CSS custom property and prefixes all inline localStorage calls
- dark-mode.js: Reads --panel-id from CSS and uses it to build the storage key for all Alpine store operations
- theme-switcher/index.blade.php: Uses the prefixed key in x-data/x-init

All read operations include a fallback to the legacy 'theme' key, ensuring users who upgrade don't lose their existing preference.

### Test plan

- Create two panels (e.g. admin with ->darkMode() and app with ->darkMode(false))
- Verify switching theme in admin does not affect app
- Verify app always stays in light mode
- Verify a user with an existing theme key in localStorage (pre-update) has their preference migrated seamlessly
- Inspect localStorage and confirm keys are theme-admin / theme-app