### PR TITLE
Make forceTLS configuration dynamic based on pusher scheme

### DIFF
--- a/packages/support/config/filament.php
+++ b/packages/support/config/filament.php
@@ -26,7 +26,7 @@ return [
         //     'authEndpoint' => '/broadcasting/auth',
         //     'disableStats' => true,
         //     'encrypted' => true,
-        //     'forceTLS' => true,
+        //     'forceTLS' => env('VITE_PUSHER_SCHEME', 'https') === 'https',
         // ],
 
     ],


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR updates the broadcasting configuration to determine the forceTLS value dynamically.
It took me quite a while to track down this configuration in my local environment, so I'm submitting this change to prevent similar confusion for others.
<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes
Nothing
<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
