### PR TITLE
Fix PHP 8.5 deprecation: null as array offset in HasRenderHooks

### DIFF
--- a/packages/panels/src/Panel/Concerns/HasRenderHooks.php
+++ b/packages/panels/src/Panel/Concerns/HasRenderHooks.php
@@ -17,6 +17,10 @@ trait HasRenderHooks
      */
     public function renderHook(string $name, Closure $hook, string | array | null $scopes = null): static
     {
+        if ($scopes === null) {
+            $scopes = [''];
+        }
+
         if (! is_array($scopes)) {
             $scopes = [$scopes];
         }


### PR DESCRIPTION
## Summary

Using `null` as an array offset is deprecated in PHP 8.5. The `HasRenderHooks::renderHook()` method wraps a `null` `$scopes` parameter into `[null]`, which then uses `null` as an array key:

```
Using null as an array offset is deprecated, use an empty string instead
in HasRenderHooks.php on line 25
```

This applies the same pattern already used in `ViewManager::registerRenderHook()` — converting `null` to `['']` before the array wrapping check:

```php
// ViewManager::registerRenderHook() (already correct)
if ($scopes === null) {
    $scopes = [''];
}

// HasRenderHooks::renderHook() (this PR)
if ($scopes === null) {
    $scopes = [''];
}

if (! is_array($scopes)) {
    $scopes = [$scopes];
}
```

## Context

- Fully backwards-compatible with PHP 8.2+
- Aligns `HasRenderHooks` with the existing `ViewManager` implementation
- Fixes 5 deprecation warnings per page load on PHP 8.5