### PR TITLE
fix: download recovery codes with filename

### DIFF
--- a/packages/panels/src/Auth/MultiFactor/App/Actions/RegenerateAppAuthenticationRecoveryCodesAction.php
+++ b/packages/panels/src/Auth/MultiFactor/App/Actions/RegenerateAppAuthenticationRecoveryCodesAction.php
@@ -124,7 +124,7 @@ class RegenerateAppAuthenticationRecoveryCodesAction
                                     ->label(__('filament-panels::auth/multi-factor/recovery-codes-modal-content.actions.download.label'))
                                     ->link()
                                     ->url('data:application/octet-stream,' . urlencode(implode(PHP_EOL, $arguments['recoveryCodes'])))
-                                    ->extraAttributes(['download' => true])
+                                    ->extraAttributes(['download' => 'recovery-codes.txt'])
                                     ->toHtml() .
                                 ' ' .
                                 __('filament-panels::auth/multi-factor/recovery-codes-modal-content.actions.2')

--- a/packages/panels/src/Auth/MultiFactor/App/Actions/SetUpAppAuthenticationAction.php
+++ b/packages/panels/src/Auth/MultiFactor/App/Actions/SetUpAppAuthenticationAction.php
@@ -146,7 +146,7 @@ class SetUpAppAuthenticationAction
                                     ->label(__('filament-panels::auth/multi-factor/recovery-codes-modal-content.actions.download.label'))
                                     ->link()
                                     ->url('data:application/octet-stream,' . urlencode(implode(PHP_EOL, $recoveryCodes)))
-                                    ->extraAttributes(['download' => true])
+                                    ->extraAttributes(['download' => 'recovery-codes.txt'])
                                     ->toHtml() .
                                 ' ' .
                                 __('filament-panels::auth/multi-factor/recovery-codes-modal-content.actions.2')


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Currently the recovery-codes download uses `download="true"` on the anchor element. It has `application/octet-stream` as the content type, presumably to reliably force a download instead of potentially displaying it in the browser. However, this combination means the browser is in charge of picking a filename. And because it's an octet-stream this often leads to just `download` as the filename (no extension with a vague name).

The `download` attribute also allows for a string instead of just `true`, this string is then used by the browser for the filename, so the downloaded file would now be `recovery-codes.txt`. This could be extended by including the app-name, but I feel like this is fine and definitely an improvement over a file named `download`.

## Visual changes

No visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
