### PR TITLE
feat: allow passing a confirmation message directly into copyable()    

### DIFF
--- a/packages/infolists/docs/02-text-entry.md
+++ b/packages/infolists/docs/02-text-entry.md
@@ -756,6 +756,16 @@ TextEntry::make('apiKey')
     ->copyMessageDuration(1500)
 ```
 
+As a shorthand, you may pass the confirmation message directly into `copyable()`:
+
+```php
+use Filament\Infolists\Components\TextEntry;
+
+TextEntry::make('apiKey')
+    ->label('API key')
+    ->copyable('Copied!')
+```
+
 <AutoScreenshot name="infolists/entries/text/copyable" alt="Text entry with a button to copy it" version="4.x" />
 
 Optionally, you may pass a boolean value to control if the text should be copyable or not:

--- a/packages/infolists/docs/05-color-entry.md
+++ b/packages/infolists/docs/05-color-entry.md
@@ -29,6 +29,15 @@ ColorEntry::make('color')
     ->copyMessageDuration(1500)
 ```
 
+As a shorthand, you may pass the confirmation message directly into `copyable()`:
+
+```php
+use Filament\Infolists\Components\ColorEntry;
+
+ColorEntry::make('color')
+    ->copyable('Copied!')
+```
+
 <AutoScreenshot name="infolists/entries/color/copyable" alt="Color entry with a button to copy it" version="4.x" />
 
 Optionally, you may pass a boolean value to control if the color should be copyable or not:

--- a/packages/infolists/docs/06-code-entry.md
+++ b/packages/infolists/docs/06-code-entry.md
@@ -75,6 +75,15 @@ CodeEntry::make('code')
     ->copyMessageDuration(1500)
 ```
 
+As a shorthand, you may pass the confirmation message directly into `copyable()`:
+
+```php
+use Filament\Infolists\Components\CodeEntry;
+
+CodeEntry::make('code')
+    ->copyable('Copied!')
+```
+
 Optionally, you may pass a boolean value to control if the code should be copyable or not:
 
 ```php

--- a/packages/support/src/Concerns/CanBeCopied.php
+++ b/packages/support/src/Concerns/CanBeCopied.php
@@ -14,8 +14,15 @@ trait CanBeCopied
 
     protected int | Closure | null $copyMessageDuration = null;
 
-    public function copyable(bool | Closure $condition = true): static
+    public function copyable(bool | string | Closure $condition = true): static
     {
+        if (is_string($condition)) {
+            $this->isCopyable = true;
+            $this->copyMessage = $condition;
+
+            return $this;
+        }
+
         $this->isCopyable = $condition;
 
         return $this;

--- a/packages/tables/docs/02-columns/02-text.md
+++ b/packages/tables/docs/02-columns/02-text.md
@@ -769,6 +769,15 @@ TextColumn::make('email')
     ->copyMessageDuration(1500)
 ```
 
+As a shorthand, you may pass the confirmation message directly into `copyable()`:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('email')
+    ->copyable('Email address copied')
+```
+
 <AutoScreenshot name="tables/columns/text/copyable" alt="Text column with a button to copy it" version="4.x" />
 
 Optionally, you may pass a boolean value to control if the text should be copyable or not:

--- a/packages/tables/docs/02-columns/05-color.md
+++ b/packages/tables/docs/02-columns/05-color.md
@@ -30,6 +30,15 @@ ColorColumn::make('color')
     ->copyMessageDuration(1500)
 ```
 
+As a shorthand, you may pass the confirmation message directly into `copyable()`:
+
+```php
+use Filament\Tables\Columns\ColorColumn;
+
+ColorColumn::make('color')
+    ->copyable('Copied!')
+```
+
 <AutoScreenshot name="tables/columns/color/copyable" alt="Color column with a button to copy it" version="4.x" />
 
 Optionally, you may pass a boolean value to control if the text should be copyable or not:

--- a/tests/src/Schemas/Components/TextTest.php
+++ b/tests/src/Schemas/Components/TextTest.php
@@ -396,6 +396,21 @@ describe('copying', function (): void {
 
         expect($text->getCopyMessageDuration('Test'))->toBe(3000);
     });
+
+    it('can set `copyable()` with a string message', function (): void {
+        $text = Text::make('Test')->copyable('Copied Success');
+
+        expect($text->isCopyable('Test'))->toBeTrue()
+            ->and($text->getCopyMessage('Test'))->toBe('Copied Success');
+    });
+
+    it('still allows overriding the message via `copyMessage()` after `copyable(string)`', function (): void {
+        $text = Text::make('Test')
+            ->copyable('First')
+            ->copyMessage('Second');
+
+        expect($text->getCopyMessage('Test'))->toBe('Second');
+    });
 });
 
 describe('rendering', function (): void {


### PR DESCRIPTION
## Description

Previously, making a column or entry copyable with a custom confirmation message required two separate calls:

```php
TextColumn::make('email')
    ->copyable()
    ->copyMessage('Email address copied');
```

This PR introduces a string overload for `copyable()`, allowing the message to be passed inline:

```php
TextColumn::make('email')
    ->copyable('Email address copied');
```

The change is implemented in `Filament\Support\Concerns\CanBeCopied::copyable()` and automatically applies to all consumers of the trait, including:

* `TextColumn`
* `ColorColumn`
* `TextEntry`
* `ColorEntry`
* `CodeEntry`
* Text schema component

All existing call signatures continue to behave exactly as before:

* `copyable()`
* `copyable(true)`
* `copyable(false)`
* `copyable(fn () => ...)`

The standalone `->copyMessage()` method remains unchanged and takes precedence when both are used.

This patch also applies cleanly to the `5.x` branch. A follow-up PR can be opened once this is merged.

## Visual Changes

No visual changes. The rendered output is identical to using:

```php
->copyable()->copyMessage('...')
```


## Functional Changes

* [x] Code style has been fixed by running `composer cs`.
* [x] Changes have been tested and do not break existing functionality.
* [x] Documentation is up to date.