### PR TITLE
fix: cast Select initialState to string to match $wire.$entangle type

### DIFF
--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -161,7 +161,7 @@
                             hasInitialNoOptionsMessage: @js($hasInitialNoOptionsMessage),
                             initialOptionLabel: @js((blank($state) || $isMultiple) ? null : $getOptionLabel()),
                             initialOptionLabels: @js((filled($state) && $isMultiple) ? $getOptionLabelsForJs() : []),
-                            initialState: @js($state),
+                            initialState: @js(is_array($state) ? $state : ($state !== null ? (string) $state : null)),
                             isAutofocused: @js($isAutofocused),
                             isDisabled: @js($isDisabled),
                             isHtmlAllowed: @js($isHtmlAllowed),


### PR DESCRIPTION
## Description

When a Select component hydrates on page load, `initialState` is set via `@js($state)` which preserves the PHP type (e.g. integer `490`). However, the reactive `state` property is bound via `$wire.$entangle()` which always returns **strings** (e.g. `"490"`).

This causes a strict equality mismatch (`===`) in the JavaScript `getLabelForSingleSelection()` method where `state !== initialState` (e.g. `"490" !== 490`), so the pre-rendered `initialOptionLabel` is skipped.

The component then falls back to an async `getOptionLabelUsing()` call via `Livewire.fireAction()`. When multiple Select components exist on the same form (e.g. a customer select + user selects inside a repeater), the async resolution causes all selects to display the same (last-resolved) label.

### Steps to reproduce

1. Create a form with multiple Select components that use `relationship()` or `getOptionLabelUsing()`
2. The selects should have **integer** primary key values (standard auto-increment IDs)
3. Load the edit page — all selects display the same label (the last one resolved)

### Root cause

```
// In select.blade.php:
initialState: @js($state),           // → integer 490
state: $wire.$entangle('...')         // → string "490"

// In select.js getLabelForSingleSelection():
if (this.state === this.initialState)  // "490" === 490 → false!
    return this.initialOptionLabel     // ← skipped, falls back to async
```

### Fix

Cast scalar `initialState` values to string to match the type from `$wire.$entangle()`, while preserving array values for multi-select components:

```php
// Before:
initialState: @js($state),

// After:
initialState: @js(is_array($state) ? $state : ($state !== null ? (string) $state : null)),
```

## Visual changes

N/A — this is a data type fix, no visual changes to the component itself. The visual bug (all selects showing the same label) is resolved.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.