### PR TITLE
docs: add local development quickstart for contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,20 @@ composer install
 npm install
 cp .env.example .env
 php artisan key:generate
+touch database/database.sqlite
+# Update `.env` to use SQLite before migrating.
 php artisan migrate
+```
+
+Run the dev servers in separate terminals:
+
+```bash
+cd docs-assets/app
 npm run dev
+```
+
+```bash
+cd docs-assets/app
 php artisan serve
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,40 @@ With a solid Laravel foundation and a polished UI, you can focus on what makes y
 
 Please see our [contributing guide](https://filamentphp.com/docs/5.x/introduction/contributing).
 
+### Local development quickstart
+
+If you want to work on Filament locally, install the monorepo dependencies first:
+
+```bash
+composer install
+npm install
+```
+
+You can run the test suite with:
+
+```bash
+composer test:sqlite
+```
+
+If your change affects frontend assets, rebuild them with:
+
+```bash
+npm run build
+```
+
+To test changes in a Laravel app inside this repository, you can use the demo app in [`docs-assets/app`](docs-assets/app):
+
+```bash
+cd docs-assets/app
+composer install
+npm install
+cp .env.example .env
+php artisan key:generate
+php artisan migrate
+npm run dev
+php artisan serve
+```
+
 ## Need Help?
 
 🐞 If you spot a bug, please [submit a detailed issue](https://github.com/filamentphp/filament/issues/new?template=bug_report.yml), and wait for assistance.


### PR DESCRIPTION
## Summary

This PR adds a short local development quickstart to the root README for contributors.

## Why

The current contribution guidance links to the docs, but new contributors still need to figure out the basic monorepo setup, how to run the demo app, and which test command to use. This adds a small copy-paste-friendly section to reduce that friction.

## Changes

- add `composer install` and `npm install` setup steps
- document `composer test:sqlite`
- document `npm run build` for frontend-related changes
- document how to run the demo app from `docs-assets/app`

## Testing

- no runtime code changes
- docs-only change
