### PR TITLE
Add page header heading render hook

### DIFF
--- a/docs/09-advanced/01-render-hooks.md
+++ b/docs/09-advanced/01-render-hooks.md
@@ -70,6 +70,7 @@ use Filament\View\PanelsRenderHook;
 - `PanelsRenderHook::PAGE_FOOTER_WIDGETS_BEFORE` - Before the page footer widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_FOOTER_WIDGETS_END` - End of the page footer widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_FOOTER_WIDGETS_START` - Start of the page footer widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
+- `PanelsRenderHook::PAGE_HEADER_HEADING_BEFORE` - Before the page header heading, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_HEADER_ACTIONS_AFTER` - After the page header actions, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_HEADER_ACTIONS_BEFORE` - Before the page header actions, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_HEADER_WIDGETS_AFTER` - After the page header widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class

--- a/docs/09-advanced/01-render-hooks.md
+++ b/docs/09-advanced/01-render-hooks.md
@@ -70,9 +70,10 @@ use Filament\View\PanelsRenderHook;
 - `PanelsRenderHook::PAGE_FOOTER_WIDGETS_BEFORE` - Before the page footer widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_FOOTER_WIDGETS_END` - End of the page footer widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_FOOTER_WIDGETS_START` - Start of the page footer widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
-- `PanelsRenderHook::PAGE_HEADER_HEADING_BEFORE` - Before the page header heading, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_HEADER_ACTIONS_AFTER` - After the page header actions, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_HEADER_ACTIONS_BEFORE` - Before the page header actions, also [can be scoped](#scoping-render-hooks) to the page or resource class
+- `PanelsRenderHook::PAGE_HEADER_HEADING_AFTER` - After the page header heading, also [can be scoped](#scoping-render-hooks) to the page or resource class
+- `PanelsRenderHook::PAGE_HEADER_HEADING_BEFORE` - Before the page header heading, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_HEADER_WIDGETS_AFTER` - After the page header widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_HEADER_WIDGETS_BEFORE` - Before the page header widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class
 - `PanelsRenderHook::PAGE_HEADER_WIDGETS_END` - End of the page header widgets, also [can be scoped](#scoping-render-hooks) to the page or resource class

--- a/packages/panels/resources/views/components/header/index.blade.php
+++ b/packages/panels/resources/views/components/header/index.blade.php
@@ -19,6 +19,14 @@
             <x-filament::breadcrumbs :breadcrumbs="$breadcrumbs" />
         @endif
 
+        @php
+            $beforeHeading = \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_HEADER_HEADING_BEFORE, scopes: $this->getRenderHookScopes());
+        @endphp
+
+        @if (filled($beforeHeading))
+            {{ $beforeHeading }}
+        @endif
+
         @if (filled($heading))
             <h1 class="fi-header-heading">
                 {{ $heading }}

--- a/packages/panels/resources/views/components/header/index.blade.php
+++ b/packages/panels/resources/views/components/header/index.blade.php
@@ -19,19 +19,15 @@
             <x-filament::breadcrumbs :breadcrumbs="$breadcrumbs" />
         @endif
 
-        @php
-            $beforeHeading = \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_HEADER_HEADING_BEFORE, scopes: $this->getRenderHookScopes());
-        @endphp
-
-        @if (filled($beforeHeading))
-            {{ $beforeHeading }}
-        @endif
+        {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_HEADER_HEADING_BEFORE, scopes: $this->getRenderHookScopes()) }}
 
         @if (filled($heading))
             <h1 class="fi-header-heading">
                 {{ $heading }}
             </h1>
         @endif
+
+        {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_HEADER_HEADING_AFTER, scopes: $this->getRenderHookScopes()) }}
 
         @if (filled($subheading))
             <p class="fi-header-subheading">

--- a/packages/panels/src/View/PanelsRenderHook.php
+++ b/packages/panels/src/View/PanelsRenderHook.php
@@ -60,11 +60,13 @@ class PanelsRenderHook
 
     const PAGE_FOOTER_WIDGETS_START = 'panels::page.footer-widgets.start';
 
-    const PAGE_HEADER_HEADING_BEFORE = 'panels::page.header.heading.before';
-
     const PAGE_HEADER_ACTIONS_AFTER = 'panels::page.header.actions.after';
 
     const PAGE_HEADER_ACTIONS_BEFORE = 'panels::page.header.actions.before';
+
+    const PAGE_HEADER_HEADING_AFTER = 'panels::page.header.heading.after';
+
+    const PAGE_HEADER_HEADING_BEFORE = 'panels::page.header.heading.before';
 
     const PAGE_HEADER_WIDGETS_AFTER = 'panels::page.header-widgets.after';
 

--- a/packages/panels/src/View/PanelsRenderHook.php
+++ b/packages/panels/src/View/PanelsRenderHook.php
@@ -60,6 +60,8 @@ class PanelsRenderHook
 
     const PAGE_FOOTER_WIDGETS_START = 'panels::page.footer-widgets.start';
 
+    const PAGE_HEADER_HEADING_BEFORE = 'panels::page.header.heading.before';
+
     const PAGE_HEADER_ACTIONS_AFTER = 'panels::page.header.actions.after';
 
     const PAGE_HEADER_ACTIONS_BEFORE = 'panels::page.header.actions.before';


### PR DESCRIPTION
## Description

Add `PAGE_HEADER_HEADING_BEFORE` hook.

## Visual changes

<img width="3248" height="2120" alt="screenshot-2026-04-14 -001088@2x" src="https://github.com/user-attachments/assets/53a9fe0b-9418-4559-9de2-69c036eb1118" />

<img width="3248" height="2120" alt="screenshot-2026-04-14 -001087@2x" src="https://github.com/user-attachments/assets/03076b16-3cfe-4896-9234-fc36feb011e8" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
