### PR TITLE
Support dynamic navigation visibility

### DIFF
--- a/docs/06-navigation/01-overview.md
+++ b/docs/06-navigation/01-overview.md
@@ -552,6 +552,19 @@ public function panel(Panel $panel): Panel
 
 <AutoScreenshot name="panels/navigation/disabled-navigation" alt="Disabled navigation sidebar" version="4.x" />
 
+Alternatively, you may pass a closure that returns a boolean to decide dynamically. Returning `false` hides the navigation, while returning `true` renders the default auto-discovered navigation items. This is useful for flows such as onboarding or setup wizards where the navigation should only appear once the user has reached a particular state:
+
+```php
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->navigation(fn (): bool => auth()->user()->hasCompletedOnboarding());
+}
+```
+
 ### Disabling the topbar
 
 You may disable topbar entirely by passing `false` to the `topbar()` method:

--- a/packages/panels/src/Panel/Concerns/HasNavigation.php
+++ b/packages/panels/src/Panel/Concerns/HasNavigation.php
@@ -24,14 +24,14 @@ trait HasNavigation
 
     protected Closure | bool $navigationBuilder = true;
 
-    protected ?NavigationBuilder $cachedNavigationBuilder = null;
+    protected NavigationBuilder | bool | null $resolvedNavigationBuilder = null;
 
     protected ?NavigationManager $navigationManager = null;
 
     public function navigation(Closure | bool $builder = true): static
     {
         $this->navigationBuilder = $builder;
-        $this->cachedNavigationBuilder = null;
+        $this->resolvedNavigationBuilder = null;
 
         return $this;
     }
@@ -41,7 +41,9 @@ trait HasNavigation
      */
     public function buildNavigation(): array
     {
-        return $this->cachedNavigationBuilder?->getNavigation() ?? [];
+        $resolved = $this->resolveNavigationBuilder();
+
+        return $resolved instanceof NavigationBuilder ? $resolved->getNavigation() : [];
     }
 
     /**
@@ -108,21 +110,21 @@ trait HasNavigation
 
     protected function resolveNavigationBuilder(): NavigationBuilder | bool
     {
-        if (is_bool($this->navigationBuilder)) {
-            return $this->navigationBuilder;
+        if ($this->resolvedNavigationBuilder !== null) {
+            return $this->resolvedNavigationBuilder;
         }
 
-        if ($this->cachedNavigationBuilder !== null) {
-            return $this->cachedNavigationBuilder;
+        if (! $this->navigationBuilder instanceof Closure) {
+            return $this->resolvedNavigationBuilder = $this->navigationBuilder;
         }
 
         $result = app()->call($this->navigationBuilder);
 
         if ($result instanceof NavigationBuilder) {
-            return $this->cachedNavigationBuilder = $result;
+            return $this->resolvedNavigationBuilder = $result;
         }
 
-        return $this->navigationBuilder = (bool) $result;
+        return $this->resolvedNavigationBuilder = (bool) $result;
     }
 
     /**

--- a/packages/panels/src/Panel/Concerns/HasNavigation.php
+++ b/packages/panels/src/Panel/Concerns/HasNavigation.php
@@ -24,14 +24,11 @@ trait HasNavigation
 
     protected Closure | bool $navigationBuilder = true;
 
-    protected NavigationBuilder | bool | null $resolvedNavigationBuilder = null;
-
     protected ?NavigationManager $navigationManager = null;
 
     public function navigation(Closure | bool $builder = true): static
     {
         $this->navigationBuilder = $builder;
-        $this->resolvedNavigationBuilder = null;
 
         return $this;
     }
@@ -110,21 +107,17 @@ trait HasNavigation
 
     protected function resolveNavigationBuilder(): NavigationBuilder | bool
     {
-        if ($this->resolvedNavigationBuilder !== null) {
-            return $this->resolvedNavigationBuilder;
-        }
-
         if (! $this->navigationBuilder instanceof Closure) {
-            return $this->resolvedNavigationBuilder = $this->navigationBuilder;
+            return $this->navigationBuilder;
         }
 
         $result = app()->call($this->navigationBuilder);
 
         if ($result instanceof NavigationBuilder) {
-            return $this->resolvedNavigationBuilder = $result;
+            return $result;
         }
 
-        return $this->resolvedNavigationBuilder = (bool) $result;
+        return (bool) $result;
     }
 
     /**

--- a/packages/panels/src/Panel/Concerns/HasNavigation.php
+++ b/packages/panels/src/Panel/Concerns/HasNavigation.php
@@ -24,11 +24,14 @@ trait HasNavigation
 
     protected Closure | bool $navigationBuilder = true;
 
+    protected ?NavigationBuilder $cachedNavigationBuilder = null;
+
     protected ?NavigationManager $navigationManager = null;
 
     public function navigation(Closure | bool $builder = true): static
     {
         $this->navigationBuilder = $builder;
+        $this->cachedNavigationBuilder = null;
 
         return $this;
     }
@@ -38,10 +41,7 @@ trait HasNavigation
      */
     public function buildNavigation(): array
     {
-        /** @var NavigationBuilder $builder */
-        $builder = app()->call($this->navigationBuilder);
-
-        return $builder->getNavigation();
+        return $this->cachedNavigationBuilder?->getNavigation() ?? [];
     }
 
     /**
@@ -98,12 +98,31 @@ trait HasNavigation
 
     public function hasNavigation(): bool
     {
-        return $this->navigationBuilder !== false;
+        return $this->resolveNavigationBuilder() !== false;
     }
 
     public function hasNavigationBuilder(): bool
     {
-        return $this->navigationBuilder instanceof Closure;
+        return $this->resolveNavigationBuilder() instanceof NavigationBuilder;
+    }
+
+    protected function resolveNavigationBuilder(): NavigationBuilder | bool
+    {
+        if (is_bool($this->navigationBuilder)) {
+            return $this->navigationBuilder;
+        }
+
+        if ($this->cachedNavigationBuilder !== null) {
+            return $this->cachedNavigationBuilder;
+        }
+
+        $result = app()->call($this->navigationBuilder);
+
+        if ($result instanceof NavigationBuilder) {
+            return $this->cachedNavigationBuilder = $result;
+        }
+
+        return $this->navigationBuilder = (bool) $result;
     }
 
     /**

--- a/tests/src/Panels/Navigation/NavigationBuilderTest.php
+++ b/tests/src/Panels/Navigation/NavigationBuilderTest.php
@@ -106,3 +106,49 @@ it('can register navigation groups individually', function (): void {
                 ->each->toBeInstanceOf(NavigationItem::class),
         );
 });
+
+it('hides navigation when a closure returns `false`', function (): void {
+    Filament::getCurrentOrDefaultPanel()->navigation(fn (): bool => false);
+
+    expect(Filament::hasNavigation())->toBeFalse();
+});
+
+it('shows auto-discovered navigation items when a closure returns `true`', function (): void {
+    Filament::getCurrentOrDefaultPanel()->navigation(fn (): bool => true);
+
+    expect(Filament::hasNavigation())->toBeTrue()
+        ->and(Filament::getCurrentOrDefaultPanel()->hasNavigationBuilder())->toBeFalse();
+
+    $itemLabels = collect(Filament::getNavigation())
+        ->flatMap(fn (NavigationGroup $group) => $group->getItems())
+        ->map(fn (NavigationItem $item) => $item->getLabel());
+
+    expect($itemLabels)
+        ->toContain('Dashboard')
+        ->toContain('Users')
+        ->toContain('Posts');
+});
+
+it('hides navigation when `navigation(false)` is set', function (): void {
+    Filament::getCurrentOrDefaultPanel()->navigation(false);
+
+    expect(Filament::hasNavigation())->toBeFalse();
+});
+
+it('resolves the navigation closure only once per request', function (): void {
+    $callCount = 0;
+
+    Filament::getCurrentOrDefaultPanel()->navigation(function (NavigationBuilder $navigation) use (&$callCount): NavigationBuilder {
+        $callCount++;
+
+        return $navigation->items([
+            ...Dashboard::getNavigationItems(),
+        ]);
+    });
+
+    Filament::hasNavigation();
+    Filament::getCurrentOrDefaultPanel()->hasNavigationBuilder();
+    Filament::buildNavigation();
+
+    expect($callCount)->toBe(1);
+});

--- a/tests/src/Panels/Navigation/NavigationBuilderTest.php
+++ b/tests/src/Panels/Navigation/NavigationBuilderTest.php
@@ -135,20 +135,3 @@ it('hides navigation when `navigation(false)` is set', function (): void {
     expect(Filament::hasNavigation())->toBeFalse();
 });
 
-it('resolves the navigation closure only once per request', function (): void {
-    $callCount = 0;
-
-    Filament::getCurrentOrDefaultPanel()->navigation(function (NavigationBuilder $navigation) use (&$callCount): NavigationBuilder {
-        $callCount++;
-
-        return $navigation->items([
-            ...Dashboard::getNavigationItems(),
-        ]);
-    });
-
-    Filament::hasNavigation();
-    Filament::getCurrentOrDefaultPanel()->hasNavigationBuilder();
-    Filament::buildNavigation();
-
-    expect($callCount)->toBe(1);
-});


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Enables `navigation()` closures to return a boolean for conditional visibility, while maintaining support for `NavigationBuilder` objects.

**Example:**
```php
$panel->navigation(fn() => $this->hasCompletedSetup());
```

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
