### PR TITLE
add missing generics to CreateRecord

### DIFF
--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -27,6 +27,7 @@ use Throwable;
 
 /**
  * @template TModel of Model = Model
+ *
  * @property-read Schema $form
  */
 class CreateRecord extends Page
@@ -34,7 +35,7 @@ class CreateRecord extends Page
     use CanUseDatabaseTransactions;
     use HasUnsavedDataChangesAlert;
 
-    /** @var TModel|null */
+    /** @var ?TModel */
     public ?Model $record = null;
 
     /**
@@ -368,7 +369,7 @@ class CreateRecord extends Page
     }
 
     /**
-     * @return TModel|null
+     * @return ?TModel
      */
     public function getRecord(): ?Model
     {

--- a/packages/panels/src/Resources/Pages/CreateRecord.php
+++ b/packages/panels/src/Resources/Pages/CreateRecord.php
@@ -26,6 +26,7 @@ use Livewire\Attributes\Locked;
 use Throwable;
 
 /**
+ * @template TModel of Model = Model
  * @property-read Schema $form
  */
 class CreateRecord extends Page
@@ -33,6 +34,7 @@ class CreateRecord extends Page
     use CanUseDatabaseTransactions;
     use HasUnsavedDataChangesAlert;
 
+    /** @var TModel|null */
     public ?Model $record = null;
 
     /**
@@ -199,6 +201,7 @@ class CreateRecord extends Page
 
     /**
      * @param  array<string, mixed>  $data
+     * @return TModel
      */
     protected function handleRecordCreation(array $data): Model
     {
@@ -347,7 +350,7 @@ class CreateRecord extends Page
     }
 
     /**
-     * @return Model|class-string<Model>|null
+     * @return TModel|class-string<TModel>|null
      */
     protected function getMountedActionSchemaModel(): Model | string | null
     {
@@ -364,6 +367,9 @@ class CreateRecord extends Page
         static::$canCreateAnother = false;
     }
 
+    /**
+     * @return TModel|null
+     */
     public function getRecord(): ?Model
     {
         return $this->record;


### PR DESCRIPTION
## Description

Resource page generics were added here https://github.com/filamentphp/filament/pull/17931 but the CreateRecord class was skipped.

## Visual changes

none

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
