### PR TITLE
feat: add DateRangeFilter with inline layout, native toggle, and per-picker customization

### DIFF
--- a/packages/tables/docs/03-filters/06-date-range.md
+++ b/packages/tables/docs/03-filters/06-date-range.md
@@ -1,0 +1,122 @@
+---
+title: Date range filters
+---
+import AutoScreenshot from "@components/AutoScreenshot.astro"
+
+## Introduction
+
+Date range filters allow users to scope records by a start date, an end date, or both. To use one, create a filter using the `DateRangeFilter` class:
+
+```php
+use Filament\Tables\Filters\DateRangeFilter;
+
+DateRangeFilter::make('created_at')
+```
+
+This renders two date pickers — "From" and "Until" — in the filter form. When either is filled, the query is scoped using `whereDate` on the filter's attribute. You do not need to provide a custom `query()` callback for the common case.
+
+## Customizing the column used by a date range filter
+
+The column name used to scope the query defaults to the name of the filter. To customize this, you may use the `attribute()` method:
+
+```php
+use Filament\Tables\Filters\DateRangeFilter;
+
+DateRangeFilter::make('published')
+    ->attribute('published_at')
+```
+
+## Customizing the field labels
+
+You may change the label for either picker using `fromLabel()` and `untilLabel()`:
+
+```php
+use Filament\Tables\Filters\DateRangeFilter;
+
+DateRangeFilter::make('created_at')
+    ->fromLabel('Start date')
+    ->untilLabel('End date')
+```
+
+## Rendering both pickers on one line
+
+By default, the two pickers are stacked vertically. You may render them side by side using `inline()`:
+
+```php
+use Filament\Tables\Filters\DateRangeFilter;
+
+DateRangeFilter::make('created_at')
+    ->inline()
+```
+
+## Disabling the "until" picker
+
+If you only need a lower bound — for example, to filter records created after a certain date — you may hide the "Until" picker using `withoutUntil()`:
+
+```php
+use Filament\Tables\Filters\DateRangeFilter;
+
+DateRangeFilter::make('created_at')
+    ->withoutUntil()
+```
+
+You may also pass a boolean or a closure to conditionally disable it:
+
+```php
+use Filament\Tables\Filters\DateRangeFilter;
+
+DateRangeFilter::make('created_at')
+    ->withoutUntil(fn (): bool => auth()->user()->isRestricted())
+```
+
+## Using the custom JS date picker
+
+By default, both pickers use the browser's native date input. You may opt into the custom JavaScript picker by calling `native(false)`:
+
+```php
+use Filament\Tables\Filters\DateRangeFilter;
+
+DateRangeFilter::make('created_at')
+    ->native(false)
+```
+
+## Customizing each date picker individually
+
+If you need to configure the "From" or "Until" picker beyond the shared options — for example to set a minimum date, maximum date, or placeholder — you may pass a closure to `modifyFromDatePickerUsing()` or `modifyUntilDatePickerUsing()`. The closure receives the `DatePicker` instance and should return it:
+
+```php
+use Filament\Forms\Components\DatePicker;
+use Filament\Tables\Filters\DateRangeFilter;
+
+DateRangeFilter::make('created_at')
+    ->modifyFromDatePickerUsing(fn (DatePicker $datePicker): DatePicker => $datePicker
+        ->minDate('2020-01-01')
+        ->placeholder('Start date'),
+    )
+    ->modifyUntilDatePickerUsing(fn (DatePicker $datePicker): DatePicker => $datePicker
+        ->maxDate(now())
+        ->placeholder('End date'),
+    )
+```
+
+## Customizing the query
+
+If you need custom filtering logic — for example to filter on a relationship or a computed column — you may pass a `query()` callback. The `$data` array contains `date_from` and `date_until` keys:
+
+```php
+use Filament\Tables\Filters\DateRangeFilter;
+use Illuminate\Database\Eloquent\Builder;
+
+DateRangeFilter::make('created_at')
+    ->query(function (Builder $query, array $data): Builder {
+        return $query
+            ->when(
+                $data['date_from'],
+                fn (Builder $query, string $date): Builder => $query->whereDate('created_at', '>=', $date),
+            )
+            ->when(
+                $data['date_until'],
+                fn (Builder $query, string $date): Builder => $query->whereDate('created_at', '<=', $date),
+            );
+    })
+```

--- a/packages/tables/resources/lang/en/table.php
+++ b/packages/tables/resources/lang/en/table.php
@@ -168,6 +168,27 @@ return [
 
         'indicator' => 'Active filters',
 
+        'date_range' => [
+
+            'fields' => [
+
+                'date_from' => [
+                    'label' => 'From',
+                ],
+
+                'date_until' => [
+                    'label' => 'Until',
+                ],
+
+            ],
+
+            'indicator' => [
+                'from' => 'From :date',
+                'until' => 'Until :date',
+            ],
+
+        ],
+
         'multi_select' => [
             'placeholder' => 'All',
         ],

--- a/packages/tables/src/Filters/DateRangeFilter.php
+++ b/packages/tables/src/Filters/DateRangeFilter.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Filament\Tables\Filters;
+
+use Closure;
+use Filament\Forms\Components\DatePicker;
+use Filament\Schemas\Components\Grid;
+use Illuminate\Database\Eloquent\Builder;
+
+class DateRangeFilter extends BaseFilter
+{
+    protected string | Closure | null $attribute = null;
+
+    protected string | Closure | null $fromLabel = null;
+
+    protected string | Closure | null $untilLabel = null;
+
+    protected bool | Closure $isInline = false;
+
+    protected bool | Closure $hasUntil = true;
+
+    protected bool | Closure $isNative = true;
+
+    protected ?Closure $modifyFromDatePickerUsing = null;
+
+    protected ?Closure $modifyUntilDatePickerUsing = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->indicateUsing(function (DateRangeFilter $filter, array $state): array {
+            $indicators = [];
+
+            if (filled($state['date_from'] ?? null)) {
+                $indicator = $filter->getIndicator();
+
+                if (! $indicator instanceof Indicator) {
+                    $indicator = Indicator::make(__('filament-tables::table.filters.date_range.indicator.from', [
+                        'date' => $state['date_from'],
+                    ]))->removeField('date_from');
+                }
+
+                $indicators['date_from'] = $indicator;
+            }
+
+            if ($filter->hasUntil() && filled($state['date_until'] ?? null)) {
+                $indicator = $filter->getIndicator();
+
+                if (! $indicator instanceof Indicator) {
+                    $indicator = Indicator::make(__('filament-tables::table.filters.date_range.indicator.until', [
+                        'date' => $state['date_until'],
+                    ]))->removeField('date_until');
+                }
+
+                $indicators['date_until'] = $indicator;
+            }
+
+            return $indicators;
+        });
+    }
+
+    public function attribute(string | Closure $name): static
+    {
+        $this->attribute = $name;
+
+        return $this;
+    }
+
+    public function fromLabel(string | Closure | null $label): static
+    {
+        $this->fromLabel = $label;
+
+        return $this;
+    }
+
+    public function untilLabel(string | Closure | null $label): static
+    {
+        $this->untilLabel = $label;
+
+        return $this;
+    }
+
+    public function inline(bool | Closure $condition = true): static
+    {
+        $this->isInline = $condition;
+
+        return $this;
+    }
+
+    public function modifyFromDatePickerUsing(?Closure $callback): static
+    {
+        $this->modifyFromDatePickerUsing = $callback;
+
+        return $this;
+    }
+
+    public function modifyUntilDatePickerUsing(?Closure $callback): static
+    {
+        $this->modifyUntilDatePickerUsing = $callback;
+
+        return $this;
+    }
+
+    public function native(bool | Closure $condition = true): static
+    {
+        $this->isNative = $condition;
+
+        return $this;
+    }
+
+    public function isNative(): bool
+    {
+        return (bool) $this->evaluate($this->isNative);
+    }
+
+    public function withoutUntil(bool | Closure $condition = true): static
+    {
+        $this->hasUntil = static function () use ($condition): bool {
+            return ! (bool) (is_callable($condition) ? $condition() : $condition);
+        };
+
+        return $this;
+    }
+
+    public function getAttribute(): string
+    {
+        return $this->evaluate($this->attribute) ?? $this->getName();
+    }
+
+    public function getFromLabel(): string
+    {
+        return $this->evaluate($this->fromLabel)
+            ?? __('filament-tables::table.filters.date_range.fields.date_from.label');
+    }
+
+    public function getUntilLabel(): string
+    {
+        return $this->evaluate($this->untilLabel)
+            ?? __('filament-tables::table.filters.date_range.fields.date_until.label');
+    }
+
+    public function isInline(): bool
+    {
+        return (bool) $this->evaluate($this->isInline);
+    }
+
+    public function hasUntil(): bool
+    {
+        return (bool) $this->evaluate($this->hasUntil);
+    }
+
+    public function apply(Builder $query, array $data = []): Builder
+    {
+        if ($this->hasQueryModificationCallback()) {
+            return parent::apply($query, $data);
+        }
+
+        if (filled($data['date_from'] ?? null)) {
+            $query->whereDate($this->getAttribute(), '>=', $data['date_from']);
+        }
+
+        if ($this->hasUntil() && filled($data['date_until'] ?? null)) {
+            $query->whereDate($this->getAttribute(), '<=', $data['date_until']);
+        }
+
+        return $query;
+    }
+
+    public function getSchemaComponents(): array
+    {
+        $fromPicker = DatePicker::make('date_from')
+            ->label($this->getFromLabel())
+            ->native($this->isNative());
+
+        if ($this->modifyFromDatePickerUsing) {
+            $fromPicker = $this->evaluate($this->modifyFromDatePickerUsing, [
+                'datePicker' => $fromPicker,
+            ]) ?? $fromPicker;
+        }
+
+        if (! $this->hasUntil()) {
+            if ($this->isInline()) {
+                return [Grid::make(1)->schema([$fromPicker])];
+            }
+
+            return [$fromPicker];
+        }
+
+        $untilPicker = DatePicker::make('date_until')
+            ->label($this->getUntilLabel())
+            ->native($this->isNative());
+
+        if ($this->modifyUntilDatePickerUsing) {
+            $untilPicker = $this->evaluate($this->modifyUntilDatePickerUsing, [
+                'datePicker' => $untilPicker,
+            ]) ?? $untilPicker;
+        }
+
+        if ($this->isInline()) {
+            return [Grid::make(2)->schema([$fromPicker, $untilPicker])];
+        }
+
+        return [$fromPicker, $untilPicker];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getResetState(): array
+    {
+        return [
+            'date_from' => null,
+            'date_until' => null,
+        ];
+    }
+}

--- a/tests/src/Tables/Filters/DateRangeFilterTest.php
+++ b/tests/src/Tables/Filters/DateRangeFilterTest.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Filament\Tests\Tables\Filters;
+
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\DatePicker;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Tables;
+use Filament\Tables\Filters\DateRangeFilter;
+use Filament\Tables\Table;
+use Filament\Tests\Fixtures\Models\Post;
+use Filament\Tests\Tables\TestCase;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+
+use function Filament\Tests\livewire;
+
+uses(TestCase::class);
+
+class DateRangeFilterTest extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use Tables\Concerns\InteractsWithTable;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(Post::query())
+            ->columns([
+                Tables\Columns\TextColumn::make('title'),
+            ])
+            ->filters([
+                DateRangeFilter::make('created_at'),
+            ]);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.table');
+    }
+}
+
+describe('filtering records', function (): void {
+    it('can render table with `DateRangeFilter`', function (): void {
+        Post::factory()->count(5)->create();
+
+        livewire(DateRangeFilterTest::class)
+            ->assertSuccessful();
+    });
+
+    it('can filter records by `date_from`', function (): void {
+        $oldPosts = Post::factory()->count(2)->create(['created_at' => '2024-01-01']);
+        $newPosts = Post::factory()->count(3)->create(['created_at' => '2024-06-01']);
+
+        livewire(DateRangeFilterTest::class)
+            ->assertCanSeeTableRecords($oldPosts->merge($newPosts))
+            ->filterTable('created_at', ['date_from' => '2024-03-01', 'date_until' => null])
+            ->assertCanSeeTableRecords($newPosts)
+            ->assertCanNotSeeTableRecords($oldPosts);
+    });
+
+    it('can filter records by `date_until`', function (): void {
+        $oldPosts = Post::factory()->count(2)->create(['created_at' => '2024-01-01']);
+        $newPosts = Post::factory()->count(3)->create(['created_at' => '2024-06-01']);
+
+        livewire(DateRangeFilterTest::class)
+            ->assertCanSeeTableRecords($oldPosts->merge($newPosts))
+            ->filterTable('created_at', ['date_from' => null, 'date_until' => '2024-03-01'])
+            ->assertCanSeeTableRecords($oldPosts)
+            ->assertCanNotSeeTableRecords($newPosts);
+    });
+
+    it('can filter records by both `date_from` and `date_until`', function (): void {
+        $earlyPosts = Post::factory()->count(2)->create(['created_at' => '2024-01-01']);
+        $midPosts = Post::factory()->count(2)->create(['created_at' => '2024-04-01']);
+        $latePosts = Post::factory()->count(2)->create(['created_at' => '2024-09-01']);
+
+        livewire(DateRangeFilterTest::class)
+            ->filterTable('created_at', ['date_from' => '2024-03-01', 'date_until' => '2024-06-01'])
+            ->assertCanSeeTableRecords($midPosts)
+            ->assertCanNotSeeTableRecords($earlyPosts)
+            ->assertCanNotSeeTableRecords($latePosts);
+    });
+
+    it('can reset `DateRangeFilter` to show all records', function (): void {
+        $oldPosts = Post::factory()->count(2)->create(['created_at' => '2024-01-01']);
+        $newPosts = Post::factory()->count(3)->create(['created_at' => '2024-06-01']);
+
+        livewire(DateRangeFilterTest::class)
+            ->filterTable('created_at', ['date_from' => '2024-03-01', 'date_until' => null])
+            ->assertCanNotSeeTableRecords($oldPosts)
+            ->resetTableFilters()
+            ->assertCanSeeTableRecords($oldPosts->merge($newPosts));
+    });
+});
+
+describe('options and properties', function (): void {
+    it('can get `getAttribute()` from filter name by default', function (): void {
+        $filter = DateRangeFilter::make('created_at');
+
+        expect($filter->getAttribute())->toBe('created_at');
+    });
+
+    it('can set `attribute()` to override the queried column', function (): void {
+        $filter = DateRangeFilter::make('published')
+            ->attribute('published_at');
+
+        expect($filter->getAttribute())->toBe('published_at');
+    });
+
+    it('returns two `DatePicker` fields from `getSchemaComponents()` by default', function (): void {
+        $filter = DateRangeFilter::make('created_at');
+
+        expect($filter->getSchemaComponents())->toHaveCount(2);
+    });
+
+    it('has correct `getResetState()`', function (): void {
+        $filter = DateRangeFilter::make('created_at');
+
+        expect($filter->getResetState())->toBe([
+            'date_from' => null,
+            'date_until' => null,
+        ]);
+    });
+
+    it('can set `fromLabel()`', function (): void {
+        $filter = DateRangeFilter::make('created_at')
+            ->fromLabel('Start date');
+
+        expect($filter->getFromLabel())->toBe('Start date');
+    });
+
+    it('can set `fromLabel()` with a `Closure`', function (): void {
+        $filter = DateRangeFilter::make('created_at')
+            ->fromLabel(static fn (): string => 'Dynamic from');
+
+        expect($filter->getFromLabel())->toBe('Dynamic from');
+    });
+
+    it('can set `untilLabel()`', function (): void {
+        $filter = DateRangeFilter::make('created_at')
+            ->untilLabel('End date');
+
+        expect($filter->getUntilLabel())->toBe('End date');
+    });
+
+    it('can set `untilLabel()` with a `Closure`', function (): void {
+        $filter = DateRangeFilter::make('created_at')
+            ->untilLabel(static fn (): string => 'Dynamic until');
+
+        expect($filter->getUntilLabel())->toBe('Dynamic until');
+    });
+
+    it('defaults `isInline()` to `false`', function (): void {
+        $filter = DateRangeFilter::make('created_at');
+
+        expect($filter->isInline())->toBeFalse();
+    });
+
+    it('can set `inline()`', function (): void {
+        $filter = DateRangeFilter::make('created_at')->inline();
+
+        expect($filter->isInline())->toBeTrue();
+    });
+
+    it('can set `inline()` to `false`', function (): void {
+        $filter = DateRangeFilter::make('created_at')->inline()->inline(false);
+
+        expect($filter->isInline())->toBeFalse();
+    });
+
+    it('wraps pickers in a `Grid` when `inline()` is set', function (): void {
+        $filter = DateRangeFilter::make('created_at')->inline();
+
+        $components = $filter->getSchemaComponents();
+
+        expect($components)->toHaveCount(1)
+            ->and($components[0])->toBeInstanceOf(\Filament\Schemas\Components\Grid::class);
+    });
+
+    it('defaults `hasUntil()` to `true`', function (): void {
+        $filter = DateRangeFilter::make('created_at');
+
+        expect($filter->hasUntil())->toBeTrue();
+    });
+
+    it('can disable the until picker with `withoutUntil()`', function (): void {
+        $filter = DateRangeFilter::make('created_at')->withoutUntil();
+
+        expect($filter->hasUntil())->toBeFalse();
+    });
+
+    it('returns one field from `getSchemaComponents()` when `withoutUntil()` is set', function (): void {
+        $filter = DateRangeFilter::make('created_at')->withoutUntil();
+
+        expect($filter->getSchemaComponents())->toHaveCount(1);
+    });
+
+    it('defaults `isNative()` to `true`', function (): void {
+        $filter = DateRangeFilter::make('created_at');
+
+        expect($filter->isNative())->toBeTrue();
+    });
+
+    it('can set `native()` to `false`', function (): void {
+        $filter = DateRangeFilter::make('created_at')->native(false);
+
+        expect($filter->isNative())->toBeFalse();
+    });
+
+    it('can set `native()` with a `Closure`', function (): void {
+        $filter = DateRangeFilter::make('created_at')
+            ->native(static fn (): bool => false);
+
+        expect($filter->isNative())->toBeFalse();
+    });
+
+    it('can modify the from `DatePicker` using `modifyFromDatePickerUsing()`', function (): void {
+        $filter = DateRangeFilter::make('created_at')
+            ->modifyFromDatePickerUsing(function (DatePicker $datePicker): DatePicker {
+                return $datePicker->placeholder('Pick a start date');
+            });
+
+        $components = $filter->getSchemaComponents();
+
+        expect($components[0])->toBeInstanceOf(DatePicker::class);
+    });
+
+    it('can modify the until `DatePicker` using `modifyUntilDatePickerUsing()`', function (): void {
+        $filter = DateRangeFilter::make('created_at')
+            ->modifyUntilDatePickerUsing(function (DatePicker $datePicker): DatePicker {
+                return $datePicker->placeholder('Pick an end date');
+            });
+
+        $components = $filter->getSchemaComponents();
+
+        expect($components[1])->toBeInstanceOf(DatePicker::class);
+    });
+});


### PR DESCRIPTION
## Description

Filament currently lacks a built-in date range filter. Users must either implement a custom filter from scratch or rely on the `QueryBuilder`, both of which introduce unnecessary complexity for a very common use case.

This PR introduces a `DateRangeFilter` class to the tables package:

```php
DateRangeFilter::make('created_at');
```

This renders **"From"** and **"Until"** date pickers in the filter form and automatically scopes the query using `whereDate`. No custom `query()` callback is required for standard use cases.

---

## API

```php
DateRangeFilter::make('created_at')
    ->attribute('published_at') // Override the queried column (defaults to the filter name)
    ->fromLabel('Start date') // Custom label for the "From" picker
    ->untilLabel('End date') // Custom label for the "Until" picker
    ->inline() // Render both pickers side by side in a 2-column grid
    ->native(false) // Use the custom JS date picker instead of the browser native input
    ->withoutUntil() // From-only mode — hides the "Until" picker
    ->modifyFromDatePickerUsing(
        fn (DatePicker $datePicker) => $datePicker->minDate('2020-01-01'),
    )
    ->modifyUntilDatePickerUsing(
        fn (DatePicker $datePicker) => $datePicker->maxDate(now()),
    );
```

A custom `query()` callback is still supported for non-standard filtering logic.


## What’s Included

* `DateRangeFilter` class with `whereDate` scoping for both bounds
* Active filter indicators for each picker independently, with per-field removal support
* Full test coverage in `tests/src/Tables/Filters/DateRangeFilterTest.php`
* Documentation at `packages/tables/docs/03-filters/06-date-range.md`
* Translation keys under `filament-tables::table.filters.date_range`


## Visual Changes

No visual changes. The filter uses existing `DatePicker` and `Grid` components already present in Filament. 


## Functional Changes

* [x] Code style has been fixed by running `composer cs`.
* [x] Changes have been tested and do not break existing functionality.
* [x] Documentation is up to date.