### PR TITLE
Check for HasManyDeep in applySearchConstraint method

### DIFF
--- a/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
+use Staudenmeir\EloquentHasManyDeep\HasManyDeep;
 use Znck\Eloquent\Relations\BelongsToThrough;
 
 use function Filament\Support\generate_search_column_expression;
@@ -95,7 +96,8 @@ trait InteractsWithTableQuery
 
                         $relatedTable = $model->getTable();
 
-                        if ($relationship instanceof BelongsToThrough) {
+                        if ($relationship instanceof BelongsToThrough || (class_exists('Staudenmeir\\EloquentHasManyDeep\\HasManyDeep') && $relationship instanceof HasManyDeep)) {
+
                             $relatedTable = $relationship->getRelated()->getTable();
                             $searchColumn = str($searchColumn)->startsWith("{$relatedTable}.")
                                 ? $searchColumn

--- a/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
+++ b/packages/tables/src/Columns/Concerns/InteractsWithTableQuery.php
@@ -96,8 +96,7 @@ trait InteractsWithTableQuery
 
                         $relatedTable = $model->getTable();
 
-                        if ($relationship instanceof BelongsToThrough || (class_exists('Staudenmeir\\EloquentHasManyDeep\\HasManyDeep') && $relationship instanceof HasManyDeep)) {
-
+                        if (($relationship instanceof BelongsToThrough) || ($relationship instanceof HasManyDeep)) {
                             $relatedTable = $relationship->getRelated()->getTable();
                             $searchColumn = str($searchColumn)->startsWith("{$relatedTable}.")
                                 ? $searchColumn


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Added check for Staudenmeir's HasManyDeep in applySearchConstraints, as it needs to be treated the same way as BelongsToThrough, derefencing the actual target table name for passing to getJsonSafeColumnName.

I've tested this with a couple of uses of HasManyDeep, and I think it should "just work" regardless of depth.

Without this change, any use of a HasManyDeep column search just blows up, as it treats the dotted relation as a JSON path.

Not sure if I need to do the class_exists() check, and/or I should inline the namespace rather than a 'use'.

<!-- Describe the addressed issue or the need for the new or updated functionality. -->

## Visual changes

None

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
