### PR TITLE
Fix dashboard route overwritten by home redirect when using tenant domain binding field

### DIFF
--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -8,6 +8,7 @@ use Filament\Facades\Filament;
 use Filament\Http\Controllers\RedirectToHomeController;
 use Filament\Http\Controllers\RedirectToTenantController;
 use Filament\Panel;
+use Illuminate\Routing\RouteUri;
 use Illuminate\Support\Facades\Route;
 
 Route::name('filament.')
@@ -175,9 +176,10 @@ Route::name('filament.')
                                             Filament::setCurrentResourceConfigurationKey(null);
                                         }
 
-                                        $rootUri = preg_replace('/\{(\w+):\w+\}/', '{$1}', trim(Route::getLastGroupPrefix(), '/')) ?: '/';
                                         $groupStack = Route::getGroupStack();
-                                        $rootKey = (end($groupStack)['domain'] ?? '') . $rootUri;
+                                        $rootDomain = RouteUri::parse(end($groupStack)['domain'] ?? '')->uri;
+                                        $rootUri = RouteUri::parse(trim(Route::getLastGroupPrefix(), '/') ?: '/')->uri;
+                                        $rootKey = $rootDomain . $rootUri;
 
                                         if (! isset(Route::getRoutes()->getRoutesByMethod()['GET'][$rootKey])) {
                                             Route::get('/', RedirectToHomeController::class)->name('home');

--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -8,6 +8,7 @@ use Filament\Facades\Filament;
 use Filament\Http\Controllers\RedirectToHomeController;
 use Filament\Http\Controllers\RedirectToTenantController;
 use Filament\Panel;
+use Illuminate\Foundation\Application;
 use Illuminate\Routing\RouteUri;
 use Illuminate\Support\Facades\Route;
 
@@ -141,6 +142,10 @@ Route::name('filament.')
                                             $routes($panel);
                                         }
 
+                                        if (version_compare(Application::VERSION, '13.0.0', '<')) {
+                                            Route::get('/', RedirectToHomeController::class)->name('home');
+                                        }
+
                                         Route::name('tenant.')->group(function () use ($panel): void {
                                             if ($panel->hasTenantBilling()) {
                                                 Route::get($panel->getTenantBillingRouteSlug(), $panel->getTenantBillingProvider()->getRouteAction())
@@ -176,13 +181,15 @@ Route::name('filament.')
                                             Filament::setCurrentResourceConfigurationKey(null);
                                         }
 
-                                        $groupStack = Route::getGroupStack();
-                                        $rootDomain = RouteUri::parse(end($groupStack)['domain'] ?? '')->uri;
-                                        $rootUri = RouteUri::parse(trim(Route::getLastGroupPrefix(), '/') ?: '/')->uri;
-                                        $rootKey = $rootDomain . $rootUri;
+                                        if (version_compare(Application::VERSION, '13.0.0', '>=')) {
+                                            $groupStack = Route::getGroupStack();
+                                            $rootDomain = RouteUri::parse(end($groupStack)['domain'] ?? '')->uri;
+                                            $rootUri = RouteUri::parse(trim(Route::getLastGroupPrefix(), '/') ?: '/')->uri;
+                                            $rootKey = $rootDomain . $rootUri;
 
-                                        if (! isset(Route::getRoutes()->getRoutesByMethod()['GET'][$rootKey])) {
-                                            Route::get('/', RedirectToHomeController::class)->name('home');
+                                            if (! isset(Route::getRoutes()->getRoutesByMethod()['GET'][$rootKey])) {
+                                                Route::get('/', RedirectToHomeController::class)->name('home');
+                                            }
                                         }
                                     });
 

--- a/packages/panels/routes/web.php
+++ b/packages/panels/routes/web.php
@@ -142,7 +142,7 @@ Route::name('filament.')
                                             $routes($panel);
                                         }
 
-                                        if (version_compare(Application::VERSION, '13.0.0', '<')) {
+                                        if (version_compare(Application::VERSION, '13.0.0', '<')) { /** @phpstan-ignore if.alwaysFalse, if.alwaysTrue */
                                             Route::get('/', RedirectToHomeController::class)->name('home');
                                         }
 
@@ -181,7 +181,7 @@ Route::name('filament.')
                                             Filament::setCurrentResourceConfigurationKey(null);
                                         }
 
-                                        if (version_compare(Application::VERSION, '13.0.0', '>=')) {
+                                        if (version_compare(Application::VERSION, '13.0.0', '>=')) { /** @phpstan-ignore if.alwaysTrue, if.alwaysFalse */
                                             $groupStack = Route::getGroupStack();
                                             $rootDomain = RouteUri::parse(end($groupStack)['domain'] ?? '')->uri;
                                             $rootUri = RouteUri::parse(trim(Route::getLastGroupPrefix(), '/') ?: '/')->uri;

--- a/tests/src/Panels/Routes/SingleAndMultiDomainTest.php
+++ b/tests/src/Panels/Routes/SingleAndMultiDomainTest.php
@@ -36,8 +36,8 @@ it('panels with multiple domains should use the domain in names of all routes', 
 });
 
 it('does not register the home route when a page already owns the root path', function (): void {
-    expect(Route::getRoutes()->getByName('filament.single-domain.home'))->toBeNull();
-    expect(Route::getRoutes()->getByName('filament.single-domain.pages.dashboard'))->not->toBeNull();
+    expect(Route::getRoutes()->getByName('filament.single-domain.home'))->toBeNull()
+        ->and(Route::getRoutes()->getByName('filament.single-domain.pages.dashboard'))->not->toBeNull();
 });
 
 it('preserves the dashboard route when registered on a panel without a domain', function (): void {

--- a/tests/src/Panels/Routes/TenantDomainBindingFieldTest.php
+++ b/tests/src/Panels/Routes/TenantDomainBindingFieldTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Filament\Tests\Panels\Pages\TestCase;
+use Illuminate\Support\Facades\Route;
+
+uses(TestCase::class);
+
+it('registers the dashboard route when using a tenant domain binding field', function (): void {
+    $route = Route::getRoutes()->getByName('filament.domain-tenancy.pages.dashboard');
+
+    expect($route)->not->toBeNull()
+        ->and($route->getDomain())->toBe('{tenant}')
+        ->and($route->uri())->toBe('domain-tenancy');
+});
+
+it('does not register the home redirect when the dashboard occupies the root path with a tenant domain binding field', function (): void {
+    expect(Route::getRoutes()->getByName('filament.domain-tenancy.home'))->toBeNull();
+});


### PR DESCRIPTION
## Description
   When `tenantDomain()` uses a binding field like `{tenant:domain}`, the root route collision check did not normalize the domain portion of the route key.

  Since Laravel stores routes by normalized domain and URI, this caused the dashboard route to be missed and the `home` redirect to be registered as well.

  This updates the check to use `RouteUri::parse()` for both the domain and URI so it matches Laravel's route normalization.

## Visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
