### PR TITLE
add tabindex to login form

### DIFF
--- a/packages/panels/src/Auth/Pages/Login.php
+++ b/packages/panels/src/Auth/Pages/Login.php
@@ -248,7 +248,6 @@ class Login extends SimplePage
             ->email()
             ->required()
             ->autocomplete()
-            ->extraInputAttributes(['tabindex' => 1])
             ->autofocus();
     }
 
@@ -256,11 +255,10 @@ class Login extends SimplePage
     {
         return TextInput::make('password')
             ->label(__('filament-panels::auth/pages/login.form.password.label'))
-            ->hint(filament()->hasPasswordReset() ? new HtmlString(Blade::render('<x-filament::link :href="filament()->getRequestPasswordResetUrl()"> {{ __(\'filament-panels::auth/pages/login.actions.request_password_reset.label\') }}</x-filament::link>')) : null)
+            ->hint(filament()->hasPasswordReset() ? new HtmlString(Blade::render('<x-filament::link :href="filament()->getRequestPasswordResetUrl()" tabindex="-1"> {{ __(\'filament-panels::auth/pages/login.actions.request_password_reset.label\') }}</x-filament::link>')) : null)
             ->password()
             ->revealable(filament()->arePasswordsRevealable())
             ->autocomplete('current-password')
-            ->extraInputAttributes(['tabindex' => 2])
             ->required();
     }
 
@@ -356,7 +354,6 @@ class Login extends SimplePage
     {
         return Action::make('authenticate')
             ->label(__('filament-panels::auth/pages/login.form.actions.authenticate.label'))
-            ->extraAttributes(['tabindex' => 3])
             ->submit('authenticate');
     }
 

--- a/packages/panels/src/Auth/Pages/Login.php
+++ b/packages/panels/src/Auth/Pages/Login.php
@@ -248,6 +248,7 @@ class Login extends SimplePage
             ->email()
             ->required()
             ->autocomplete()
+            ->extraInputAttributes(['tabindex' => 1])
             ->autofocus();
     }
 
@@ -259,6 +260,7 @@ class Login extends SimplePage
             ->password()
             ->revealable(filament()->arePasswordsRevealable())
             ->autocomplete('current-password')
+            ->extraInputAttributes(['tabindex' => 2])
             ->required();
     }
 
@@ -354,6 +356,7 @@ class Login extends SimplePage
     {
         return Action::make('authenticate')
             ->label(__('filament-panels::auth/pages/login.form.actions.authenticate.label'))
+            ->extraAttributes(['tabindex' => 3])
             ->submit('authenticate');
     }
 


### PR DESCRIPTION
## Description

Add tabindex to login-form fields for easier form-usage with keyboard. this especially happens when "forget password" is enabled, then tab jumps from "e-mailaddress" to "forgot password". this fix  makes it jump to "password".

Also mentioned here: https://github.com/filamentphp/filament/discussions/7264

## Visual changes

none

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
