### PR TITLE
Enhance search column expression for pgsql prefix

### DIFF
--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -245,6 +245,12 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
     {
         $driverName = $databaseConnection->getDriverName();
 
+        // Support laravel table prefix with pgsql
+        $tablePrefix = $databaseConnection->getTablePrefix();
+        if ($driverName === 'pgsql' && filled($tablePrefix) && str_contains($column, '.')) {
+            $column = $tablePrefix . $column;
+        }
+        
         $column = match ($driverName) {
             'pgsql' => (
                 str($column)->contains('->')

--- a/packages/support/src/helpers.php
+++ b/packages/support/src/helpers.php
@@ -245,12 +245,10 @@ if (! function_exists('Filament\Support\generate_search_column_expression')) {
     {
         $driverName = $databaseConnection->getDriverName();
 
-        // Support laravel table prefix with pgsql
-        $tablePrefix = $databaseConnection->getTablePrefix();
-        if ($driverName === 'pgsql' && filled($tablePrefix) && str_contains($column, '.')) {
-            $column = $tablePrefix . $column;
+        if ($driverName === 'pgsql' && str_contains($column, '.')) {
+            $column = $databaseConnection->getTablePrefix() . $column;
         }
-        
+
         $column = match ($driverName) {
             'pgsql' => (
                 str($column)->contains('->')

--- a/tests/src/Support/helpersTest.php
+++ b/tests/src/Support/helpersTest.php
@@ -111,6 +111,7 @@ it('will generate a column expression for Postgres with colons in the table name
 
     $databaseConnection = Mockery::mock(Connection::class);
     $databaseConnection->shouldReceive('getDriverName')->andReturn('pgsql');
+    $databaseConnection->shouldReceive('getTablePrefix')->andReturn('');
     $databaseConnection->shouldReceive('getConfig')->with('search_collation')->andReturn(null);
 
     $grammar = new PostgresGrammar($databaseConnection);
@@ -123,6 +124,26 @@ it('will generate a column expression for Postgres with colons in the table name
     ->with([
         ['blog:posts.title', 'lower("blog:posts"."title"::text)'],
         ['blog:posts:comments.author.name', 'lower("blog:posts:comments"."author"."name"::text)'],
+    ]);
+
+it('will generate a search column expression for Postgres with a table prefix', function (string $column, string $expectedExpression): void {
+    $isSearchForcedCaseInsensitive = true;
+
+    $databaseConnection = Mockery::mock(Connection::class);
+    $databaseConnection->shouldReceive('getDriverName')->andReturn('pgsql');
+    $databaseConnection->shouldReceive('getTablePrefix')->andReturn('app_');
+    $databaseConnection->shouldReceive('getConfig')->with('search_collation')->andReturn(null);
+
+    $grammar = new PostgresGrammar($databaseConnection);
+
+    $actualExpression = generate_search_column_expression($column, $isSearchForcedCaseInsensitive, $databaseConnection);
+
+    expect($actualExpression->getValue($grammar))
+        ->toBe($expectedExpression);
+})
+    ->with([
+        ['posts.title', 'lower("app_posts"."title"::text)'],
+        ['posts.data->name', "lower(\"app_posts\".\"data\"->>'name'::text)"],
     ]);
 
 it('will generate a JSON search column expression for Postgres with explicit ->> operator', function (): void {


### PR DESCRIPTION
Added support for Laravel table prefix in PostgreSQL.

fixes https://github.com/filamentphp/filament/issues/19692

## Functional changes

- [ ] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
