### PR TITLE
Fix crypto.randomUUID error in non-secure HTTP contexts

### DIFF
--- a/packages/notifications/resources/js/Notification.js
+++ b/packages/notifications/resources/js/Notification.js
@@ -1,6 +1,17 @@
+const generateUuid = () => {
+    if (typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID()
+    }
+
+    // Fallback for non-secure contexts (HTTP) using crypto.getRandomValues()
+    return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
+        (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+    )
+}
+
 class Notification {
     constructor() {
-        this.id(crypto.randomUUID())
+        this.id(generateUuid())
 
         return this
     }


### PR DESCRIPTION
Fixes #19421. The native crypto.randomUUID() API is only available in secure contexts (HTTPS), causing error notifications to crash in non-secure HTTP contexts. This change adds a fallback using crypto.getRandomValues() which works in both secure and non-secure contexts.