### PR TITLE
fix: Only use x-show on logo when sidebar is collapsible

### DIFF
--- a/packages/panels/resources/views/livewire/sidebar.blade.php
+++ b/packages/panels/resources/views/livewire/sidebar.blade.php
@@ -73,7 +73,11 @@
 
                 {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::SIDEBAR_LOGO_BEFORE) }}
 
-                <div x-show="$store.sidebar.isOpen" class="fi-sidebar-header-logo-ctn">
+                @if ($isSidebarCollapsibleOnDesktop)
+                    <div x-show="$store.sidebar.isOpen" class="fi-sidebar-header-logo-ctn">
+                @else
+                    <div class="fi-sidebar-header-logo-ctn">
+                @endif
                     @if ($homeUrl = filament()->getHomeUrl())
                         <a {{ \Filament\Support\generate_href_html($homeUrl) }}>
                             <x-filament-panels::logo />

--- a/packages/panels/resources/views/livewire/sidebar.blade.php
+++ b/packages/panels/resources/views/livewire/sidebar.blade.php
@@ -73,11 +73,12 @@
 
                 {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::SIDEBAR_LOGO_BEFORE) }}
 
-                @if ($isSidebarCollapsibleOnDesktop)
-                    <div x-show="$store.sidebar.isOpen" class="fi-sidebar-header-logo-ctn">
-                @else
-                    <div class="fi-sidebar-header-logo-ctn">
-                @endif
+                <div
+                    @if ($isSidebarCollapsibleOnDesktop || $isSidebarFullyCollapsibleOnDesktop)
+                        x-show="$store.sidebar.isOpen"
+                    @endif
+                    class="fi-sidebar-header-logo-ctn"
+                >
                     @if ($homeUrl = filament()->getHomeUrl())
                         <a {{ \Filament\Support\generate_href_html($homeUrl) }}>
                             <x-filament-panels::logo />


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

When switching to `->topbar(false)` the localStorage entry for `isOpen` might be false which leads to the logo being hidden in the sidebar. There is no way to change that without clearing users localStorage so we only should check for `isOpen` when the sidebar is actually collapsible.


## Visual changes

<img width="432" height="225" alt="grafik" src="https://github.com/user-attachments/assets/2fe68aa3-8db9-4952-ac05-c0e9b8ef414f" />

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
