### PR TITLE
 Fix PHPStan errors and redundant code in in() validation method

### DIFF
--- a/packages/actions/src/ActionGroup.php
+++ b/packages/actions/src/ActionGroup.php
@@ -712,7 +712,7 @@ class ActionGroup extends ViewComponent implements Arrayable, HasEmbeddedView
             [
                 'attributes' => new ComponentAttributeBag,
                 ...$this->extractPublicMethods(),
-                ...(isset($this->viewIdentifier) ? [$this->viewIdentifier => $this] : []),
+                $this->viewIdentifier => $this,
                 ...$this->viewData,
             ],
         );

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -253,14 +253,6 @@ trait CanBeValidated
 
         $this->inValidationRuleValues = $values;
 
-        match ($condition) {
-            true => $this->inValidationRuleValues = $values,
-            false => null,
-            default => $this->inValidationRuleValues = fn (Component $component): ?Closure => $component->evaluate($condition) ?
-                $values :
-                null,
-        };
-
         return $this;
     }
 

--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -256,7 +256,7 @@ trait CanBeValidated
         match ($condition) {
             true => $this->inValidationRuleValues = $values,
             false => null,
-            default => $this->inValidationRuleValues = fn (Component $component): array | Arrayable | string | Closure | null => $component->evaluate($condition) ?
+            default => $this->inValidationRuleValues = fn (Component $component): ?Closure => $component->evaluate($condition) ?
                 $values :
                 null,
         };

--- a/packages/tables/src/Concerns/InteractsWithTable.php
+++ b/packages/tables/src/Concerns/InteractsWithTable.php
@@ -127,7 +127,7 @@ trait InteractsWithTable
         }
 
         $this->tableColumnSearches = $this->castTableColumnSearches(
-            $this->tableColumnSearches ?? [],
+            $this->tableColumnSearches,
         );
 
         if ($shouldPersistColumnSearchesInSession) {


### PR DESCRIPTION
## Description

Remove redundant `??` on non-nullable `$tableColumnSearches`, unnecessary `isset()` on always-initialized `$viewIdentifier`, and duplicate match block in `in()` that was left   
  over from a refactor. 

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
