### PR TITLE
Fix: set hasModal in slideOver

### DIFF
--- a/packages/actions/src/Concerns/CanOpenModal.php
+++ b/packages/actions/src/Concerns/CanOpenModal.php
@@ -161,6 +161,7 @@ trait CanOpenModal
 
     public function slideOver(bool | Closure $condition = true): static
     {
+        $this->hasModal = $condition;
         $this->isModalSlideOver = $condition;
 
         return $this;


### PR DESCRIPTION
## Description

Currently, using `slideOver()` without `modal()` has no effect. If this is intentional behavior, I understand, but it doesn’t seem to make much sense and can be confusing.

This PR changes this behavior by enabling the modal automatically when `slideOver()` is called.

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
