### PR TITLE
Introduce ToolbarButton enum

### DIFF
--- a/packages/forms/docs/10-rich-editor.md
+++ b/packages/forms/docs/10-rich-editor.md
@@ -70,6 +70,19 @@ RichEditor::make('content')
 
 Each nested array in the main array represents a group of buttons in the toolbar.
 
+Alternatively, you may use the `Filament\Support\Enums\ToolbarButton` enum cases instead of string values:
+
+```php
+use Filament\Forms\Components\RichEditor;
+use Filament\Support\Enums\ToolbarButton;
+
+RichEditor::make('content')
+    ->toolbarButtons([
+        [ToolbarButton::Bold, ToolbarButton::Italic],
+        [ToolbarButton::Undo, ToolbarButton::Redo],
+    ])
+```
+
 Additional tools available in the toolbar include:
 
 - `h1` - Applies the "h1" tag to the text.

--- a/packages/forms/docs/11-markdown-editor.md
+++ b/packages/forms/docs/11-markdown-editor.md
@@ -45,6 +45,19 @@ MarkdownEditor::make('content')
 
 Each nested array in the main array represents a group of buttons in the toolbar.
 
+Alternatively, you may use the `Filament\Support\Enums\ToolbarButton` enum cases instead of string values:
+
+```php
+use Filament\Forms\Components\MarkdownEditor;
+use Filament\Support\Enums\ToolbarButton;
+
+MarkdownEditor::make('content')
+    ->toolbarButtons([
+        [ToolbarButton::Bold, ToolbarButton::Italic],
+        [ToolbarButton::Undo, ToolbarButton::Redo],
+    ])
+```
+
 <UtilityInjection set="formFields" version="4.x">As well as allowing a static value, the `toolbarButtons()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 ## Uploading images to the editor

--- a/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
+++ b/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
@@ -218,7 +218,7 @@ trait InteractsWithToolbarButtons
     private function normalizeToolbarButtons(array $buttons): array
     {
         return collect($buttons)
-            ->map(function (array|string|ToolbarButton $buttonGroup): string|array {
+            ->map(function (array | string | ToolbarButton $buttonGroup): string | array {
                 if (is_array($buttonGroup)) {
                     return $this->normalizeToolbarButtons($buttonGroup);
                 }

--- a/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
+++ b/packages/forms/src/Components/Concerns/InteractsWithToolbarButtons.php
@@ -4,6 +4,7 @@ namespace Filament\Forms\Components\Concerns;
 
 use Closure;
 use Exception;
+use Filament\Support\Enums\ToolbarButton;
 use LogicException;
 
 trait InteractsWithToolbarButtons
@@ -28,13 +29,15 @@ trait InteractsWithToolbarButtons
     }
 
     /**
-     * @param  array<string | array<string>>  $buttonsToDisable
+     * @param  array<string | array<string> | ToolbarButton>  $buttonsToDisable
      */
     public function disableToolbarButtons(array $buttonsToDisable = []): static
     {
         if ($this->toolbarButtons instanceof Closure) {
             throw new LogicException('You cannot use the `disableToolbarButtons()` method when the toolbar buttons are dynamically returned from a function. Instead, do not return the disabled buttons from the function.');
         }
+
+        $buttonsToDisable = $this->normalizeToolbarButtons($buttonsToDisable);
 
         $this->toolbarButtonsModifications[] = [
             'type' => 'disable',
@@ -45,13 +48,15 @@ trait InteractsWithToolbarButtons
     }
 
     /**
-     * @param  array<string | array<string | array<string>>>  $buttonsToEnable
+     * @param  array<string | array<string | array<string>> | ToolbarButton>  $buttonsToEnable
      */
     public function enableToolbarButtons(array $buttonsToEnable = []): static
     {
         if ($this->toolbarButtons instanceof Closure) {
             throw new LogicException('You cannot use the `enableToolbarButtons()` method when the toolbar buttons are dynamically returned from a function. Instead, return the enabled buttons from the function.');
         }
+
+        $buttonsToEnable = $this->normalizeToolbarButtons($buttonsToEnable);
 
         $this->toolbarButtonsModifications[] = [
             'type' => 'enable',
@@ -62,10 +67,14 @@ trait InteractsWithToolbarButtons
     }
 
     /**
-     * @param  array<string | array<string>> | Closure | null  $buttons
+     * @param  array<string | array<string> | ToolbarButton> | Closure | null  $buttons
      */
     public function toolbarButtons(array | Closure | null $buttons): static
     {
+        if (is_array($buttons)) {
+            $buttons = $this->normalizeToolbarButtons($buttons);
+        }
+
         $this->toolbarButtons = $buttons;
         $this->toolbarButtonsModifications = [];
 
@@ -173,10 +182,16 @@ trait InteractsWithToolbarButtons
     }
 
     /**
-     * @param  string | array<string>  $button
+     * @param  string | array<string> | ToolbarButton  $button
      */
-    public function hasToolbarButton(string | array $button): bool
+    public function hasToolbarButton(string | array | ToolbarButton $button): bool
     {
+        if (is_array($button)) {
+            $button = $this->normalizeToolbarButtons($button);
+        } else {
+            $button = $button instanceof ToolbarButton ? $button->value : $button;
+        }
+
         foreach ($this->getToolbarButtons() as $buttonGroup) {
             if (is_array($button)) {
                 foreach ($button as $singleButton) {
@@ -195,5 +210,25 @@ trait InteractsWithToolbarButtons
     public function hasCustomToolbarButtons(): bool
     {
         return $this->evaluate($this->toolbarButtons) !== null;
+    }
+
+    /**
+     * @param  array<string | array<string | array<string>> | ToolbarButton>  $buttons
+     */
+    private function normalizeToolbarButtons(array $buttons): array
+    {
+        return collect($buttons)
+            ->map(function (array|string|ToolbarButton $buttonGroup): string|array {
+                if (is_array($buttonGroup)) {
+                    return $this->normalizeToolbarButtons($buttonGroup);
+                }
+
+                if ($buttonGroup instanceof ToolbarButton) {
+                    return $buttonGroup->value;
+                }
+
+                return $buttonGroup;
+            })
+            ->all();
     }
 }

--- a/packages/support/src/Enums/ToolbarButton.php
+++ b/packages/support/src/Enums/ToolbarButton.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Filament\Support\Enums;
+
+enum ToolbarButton: string
+{
+    case AlignCenter = 'alignCenter';
+
+    case AlignEnd = 'alignEnd';
+
+    case AlignJustify = 'alignJustify';
+
+    case AlignStart = 'alignStart';
+
+    case AttachFiles = 'attachFiles';
+
+    case Blockquote = 'blockquote';
+
+    case Bold = 'bold';
+
+    case BulletList = 'bulletList';
+
+    case ClearFormatting = 'clearFormatting';
+
+    case Code = 'code';
+
+    case CodeBlock = 'codeBlock';
+
+    case CustomBlocks = 'customBlocks';
+
+    case Details = 'details';
+
+    case Grid = 'grid';
+
+    case GridDelete = 'gridDelete';
+
+    case H1 = 'h1';
+
+    case H2 = 'h2';
+
+    case H3 = 'h3';
+
+    case Heading = 'heading';
+
+    case Highlight = 'highlight';
+
+    case HorizontalRule = 'horizontalRule';
+
+    case Italic = 'italic';
+
+    case Lead = 'lead';
+
+    case Link = 'link';
+
+    case MergeTags = 'mergeTags';
+
+    case OrderedList = 'orderedList';
+
+    case Redo = 'redo';
+
+    case Small = 'small';
+
+    case Strike = 'strike';
+
+    case Subscript = 'subscript';
+
+    case Superscript = 'superscript';
+
+    case Table = 'table';
+
+    case TableAddColumnAfter = 'tableAddColumnAfter';
+
+    case TableAddColumnBefore = 'tableAddColumnBefore';
+
+    case TableAddRowAfter = 'tableAddRowAfter';
+
+    case TableAddRowBefore = 'tableAddRowBefore';
+
+    case TableDelete = 'tableDelete';
+
+    case TableDeleteColumn = 'tableDeleteColumn';
+
+    case TableDeleteRow = 'tableDeleteRow';
+
+    case TableMergeCells = 'tableMergeCells';
+
+    case TableSplitCell = 'tableSplitCell';
+
+    case TableToggleHeaderCell = 'tableToggleHeaderCell';
+
+    case TableToggleHeaderRow = 'tableToggleHeaderRow';
+
+    case TextColor = 'textColor';
+
+    case Underline = 'underline';
+
+    case Undo = 'undo';
+}


### PR DESCRIPTION


<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

It adds the ability to use enum cases instead of hardcoded strings when working with toolbar buttons:
```php
RichEditor::make('txt')
    ->toolbarButtons([
        [ToolbarButton::Bold, ToolbarButton::Italic, ToolbarButton::Underline],
        [ToolbarButton::AttachFiles],
    ])
```

## Visual changes

\-

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
