### PR TITLE
Fix MFA recovery code download broken by wire:navigate in SPA mode

### DIFF
--- a/packages/panels/src/Auth/MultiFactor/App/Actions/RegenerateAppAuthenticationRecoveryCodesAction.php
+++ b/packages/panels/src/Auth/MultiFactor/App/Actions/RegenerateAppAuthenticationRecoveryCodesAction.php
@@ -123,8 +123,8 @@ class RegenerateAppAuthenticationRecoveryCodesAction
                                 Action::make('download')
                                     ->label(__('filament-panels::auth/multi-factor/recovery-codes-modal-content.actions.download.label'))
                                     ->link()
-                                    ->url('data:application/octet-stream,' . urlencode(implode(PHP_EOL, $arguments['recoveryCodes'])))
-                                    ->extraAttributes(['download' => true])
+                                    ->url('data:application/octet-stream,' . urlencode(implode(PHP_EOL, $arguments['recoveryCodes'])), shouldOpenInNewTab: true)
+                                    ->extraAttributes(['download' => 'recovery-codes.txt'])
                                     ->toHtml() .
                                 ' ' .
                                 __('filament-panels::auth/multi-factor/recovery-codes-modal-content.actions.2')

--- a/packages/panels/src/Auth/MultiFactor/App/Actions/SetUpAppAuthenticationAction.php
+++ b/packages/panels/src/Auth/MultiFactor/App/Actions/SetUpAppAuthenticationAction.php
@@ -145,8 +145,8 @@ class SetUpAppAuthenticationAction
                                 Action::make('download')
                                     ->label(__('filament-panels::auth/multi-factor/recovery-codes-modal-content.actions.download.label'))
                                     ->link()
-                                    ->url('data:application/octet-stream,' . urlencode(implode(PHP_EOL, $recoveryCodes)))
-                                    ->extraAttributes(['download' => true])
+                                    ->url('data:application/octet-stream,' . urlencode(implode(PHP_EOL, $recoveryCodes)), shouldOpenInNewTab: true)
+                                    ->extraAttributes(['download' => 'recovery-codes.txt'])
                                     ->toHtml() .
                                 ' ' .
                                 __('filament-panels::auth/multi-factor/recovery-codes-modal-content.actions.2')


### PR DESCRIPTION
## Summary

The MFA recovery code download action uses a `data:application/octet-stream` URL. In SPA mode, `is_app_url()` incorrectly returns `true` for `data:` URLs because `parse_url('data:...', PHP_URL_HOST)` returns `null`, and `(! null)` evaluates to `true`. This causes `wire:navigate` to be added to the download link, which makes Livewire intercept the click and navigate to the `data:` URL as if it were a page — resulting in a 404.

## Root cause

In `generate_href_html()`:
```php
$shouldOpenInNewTab  // false (not set)
$shouldOpenInSpaMode // null → falls through to FilamentView::hasSpaMode($url)
// hasSpaMode calls is_app_url(), which returns true for data: URLs → wire:navigate is added
```

## Fix

Adds `shouldOpenInNewTab: true` to the download action in both `SetUpAppAuthenticationAction` and `RegenerateAppAuthenticationRecoveryCodesAction`. This is consistent with how other download actions in Filament handle this:

- `ExportFormat.php:31` — `->url(..., shouldOpenInNewTab: true)`
- `ImportAction.php:312` — `->url(..., shouldOpenInNewTab: true)`

Also sets a proper filename (`recovery-codes.txt`) via the `download` attribute instead of `true` (which results in the file being named just "download" or "1").

## Steps to reproduce

1. Enable SPA mode on a panel (`->spa()`)
2. Set up MFA with recovery codes
3. In the setup modal, click "Download" to download recovery codes
4. → 404 error instead of file download

This is the 5.x counterpart to #19455.
