### PR TITLE
fix: Preserve hint tooltip on single-arg hintIcon

### DIFF
--- a/packages/forms/src/Components/Concerns/HasHint.php
+++ b/packages/forms/src/Components/Concerns/HasHint.php
@@ -109,7 +109,10 @@ trait HasHint
     public function hintIcon(string | BackedEnum | Htmlable | Closure | null $icon, string | Closure | null $tooltip = null): static
     {
         $this->hintIcon = $icon;
-        $this->hintIconTooltip($tooltip);
+
+        if (func_num_args() >= 2) {
+            $this->hintIconTooltip($tooltip);
+        }
 
         return $this;
     }

--- a/packages/infolists/src/Components/Concerns/HasHint.php
+++ b/packages/infolists/src/Components/Concerns/HasHint.php
@@ -108,7 +108,10 @@ trait HasHint
     public function hintIcon(string | BackedEnum | Htmlable | Closure | null $icon, string | Closure | null $tooltip = null): static
     {
         $this->hintIcon = $icon;
-        $this->hintIconTooltip($tooltip);
+
+        if (func_num_args() >= 2) {
+            $this->hintIconTooltip($tooltip);
+        }
 
         return $this;
     }

--- a/tests/src/Forms/HintTest.php
+++ b/tests/src/Forms/HintTest.php
@@ -77,3 +77,31 @@ class TestComponentWithFormWithTestFieldHint extends Livewire
             ->statePath('data');
     }
 }
+
+it('can set a hint icon tooltip via hintIcon second parameter', function (): void {
+    $field = TextInput::make('test')
+        ->container(Schema::make(Livewire::make()))
+        ->hintIcon('heroicon-o-information-circle', 'Example tooltip');
+    expect($field->getHintIconTooltip())
+        ->toBe('Example tooltip');
+});
+
+it('does not clear a previously set hint icon tooltip when calling hintIcon without a tooltip', function (): void {
+    $field = TextInput::make('test')
+        ->container(Schema::make(Livewire::make()))
+        ->hintIconTooltip('Example tooltip')
+        ->hintIcon('heroicon-o-information-circle');
+
+    expect($field->getHintIconTooltip())
+        ->toBe('Example tooltip');
+});
+
+it('can clear a previously set hint icon tooltip by explicitly passing null to hintIcon', function (): void {
+    $field = TextInput::make('test')
+        ->container(Schema::make(Livewire::make()))
+        ->hintIconTooltip('Example tooltip')
+        ->hintIcon('heroicon-o-information-circle', null);
+
+    expect($field->getHintIconTooltip())
+        ->toBeNull();
+});

--- a/tests/src/Infolists/EntryTest.php
+++ b/tests/src/Infolists/EntryTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Schema;
+use Filament\Tests\Fixtures\Livewire\Livewire;
 use Filament\Tests\Tables\TestCase;
 
 uses(TestCase::class);
@@ -26,3 +28,32 @@ class IdEntry extends TextEntry
         return 'id';
     }
 }
+
+it('can set a hint icon tooltip via hintIcon second parameter', function (): void {
+    $entry = TextEntry::make('test')
+        ->container(Schema::make(Livewire::make()))
+        ->hintIcon('heroicon-o-information-circle', 'Example tooltip');
+
+    expect($entry->getHintIconTooltip())
+        ->toBe('Example tooltip');
+});
+
+it('does not clear a previously set hint icon tooltip when calling hintIcon without a tooltip', function (): void {
+    $entry = TextEntry::make('test')
+        ->container(Schema::make(Livewire::make()))
+        ->hintIconTooltip('Example tooltip')
+        ->hintIcon('heroicon-o-information-circle');
+
+    expect($entry->getHintIconTooltip())
+        ->toBe('Example tooltip');
+});
+
+it('can clear a previously set hint icon tooltip by explicitly passing null to hintIcon', function (): void {
+    $entry = TextEntry::make('test')
+        ->container(Schema::make(Livewire::make()))
+        ->hintIconTooltip('Example tooltip')
+        ->hintIcon('heroicon-o-information-circle', null);
+
+    expect($entry->getHintIconTooltip())
+        ->toBeNull();
+});


### PR DESCRIPTION
## Description

Only call hintIconTooltip from hintIcon when a second argument is passed (forms and infolists HasHint).

Documentation:
- Add overview sections for the HasHint Trait. 
- Point the Hint reference in validation doc at the new anchor in overview.

Fixes #19620 

## Visual changes

N/A

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
