### PR TITLE
fix: fall back to arguments() when invokedArguments is null in getJsClickHandler

### DIFF
--- a/docs-assets/app/app/Filament/Clusters/Settings/Pages/ManageApi.php
+++ b/docs-assets/app/app/Filament/Clusters/Settings/Pages/ManageApi.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Clusters\Settings\Pages;
 
 use App\Filament\Clusters\Settings\SettingsCluster;
+use BackedEnum;
 use Filament\Pages\Page;
 use Filament\Support\Icons\Heroicon;
 
@@ -14,7 +15,7 @@ class ManageApi extends Page
 
     protected static ?string $title = 'API';
 
-    protected static string | \BackedEnum | null $navigationIcon = Heroicon::OutlinedCodeBracket;
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedCodeBracket;
 
     protected static ?int $navigationSort = 8;
 }

--- a/docs-assets/app/app/Filament/Clusters/Settings/Pages/ManageAppearance.php
+++ b/docs-assets/app/app/Filament/Clusters/Settings/Pages/ManageAppearance.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Clusters\Settings\Pages;
 
 use App\Filament\Clusters\Settings\SettingsCluster;
+use BackedEnum;
 use Filament\Pages\Page;
 use Filament\Support\Icons\Heroicon;
 
@@ -12,7 +13,7 @@ class ManageAppearance extends Page
 
     protected static ?string $navigationLabel = 'Appearance';
 
-    protected static string | \BackedEnum | null $navigationIcon = Heroicon::OutlinedPaintBrush;
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedPaintBrush;
 
     protected static ?int $navigationSort = 4;
 }

--- a/docs-assets/app/app/Filament/Clusters/Settings/Pages/ManageBilling.php
+++ b/docs-assets/app/app/Filament/Clusters/Settings/Pages/ManageBilling.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Clusters\Settings\Pages;
 
 use App\Filament\Clusters\Settings\SettingsCluster;
+use BackedEnum;
 use Filament\Pages\Page;
 use Filament\Support\Icons\Heroicon;
 
@@ -12,7 +13,7 @@ class ManageBilling extends Page
 
     protected static ?string $navigationLabel = 'Billing';
 
-    protected static string | \BackedEnum | null $navigationIcon = Heroicon::OutlinedCreditCard;
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedCreditCard;
 
     protected static ?int $navigationSort = 6;
 }

--- a/docs-assets/app/app/Filament/Clusters/Settings/Pages/ManageGeneral.php
+++ b/docs-assets/app/app/Filament/Clusters/Settings/Pages/ManageGeneral.php
@@ -3,6 +3,8 @@
 namespace App\Filament\Clusters\Settings\Pages;
 
 use App\Filament\Clusters\Settings\SettingsCluster;
+use BackedEnum;
+use Filament\Actions\Action;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
@@ -21,7 +23,7 @@ class ManageGeneral extends Page
 
     protected static ?string $navigationLabel = 'General';
 
-    protected static string | \BackedEnum | null $navigationIcon = Heroicon::OutlinedCog6Tooth;
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedCog6Tooth;
 
     protected static ?int $navigationSort = 1;
 
@@ -113,7 +115,7 @@ class ManageGeneral extends Page
     protected function getFormActions(): array
     {
         return [
-            \Filament\Actions\Action::make('save')
+            Action::make('save')
                 ->label('Save changes')
                 ->submit('form'),
         ];

--- a/docs-assets/app/app/Filament/Clusters/Settings/Pages/ManageIntegrations.php
+++ b/docs-assets/app/app/Filament/Clusters/Settings/Pages/ManageIntegrations.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Clusters\Settings\Pages;
 
 use App\Filament\Clusters\Settings\SettingsCluster;
+use BackedEnum;
 use Filament\Pages\Page;
 use Filament\Support\Icons\Heroicon;
 
@@ -12,7 +13,7 @@ class ManageIntegrations extends Page
 
     protected static ?string $navigationLabel = 'Integrations';
 
-    protected static string | \BackedEnum | null $navigationIcon = Heroicon::OutlinedBolt;
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedBolt;
 
     protected static ?int $navigationSort = 3;
 }

--- a/docs-assets/app/app/Filament/Clusters/Settings/Pages/ManageNotifications.php
+++ b/docs-assets/app/app/Filament/Clusters/Settings/Pages/ManageNotifications.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Clusters\Settings\Pages;
 
 use App\Filament\Clusters\Settings\SettingsCluster;
+use BackedEnum;
 use Filament\Pages\Page;
 use Filament\Support\Icons\Heroicon;
 
@@ -12,7 +13,7 @@ class ManageNotifications extends Page
 
     protected static ?string $navigationLabel = 'Notifications';
 
-    protected static string | \BackedEnum | null $navigationIcon = Heroicon::OutlinedBell;
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedBell;
 
     protected static ?int $navigationSort = 2;
 }

--- a/docs-assets/app/app/Filament/Clusters/Settings/Pages/ManageSecurity.php
+++ b/docs-assets/app/app/Filament/Clusters/Settings/Pages/ManageSecurity.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Clusters\Settings\Pages;
 
 use App\Filament\Clusters\Settings\SettingsCluster;
+use BackedEnum;
 use Filament\Pages\Page;
 use Filament\Support\Icons\Heroicon;
 
@@ -12,7 +13,7 @@ class ManageSecurity extends Page
 
     protected static ?string $navigationLabel = 'Security';
 
-    protected static string | \BackedEnum | null $navigationIcon = Heroicon::OutlinedShieldCheck;
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedShieldCheck;
 
     protected static ?int $navigationSort = 5;
 }

--- a/docs-assets/app/app/Filament/Clusters/Settings/Pages/ManageTeam.php
+++ b/docs-assets/app/app/Filament/Clusters/Settings/Pages/ManageTeam.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Clusters\Settings\Pages;
 
 use App\Filament\Clusters\Settings\SettingsCluster;
+use BackedEnum;
 use Filament\Pages\Page;
 use Filament\Support\Icons\Heroicon;
 
@@ -12,7 +13,7 @@ class ManageTeam extends Page
 
     protected static ?string $navigationLabel = 'Team';
 
-    protected static string | \BackedEnum | null $navigationIcon = Heroicon::OutlinedUserGroup;
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedUserGroup;
 
     protected static ?int $navigationSort = 7;
 }

--- a/docs-assets/app/app/Filament/Clusters/Settings/Pages/ManageWebhooks.php
+++ b/docs-assets/app/app/Filament/Clusters/Settings/Pages/ManageWebhooks.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Clusters\Settings\Pages;
 
 use App\Filament\Clusters\Settings\SettingsCluster;
+use BackedEnum;
 use Filament\Pages\Page;
 use Filament\Support\Icons\Heroicon;
 
@@ -12,7 +13,7 @@ class ManageWebhooks extends Page
 
     protected static ?string $navigationLabel = 'Webhooks';
 
-    protected static string | \BackedEnum | null $navigationIcon = Heroicon::OutlinedLink;
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedLink;
 
     protected static ?int $navigationSort = 9;
 }

--- a/docs-assets/app/app/Filament/Clusters/Settings/SettingsCluster.php
+++ b/docs-assets/app/app/Filament/Clusters/Settings/SettingsCluster.php
@@ -2,13 +2,14 @@
 
 namespace App\Filament\Clusters\Settings;
 
+use BackedEnum;
 use Filament\Clusters\Cluster;
 use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Support\Icons\Heroicon;
 
 class SettingsCluster extends Cluster
 {
-    protected static string | \BackedEnum | null $navigationIcon = Heroicon::OutlinedCog6Tooth;
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedCog6Tooth;
 
     protected static ?string $navigationLabel = 'Settings';
 

--- a/docs-assets/app/app/Filament/Pages/Analytics.php
+++ b/docs-assets/app/app/Filament/Pages/Analytics.php
@@ -2,18 +2,20 @@
 
 namespace App\Filament\Pages;
 
+use BackedEnum;
 use Filament\Actions\Action;
 use Filament\Pages\Page;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\View;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
+use UnitEnum;
 
 class Analytics extends Page
 {
-    protected static string | \BackedEnum | null $navigationIcon = Heroicon::OutlinedChartBarSquare;
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedChartBarSquare;
 
-    protected static string | \UnitEnum | null $navigationGroup = 'Reports';
+    protected static string | UnitEnum | null $navigationGroup = 'Reports';
 
     public function content(Schema $schema): Schema
     {

--- a/docs-assets/app/app/Filament/Pages/AnalyticsWithSubheading.php
+++ b/docs-assets/app/app/Filament/Pages/AnalyticsWithSubheading.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Pages;
 
+use BackedEnum;
 use Filament\Actions\Action;
 use Filament\Pages\Page;
 use Filament\Schemas\Components\Section;
@@ -11,7 +12,7 @@ use Filament\Support\Icons\Heroicon;
 
 class AnalyticsWithSubheading extends Page
 {
-    protected static string | \BackedEnum | null $navigationIcon = Heroicon::OutlinedChartBarSquare;
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedChartBarSquare;
 
     protected static bool $shouldRegisterNavigation = false;
 

--- a/docs-assets/app/app/Filament/Pages/ManageHomepage.php
+++ b/docs-assets/app/app/Filament/Pages/ManageHomepage.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Pages;
 
 use App\Models\WebsitePage;
+use BackedEnum;
 use Filament\Actions\Action;
 use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\TextInput;
@@ -20,7 +21,7 @@ class ManageHomepage extends Page
 {
     protected string $view = 'filament.pages.manage-homepage';
 
-    protected static string | \BackedEnum | null $navigationIcon = Heroicon::OutlinedHome;
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedHome;
 
     protected static ?int $navigationSort = 5;
 

--- a/docs-assets/app/app/Filament/Resources/PostResource.php
+++ b/docs-assets/app/app/Filament/Resources/PostResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\PostResource\Pages;
 use App\Models\Post;
+use BackedEnum;
 use Filament\Actions;
 use Filament\Actions\Action;
 use Filament\Forms;
@@ -22,7 +23,7 @@ class PostResource extends Resource
 {
     protected static ?string $model = Post::class;
 
-    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-document-text';
+    protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-document-text';
 
     protected static ?string $recordTitleAttribute = 'title';
 

--- a/docs-assets/app/app/Filament/Resources/PostResource/Resources/CommentResource/CommentResource.php
+++ b/docs-assets/app/app/Filament/Resources/PostResource/Resources/CommentResource/CommentResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\PostResource\Resources\CommentResource;
 
 use App\Filament\Resources\PostResource;
 use App\Models\Comment;
+use BackedEnum;
 use Filament\Resources\Resource;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
@@ -15,7 +16,7 @@ class CommentResource extends Resource
 
     protected static ?string $parentResource = PostResource::class;
 
-    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-chat-bubble-left-right';
+    protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-chat-bubble-left-right';
 
     public static function table(Table $table): Table
     {

--- a/docs-assets/app/app/Filament/Resources/TagResource.php
+++ b/docs-assets/app/app/Filament/Resources/TagResource.php
@@ -4,20 +4,22 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\TagResource\Pages;
 use App\Models\Tag;
+use BackedEnum;
 use Filament\Actions;
 use Filament\Forms;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Table;
+use UnitEnum;
 
 class TagResource extends Resource
 {
     protected static ?string $model = Tag::class;
 
-    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-tag';
+    protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-tag';
 
-    protected static string | \UnitEnum | null $navigationGroup = 'Content';
+    protected static string | UnitEnum | null $navigationGroup = 'Content';
 
     protected static ?int $navigationSort = 3;
 

--- a/docs-assets/app/app/Filament/Resources/UserResource.php
+++ b/docs-assets/app/app/Filament/Resources/UserResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\UserResource\Pages;
 use App\Filament\Resources\UserResource\RelationManagers;
 use App\Models\User;
+use BackedEnum;
 use Filament\Forms;
 use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
@@ -17,7 +18,7 @@ class UserResource extends Resource
 {
     protected static ?string $model = User::class;
 
-    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-users';
+    protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-users';
 
     public static function getSubNavigationPosition(): SubNavigationPosition
     {

--- a/docs-assets/app/app/Filament/Resources/UserResource/Pages/ManageUserComments.php
+++ b/docs-assets/app/app/Filament/Resources/UserResource/Pages/ManageUserComments.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\UserResource\Pages;
 
 use App\Filament\Resources\UserResource;
+use BackedEnum;
 use Filament\Forms;
 use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Schemas\Schema;
@@ -15,7 +16,7 @@ class ManageUserComments extends ManageRelatedRecords
 
     protected static string $relationship = 'comments';
 
-    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-chat-bubble-left-right';
+    protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-chat-bubble-left-right';
 
     public static function getNavigationLabel(): string
     {

--- a/docs-assets/app/app/Filament/Resources/UserResource/Pages/ManageUserNotifications.php
+++ b/docs-assets/app/app/Filament/Resources/UserResource/Pages/ManageUserNotifications.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\UserResource\Pages;
 
 use App\Filament\Resources\UserResource;
+use BackedEnum;
 use Filament\Forms;
 use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Schemas\Schema;
@@ -15,7 +16,7 @@ class ManageUserNotifications extends ManageRelatedRecords
 
     protected static string $relationship = 'notifications';
 
-    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-bell';
+    protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-bell';
 
     public static function getNavigationLabel(): string
     {

--- a/docs-assets/app/app/Filament/Resources/UserResource/Pages/ManageUserOrders.php
+++ b/docs-assets/app/app/Filament/Resources/UserResource/Pages/ManageUserOrders.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\UserResource\Pages;
 
 use App\Filament\Resources\UserResource;
+use BackedEnum;
 use Filament\Forms;
 use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Schemas\Schema;
@@ -15,7 +16,7 @@ class ManageUserOrders extends ManageRelatedRecords
 
     protected static string $relationship = 'orders';
 
-    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-shopping-bag';
+    protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-shopping-bag';
 
     public static function getNavigationLabel(): string
     {

--- a/docs-assets/app/app/Filament/Resources/UserResource/Pages/ManageUserPayments.php
+++ b/docs-assets/app/app/Filament/Resources/UserResource/Pages/ManageUserPayments.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\UserResource\Pages;
 
 use App\Filament\Resources\UserResource;
+use BackedEnum;
 use Filament\Forms;
 use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Schemas\Schema;
@@ -15,7 +16,7 @@ class ManageUserPayments extends ManageRelatedRecords
 
     protected static string $relationship = 'payments';
 
-    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-credit-card';
+    protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-credit-card';
 
     public static function getNavigationLabel(): string
     {

--- a/docs-assets/app/app/Filament/Resources/UserResource/Pages/ManageUserPosts.php
+++ b/docs-assets/app/app/Filament/Resources/UserResource/Pages/ManageUserPosts.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\UserResource\Pages;
 
 use App\Filament\Resources\UserResource;
+use BackedEnum;
 use Filament\Actions;
 use Filament\Forms;
 use Filament\Resources\Pages\ManageRelatedRecords;
@@ -16,7 +17,7 @@ class ManageUserPosts extends ManageRelatedRecords
 
     protected static string $relationship = 'posts';
 
-    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-document-text';
+    protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-document-text';
 
     public static function getNavigationLabel(): string
     {

--- a/docs-assets/app/app/Filament/Resources/UserResource/Pages/ManageUserSettings.php
+++ b/docs-assets/app/app/Filament/Resources/UserResource/Pages/ManageUserSettings.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\UserResource\Pages;
 
 use App\Filament\Resources\UserResource;
+use BackedEnum;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Toggle;
@@ -20,7 +21,7 @@ class ManageUserSettings extends Page
 {
     protected static string $resource = UserResource::class;
 
-    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-cog-6-tooth';
+    protected static string | BackedEnum | null $navigationIcon = 'heroicon-o-cog-6-tooth';
 
     protected static ?string $navigationLabel = 'Settings';
 

--- a/docs-assets/app/app/Livewire/Forms/Fields/DateTimePickerSchema.php
+++ b/docs-assets/app/app/Livewire/Forms/Fields/DateTimePickerSchema.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Forms\Fields;
 
+use Carbon\Carbon;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\TimePicker;
@@ -93,7 +94,7 @@ class DateTimePickerSchema
                         ->label('Custom starts at')
                         ->native(false)
                         ->placeholder('Jan 1, 2000')
-                        ->defaultFocusedDate(\Carbon\Carbon::parse('2000-01-01')),
+                        ->defaultFocusedDate(Carbon::parse('2000-01-01')),
                 ]),
             Group::make()
                 ->id('dateTimePickerAffix')

--- a/docs-assets/app/app/Livewire/Forms/Fields/RichEditorSchema.php
+++ b/docs-assets/app/app/Livewire/Forms/Fields/RichEditorSchema.php
@@ -2,6 +2,9 @@
 
 namespace App\Livewire\Forms\Fields;
 
+use App\RichContentBlocks\CallToActionBlock;
+use App\RichContentBlocks\HeroBlock;
+use App\RichContentBlocks\TestimonialBlock;
 use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\RichEditor\MentionProvider;
 use Filament\Forms\Components\RichEditor\TextColor;
@@ -114,9 +117,9 @@ class RichEditorSchema
                     RichEditor::make('richEditorCustomBlocks')
                         ->label('Content')
                         ->customBlocks([
-                            \App\RichContentBlocks\HeroBlock::class,
-                            \App\RichContentBlocks\CallToActionBlock::class,
-                            \App\RichContentBlocks\TestimonialBlock::class,
+                            HeroBlock::class,
+                            CallToActionBlock::class,
+                            TestimonialBlock::class,
                         ]),
                 ]),
             Group::make()

--- a/docs-assets/app/app/Livewire/PaginationDemo.php
+++ b/docs-assets/app/app/Livewire/PaginationDemo.php
@@ -3,6 +3,7 @@
 namespace App\Livewire;
 
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
 use Livewire\Component;
 
 class PaginationDemo extends Component
@@ -22,7 +23,7 @@ class PaginationDemo extends Component
         );
 
         // Pass perPage + 1 items so Paginator knows there are more pages
-        $simplePaginator = new \Illuminate\Pagination\Paginator(
+        $simplePaginator = new Paginator(
             $items->forPage(2, 10)->push(21),
             10,
             2,

--- a/docs-assets/app/app/Livewire/TablesDemo.php
+++ b/docs-assets/app/app/Livewire/TablesDemo.php
@@ -17,6 +17,11 @@ use Filament\Actions\EditAction;
 use Filament\Actions\ForceDeleteBulkAction;
 use Filament\Actions\ViewAction;
 use Filament\Forms\Components\DatePicker;
+use Filament\QueryBuilder\Constraints\BooleanConstraint;
+use Filament\QueryBuilder\Constraints\DateConstraint;
+use Filament\QueryBuilder\Constraints\SelectConstraint;
+use Filament\QueryBuilder\Constraints\TextConstraint;
+use Filament\Schemas\Components\Section;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Support\Enums\Alignment;
@@ -49,6 +54,7 @@ use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Enums\ColumnManagerLayout;
 use Filament\Tables\Enums\FiltersLayout;
+use Filament\Tables\Enums\PaginationMode;
 use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\Indicator;
@@ -1426,7 +1432,7 @@ class TablesDemo extends Component implements HasActions, HasSchemas, HasTable
             ->filtersFormColumns(2)
             ->filtersFormWidth(Width::FourExtraLarge)
             ->filtersFormSchema(fn (array $filters): array => [
-                \Filament\Schemas\Components\Section::make('Visibility')
+                Section::make('Visibility')
                     ->description('These filters affect the visibility of the records in the table.')
                     ->schema([
                         $filters['is_featured'],
@@ -1497,15 +1503,15 @@ class TablesDemo extends Component implements HasActions, HasSchemas, HasTable
             ->filters([
                 QueryBuilder::make()
                     ->constraints([
-                        \Filament\QueryBuilder\Constraints\TextConstraint::make('title'),
-                        \Filament\QueryBuilder\Constraints\BooleanConstraint::make('is_featured'),
-                        \Filament\QueryBuilder\Constraints\SelectConstraint::make('status')
+                        TextConstraint::make('title'),
+                        BooleanConstraint::make('is_featured'),
+                        SelectConstraint::make('status')
                             ->options([
                                 'draft' => 'Draft',
                                 'reviewing' => 'Reviewing',
                                 'published' => 'Published',
                             ]),
-                        \Filament\QueryBuilder\Constraints\DateConstraint::make('created_at'),
+                        DateConstraint::make('created_at'),
                     ]),
             ], layout: FiltersLayout::AboveContent);
     }
@@ -2562,7 +2568,7 @@ class TablesDemo extends Component implements HasActions, HasSchemas, HasTable
                     }),
                 TextColumn::make('author.name'),
             ])
-            ->paginationMode(\Filament\Tables\Enums\PaginationMode::Cursor)
+            ->paginationMode(PaginationMode::Cursor)
             ->defaultPaginationPageOption(5);
     }
 
@@ -2583,7 +2589,7 @@ class TablesDemo extends Component implements HasActions, HasSchemas, HasTable
                     }),
                 TextColumn::make('author.name'),
             ])
-            ->paginationMode(\Filament\Tables\Enums\PaginationMode::Simple)
+            ->paginationMode(PaginationMode::Simple)
             ->defaultPaginationPageOption(3);
     }
 

--- a/docs-assets/app/app/Providers/Filament/AdminPanelProvider.php
+++ b/docs-assets/app/app/Providers/Filament/AdminPanelProvider.php
@@ -7,6 +7,10 @@ use App\Filament\Pages\Analytics;
 use App\Filament\Resources\PostResource;
 use App\Filament\Resources\TagResource;
 use App\Filament\Resources\UserResource;
+use App\Filament\Widgets\DashboardOrdersChart;
+use App\Filament\Widgets\DashboardRevenueChart;
+use App\Filament\Widgets\DashboardStatsOverview;
+use App\Filament\Widgets\DashboardTableWidget;
 use App\Http\Middleware\AutoLogin;
 use Filament\Auth\MultiFactor\App\AppAuthentication;
 use Filament\Auth\MultiFactor\Email\EmailAuthentication;
@@ -17,7 +21,6 @@ use Filament\Http\Middleware\DispatchServingFilamentEvent;
 use Filament\Navigation\NavigationBuilder;
 use Filament\Navigation\NavigationGroup;
 use Filament\Navigation\NavigationItem;
-use Filament\Pages;
 use Filament\Pages\Dashboard;
 use Filament\Panel;
 use Filament\PanelProvider;
@@ -63,7 +66,7 @@ class AdminPanelProvider extends PanelProvider
             ->discoverPages(in: app_path('Filament/Pages'), for: app()->getNamespace() . 'Filament\\Pages')
             ->discoverClusters(in: app_path('Filament/Clusters'), for: app()->getNamespace() . 'Filament\\Clusters')
             ->pages([
-                Pages\Dashboard::class,
+                Dashboard::class,
             ])
             ->navigation(function (NavigationBuilder $builder): NavigationBuilder {
                 return $builder
@@ -114,10 +117,10 @@ class AdminPanelProvider extends PanelProvider
             )
             ->globalSearchFieldKeyBindingSuffix()
             ->widgets([
-                \App\Filament\Widgets\DashboardStatsOverview::class,
-                \App\Filament\Widgets\DashboardRevenueChart::class,
-                \App\Filament\Widgets\DashboardOrdersChart::class,
-                \App\Filament\Widgets\DashboardTableWidget::class,
+                DashboardStatsOverview::class,
+                DashboardRevenueChart::class,
+                DashboardOrdersChart::class,
+                DashboardTableWidget::class,
             ])
             ->middleware([
                 EncryptCookies::class,

--- a/docs-assets/app/app/Providers/Filament/TenancyDemoPanelProvider.php
+++ b/docs-assets/app/app/Providers/Filament/TenancyDemoPanelProvider.php
@@ -13,7 +13,6 @@ use Filament\Http\Middleware\DispatchServingFilamentEvent;
 use Filament\Navigation\NavigationBuilder;
 use Filament\Navigation\NavigationGroup;
 use Filament\Navigation\NavigationItem;
-use Filament\Pages;
 use Filament\Pages\Dashboard;
 use Filament\Panel;
 use Filament\PanelProvider;
@@ -41,7 +40,7 @@ class TenancyDemoPanelProvider extends PanelProvider
                 'primary' => Color::Amber,
             ])
             ->pages([
-                Pages\Dashboard::class,
+                Dashboard::class,
             ])
             ->navigation(function (NavigationBuilder $builder): NavigationBuilder {
                 return $builder

--- a/docs-assets/app/database/seeders/DatabaseSeeder.php
+++ b/docs-assets/app/database/seeders/DatabaseSeeder.php
@@ -9,6 +9,7 @@ use App\Models\Tag;
 use App\Models\Team;
 use App\Models\User;
 use App\Models\WebsitePage;
+use Carbon\Carbon;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
 
@@ -68,8 +69,8 @@ class DatabaseSeeder extends Seeder
                 'rating' => $post['rating'],
                 'description' => $post['description'],
                 'author_id' => $allUsers[$post['author_index']]->id,
-                'created_at' => \Carbon\Carbon::parse($baseDate)->subDays(count($posts) - $index),
-                'updated_at' => \Carbon\Carbon::parse($baseDate)->subDays(count($posts) - $index),
+                'created_at' => Carbon::parse($baseDate)->subDays(count($posts) - $index),
+                'updated_at' => Carbon::parse($baseDate)->subDays(count($posts) - $index),
             ]);
         }
 
@@ -93,8 +94,8 @@ class DatabaseSeeder extends Seeder
                 'user_id' => $allUsers[$comment['user_index']]->id,
                 'body' => $comment['body'],
                 'is_approved' => $comment['is_approved'],
-                'created_at' => \Carbon\Carbon::parse($baseDate)->subDays(count($comments) - $index),
-                'updated_at' => \Carbon\Carbon::parse($baseDate)->subDays(count($comments) - $index),
+                'created_at' => Carbon::parse($baseDate)->subDays(count($comments) - $index),
+                'updated_at' => Carbon::parse($baseDate)->subDays(count($comments) - $index),
             ]);
         }
 
@@ -142,8 +143,8 @@ class DatabaseSeeder extends Seeder
                 'post_id' => $allPosts[$link['post_index']]->id,
                 'url' => $link['url'],
                 'label' => $link['label'],
-                'created_at' => \Carbon\Carbon::parse($baseDate)->subDays(count($links) - $index),
-                'updated_at' => \Carbon\Carbon::parse($baseDate)->subDays(count($links) - $index),
+                'created_at' => Carbon::parse($baseDate)->subDays(count($links) - $index),
+                'updated_at' => Carbon::parse($baseDate)->subDays(count($links) - $index),
             ]);
         }
 

--- a/packages/actions/src/Action.php
+++ b/packages/actions/src/Action.php
@@ -466,7 +466,7 @@ class Action extends ViewComponent implements Arrayable
 
         $argumentsParameter = '';
 
-        if (count($arguments = $this->getInvokedArguments() ?? [])) {
+        if (count($arguments = $this->getInvokedArguments() ?? $this->getArguments())) {
             $argumentsParameter .= ', ';
             $argumentsParameter .= Js::from($arguments);
         }


### PR DESCRIPTION
## Description

When `getJsClickHandler()` was updated to use `getInvokedArguments()` (the property set by `__invoke()`), the fallback was changed from `$this->getArguments()` to `[]`. This means arguments set via the `arguments()` method are silently dropped from the generated `wire:click` handler — even though the action reports them correctly via `getArguments()`.

This breaks ActionGroup children used as repeater item actions. These actions cannot use `__invoke()` (which clones the action) because the cloned instances aren't connected to the ActionGroup's rendering pipeline. They must use `arguments()` directly, but the current code ignores that property when generating the JavaScript click handler.

**Regression from v3.x** where `getJsClickHandler()` used `$this->getArguments()` directly.

### Reproduction

1. Create a Repeater with `labeledItemActions` containing an `ActionGroup`
2. Inside the ActionGroup, add actions that need `$arguments['item']` (the repeater item key)
3. In the Blade view, set arguments on the flat actions via `$flatAction->arguments(['item' => $itemKey])`
4. Click an action inside the dropdown — `$arguments` is always `[]` in the callback

### Fix

Fall back to `$this->getArguments()` when `invokedArguments` is null, preserving the `invokedArguments` priority when present:

```diff
- if (count($arguments = $this->getInvokedArguments() ?? [])) {
+ if (count($arguments = $this->getInvokedArguments() ?? $this->getArguments())) {
```

## Visual changes

No visual changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.