### PR TITLE
add missing Persian translations for export column selection actions

### DIFF
--- a/packages/actions/resources/lang/fa/export.php
+++ b/packages/actions/resources/lang/fa/export.php
@@ -14,6 +14,18 @@ return [
 
                 'label' => 'ستون ها',
 
+                'actions' => [
+
+                    'select_all' => [
+                        'label' => 'انتخاب همه',
+                    ],
+
+                    'deselect_all' => [
+                        'label' => 'لغو انتخاب همه',
+                    ],
+
+                ],
+
                 'form' => [
 
                     'is_enabled' => [


### PR DESCRIPTION
This PR adds missing Persian (`fa`) translations for the export column
selection actions in the Filament actions export language file.

Added translations:
- `actions.select_all`
- `actions.deselect_all`

These keys were not previously defined in the Persian locale, which caused
the UI labels for selecting/deselecting all export columns to appear in
English.

This change ensures proper localization for Persian users.