### PR TITLE
Fix FilamentTimezone not working as expected

### DIFF
--- a/packages/support/src/SupportServiceProvider.php
+++ b/packages/support/src/SupportServiceProvider.php
@@ -76,6 +76,11 @@ class SupportServiceProvider extends PackageServiceProvider
             fn () => new CliManager,
         );
 
+        $this->app->singleton(
+            TimezoneManager::class,
+            fn () => new TimezoneManager,
+        );
+
         $this->app->scoped(
             ScopedComponentManager::class,
             fn () => $this->app->make(ComponentManager::class)->clone(),

--- a/tests/src/Support/Facades/FilamentTimezoneTest.php
+++ b/tests/src/Support/Facades/FilamentTimezoneTest.php
@@ -8,11 +8,5 @@ uses(TestCase::class);
 it('can be set to a specific timezone', function (): void {
     FilamentTimezone::set('America/Vancouver');
 
-    // Simulate what happens when the facade resolves a fresh instance
-    // (e.g., across Livewire requests or when facade cache is cleared)
-    FilamentTimezone::clearResolvedInstance(
-        \Filament\Support\TimezoneManager::class,
-    );
-
     expect(FilamentTimezone::get())->toBe('America/Vancouver');
 });

--- a/tests/src/Support/FilamentTimezoneTest.php
+++ b/tests/src/Support/FilamentTimezoneTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Filament\Support\Facades\FilamentTimezone;
+use Filament\Tests\TestCase;
+
+uses(TestCase::class);
+
+it('can be set to a specific timezone', function (): void {
+    FilamentTimezone::set('America/Vancouver');
+
+    // Simulate what happens when the facade resolves a fresh instance
+    // (e.g., across Livewire requests or when facade cache is cleared)
+    FilamentTimezone::clearResolvedInstance(
+        \Filament\Support\TimezoneManager::class,
+    );
+
+    expect(FilamentTimezone::get())->toBe('America/Vancouver');
+});


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

<!-- Describe the addressed issue or the need for the new or updated functionality. -->
Description:

### Bug

`FilamentTimezone::set()` has no effect on date/time display in table columns, infolist entries, or form components. All `datetime` values continue to display in the application's default timezone
`config('app.timezone')` regardless of what timezone is configured via `FilamentTimezone::set()`.

### Root Cause

`TimezoneManager` is not registered as a singleton in the service container. The FilamentTimezone facade resolves `TimezoneManager::class` as its accessor:

```php
  // Facades/FilamentTimezone.php
  protected static function getFacadeAccessor(): string
  {
      return TimezoneManager::class;
  }
```

When `FilamentTimezone::set()` is called (typically in a service provider's boot() method), the facade resolves a `TimezoneManager` instance from the container and stores the timezone/closure on it. However, since `TimezoneManager` is not bound as a singleton, Laravel creates a new instance every time it is subsequently resolved. When Filament components later call `FilamentTimezone::get()` during
rendering, they receive a fresh TimezoneManager instance that has no timezone set, so it falls back to `config('app.timezone')`.

Other manager classes in the same package are correctly registered as singletons in SupportServiceProvider:

```php
$this->app->singleton(AssetManager::class, fn () => new AssetManager);
$this->app->singleton(CliManager::class, fn () => new CliManager);
```

TimezoneManager was missed.

### Steps to Reproduce

1. Set the application timezone to UTC in config/app.php
2. In a service provider's `boot()` method, configure a display timezone: `FilamentTimezone::set('America/New_York');`
2. Or with a closure:
```php
FilamentTimezone::set(function (): string {
    return Auth::user()->timezone ?? 'America/New_York';
});
```
4. Create a table with a `->dateTime()` column displaying a UTC-stored timestamp
5. Observe that the datetime is still displayed in UTC, not in the configured timezone

### Fix

Register TimezoneManager as a singleton in SupportServiceProvider::register(): `$this->app->singleton(TimezoneManager::class);`

This ensures the same instance is used for both set() and get() calls throughout the request lifecycle.

### Workaround

Until this is fixed upstream, applications can register the singleton themselves in their AppServiceProvider:

```php
public function register(): void
{
    $this->app->singleton(\Filament\Support\TimezoneManager::class);
}
```

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
