### PR TITLE
Fix N+1 styling & evaluation bottleneck during ActionGroup rendering in tables.

### DIFF
--- a/packages/actions/src/Concerns/CanBeHidden.php
+++ b/packages/actions/src/Concerns/CanBeHidden.php
@@ -11,9 +11,14 @@ trait CanBeHidden
 
     protected bool | Closure $isVisible = true;
 
+    protected ?bool $isHiddenCache = null;
+
+    protected ?bool $isHiddenInGroupCache = null;
+
     public function hidden(bool | Closure $condition = true): static
     {
         $this->isHidden = $condition;
+        $this->flushHiddenCache();
 
         return $this;
     }
@@ -21,40 +26,55 @@ trait CanBeHidden
     public function visible(bool | Closure $condition = true): static
     {
         $this->isVisible = $condition;
+        $this->flushHiddenCache();
 
         return $this;
     }
 
+    public function flushHiddenCache(): void
+    {
+        $this->isHiddenCache = null;
+        $this->isHiddenInGroupCache = null;
+    }
+
     public function isHidden(): bool
     {
-        if ($this->getGroup()?->baseIsHidden()) {
-            return true;
+        if ($this->isHiddenCache !== null) {
+            return $this->isHiddenCache;
         }
 
-        return $this->isHiddenInGroup();
+        if ($this->getGroup()?->baseIsHidden()) {
+            return $this->isHiddenCache = true;
+        }
+
+        return $this->isHiddenCache = $this->isHiddenInGroup();
     }
 
     public function isHiddenInGroup(): bool
     {
+        if ($this->isHiddenInGroupCache !== null) {
+            return $this->isHiddenInGroupCache;
+        }
+
         if ($this->evaluate($this->isHidden)) {
-            return true;
+            return $this->isHiddenInGroupCache = true;
         }
 
         if (! $this->evaluate($this->isVisible)) {
-            return true;
+            return $this->isHiddenInGroupCache = true;
         }
 
         if ($this instanceof ActionGroup) {
             foreach ($this->getActions() as $action) {
                 if (! $action->isHiddenInGroup()) {
-                    return false;
+                    return $this->isHiddenInGroupCache = false;
                 }
             }
 
-            return true;
+            return $this->isHiddenInGroupCache = true;
         }
 
-        return ! $this->isAuthorizedOrNotHiddenWhenUnauthorized();
+        return $this->isHiddenInGroupCache = (! $this->isAuthorizedOrNotHiddenWhenUnauthorized());
     }
 
     public function isVisible(): bool

--- a/packages/actions/src/Concerns/CanBeHidden.php
+++ b/packages/actions/src/Concerns/CanBeHidden.php
@@ -35,6 +35,14 @@ trait CanBeHidden
     {
         $this->isHiddenCache = null;
         $this->isHiddenInGroupCache = null;
+
+        if ($this instanceof ActionGroup) {
+            foreach ($this->getActions() as $action) {
+                if (method_exists($action, 'flushHiddenCache')) {
+                    $action->flushHiddenCache();
+                }
+            }
+        }
     }
 
     public function isHidden(): bool

--- a/packages/actions/src/Concerns/InteractsWithRecord.php
+++ b/packages/actions/src/Concerns/InteractsWithRecord.php
@@ -17,29 +17,33 @@ trait InteractsWithRecord
     /**
      * @var Model | class-string<Model> | array<string, mixed> | Closure | null
      */
-    protected Model | string | array | Closure | null $record = null;
+    protected Model|string|array|Closure|null $record = null;
 
     protected ?Closure $resolveRecordUsing = null;
 
     /**
      * @var class-string<Model>|Closure|null
      */
-    protected string | Closure | null $model = null;
+    protected string|Closure|null $model = null;
 
-    protected string | Closure | null $modelLabel = null;
+    protected string|Closure|null $modelLabel = null;
 
-    protected string | Closure | null $pluralModelLabel = null;
+    protected string|Closure|null $pluralModelLabel = null;
 
-    protected string | Closure | null $recordTitle = null;
+    protected string|Closure|null $recordTitle = null;
 
-    protected string | Closure | null $recordTitleAttribute = null;
+    protected string|Closure|null $recordTitleAttribute = null;
 
     /**
      * @param  Model | string | array<string, mixed> | Closure | null  $record
      */
-    public function record(Model | string | array | Closure | null $record): static
+    public function record(Model|string|array|Closure|null $record): static
     {
         $this->record = $record;
+
+        if (method_exists($this, 'flushHiddenCache')) {
+            $this->flushHiddenCache();
+        }
 
         return $this;
     }
@@ -54,35 +58,35 @@ trait InteractsWithRecord
     /**
      * @param  class-string<Model>|Closure|null  $model
      */
-    public function model(string | Closure | null $model): static
+    public function model(string|Closure|null $model): static
     {
         $this->model = $model;
 
         return $this;
     }
 
-    public function modelLabel(string | Closure | null $label): static
+    public function modelLabel(string|Closure|null $label): static
     {
         $this->modelLabel = $label;
 
         return $this;
     }
 
-    public function pluralModelLabel(string | Closure | null $label): static
+    public function pluralModelLabel(string|Closure|null $label): static
     {
         $this->pluralModelLabel = $label;
 
         return $this;
     }
 
-    public function recordTitle(string | Closure | null $title): static
+    public function recordTitle(string|Closure|null $title): static
     {
         $this->recordTitle = $title;
 
         return $this;
     }
 
-    public function recordTitleAttribute(string | Closure | null $attribute): static
+    public function recordTitleAttribute(string|Closure|null $attribute): static
     {
         $this->recordTitleAttribute = $attribute;
 
@@ -92,13 +96,13 @@ trait InteractsWithRecord
     /**
      * @return Model | array<string, mixed> | null
      */
-    public function getRecord(bool $withDefault = true): Model | array | null
+    public function getRecord(bool $withDefault = true): Model|array|null
     {
         $record = $this->evaluate($this->record);
 
-        $isRecordKey = filled($record) && (! $record instanceof Model) && (! is_array($record));
+        $isRecordKey = filled($record) && (!$record instanceof Model) && (!is_array($record));
 
-        if ($isRecordKey && (! $this->resolveRecordUsing)) {
+        if ($isRecordKey && (!$this->resolveRecordUsing)) {
             throw new LogicException("Could not resolve record from key [{$record}] without a [resolveRecordUsing()] callback.");
         }
 
@@ -108,7 +112,7 @@ trait InteractsWithRecord
             ]);
         }
 
-        if ($isRecordKey && $record && (! $this->record instanceof Closure)) {
+        if ($isRecordKey && $record && (!$this->record instanceof Closure)) {
             $this->record = $record;
         }
 
@@ -135,12 +139,12 @@ trait InteractsWithRecord
      * @param  Model | array<string, mixed> | null  $record
      * @return Model | array<string, mixed> | null
      */
-    protected function ensureCorrectRecordType(Model | array | null $record): Model | array | null
+    protected function ensureCorrectRecordType(Model|array|null $record): Model|array|null
     {
         if (
             ($record instanceof Model)
             && filled($customModel = $this->getCustomModel())
-            && (! $record instanceof $customModel)
+            && (!$record instanceof $customModel)
         ) {
             return null;
         }
@@ -155,7 +159,7 @@ trait InteractsWithRecord
         if (
             ($record instanceof Model)
             && filled($customModel = $this->getCustomModel())
-            && (! $record instanceof $customModel)
+            && (!$record instanceof $customModel)
         ) {
             $record = null;
         }
@@ -180,7 +184,7 @@ trait InteractsWithRecord
     /**
      * @param  Model | array<string, mixed>  $record
      */
-    public function resolveRecordKey(Model | array $record): ?string
+    public function resolveRecordKey(Model|array $record): ?string
     {
         if (is_array($record)) {
             return strval($record[ArrayRecord::getKeyName()] ?? throw new LogicException('Record arrays must have a unique [' . ArrayRecord::getKeyName() . '] entry for identification.'));
@@ -206,7 +210,7 @@ trait InteractsWithRecord
             ],
             typedInjections: ($record instanceof Model) ? [
                 Model::class => $record,
-                $record::class => $record,
+                    $record::class => $record,
             ] : [],
         );
 
@@ -314,7 +318,7 @@ trait InteractsWithRecord
 
         $model = $this->getModel();
 
-        if (! $model) {
+        if (!$model) {
             return $this instanceof Action ? $this->getHasActionsLivewire()?->getDefaultActionModelLabel($this) : null;
         }
 

--- a/packages/actions/src/Concerns/InteractsWithRecord.php
+++ b/packages/actions/src/Concerns/InteractsWithRecord.php
@@ -17,27 +17,27 @@ trait InteractsWithRecord
     /**
      * @var Model | class-string<Model> | array<string, mixed> | Closure | null
      */
-    protected Model|string|array|Closure|null $record = null;
+    protected Model | string | array | Closure | null $record = null;
 
     protected ?Closure $resolveRecordUsing = null;
 
     /**
      * @var class-string<Model>|Closure|null
      */
-    protected string|Closure|null $model = null;
+    protected string | Closure | null $model = null;
 
-    protected string|Closure|null $modelLabel = null;
+    protected string | Closure | null $modelLabel = null;
 
-    protected string|Closure|null $pluralModelLabel = null;
+    protected string | Closure | null $pluralModelLabel = null;
 
-    protected string|Closure|null $recordTitle = null;
+    protected string | Closure | null $recordTitle = null;
 
-    protected string|Closure|null $recordTitleAttribute = null;
+    protected string | Closure | null $recordTitleAttribute = null;
 
     /**
      * @param  Model | string | array<string, mixed> | Closure | null  $record
      */
-    public function record(Model|string|array|Closure|null $record): static
+    public function record(Model | string | array | Closure | null $record): static
     {
         $this->record = $record;
 
@@ -58,35 +58,35 @@ trait InteractsWithRecord
     /**
      * @param  class-string<Model>|Closure|null  $model
      */
-    public function model(string|Closure|null $model): static
+    public function model(string | Closure | null $model): static
     {
         $this->model = $model;
 
         return $this;
     }
 
-    public function modelLabel(string|Closure|null $label): static
+    public function modelLabel(string | Closure | null $label): static
     {
         $this->modelLabel = $label;
 
         return $this;
     }
 
-    public function pluralModelLabel(string|Closure|null $label): static
+    public function pluralModelLabel(string | Closure | null $label): static
     {
         $this->pluralModelLabel = $label;
 
         return $this;
     }
 
-    public function recordTitle(string|Closure|null $title): static
+    public function recordTitle(string | Closure | null $title): static
     {
         $this->recordTitle = $title;
 
         return $this;
     }
 
-    public function recordTitleAttribute(string|Closure|null $attribute): static
+    public function recordTitleAttribute(string | Closure | null $attribute): static
     {
         $this->recordTitleAttribute = $attribute;
 
@@ -96,13 +96,13 @@ trait InteractsWithRecord
     /**
      * @return Model | array<string, mixed> | null
      */
-    public function getRecord(bool $withDefault = true): Model|array|null
+    public function getRecord(bool $withDefault = true): Model | array | null
     {
         $record = $this->evaluate($this->record);
 
-        $isRecordKey = filled($record) && (!$record instanceof Model) && (!is_array($record));
+        $isRecordKey = filled($record) && (! $record instanceof Model) && (! is_array($record));
 
-        if ($isRecordKey && (!$this->resolveRecordUsing)) {
+        if ($isRecordKey && (! $this->resolveRecordUsing)) {
             throw new LogicException("Could not resolve record from key [{$record}] without a [resolveRecordUsing()] callback.");
         }
 
@@ -112,7 +112,7 @@ trait InteractsWithRecord
             ]);
         }
 
-        if ($isRecordKey && $record && (!$this->record instanceof Closure)) {
+        if ($isRecordKey && $record && (! $this->record instanceof Closure)) {
             $this->record = $record;
         }
 
@@ -139,12 +139,12 @@ trait InteractsWithRecord
      * @param  Model | array<string, mixed> | null  $record
      * @return Model | array<string, mixed> | null
      */
-    protected function ensureCorrectRecordType(Model|array|null $record): Model|array|null
+    protected function ensureCorrectRecordType(Model | array | null $record): Model | array | null
     {
         if (
             ($record instanceof Model)
             && filled($customModel = $this->getCustomModel())
-            && (!$record instanceof $customModel)
+            && (! $record instanceof $customModel)
         ) {
             return null;
         }
@@ -159,7 +159,7 @@ trait InteractsWithRecord
         if (
             ($record instanceof Model)
             && filled($customModel = $this->getCustomModel())
-            && (!$record instanceof $customModel)
+            && (! $record instanceof $customModel)
         ) {
             $record = null;
         }
@@ -184,7 +184,7 @@ trait InteractsWithRecord
     /**
      * @param  Model | array<string, mixed>  $record
      */
-    public function resolveRecordKey(Model|array $record): ?string
+    public function resolveRecordKey(Model | array $record): ?string
     {
         if (is_array($record)) {
             return strval($record[ArrayRecord::getKeyName()] ?? throw new LogicException('Record arrays must have a unique [' . ArrayRecord::getKeyName() . '] entry for identification.'));
@@ -210,7 +210,7 @@ trait InteractsWithRecord
             ],
             typedInjections: ($record instanceof Model) ? [
                 Model::class => $record,
-                    $record::class => $record,
+                $record::class => $record,
             ] : [],
         );
 
@@ -318,7 +318,7 @@ trait InteractsWithRecord
 
         $model = $this->getModel();
 
-        if (!$model) {
+        if (! $model) {
             return $this instanceof Action ? $this->getHasActionsLivewire()?->getDefaultActionModelLabel($this) : null;
         }
 


### PR DESCRIPTION
## Description

**Fixes severe N+1 styling & evaluation bottleneck during ActionGroup rendering in tables.**

Previously, when actions were placed inside an `ActionGroup` in tables, the trait `CanBeHidden` would repetitively evaluate closures and perform Gate authorization checks up to 3-6 times per individual action for the exact same table row. This mathematically resulted in hundreds of excessive and completely redundant checks (e.g., 50 rows * 3 actions inside a dropdown generated approximately 870 Gate checks instead of the absolute theoretical minimum of 150 checks).

This PR solves this bottleneck by implementing an **Instance-Level Caching (Memoization)** mechanism safely attached to the cloned component instance lifecycle. 

- Internal Action state queries (`isHidden` / `isHiddenInGroup`) have been smartly cached via simple `?bool` computed properties.
- Completely respects Filament's dynamic `toHtml` lifecycle. The cache naturally stays fresh per table-row because Filament handles context isolation via cloning action instances per row.
- **Bulletproof Cache Invalidation:** Handled dynamic mutations automatically via `flushHiddenCache()`. Since records and visibility states can be mutated manually before evaluation (e.g., `->record()`, `->hidden()`, `->visible()`), the state cache gracefully invalidates itself, cascading down dynamically to any inner actions inside an `ActionGroup` to ensure no stale authorizations or evaluations are rendered ever.

Because of this, rendering complex ActionGroups on bulk lists is now extremely lightweight and triggers the exact mathematical minimum of Gate checks.

## Visual changes

**Before applying the cache optimization (870+ duplicate Gate queries detected):**  
![WhatsApp Image 2026-04-07 at 23 49 43](https://github.com/user-attachments/assets/72261f43-0700-4ffa-b0b5-f2b5651764d3)

**After the Instance-Level Rendering Optimization (reduced to ideal minimum):**  
<img width="1920" height="863" alt="SCR-20260408-cjdm" src="https://github.com/user-attachments/assets/b5f3a58f-eec8-41c3-be99-44443752fa53" />

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date (N/A).
