### PR TITLE
Add `$short` parameter to `since()` and `sinceTooltip()`

### DIFF
--- a/packages/infolists/docs/02-text-entry.md
+++ b/packages/infolists/docs/02-text-entry.md
@@ -207,6 +207,15 @@ TextEntry::make('created_at')
     ->since()
 ```
 
+You may pass `short: true` to use abbreviated units (e.g., "1h ago" instead of "1 hour ago"):
+
+```php
+use Filament\Infolists\Components\TextEntry;
+
+TextEntry::make('created_at')
+    ->since(short: true)
+```
+
 #### Displaying a formatting date in a tooltip
 
 Additionally, you can use the `dateTooltip()`, `dateTimeTooltip()`, `timeTooltip()`, `isoDateTooltip()`, `isoDateTimeTooltip()`, `isoTime()`, `isoTimeTooltip()`, or `sinceTooltip()` method to display a formatted date in a [tooltip](overview#adding-a-tooltip-to-an-entry), often to provide extra information:

--- a/packages/infolists/src/Components/Concerns/CanFormatState.php
+++ b/packages/infolists/src/Components/Concerns/CanFormatState.php
@@ -115,18 +115,18 @@ trait CanFormatState
         return $this;
     }
 
-    public function since(string | Closure | null $timezone = null): static
+    public function since(string | Closure | null $timezone = null, bool | Closure $short = false): static
     {
         $this->isDateTime = true;
 
-        $this->formatStateUsing(static function (TextEntry $component, $state) use ($timezone): ?string {
+        $this->formatStateUsing(static function (TextEntry $component, $state) use ($timezone, $short): ?string {
             if (blank($state)) {
                 return null;
             }
 
             return Carbon::parse($state)
                 ->setTimezone($component->evaluate($timezone) ?? $component->getTimezone())
-                ->diffForHumans();
+                ->diffForHumans(short: (bool) $component->evaluate($short));
         });
 
         return $this;
@@ -165,16 +165,16 @@ trait CanFormatState
         return $this;
     }
 
-    public function sinceTooltip(string | Closure | null $timezone = null): static
+    public function sinceTooltip(string | Closure | null $timezone = null, bool | Closure $short = false): static
     {
-        $this->tooltip(static function (TextEntry $component, mixed $state) use ($timezone): ?string {
+        $this->tooltip(static function (TextEntry $component, mixed $state) use ($timezone, $short): ?string {
             if (blank($state)) {
                 return null;
             }
 
             return Carbon::parse($state)
                 ->setTimezone($component->evaluate($timezone) ?? $component->getTimezone())
-                ->diffForHumans();
+                ->diffForHumans(short: (bool) $component->evaluate($short));
         });
 
         return $this;

--- a/packages/tables/docs/02-columns/02-text.md
+++ b/packages/tables/docs/02-columns/02-text.md
@@ -207,6 +207,15 @@ TextColumn::make('created_at')
     ->since()
 ```
 
+You may pass `short: true` to use abbreviated units (e.g., "1h ago" instead of "1 hour ago"):
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('created_at')
+    ->since(short: true)
+```
+
 #### Displaying a formatting date in a tooltip
 
 Additionally, you can use the `dateTooltip()`, `dateTimeTooltip()`, `timeTooltip()`, `isoDateTooltip()`, `isoDateTimeTooltip()`, `isoTime()`, `isoTimeTooltip()`, or `sinceTooltip()` method to display a formatted date in a [tooltip](overview#adding-a-tooltip-to-an-column), often to provide extra information:

--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -115,18 +115,18 @@ trait CanFormatState
         return $this;
     }
 
-    public function since(string | Closure | null $timezone = null): static
+    public function since(string | Closure | null $timezone = null, bool | Closure $short = false): static
     {
         $this->isDateTime = true;
 
-        $this->formatStateUsing(static function (TextColumn $column, $state) use ($timezone): ?string {
+        $this->formatStateUsing(static function (TextColumn $column, $state) use ($timezone, $short): ?string {
             if (blank($state)) {
                 return null;
             }
 
             return Carbon::parse($state)
                 ->setTimezone($column->evaluate($timezone) ?? $column->getTimezone())
-                ->diffForHumans();
+                ->diffForHumans(short: (bool) $column->evaluate($short));
         });
 
         return $this;
@@ -165,16 +165,16 @@ trait CanFormatState
         return $this;
     }
 
-    public function sinceTooltip(string | Closure | null $timezone = null): static
+    public function sinceTooltip(string | Closure | null $timezone = null, bool | Closure $short = false): static
     {
-        $this->tooltip(static function (TextColumn $column, mixed $state) use ($timezone): ?string {
+        $this->tooltip(static function (TextColumn $column, mixed $state) use ($timezone, $short): ?string {
             if (blank($state)) {
                 return null;
             }
 
             return Carbon::parse($state)
                 ->setTimezone($column->evaluate($timezone) ?? $column->getTimezone())
-                ->diffForHumans();
+                ->diffForHumans(short: (bool) $column->evaluate($short));
         });
 
         return $this;


### PR DESCRIPTION
## Description

Adds a `$short` parameter to `since()` and `sinceTooltip()` on both `TextColumn` and `TextEntry`, enabling abbreviated relative timestamps via Carbon's `diffForHumans(short: true)` (e.g., "1h ago" instead of "1 hour ago").

```php
TextColumn::make('created_at')->since(short: true)
```

### Note on tests

There are no existing tests for `since()`, `sinceTooltip()`, or any of the date formatting methods in `CanFormatState`. Happy to add test coverage for the new `$short` parameter (and the existing methods) if desired.

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.