### PR TITLE
Add loading indicator SVG configuration

### DIFF
--- a/packages/support/config/filament.php
+++ b/packages/support/config/filament.php
@@ -117,4 +117,23 @@ return [
 
     'system_route_prefix' => 'filament',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Loading Indicator SVG
+    |--------------------------------------------------------------------------
+    |
+    | Define a custom SVG icon to use as the loading indicator.
+    |
+    | The "__attributes__" placeholder will be automatically replaced
+    | at runtime with dynamic attributes (e.g. class, style, wire:loading).
+    |
+    | Example: <svg __attributes__ xmlns='...' ...> </svg>
+    |           ↑ becomes → <svg wire:loading ...>
+    |
+    | You can swap this for any SVG icon you like.
+    |
+    */
+    
+    'loading_indicator_svg' => ""
+
 ];


### PR DESCRIPTION
Added configuration option for custom loading indicator SVG.

## Description
Previously, the loading indicator SVG was hardcoded and could not be 
customized without modifying the package source. This adds a 
`loading_indicator_svg` key to the config file, allowing users to 
define their own SVG icon for the loading indicator.

The `__attributes__` placeholder is injected into the SVG at runtime, 
so dynamic attributes (e.g. `wire:loading`, `class`) are still applied 
correctly regardless of which SVG is used.

## Visual changes
Before (Default Loader):

<img width="1323" height="765" alt="1" src="https://github.com/user-attachments/assets/612aac74-6063-4932-b263-bf637265b432" />

<img width="394" height="55" alt="Screenshot 2026-03-04 180339" src="https://github.com/user-attachments/assets/ec541a11-0838-4bdb-ba01-352cc5af7a8d" />

After (Lucide Loader):

<img width="1308" height="754" alt="3" src="https://github.com/user-attachments/assets/f1fdc683-8de8-464a-9cdf-1399a8378310" />

<img width="399" height="54" alt="Screenshot 2026-03-04 180421" src="https://github.com/user-attachments/assets/c2b5e39f-565a-46d4-8131-82d8e83c3b04" />

## Functional changes
- [] Code style has been fixed by running the `composer cs` command.
- [] Changes have been tested to not break existing functionality.
- [] Documentation is up-to-date.

