### PR TITLE
Fix Summarizer Issue with BelongsToMany Pivot Fields

### DIFF
--- a/packages/tables/src/Columns/Summarizers/Summarizer.php
+++ b/packages/tables/src/Columns/Summarizers/Summarizer.php
@@ -113,23 +113,29 @@ class Summarizer extends ViewComponent implements HasEmbeddedView
                         return $relatedQuery;
                     },
                 );
-        } elseif ($query && str($attribute)->startsWith('pivot.')) {
+        } elseif ($query) {
             // https://github.com/filamentphp/filament/issues/12501
+            // Handle pivot columns in BelongsToMany context.
+            // This handles two cases:
+            // 1. Columns defined as 'pivot.quantity' (direct pivot access)
+            // 2. Columns defined as 'quantity' in a RelationManager (implicit pivot column)
 
-            $pivotAttribute = (string) str($attribute)
-                ->after('pivot.')
-                ->prepend('pivot_');
+            $pivotAttribute = str($attribute)->startsWith('pivot.')
+                ? (string) str($attribute)->after('pivot.')->prepend('pivot_')
+                : 'pivot_' . $attribute;
 
             $isPivotAttributeSelected = collect($query->getQuery()->getColumns())
                 ->contains(fn (string $column): bool => str($column)->endsWith(" as {$pivotAttribute}"));
 
-            $attribute = $isPivotAttributeSelected ? $pivotAttribute : $attribute;
-
-            // Avoid duplicate columns in the subquery by selecting pivot columns individually.
             if ($isPivotAttributeSelected) {
+                $attribute = $pivotAttribute;
+
+                // Remove ALL wildcards to prevent duplicate column errors when
+                // this query is used as a subquery. Both pivot table and related
+                // model table wildcards can cause "Duplicate column name 'id'" errors.
                 $query->getQuery()->columns = array_filter(
                     $query->getQuery()->columns,
-                    fn (mixed $column): bool => $column !== "{$query->getQuery()->joins[0]->table}.*",
+                    fn (mixed $column): bool => ! is_string($column) || ! str($column)->endsWith('.*'),
                 );
             }
         }

--- a/packages/tables/src/Columns/Summarizers/Summarizer.php
+++ b/packages/tables/src/Columns/Summarizers/Summarizer.php
@@ -129,16 +129,20 @@ class Summarizer extends ViewComponent implements HasEmbeddedView
 
             if ($isPivotAttributeSelected) {
                 $attribute = $pivotAttribute;
+            }
 
-                // Remove the join table's wildcard to prevent duplicate column
-                // errors (e.g., both tables have `id`) when the query is used
-                // as a subquery in MySQL.
-                if ($joinTable = ($query->getQuery()->joins[0]->table ?? null)) {
-                    $query->getQuery()->columns = array_filter(
-                        $query->getQuery()->columns,
-                        fn (mixed $column): bool => ! is_string($column) || $column !== "{$joinTable}.*",
-                    );
-                }
+            // Remove the join table's wildcard to prevent duplicate column
+            // errors (e.g., both tables have `id`) when the query is used
+            // as a subquery in MySQL. This applies to all columns in a
+            // `BelongsToMany` context, not just pivot columns.
+            $hasPivotColumns = collect($query->getQuery()->getColumns())
+                ->contains(fn (string $column): bool => str($column)->contains(' as pivot_'));
+
+            if ($hasPivotColumns && ($joinTable = ($query->getQuery()->joins[0]->table ?? null))) {
+                $query->getQuery()->columns = array_filter(
+                    $query->getQuery()->columns,
+                    fn (mixed $column): bool => ! is_string($column) || $column !== "{$joinTable}.*",
+                );
             }
         }
 

--- a/packages/tables/src/Columns/Summarizers/Summarizer.php
+++ b/packages/tables/src/Columns/Summarizers/Summarizer.php
@@ -115,10 +115,10 @@ class Summarizer extends ViewComponent implements HasEmbeddedView
                 );
         } elseif ($query) {
             // https://github.com/filamentphp/filament/issues/12501
-            // Handle pivot columns in BelongsToMany context.
+            // Handle pivot columns in `BelongsToMany` context.
             // This handles two cases:
-            // 1. Columns defined as 'pivot.quantity' (direct pivot access)
-            // 2. Columns defined as 'quantity' in a RelationManager (implicit pivot column)
+            // 1. Columns defined as `pivot.quantity` (direct pivot access)
+            // 2. Columns defined as `quantity` in a `RelationManager` (implicit pivot column)
 
             $pivotAttribute = str($attribute)->startsWith('pivot.')
                 ? (string) str($attribute)->after('pivot.')->prepend('pivot_')
@@ -130,13 +130,15 @@ class Summarizer extends ViewComponent implements HasEmbeddedView
             if ($isPivotAttributeSelected) {
                 $attribute = $pivotAttribute;
 
-                // Remove ALL wildcards to prevent duplicate column errors when
-                // this query is used as a subquery. Both pivot table and related
-                // model table wildcards can cause "Duplicate column name 'id'" errors.
-                $query->getQuery()->columns = array_filter(
-                    $query->getQuery()->columns,
-                    fn (mixed $column): bool => ! is_string($column) || ! str($column)->endsWith('.*'),
-                );
+                // Remove the join table's wildcard to prevent duplicate column
+                // errors (e.g., both tables have `id`) when the query is used
+                // as a subquery in MySQL.
+                if ($joinTable = ($query->getQuery()->joins[0]->table ?? null)) {
+                    $query->getQuery()->columns = array_filter(
+                        $query->getQuery()->columns,
+                        fn (mixed $column): bool => ! is_string($column) || $column !== "{$joinTable}.*",
+                    );
+                }
             }
         }
 

--- a/packages/tables/src/Concerns/CanSummarizeRecords.php
+++ b/packages/tables/src/Concerns/CanSummarizeRecords.php
@@ -35,6 +35,22 @@ trait CanSummarizeRecords
 
         $selects = [];
 
+        // https://github.com/filamentphp/filament/issues/19594
+        // Check if we have pivot columns selected (BelongsToMany RelationManager context)
+        $queryColumns = $query->getQuery()->getColumns() ?? [];
+        $hasPivotColumns = collect($queryColumns)->contains(
+            fn (mixed $column): bool => is_string($column) && str($column)->contains(' as pivot_'),
+        );
+
+        // If we have pivot columns, remove wildcards to prevent duplicate column errors
+        // when the query is used as a subquery in MySQL.
+        if ($hasPivotColumns) {
+            $query->getQuery()->columns = array_filter(
+                $queryColumns,
+                fn (mixed $column): bool => ! is_string($column) || ! str($column)->endsWith('.*'),
+            );
+        }
+
         foreach ($this->getTable()->getVisibleColumns() as $column) {
             $summarizers = $column->getSummarizers($query);
 
@@ -46,7 +62,18 @@ trait CanSummarizeRecords
                 continue;
             }
 
-            $qualifiedAttribute = $query->getModel()->qualifyColumn($column->getName());
+            $columnName = $column->getName();
+
+            // https://github.com/filamentphp/filament/issues/19594
+            // Check if this column is actually a pivot column by looking for its alias
+            $pivotAlias = 'pivot_' . $columnName;
+            $isPivotColumn = $hasPivotColumns && collect($query->getQuery()->getColumns())
+                ->contains(fn (mixed $col): bool => is_string($col) && str($col)->endsWith(" as {$pivotAlias}"));
+
+            // Use the pivot alias if this is a pivot column, otherwise qualify with the model's table
+            $qualifiedAttribute = $isPivotColumn
+                ? $pivotAlias
+                : $query->getModel()->qualifyColumn($columnName);
 
             foreach ($summarizers as $summarizer) {
                 if ($summarizer->hasQueryModification()) {

--- a/packages/tables/src/Concerns/CanSummarizeRecords.php
+++ b/packages/tables/src/Concerns/CanSummarizeRecords.php
@@ -65,8 +65,11 @@ trait CanSummarizeRecords
             $columnName = $column->getName();
 
             // https://github.com/filamentphp/filament/issues/19594
-            // Check if this column is actually a pivot column by looking for its alias
-            $pivotAlias = 'pivot_' . $columnName;
+            // Check if this column is actually a pivot column by looking for its alias.
+            // Handle both 'pivot.amount_total' (explicit) and 'quantity' (implicit) column names.
+            $pivotAlias = str($columnName)->startsWith('pivot.')
+                ? (string) str($columnName)->after('pivot.')->prepend('pivot_')
+                : 'pivot_' . $columnName;
             $isPivotColumn = $hasPivotColumns && collect($query->getQuery()->getColumns())
                 ->contains(fn (mixed $col): bool => is_string($col) && str($col)->endsWith(" as {$pivotAlias}"));
 

--- a/packages/tables/src/Concerns/CanSummarizeRecords.php
+++ b/packages/tables/src/Concerns/CanSummarizeRecords.php
@@ -39,7 +39,7 @@ trait CanSummarizeRecords
         // Check if we have pivot columns selected (BelongsToMany RelationManager context)
         $queryColumns = $query->getQuery()->getColumns();
         $hasPivotColumns = collect($queryColumns)->contains(
-            fn (mixed $column): bool => is_string($column) && str($column)->contains(' as pivot_'),
+            fn (string $column): bool => str($column)->contains(' as pivot_'),
         );
 
         // If we have pivot columns, remove wildcards to prevent duplicate column errors
@@ -47,7 +47,7 @@ trait CanSummarizeRecords
         if ($hasPivotColumns) {
             $query->getQuery()->columns = array_filter(
                 $queryColumns,
-                fn (mixed $column): bool => ! is_string($column) || ! str($column)->endsWith('.*'),
+                fn (string $column): bool => ! str($column)->endsWith('.*'),
             );
         }
 
@@ -71,7 +71,7 @@ trait CanSummarizeRecords
                 ? (string) str($columnName)->after('pivot.')->prepend('pivot_')
                 : 'pivot_' . $columnName;
             $isPivotColumn = $hasPivotColumns && collect($query->getQuery()->getColumns())
-                ->contains(fn (mixed $col): bool => is_string($col) && str($col)->endsWith(" as {$pivotAlias}"));
+                ->contains(fn (string $col): bool => str($col)->endsWith(" as {$pivotAlias}"));
 
             // Use the pivot alias if this is a pivot column, otherwise qualify with the model's table
             $qualifiedAttribute = $isPivotColumn

--- a/packages/tables/src/Concerns/CanSummarizeRecords.php
+++ b/packages/tables/src/Concerns/CanSummarizeRecords.php
@@ -37,7 +37,7 @@ trait CanSummarizeRecords
 
         // https://github.com/filamentphp/filament/issues/19594
         // Check if we have pivot columns selected (BelongsToMany RelationManager context)
-        $queryColumns = $query->getQuery()->getColumns() ?? [];
+        $queryColumns = $query->getQuery()->getColumns();
         $hasPivotColumns = collect($queryColumns)->contains(
             fn (mixed $column): bool => is_string($column) && str($column)->contains(' as pivot_'),
         );

--- a/packages/tables/src/Concerns/CanSummarizeRecords.php
+++ b/packages/tables/src/Concerns/CanSummarizeRecords.php
@@ -36,18 +36,18 @@ trait CanSummarizeRecords
         $selects = [];
 
         // https://github.com/filamentphp/filament/issues/19594
-        // Check if we have pivot columns selected (BelongsToMany RelationManager context)
-        $queryColumns = $query->getQuery()->getColumns();
-        $hasPivotColumns = collect($queryColumns)->contains(
-            fn (string $column): bool => str($column)->contains(' as pivot_'),
-        );
+        // Check if we have pivot columns selected (`BelongsToMany` `RelationManager` context)
+        $hasPivotColumns = collect($query->getQuery()->getColumns())
+            ->contains(fn (string $column): bool => str($column)->contains(' as pivot_'));
 
-        // If we have pivot columns, remove wildcards to prevent duplicate column errors
-        // when the query is used as a subquery in MySQL.
-        if ($hasPivotColumns) {
+        // If we have pivot columns, remove the join table's wildcard to prevent
+        // duplicate column errors (e.g., both tables have `id`) when the query
+        // is used as a subquery in MySQL. Only the join table's wildcard is removed
+        // so that non-pivot columns from the related model remain accessible.
+        if ($hasPivotColumns && ($joinTable = ($query->getQuery()->joins[0]->table ?? null))) {
             $query->getQuery()->columns = array_filter(
-                $queryColumns,
-                fn (string $column): bool => ! str($column)->endsWith('.*'),
+                $query->getQuery()->columns,
+                fn (mixed $column): bool => ! is_string($column) || $column !== "{$joinTable}.*",
             );
         }
 
@@ -66,7 +66,7 @@ trait CanSummarizeRecords
 
             // https://github.com/filamentphp/filament/issues/19594
             // Check if this column is actually a pivot column by looking for its alias.
-            // Handle both 'pivot.amount_total' (explicit) and 'quantity' (implicit) column names.
+            // Handle both `pivot.amount_total` (explicit) and `quantity` (implicit) column names.
             $pivotAlias = str($columnName)->startsWith('pivot.')
                 ? (string) str($columnName)->after('pivot.')->prepend('pivot_')
                 : 'pivot_' . $columnName;

--- a/tests/database/migrations/0013_create_department_ticket_table.php
+++ b/tests/database/migrations/0013_create_department_ticket_table.php
@@ -12,6 +12,8 @@ return new class extends Migration
             $table->id();
             $table->unsignedBigInteger('department_id');
             $table->unsignedBigInteger('ticket_id');
+            $table->unsignedInteger('quantity')->default(1);
+            $table->unsignedInteger('price')->default(0);
             $table->timestamps();
         });
     }

--- a/tests/src/Fixtures/Models/Ticket.php
+++ b/tests/src/Fixtures/Models/Ticket.php
@@ -20,6 +20,8 @@ class Ticket extends Model
 
     public function departments(): BelongsToMany
     {
-        return $this->belongsToMany(Department::class);
+        return $this->belongsToMany(Department::class)
+            ->withPivot(['quantity', 'price'])
+            ->withTimestamps();
     }
 }

--- a/tests/src/Fixtures/Resources/Tickets/RelationManagers/DepartmentsWithMixedSummaryRelationManager.php
+++ b/tests/src/Fixtures/Resources/Tickets/RelationManagers/DepartmentsWithMixedSummaryRelationManager.php
@@ -3,11 +3,12 @@
 namespace Filament\Tests\Fixtures\Resources\Tickets\RelationManagers;
 
 use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\Summarizers\Count;
 use Filament\Tables\Columns\Summarizers\Sum;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 
-class DepartmentsWithPivotSummaryRelationManager extends RelationManager
+class DepartmentsWithMixedSummaryRelationManager extends RelationManager
 {
     protected static string $relationship = 'departments';
 
@@ -15,11 +16,10 @@ class DepartmentsWithPivotSummaryRelationManager extends RelationManager
     {
         return $table
             ->columns([
-                TextColumn::make('name'),
-                // Test implicit pivot column (just `quantity`)
+                TextColumn::make('name')
+                    ->summarize(Count::make('name_count')),
                 TextColumn::make('quantity')
                     ->summarize(Sum::make('quantity_sum')),
-                // Test explicit pivot column (`pivot.price`)
                 TextColumn::make('pivot.price')
                     ->summarize(Sum::make('price_sum')),
             ]);

--- a/tests/src/Fixtures/Resources/Tickets/RelationManagers/DepartmentsWithPivotSummaryRelationManager.php
+++ b/tests/src/Fixtures/Resources/Tickets/RelationManagers/DepartmentsWithPivotSummaryRelationManager.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Resources\Tickets\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\Summarizers\Sum;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class DepartmentsWithPivotSummaryRelationManager extends RelationManager
+{
+    protected static string $relationship = 'departments';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name'),
+                // Test implicit pivot column (just 'quantity')
+                TextColumn::make('quantity')
+                    ->summarize(Sum::make('quantity_sum')),
+                // Test explicit pivot column ('pivot.price')
+                TextColumn::make('pivot.price')
+                    ->summarize(Sum::make('price_sum')),
+            ]);
+    }
+}

--- a/tests/src/Panels/Resources/RelationManagerTest.php
+++ b/tests/src/Panels/Resources/RelationManagerTest.php
@@ -20,6 +20,7 @@ use Filament\Tests\Fixtures\Resources\Tickets\Pages\EditTicket;
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsRelationManager;
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsRelationManagerWithTabs;
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithAttachTableSelectRelationManager;
+use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithPivotSummaryRelationManager;
 use Filament\Tests\Panels\Resources\TestCase;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Support\Str;
@@ -312,4 +313,24 @@ it('cannot access record for action after record no longer matches tab without `
         ->set('activeTab', 'a_names')
         ->mountTableAction(DeleteAction::class, $department)
         ->assertTableActionNotMounted(DeleteAction::class);
+});
+
+// https://github.com/filamentphp/filament/issues/19594
+it('can summarize pivot columns in a BelongsToMany relation manager', function (): void {
+    $ticket = Ticket::factory()->create();
+    $departments = Department::factory()->count(3)->create();
+
+    // Attach departments with pivot data
+    $ticket->departments()->attach($departments[0], ['quantity' => 10, 'price' => 1000]);
+    $ticket->departments()->attach($departments[1], ['quantity' => 20, 'price' => 2000]);
+    $ticket->departments()->attach($departments[2], ['quantity' => 30, 'price' => 3000]);
+
+    // Test both implicit ('quantity') and explicit ('pivot.price') pivot column summarizers
+    livewire(DepartmentsWithPivotSummaryRelationManager::class, [
+        'ownerRecord' => $ticket,
+        'pageClass' => EditTicket::class,
+    ])
+        ->assertSuccessful()
+        ->assertTableColumnSummarySet('quantity', 'quantity_sum', 60)    // 10 + 20 + 30
+        ->assertTableColumnSummarySet('pivot.price', 'price_sum', 6000); // 1000 + 2000 + 3000
 });

--- a/tests/src/Panels/Resources/RelationManagerTest.php
+++ b/tests/src/Panels/Resources/RelationManagerTest.php
@@ -20,6 +20,7 @@ use Filament\Tests\Fixtures\Resources\Tickets\Pages\EditTicket;
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsRelationManager;
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsRelationManagerWithTabs;
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithAttachTableSelectRelationManager;
+use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithMixedSummaryRelationManager;
 use Filament\Tests\Fixtures\Resources\Tickets\RelationManagers\DepartmentsWithPivotSummaryRelationManager;
 use Filament\Tests\Panels\Resources\TestCase;
 use Illuminate\Auth\Access\Response;
@@ -316,7 +317,7 @@ it('cannot access record for action after record no longer matches tab without `
 });
 
 // https://github.com/filamentphp/filament/issues/19594
-it('can summarize pivot columns in a BelongsToMany relation manager', function (): void {
+it('can summarize pivot columns in a `BelongsToMany` `RelationManager`', function (): void {
     $ticket = Ticket::factory()->create();
     $departments = Department::factory()->count(3)->create();
 
@@ -325,7 +326,7 @@ it('can summarize pivot columns in a BelongsToMany relation manager', function (
     $ticket->departments()->attach($departments[1], ['quantity' => 20, 'price' => 2000]);
     $ticket->departments()->attach($departments[2], ['quantity' => 30, 'price' => 3000]);
 
-    // Test both implicit ('quantity') and explicit ('pivot.price') pivot column summarizers
+    // Test both implicit (`quantity`) and explicit (`pivot.price`) pivot column summarizers
     livewire(DepartmentsWithPivotSummaryRelationManager::class, [
         'ownerRecord' => $ticket,
         'pageClass' => EditTicket::class,
@@ -333,4 +334,22 @@ it('can summarize pivot columns in a BelongsToMany relation manager', function (
         ->assertSuccessful()
         ->assertTableColumnSummarySet('quantity', 'quantity_sum', 60)    // 10 + 20 + 30
         ->assertTableColumnSummarySet('pivot.price', 'price_sum', 6000); // 1000 + 2000 + 3000
+});
+
+it('can summarize both pivot and non-pivot columns in a `BelongsToMany` `RelationManager`', function (): void {
+    $ticket = Ticket::factory()->create();
+    $departments = Department::factory()->count(3)->create();
+
+    $ticket->departments()->attach($departments[0], ['quantity' => 10, 'price' => 1000]);
+    $ticket->departments()->attach($departments[1], ['quantity' => 20, 'price' => 2000]);
+    $ticket->departments()->attach($departments[2], ['quantity' => 30, 'price' => 3000]);
+
+    livewire(DepartmentsWithMixedSummaryRelationManager::class, [
+        'ownerRecord' => $ticket,
+        'pageClass' => EditTicket::class,
+    ])
+        ->assertSuccessful()
+        ->assertTableColumnSummarySet('name', 'name_count', 3)
+        ->assertTableColumnSummarySet('quantity', 'quantity_sum', 60)
+        ->assertTableColumnSummarySet('pivot.price', 'price_sum', 6000);
 });


### PR DESCRIPTION
Fixes issue #19594.

When using `Sum::make()` or other summarizers on pivot columns in a BelongsToMany RelationManager, MySQL would fail with "Duplicate column name 'id'" because the summary query included both pivot_table.* and related_table.* wildcards.

This fix detects pivot columns by checking for `pivot_` aliased columns in the query, removes the wildcard selects to prevent duplicate column errors, and uses the correct pivot alias e.g., `pivot_quantity`) instead of qualifying with the related model's table name.

Note that this fix supports both implicit pivot columns (`quantity`) and explicit pivot columns (`pivot.quantity`). While explicit pivot columns are undocumented, they appear to have always worked. Additionally the fix to the original issue #12501 in PR #12821 made specific reference to columns beginning with `pivot.`.

_Full Disclosure:_ As this was a bit beyond my skill level, I prompted Claude with a summary of the issue and the idea for how to fix. I spent quite awhile massaging Claude's implementation code and testing - and I feel confident that it works well. However, I'm certainly open to notes and/or changes.

## Visual changes

There are no visual changes as part of this PR.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
