### PR TITLE
fix: pass `badgeTooltip` through sub-navigation tabs template

### DIFF
--- a/packages/panels/resources/views/components/page/sub-navigation/tabs.blade.php
+++ b/packages/panels/resources/views/components/page/sub-navigation/tabs.blade.php
@@ -28,6 +28,7 @@
                         @php
                             $navigationItemBadge = $navigationItem->getBadge();
                             $navigationItemBadgeColor = $navigationItem->getBadgeColor();
+                            $navigationItemBadgeTooltip = $navigationItem->getBadgeTooltip();
                             $navigationItemIcon = $navigationItem->isActive() ? ($navigationItem->getActiveIcon() ?? $navigationItem->getIcon()) : $navigationItem->getIcon();
                             $navigationItemUrl = $navigationItem->getUrl();
                             $shouldNavigationItemOpenUrlInNewTab = $navigationItem->shouldOpenUrlInNewTab();
@@ -37,6 +38,7 @@
                         <x-filament::dropdown.list.item
                             :badge="$navigationItemBadge"
                             :badge-color="$navigationItemBadgeColor"
+                            :badge-tooltip="$navigationItemBadgeTooltip"
                             :href="$navigationItemUrl"
                             :icon="$navigationItemIcon"
                             tag="a"
@@ -60,6 +62,7 @@
                     $isNavigationItemActive = $navigationItem->isActive();
                     $navigationItemBadge = $navigationItem->getBadge();
                     $navigationItemBadgeColor = $navigationItem->getBadgeColor();
+                    $navigationItemBadgeTooltip = $navigationItem->getBadgeTooltip();
                     $navigationItemIcon = $navigationItem->isActive() ? ($navigationItem->getActiveIcon() ?? $navigationItem->getIcon()) : $navigationItem->getIcon();
                     $navigationItemUrl = $navigationItem->getUrl();
                     $shouldNavigationItemOpenUrlInNewTab = $navigationItem->shouldOpenUrlInNewTab();
@@ -70,6 +73,7 @@
                     :active="$isNavigationItemActive"
                     :badge="$navigationItemBadge"
                     :badge-color="$navigationItemBadgeColor"
+                    :badge-tooltip="$navigationItemBadgeTooltip"
                     :href="$navigationItemUrl"
                     :icon="$navigationItemIcon"
                     tag="a"


### PR DESCRIPTION
## Description

The sub-navigation tabs template extracts `badge` and `badgeColor` from each navigation item and passes them to the rendered tab & dropdown components, but `badgeTooltip` is not currently extracted or passed through.

This is happening despite `NavigationItem` already supporting a `getBadgeTooltip()` and both `<x-filament::tabs.item />` and `<x-filament::dropdown.list.item />` already accepting the `badgeTooltip` prop.

## Visual changes

<img width="275" height="108" alt="Screenshot 2026-03-13 at 8 57 01 AM" src="https://github.com/user-attachments/assets/4a0f4b73-4754-46f5-811b-fabeac547ea4" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
