### PR TITLE
Add hiddenLabel() support to table column summarizers

### DIFF
--- a/packages/tables/docs/06-summaries.md
+++ b/packages/tables/docs/06-summaries.md
@@ -192,6 +192,28 @@ TextColumn::make('price')
     ->summarize(Sum::make()->label('Total'))
 ```
 
+### Hiding a summarizer's label
+
+It may be tempting to set the label to an empty string to hide it, but this is not recommended. Setting the label to an empty string will not communicate the purpose of the summarizer to screen readers, even if the purpose is clear visually. Instead, you should use the `hiddenLabel()` method, so it is hidden visually but still accessible to screen readers:
+
+```php
+use Filament\Tables\Columns\Summarizers\Sum;
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('price')
+    ->summarize(Sum::make()->hiddenLabel())
+```
+
+You can also conditionally hide the label:
+
+```php
+use Filament\Tables\Columns\Summarizers\Sum;
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('price')
+    ->summarize(Sum::make()->hiddenLabel(FeatureFlag::active()))
+```
+
 ## Scoping the dataset
 
 You may apply a database query scope to a summarizer's dataset using the `query()` method:

--- a/packages/tables/src/Columns/Summarizers/Concerns/HasLabel.php
+++ b/packages/tables/src/Columns/Summarizers/Concerns/HasLabel.php
@@ -6,9 +6,18 @@ use Closure;
 
 trait HasLabel
 {
+    protected bool | Closure $isLabelHidden = false;
+
     protected string | Closure | null $label = null;
 
     protected bool $shouldTranslateLabel = false;
+
+    public function hiddenLabel(bool | Closure $condition = true): static
+    {
+        $this->isLabelHidden = $condition;
+
+        return $this;
+    }
 
     public function label(string | Closure | null $label): static
     {
@@ -37,6 +46,11 @@ trait HasLabel
         }
 
         return $this->shouldTranslateLabel ? __($label) : $label;
+    }
+
+    public function isLabelHidden(): bool
+    {
+        return (bool) $this->evaluate($this->isLabelHidden);
     }
 
     public function getDefaultLabel(): ?string

--- a/packages/tables/src/Columns/Summarizers/Summarizer.php
+++ b/packages/tables/src/Columns/Summarizers/Summarizer.php
@@ -206,14 +206,17 @@ class Summarizer extends ViewComponent implements HasEmbeddedView
 
     public function toEmbeddedHtml(): string
     {
+        $label = $this->getLabel();
+        $isLabelHidden = $this->isLabelHidden();
+
         $attributes = $this->getExtraAttributeBag()
             ->class(['fi-ta-text-summary']);
 
         ob_start(); ?>
 
         <div <?= $attributes->toHtml() ?>>
-            <?php if (filled($label = $this->getLabel())) { ?>
-                <span class="fi-ta-text-summary-label">
+            <?php if (filled($label)) { ?>
+                <span class="fi-ta-text-summary-label<?= $isLabelHidden ? ' fi-sr-only' : '' ?>">
                     <?= e($label) ?>
                 </span>
             <?php } ?>


### PR DESCRIPTION
## Description

The `hiddenLabel()` method exists on the actions and form components but was missing from table column summarizers, so calling `Sum::make()->hiddenLabel()` would result in an error. This PR adds `hiddenLabel()` support to the summarizers' `HasLabel` trait and updates `Summarizer::toEmbeddedHtml()` to render the label with the `fi-sr-only` class when hidden, matching the existing form component implementation.

While using `->label('')` was possible to achieve the same result, adding `hiddenLabel()` allows screen readers to function properly. This change also improves consistency across the codebase.

## Visual changes

_Before_
<img width="1018" height="118" alt="Before" src="https://github.com/user-attachments/assets/1abde723-c657-457e-bcb1-60bfd5722927" />

_After_
<img width="1024" height="88" alt="After" src="https://github.com/user-attachments/assets/6a24b943-3035-4d9f-8a30-cf4c98bfc3a1" />

## Functional changes
- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
