### PR TITLE
Chore: Openspout v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "league/csv": "^9.27",
         "league/flysystem-aws-s3-v3": "^3.0",
         "nunomaduro/termwind": "^2.0",
-        "openspout/openspout": "^4.23",
+        "openspout/openspout": "^4.23|^5.0",
         "orchestra/testbench": "^9.0|^10.0|^11.0",
         "pestphp/pest": "^3.7|^4.0",
         "pestphp/pest-plugin-browser": "^4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a37dd210ea840b549149abef093c6b6b",
+    "content-hash": "0ab98a4f43cbfbc3d975dea692e137ea",
     "packages": [],
     "packages-dev": [
         {
@@ -6053,36 +6053,36 @@
         },
         {
             "name": "openspout/openspout",
-            "version": "v4.32.0",
+            "version": "v5.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/openspout/openspout.git",
-                "reference": "41f045c1f632e1474e15d4c7bc3abcb4a153563d"
+                "reference": "bac831f8d2702fd4504ff9e4120352a859ee7087"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/openspout/openspout/zipball/41f045c1f632e1474e15d4c7bc3abcb4a153563d",
-                "reference": "41f045c1f632e1474e15d4c7bc3abcb4a153563d",
+                "url": "https://api.github.com/repos/openspout/openspout/zipball/bac831f8d2702fd4504ff9e4120352a859ee7087",
+                "reference": "bac831f8d2702fd4504ff9e4120352a859ee7087",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
-                "ext-fileinfo": "*",
                 "ext-filter": "*",
                 "ext-libxml": "*",
                 "ext-xmlreader": "*",
                 "ext-zip": "*",
-                "php": "~8.3.0 || ~8.4.0 || ~8.5.0"
+                "php": "~8.4.0 || ~8.5.0"
             },
             "require-dev": {
+                "ext-fileinfo": "*",
                 "ext-zlib": "*",
-                "friendsofphp/php-cs-fixer": "^3.86.0",
-                "infection/infection": "^0.31.2",
-                "phpbench/phpbench": "^1.4.1",
-                "phpstan/phpstan": "^2.1.22",
-                "phpstan/phpstan-phpunit": "^2.0.7",
-                "phpstan/phpstan-strict-rules": "^2.0.6",
-                "phpunit/phpunit": "^12.3.7"
+                "friendsofphp/php-cs-fixer": "^3.94.2",
+                "infection/infection": "^0.32.6",
+                "phpbench/phpbench": "^1.5.1",
+                "phpstan/phpstan": "^2.1.42",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "phpstan/phpstan-strict-rules": "^2.0.10",
+                "phpunit/phpunit": "^13.0.5"
             },
             "suggest": {
                 "ext-iconv": "To handle non UTF-8 CSV files (if \"php-mbstring\" is not already installed or is too limited)",
@@ -6130,7 +6130,7 @@
             ],
             "support": {
                 "issues": "https://github.com/openspout/openspout/issues",
-                "source": "https://github.com/openspout/openspout/tree/v4.32.0"
+                "source": "https://github.com/openspout/openspout/tree/v5.5.0"
             },
             "funding": [
                 {
@@ -6142,7 +6142,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-03T16:03:54+00:00"
+            "time": "2026-03-18T12:57:56+00:00"
         },
         {
             "name": "orchestra/canvas",

--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -224,7 +224,11 @@ abstract class Exporter
      */
     public function makeXlsxRow(array $values, ?Style $style = null): Row
     {
-        return Row::fromValues($values, $style);
+        // @phpstan-ignore function.alreadyNarrowedType
+        return \method_exists(Row::class, 'fromValuesWithStyle')
+            ? Row::fromValuesWithStyle($values, $style)
+            // @phpstan-ignore argument.type
+            : Row::fromValues($values, $style);
     }
 
     public function configureXlsxWriterBeforeClose(Writer $writer): Writer

--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -227,7 +227,7 @@ abstract class Exporter
         // @phpstan-ignore-next-line - We need to ignore this for now, as we still support OpenSpout v4, which does not have the `fromValuesWithStyle` method.
         return \method_exists(Row::class, 'fromValuesWithStyle')
             ? Row::fromValuesWithStyle($values, $style)
-            // @phpstan-ignore -next-line - We need to ignore this for now, as we still support OpenSpout v4, which does not have the `fromValuesWithStyle` method.
+            // @phpstan-ignore-next-line - We need to ignore this for now, as we still support OpenSpout v4, which does not have the `fromValuesWithStyle` method.
             : Row::fromValues($values, $style);
     }
 

--- a/packages/actions/src/Exports/Exporter.php
+++ b/packages/actions/src/Exports/Exporter.php
@@ -224,10 +224,10 @@ abstract class Exporter
      */
     public function makeXlsxRow(array $values, ?Style $style = null): Row
     {
-        // @phpstan-ignore function.alreadyNarrowedType
+        // @phpstan-ignore-next-line - We need to ignore this for now, as we still support OpenSpout v4, which does not have the `fromValuesWithStyle` method.
         return \method_exists(Row::class, 'fromValuesWithStyle')
             ? Row::fromValuesWithStyle($values, $style)
-            // @phpstan-ignore argument.type
+            // @phpstan-ignore -next-line - We need to ignore this for now, as we still support OpenSpout v4, which does not have the `fromValuesWithStyle` method.
             : Row::fromValues($values, $style);
     }
 


### PR DESCRIPTION
This PR allows openspout v5.

One breaking change detected is that `Row::fromValues` has been replaced by `Row::fromValuesWithStyle`.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
