### PR TITLE
Fix: Add null check for mounted action before rendering

### DIFF
--- a/packages/support/src/Livewire/Partials/PartialsComponentHook.php
+++ b/packages/support/src/Livewire/Partials/PartialsComponentHook.php
@@ -167,9 +167,12 @@ class PartialsComponentHook extends ComponentHook
         } elseif ($this->shouldRenderMountedActionOnly()) {
             $action = $this->component->getMountedAction();
 
-            $renderAndQueuePartials(fn (): array => [
-                "action-modals.{$action->getNestingIndex()}" => $action->renderModal(),
-            ]);
+            if ($action !== null) {
+                $renderAndQueuePartials(fn (): array => [
+                    "action-modals.{$action->getNestingIndex()}" => $action->renderModal(),
+                ]);
+            }
+            
         }
 
         if ($this->shouldRenderMountedActionsOnly(whenActionMounted: $isLackingPartialRendersToCoverAllCallsAndUpdates)) {

--- a/packages/support/src/Livewire/Partials/PartialsComponentHook.php
+++ b/packages/support/src/Livewire/Partials/PartialsComponentHook.php
@@ -172,7 +172,7 @@ class PartialsComponentHook extends ComponentHook
                     "action-modals.{$action->getNestingIndex()}" => $action->renderModal(),
                 ]);
             }
-            
+
         }
 
         if ($this->shouldRenderMountedActionsOnly(whenActionMounted: $isLackingPartialRendersToCoverAllCallsAndUpdates)) {

--- a/tests/src/Forms/Components/MorphToSelectTest.php
+++ b/tests/src/Forms/Components/MorphToSelectTest.php
@@ -6,6 +6,7 @@ use Filament\Forms\Components\MorphToSelect;
 use Filament\Tests\Fixtures\Models\Post;
 use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\TestCase;
+use InvalidArgumentException;
 
 uses(TestCase::class);
 
@@ -64,7 +65,7 @@ it('can set `modifyKeySelectUsing()` callback', function (): void {
 
 it('throws `InvalidArgumentException` when name is blank', function (): void {
     MorphToSelect::make('');
-})->throws(\InvalidArgumentException::class);
+})->throws(InvalidArgumentException::class);
 
 describe('label auto-generation', function (): void {
     it('auto-generates label from kebab name', function (): void {

--- a/tests/src/Infolists/Components/IconEntryTest.php
+++ b/tests/src/Infolists/Components/IconEntryTest.php
@@ -2,7 +2,6 @@
 
 namespace Filament\Tests\Infolists\Components;
 
-use Filament\Infolists;
 use Filament\Infolists\Components\IconEntry;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
@@ -279,7 +278,7 @@ class TestComponentWithIconEntry extends Component implements HasSchemas
                 'status' => 'active',
             ])
             ->components([
-                Infolists\Components\IconEntry::make('status')
+                IconEntry::make('status')
                     ->icon(Heroicon::Check),
             ]);
     }
@@ -305,7 +304,7 @@ class IconEntryWithUrl extends Component implements HasSchemas
                 'icon_with_url' => 'https://example.com/icon-link',
             ])
             ->components([
-                Infolists\Components\IconEntry::make('icon_with_url')
+                IconEntry::make('icon_with_url')
                     ->icon(Heroicon::Link)
                     ->url(static fn (?string $state): ?string => $state),
             ]);

--- a/tests/src/Schemas/Components/Utilities/SetTest.php
+++ b/tests/src/Schemas/Components/Utilities/SetTest.php
@@ -67,7 +67,7 @@ it('returns the state value from `__invoke()`', function (): void {
 });
 
 it('can set `skipComponentsChildContainersWhileSearching()`', function (): void {
-    $component = (new \Filament\Schemas\Components\Component)
+    $component = (new Filament\Schemas\Components\Component)
         ->container(Schema::make(Livewire::make()));
 
     $set = new Set($component);

--- a/tests/src/Support/EloquentSerializer/EloquentSerializerTest.php
+++ b/tests/src/Support/EloquentSerializer/EloquentSerializerTest.php
@@ -254,7 +254,7 @@ describe('relationship serialization', function (): void {
 
 describe('error handling', function (): void {
     it('throws when unserializing invalid data', function (): void {
-        $this->expectException(\Throwable::class);
+        $this->expectException(Throwable::class);
 
         $this->serializer->unserialize('invalid');
     });

--- a/tests/src/Tables/Columns/ColumnTest.php
+++ b/tests/src/Tables/Columns/ColumnTest.php
@@ -237,7 +237,7 @@ class RenderColumnWithCustomLabel extends Component implements HasActions, HasSc
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->label('Custom Title'),
+            TextColumn::make('title')->label('Custom Title'),
         ]);
     }
 
@@ -256,7 +256,7 @@ class RenderColumnWithAlignment extends Component implements HasActions, HasSche
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->alignment(Alignment::Center),
+            TextColumn::make('title')->alignment(Alignment::Center),
         ]);
     }
 
@@ -275,7 +275,7 @@ class RenderColumnWithPlaceholder extends Component implements HasActions, HasSc
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('content')->placeholder('N/A'),
+            TextColumn::make('content')->placeholder('N/A'),
         ]);
     }
 
@@ -294,7 +294,7 @@ class RenderColumnWithWidth extends Component implements HasActions, HasSchemas,
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->width('200px'),
+            TextColumn::make('title')->width('200px'),
         ]);
     }
 
@@ -313,8 +313,8 @@ class RenderColumnWithHidden extends Component implements HasActions, HasSchemas
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title'),
-            Tables\Columns\TextColumn::make('content')->hidden(),
+            TextColumn::make('title'),
+            TextColumn::make('content')->hidden(),
         ]);
     }
 
@@ -333,7 +333,7 @@ class RenderColumnWithSortable extends Component implements HasActions, HasSchem
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->sortable(),
+            TextColumn::make('title')->sortable(),
         ]);
     }
 
@@ -352,7 +352,7 @@ class RenderColumnWithSearchable extends Component implements HasActions, HasSch
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->searchable(),
+            TextColumn::make('title')->searchable(),
         ]);
     }
 
@@ -371,7 +371,7 @@ class RenderColumnWithToggleable extends Component implements HasActions, HasSch
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->toggleable(),
+            TextColumn::make('title')->toggleable(),
         ]);
     }
 
@@ -390,7 +390,7 @@ class RenderColumnWithGrowFalse extends Component implements HasActions, HasSche
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->grow(false),
+            TextColumn::make('title')->grow(false),
         ]);
     }
 

--- a/tests/src/Tables/Columns/IconColumnTest.php
+++ b/tests/src/Tables/Columns/IconColumnTest.php
@@ -223,7 +223,7 @@ class TestTableWithIconColumn extends Component implements HasActions, HasSchema
             ->query(Post::query())
             ->columns([
                 Tables\Columns\TextColumn::make('title'),
-                Tables\Columns\IconColumn::make('is_published')
+                IconColumn::make('is_published')
                     ->boolean(),
             ]);
     }
@@ -243,7 +243,7 @@ class RenderIconColumnWithSize extends Component implements HasActions, HasSchem
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\IconColumn::make('is_published')->boolean()->size(IconSize::Small),
+            IconColumn::make('is_published')->boolean()->size(IconSize::Small),
         ]);
     }
 
@@ -262,7 +262,7 @@ class RenderIconColumnWithClosureSize extends Component implements HasActions, H
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\IconColumn::make('is_published')->boolean()->size(static fn (): IconSize => IconSize::Large),
+            IconColumn::make('is_published')->boolean()->size(static fn (): IconSize => IconSize::Large),
         ]);
     }
 
@@ -281,7 +281,7 @@ class RenderIconColumnWithStringSize extends Component implements HasActions, Ha
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\IconColumn::make('is_published')->boolean()->size('lg'),
+            IconColumn::make('is_published')->boolean()->size('lg'),
         ]);
     }
 
@@ -300,7 +300,7 @@ class RenderIconColumnWithFalseColor extends Component implements HasActions, Ha
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\IconColumn::make('is_published')->boolean()->falseColor('warning'),
+            IconColumn::make('is_published')->boolean()->falseColor('warning'),
         ]);
     }
 
@@ -319,7 +319,7 @@ class RenderIconColumnWithTrueColor extends Component implements HasActions, Has
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\IconColumn::make('is_published')->boolean()->trueColor('info'),
+            IconColumn::make('is_published')->boolean()->trueColor('info'),
         ]);
     }
 
@@ -338,7 +338,7 @@ class RenderIconColumnWithFalseIcon extends Component implements HasActions, Has
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\IconColumn::make('is_published')->boolean()->falseIcon('heroicon-o-x-mark'),
+            IconColumn::make('is_published')->boolean()->falseIcon('heroicon-o-x-mark'),
         ]);
     }
 
@@ -357,7 +357,7 @@ class RenderIconColumnWithTrueIcon extends Component implements HasActions, HasS
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\IconColumn::make('is_published')->boolean()->trueIcon('heroicon-o-check'),
+            IconColumn::make('is_published')->boolean()->trueIcon('heroicon-o-check'),
         ]);
     }
 
@@ -376,7 +376,7 @@ class RenderIconColumnWithListWithLineBreaks extends Component implements HasAct
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\IconColumn::make('is_published')->boolean()->listWithLineBreaks(),
+            IconColumn::make('is_published')->boolean()->listWithLineBreaks(),
         ]);
     }
 
@@ -395,7 +395,7 @@ class RenderIconColumnWithClosureBoolean extends Component implements HasActions
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\IconColumn::make('is_published')->boolean(static fn (): bool => true),
+            IconColumn::make('is_published')->boolean(static fn (): bool => true),
         ]);
     }
 
@@ -414,7 +414,7 @@ class RenderIconColumnWithTrueCombined extends Component implements HasActions, 
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\IconColumn::make('is_published')->boolean()->true('heroicon-o-star', 'warning'),
+            IconColumn::make('is_published')->boolean()->true('heroicon-o-star', 'warning'),
         ]);
     }
 
@@ -433,7 +433,7 @@ class RenderIconColumnWithFalseCombined extends Component implements HasActions,
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\IconColumn::make('is_published')->boolean()->false('heroicon-o-x-circle', 'gray'),
+            IconColumn::make('is_published')->boolean()->false('heroicon-o-x-circle', 'gray'),
         ]);
     }
 

--- a/tests/src/Tables/Columns/ImageColumnTest.php
+++ b/tests/src/Tables/Columns/ImageColumnTest.php
@@ -296,7 +296,7 @@ class TestTableWithImageColumn extends Component implements HasActions, HasSchem
             ->query(Post::query())
             ->columns([
                 Tables\Columns\TextColumn::make('title'),
-                Tables\Columns\ImageColumn::make('title'),
+                ImageColumn::make('title'),
             ]);
     }
 
@@ -315,7 +315,7 @@ class RenderImageColumnWithCircular extends Component implements HasActions, Has
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->circular(),
+            ImageColumn::make('title')->circular(),
         ]);
     }
 
@@ -334,7 +334,7 @@ class RenderImageColumnWithClosureCircular extends Component implements HasActio
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->circular(static fn (): bool => true),
+            ImageColumn::make('title')->circular(static fn (): bool => true),
         ]);
     }
 
@@ -353,7 +353,7 @@ class RenderImageColumnWithSquare extends Component implements HasActions, HasSc
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->square(),
+            ImageColumn::make('title')->square(),
         ]);
     }
 
@@ -372,7 +372,7 @@ class RenderImageColumnWithStacked extends Component implements HasActions, HasS
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->stacked(),
+            ImageColumn::make('title')->stacked(),
         ]);
     }
 
@@ -391,7 +391,7 @@ class RenderImageColumnWithClosureStacked extends Component implements HasAction
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->stacked(static fn (): bool => true),
+            ImageColumn::make('title')->stacked(static fn (): bool => true),
         ]);
     }
 
@@ -410,7 +410,7 @@ class RenderImageColumnWithOverlap extends Component implements HasActions, HasS
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->stacked()->overlap(3),
+            ImageColumn::make('title')->stacked()->overlap(3),
         ]);
     }
 
@@ -429,7 +429,7 @@ class RenderImageColumnWithClosureOverlap extends Component implements HasAction
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->stacked()->overlap(static fn (): int => 5),
+            ImageColumn::make('title')->stacked()->overlap(static fn (): int => 5),
         ]);
     }
 
@@ -448,7 +448,7 @@ class RenderImageColumnWithRing extends Component implements HasActions, HasSche
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->stacked()->ring(2),
+            ImageColumn::make('title')->stacked()->ring(2),
         ]);
     }
 
@@ -467,7 +467,7 @@ class RenderImageColumnWithClosureRing extends Component implements HasActions, 
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->stacked()->ring(static fn (): int => 4),
+            ImageColumn::make('title')->stacked()->ring(static fn (): int => 4),
         ]);
     }
 
@@ -486,7 +486,7 @@ class RenderImageColumnWithLimit extends Component implements HasActions, HasSch
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->limit(5),
+            ImageColumn::make('title')->limit(5),
         ]);
     }
 
@@ -505,7 +505,7 @@ class RenderImageColumnWithClosureLimit extends Component implements HasActions,
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->limit(static fn (): int => 10),
+            ImageColumn::make('title')->limit(static fn (): int => 10),
         ]);
     }
 
@@ -524,7 +524,7 @@ class RenderImageColumnWithLimitedRemainingText extends Component implements Has
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->limit(1)->limitedRemainingText(),
+            ImageColumn::make('title')->limit(1)->limitedRemainingText(),
         ]);
     }
 
@@ -543,7 +543,7 @@ class RenderImageColumnWithImageHeightInt extends Component implements HasAction
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->imageHeight(100),
+            ImageColumn::make('title')->imageHeight(100),
         ]);
     }
 
@@ -562,7 +562,7 @@ class RenderImageColumnWithImageHeightString extends Component implements HasAct
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->imageHeight('4rem'),
+            ImageColumn::make('title')->imageHeight('4rem'),
         ]);
     }
 
@@ -581,7 +581,7 @@ class RenderImageColumnWithImageWidth extends Component implements HasActions, H
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->imageWidth(80),
+            ImageColumn::make('title')->imageWidth(80),
         ]);
     }
 
@@ -600,7 +600,7 @@ class RenderImageColumnWithImageSize extends Component implements HasActions, Ha
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->imageSize(64),
+            ImageColumn::make('title')->imageSize(64),
         ]);
     }
 
@@ -619,7 +619,7 @@ class RenderImageColumnWithDefaultImageUrl extends Component implements HasActio
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->defaultImageUrl('https://example.com/default.jpg'),
+            ImageColumn::make('title')->defaultImageUrl('https://example.com/default.jpg'),
         ]);
     }
 
@@ -638,7 +638,7 @@ class RenderImageColumnWithExtraImgAttributes extends Component implements HasAc
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->extraImgAttributes(['loading' => 'lazy']),
+            ImageColumn::make('title')->extraImgAttributes(['loading' => 'lazy']),
         ]);
     }
 
@@ -657,7 +657,7 @@ class RenderImageColumnWithNoCheckFileExistence extends Component implements Has
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->checkFileExistence(false),
+            ImageColumn::make('title')->checkFileExistence(false),
         ]);
     }
 
@@ -676,7 +676,7 @@ class RenderImageColumnWithClosureCheckFileExistence extends Component implement
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\ImageColumn::make('title')->checkFileExistence(static fn (): bool => false),
+            ImageColumn::make('title')->checkFileExistence(static fn (): bool => false),
         ]);
     }
 

--- a/tests/src/Tables/Columns/Layout/LayoutComponentTest.php
+++ b/tests/src/Tables/Columns/Layout/LayoutComponentTest.php
@@ -266,7 +266,7 @@ class RenderTableWithStackAlignment extends LivewireComponent implements HasActi
         ]);
     }
 
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): Illuminate\Contracts\View\View
     {
         return view('livewire.table');
     }
@@ -285,7 +285,7 @@ class RenderTableWithStackSpace extends LivewireComponent implements HasActions,
         ]);
     }
 
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): Illuminate\Contracts\View\View
     {
         return view('livewire.table');
     }
@@ -304,7 +304,7 @@ class RenderTableWithStackCollapsible extends LivewireComponent implements HasAc
         ]);
     }
 
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): Illuminate\Contracts\View\View
     {
         return view('livewire.table');
     }
@@ -323,7 +323,7 @@ class RenderTableWithStackCollapsed extends LivewireComponent implements HasActi
         ]);
     }
 
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): Illuminate\Contracts\View\View
     {
         return view('livewire.table');
     }
@@ -342,7 +342,7 @@ class RenderTableWithGridColumns extends LivewireComponent implements HasActions
         ]);
     }
 
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): Illuminate\Contracts\View\View
     {
         return view('livewire.table');
     }
@@ -361,7 +361,7 @@ class RenderTableWithGridResponsive extends LivewireComponent implements HasActi
         ]);
     }
 
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): Illuminate\Contracts\View\View
     {
         return view('livewire.table');
     }
@@ -380,7 +380,7 @@ class RenderTableWithSplit extends LivewireComponent implements HasActions, HasS
         ]);
     }
 
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): Illuminate\Contracts\View\View
     {
         return view('livewire.table');
     }
@@ -399,7 +399,7 @@ class RenderTableWithSplitFrom extends LivewireComponent implements HasActions, 
         ]);
     }
 
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): Illuminate\Contracts\View\View
     {
         return view('livewire.table');
     }
@@ -418,7 +418,7 @@ class RenderTableWithPanel extends LivewireComponent implements HasActions, HasS
         ]);
     }
 
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): Illuminate\Contracts\View\View
     {
         return view('livewire.table');
     }

--- a/tests/src/Tables/Columns/SelectColumnTest.php
+++ b/tests/src/Tables/Columns/SelectColumnTest.php
@@ -461,7 +461,7 @@ class TestTableWithRelationshipSelectColumn extends Component implements HasActi
         return $table
             ->query(Post::query())
             ->columns([
-                Tables\Columns\SelectColumn::make('author_id')
+                SelectColumn::make('author_id')
                     ->optionsRelationship('author', 'name'),
             ]);
     }
@@ -483,7 +483,7 @@ class TestTableWithSearchableRelationshipSelectColumn extends Component implemen
         return $table
             ->query(Post::query())
             ->columns([
-                Tables\Columns\SelectColumn::make('author_id')
+                SelectColumn::make('author_id')
                     ->optionsRelationship('author', 'name')
                     ->searchableOptions(),
             ]);
@@ -506,7 +506,7 @@ class TestTableWithCustomLabelRelationshipSelectColumn extends Component impleme
         return $table
             ->query(Post::query())
             ->columns([
-                Tables\Columns\SelectColumn::make('author_id')
+                SelectColumn::make('author_id')
                     ->optionsRelationship('author', 'name')
                     ->getOptionLabelFromRecordUsing(static fn (User $record): string => "Author: {$record->name}"),
             ]);
@@ -530,7 +530,7 @@ class TestTableWithSelectColumn extends Component implements HasActions, HasSche
             ->query(Post::query())
             ->columns([
                 Tables\Columns\TextColumn::make('title'),
-                Tables\Columns\SelectColumn::make('rating')
+                SelectColumn::make('rating')
                     ->options([
                         1 => '1 Star',
                         2 => '2 Stars',
@@ -556,7 +556,7 @@ class RenderSelectColumnWithNonNative extends Component implements HasActions, H
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\SelectColumn::make('rating')->options([1 => '1', 2 => '2', 3 => '3'])->native(false),
+            SelectColumn::make('rating')->options([1 => '1', 2 => '2', 3 => '3'])->native(false),
         ]);
     }
 
@@ -575,7 +575,7 @@ class RenderSelectColumnWithClosureNative extends Component implements HasAction
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\SelectColumn::make('rating')->options([1 => '1', 2 => '2'])->native(static fn (): bool => false),
+            SelectColumn::make('rating')->options([1 => '1', 2 => '2'])->native(static fn (): bool => false),
         ]);
     }
 
@@ -594,7 +594,7 @@ class RenderSelectColumnWithSearchable extends Component implements HasActions, 
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\SelectColumn::make('rating')->options([1 => '1', 2 => '2', 3 => '3'])->searchableOptions(),
+            SelectColumn::make('rating')->options([1 => '1', 2 => '2', 3 => '3'])->searchableOptions(),
         ]);
     }
 
@@ -613,7 +613,7 @@ class RenderSelectColumnWithOptionsLimit extends Component implements HasActions
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\SelectColumn::make('rating')->options([1 => '1', 2 => '2'])->optionsLimit(100),
+            SelectColumn::make('rating')->options([1 => '1', 2 => '2'])->optionsLimit(100),
         ]);
     }
 
@@ -632,7 +632,7 @@ class RenderSelectColumnWithClosureOptionsLimit extends Component implements Has
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\SelectColumn::make('rating')->options([1 => '1'])->optionsLimit(static fn (): int => 100),
+            SelectColumn::make('rating')->options([1 => '1'])->optionsLimit(static fn (): int => 100),
         ]);
     }
 
@@ -651,7 +651,7 @@ class RenderSelectColumnWithPosition extends Component implements HasActions, Ha
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\SelectColumn::make('rating')->options([1 => '1'])->native(false)->position('bottom'),
+            SelectColumn::make('rating')->options([1 => '1'])->native(false)->position('bottom'),
         ]);
     }
 
@@ -670,7 +670,7 @@ class RenderSelectColumnWithClosurePosition extends Component implements HasActi
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\SelectColumn::make('rating')->options([1 => '1'])->native(false)->position(static fn (): string => 'bottom'),
+            SelectColumn::make('rating')->options([1 => '1'])->native(false)->position(static fn (): string => 'bottom'),
         ]);
     }
 
@@ -689,7 +689,7 @@ class RenderSelectColumnWithNoWrapLabels extends Component implements HasActions
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\SelectColumn::make('rating')->options([1 => '1'])->native(false)->wrapOptionLabels(false),
+            SelectColumn::make('rating')->options([1 => '1'])->native(false)->wrapOptionLabels(false),
         ]);
     }
 
@@ -708,7 +708,7 @@ class RenderSelectColumnWithClosureWrapLabels extends Component implements HasAc
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\SelectColumn::make('rating')->options([1 => '1'])->native(false)->wrapOptionLabels(static fn (): bool => false),
+            SelectColumn::make('rating')->options([1 => '1'])->native(false)->wrapOptionLabels(static fn (): bool => false),
         ]);
     }
 
@@ -727,7 +727,7 @@ class RenderSelectColumnWithAllowHtml extends Component implements HasActions, H
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\SelectColumn::make('rating')->options([1 => '<b>1</b>'])->allowOptionsHtml(),
+            SelectColumn::make('rating')->options([1 => '<b>1</b>'])->allowOptionsHtml(),
         ]);
     }
 
@@ -746,7 +746,7 @@ class RenderSelectColumnWithPreload extends Component implements HasActions, Has
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\SelectColumn::make('rating')->options([1 => '1', 2 => '2'])->native(false)->preloadOptions(),
+            SelectColumn::make('rating')->options([1 => '1', 2 => '2'])->native(false)->preloadOptions(),
         ]);
     }
 
@@ -765,7 +765,7 @@ class RenderSelectColumnWithNoOptionsMessage extends Component implements HasAct
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\SelectColumn::make('rating')->options([1 => '1'])->native(false)->noOptionsMessage('Nothing here'),
+            SelectColumn::make('rating')->options([1 => '1'])->native(false)->noOptionsMessage('Nothing here'),
         ]);
     }
 
@@ -784,7 +784,7 @@ class RenderSelectColumnWithSearchDebounce extends Component implements HasActio
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\SelectColumn::make('rating')->options([1 => '1'])->searchableOptions()->optionsSearchDebounce(500),
+            SelectColumn::make('rating')->options([1 => '1'])->searchableOptions()->optionsSearchDebounce(500),
         ]);
     }
 
@@ -803,7 +803,7 @@ class RenderSelectColumnWithLoadingMessage extends Component implements HasActio
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\SelectColumn::make('rating')->options([1 => '1'])->native(false)->optionsLoadingMessage('Please wait...'),
+            SelectColumn::make('rating')->options([1 => '1'])->native(false)->optionsLoadingMessage('Please wait...'),
         ]);
     }
 

--- a/tests/src/Tables/Columns/TextColumnTest.php
+++ b/tests/src/Tables/Columns/TextColumnTest.php
@@ -209,7 +209,7 @@ class RenderTextColumn extends Component implements HasActions, HasSchemas, Tabl
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title'),
+            TextColumn::make('title'),
         ]);
     }
 
@@ -228,7 +228,7 @@ class RenderTextColumnWithBadge extends Component implements HasActions, HasSche
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->badge(),
+            TextColumn::make('title')->badge(),
         ]);
     }
 
@@ -247,7 +247,7 @@ class RenderTextColumnWithClosureBadge extends Component implements HasActions, 
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->badge(static fn (): bool => true),
+            TextColumn::make('title')->badge(static fn (): bool => true),
         ]);
     }
 
@@ -266,7 +266,7 @@ class RenderTextColumnWithBadgeUndone extends Component implements HasActions, H
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->badge()->badge(false),
+            TextColumn::make('title')->badge()->badge(false),
         ]);
     }
 
@@ -285,7 +285,7 @@ class RenderTextColumnWithBulleted extends Component implements HasActions, HasS
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->bulleted(),
+            TextColumn::make('title')->bulleted(),
         ]);
     }
 
@@ -304,7 +304,7 @@ class RenderTextColumnWithListWithLineBreaks extends Component implements HasAct
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->listWithLineBreaks(),
+            TextColumn::make('title')->listWithLineBreaks(),
         ]);
     }
 
@@ -323,7 +323,7 @@ class RenderTextColumnWithLimitList extends Component implements HasActions, Has
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->limitList(5),
+            TextColumn::make('title')->limitList(5),
         ]);
     }
 
@@ -342,7 +342,7 @@ class RenderTextColumnWithClosureLimitList extends Component implements HasActio
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->limitList(static fn (): int => 10),
+            TextColumn::make('title')->limitList(static fn (): int => 10),
         ]);
     }
 
@@ -361,7 +361,7 @@ class RenderTextColumnWithDefaultLimitList extends Component implements HasActio
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->limitList(),
+            TextColumn::make('title')->limitList(),
         ]);
     }
 
@@ -380,7 +380,7 @@ class RenderTextColumnWithSizeEnum extends Component implements HasActions, HasS
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->size(TextSize::Large),
+            TextColumn::make('title')->size(TextSize::Large),
         ]);
     }
 
@@ -399,7 +399,7 @@ class RenderTextColumnWithClosureSize extends Component implements HasActions, H
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->size(static fn (): TextSize => TextSize::Large),
+            TextColumn::make('title')->size(static fn (): TextSize => TextSize::Large),
         ]);
     }
 
@@ -418,7 +418,7 @@ class RenderTextColumnWithSizeBase extends Component implements HasActions, HasS
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->size('base'),
+            TextColumn::make('title')->size('base'),
         ]);
     }
 
@@ -437,7 +437,7 @@ class RenderTextColumnWithSizeString extends Component implements HasActions, Ha
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->size('lg'),
+            TextColumn::make('title')->size('lg'),
         ]);
     }
 
@@ -456,7 +456,7 @@ class RenderTextColumnWithExpandableLimitedList extends Component implements Has
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->listWithLineBreaks()->limitList(1)->expandableLimitedList(),
+            TextColumn::make('title')->listWithLineBreaks()->limitList(1)->expandableLimitedList(),
         ]);
     }
 
@@ -475,7 +475,7 @@ class RenderTextColumnWithClosureExpandableLimitedList extends Component impleme
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextColumn::make('title')->listWithLineBreaks()->limitList(1)->expandableLimitedList(static fn (): bool => true),
+            TextColumn::make('title')->listWithLineBreaks()->limitList(1)->expandableLimitedList(static fn (): bool => true),
         ]);
     }
 

--- a/tests/src/Tables/Columns/TextInputColumnTest.php
+++ b/tests/src/Tables/Columns/TextInputColumnTest.php
@@ -271,7 +271,7 @@ class TestTableWithTextInputColumn extends Component implements HasActions, HasS
             ->query(Post::query())
             ->columns([
                 Tables\Columns\TextColumn::make('title'),
-                Tables\Columns\TextInputColumn::make('rating'),
+                TextInputColumn::make('rating'),
             ]);
     }
 
@@ -290,7 +290,7 @@ class RenderTextInputColumnWithType extends Component implements HasActions, Has
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextInputColumn::make('rating')->type('number'),
+            TextInputColumn::make('rating')->type('number'),
         ]);
     }
 
@@ -309,7 +309,7 @@ class RenderTextInputColumnWithClosureType extends Component implements HasActio
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextInputColumn::make('rating')->type(static fn (): string => 'email'),
+            TextInputColumn::make('rating')->type(static fn (): string => 'email'),
         ]);
     }
 
@@ -328,7 +328,7 @@ class RenderTextInputColumnWithMask extends Component implements HasActions, Has
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextInputColumn::make('title')->mask('999-999-9999'),
+            TextInputColumn::make('title')->mask('999-999-9999'),
         ]);
     }
 
@@ -347,7 +347,7 @@ class RenderTextInputColumnWithClosureMask extends Component implements HasActio
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextInputColumn::make('title')->mask(static fn (): string => '(999) 999-9999'),
+            TextInputColumn::make('title')->mask(static fn (): string => '(999) 999-9999'),
         ]);
     }
 
@@ -366,7 +366,7 @@ class RenderTextInputColumnWithRawJsMask extends Component implements HasActions
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextInputColumn::make('title')->mask(RawJs::make('$money($input)')),
+            TextInputColumn::make('title')->mask(RawJs::make('$money($input)')),
         ]);
     }
 
@@ -385,7 +385,7 @@ class RenderTextInputColumnWithPrefix extends Component implements HasActions, H
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextInputColumn::make('rating')->prefix('$'),
+            TextInputColumn::make('rating')->prefix('$'),
         ]);
     }
 
@@ -404,7 +404,7 @@ class RenderTextInputColumnWithClosurePrefix extends Component implements HasAct
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextInputColumn::make('rating')->prefix(static fn (): string => '€'),
+            TextInputColumn::make('rating')->prefix(static fn (): string => '€'),
         ]);
     }
 
@@ -423,7 +423,7 @@ class RenderTextInputColumnWithInlinePrefix extends Component implements HasActi
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextInputColumn::make('rating')->prefix('$', isInline: true),
+            TextInputColumn::make('rating')->prefix('$', isInline: true),
         ]);
     }
 
@@ -442,7 +442,7 @@ class RenderTextInputColumnWithSuffix extends Component implements HasActions, H
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextInputColumn::make('rating')->suffix('USD'),
+            TextInputColumn::make('rating')->suffix('USD'),
         ]);
     }
 
@@ -461,7 +461,7 @@ class RenderTextInputColumnWithClosureSuffix extends Component implements HasAct
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextInputColumn::make('rating')->suffix(static fn (): string => 'EUR'),
+            TextInputColumn::make('rating')->suffix(static fn (): string => 'EUR'),
         ]);
     }
 
@@ -480,7 +480,7 @@ class RenderTextInputColumnWithInlineSuffix extends Component implements HasActi
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextInputColumn::make('rating')->suffix('USD', isInline: true),
+            TextInputColumn::make('rating')->suffix('USD', isInline: true),
         ]);
     }
 
@@ -499,7 +499,7 @@ class RenderTextInputColumnWithPrefixIcon extends Component implements HasAction
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextInputColumn::make('rating')->prefixIcon('heroicon-o-currency-dollar'),
+            TextInputColumn::make('rating')->prefixIcon('heroicon-o-currency-dollar'),
         ]);
     }
 
@@ -518,7 +518,7 @@ class RenderTextInputColumnWithSuffixIcon extends Component implements HasAction
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextInputColumn::make('rating')->suffixIcon('heroicon-o-check'),
+            TextInputColumn::make('rating')->suffixIcon('heroicon-o-check'),
         ]);
     }
 
@@ -537,7 +537,7 @@ class RenderTextInputColumnWithPrefixIconColor extends Component implements HasA
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextInputColumn::make('rating')->prefixIcon('heroicon-o-currency-dollar')->prefixIconColor('success'),
+            TextInputColumn::make('rating')->prefixIcon('heroicon-o-currency-dollar')->prefixIconColor('success'),
         ]);
     }
 
@@ -556,7 +556,7 @@ class RenderTextInputColumnWithClosurePrefixIconColor extends Component implemen
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextInputColumn::make('rating')->prefixIcon('heroicon-o-currency-dollar')->prefixIconColor(static fn (): string => 'info'),
+            TextInputColumn::make('rating')->prefixIcon('heroicon-o-currency-dollar')->prefixIconColor(static fn (): string => 'info'),
         ]);
     }
 
@@ -575,7 +575,7 @@ class RenderTextInputColumnWithSuffixIconColor extends Component implements HasA
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextInputColumn::make('rating')->suffixIcon('heroicon-o-check')->suffixIconColor('danger'),
+            TextInputColumn::make('rating')->suffixIcon('heroicon-o-check')->suffixIconColor('danger'),
         ]);
     }
 
@@ -594,7 +594,7 @@ class RenderTextInputColumnWithInlinePrefixMethod extends Component implements H
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextInputColumn::make('rating')->prefix('$')->inlinePrefix(),
+            TextInputColumn::make('rating')->prefix('$')->inlinePrefix(),
         ]);
     }
 
@@ -613,7 +613,7 @@ class RenderTextInputColumnWithInlineSuffixMethod extends Component implements H
     public function table(Table $table): Table
     {
         return $table->query(Post::query())->columns([
-            Tables\Columns\TextInputColumn::make('rating')->suffix('USD')->inlineSuffix(),
+            TextInputColumn::make('rating')->suffix('USD')->inlineSuffix(),
         ]);
     }
 

--- a/tests/src/Tables/Filters/SelectFilterTest.php
+++ b/tests/src/Tables/Filters/SelectFilterTest.php
@@ -159,9 +159,9 @@ class TestTableWithSelectFilter extends Component implements HasActions, HasSche
                 Tables\Columns\TextColumn::make('rating'),
             ])
             ->filters([
-                Tables\Filters\SelectFilter::make('author')
+                SelectFilter::make('author')
                     ->relationship('author', 'name'),
-                Tables\Filters\SelectFilter::make('rating')
+                SelectFilter::make('rating')
                     ->options([
                         1 => '1 Star',
                         2 => '2 Stars',
@@ -193,7 +193,7 @@ class TestTableWithEmptyRelationshipFilter extends Component implements HasActio
                 Tables\Columns\TextColumn::make('author.name'),
             ])
             ->filters([
-                Tables\Filters\SelectFilter::make('author')
+                SelectFilter::make('author')
                     ->relationship('author', 'name', hasEmptyOption: true),
             ]);
     }
@@ -219,7 +219,7 @@ class TestTableWithMultipleEmptyRelationshipFilter extends Component implements 
                 Tables\Columns\TextColumn::make('author.name'),
             ])
             ->filters([
-                Tables\Filters\SelectFilter::make('author')
+                SelectFilter::make('author')
                     ->relationship('author', 'name', hasEmptyOption: true)
                     ->multiple(),
             ]);
@@ -233,7 +233,7 @@ class TestTableWithMultipleEmptyRelationshipFilter extends Component implements 
 
 describe('options and properties', function (): void {
     it('can get `getOptions()` from static array', function (): void {
-        $filter = Tables\Filters\SelectFilter::make('status')
+        $filter = SelectFilter::make('status')
             ->options([
                 'active' => 'Active',
                 'inactive' => 'Inactive',
@@ -246,7 +246,7 @@ describe('options and properties', function (): void {
     });
 
     it('can get `getOptions()` from closure', function (): void {
-        $filter = Tables\Filters\SelectFilter::make('status')
+        $filter = SelectFilter::make('status')
             ->options(fn (): array => [
                 'active' => 'Active',
                 'inactive' => 'Inactive',
@@ -259,7 +259,7 @@ describe('options and properties', function (): void {
     });
 
     it('can get `getOptions()` from enum class string', function (): void {
-        $filter = Tables\Filters\SelectFilter::make('status')
+        $filter = SelectFilter::make('status')
             ->options(StringBackedEnum::class);
 
         $options = $filter->getOptions();
@@ -272,40 +272,40 @@ describe('options and properties', function (): void {
     });
 
     it('returns empty array for `getOptions()` when no options set', function (): void {
-        $filter = Tables\Filters\SelectFilter::make('status');
+        $filter = SelectFilter::make('status');
 
         expect($filter->getOptions())->toBe([]);
     });
 
     it('can check `isMultiple()` returns correct value', function (): void {
-        $singleFilter = Tables\Filters\SelectFilter::make('status');
-        $multipleFilter = Tables\Filters\SelectFilter::make('status')->multiple();
+        $singleFilter = SelectFilter::make('status');
+        $multipleFilter = SelectFilter::make('status')->multiple();
 
         expect($singleFilter->isMultiple())->toBeFalse();
         expect($multipleFilter->isMultiple())->toBeTrue();
     });
 
     it('can check `isSearchable()` returns correct value', function (): void {
-        $nonSearchableFilter = Tables\Filters\SelectFilter::make('status');
-        $searchableFilter = Tables\Filters\SelectFilter::make('status')->searchable();
+        $nonSearchableFilter = SelectFilter::make('status');
+        $searchableFilter = SelectFilter::make('status')->searchable();
 
         expect($nonSearchableFilter->getSearchable())->toBeFalse();
         expect($searchableFilter->getSearchable())->toBeTrue();
     });
 
     it('can get options limit using `getOptionsLimit()`', function (): void {
-        $defaultFilter = Tables\Filters\SelectFilter::make('status');
-        $limitedFilter = Tables\Filters\SelectFilter::make('status')->optionsLimit(100);
+        $defaultFilter = SelectFilter::make('status');
+        $limitedFilter = SelectFilter::make('status')->optionsLimit(100);
 
         expect($defaultFilter->getOptionsLimit())->toBe(50);
         expect($limitedFilter->getOptionsLimit())->toBe(100);
     });
 
     it('can check `queriesRelationships()` returns `true` when relationship is set', function (): void {
-        $withoutRelationship = Tables\Filters\SelectFilter::make('status')
+        $withoutRelationship = SelectFilter::make('status')
             ->options(['active' => 'Active']);
 
-        $withRelationship = Tables\Filters\SelectFilter::make('author')
+        $withRelationship = SelectFilter::make('author')
             ->relationship('author', 'name');
 
         expect($withoutRelationship->queriesRelationships())->toBeFalse();
@@ -313,31 +313,31 @@ describe('options and properties', function (): void {
     });
 
     it('can get `getRelationshipName()` from string', function (): void {
-        $filter = Tables\Filters\SelectFilter::make('author')
+        $filter = SelectFilter::make('author')
             ->relationship('author', 'name');
 
         expect($filter->getRelationshipName())->toBe('author');
     });
 
     it('can get `getRelationshipName()` from closure', function (): void {
-        $filter = Tables\Filters\SelectFilter::make('author')
+        $filter = SelectFilter::make('author')
             ->relationship(fn (): string => 'author', 'name');
 
         expect($filter->getRelationshipName())->toBe('author');
     });
 
     it('can get `getRelationshipTitleAttribute()`', function (): void {
-        $filter = Tables\Filters\SelectFilter::make('author')
+        $filter = SelectFilter::make('author')
             ->relationship('author', 'name');
 
         expect($filter->getRelationshipTitleAttribute())->toBe('name');
     });
 
     it('can check `hasEmptyRelationshipOption()` returns `true` when `hasEmptyOption` is set', function (): void {
-        $withoutEmptyOption = Tables\Filters\SelectFilter::make('author')
+        $withoutEmptyOption = SelectFilter::make('author')
             ->relationship('author', 'name');
 
-        $withEmptyOption = Tables\Filters\SelectFilter::make('author')
+        $withEmptyOption = SelectFilter::make('author')
             ->relationship('author', 'name', hasEmptyOption: true);
 
         expect($withoutEmptyOption->hasEmptyRelationshipOption())->toBeFalse();
@@ -345,14 +345,14 @@ describe('options and properties', function (): void {
     });
 
     it('can get default empty relationship option label', function (): void {
-        $filter = Tables\Filters\SelectFilter::make('author')
+        $filter = SelectFilter::make('author')
             ->relationship('author', 'name', hasEmptyOption: true);
 
         expect($filter->getEmptyRelationshipOptionLabel())->toBe(__('filament-tables::table.filters.select.relationship.empty_option_label'));
     });
 
     it('can get custom empty relationship option label', function (): void {
-        $filter = Tables\Filters\SelectFilter::make('author')
+        $filter = SelectFilter::make('author')
             ->relationship('author', 'name', hasEmptyOption: true)
             ->emptyRelationshipOptionLabel('No Author');
 
@@ -360,10 +360,10 @@ describe('options and properties', function (): void {
     });
 
     it('can check `isPreloaded()` returns correct value', function (): void {
-        $notPreloaded = Tables\Filters\SelectFilter::make('author')
+        $notPreloaded = SelectFilter::make('author')
             ->relationship('author', 'name');
 
-        $preloaded = Tables\Filters\SelectFilter::make('author')
+        $preloaded = SelectFilter::make('author')
             ->relationship('author', 'name')
             ->preload();
 
@@ -372,48 +372,48 @@ describe('options and properties', function (): void {
     });
 
     it('can check `isNative()` returns correct value', function (): void {
-        $nativeFilter = Tables\Filters\SelectFilter::make('status');
-        $nonNativeFilter = Tables\Filters\SelectFilter::make('status')->native(false);
+        $nativeFilter = SelectFilter::make('status');
+        $nonNativeFilter = SelectFilter::make('status')->native(false);
 
         expect($nativeFilter->isNative())->toBeTrue();
         expect($nonNativeFilter->isNative())->toBeFalse();
     });
 
     it('can check `canSelectPlaceholder()` returns correct value', function (): void {
-        $withPlaceholder = Tables\Filters\SelectFilter::make('status');
-        $withoutPlaceholder = Tables\Filters\SelectFilter::make('status')->selectablePlaceholder(false);
+        $withPlaceholder = SelectFilter::make('status');
+        $withoutPlaceholder = SelectFilter::make('status')->selectablePlaceholder(false);
 
         expect($withPlaceholder->canSelectPlaceholder())->toBeTrue();
         expect($withoutPlaceholder->canSelectPlaceholder())->toBeFalse();
     });
 
     it('can get `getAttribute()` returns filter name by default', function (): void {
-        $filter = Tables\Filters\SelectFilter::make('status');
+        $filter = SelectFilter::make('status');
 
         expect($filter->getAttribute())->toBe('status');
     });
 
     it('can get custom `getAttribute()`', function (): void {
-        $filter = Tables\Filters\SelectFilter::make('status')
+        $filter = SelectFilter::make('status')
             ->attribute('custom_status');
 
         expect($filter->getAttribute())->toBe('custom_status');
     });
 
     it('can set `forceSearchCaseInsensitive()` and get with `isSearchForcedCaseInsensitive()`', function (): void {
-        $filter = Tables\Filters\SelectFilter::make('status')->forceSearchCaseInsensitive();
+        $filter = SelectFilter::make('status')->forceSearchCaseInsensitive();
 
         expect($filter->isSearchForcedCaseInsensitive())->toBeTrue();
     });
 
     it('can set `forceSearchCaseInsensitive()` to `false` and get with `isSearchForcedCaseInsensitive()`', function (): void {
-        $filter = Tables\Filters\SelectFilter::make('status')->forceSearchCaseInsensitive(false);
+        $filter = SelectFilter::make('status')->forceSearchCaseInsensitive(false);
 
         expect($filter->isSearchForcedCaseInsensitive())->toBeFalse();
     });
 
     it('defaults `isSearchForcedCaseInsensitive()` to `null`', function (): void {
-        $filter = Tables\Filters\SelectFilter::make('status');
+        $filter = SelectFilter::make('status');
 
         expect($filter->isSearchForcedCaseInsensitive())->toBeNull();
     });
@@ -421,7 +421,7 @@ describe('options and properties', function (): void {
 
 describe('form field generation', function (): void {
     it('can get `getFormField()` returns `Select` component', function (): void {
-        $filter = Tables\Filters\SelectFilter::make('status')
+        $filter = SelectFilter::make('status')
             ->options(['active' => 'Active', 'inactive' => 'Inactive']);
 
         $formField = $filter->getFormField();
@@ -431,7 +431,7 @@ describe('form field generation', function (): void {
     });
 
     it('can get `getFormField()` returns `Select` component with `values` name for multiple filter', function (): void {
-        $filter = Tables\Filters\SelectFilter::make('status')
+        $filter = SelectFilter::make('status')
             ->multiple()
             ->options(['active' => 'Active', 'inactive' => 'Inactive']);
 
@@ -443,7 +443,7 @@ describe('form field generation', function (): void {
     });
 
     it('can get `getFormField()` with relationship configuration', function (): void {
-        $filter = Tables\Filters\SelectFilter::make('author')
+        $filter = SelectFilter::make('author')
             ->relationship('author', 'name')
             ->searchable()
             ->preload();
@@ -459,7 +459,7 @@ describe('form field generation', function (): void {
         User::factory()->count(3)->create();
 
         livewire(TestTableWithSearchableRelationshipFilter::class)
-            ->assertTableFilterExists('author', function (Tables\Filters\SelectFilter $filter): bool {
+            ->assertTableFilterExists('author', function (SelectFilter $filter): bool {
                 $formField = $filter->getFormField();
 
                 expect($formField->getOptions())->toBe([]);
@@ -527,7 +527,7 @@ describe('relationship filtering', function (): void {
                     Tables\Columns\TextColumn::make('author.name'),
                 ])
                 ->filters([
-                    Tables\Filters\SelectFilter::make('author')
+                    SelectFilter::make('author')
                         ->relationship('author', 'name')
                         ->searchable(),
                 ]);
@@ -554,7 +554,7 @@ describe('relationship filtering', function (): void {
                     Tables\Columns\TextColumn::make('author.name'),
                 ])
                 ->filters([
-                    Tables\Filters\SelectFilter::make('author')
+                    SelectFilter::make('author')
                         ->relationship('author', 'name')
                         ->preload(),
                 ]);
@@ -581,7 +581,7 @@ describe('relationship filtering', function (): void {
                     Tables\Columns\TextColumn::make('author.name'),
                 ])
                 ->filters([
-                    Tables\Filters\SelectFilter::make('author')
+                    SelectFilter::make('author')
                         ->relationship(
                             'author',
                             'name',
@@ -612,7 +612,7 @@ describe('relationship filtering', function (): void {
                     Tables\Columns\TextColumn::make('author.name'),
                 ])
                 ->filters([
-                    Tables\Filters\SelectFilter::make('author')
+                    SelectFilter::make('author')
                         ->relationship('author', 'name')
                         ->getOptionLabelFromRecordUsing(fn (User $record): string => "{$record->name} ({$record->email})")
                         ->preload(),

--- a/tests/src/Tables/Filters/TernaryFilterTest.php
+++ b/tests/src/Tables/Filters/TernaryFilterTest.php
@@ -151,7 +151,7 @@ class TestTableWithNullableTernaryFilter extends Component implements HasActions
                 Tables\Columns\TextColumn::make('content'),
             ])
             ->filters([
-                Tables\Filters\TernaryFilter::make('content')
+                TernaryFilter::make('content')
                     ->nullable(),
             ]);
     }
@@ -178,7 +178,7 @@ class TestTableWithTernaryFilter extends Component implements HasActions, HasSch
                     ->boolean(),
             ])
             ->filters([
-                Tables\Filters\TernaryFilter::make('is_published'),
+                TernaryFilter::make('is_published'),
             ]);
     }
 


### PR DESCRIPTION
## Description

I'm getting a lot of `Call to a member function getNestingIndex() on null` errors in production. Happen on both v4 and v5 sites

This PR just simply adds a null check

## Visual changes

None

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
