### PR TITLE
Fix is_app_url() returning true for non-HTTP URLs (data:, mailto:, tel:)

### DIFF
--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -122,7 +122,7 @@ if (! function_exists('Filament\Support\is_app_url')) {
 
         $scheme = parse_url($url, PHP_URL_SCHEME);
 
-        if ($scheme !== null && ! in_array($scheme, ['http', 'https'], true)) {
+        if ($scheme && (! in_array($scheme, ['http', 'https'], strict: true))) {
             return false;
         }
 

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -120,6 +120,12 @@ if (! function_exists('Filament\Support\is_app_url')) {
             return true;
         }
 
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+
+        if ($scheme !== null && ! in_array($scheme, ['http', 'https'], true)) {
+            return false;
+        }
+
         $urlHost = parse_url($url, PHP_URL_HOST);
 
         return (! $urlHost) || $urlHost === request()->getHost();


### PR DESCRIPTION
## Summary

`is_app_url()` incorrectly returns `true` for URLs with non-HTTP schemes like `data:`, `mailto:`, `tel:`, `javascript:`, and `blob:`. This causes `wire:navigate` to be added to these links in SPA mode, breaking their functionality.

## Root cause

`parse_url('data:application/octet-stream,...', PHP_URL_HOST)` returns `null` because `data:` URLs have no host. The existing check `(! $urlHost)` then evaluates to `true`, treating the URL as an app URL.

The `(! $urlHost)` fallback was intended for schemeless relative URLs like `?query=value`, `#anchor`, or `some/path` — which also have no host but are legitimate app URLs. The problem is that non-HTTP scheme URLs (`data:`, `mailto:`, `tel:`, etc.) also have no host, but are definitely not app URLs.

## Fix

Adds a scheme check before the host comparison: if a URL has a scheme that is not `http` or `https`, it cannot be an app URL and returns `false` early.

```php
$scheme = parse_url($url, PHP_URL_SCHEME);

if ($scheme !== null && ! in_array($scheme, ['http', 'https'], true)) {
    return false;
}
```

This preserves existing behavior for all other cases:

| URL type | scheme | Behavior |
|---|---|---|
| `/dashboard` | — | Caught by leading `/` check ✅ |
| `?q=1`, `#anchor`, `path` | `null` | New check skipped, `(! $urlHost)` returns true ✅ |
| `https://same-host/...` | `https` | New check skipped, host comparison ✅ |
| `https://other-host/...` | `https` | New check skipped, host comparison → false ✅ |
| `data:application/...` | `data` | **New: returns false** ✅ |
| `mailto:user@example.com` | `mailto` | **New: returns false** ✅ |
| `tel:+49123` | `tel` | **New: returns false** ✅ |

## Steps to reproduce

1. Enable SPA mode on a panel (`->spa()`)
2. Set up MFA with recovery codes
3. Click "Download" to download recovery codes
4. → 404 error (Livewire tries to SPA-navigate to `data:application/octet-stream,...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)