### PR TITLE
Improve/boost guidelines v4

### DIFF
--- a/packages/panels/resources/boost/guidelines/core.blade.php
+++ b/packages/panels/resources/boost/guidelines/core.blade.php
@@ -1,13 +1,12 @@
 ## Filament
 
-- Filament is used by this application. Follow the existing conventions for how and where it is implemented.
-- Filament is a Server-Driven UI (SDUI) framework for Laravel that lets you define user interfaces in PHP using structured configuration objects. Built on Livewire, Alpine.js, and Tailwind CSS.
+- Filament is a Laravel UI framework built on Livewire, Alpine.js, and Tailwind CSS. UIs are defined in PHP via fluent, chainable components. Follow existing conventions in this app.
 - Use the `search-docs` tool for official documentation on Artisan commands, code examples, testing, relationships, and idiomatic practices. If `search-docs` is unavailable, refer to https://filamentphp.com/docs.
 
 ### Artisan
 
 - Always use Filament-specific Artisan commands to create files. Find available commands with the `list-artisan-commands` tool, or run `php artisan --help`.
-- Always inspect required options before running a command, and always pass `--no-interaction`.
+- Inspect required options before running, and always pass `--no-interaction`.
 
 ### Patterns
 
@@ -33,11 +32,10 @@ TextInput::make('company_name')
 </code-snippet>
 @endverbatim
 
-Use `Set $set` in `afterStateUpdated` to reactively mutate another field's value:
+Use `Set $set` inside `->afterStateUpdated()` on a `->live()` field to mutate another field reactively. Prefer `->live(onBlur: true)` on text inputs to avoid per-keystroke updates:
 
 @verbatim
-<code-snippet name="Reactive field mutation with Set" lang="php">
-use Filament\Forms\Components\TextInput;
+<code-snippet name="Reactive field update" lang="php">
 use Filament\Schemas\Components\Utilities\Set;
 use Illuminate\Support\Str;
 
@@ -55,52 +53,33 @@ TextInput::make('slug')
 </code-snippet>
 @endverbatim
 
-Use `state()` with a `Closure` to compute derived column values:
-
-@verbatim
-<code-snippet name="Computed table column value" lang="php">
-use Filament\Tables\Columns\TextColumn;
-
-TextColumn::make('full_name')
-    ->state(fn (User $record): string => "{$record->first_name} {$record->last_name}"),
-
-</code-snippet>
-@endverbatim
-
-Use `Section` and `Grid` for layout. Always set `->columns()` on the grid and `->columnSpan()` on fields explicitly — they do not span full-width by default:
+Compose layout by nesting `Section` and `Grid`. Children need explicit `->columnSpan()` or `->columnSpanFull()`:
 
 @verbatim
 <code-snippet name="Section and Grid layout" lang="php">
-use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 
 Section::make('Details')
     ->schema([
-        Grid::make(2)
-            ->schema([
-                TextInput::make('first_name')
-                    ->required()
-                    ->columnSpan(1),
-
-                TextInput::make('last_name')
-                    ->required()
-                    ->columnSpan(1),
-
-                TextInput::make('bio')
-                    ->columnSpanFull(),
-            ]),
+        Grid::make(2)->schema([
+            TextInput::make('first_name')
+                ->columnSpan(1),
+            TextInput::make('last_name')
+                ->columnSpan(1),
+            TextInput::make('bio')
+                ->columnSpanFull(),
+        ]),
     ]),
 
 </code-snippet>
 @endverbatim
 
-Use `Repeater` to manage a `HasMany` relationship inline. Always use `->schema()`, never `->fields()`:
+Use `Repeater` for inline `HasMany` management. `->relationship()` with no args binds to the relationship matching the field name:
 
 @verbatim
 <code-snippet name="Repeater for HasMany" lang="php">
 use Filament\Forms\Components\Repeater;
-use Filament\Forms\Components\TextInput;
 
 Repeater::make('qualifications')
     ->relationship()
@@ -115,7 +94,19 @@ Repeater::make('qualifications')
 </code-snippet>
 @endverbatim
 
-Use `SelectFilter` for enum or relationship-based filtering, and `Filter` with a query closure for custom logic:
+Use `state()` with a `Closure` to compute derived column values:
+
+@verbatim
+<code-snippet name="Computed table column value" lang="php">
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('full_name')
+    ->state(fn (User $record): string => "{$record->first_name} {$record->last_name}"),
+
+</code-snippet>
+@endverbatim
+
+Use `SelectFilter` for enum or relationship filters, and `Filter` with a `->query()` closure for custom logic:
 
 @verbatim
 <code-snippet name="Table filters" lang="php">
@@ -135,12 +126,11 @@ Filter::make('verified')
 </code-snippet>
 @endverbatim
 
-Actions encapsulate a button with an optional modal form and logic:
+Actions are buttons that encapsulate optional modal forms and behavior:
 
 @verbatim
 <code-snippet name="Action with modal form" lang="php">
 use Filament\Actions\Action;
-use Filament\Forms\Components\TextInput;
 
 Action::make('updateEmail')
     ->schema([
@@ -148,22 +138,21 @@ Action::make('updateEmail')
             ->email()
             ->required(),
     ])
-    ->action(fn (array $data, User $record) => $record->update($data))
+    ->action(fn (array $data, User $record) => $record->update($data)),
 
 </code-snippet>
 @endverbatim
 
 ### Testing
 
-Always authenticate before testing panel functionality using `actingAs()`. Filament uses Livewire, so use `livewire()` (available when `pestphp/pest-plugin-livewire` is in `composer.json`):
+Testing setup (requires `pestphp/pest-plugin-livewire` in `composer.json`):
+
+- Always call `$this->actingAs(User::factory()->create())` before testing panel functionality.
+- For edit pages, pass `['record' => $user->id]`, use `->call('save')` (not `->call('create')`), and do not assert `->assertRedirect()` (edit pages do not redirect after save).
 
 @verbatim
 <code-snippet name="Table test" lang="php">
 use function Pest\Livewire\livewire;
-
-$user = User::factory()->create();
-
-$this->actingAs($user);
 
 livewire(ListUsers::class)
     ->assertCanSeeTableRecords($users)
@@ -175,9 +164,6 @@ livewire(ListUsers::class)
 
 <code-snippet name="Create resource test" lang="php">
 use function Pest\Laravel\assertDatabaseHas;
-use function Pest\Livewire\livewire;
-
-$this->actingAs(User::factory()->create());
 
 livewire(CreateUser::class)
     ->fillForm([
@@ -186,6 +172,7 @@ livewire(CreateUser::class)
     ])
     ->call('create')
     ->assertNotified()
+    ->assertHasNoFormErrors()
     ->assertRedirect();
 
 assertDatabaseHas(User::class, [
@@ -196,31 +183,20 @@ assertDatabaseHas(User::class, [
 </code-snippet>
 
 <code-snippet name="Edit resource test" lang="php">
-use function Pest\Laravel\assertDatabaseHas;
-use function Pest\Livewire\livewire;
-
-$this->actingAs(User::factory()->create());
-
 livewire(EditUser::class, ['record' => $user->id])
-    ->fillForm([
-        'name' => 'Updated Name',
-        'email' => 'updated@example.com',
-    ])
+    ->fillForm(['name' => 'Updated'])
     ->call('save')
     ->assertNotified()
     ->assertHasNoFormErrors();
 
 assertDatabaseHas(User::class, [
     'id' => $user->id,
-    'name' => 'Updated Name',
-    'email' => 'updated@example.com',
+    'name' => 'Updated',
 ]);
 
 </code-snippet>
 
 <code-snippet name="Testing validation" lang="php">
-use function Pest\Livewire\livewire;
-
 livewire(CreateUser::class)
     ->fillForm([
         'name' => null,
@@ -234,21 +210,13 @@ livewire(CreateUser::class)
     ->assertNotNotified();
 
 </code-snippet>
+@endverbatim
 
-<code-snippet name="Calling actions in pages" lang="php">
-use Filament\Actions\DeleteAction;
-use function Pest\Livewire\livewire;
+Use `->callAction(DeleteAction::class)` for page actions, or `->callAction(TestAction::make('name')->table($record))` for table actions:
 
-livewire(EditUser::class, ['record' => $user->id])
-    ->callAction(DeleteAction::class)
-    ->assertNotified()
-    ->assertRedirect();
-
-</code-snippet>
-
-<code-snippet name="Calling actions in tables" lang="php">
+@verbatim
+<code-snippet name="Calling actions" lang="php">
 use Filament\Actions\Testing\TestAction;
-use function Pest\Livewire\livewire;
 
 livewire(ListUsers::class)
     ->callAction(TestAction::make('promote')->table($user), [
@@ -265,17 +233,19 @@ livewire(ListUsers::class)
 - Infolist entries (`TextEntry`, `IconEntry`, etc.): `Filament\Infolists\Components\`
 - Layout components (`Grid`, `Section`, `Fieldset`, `Tabs`, `Wizard`, etc.): `Filament\Schemas\Components\`
 - Schema utilities (`Get`, `Set`, etc.): `Filament\Schemas\Components\Utilities\`
+- Table columns (`TextColumn`, `IconColumn`, etc.): `Filament\Tables\Columns\`
+- Table filters (`SelectFilter`, `Filter`, etc.): `Filament\Tables\Filters\`
 - Actions (`DeleteAction`, `CreateAction`, etc.): `Filament\Actions\`. Never use `Filament\Tables\Actions\`, `Filament\Forms\Actions\`, or any other sub-namespace for actions.
 - Icons: `Filament\Support\Icons\Heroicon` enum (e.g., `Heroicon::PencilSquare`)
 
 ### Common Mistakes
 
 - **Never assume public file visibility.** File visibility is `private` by default. Always use `->visibility('public')` when public access is needed.
-- **Never assume full-width layout.** `Grid`, `Section`, and `Fieldset` do not span all columns by default. Explicitly set column spans when needed.
-- **Use `Select::make()->relationship()` for BelongsTo fields.** Never use a separate `BelongsToSelect` component — it does not exist in v4. The correct pattern is `Select::make('author_id')->relationship('author', 'name')`.
-- **Use `->schema()` on `Repeater`, not `->fields()`.** The method `->fields()` does not exist. Always use `->schema([])`.
-- **Never add `->dehydrated(false)` to fields that need to be saved.** This removes the field value from the form state and the data will not be passed to `->action()` or the save handler. Only use it for helper/UI-only fields.
-- **Use correct property types when overriding Page, Resource, and Widget properties.** These properties have union types or changed modifiers that must be preserved:
-    - `$navigationIcon`: `protected static string | BackedEnum | null` (not `?string`)
-    - `$navigationGroup`: `protected static string | UnitEnum | null` (not `?string`)
-    - `$view`: `protected string` (not `protected static string`) on Page and Widget classes
+- **Never assume full-width layout.** `Grid`, `Section`, `Fieldset`, and `Repeater` do not span all columns by default.
+- **Use `Select::make('author_id')->relationship('author', 'name')` for BelongsTo fields.** `BelongsToSelect` does not exist in v4.
+- **`Repeater` uses `->schema()`, not `->fields()`.**
+- **Never add `->dehydrated(false)` to fields that need to be saved.** It strips the value from form state before `->action()` or the save handler runs. Only use it for helper/UI-only fields.
+- **Use correct property types when overriding `Page`, `Resource`, and `Widget` properties.** These properties have union types or changed modifiers that must be preserved:
+  - `$navigationIcon`: `protected static string | BackedEnum | null` (not `?string`)
+  - `$navigationGroup`: `protected static string | UnitEnum | null` (not `?string`)
+  - `$view`: `protected string` (not `protected static string`) on `Page` and `Widget` classes

--- a/packages/panels/resources/boost/guidelines/core.blade.php
+++ b/packages/panels/resources/boost/guidelines/core.blade.php
@@ -30,7 +30,29 @@ TextInput::make('company_name')
     ->required()
     ->visible(fn (Get $get): bool => $get('type') === 'business'),
 
-</code-snippet>
+</code-snippet>code-snippet>
+@endverbatim
+
+Use `Get $get` and `Set $set` together to reactively mutate another field's value:
+
+@verbatim
+<code-snippet name="Reactive field mutation with Get and Set" lang="php">
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
+
+TextInput::make('title')
+    ->required()
+    ->live(onBlur: true)
+    ->afterStateUpdated(fn (Get $get, Set $set, ?string $state) => $set(
+        'slug',
+        str($state ?? '')->slug()->toString(),
+    )),
+
+TextInput::make('slug')
+    ->required(),
+
+</code-snippet>code-snippet>
 @endverbatim
 
 Use `state()` with a `Closure` to compute derived column values:
@@ -42,7 +64,27 @@ use Filament\Tables\Columns\TextColumn;
 TextColumn::make('full_name')
     ->state(fn (User $record): string => "{$record->first_name} {$record->last_name}"),
 
-</code-snippet>
+</code-snippet>code-snippet>
+@endverbatim
+
+Use `SelectFilter` for enum or relationship-based filtering, and `Filter` with a query closure for custom logic:
+
+@verbatim
+<code-snippet name="Table filters" lang="php">
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
+use Illuminate\Database\Eloquent\Builder;
+
+SelectFilter::make('status')
+    ->options(UserStatus::class),
+
+SelectFilter::make('author')
+    ->relationship('author', 'name'),
+
+Filter::make('verified')
+    ->query(fn (Builder $query) => $query->whereNotNull('email_verified_at')),
+
+</code-snippet>code-snippet>
 @endverbatim
 
 Actions encapsulate a button with an optional modal form and logic:
@@ -60,7 +102,7 @@ Action::make('updateEmail')
     ])
     ->action(fn (array $data, User $record) => $record->update($data))
 
-</code-snippet>
+</code-snippet>code-snippet>
 @endverbatim
 
 ### Testing
@@ -77,7 +119,7 @@ livewire(ListUsers::class)
     ->assertCanSeeTableRecords($users->take(1))
     ->assertCanNotSeeTableRecords($users->skip(1));
 
-</code-snippet>
+</code-snippet>code-snippet>
 
 <code-snippet name="Create resource test" lang="php">
 use function Pest\Laravel\assertDatabaseHas;
@@ -97,7 +139,28 @@ assertDatabaseHas(User::class, [
     'email' => 'test@example.com',
 ]);
 
-</code-snippet>
+</code-snippet>code-snippet>
+
+<code-snippet name="Edit resource test" lang="php">
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Livewire\livewire;
+
+livewire(EditUser::class, ['record' => $user->id])
+    ->fillForm([
+        'name' => 'Updated Name',
+        'email' => 'updated@example.com',
+    ])
+    ->call('save')
+    ->assertNotified()
+    ->assertHasNoFormErrors();
+
+assertDatabaseHas(User::class, [
+    'id' => $user->id,
+    'name' => 'Updated Name',
+    'email' => 'updated@example.com',
+]);
+
+</code-snippet>code-snippet>
 
 <code-snippet name="Testing validation" lang="php">
 use function Pest\Livewire\livewire;
@@ -114,7 +177,7 @@ livewire(CreateUser::class)
     ])
     ->assertNotNotified();
 
-</code-snippet>
+</code-snippet>code-snippet>
 
 <code-snippet name="Calling actions in pages" lang="php">
 use Filament\Actions\DeleteAction;
@@ -125,7 +188,7 @@ livewire(EditUser::class, ['record' => $user->id])
     ->assertNotified()
     ->assertRedirect();
 
-</code-snippet>
+</code-snippet>code-snippet>
 
 <code-snippet name="Calling actions in tables" lang="php">
 use Filament\Actions\Testing\TestAction;
@@ -137,7 +200,7 @@ livewire(ListUsers::class)
     ])
     ->assertNotified();
 
-</code-snippet>
+</code-snippet>code-snippet>
 @endverbatim
 
 ### Correct Namespaces
@@ -153,7 +216,8 @@ livewire(ListUsers::class)
 
 - **Never assume public file visibility.** File visibility is `private` by default. Always use `->visibility('public')` when public access is needed.
 - **Never assume full-width layout.** `Grid`, `Section`, and `Fieldset` do not span all columns by default. Explicitly set column spans when needed.
+- **Use `Select::make()->relationship()` for BelongsTo fields.** Never use a separate `BelongsToSelect` component — it does not exist in v4. The correct pattern is `Select::make('author_id')->relationship('author', 'name')`.
 - **Use correct property types when overriding Page, Resource, and Widget properties.** These properties have union types or changed modifiers that must be preserved:
-  - `$navigationIcon`: `protected static string | BackedEnum | null` (not `?string`)
-  - `$navigationGroup`: `protected static string | UnitEnum | null` (not `?string`)
-  - `$view`: `protected string` (not `protected static string`) on Page and Widget classes
+    - `$navigationIcon`: `protected static string | BackedEnum | null` (not `?string`)
+    - `$navigationGroup`: `protected static string | UnitEnum | null` (not `?string`)
+    - `$view`: `protected string` (not `protected static string`) on Page and Widget classes

--- a/packages/panels/resources/boost/guidelines/core.blade.php
+++ b/packages/panels/resources/boost/guidelines/core.blade.php
@@ -30,29 +30,29 @@ TextInput::make('company_name')
     ->required()
     ->visible(fn (Get $get): bool => $get('type') === 'business'),
 
-</code-snippet>code-snippet>
+</code-snippet>
 @endverbatim
 
-Use `Get $get` and `Set $set` together to reactively mutate another field's value:
+Use `Set $set` in `afterStateUpdated` to reactively mutate another field's value:
 
 @verbatim
-<code-snippet name="Reactive field mutation with Get and Set" lang="php">
+<code-snippet name="Reactive field mutation with Set" lang="php">
 use Filament\Forms\Components\TextInput;
-use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
+use Illuminate\Support\Str;
 
 TextInput::make('title')
     ->required()
     ->live(onBlur: true)
-    ->afterStateUpdated(fn (Get $get, Set $set, ?string $state) => $set(
+    ->afterStateUpdated(fn (Set $set, ?string $state) => $set(
         'slug',
-        str($state ?? '')->slug()->toString(),
+        Str::slug($state ?? ''),
     )),
 
 TextInput::make('slug')
     ->required(),
 
-</code-snippet>code-snippet>
+</code-snippet>
 @endverbatim
 
 Use `state()` with a `Closure` to compute derived column values:
@@ -64,7 +64,55 @@ use Filament\Tables\Columns\TextColumn;
 TextColumn::make('full_name')
     ->state(fn (User $record): string => "{$record->first_name} {$record->last_name}"),
 
-</code-snippet>code-snippet>
+</code-snippet>
+@endverbatim
+
+Use `Section` and `Grid` for layout. Always set `->columns()` on the grid and `->columnSpan()` on fields explicitly — they do not span full-width by default:
+
+@verbatim
+<code-snippet name="Section and Grid layout" lang="php">
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Section;
+
+Section::make('Details')
+    ->schema([
+        Grid::make(2)
+            ->schema([
+                TextInput::make('first_name')
+                    ->required()
+                    ->columnSpan(1),
+
+                TextInput::make('last_name')
+                    ->required()
+                    ->columnSpan(1),
+
+                TextInput::make('bio')
+                    ->columnSpanFull(),
+            ]),
+    ]),
+
+</code-snippet>
+@endverbatim
+
+Use `Repeater` to manage a `HasMany` relationship inline. Always use `->schema()`, never `->fields()`:
+
+@verbatim
+<code-snippet name="Repeater for HasMany" lang="php">
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\TextInput;
+
+Repeater::make('qualifications')
+    ->relationship()
+    ->schema([
+        TextInput::make('institution')
+            ->required(),
+        TextInput::make('qualification')
+            ->required(),
+    ])
+    ->columns(2),
+
+</code-snippet>
 @endverbatim
 
 Use `SelectFilter` for enum or relationship-based filtering, and `Filter` with a query closure for custom logic:
@@ -84,7 +132,7 @@ SelectFilter::make('author')
 Filter::make('verified')
     ->query(fn (Builder $query) => $query->whereNotNull('email_verified_at')),
 
-</code-snippet>code-snippet>
+</code-snippet>
 @endverbatim
 
 Actions encapsulate a button with an optional modal form and logic:
@@ -102,16 +150,20 @@ Action::make('updateEmail')
     ])
     ->action(fn (array $data, User $record) => $record->update($data))
 
-</code-snippet>code-snippet>
+</code-snippet>
 @endverbatim
 
 ### Testing
 
-Always authenticate before testing panel functionality. Filament uses Livewire, so use `Livewire::test()` or `livewire()` (available when `pestphp/pest-plugin-livewire` is in `composer.json`):
+Always authenticate before testing panel functionality using `actingAs()`. Filament uses Livewire, so use `livewire()` (available when `pestphp/pest-plugin-livewire` is in `composer.json`):
 
 @verbatim
 <code-snippet name="Table test" lang="php">
 use function Pest\Livewire\livewire;
+
+$user = User::factory()->create();
+
+$this->actingAs($user);
 
 livewire(ListUsers::class)
     ->assertCanSeeTableRecords($users)
@@ -119,11 +171,13 @@ livewire(ListUsers::class)
     ->assertCanSeeTableRecords($users->take(1))
     ->assertCanNotSeeTableRecords($users->skip(1));
 
-</code-snippet>code-snippet>
+</code-snippet>
 
 <code-snippet name="Create resource test" lang="php">
 use function Pest\Laravel\assertDatabaseHas;
 use function Pest\Livewire\livewire;
+
+$this->actingAs(User::factory()->create());
 
 livewire(CreateUser::class)
     ->fillForm([
@@ -139,11 +193,13 @@ assertDatabaseHas(User::class, [
     'email' => 'test@example.com',
 ]);
 
-</code-snippet>code-snippet>
+</code-snippet>
 
 <code-snippet name="Edit resource test" lang="php">
 use function Pest\Laravel\assertDatabaseHas;
 use function Pest\Livewire\livewire;
+
+$this->actingAs(User::factory()->create());
 
 livewire(EditUser::class, ['record' => $user->id])
     ->fillForm([
@@ -160,7 +216,7 @@ assertDatabaseHas(User::class, [
     'email' => 'updated@example.com',
 ]);
 
-</code-snippet>code-snippet>
+</code-snippet>
 
 <code-snippet name="Testing validation" lang="php">
 use function Pest\Livewire\livewire;
@@ -177,7 +233,7 @@ livewire(CreateUser::class)
     ])
     ->assertNotNotified();
 
-</code-snippet>code-snippet>
+</code-snippet>
 
 <code-snippet name="Calling actions in pages" lang="php">
 use Filament\Actions\DeleteAction;
@@ -188,7 +244,7 @@ livewire(EditUser::class, ['record' => $user->id])
     ->assertNotified()
     ->assertRedirect();
 
-</code-snippet>code-snippet>
+</code-snippet>
 
 <code-snippet name="Calling actions in tables" lang="php">
 use Filament\Actions\Testing\TestAction;
@@ -200,12 +256,12 @@ livewire(ListUsers::class)
     ])
     ->assertNotified();
 
-</code-snippet>code-snippet>
+</code-snippet>
 @endverbatim
 
 ### Correct Namespaces
 
-- Form fields (`TextInput`, `Select`, etc.): `Filament\Forms\Components\`
+- Form fields (`TextInput`, `Select`, `Repeater`, etc.): `Filament\Forms\Components\`
 - Infolist entries (`TextEntry`, `IconEntry`, etc.): `Filament\Infolists\Components\`
 - Layout components (`Grid`, `Section`, `Fieldset`, `Tabs`, `Wizard`, etc.): `Filament\Schemas\Components\`
 - Schema utilities (`Get`, `Set`, etc.): `Filament\Schemas\Components\Utilities\`
@@ -217,6 +273,8 @@ livewire(ListUsers::class)
 - **Never assume public file visibility.** File visibility is `private` by default. Always use `->visibility('public')` when public access is needed.
 - **Never assume full-width layout.** `Grid`, `Section`, and `Fieldset` do not span all columns by default. Explicitly set column spans when needed.
 - **Use `Select::make()->relationship()` for BelongsTo fields.** Never use a separate `BelongsToSelect` component — it does not exist in v4. The correct pattern is `Select::make('author_id')->relationship('author', 'name')`.
+- **Use `->schema()` on `Repeater`, not `->fields()`.** The method `->fields()` does not exist. Always use `->schema([])`.
+- **Never add `->dehydrated(false)` to fields that need to be saved.** This removes the field value from the form state and the data will not be passed to `->action()` or the save handler. Only use it for helper/UI-only fields.
 - **Use correct property types when overriding Page, Resource, and Widget properties.** These properties have union types or changed modifiers that must be preserved:
     - `$navigationIcon`: `protected static string | BackedEnum | null` (not `?string`)
     - `$navigationGroup`: `protected static string | UnitEnum | null` (not `?string`)


### PR DESCRIPTION
## Description

This PR adds four incremental improvements to the Filament v4 Boost guidelines (`packages/panels/resources/boost/guidelines/core.blade.php`), addressing gaps where the existing file had no coverage and where AI tools commonly make mistakes.

### Changes

**1. Reactive field mutation with `Get` and `Set` (new code snippet)**

The existing guidelines show `Get $get` for reading field values, but never show `Set $set` for mutating another field reactively. This is an extremely common pattern (e.g. auto-populating a slug from a title) and `Set` is already listed in the Correct Namespaces section without any example. Added a concrete `afterStateUpdated` + `Set` snippet.

**2. Table filters (new code snippet)**

Table filters (`SelectFilter`, `Filter` with a query closure) are a core feature of Filament tables with zero coverage in the current guidelines. AI tools frequently put filters in the wrong method, use wrong chaining, or invent non-existent classes. Added a snippet covering `SelectFilter` with enum options, `SelectFilter` with a relationship, and `Filter` with a custom `Builder` closure.

**3. Edit resource test (new code snippet)**

The Testing section only covered `CreateUser`. Editing an existing record has different syntax (`->call('save')` vs `->call('create')`, pre-loaded form state, `assertHasNoFormErrors()`). Added a complementary `EditUser` test snippet to complete the CRUD testing picture.

**4. `Select::make()->relationship()` common mistake (new bullet in Common Mistakes)**

A very frequent AI error is using a non-existent `BelongsToSelect` component or incorrect approaches for BelongsTo relationships. The correct v4 pattern is `Select::make('author_id')->relationship('author', 'name')`. Added this as a clear common mistake with the correct pattern shown inline.

## Visual changes

None — this is a guidelines-only Blade file with no UI impact.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [ ] - [x] Changes have been tested to not break existing functionality.
- [ ] - [x] Documentation is up-to-date.