### PR TITLE
Fix dashboard route overwritten by home redirect when using tenant slug attribute

### DIFF
--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -175,7 +175,7 @@ Route::name('filament.')
                                             Filament::setCurrentResourceConfigurationKey(null);
                                         }
 
-                                        $rootUri = trim(Route::getLastGroupPrefix(), '/') ?: '/';
+                                        $rootUri = preg_replace('/\{(\w+):\w+\}/', '{$1}', trim(Route::getLastGroupPrefix(), '/')) ?: '/';
                                         $groupStack = Route::getGroupStack();
                                         $rootKey = (end($groupStack)['domain'] ?? '') . $rootUri;
 

--- a/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakePageCommandTest/it_can_generate_a_manage_related_records_page_class_in_a_resource_with_a_generated_form_schema_and_table_columns.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakePageCommandTest/it_can_generate_a_manage_related_records_page_class_in_a_resource_with_a_generated_form_schema_and_table_columns.snap
@@ -26,6 +26,7 @@ class ManageUserTeams extends ManageRelatedRecords
             ->components([
                 Forms\Components\TextInput::make('name')
                     ->required(),
+                Forms\Components\TextInput::make('slug'),
                 Forms\Components\Textarea::make('description')
                     ->columnSpanFull(),
                 Forms\Components\TextInput::make('budget')
@@ -43,6 +44,8 @@ class ManageUserTeams extends ManageRelatedRecords
             ->recordTitleAttribute('name')
             ->columns([
                 Tables\Columns\TextColumn::make('name')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('slug')
                     ->searchable(),
                 Tables\Columns\TextColumn::make('budget')
                     ->numeric()

--- a/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeRelationManagerCommandTest/it_can_generate_a_relation_manager_with_a_generated_form_schema_and_table_columns.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/Legacy/LegacyMakeRelationManagerCommandTest/it_can_generate_a_relation_manager_with_a_generated_form_schema_and_table_columns.snap
@@ -19,6 +19,7 @@ class TeamsRelationManager extends RelationManager
             ->components([
                 Forms\Components\TextInput::make('name')
                     ->required(),
+                Forms\Components\TextInput::make('slug'),
                 Forms\Components\Textarea::make('description')
                     ->columnSpanFull(),
                 Forms\Components\TextInput::make('budget')
@@ -36,6 +37,8 @@ class TeamsRelationManager extends RelationManager
             ->recordTitleAttribute('name')
             ->columns([
                 Tables\Columns\TextColumn::make('name')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('slug')
                     ->searchable(),
                 Tables\Columns\TextColumn::make('budget')
                     ->numeric()

--- a/tests/.pest/snapshots/src/Panels/Commands/MakePageCommandTest/it_can_generate_a_manage_related_records_page_class_in_a_resource_with_a_generated_form_schema_and_table_columns.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/MakePageCommandTest/it_can_generate_a_manage_related_records_page_class_in_a_resource_with_a_generated_form_schema_and_table_columns.snap
@@ -35,6 +35,7 @@ class ManageUserTeams extends ManageRelatedRecords
             ->components([
                 TextInput::make('name')
                     ->required(),
+                TextInput::make('slug'),
                 Textarea::make('description')
                     ->columnSpanFull(),
                 TextInput::make('budget')
@@ -52,6 +53,8 @@ class ManageUserTeams extends ManageRelatedRecords
             ->recordTitleAttribute('name')
             ->columns([
                 TextColumn::make('name')
+                    ->searchable(),
+                TextColumn::make('slug')
                     ->searchable(),
                 TextColumn::make('budget')
                     ->numeric()

--- a/tests/.pest/snapshots/src/Panels/Commands/MakeRelationManagerCommandTest/it_can_generate_a_relation_manager_with_a_generated_form_schema_and_table_columns.snap
+++ b/tests/.pest/snapshots/src/Panels/Commands/MakeRelationManagerCommandTest/it_can_generate_a_relation_manager_with_a_generated_form_schema_and_table_columns.snap
@@ -28,6 +28,7 @@ class TeamsRelationManager extends RelationManager
             ->components([
                 TextInput::make('name')
                     ->required(),
+                TextInput::make('slug'),
                 Textarea::make('description')
                     ->columnSpanFull(),
                 TextInput::make('budget')
@@ -45,6 +46,8 @@ class TeamsRelationManager extends RelationManager
             ->recordTitleAttribute('name')
             ->columns([
                 TextColumn::make('name')
+                    ->searchable(),
+                TextColumn::make('slug')
                     ->searchable(),
                 TextColumn::make('budget')
                     ->numeric()

--- a/tests/database/factories/TeamFactory.php
+++ b/tests/database/factories/TeamFactory.php
@@ -13,6 +13,7 @@ class TeamFactory extends Factory
     {
         return [
             'name' => $this->faker->company(),
+            'slug' => $this->faker->unique()->slug(),
             'description' => $this->faker->sentence(),
         ];
     }

--- a/tests/database/migrations/0001_create_teams_table.php
+++ b/tests/database/migrations/0001_create_teams_table.php
@@ -11,6 +11,7 @@ return new class extends Migration
         Schema::create('teams', function (Blueprint $table): void {
             $table->id();
             $table->string('name');
+            $table->string('slug')->unique()->nullable();
             $table->text('description')->nullable();
             $table->decimal('budget', 10, 2)->default(0);
             $table->foreignId('company_id')->nullable();

--- a/tests/src/Fixtures/Providers/SlugTenancyPanelProvider.php
+++ b/tests/src/Fixtures/Providers/SlugTenancyPanelProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Providers;
+
+use Filament\Http\Middleware\Authenticate;
+use Filament\Http\Middleware\AuthenticateSession;
+use Filament\Http\Middleware\DisableBladeIconComponents;
+use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Http\Middleware\IdentifyTenant;
+use Filament\Pages;
+use Filament\Panel;
+use Filament\PanelProvider;
+use Filament\Tests\Fixtures\Models\Team;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
+
+class SlugTenancyPanelProvider extends PanelProvider
+{
+    public function panel(Panel $panel): Panel
+    {
+        return $panel
+            ->id('slug-tenancy')
+            ->path('slug-tenancy')
+            ->tenant(Team::class, 'slug')
+            ->login()
+            ->pages([
+                Pages\Dashboard::class,
+            ])
+            ->middleware([
+                EncryptCookies::class,
+                AddQueuedCookiesToResponse::class,
+                StartSession::class,
+                AuthenticateSession::class,
+                ShareErrorsFromSession::class,
+                class_exists(PreventRequestForgery::class) ? PreventRequestForgery::class : VerifyCsrfToken::class,
+                SubstituteBindings::class,
+                DisableBladeIconComponents::class,
+                DispatchServingFilamentEvent::class,
+                IdentifyTenant::class,
+            ])
+            ->authMiddleware([
+                Authenticate::class,
+            ]);
+    }
+}

--- a/tests/src/Panels/Routes/TenantSlugAttributeTest.php
+++ b/tests/src/Panels/Routes/TenantSlugAttributeTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Filament\Tests\Panels\Pages\TestCase;
+use Illuminate\Support\Facades\Route;
+
+uses(TestCase::class);
+
+it('registers the dashboard route when using a tenant slug attribute', function (): void {
+    $route = Route::getRoutes()->getByName('filament.slug-tenancy.pages.dashboard');
+
+    expect($route)->not->toBeNull()
+        ->and($route->uri())->toBe('slug-tenancy/{tenant}');
+});
+
+it('does not register the home redirect when the dashboard occupies the root path with a tenant slug attribute', function (): void {
+    expect(Route::getRoutes()->getByName('filament.slug-tenancy.home'))->toBeNull();
+});

--- a/tests/src/TestCase.php
+++ b/tests/src/TestCase.php
@@ -29,6 +29,7 @@ use Filament\Tests\Fixtures\Providers\Fixtures\Providers\SingleDomainPanel;
 use Filament\Tests\Fixtures\Providers\MultiDomainPanel;
 use Filament\Tests\Fixtures\Providers\RequiredMultiFactorAuthenticationPanelProvider;
 use Filament\Tests\Fixtures\Providers\SlugsPanelProvider;
+use Filament\Tests\Fixtures\Providers\SlugTenancyPanelProvider;
 use Filament\Tests\Fixtures\Providers\TenancyPanelProvider;
 use Filament\Widgets\WidgetsServiceProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -72,6 +73,7 @@ abstract class TestCase extends BaseTestCase
             MultiDomainPanel::class,
             SingleDomainPanel::class,
             SlugsPanelProvider::class,
+            SlugTenancyPanelProvider::class,
             TenancyPanelProvider::class,
             PowerJoinsServiceProvider::class,
         ];


### PR DESCRIPTION
Fixes #19582

## Problem

When a panel uses `->tenant(Model::class, 'slug')` with a tenant slug attribute, the Dashboard page route (`filament.{panel}.pages.dashboard`) is never registered. Instead, it's overwritten by the `home` redirect (`RedirectToHomeController`).

**Root cause:** `Route::getLastGroupPrefix()` returns the raw group prefix including binding syntax (`admin/{tenant:slug}`), but Laravel's `RouteCollection` indexes routes by the normalized URI without binding syntax (`admin/{tenant}`). The `isset()` check fails due to this key mismatch, so the guard thinks no root route exists and registers the home redirect — which overwrites the Dashboard.

## Fix

Strip binding syntax from `$rootUri` before looking it up in the route collection:

```php
// Before
$rootUri = trim(Route::getLastGroupPrefix(), '/') ?: '/';

// After
$rootUri = preg_replace('/\{(\w+):\w+\}/', '{$1}', trim(Route::getLastGroupPrefix(), '/')) ?: '/';
```

## Tests

Added two tests that verify:
1. The dashboard route is registered when using a tenant slug attribute
2. The home redirect is **not** registered when the dashboard already occupies the root path

Both tests fail without the fix and pass with it. All existing route tests continue to pass.