### PR TITLE
Fix typos in documentation

### DIFF
--- a/packages/actions/docs/08-replicate.md
+++ b/packages/actions/docs/08-replicate.md
@@ -90,7 +90,7 @@ ReplicateAction::make()
 To disable the notification altogether, use the `successNotification(null)` method:
 
 ```php
-use Filament\Actions\RestoreAction;
+use Filament\Actions\ReplicateAction;
 
 ReplicateAction::make()
     ->successNotification(null)

--- a/packages/actions/docs/11-import.md
+++ b/packages/actions/docs/11-import.md
@@ -755,7 +755,7 @@ If you'd like to customize the middleware that is applied to jobs of a certain i
 
 ### Customizing the import job retries
 
-By default, the import system will retry a job for 24 hours, or until it fails 5 times with unhandled exceptions, whichever happens first. This is to allow for temporary issues, such as the database being unavailable, to be resolved. You may change the time period for the job to retry, which is defined in the `getJobRetryUntil()` method on the exporter class:
+By default, the import system will retry a job for 24 hours, or until it fails 5 times with unhandled exceptions, whichever happens first. This is to allow for temporary issues, such as the database being unavailable, to be resolved. You may change the time period for the job to retry, which is defined in the `getJobRetryUntil()` method on the importer class:
 
 ```php
 use Carbon\CarbonInterface;


### PR DESCRIPTION
## Description

Fixes documentation typos in the replicate and import action guides.

## Visual changes

N/A — documentation text change only.

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
