### PR TITLE
fix(docs): incorrect formatting in avatar documentation

### DIFF
--- a/docs/12-components/03-avatar.md
+++ b/docs/12-components/03-avatar.md
@@ -52,3 +52,4 @@ You can also pass your own custom size classes into the `size` attribute:
     alt="Dan Harrin"
     size="w-12 h-12"
 />
+```


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

This PR fixes the last code block on the [avatar component](https://filamentphp.com/docs/5.x/components/avatar) documentation page.

## Visual changes

<img width="758" height="545" alt="Screenshot 2026-04-01 at 08 51 59" src="https://github.com/user-attachments/assets/c9f5c524-2422-45d1-976d-35283bb566aa" />