### PR TITLE
fix(forms): update missing Turkish (tr) translations in components.php

### DIFF
--- a/packages/forms/resources/lang/tr/components.php
+++ b/packages/forms/resources/lang/tr/components.php
@@ -562,7 +562,18 @@ return [
 
         ],
 
+        'file_attachments_accepted_file_types_message' => 'Yüklenen dosyalar şu türlerden olmalıdır: :values.',
+
+        'file_attachments_max_size_message' => 'Yüklenen dosyalar :max kilobayttan büyük olmamalıdır.',
+
         'no_merge_tag_search_results_message' => 'Uygun birleşme etiketi bulunamadı.',
+
+        'mentions' => [
+            'no_options_message' => 'Seçenek bulunamadı.',
+            'no_search_results_message' => 'Aramanızla eşleşen sonuç bulunamadı.',
+            'search_prompt' => 'Aramak için yazmaya başlayın...',
+            'searching_message' => 'Aranıyor...',
+        ],
 
         'tools' => [
             'align_center' => 'Ortaya hizala',
@@ -611,6 +622,8 @@ return [
             'underline' => 'Altı çizili',
             'undo' => 'Geri al',
         ],
+
+        'uploading_file_message' => 'Dosya yükleniyor...',
 
     ],
 
@@ -673,6 +686,8 @@ return [
 
         'max_items_message' => 'Sadece :count adet seçilebilir.',
 
+        'no_options_message' => 'Seçenek bulunamadı.',
+
         'no_search_results_message' => 'Arama kriterlerinize uyan seçenek yok.',
 
         'placeholder' => 'Bir seçenek seçin',
@@ -684,7 +699,17 @@ return [
     ],
 
     'tags_input' => [
+
+        'actions' => [
+
+            'delete' => [
+                'label' => 'Sil',
+            ],
+
+        ],
+
         'placeholder' => 'Yeni etiket',
+
     ],
 
     'text_input' => [

--- a/translators.csv
+++ b/translators.csv
@@ -51,3 +51,4 @@ sv;     ;maurelius7390;496175168431849482
 sw;     ;ngaiza_287;817131592350302208
 pl;webard;webard;1387370568445202454
 lt;donatiss;donatis07;883253450207543327
+tr;iamcanturk;;


### PR DESCRIPTION
## Description

This PR updates missing Turkish (tr) translation keys in the forms package 
to improve localization consistency and prevent untranslated strings 
from appearing in the UI.

## Visual changes

None

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.