### PR TITLE
Add configurable temporary URL expiry duration

### DIFF
--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -153,7 +153,7 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
                 try {
                     $url = $storage->temporaryUrl(
                         $file,
-                        now()->addMinutes(config('filament.temporary_url_expiry', 30))->endOfHour(),
+                        now()->addMinutes(config('filament.temporary_file_url_expiry_minutes', 30))->endOfHour(),
                     );
                 } catch (Throwable $exception) {
                     // This driver does not support creating temporary URLs.

--- a/packages/forms/src/Components/BaseFileUpload.php
+++ b/packages/forms/src/Components/BaseFileUpload.php
@@ -153,7 +153,7 @@ class BaseFileUpload extends Field implements Contracts\HasNestedRecursiveValida
                 try {
                     $url = $storage->temporaryUrl(
                         $file,
-                        now()->addMinutes(30)->endOfHour(),
+                        now()->addMinutes(config('filament.temporary_url_expiry', 30))->endOfHour(),
                     );
                 } catch (Throwable $exception) {
                     // This driver does not support creating temporary URLs.

--- a/packages/forms/src/Components/Concerns/HasFileAttachments.php
+++ b/packages/forms/src/Components/Concerns/HasFileAttachments.php
@@ -247,7 +247,7 @@ trait HasFileAttachments
             try {
                 return $storage->temporaryUrl(
                     $file,
-                    now()->addMinutes(30)->endOfHour(),
+                    now()->addMinutes(config('filament.temporary_url_expiry', 30))->endOfHour(),
                 );
             } catch (Throwable $exception) {
                 // This driver does not support creating temporary URLs.

--- a/packages/forms/src/Components/Concerns/HasFileAttachments.php
+++ b/packages/forms/src/Components/Concerns/HasFileAttachments.php
@@ -247,7 +247,7 @@ trait HasFileAttachments
             try {
                 return $storage->temporaryUrl(
                     $file,
-                    now()->addMinutes(config('filament.temporary_url_expiry', 30))->endOfHour(),
+                    now()->addMinutes(config('filament.temporary_file_url_expiry_minutes', 30))->endOfHour(),
                 );
             } catch (Throwable $exception) {
                 // This driver does not support creating temporary URLs.

--- a/packages/forms/src/Components/RichEditor/RichContentRenderer.php
+++ b/packages/forms/src/Components/RichEditor/RichContentRenderer.php
@@ -178,7 +178,7 @@ class RichContentRenderer implements Htmlable
             try {
                 return $storage->temporaryUrl(
                     $file,
-                    now()->addMinutes(config('filament.temporary_url_expiry', 30))->endOfHour(),
+                    now()->addMinutes(config('filament.temporary_file_url_expiry_minutes', 30))->endOfHour(),
                 );
             } catch (Throwable $exception) {
                 // This driver does not support creating temporary URLs.

--- a/packages/forms/src/Components/RichEditor/RichContentRenderer.php
+++ b/packages/forms/src/Components/RichEditor/RichContentRenderer.php
@@ -178,7 +178,7 @@ class RichContentRenderer implements Htmlable
             try {
                 return $storage->temporaryUrl(
                     $file,
-                    now()->addMinutes(30)->endOfHour(),
+                    now()->addMinutes(config('filament.temporary_url_expiry', 30))->endOfHour(),
                 );
             } catch (Throwable $exception) {
                 // This driver does not support creating temporary URLs.

--- a/packages/infolists/src/Components/ImageEntry.php
+++ b/packages/infolists/src/Components/ImageEntry.php
@@ -219,7 +219,7 @@ class ImageEntry extends Entry implements HasEmbeddedView
             try {
                 return $storage->temporaryUrl(
                     $state,
-                    now()->addMinutes(30)->endOfHour(),
+                    now()->addMinutes(config('filament.temporary_url_expiry', 30))->endOfHour(),
                 );
             } catch (Throwable $exception) {
                 // This driver does not support creating temporary URLs.

--- a/packages/infolists/src/Components/ImageEntry.php
+++ b/packages/infolists/src/Components/ImageEntry.php
@@ -219,7 +219,7 @@ class ImageEntry extends Entry implements HasEmbeddedView
             try {
                 return $storage->temporaryUrl(
                     $state,
-                    now()->addMinutes(config('filament.temporary_url_expiry', 30))->endOfHour(),
+                    now()->addMinutes(config('filament.temporary_file_url_expiry_minutes', 30))->endOfHour(),
                 );
             } catch (Throwable $exception) {
                 // This driver does not support creating temporary URLs.

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/RichEditor/FileAttachmentProviders/SpatieMediaLibraryFileAttachmentProvider.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/RichEditor/FileAttachmentProviders/SpatieMediaLibraryFileAttachmentProvider.php
@@ -119,7 +119,7 @@ class SpatieMediaLibraryFileAttachmentProvider implements FileAttachmentProvider
         if ($this->attribute->getFileAttachmentsVisibility() === 'private') {
             try {
                 return $fileAttachment->getTemporaryUrl(
-                    now()->addMinutes(30)->endOfHour(),
+                    now()->addMinutes(config('filament.temporary_url_expiry', 30))->endOfHour(),
                 );
             } catch (Throwable $exception) {
                 // This driver does not support creating temporary URLs.

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/RichEditor/FileAttachmentProviders/SpatieMediaLibraryFileAttachmentProvider.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/RichEditor/FileAttachmentProviders/SpatieMediaLibraryFileAttachmentProvider.php
@@ -119,7 +119,7 @@ class SpatieMediaLibraryFileAttachmentProvider implements FileAttachmentProvider
         if ($this->attribute->getFileAttachmentsVisibility() === 'private') {
             try {
                 return $fileAttachment->getTemporaryUrl(
-                    now()->addMinutes(config('filament.temporary_url_expiry', 30))->endOfHour(),
+                    now()->addMinutes(config('filament.temporary_file_url_expiry_minutes', 30))->endOfHour(),
                 );
             } catch (Throwable $exception) {
                 // This driver does not support creating temporary URLs.

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -94,7 +94,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
                 try {
                     $url = $media?->getTemporaryUrl(
-                        now()->addMinutes(config('filament.temporary_url_expiry', 30))->endOfHour(),
+                        now()->addMinutes(config('filament.temporary_file_url_expiry_minutes', 30))->endOfHour(),
                         (filled($conversion) && $media->hasGeneratedConversion($conversion)) ? $conversion : '',
                     );
                 } catch (Throwable $exception) {

--- a/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -94,7 +94,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
                 try {
                     $url = $media?->getTemporaryUrl(
-                        now()->addMinutes(30)->endOfHour(),
+                        now()->addMinutes(config('filament.temporary_url_expiry', 30))->endOfHour(),
                         (filled($conversion) && $media->hasGeneratedConversion($conversion)) ? $conversion : '',
                     );
                 } catch (Throwable $exception) {

--- a/packages/spatie-laravel-media-library-plugin/src/Infolists/Components/SpatieMediaLibraryImageEntry.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Infolists/Components/SpatieMediaLibraryImageEntry.php
@@ -115,7 +115,7 @@ class SpatieMediaLibraryImageEntry extends ImageEntry
             if ($this->getVisibility() === 'private') {
                 try {
                     return $media->getTemporaryUrl(
-                        now()->addMinutes(30)->endOfHour(),
+                        now()->addMinutes(config('filament.temporary_url_expiry', 30))->endOfHour(),
                         $conversion ?? '',
                     );
                 } catch (Throwable $exception) {

--- a/packages/spatie-laravel-media-library-plugin/src/Infolists/Components/SpatieMediaLibraryImageEntry.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Infolists/Components/SpatieMediaLibraryImageEntry.php
@@ -115,7 +115,7 @@ class SpatieMediaLibraryImageEntry extends ImageEntry
             if ($this->getVisibility() === 'private') {
                 try {
                     return $media->getTemporaryUrl(
-                        now()->addMinutes(config('filament.temporary_url_expiry', 30))->endOfHour(),
+                        now()->addMinutes(config('filament.temporary_file_url_expiry_minutes', 30))->endOfHour(),
                         $conversion ?? '',
                     );
                 } catch (Throwable $exception) {

--- a/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
@@ -113,7 +113,7 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
             if ($this->getVisibility() === 'private') {
                 try {
                     return $media->getTemporaryUrl(
-                        now()->addMinutes(config('filament.temporary_url_expiry', 30))->endOfHour(),
+                        now()->addMinutes(config('filament.temporary_file_url_expiry_minutes', 30))->endOfHour(),
                         $conversion ?? '',
                     );
                 } catch (Throwable $exception) {

--- a/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
+++ b/packages/spatie-laravel-media-library-plugin/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
@@ -113,7 +113,7 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
             if ($this->getVisibility() === 'private') {
                 try {
                     return $media->getTemporaryUrl(
-                        now()->addMinutes(30)->endOfHour(),
+                        now()->addMinutes(config('filament.temporary_url_expiry', 30))->endOfHour(),
                         $conversion ?? '',
                     );
                 } catch (Throwable $exception) {

--- a/packages/support/config/filament.php
+++ b/packages/support/config/filament.php
@@ -45,15 +45,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Temporary URL Expiry
+    | Temporary File URL Expiry
     |--------------------------------------------------------------------------
     |
-    | This is the duration in minutes for which temporary URLs will be valid.
-    | This applies to private files in file uploads, images, and other media.
+    | When Filament generates temporary URLs for previewing private files
+    | (file uploads, image columns, image entries, rich editor attachments,
+    | etc.), this value controls how many minutes those URLs remain valid.
+    |
+    | The generated URL's expiry is rounded up to the end of the hour it
+    | falls in, so the effective lifetime will be between this value and
+    | this value plus up to 60 minutes.
     |
     */
 
-    'temporary_url_expiry' => 30,
+    'temporary_file_url_expiry_minutes' => 30,
 
     /*
     |--------------------------------------------------------------------------

--- a/packages/support/config/filament.php
+++ b/packages/support/config/filament.php
@@ -45,6 +45,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Temporary URL Expiry
+    |--------------------------------------------------------------------------
+    |
+    | This is the duration in minutes for which temporary URLs will be valid.
+    | This applies to private files in file uploads, images, and other media.
+    |
+    */
+
+    'temporary_url_expiry' => 30,
+
+    /*
+    |--------------------------------------------------------------------------
     | Assets Path
     |--------------------------------------------------------------------------
     |

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -213,7 +213,7 @@ class ImageColumn extends Column implements HasEmbeddedView
             try {
                 return $storage->temporaryUrl(
                     $state,
-                    now()->addMinutes(30)->endOfHour(),
+                    now()->addMinutes(config('filament.temporary_url_expiry', 30))->endOfHour(),
                 );
             } catch (Throwable $exception) {
                 // This driver does not support creating temporary URLs.

--- a/packages/tables/src/Columns/ImageColumn.php
+++ b/packages/tables/src/Columns/ImageColumn.php
@@ -213,7 +213,7 @@ class ImageColumn extends Column implements HasEmbeddedView
             try {
                 return $storage->temporaryUrl(
                     $state,
-                    now()->addMinutes(config('filament.temporary_url_expiry', 30))->endOfHour(),
+                    now()->addMinutes(config('filament.temporary_file_url_expiry_minutes', 30))->endOfHour(),
                 );
             } catch (Throwable $exception) {
                 // This driver does not support creating temporary URLs.


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Add configurable temporary URL expiry duration for private files. The expiry was hardcoded to 30 minutes, now users can customize it via config.

## Visual changes

N/A - no visual changes

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.

---

**Usage:**

```php
// config/filament.php
'temporary_url_expiry' => 60, // minutes (default: 30)
```