### PR TITLE
Add partial rendering test page and related component tests

### DIFF
--- a/tests/resources/views/pages/partial-rendering-test.blade.php
+++ b/tests/resources/views/pages/partial-rendering-test.blade.php
@@ -1,0 +1,7 @@
+<x-filament-panels::page>
+    <form wire:submit="save">
+        {{ $this->form }}
+
+        <x-filament::button type="submit">Save</x-filament::button>
+    </form>
+</x-filament-panels::page>

--- a/tests/src/Fixtures/Pages/PartialRenderingTest.php
+++ b/tests/src/Fixtures/Pages/PartialRenderingTest.php
@@ -80,9 +80,7 @@ class PartialRenderingTest extends Page
                             )
                             ->live()
                             ->skipRenderAfterStateUpdated()
-                            ->afterStateUpdated(function (string $state) {
-                                $this->answer = "You answered: {$state}";
-                            })
+                            ->afterStateUpdated(fn (string $state) => $this->answer = "You answered: {$state}")
                             ->extraFieldWrapperAttributes(['class' => 'question']),
                     ]),
             ])

--- a/tests/src/Fixtures/Pages/PartialRenderingTest.php
+++ b/tests/src/Fixtures/Pages/PartialRenderingTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Filament\Tests\Fixtures\Pages;
+
+use BackedEnum;
+use Filament\Forms\Components\Radio;
+use Filament\Forms\Components\TextInput;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Pages\Page;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Support\Str;
+
+class PartialRenderingTest extends Page
+{
+    protected string $view = 'pages.partial-rendering-test';
+
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedDocumentText;
+
+    protected static ?int $navigationSort = 10;
+
+    public ?array $data = [];
+
+    public ?string $answer = null;
+
+    public function mount(): void
+    {
+        $this->form->fill();
+    }
+
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->schema([
+                Section::make('Partially render components')
+                    ->columns(3)
+                    ->schema([
+                        TextEntry::make('product_sku')
+                            ->label('Product SKU')
+                            ->state(fn (): string => Str::upper(Str::random(8)))
+                            ->extraAttributes(['class' => 'product-sku']),
+                        TextInput::make('product_name')
+                            ->label('Product Name')
+                            ->required()
+                            ->live(debounce: 500)
+                            ->partiallyRenderComponentsAfterStateUpdated(['product_slug'])
+                            ->afterStateUpdated(fn (Set $set, ?string $state) => $set('product_slug', Str::slug($state))),
+                        TextInput::make('product_slug')
+                            ->required()
+                            ->label('Product Slug'),
+                    ]),
+                Section::make('Partially render self')
+                    ->columns(2)
+                    ->schema([
+                        TextInput::make('post_title')
+                            ->label('Post Title')
+                            ->live(debounce: 500)
+                            ->partiallyRenderAfterStateUpdated()
+                            ->afterLabel(fn (Get $get): ?string => filled($get('post_title')) ?
+                                '/' . Str::slug($get('post_title')) :
+                                null),
+                        TextEntry::make('post_date')
+                            ->label('Post Date')
+                            ->state(fn (): string => now()->format('Y-m-d H:i:s'))
+                            ->extraAttributes(['class' => 'post-date']),
+                    ]),
+                Section::make('Skip render')
+                    ->schema([
+                        Radio::make('question')
+                            ->label(fn (): string => fake()->sentence())
+                            ->required()
+                            ->options(
+                                fn (): array => collect(fake()->words(5))
+                                    ->shuffle()
+                                    ->mapWithKeys(fn ($v, $k) => [$k + 1 => $v])
+                                    ->all()
+                            )
+                            ->live()
+                            ->skipRenderAfterStateUpdated()
+                            ->afterStateUpdated(function (string $state) {
+                                $this->answer = "You answered: {$state}";
+                            })
+                            ->extraFieldWrapperAttributes(['class' => 'question']),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->form->getState();
+    }
+}

--- a/tests/src/Fixtures/Providers/AdminPanelProvider.php
+++ b/tests/src/Fixtures/Providers/AdminPanelProvider.php
@@ -36,6 +36,7 @@ use Filament\Tests\Fixtures\Pages\KeyValueTest;
 use Filament\Tests\Fixtures\Pages\ManageSiteSettings;
 use Filament\Tests\Fixtures\Pages\MarkdownEditorBrowserTest;
 use Filament\Tests\Fixtures\Pages\OneTimeCodeInputBrowserTest;
+use Filament\Tests\Fixtures\Pages\PartialRenderingTest;
 use Filament\Tests\Fixtures\Pages\QueryBuilderTableTest;
 use Filament\Tests\Fixtures\Pages\RadioTest;
 use Filament\Tests\Fixtures\Pages\RepeaterTest;
@@ -118,6 +119,7 @@ class AdminPanelProvider extends PanelProvider
                 ManageSiteSettings::class,
                 MarkdownEditorBrowserTest::class,
                 OneTimeCodeInputBrowserTest::class,
+                PartialRenderingTest::class,
                 QueryBuilderTableTest::class,
                 RadioTest::class,
                 RepeaterTest::class,

--- a/tests/src/Forms/PartialRenderingTest.php
+++ b/tests/src/Forms/PartialRenderingTest.php
@@ -89,4 +89,4 @@ describe('partial rendering', function (): void {
                 ->assertNoAccessibilityIssues();
         });
     });
-})->only();
+});

--- a/tests/src/Forms/PartialRenderingTest.php
+++ b/tests/src/Forms/PartialRenderingTest.php
@@ -32,10 +32,6 @@ describe('partial rendering', function (): void {
                 ->assertSee($productSku)
                 ->assertNoSmoke()
                 ->assertNoAccessibilityIssues();
-
-            visit('/partial-rendering-test')
-                ->inDarkMode()
-                ->assertNoAccessibilityIssues();
         });
     });
 

--- a/tests/src/Forms/PartialRenderingTest.php
+++ b/tests/src/Forms/PartialRenderingTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Filament\Tests\Forms;
+
+use Filament\Tests\Fixtures\Models\User;
+use Filament\Tests\TestCase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+
+uses(TestCase::class);
+
+beforeEach(function (): void {
+    Artisan::call('filament:assets');
+});
+
+describe('partial rendering', function (): void {
+    it('can use `partiallyRenderComponentsAfterStateUpdated()` to re-render only the specified fields', function (): void {
+        retry(10, function (): void {
+            $this->actingAs(User::factory()->create());
+
+            $productName = fake()->sentence;
+
+            $page = visit('/partial-rendering-test');
+
+            $productSku = $page->text('.product-sku');
+
+            $page
+                ->assertSee('Product SKU')
+                ->assertSee('Product Name')
+                ->fill('#form\.product_name', $productName)
+                ->wait(3)
+                ->assertSee($productSku)
+                ->assertNoSmoke()
+                ->assertNoAccessibilityIssues();
+
+            visit('/partial-rendering-test')
+                ->inDarkMode()
+                ->assertNoAccessibilityIssues();
+        });
+    });
+
+    it('can use `partiallyRenderAfterStateUpdated()` to re-render only the current component', function (): void {
+        retry(10, function (): void {
+            $this->actingAs(User::factory()->create());
+
+            $page = visit('/partial-rendering-test');
+
+            $postTitle = fake()->sentence;
+            $postDate = $page->text('.post-date');
+
+            $page
+                ->assertSee('Post Title')
+                ->assertSee('Post Date')
+                ->fill('#form\.post_title', $postTitle)
+                ->wait(1)
+                ->assertSee('/' . Str::slug($postTitle))
+                ->assertSee($postDate)
+                ->assertNoSmoke()
+                ->assertNoAccessibilityIssues();
+        });
+    });
+
+    it('can use `skipRenderAfterStateUpdated()` to prevent the Livewire component from re-rendering when a field is updated', function (): void {
+        retry(10, callback: function (): void {
+            $this->actingAs(User::factory()->create());
+
+            $page = visit('/partial-rendering-test');
+
+            $question = $page->text('.question .fi-fo-field-label-content');
+            $answer = (string) fake()->numberBetween(1, 5);
+
+            $page
+                ->assertSee($question)
+                ->radio("#form\.question-{$answer}", $answer)
+                ->wait(1)
+                ->assertSee($question)
+                ->assertNoSmoke()
+                ->assertNoAccessibilityIssues();
+        });
+    });
+
+    it('has no accessibility issues in dark mode', function (): void {
+        retry(10, callback: function (): void {
+            $this->actingAs(User::factory()->create());
+
+            visit('/partial-rendering-test')
+                ->inDarkMode()
+                ->assertNoSmoke()
+                ->assertNoAccessibilityIssues();
+        });
+    });
+})->only();


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Summary

Adds a new `PartialRenderingTest` Livewire page with browser tests that verify Filament's partial rendering behavior when form components update. The tests exercise `afterStateUpdated` callbacks to ensure only the  intended components re-render, and validate accessibility in both light and dark modes via `assertNoAccessibilityIssues()`.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
