### PR TITLE
fix: Rich editor glitching when list items without child block nodes are clicked

### DIFF
--- a/packages/forms/src/Components/RichEditor/StateCasts/RichEditorStateCast.php
+++ b/packages/forms/src/Components/RichEditor/StateCasts/RichEditorStateCast.php
@@ -112,6 +112,9 @@ class RichEditorStateCast implements StateCast
         return $editor->getDocument();
     }
 
+    /**
+     * https://github.com/filamentphp/filament/issues/19529
+     */
     protected function normalizeListItemContent(Editor $editor): void
     {
         $editor->descendants(function (object &$node): void {

--- a/packages/forms/src/Components/RichEditor/StateCasts/RichEditorStateCast.php
+++ b/packages/forms/src/Components/RichEditor/StateCasts/RichEditorStateCast.php
@@ -107,8 +107,33 @@ class RichEditorStateCast implements StateCast
         }
 
         $this->hydrateMentionLabels($editor);
+        $this->normalizeListItemContent($editor);
 
         return $editor->getDocument();
+    }
+
+    protected function normalizeListItemContent(Editor $editor): void
+    {
+        $editor->descendants(function (object &$node): void {
+            if ($node->type !== 'listItem') {
+                return;
+            }
+
+            if (! isset($node->content) || ! is_array($node->content)) {
+                return;
+            }
+
+            $firstChild = $node->content[0] ?? null;
+
+            if (! $firstChild || $firstChild->type !== 'text') {
+                return;
+            }
+
+            $node->content = [(object) [
+                'type' => 'paragraph',
+                'content' => $node->content,
+            ]];
+        });
     }
 
     protected function hydrateMentionLabels(Editor $editor): void

--- a/tests/src/Forms/Components/RichEditorTest.php
+++ b/tests/src/Forms/Components/RichEditorTest.php
@@ -538,3 +538,81 @@ test('`RichContentRenderer` resolves file attachment provider from plugin implem
     expect($renderer->getFileAttachmentProvider())
         ->toBe($plugin->getFileAttachmentProvider());
 });
+
+test('list items with bare text content are wrapped in paragraphs on fill', function (): void {
+    $schema = Schema::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            RichEditor::make('content')->json(),
+        ])
+        ->fill([
+            'content' => '<ul><li>First item</li><li>Second item</li></ul>',
+        ]);
+
+    $state = $schema->getState()['content'];
+
+    $bulletList = collect($state['content'])->firstWhere('type', 'bulletList');
+
+    expect($bulletList)->not->toBeNull();
+
+    foreach ($bulletList['content'] as $listItem) {
+        expect($listItem['type'])->toBe('listItem');
+        expect($listItem['content'][0]['type'])->toBe('paragraph');
+    }
+
+    $firstParagraph = $bulletList['content'][0]['content'][0];
+    $secondParagraph = $bulletList['content'][1]['content'][0];
+
+    expect($firstParagraph['content'][0]['text'])->toBe('First item');
+    expect($secondParagraph['content'][0]['text'])->toBe('Second item');
+});
+
+test('list items with marked text content are wrapped in paragraphs on fill', function (): void {
+    $schema = Schema::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            RichEditor::make('content')->json(),
+        ])
+        ->fill([
+            'content' => '<ul><li><strong>Bold item</strong> with text</li></ul>',
+        ]);
+
+    $state = $schema->getState()['content'];
+
+    $bulletList = collect($state['content'])->firstWhere('type', 'bulletList');
+    $firstLi = $bulletList['content'][0];
+    $paragraph = $firstLi['content'][0];
+
+    expect($paragraph['type'])->toBe('paragraph');
+
+    $boldText = $paragraph['content'][0];
+    $plainText = $paragraph['content'][1];
+
+    expect($boldText['type'])->toBe('text');
+    expect($boldText['text'])->toBe('Bold item');
+    expect($boldText['marks'][0]['type'])->toBe('bold');
+
+    expect($plainText['type'])->toBe('text');
+    expect($plainText['text'])->toBe(' with text');
+    expect($plainText)->not->toHaveKey('marks');
+});
+
+test('list items already containing paragraphs are not double-wrapped on fill', function (): void {
+    $schema = Schema::make(Livewire::make())
+        ->statePath('data')
+        ->components([
+            RichEditor::make('content')->json(),
+        ])
+        ->fill([
+            'content' => '<ul><li><p>Already wrapped</p></li></ul>',
+        ]);
+
+    $state = $schema->getState()['content'];
+
+    $bulletList = collect($state['content'])->firstWhere('type', 'bulletList');
+    $firstLi = $bulletList['content'][0];
+
+    expect($firstLi['content'][0]['type'])->toBe('paragraph');
+    expect($firstLi['content'][0]['content'][0]['type'])->toBe('text');
+    expect($firstLi['content'][0]['content'][0]['text'])->toBe('Already wrapped');
+});


### PR DESCRIPTION
Fixes #19529.