### PR TITLE
Add missing German translations for tenant menu search field

### DIFF
--- a/packages/panels/resources/lang/de/layout.php
+++ b/packages/panels/resources/lang/de/layout.php
@@ -63,7 +63,7 @@ return [
     'tenant_menu' => [
 
         'search_field' => [
-            'label' => 'Mandantensuche',
+            'label' => 'Mandant suchen',
             'placeholder' => 'Suchen',
         ],
 

--- a/packages/panels/resources/lang/de/layout.php
+++ b/packages/panels/resources/lang/de/layout.php
@@ -60,4 +60,13 @@ return [
         'alt' => 'Logo von :name',
     ],
 
+    'tenant_menu' => [
+
+        'search_field' => [
+            'label' => 'Mandantensuche',
+            'placeholder' => 'Suchen',
+        ],
+
+    ],
+
 ];


### PR DESCRIPTION
## Summary
- Adds missing German (`de`) translations for `tenant_menu.search_field.label` and `tenant_menu.search_field.placeholder` in `packages/panels/resources/lang/de/layout.php`
- These keys exist in the English translation but were missing from the German file

## Changes
- `Mandant suchen` for `tenant_menu.search_field.label` (en: "Tenant search")
- `Suchen` for `tenant_menu.search_field.placeholder` (en: "Search")