### PR TITLE
Add deferred badge loading for relation manager tabs

### DIFF
--- a/docs/03-resources/07-managing-relationships.md
+++ b/docs/03-resources/07-managing-relationships.md
@@ -839,6 +839,37 @@ RelationGroup::make('Contacts', [
         ->icon('heroicon-m-document-text'));
 ```
 
+#### Deferring the loading of relation manager tab badges
+
+If `getBadge()` runs an expensive query, set `$deferBadge = true` to load it asynchronously after the page renders:
+
+```php
+use Illuminate\Database\Eloquent\Model;
+
+protected static bool $deferBadge = true;
+
+public static function getBadge(Model $ownerRecord, string $pageClass): ?string
+{
+    $count = $ownerRecord->tickets()->count();
+
+    return $count > 0 ? (string) $count : null;
+}
+```
+
+> `getBadge()` is automatically wrapped in a closure when `$deferBadge` is `true`. Override `isBadgeDeferred()` for dynamic, per-record control.
+
+If you are using a [relation group](#grouping-relation-managers), use the fluent `deferBadge()` method:
+
+```php
+use Filament\Resources\RelationManagers\RelationGroup;
+
+RelationGroup::make('Contacts', [
+    // ...
+])
+    ->badge(fn (Model $ownerRecord): string => (string) $ownerRecord->contacts()->count())
+    ->deferBadge();
+```
+
 ## Sharing a resource's form and table with a relation manager
 
 You may decide that you want a resource's form and table to be identical to a relation manager's, and subsequently want to reuse the code you previously wrote. This is easy, by calling the `form()` and `table()` methods of the resource from the relation manager:

--- a/packages/panels/src/Resources/Pages/Concerns/HasRelationManagers.php
+++ b/packages/panels/src/Resources/Pages/Concerns/HasRelationManagers.php
@@ -162,6 +162,7 @@ trait HasRelationManagers
                 ->all();
 
             return Tabs::make()
+                ->key('relationManagerTabs')
                 ->livewireProperty('activeRelationManager')
                 ->contained(false)
                 ->tabs($tabs);

--- a/packages/panels/src/Resources/RelationManagers/RelationGroup.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationGroup.php
@@ -23,6 +23,8 @@ class RelationGroup extends Component
      */
     protected string | array | Closure | null $badgeColor = null;
 
+    protected bool | Closure $deferBadge = false;
+
     protected ?Model $ownerRecord = null;
 
     protected ?string $pageClass = null;
@@ -82,6 +84,18 @@ class RelationGroup extends Component
     public function getLabel(): string
     {
         return $this->evaluate($this->label);
+    }
+
+    public function deferBadge(bool | Closure $condition = true): static
+    {
+        $this->deferBadge = $condition;
+
+        return $this;
+    }
+
+    public function isBadgeDeferred(): bool
+    {
+        return (bool) $this->evaluate($this->deferBadge);
     }
 
     public function tab(?Closure $callback): static
@@ -176,8 +190,13 @@ class RelationGroup extends Component
 
     public function getTabComponent(): Tab
     {
+        $isDeferred = $this->isBadgeDeferred();
+
         $tab = Tab::make($this->getLabel())
-            ->badge($this->getBadge())
+            ->badge($isDeferred
+                ? fn () => $this->getBadge()
+                : $this->getBadge())
+            ->deferBadge($isDeferred)
             ->badgeColor($this->getBadgeColor())
             ->badgeTooltip($this->getBadgeTooltip())
             ->icon($this->getIcon())

--- a/packages/panels/src/Resources/RelationManagers/RelationManager.php
+++ b/packages/panels/src/Resources/RelationManagers/RelationManager.php
@@ -113,6 +113,8 @@ class RelationManager extends Component implements HasActions, HasRenderHookScop
 
     protected static string | Htmlable | null $badgeTooltip = null;
 
+    protected static bool $deferBadge = false;
+
     public function mount(): void
     {
         $this->loadDefaultActiveTab();
@@ -152,12 +154,22 @@ class RelationManager extends Component implements HasActions, HasRenderHookScop
 
     public static function getTabComponent(Model $ownerRecord, string $pageClass): Tab
     {
+        $isDeferred = static::isBadgeDeferred($ownerRecord, $pageClass);
+
         return Tab::make(static::class::getTitle($ownerRecord, $pageClass))
-            ->badge(static::class::getBadge($ownerRecord, $pageClass))
+            ->badge($isDeferred
+                ? static fn () => static::class::getBadge($ownerRecord, $pageClass)
+                : static::class::getBadge($ownerRecord, $pageClass))
+            ->deferBadge($isDeferred)
             ->badgeColor(static::class::getBadgeColor($ownerRecord, $pageClass))
             ->badgeTooltip(static::class::getBadgeTooltip($ownerRecord, $pageClass))
             ->icon(static::class::getIcon($ownerRecord, $pageClass))
             ->iconPosition(static::class::getIconPosition($ownerRecord, $pageClass));
+    }
+
+    public static function isBadgeDeferred(Model $ownerRecord, string $pageClass): bool
+    {
+        return static::$deferBadge;
     }
 
     public static function getIcon(Model $ownerRecord, string $pageClass): string | BackedEnum | Htmlable | null

--- a/tests/src/Fixtures/Resources/Tickets/RelationManagers/DepartmentsWithDeferredBadgeRelationManager.php
+++ b/tests/src/Fixtures/Resources/Tickets/RelationManagers/DepartmentsWithDeferredBadgeRelationManager.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Resources\Tickets\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables\Table;
+use Filament\Tests\Fixtures\Resources\Departments\Schemas\DepartmentForm;
+use Filament\Tests\Fixtures\Resources\Departments\Tables\DepartmentsTable;
+use Illuminate\Database\Eloquent\Model;
+
+class DepartmentsWithDeferredBadgeRelationManager extends RelationManager
+{
+    protected static string $relationship = 'departments';
+
+    protected static bool $deferBadge = true;
+
+    public static function getBadge(Model $ownerRecord, string $pageClass): ?string
+    {
+        $count = $ownerRecord->departments()->count();
+
+        return $count > 0 ? (string) $count : null;
+    }
+
+    public function table(Table $table): Table
+    {
+        return DepartmentsTable::configure($table);
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return DepartmentForm::configure($schema);
+    }
+}

--- a/tests/src/Panels/Resources/RelationManagerTest.php
+++ b/tests/src/Panels/Resources/RelationManagerTest.php
@@ -20,6 +20,7 @@ use Filament\Tests\Fixtures\Resources\Tickets\Pages\EditTicket;
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsRelationManager;
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsRelationManagerWithTabs;
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithAttachTableSelectRelationManager;
+use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithDeferredBadgeRelationManager;
 use Filament\Tests\Panels\Resources\TestCase;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Support\Str;
@@ -312,4 +313,31 @@ it('cannot access record for action after record no longer matches tab without `
         ->set('activeTab', 'a_names')
         ->mountTableAction(DeleteAction::class, $department)
         ->assertTableActionNotMounted(DeleteAction::class);
+});
+
+it('defers badge loading when $deferBadge is true', function (): void {
+    $ticket = Ticket::factory()->create();
+
+    $tab = DepartmentsWithDeferredBadgeRelationManager::getTabComponent($ticket, EditTicket::class);
+
+    expect($tab->isBadgeDeferred())->toBeTrue();
+});
+
+it('returns the correct deferred badge value', function (): void {
+    $ticket = Ticket::factory()
+        ->hasAttached(Department::factory(3))
+        ->create();
+
+    $tab = DepartmentsWithDeferredBadgeRelationManager::getTabComponent($ticket, EditTicket::class);
+
+    expect($tab->isBadgeDeferred())->toBeTrue()
+        ->and($tab->getBadge())->toBe('3');
+});
+
+it('does not defer badge loading by default', function (): void {
+    $ticket = Ticket::factory()->create();
+
+    $tab = DepartmentsRelationManager::getTabComponent($ticket, EditTicket::class);
+
+    expect($tab->isBadgeDeferred())->toBeFalse();
 });


### PR DESCRIPTION
## Description

Extends the deferred tab badge loading introduced in #19336 to relation manager tabs.

**Problem:** `RelationManager::getTabComponent()` evaluates `getBadge()` synchronously, and the `Tabs` component built by `HasRelationManagers` has no key — both of which prevent `deferBadge()` from working.

**Solution:**
- Add `protected static bool $deferBadge = false` to `RelationManager` (overrideable via `isBadgeDeferred()` for dynamic, per-record control)
- Add fluent `->deferBadge()` to `RelationGroup`
- Add `->key('relationManagerTabs')` to the `Tabs` built in `HasRelationManagers`

## Consumer usage

```php
class TicketsRelationManager extends RelationManager
{
    protected static bool $deferBadge = true;

    public static function getBadge(Model $ownerRecord, string $pageClass): ?string
    {
        $count = $ownerRecord->tickets()->count();

        return $count > 0 ? (string) $count : null;
    }
}
```

No need to override `getTabComponent()` or the Edit page class.

## Checklist

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested — all 56 existing tests pass, 3 new tests added.
- [x] Documentation is up-to-date.