### PR TITLE
fix: SubNavigationPosition::Top renders dropdown on mobile instead of…

### DIFF
--- a/packages/panels/resources/css/components/page.css
+++ b/packages/panels/resources/css/components/page.css
@@ -14,6 +14,10 @@
     @apply flex flex-col gap-y-7;
 }
 
+.fi-page-has-sub-navigation-top .fi-page-sub-navigation-tabs {
+    @apply flex;
+}
+
 .fi-page-sub-navigation-tabs {
     @apply hidden md:flex;
 }

--- a/packages/panels/resources/views/components/page/index.blade.php
+++ b/packages/panels/resources/views/components/page/index.blade.php
@@ -24,7 +24,7 @@
     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_START, scopes: $this->getRenderHookScopes()) }}
 
     <div class="fi-page-header-main-ctn">
-        @if ($subNavigation)
+        @if ($subNavigation && $subNavigationPosition !== SubNavigationPosition::Top)
             <div
                 class="fi-page-main-sub-navigation-mobile-menu-render-hook-ctn"
             >
@@ -91,9 +91,13 @@
                 @if ($subNavigationPosition === SubNavigationPosition::Top)
                     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_SUB_NAVIGATION_TOP_BEFORE, scopes: $this->getRenderHookScopes()) }}
 
+                    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_SUB_NAVIGATION_MOBILE_MENU_BEFORE, scopes: $this->getRenderHookScopes()) }}
+
                     <x-filament-panels::page.sub-navigation.tabs
                         :navigation="$subNavigation"
                     />
+
+                    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_SUB_NAVIGATION_MOBILE_MENU_AFTER, scopes: $this->getRenderHookScopes()) }}
 
                     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_SUB_NAVIGATION_TOP_AFTER, scopes: $this->getRenderHookScopes()) }}
                 @endif


### PR DESCRIPTION
## Description

When using `SubNavigationPosition::Top` in a Cluster, sub-navigation renders correctly as horizontal tabs on desktop but collapses into a dropdown button on mobile (below the `md` breakpoint). This is inconsistent with Resource pages, where the same tab navigation renders correctly on all screen sizes.

`Start` and `End` positions are unaffected — they correctly continue to use the mobile dropdown to represent their sidebar navigation on small screens.

## Visual changes

### ❌ Before — Cluster `SubNavigationPosition::Top` on mobile renders dropdown (bug)
<img width="282" height="259" alt="Screenshot 2026-03-18 at 7 59 36 AM" src="https://github.com/user-attachments/assets/a233415a-bceb-45cb-82c3-51822f04e7bf" />

### ✅ After — Cluster `SubNavigationPosition::Top` on mobile renders tabs (fixed)
<img width="282" height="266" alt="Screenshot 2026-03-18 at 8 02 44 AM" src="https://github.com/user-attachments/assets/fd18a925-f716-4eed-a162-91eee723eacf" />

## Functional changes
- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.

### What changed

**`page.blade.php`**
- The mobile-menu dropdown and its render hooks are now skipped for `SubNavigationPosition::Top`
- `PAGE_SUB_NAVIGATION_MOBILE_MENU_BEFORE` and `PAGE_SUB_NAVIGATION_MOBILE_MENU_AFTER` hooks are re-fired inside `fi-page-main`, wrapping the tabs component directly, so any hook content renders in the correct DOM position adjacent to the tabs rather than detached above the page header

**`page.css`**
- Added `.fi-page-has-sub-navigation-top .fi-page-sub-navigation-tabs { @apply flex; }` to override `hidden md:flex` so tabs are always visible on all screen sizes when position is `Top`