### PR TITLE
Change Table `cacheAction` method visibility to public

### DIFF
--- a/packages/tables/src/Table/Concerns/HasActions.php
+++ b/packages/tables/src/Table/Concerns/HasActions.php
@@ -53,7 +53,7 @@ trait HasActions
         return array_key_exists($name, $this->getFlatBulkActions());
     }
 
-    protected function cacheAction(Action $action, bool $shouldOverwriteExistingAction = true): void
+    public function cacheAction(Action $action, bool $shouldOverwriteExistingAction = true): void
     {
         if (! $shouldOverwriteExistingAction) {
             if ($action instanceof BulkAction) {


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

### Context

When working with Filament tables, it's possible to define a `recordAction` to trigger an action when clicking on a row. However, this action must be registered beforehand (e.g. via `recordActions`, which renders an unwanted button in the row).

The ideal approach would be to pass an `Action` instance directly to `recordAction()`, but as an intermediate step, being able to register an action via `cacheAction()` from outside the `Table` class is already a significant improvement.

### Problem

The `cacheAction()` method on `Table` is `protected`, making it impossible to call it from a Livewire component or a resource page without resorting to workarounds.

The only way to achieve the desired behavior was to use a closure bound to `$table` to bypass visibility:

```php
(fn () => $this->cacheAction(
    Action::make('show_answers')
        ->label('Foo')
        ->schema(fn ($record) => [
            // ...
        ])
        ->action(fn ($record, $data) => /* ... */)
))->call($table);

return $table
    ->query(/* ... */)
    ->columns([/* ... */])
    ->recordAction('show_answers');
``` 

### Solution

Make `cacheAction()` `public`, allowing it to be called directly on the `Table` instance:

```php
$table->cacheAction(
    Action::make('show_answers')
        ->label('Foo')
        ->schema(fn ($record) => [
            // ...
        ])
        ->action(fn ($record, $data) => /* ... */)
);

return $table
    ->query(/* ... */)
    ->columns([/* ... */])
    ->recordAction('show_answers');
```

### Future improvements

A natural follow-up would be to allow passing an `Action` instance directly to `recordAction()`, removing the need to call `cacheAction()` altogether. This PR is a quick win in that direction, but also unlocking broader use cases.

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
