### PR TITLE
Improve: Escape URL in `generate_href_html()` output

### DIFF
--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -133,7 +133,7 @@ if (! function_exists('Filament\Support\generate_href_html')) {
             return new HtmlString('');
         }
 
-        $html = "href=\"{$url}\"";
+        $html = 'href="' . e($url) . '"';
 
         if ($shouldOpenInNewTab) {
             $html .= ' target="_blank"';
@@ -141,7 +141,7 @@ if (! function_exists('Filament\Support\generate_href_html')) {
             if (FilamentView::hasSpaPrefetching()) {
                 $html .= ' wire:navigate.hover';
             } elseif ($hasNestedClickEventHandler) {
-                $html .= ' x-on:click="if (! ($event.altKey || $event.ctrlKey || $event.metaKey || $event.shiftKey)) { $event.preventDefault(); Alpine.navigate(' . "'{$url}'" . ') }"';
+                $html .= ' x-on:click="if (! ($event.altKey || $event.ctrlKey || $event.metaKey || $event.shiftKey)) { $event.preventDefault(); Alpine.navigate($el.getAttribute(\'href\')) }"';
             } else {
                 $html .= ' wire:navigate';
             }

--- a/tests/src/Support/SpaModeTest.php
+++ b/tests/src/Support/SpaModeTest.php
@@ -196,7 +196,7 @@ test('`hasNestedClickEventHandler` forces Alpine navigation when SPA mode is ena
     FilamentView::spa(true, false);
 
     expect(generate_href_html('http://localhost/page', hasNestedClickEventHandler: true))
-        ->toHtml()->toBe('href="http://localhost/page" x-on:click="if (! ($event.altKey || $event.ctrlKey || $event.metaKey || $event.shiftKey)) { $event.preventDefault(); Alpine.navigate(\'http://localhost/page\') }"');
+        ->toHtml()->toBe('href="http://localhost/page" x-on:click="if (! ($event.altKey || $event.ctrlKey || $event.metaKey || $event.shiftKey)) { $event.preventDefault(); Alpine.navigate($el.getAttribute(\'href\')) }"');
 
     expect(generate_href_html('http://localhost/page', hasNestedClickEventHandler: false))
         ->toHtml()->toBe('href="http://localhost/page" wire:navigate');
@@ -236,7 +236,7 @@ test('`hasNestedClickEventHandler` works with `shouldOpenInSpaMode` parameter ov
     FilamentView::spa(false);
 
     expect(generate_href_html('http://localhost/page', shouldOpenInSpaMode: true, hasNestedClickEventHandler: true))
-        ->toHtml()->toBe('href="http://localhost/page" x-on:click="if (! ($event.altKey || $event.ctrlKey || $event.metaKey || $event.shiftKey)) { $event.preventDefault(); Alpine.navigate(\'http://localhost/page\') }"');
+        ->toHtml()->toBe('href="http://localhost/page" x-on:click="if (! ($event.altKey || $event.ctrlKey || $event.metaKey || $event.shiftKey)) { $event.preventDefault(); Alpine.navigate($el.getAttribute(\'href\')) }"');
 
     expect(generate_href_html('http://localhost/page', shouldOpenInSpaMode: true, hasNestedClickEventHandler: false))
         ->toHtml()->toBe('href="http://localhost/page" wire:navigate');


### PR DESCRIPTION


## Description


Improve escaping in generate_href_html output and SPA click handling.

## Visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
