### PR TITLE
Draft: Add Laravel Boost skill for Filament v3 development

### DIFF
--- a/packages/panels/resources/boost/skills/filament-development/SKILL.blade.php
+++ b/packages/panels/resources/boost/skills/filament-development/SKILL.blade.php
@@ -1,0 +1,177 @@
+---
+name: filament-development
+description: "Use for any Filament development task. Activate when user mentions Filament, Resources, Pages, Widgets, Forms, Tables, Actions, Notifications, or admin panels. Covers CRUD resources, panels, forms, tables, actions, notifications, widgets, and testing. Do not use for non-Filament Laravel UI tasks."
+license: MIT
+metadata:
+  author: filamentphp
+---
+@php
+/** @var \Laravel\Boost\Install\GuidelineAssist $assist */
+@endphp
+# Filament Development (v3)
+
+## Documentation
+
+Use `search-docs` for detailed Filament v3 patterns and API documentation.
+
+## Overview
+
+Filament is a Server-Driven UI (SDUI) framework for Laravel built on Livewire, Alpine.js, and Tailwind CSS. Components use fluent APIs with static `make()` constructors.
+
+## Artisan Commands
+
+Always use Filament-specific Artisan commands:
+
+- `{{ $assist->artisanCommand('make:filament-resource [Post] --generate') }}` – Resource with form, table, pages
+- `{{ $assist->artisanCommand('make:filament-page [Settings]') }}` – Custom page
+- `{{ $assist->artisanCommand('make:filament-widget [StatsOverview] --stats-overview') }}` – Stats widget
+- `{{ $assist->artisanCommand('make:filament-widget [LatestOrders] --table') }}` – Table widget
+
+## Panel Setup
+
+@boostsnippet("Register Panel in Service Provider", "php")
+class AdminPanelProvider extends PanelProvider
+{
+    public function panel(Panel $panel): Panel
+    {
+        return $panel
+            ->default()
+            ->id('admin')
+            ->path('admin')
+            ->login()
+            ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
+            ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
+            ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets');
+    }
+}
+@endboostsnippet
+
+## Resources
+
+Resources are static classes for CRUD interfaces, living in `app/Filament/Resources`:
+
+@boostsnippet("Resource Form", "php")
+public static function form(Form $form): Form
+{
+    return $form->schema([
+        TextInput::make('title')->required()->maxLength(255),
+        RichEditor::make('content')->columnSpanFull(),
+        Select::make('category_id')->relationship('category', 'name'),
+    ]);
+}
+@endboostsnippet
+
+@boostsnippet("Resource Table", "php")
+public static function table(Table $table): Table
+{
+    return $table
+        ->columns([
+            TextColumn::make('title')->searchable()->sortable(),
+            TextColumn::make('created_at')->dateTime()->sortable(),
+        ])
+        ->filters([
+            SelectFilter::make('category')->relationship('category', 'name'),
+        ])
+        ->actions([EditAction::make(), DeleteAction::make()])
+        ->bulkActions([DeleteBulkAction::make()]);
+}
+@endboostsnippet
+
+## Forms
+
+Use `relationship()` when options come from a relationship:
+
+@boostsnippet("Form with Relationship", "php")
+Select::make('user_id')
+    ->label('Author')
+    ->relationship('author', 'name')
+    ->required(),
+@endboostsnippet
+
+## Actions
+
+@boostsnippet("Action with Confirmation", "php")
+Action::make('approve')
+    ->color('success')
+    ->requiresConfirmation()
+    ->action(fn (Post $record) => $record->approve()),
+@endboostsnippet
+
+@boostsnippet("Action with Form Modal", "php")
+Action::make('reject')
+    ->color('danger')
+    ->form([Textarea::make('reason')->required()])
+    ->action(fn (Post $record, array $data) => $record->reject($data['reason'])),
+@endboostsnippet
+
+## Notifications
+
+@boostsnippet("Send Notification", "php")
+Notification::make()
+    ->title('Saved successfully')
+    ->success()
+    ->send();
+@endboostsnippet
+
+## Widgets
+
+@boostsnippet("Stats Overview Widget", "php")
+class StatsOverviewWidget extends StatsOverviewWidget
+{
+    protected function getStats(): array
+    {
+        return [
+            Stat::make('Total Users', User::count()),
+            Stat::make('Active Users', User::where('is_active', true)->count())
+                ->color('success'),
+        ];
+    }
+}
+@endboostsnippet
+
+## Testing
+
+Always authenticate. Use `livewire()` for Filament component tests:
+
+@boostsnippet("Test Listing Records", "php")
+it('can list posts', function () {
+    $this->actingAs(User::factory()->create());
+    $posts = Post::factory()->count(5)->create();
+
+    livewire(PostResource\Pages\ListPosts::class)
+        ->assertCanSeeTableRecords($posts);
+});
+@endboostsnippet
+
+@boostsnippet("Test Creating a Record", "php")
+it('can create a post', function () {
+    $this->actingAs(User::factory()->create());
+
+    livewire(PostResource\Pages\CreatePost::class)
+        ->fillForm(['title' => 'Hello World'])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    assertDatabaseHas(Post::class, ['title' => 'Hello World']);
+});
+@endboostsnippet
+
+@boostsnippet("Test Calling an Action", "php")
+it('can approve a post', function () {
+    $this->actingAs(User::factory()->create());
+    $post = Post::factory()->create();
+
+    livewire(PostResource\Pages\ListPosts::class)
+        ->callTableAction('approve', $post);
+
+    expect($post->refresh()->status)->toBe('approved');
+});
+@endboostsnippet
+
+## Common Pitfalls
+
+- Not using Filament Artisan commands (use `make:filament-resource` not `make:model`)
+- Forgetting to register the panel provider in `bootstrap/providers.php`
+- Using Eloquent queries instead of the `relationship()` method on form components
+- Not adding `->searchable()` or `->sortable()` on table columns that need it
+- Forgetting authentication in Filament tests

--- a/packages/panels/resources/boost/skills/filament-development/SKILL.blade.php
+++ b/packages/panels/resources/boost/skills/filament-development/SKILL.blade.php
@@ -1,35 +1,29 @@
 ---
 name: filament-development
-description: "Use for any Filament development task. Activate when user mentions Filament, Resources, Pages, Widgets, Forms, Tables, Actions, Notifications, or admin panels. Covers CRUD resources, panels, forms, tables, actions, notifications, widgets, and testing. Do not use for non-Filament Laravel UI tasks."
+description: "Activate when working with Filament admin panels, Resources, Forms, Tables, Actions, Notifications, or Widgets. Covers panel setup, scaffolding, common patterns, and Pest testing. Do not activate for plain Laravel or Livewire tasks unrelated to Filament."
 license: MIT
 metadata:
   author: filamentphp
 ---
-@php
-/** @var \Laravel\Boost\Install\GuidelineAssist $assist */
-@endphp
-# Filament Development (v3)
 
 ## Documentation
-
-Use `search-docs` for detailed Filament v3 patterns and API documentation.
+Use `search-docs` to look up specific Filament v3 APIs and configuration options.
 
 ## Overview
+Filament v3 is a server-driven UI toolkit for Laravel built on Livewire v3, Alpine.js, and Tailwind CSS. All components use a fluent, static `make()` API - never instantiate them with `new`.
 
-Filament is a Server-Driven UI (SDUI) framework for Laravel built on Livewire, Alpine.js, and Tailwind CSS. Components use fluent APIs with static `make()` constructors.
+## Scaffolding
+Always generate Filament files through Artisan, never manually:
 
-## Artisan Commands
-
-Always use Filament-specific Artisan commands:
-
-- `{{ $assist->artisanCommand('make:filament-resource [Post] --generate') }}` – Resource with form, table, pages
-- `{{ $assist->artisanCommand('make:filament-page [Settings]') }}` – Custom page
-- `{{ $assist->artisanCommand('make:filament-widget [StatsOverview] --stats-overview') }}` – Stats widget
-- `{{ $assist->artisanCommand('make:filament-widget [LatestOrders] --table') }}` – Table widget
+- `{{ $assist->artisanCommand('make:filament-resource Post --generate') }}` - Resource with form, table, and CRUD pages
+- `{{ $assist->artisanCommand('make:filament-page Settings --resource=PostResource') }}` - Custom page attached to a resource
+- `{{ $assist->artisanCommand('make:filament-widget StatsOverview --stats-overview') }}` - Stats overview widget
+- `{{ $assist->artisanCommand('make:filament-widget LatestOrders --table') }}` - Table widget
 
 ## Panel Setup
+Panels are configured in a service provider that extends `PanelProvider`. Register it in `bootstrap/providers.php` - not in `config/app.php`.
 
-@boostsnippet("Register Panel in Service Provider", "php")
+@boostsnippet("Panel Provider", "php")
 class AdminPanelProvider extends PanelProvider
 {
     public function panel(Panel $panel): Panel
@@ -39,24 +33,32 @@ class AdminPanelProvider extends PanelProvider
             ->id('admin')
             ->path('admin')
             ->login()
-            ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
-            ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
-            ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets');
+            ->discoverResources(in: app_path('Filament/Resources'), for: 'App\Filament\Resources')
+            ->discoverPages(in: app_path('Filament/Pages'), for: 'App\Filament\Pages')
+            ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\Filament\Widgets');
     }
 }
 @endboostsnippet
 
 ## Resources
-
-Resources are static classes for CRUD interfaces, living in `app/Filament/Resources`:
+Resources are static classes living in `app/Filament/Resources`. The `form()` and `table()` methods define the schema:
 
 @boostsnippet("Resource Form", "php")
 public static function form(Form $form): Form
 {
     return $form->schema([
-        TextInput::make('title')->required()->maxLength(255),
-        RichEditor::make('content')->columnSpanFull(),
-        Select::make('category_id')->relationship('category', 'name'),
+        TextInput::make('title')
+            ->required()
+            ->maxLength(255),
+        RichEditor::make('content')
+            ->columnSpanFull(),
+        Select::make('status')
+            ->options(['draft' => 'Draft', 'published' => 'Published'])
+            ->default('draft'),
+        Select::make('category_id')
+            ->relationship('category', 'name')
+            ->searchable()
+            ->preload(),
     ]);
 }
 @endboostsnippet
@@ -67,75 +69,106 @@ public static function table(Table $table): Table
     return $table
         ->columns([
             TextColumn::make('title')->searchable()->sortable(),
-            TextColumn::make('created_at')->dateTime()->sortable(),
+            TextColumn::make('status')->badge(),
+            TextColumn::make('created_at')
+                ->dateTime()
+                ->sortable()
+                ->toggleable(isToggledHiddenByDefault: true),
         ])
         ->filters([
-            SelectFilter::make('category')->relationship('category', 'name'),
+            SelectFilter::make('status')
+                ->options(['draft' => 'Draft', 'published' => 'Published']),
         ])
         ->actions([EditAction::make(), DeleteAction::make()])
         ->bulkActions([DeleteBulkAction::make()]);
 }
 @endboostsnippet
 
+
 ## Forms
+Use `relationship()` on `Select` instead of loading options manually. For uploads, use `FileUpload` not a text field:
 
-Use `relationship()` when options come from a relationship:
-
-@boostsnippet("Form with Relationship", "php")
-Select::make('user_id')
-    ->label('Author')
+@boostsnippet("Relationship Select", "php")
+Select::make('author_id')
     ->relationship('author', 'name')
+    ->searchable()
+    ->preload()
     ->required(),
 @endboostsnippet
 
+@boostsnippet("File Upload", "php")
+FileUpload::make('cover_image')
+    ->image()
+    ->disk('public')
+    ->directory('covers'),
+@endboostsnippet
+
 ## Actions
+Actions can live on table rows, form headers, page headers, or inside modals:
 
 @boostsnippet("Action with Confirmation", "php")
-Action::make('approve')
+Action::make('publish')
     ->color('success')
+    ->icon('heroicon-o-check-circle')
     ->requiresConfirmation()
-    ->action(fn (Post $record) => $record->approve()),
+    ->action(fn (Post $record) => $record->publish()),
 @endboostsnippet
 
 @boostsnippet("Action with Form Modal", "php")
 Action::make('reject')
     ->color('danger')
-    ->form([Textarea::make('reason')->required()])
+    ->form([
+        Textarea::make('reason')->required(),
+    ])
     ->action(fn (Post $record, array $data) => $record->reject($data['reason'])),
 @endboostsnippet
 
 ## Notifications
+Send flash-style notifications from actions or Livewire component methods:
 
-@boostsnippet("Send Notification", "php")
+@boostsnippet("Success Notification", "php")
 Notification::make()
-    ->title('Saved successfully')
+    ->title('Changes saved')
     ->success()
     ->send();
 @endboostsnippet
 
+@boostsnippet("Database Notification", "php")
+Notification::make()
+    ->title('Your export is ready')
+    ->body('Click to download.')
+    ->success()
+    ->sendToDatabase($user);
+@endboostsnippet
+
 ## Widgets
+Attach widgets to a panel or resource page via `getHeaderWidgets()` or `getFooterWidgets()`:
 
 @boostsnippet("Stats Overview Widget", "php")
-class StatsOverviewWidget extends StatsOverviewWidget
+class PostStatsWidget extends BaseWidget
 {
     protected function getStats(): array
     {
         return [
-            Stat::make('Total Users', User::count()),
-            Stat::make('Active Users', User::where('is_active', true)->count())
-                ->color('success'),
+            Stat::make('Total', Post::count()),
+            Stat::make('Published', Post::published()->count())
+                ->color('success')
+                ->chart([3, 7, 4, 9, 12]),
+            Stat::make('Drafts', Post::draft()->count())
+                ->color('warning'),
         ];
     }
 }
 @endboostsnippet
 
+
 ## Testing
+All Filament tests require authentication. Use `livewire()` to drive Filament pages - do not call page URLs directly:
 
-Always authenticate. Use `livewire()` for Filament component tests:
+@boostsnippet("List records", "php")
+it('lists posts', function () {
+    actingAs(User::factory()->create());
 
-@boostsnippet("Test Listing Records", "php")
-it('can list posts', function () {
-    $this->actingAs(User::factory()->create());
     $posts = Post::factory()->count(5)->create();
 
     livewire(PostResource\Pages\ListPosts::class)
@@ -143,35 +176,36 @@ it('can list posts', function () {
 });
 @endboostsnippet
 
-@boostsnippet("Test Creating a Record", "php")
-it('can create a post', function () {
-    $this->actingAs(User::factory()->create());
+@boostsnippet("Create a record", "php")
+it('creates a post', function () {
+    actingAs(User::factory()->create());
 
     livewire(PostResource\Pages\CreatePost::class)
-        ->fillForm(['title' => 'Hello World'])
+        ->fillForm(['title' => 'Hello Filament'])
         ->call('create')
         ->assertHasNoFormErrors();
 
-    assertDatabaseHas(Post::class, ['title' => 'Hello World']);
+    assertDatabaseHas('posts', ['title' => 'Hello Filament']);
 });
 @endboostsnippet
 
-@boostsnippet("Test Calling an Action", "php")
-it('can approve a post', function () {
-    $this->actingAs(User::factory()->create());
+@boostsnippet("Call a table action", "php")
+it('publishes a post', function () {
+    actingAs(User::factory()->create());
     $post = Post::factory()->create();
 
     livewire(PostResource\Pages\ListPosts::class)
-        ->callTableAction('approve', $post);
+        ->callTableAction('publish', $post);
 
-    expect($post->refresh()->status)->toBe('approved');
+    expect($post->refresh()->status)->toBe('published');
 });
 @endboostsnippet
 
-## Common Pitfalls
-
-- Not using Filament Artisan commands (use `make:filament-resource` not `make:model`)
+## Things to avoid
+- Instantiating components with `new` - always use the static `make()` constructor
+- Loading relationship options manually - use `->relationship('relation', 'column')` instead
 - Forgetting to register the panel provider in `bootstrap/providers.php`
-- Using Eloquent queries instead of the `relationship()` method on form components
-- Not adding `->searchable()` or `->sortable()` on table columns that need it
-- Forgetting authentication in Filament tests
+- Skipping `->searchable()` and `->sortable()` on columns users will want to filter or sort
+- Omitting `actingAs()` in tests - Filament enforces authentication by default
+
+


### PR DESCRIPTION
## Description

Adds a [Laravel Boost](https://github.com/laravel/boost) skill for Filament v3. The skill lives at:

```
packages/panels/resources/boost/skills/filament-development/SKILL.blade.php
```

**How the integration works:**

When a developer installs `laravel/boost` in a project that has `filament/filament` as a Composer dependency, Boost automatically discovers this skill. Boost scans each installed package for a `resources/boost/skills/` directory, then treats each subdirectory as a named skill and loads the `SKILL.blade.php` inside it. No manual registration is needed - Boost picks it up from the vendor directory.

The skill is activated contextually by the AI when the user is working on Filament-related tasks (resources, forms, tables, actions, notifications, widgets, or panel configuration).

**What the skill covers:**
- Artisan scaffolding commands (`make:filament-resource`, `make:filament-page`, `make:filament-widget`)
- - Panel provider setup and registration
- - Resource form and table schema patterns
- - Relationship-aware form components
- - Action patterns (confirmations and modal forms)
- - Notifications (flash and database)
- - Stats overview widgets
- - Pest testing patterns for listing, creating records, and calling actions
- - Common mistakes to avoid
This PR targets `3.x`. A follow-up for `4.x` can be opened separately if desired.

Related discussion: #19711 
## Visual changes

None - this is a single Blade file with no UI changes.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [ ] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.