### PR TITLE
fix: handle action groups in notifications properly

### DIFF
--- a/packages/actions/src/ActionGroup.php
+++ b/packages/actions/src/ActionGroup.php
@@ -319,7 +319,7 @@ class ActionGroup extends ViewComponent implements Arrayable, HasEmbeddedView
             'size' => $this->getSize(),
             'tooltip' => $this->getTooltip(),
             'triggerView' => $this->getTriggerView(),
-            'view' => $this->getView(),
+            'view' => $this->hasView() ? $this->getView() : null,
         ];
     }
 

--- a/packages/notifications/src/Concerns/HasActions.php
+++ b/packages/notifications/src/Concerns/HasActions.php
@@ -31,7 +31,7 @@ trait HasActions
     public function getActions(): array
     {
         return array_map(
-            fn (Action $action) => $action
+            fn (Action|ActionGroup $action) => $action
                 ->defaultView(Action::LINK_VIEW)
                 ->defaultSize(Size::Small),
             Arr::wrap($this->evaluate($this->actions)),

--- a/packages/notifications/src/Concerns/HasActions.php
+++ b/packages/notifications/src/Concerns/HasActions.php
@@ -31,9 +31,10 @@ trait HasActions
     public function getActions(): array
     {
         return array_map(
-            fn (Action|ActionGroup $action) => $action
-                ->defaultView(Action::LINK_VIEW)
-                ->defaultSize(Size::Small),
+            fn (Action | ActionGroup $action) => match (true) {
+                $action instanceof Action => $action->defaultView(Action::LINK_VIEW)->defaultSize(Size::Small),
+                $action instanceof ActionGroup => $action->defaultTriggerView(ActionGroup::LINK_VIEW)->defaultSize(Size::Small)
+            },
             Arr::wrap($this->evaluate($this->actions)),
         );
     }


### PR DESCRIPTION
Notifications is expected to handle `ActionGroup`'s , but it is buggy:

1. `Notification` `getActions()` method expects the evaluated actions to contain `ActionGroup` but the `array_map` function type hint isn't, which causes an error.
2. `ActionGroup` `toArray()` method enforces `ActionGroup` to have a `$view` or an error is thrown.

This pull request solves this issues and adds support to Notifications to contain `ActionGroup` properly as it should.