### PR TITLE
Fix: Prevent dark-to-light flash when forcing light mode via darkMode(false, true)

### DIFF
--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -12,7 +12,7 @@
     dir="{{ __('filament-panels::layout.direction') ?? 'ltr' }}"
     @class([
         'fi',
-        'dark' => filament()->hasDarkModeForced(),
+        'dark' => filament()->hasDarkMode() && filament()->hasDarkModeForced(),
     ])
 >
     <head>


### PR DESCRIPTION
## Description

When a panel is configured with `darkMode(false, true)` (force light mode), the dark CSS class is still applied to the <html> element on the server-side initial render. Alpine then removes it on hydration, causing a visible dark-to-light flash.

The root cause is that `hasDarkModeForced()` was used alone to determine the dark class, without checking whether dark mode is actually enabled via `hasDarkMode()`. All other logic (script blocks, Alpine JS, user menu toggle) already handle this correctly — the bug is isolated to the `@class` directive in `base.blade.php`.

The fix adds a compound check so the dark class is only applied when dark mode is both enabled and forced.

### Our reasoning
Our use case involves dynamically switching between light and dark mode via a query string parameter,
rather than allowing users to toggle the theme themselves. We always force the desired theme
server-side using `darkMode($isDark, true)`, where `$isDark` is determined by the query string value.

This approach lets us serve the same panel in different visual contexts — for example, embedding panel
views in external interfaces that dictate their own theme. When forcing dark mode this works perfectly,
but when forcing light mode (`darkMode(false, true)`), the server renders the `dark` class on `<html>`,
causing a flash of dark styles before Alpine hydrates and removes it. This fix ensures the initial
server-rendered HTML matches the intended theme in both directions.


## Visual changes

| Configuration | `hasDarkMode()` | `hasDarkModeForced()` | Before: `dark` class on `<html>` | After: `dark` class on `<html>` | Behavior |
|---|---|---|---|---|---|
| `darkMode()` | `true` | `false` | No | No | User can toggle light/dark (default) |
| `darkMode(true)` | `true` | `false` | No | No | Same as above |
| `darkMode(true, true)` | `true` | `true` | Yes | Yes | Force dark, no toggle |
| `darkMode(false)` | `false` | `false` | No | No | Light only, no toggle |
| `darkMode(false, true)` | `false` | `true` | **Yes (bug)** | **No (fixed)** | Force light, no toggle — was flashing dark then light |


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
