### PR TITLE
feat: Add afterCreateUsing callback to Repeater for relationship items

### DIFF
--- a/packages/forms/docs/12-repeater.md
+++ b/packages/forms/docs/12-repeater.md
@@ -439,6 +439,28 @@ Repeater::make('qualifications')
 
 <UtilityInjection set="formFields" version="4.x" extras="Data;;array<string, mixed>;;$data;;The data that is being saved by the repeater.">You can inject various utilities into the function passed to `mutateRelationshipDataBeforeSaveUsing()` as parameters.</UtilityInjection>
 
+### Running code after creating a related item
+
+You may run code after a new related item is created in the database using the `afterCreateUsing()` method. This method accepts a closure that receives the current item's data in a `$data` variable and the newly created record in a `$record` variable. This is useful when you need the record's ID to perform additional operations, such as attaching pivot data:
+
+```php
+use Filament\Forms\Components\Repeater;
+use Illuminate\Database\Eloquent\Model;
+
+Repeater::make('variants')
+    ->relationship()
+    ->schema([
+        // ...
+    ])
+    ->afterCreateUsing(function (array $data, Model $record): void {
+        if (isset($data['attributes'])) {
+            $record->attributes()->attach($data['attributes']);
+        }
+    })
+```
+
+<UtilityInjection set="formFields" version="5.x" extras="Data;;array<string, mixed>;;$data;;The data that was used to create the record.||Record;;Illuminate\Database\Eloquent\Model;;$record;;The newly created record.">You can inject various utilities into the function passed to `afterCreateUsing()` as parameters.</UtilityInjection>
+
 ### Modifying related records after retrieval
 
 You may filter or modify the related records of a repeater after they are retrieved from the database using the `modifyRecordsUsing` argument. This method accepts a function that receives a `Collection` of related records. You should return the modified collection.

--- a/packages/forms/docs/12-repeater.md
+++ b/packages/forms/docs/12-repeater.md
@@ -441,7 +441,7 @@ Repeater::make('qualifications')
 
 ### Running code after creating a related item
 
-You may run code after a new related item is created in the database using the `afterCreateUsing()` method. This method accepts a closure that receives the current item's data in a `$data` variable and the newly created record in a `$record` variable. This is useful when you need the record's ID to perform additional operations, such as attaching pivot data:
+You may run code after a new related item is created in the database using the `afterCreate()` method. This method accepts a closure that receives the current item's data in a `$data` variable and the newly created record in a `$record` variable. This is useful when you need the record's ID to perform additional operations, such as attaching pivot data:
 
 ```php
 use Filament\Forms\Components\Repeater;
@@ -452,14 +452,57 @@ Repeater::make('variants')
     ->schema([
         // ...
     ])
-    ->afterCreateUsing(function (array $data, Model $record): void {
+    ->afterCreate(function (array $data, Model $record): void {
         if (isset($data['attributes'])) {
             $record->attributes()->attach($data['attributes']);
         }
     })
 ```
 
-<UtilityInjection set="formFields" version="5.x" extras="Data;;array<string, mixed>;;$data;;The data that was used to create the record.||Record;;Illuminate\Database\Eloquent\Model;;$record;;The newly created record.">You can inject various utilities into the function passed to `afterCreateUsing()` as parameters.</UtilityInjection>
+<UtilityInjection set="formFields" version="4.x" extras="Data;;array<string, mixed>;;$data;;The data that was used to create the record.||Record;;Illuminate\Database\Eloquent\Model;;$record;;The newly created record.">You can inject various utilities into the function passed to `afterCreate()` as parameters.</UtilityInjection>
+
+### Running code after updating a related item
+
+You may run code after an existing related item is updated in the database using the `afterUpdate()` method. This method accepts a closure that receives the current item's data in a `$data` variable and the updated record in a `$record` variable:
+
+```php
+use Filament\Forms\Components\Repeater;
+use Illuminate\Database\Eloquent\Model;
+
+Repeater::make('variants')
+    ->relationship()
+    ->schema([
+        // ...
+    ])
+    ->afterUpdate(function (array $data, Model $record): void {
+        if (isset($data['attributes'])) {
+            $record->attributes()->sync($data['attributes']);
+        }
+    })
+```
+
+<UtilityInjection set="formFields" version="4.x" extras="Data;;array<string, mixed>;;$data;;The data that was used to update the record.||Record;;Illuminate\Database\Eloquent\Model;;$record;;The updated record.">You can inject various utilities into the function passed to `afterUpdate()` as parameters.</UtilityInjection>
+
+### Running code after deleting a related item
+
+You may run code after a related item is deleted from the database using the `afterDelete()` method. This method accepts a closure that receives the record that was just deleted in a `$record` variable. The record will no longer exist in the database at this point, but you can still access its attributes, such as its ID:
+
+```php
+use Filament\Forms\Components\Repeater;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Storage;
+
+Repeater::make('attachments')
+    ->relationship()
+    ->schema([
+        // ...
+    ])
+    ->afterDelete(function (Model $record): void {
+        Storage::delete($record->file_path);
+    })
+```
+
+<UtilityInjection set="formFields" version="4.x" extras="Record;;Illuminate\Database\Eloquent\Model;;$record;;The record that was just deleted.">You can inject various utilities into the function passed to `afterDelete()` as parameters.</UtilityInjection>
 
 ### Modifying related records after retrieval
 

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -102,7 +102,11 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
 
     protected ?Closure $mutateRelationshipDataBeforeSaveUsing = null;
 
-    protected ?Closure $afterCreateUsing = null;
+    protected ?Closure $afterCreate = null;
+
+    protected ?Closure $afterUpdate = null;
+
+    protected ?Closure $afterDelete = null;
 
     /**
      * @var array<string, mixed> | null
@@ -958,7 +962,10 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
                 $relationship
                     ->whereKey($recordsToDelete)
                     ->get()
-                    ->each(static fn (Model $record) => $record->delete());
+                    ->each(static function (Model $record) use ($component): void {
+                        $record->delete();
+                        $component->callAfterDelete($record);
+                    });
             }
 
             $itemOrder = 1;
@@ -986,6 +993,8 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
                         $translatableContentDriver->updateRecord($record, $itemData) :
                         $record->fill($itemData)->save();
 
+                    $component->callAfterUpdate($itemData, $record);
+
                     continue;
                 }
 
@@ -1005,8 +1014,8 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
                 }
 
                 $record = $relationship->save($record);
-                $component->afterCreate($itemData, $record);
                 $item->model($record)->saveRelationships();
+                $component->callAfterCreate($itemData, $record);
                 $existingRecords->push($record);
             }
 
@@ -1356,20 +1365,73 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         return $data;
     }
 
-    public function afterCreateUsing(?Closure $callback): static
+    public function afterCreate(?Closure $callback): static
     {
-        $this->afterCreateUsing = $callback;
+        $this->afterCreate = $callback;
 
         return $this;
     }
 
-    public function afterCreate(array $data, Model $record): void
+    public function afterUpdate(?Closure $callback): static
     {
-        if ($this->afterCreateUsing instanceof Closure) {
+        $this->afterUpdate = $callback;
+
+        return $this;
+    }
+
+    public function afterDelete(?Closure $callback): static
+    {
+        $this->afterDelete = $callback;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    protected function callAfterCreate(array $data, Model $record): void
+    {
+        if ($this->afterCreate instanceof Closure) {
             $this->evaluate(
-                $this->afterCreateUsing,
+                $this->afterCreate,
                 namedInjections: [
                     'data' => $data,
+                    'record' => $record,
+                ],
+                typedInjections: [
+                    Model::class => $record,
+                    $record::class => $record,
+                ],
+            );
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    protected function callAfterUpdate(array $data, Model $record): void
+    {
+        if ($this->afterUpdate instanceof Closure) {
+            $this->evaluate(
+                $this->afterUpdate,
+                namedInjections: [
+                    'data' => $data,
+                    'record' => $record,
+                ],
+                typedInjections: [
+                    Model::class => $record,
+                    $record::class => $record,
+                ],
+            );
+        }
+    }
+
+    protected function callAfterDelete(Model $record): void
+    {
+        if ($this->afterDelete instanceof Closure) {
+            $this->evaluate(
+                $this->afterDelete,
+                namedInjections: [
                     'record' => $record,
                 ],
                 typedInjections: [

--- a/packages/forms/src/Components/Repeater.php
+++ b/packages/forms/src/Components/Repeater.php
@@ -102,6 +102,8 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
 
     protected ?Closure $mutateRelationshipDataBeforeSaveUsing = null;
 
+    protected ?Closure $afterCreateUsing = null;
+
     /**
      * @var array<string, mixed> | null
      */
@@ -1003,6 +1005,7 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
                 }
 
                 $record = $relationship->save($record);
+                $component->afterCreate($itemData, $record);
                 $item->model($record)->saveRelationships();
                 $existingRecords->push($record);
             }
@@ -1351,6 +1354,30 @@ class Repeater extends Field implements CanConcealComponents, HasExtraItemAction
         }
 
         return $data;
+    }
+
+    public function afterCreateUsing(?Closure $callback): static
+    {
+        $this->afterCreateUsing = $callback;
+
+        return $this;
+    }
+
+    public function afterCreate(array $data, Model $record): void
+    {
+        if ($this->afterCreateUsing instanceof Closure) {
+            $this->evaluate(
+                $this->afterCreateUsing,
+                namedInjections: [
+                    'data' => $data,
+                    'record' => $record,
+                ],
+                typedInjections: [
+                    Model::class => $record,
+                    $record::class => $record,
+                ],
+            );
+        }
     }
 
     public function canConcealComponents(): bool


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

 This PR adds an `afterCreateUsing()` callback to the Repeater component when used with `->relationship()`.

Currently, the Repeater provides callbacks for mutating data before operations: 
- `mutateRelationshipDataBeforeCreateUsing()` 
- `mutateRelationshipDataBeforeSaveUsing()` 
- `mutateRelationshipDataBeforeFillUsing()`

However, there is no way to execute code after a new relationship record is created and saved. This is needed when the record's ID is required to perform additional operations, such as attaching data via a pivot 
table.

The mutateRelationshipDataBeforeCreateUsing() callback cannot solve this because the record doesn't have an ID yet at that point. 

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
