### PR TITLE
Translated to Spanish TailwindCSS color palette for Rich Editor

### DIFF
--- a/packages/forms/resources/lang/es/components.php
+++ b/packages/forms/resources/lang/es/components.php
@@ -548,6 +548,35 @@ return [
 
                         'color' => [
                             'label' => 'Color',
+
+                            'options' => [
+                                'slate' => 'Gris pizarra',
+                                'gray' => 'Gris',
+                                'zinc' => 'Zinc',
+                                'neutral' => 'Gris neutral',
+                                'stone' => 'Piedra',
+                                'mauve' => 'Malva',
+                                'olive' => 'Oliva',
+                                'mist' => 'Neblina',
+                                'taupe' => 'Gris topo',
+                                'red' => 'Rojo',
+                                'orange' => 'Naranja',
+                                'amber' => 'Ámbar',
+                                'yellow' => 'Amarillo',
+                                'lime' => 'Lima',
+                                'green' => 'Verde',
+                                'emerald' => 'Verde esmeralda',
+                                'teal' => 'Verde azulado',
+                                'cyan' => 'Turquesa',
+                                'sky' => 'Cielo',
+                                'blue' => 'Azul',
+                                'indigo' => 'Índigo',
+                                'violet' => 'Violeta',
+                                'purple' => 'Púrpura',
+                                'fuchsia' => 'Fucsia',
+                                'pink' => 'Rosado',
+                                'rose' => 'Rosa',
+                            ],
                         ],
 
                         'custom_color' => [
@@ -590,7 +619,6 @@ return [
             'custom_blocks' => 'Bloques',
             'details' => 'Detalles',
             'h1' => 'Título',
-
             'h2' => 'Encabezado 2',
             'h3' => 'Encabezado 3',
             'h4' => 'Encabezado 4',


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Translated to Spanish TailwindCSS color palette for Rich Editor

[**forms**] `components.php`

| Key                                                             | Status  |
|:---|---|
| rich_editor.actions.text_color.modal.form.color.options.slate   | Missing |
| rich_editor.actions.text_color.modal.form.color.options.gray    | Missing |
| rich_editor.actions.text_color.modal.form.color.options.zinc    | Missing |
| rich_editor.actions.text_color.modal.form.color.options.neutral | Missing |
| rich_editor.actions.text_color.modal.form.color.options.stone   | Missing |
| rich_editor.actions.text_color.modal.form.color.options.mauve   | Missing |
| rich_editor.actions.text_color.modal.form.color.options.olive   | Missing |
| rich_editor.actions.text_color.modal.form.color.options.mist    | Missing |
| rich_editor.actions.text_color.modal.form.color.options.taupe   | Missing |
| rich_editor.actions.text_color.modal.form.color.options.red     | Missing |
| rich_editor.actions.text_color.modal.form.color.options.orange  | Missing |
| rich_editor.actions.text_color.modal.form.color.options.amber   | Missing |
| rich_editor.actions.text_color.modal.form.color.options.yellow  | Missing |
| rich_editor.actions.text_color.modal.form.color.options.lime    | Missing |
| rich_editor.actions.text_color.modal.form.color.options.green   | Missing |
| rich_editor.actions.text_color.modal.form.color.options.emerald | Missing |
| rich_editor.actions.text_color.modal.form.color.options.teal    | Missing |
| rich_editor.actions.text_color.modal.form.color.options.cyan    | Missing |
| rich_editor.actions.text_color.modal.form.color.options.sky     | Missing |
| rich_editor.actions.text_color.modal.form.color.options.blue    | Missing |
| rich_editor.actions.text_color.modal.form.color.options.indigo  | Missing |
| rich_editor.actions.text_color.modal.form.color.options.violet  | Missing |
| rich_editor.actions.text_color.modal.form.color.options.purple  | Missing |
| rich_editor.actions.text_color.modal.form.color.options.fuchsia | Missing |
| rich_editor.actions.text_color.modal.form.color.options.pink    | Missing |
| rich_editor.actions.text_color.modal.form.color.options.rose    | Missing |

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
