### PR TITLE
Add filament scripts attributes

### DIFF
--- a/packages/support/config/filament.php
+++ b/packages/support/config/filament.php
@@ -59,6 +59,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Script Attributes
+    |--------------------------------------------------------------------------
+    | This is an array of attributes that will be added to all script tags
+    | rendered by Filament. You can use this to add attributes like `data-cfasync` or `async` to
+    | all scripts, or to add custom data attributes that your application may require.
+    |
+    */
+
+    'scripts' => [
+        'attributes' => [
+            // 'data-cfasync' => 'false',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Cache Path
     |--------------------------------------------------------------------------
     |

--- a/packages/support/resources/views/assets.blade.php
+++ b/packages/support/resources/views/assets.blade.php
@@ -1,5 +1,5 @@
 @if (isset($data))
-    <script>
+    <script @foreach($dataScriptAttributes ?? [] as $key => $value) @if(is_int($key)) {{ $value }} @else {{ $key }}="{{ $value }}" @endif @endforeach>
         window.filamentData = @js($data)
     </script>
 @endif

--- a/packages/support/resources/views/assets.blade.php
+++ b/packages/support/resources/views/assets.blade.php
@@ -1,5 +1,11 @@
 @if (isset($data))
-    <script @foreach($dataScriptAttributes ?? [] as $key => $value) @if(is_int($key)) {{ $value }} @else {{ $key }}="{{ $value }}" @endif @endforeach>
+    <script @foreach ($dataScriptAttributes ?? [] as $key => $value)
+        @if (is_int($key))
+            {{ $value }}
+        @else
+            {{ $key }}="{{ $value }}"
+        @endif
+    @endforeach>
         window.filamentData = @js($data)
     </script>
 @endif

--- a/packages/support/src/Assets/AssetManager.php
+++ b/packages/support/src/Assets/AssetManager.php
@@ -189,7 +189,7 @@ class AssetManager
     /**
      * @param  array<string> | null  $packages
      */
-    public function renderScripts(?array $packages = null, bool $withCore = false): string
+    public function renderScripts(?array $packages = null, bool $withCore = false, array $attributes = []): string
     {
         /** @var array<Js> $assets */
         $assets = $this->getScripts($packages, $withCore);
@@ -201,9 +201,17 @@ class AssetManager
             );
         }
 
+        $globalAttributes = config('filament.scripts.attributes', []);
+        $mergedAttributes = array_merge($globalAttributes, $attributes);
+
+        foreach ($assets as $asset) {
+            $asset->extraAttributes($mergedAttributes);
+        }
+
         return view('filament::assets', [
             'assets' => $assets,
             'data' => $this->getScriptData($packages),
+            'dataScriptAttributes' => $mergedAttributes,
         ])->render();
     }
 

--- a/packages/support/src/Assets/AssetManager.php
+++ b/packages/support/src/Assets/AssetManager.php
@@ -188,6 +188,7 @@ class AssetManager
 
     /**
      * @param  array<string> | null  $packages
+     * @param  array<int|string, string>  $attributes
      */
     public function renderScripts(?array $packages = null, bool $withCore = false, array $attributes = []): string
     {

--- a/packages/support/src/Assets/Js.php
+++ b/packages/support/src/Assets/Js.php
@@ -147,9 +147,11 @@ class Js extends Asset
 
     public function getExtraAttributesHtml(): string
     {
+        /** @var array<int|string, string> $extraAttributes */
+        $extraAttributes = $this->getExtraAttributes();
         $attributes = '';
 
-        foreach ($this->getExtraAttributes() as $key => $value) {
+        foreach ($extraAttributes as $key => $value) {
             if (is_int($key)) {
                 $attributes .= " {$value}";
             } else {

--- a/packages/support/src/Assets/Js.php
+++ b/packages/support/src/Assets/Js.php
@@ -150,7 +150,11 @@ class Js extends Asset
         $attributes = '';
 
         foreach ($this->getExtraAttributes() as $key => $value) {
-            $attributes .= " {$key}=\"{$value}\"";
+            if (is_int($key)) {
+                $attributes .= " {$value}";
+            } else {
+                $attributes .= " {$key}=\"{$value}\"";
+            }
         }
 
         return $attributes;

--- a/tests/src/Support/BladeDirectives/FilamentScriptsAttributesTest.php
+++ b/tests/src/Support/BladeDirectives/FilamentScriptsAttributesTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use Filament\Tests\TestCase;
+use Illuminate\Support\Facades\Blade;
+
+uses(TestCase::class);
+
+/*
+/ Default behavior tests
+*/
+it('renders script tags without extra attributes', function (): void {
+    $html = Blade::render('@filamentScripts');
+
+    preg_match_all('/<script[\s\S]*?>/m', $html, $matches);
+
+    expect($matches[0])->not->toBeEmpty()
+        ->and($html)->not->toContain('data-cfasync');
+});
+
+/*
+/ Inline attributes tests
+*/
+
+it('applies inline attributes to every rendered script tag', function (): void {
+    $html         = Blade::render("@filamentScripts(attributes: ['data-cfasync' => 'false'])");
+    $htmlWithout  = Blade::render('@filamentScripts');
+
+    preg_match_all('/<script[\s\S]*?src=[\s\S]*?>/m', $html, $withMatches);
+    preg_match_all('/<script[\s\S]*?src=[\s\S]*?>/m', $htmlWithout, $withoutMatches);
+
+    expect($withMatches[0])->toHaveCount(count($withoutMatches[0]));
+
+    foreach ($withMatches[0] as $tag) {
+        expect($tag)->toContain('data-cfasync="false"');
+    }
+});
+
+/*
+/ Keyed vs non-keyed attributes tests
+*/
+
+it('renders integer-keyed attributes as normal attributes, not integer keys like 0="async"', function (): void {
+    $html = Blade::render("@filamentScripts(attributes: ['data-cfasync' => 'false', 'async'])");
+
+    expect($html)
+        ->toContain('data-cfasync="false"')
+        ->toContain(' async')
+        ->not->toContain('0="async"')
+        ->not->toContain('="async"');
+});
+
+/*
+/ FilamentData script block tests
+*/
+
+it('applies inline attributes to the filamentData script block', function (): void {
+    $html = Blade::render("@filamentScripts(attributes: ['data-cfasync' => 'false'])");
+
+    expect($html)
+        ->toMatch('/<script[^>]*data-cfasync="false"[^>]*>\s*window\.filamentData/');
+});
+
+it('applies global config attributes to the filamentData script block', function (): void {
+    config(['filament.scripts.attributes' => ['data-cfasync' => 'false']]);
+
+    $html = Blade::render('@filamentScripts');
+
+    expect($html)
+        ->toMatch('/<script[^>]*data-cfasync="false"[^>]*>\s*window\.filamentData/');
+});
+
+it('applies inline attributes to both the filamentData block and all src script tags', function (): void {
+    $html = Blade::render("@filamentScripts(attributes: ['data-cfasync' => 'false'])");
+
+    preg_match_all('/<script[\s\S]*?data-cfasync="false"[\s\S]*?>/m', $html, $matches);
+
+    expect(count($matches[0]))->toBeGreaterThanOrEqual(2);
+});
+
+/*
+/ Global config attributes tests
+*/
+
+it('global config attributes apply to every script tag', function (): void {
+    config(['filament.scripts.attributes' => ['data-cfasync' => 'false']]);
+
+    $html = Blade::render('@filamentScripts');
+
+    preg_match_all('/<script[\s\S]*?src=[\s\S]*?>/m', $html, $matches);
+
+    expect($matches[0])->not->toBeEmpty();
+
+    foreach ($matches[0] as $tag) {
+        expect($tag)->toContain('data-cfasync="false"');
+    }
+});
+
+/*
+/ Overriding and merging attributes tests
+*/
+
+it('inline attributes override global config attributes for the same key', function (): void {
+    config(['filament.scripts.attributes' => ['data-cfasync' => 'false']]);
+
+    $html = Blade::render("@filamentScripts(attributes: ['data-cfasync' => 'true'])");
+
+    expect($html)
+        ->toContain('data-cfasync="true"')
+        ->not->toContain('data-cfasync="false"');
+});
+
+it('merges global config attributes with inline attributes', function (): void {
+    config(['filament.scripts.attributes' => ['data-cfasync' => 'false']]);
+
+    $html = Blade::render("@filamentScripts(attributes: ['crossorigin' => 'anonymous'])");
+
+    expect($html)
+        ->toContain('data-cfasync="false"')
+        ->toContain('crossorigin="anonymous"');
+});

--- a/tests/src/Support/BladeDirectives/FilamentScriptsAttributesTest.php
+++ b/tests/src/Support/BladeDirectives/FilamentScriptsAttributesTest.php
@@ -22,8 +22,8 @@ it('renders script tags without extra attributes', function (): void {
 */
 
 it('applies inline attributes to every rendered script tag', function (): void {
-    $html         = Blade::render("@filamentScripts(attributes: ['data-cfasync' => 'false'])");
-    $htmlWithout  = Blade::render('@filamentScripts');
+    $html = Blade::render("@filamentScripts(attributes: ['data-cfasync' => 'false'])");
+    $htmlWithout = Blade::render('@filamentScripts');
 
     preg_match_all('/<script[\s\S]*?src=[\s\S]*?>/m', $html, $withMatches);
     preg_match_all('/<script[\s\S]*?src=[\s\S]*?>/m', $htmlWithout, $withoutMatches);


### PR DESCRIPTION
## What does this PR do?

Adds an `attributes` parameter to the `@filamentScripts` Blade directive and `renderScripts()`, allowing arbitrary HTML attributes to be applied to every rendered `<script>` tag including the `window.filamentData` block.

## Usage

```blade
@filamentScripts(attributes: ['data-cfasync' => 'false'])
```

Or globally via `config/filament.php`:

```php
'scripts' => [
    'attributes' => [
        // 'data-cfasync' => 'false',
    ],
],
```

## Usage Case?

As an Example Cloudflare Rocket Loader defers JavaScript execution by default, which breaks Filament forms in blade, While admin panel could be filtered or bypassed using cloudflare rules, it may be difficult to bypass every single uri, you are using filament form in. Cloudflare requires `data-cfasync="false"` on **every** `<script>` tag to opt out. Without this, users had to override the entire `@filamentScripts` directive manually.

## Changes

I tried to make the minimal impacts or changes possible, so the changes are:
- `AssetManager::renderScripts()` now accepts `array $attributes = []`, merged with `config('filament.scripts.attributes')` (inline wins on conflict)
- `Js::getExtraAttributesHtml()` supports integer-keyed (valueless) attributes e.g. `['async']` renders as `async` not `0="async"`
- Attributes are applied to both `<script src=...>` tags and the `window.filamentData` inline block

## Tests

```bash
./vendor/bin/pest tests/src/Support/BladeDirectives/FilamentScriptsAttributesTest.php
```