### PR TITLE
feat: `ActionSeparator` for visual dividers between actions

### DIFF
--- a/packages/actions/docs/03-grouping-actions.md
+++ b/packages/actions/docs/03-grouping-actions.md
@@ -99,7 +99,32 @@ ActionGroup::make([
 
 ## Adding dividers between actions
 
-You may add dividers between groups of actions by using nested `ActionGroup` objects:
+You may add visual dividers between actions using `ActionSeparator`. It adapts to its context automatically — rendering as a vertical line between inline actions, or splitting a dropdown into separate sections:
+
+```php
+use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
+use Filament\Actions\ActionSeparator;
+
+// Between inline actions (e.g., page header actions)
+[
+    ActionGroup::make([
+        // Array of actions
+    ]),
+    ActionSeparator::make(),
+    Action::make('create'),
+]
+
+// Inside a dropdown — creates a visual section break
+ActionGroup::make([
+    Action::make('view'),
+    Action::make('edit'),
+    ActionSeparator::make(),
+    Action::make('delete'),
+])
+```
+
+Alternatively, you may add dividers inside a dropdown by using nested `ActionGroup` objects:
 
 ```php
 use Filament\Actions\ActionGroup;

--- a/packages/actions/resources/css/actions.css
+++ b/packages/actions/resources/css/actions.css
@@ -1,3 +1,7 @@
+.fi-ac-separator {
+    @apply h-6 w-px self-stretch bg-gray-200 dark:bg-white/10;
+}
+
 .fi-ac {
     @apply gap-3;
 

--- a/packages/actions/src/ActionGroup.php
+++ b/packages/actions/src/ActionGroup.php
@@ -79,7 +79,7 @@ class ActionGroup extends ViewComponent implements Arrayable, HasEmbeddedView
     public const LINK_VIEW = 'filament::components.link';
 
     /**
-     * @var array<Action | ActionGroup>
+     * @var array<Action | ActionGroup | ActionSeparator>
      */
     protected array $actions;
 
@@ -108,7 +108,7 @@ class ActionGroup extends ViewComponent implements Arrayable, HasEmbeddedView
     protected array $extraDropdownAttributes = [];
 
     /**
-     * @param  array<Action | ActionGroup>  $actions
+     * @param  array<Action | ActionGroup | ActionSeparator>  $actions
      */
     public function __construct(array $actions)
     {
@@ -116,7 +116,7 @@ class ActionGroup extends ViewComponent implements Arrayable, HasEmbeddedView
     }
 
     /**
-     * @param  array<Action | ActionGroup>  $actions
+     * @param  array<Action | ActionGroup | ActionSeparator>  $actions
      */
     public static function make(array $actions): static
     {
@@ -134,7 +134,7 @@ class ActionGroup extends ViewComponent implements Arrayable, HasEmbeddedView
     }
 
     /**
-     * @param  array<Action | ActionGroup>  $actions
+     * @param  array<Action | ActionGroup | ActionSeparator>  $actions
      */
     public function actions(array $actions): static
     {
@@ -144,7 +144,9 @@ class ActionGroup extends ViewComponent implements Arrayable, HasEmbeddedView
         foreach ($actions as $action) {
             $action->group($this);
 
-            if ($action instanceof ActionGroup) {
+            if ($action instanceof ActionSeparator) {
+                // Separators are visual-only, not added to flatActions.
+            } elseif ($action instanceof ActionGroup) {
                 $action->defaultDropdownPlacement('right-top');
 
                 $this->flatActions = [
@@ -233,12 +235,13 @@ class ActionGroup extends ViewComponent implements Arrayable, HasEmbeddedView
     }
 
     /**
-     * @return array<Action | ActionGroup>
+     * @return array<Action | ActionGroup | ActionSeparator>
      */
     public function getActions(): array
     {
         return array_map(
-            fn (Action | ActionGroup $action) => match (true) {
+            fn (Action | ActionGroup | ActionSeparator $action) => match (true) {
+                $action instanceof ActionSeparator => $action,
                 $action instanceof Action => $action->defaultView($this->isButtonGroup() ? $action::BUTTON_VIEW : $action::GROUPED_VIEW),
                 $action instanceof ActionGroup => $action->defaultTriggerView($this->isButtonGroup() ? $action::BUTTON_VIEW : $action::GROUPED_VIEW),
             },
@@ -469,8 +472,8 @@ class ActionGroup extends ViewComponent implements Arrayable, HasEmbeddedView
 
         if (! $this->hasDropdown()) {
             return collect($this->getActions())
-                ->filter(fn (Action | ActionGroup $action): bool => $action->isVisible())
-                ->map(fn (Action | ActionGroup $action): string => $action->toHtml())
+                ->filter(fn (Action | ActionGroup | ActionSeparator $action): bool => $action->isVisible())
+                ->map(fn (Action | ActionGroup | ActionSeparator $action): string => $action->toHtml())
                 ->implode('');
         }
 
@@ -727,7 +730,7 @@ class ActionGroup extends ViewComponent implements Arrayable, HasEmbeddedView
     protected function cloneActions(): void
     {
         $this->actions = array_map(
-            fn (Action | ActionGroup $action): Action | ActionGroup => $action->getClone()->group($this),
+            fn (Action | ActionGroup | ActionSeparator $action): Action | ActionGroup | ActionSeparator => $action->getClone()->group($this),
             $this->actions,
         );
 

--- a/packages/actions/src/ActionGroup.php
+++ b/packages/actions/src/ActionGroup.php
@@ -485,7 +485,12 @@ class ActionGroup extends ViewComponent implements Arrayable, HasEmbeddedView
                 continue;
             }
 
-            if ($action instanceof ActionGroup && (! $action->hasDropdown())) {
+            if ($action instanceof ActionSeparator) {
+                if (count($singleActions)) {
+                    $actionLists[] = $singleActions;
+                    $singleActions = [];
+                }
+            } elseif ($action instanceof ActionGroup && (! $action->hasDropdown())) {
                 if (count($singleActions)) {
                     $actionLists[] = $singleActions;
                     $singleActions = [];

--- a/packages/actions/src/ActionSeparator.php
+++ b/packages/actions/src/ActionSeparator.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Filament\Actions;
+
+use Filament\Support\Components\Contracts\HasEmbeddedView;
+use Filament\Support\Components\ViewComponent;
+
+class ActionSeparator extends ViewComponent implements HasEmbeddedView
+{
+    use Concerns\BelongsToGroup;
+    use Concerns\CanBeHidden;
+
+    protected string $evaluationIdentifier = 'separator';
+
+    protected string $viewIdentifier = 'separator';
+
+    public static function make(): static
+    {
+        $static = app(static::class);
+        $static->configure();
+
+        return $static;
+    }
+
+    public function isHiddenInGroup(): bool
+    {
+        if ($this->evaluate($this->isHidden)) {
+            return true;
+        }
+
+        if (! $this->evaluate($this->isVisible)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function toEmbeddedHtml(): string
+    {
+        if ($this->isHidden()) {
+            return '';
+        }
+
+        return '<div class="fi-ac-separator"></div>';
+    }
+}


### PR DESCRIPTION
<img width="796" height="336" alt="image" src="https://github.com/user-attachments/assets/de8b4e13-650f-4b42-89af-2bb9b16e17cb" />

## Summary

> _@danharrin I realize this may not be something you want to include in Filament, but I wanted to submit it as a PR before trying to release it bundled in a plugin or something._

Adds `ActionSeparator`, a lightweight component that renders a visual divider between actions. Works in page header actions, table header actions, and within action groups — adapting its appearance to the context:

- **Inline (header actions, button groups):** Renders a vertical line
- **Dropdown menus:** Splits items into separate `fi-dropdown-list` sections, using the native Filament divider pattern

### Usage

```php
use Filament\Actions\ActionSeparator;

// Page header actions
protected function getHeaderActions(): array
{
    return [
        ActionGroup::make([...])
            ->icon('heroicon-o-cog-6-tooth')
            ->color('gray'),
        ActionSeparator::make(),
        Action::make('create')
            ->label('New Record'),
    ];
}

// Inside a dropdown — creates a visual section break
ActionGroup::make([
    Action::make('edit')->label('Edit'),
    Action::make('duplicate')->label('Duplicate'),
    ActionSeparator::make(),
    Action::make('delete')->label('Delete')->color('danger'),
])
```

### Implementation

- `ActionSeparator` extends `ViewComponent` (same base as `Action` and `ActionGroup`)
- Uses `BelongsToGroup` and `CanBeHidden` concerns for visibility control and group nesting
- Overrides `isHiddenInGroup()` to skip authorization checks (not applicable to separators)
- Renders as `<div class="fi-ac-separator">` with a CSS hook
- In dropdown `ActionGroup`, splits the action list into separate `fi-dropdown-list` sections (same mechanism that nested `ActionGroup` uses)
- `ActionGroup` type unions updated to accept `ActionSeparator` in `actions()`, `getActions()`, `toEmbeddedHtml()`, and `cloneActions()`
- Separators are excluded from `flatActions` since they are visual-only