### PR TITLE
fix: Type hint for action in notifcations getActions method 

### DIFF
--- a/packages/notifications/src/Concerns/HasActions.php
+++ b/packages/notifications/src/Concerns/HasActions.php
@@ -31,7 +31,7 @@ trait HasActions
     public function getActions(): array
     {
         return array_map(
-            fn (Action $action) => $action
+            fn (Action|ActionGroup $action) => $action
                 ->defaultView(Action::LINK_VIEW)
                 ->defaultSize(Size::Small),
             Arr::wrap($this->evaluate($this->actions)),


### PR DESCRIPTION
Notifications `getActions()` method expects the evaluated `actions` to contain `ActionGroup` but the `array_map` function type hint isn't, which causes an error.