### PR TITLE
Chore/et translations imrovements

### DIFF
--- a/packages/panels/resources/lang/et/auth/pages/email-verification/email-verification-prompt.php
+++ b/packages/panels/resources/lang/et/auth/pages/email-verification/email-verification-prompt.php
@@ -15,14 +15,14 @@ return [
     ],
 
     'messages' => [
-        'notification_not_received' => 'Ei ole saanud e-posti, mille me saatsime?',
-        'notification_sent' => 'Oleme saatnud e-kirja aadressile :email, mis sisaldab juhiseid, kuidas kinnitada oma e-posti aadressi.',
+        'notification_not_received' => 'Kas te ei saanud meie saadetud e-kirja?',
+        'notification_sent' => 'Saatsime e-kirja aadressile :email, mis sisaldab juhiseid teie e-posti aadressi kinnitamiseks.',
     ],
 
     'notifications' => [
 
         'notification_resent' => [
-            'title' => 'Oleme e-kirja uuesti saatnud.',
+            'title' => 'Saatsime e-kirja uuesti.',
         ],
 
         'notification_resend_throttled' => [

--- a/packages/panels/resources/lang/et/auth/pages/login.php
+++ b/packages/panels/resources/lang/et/auth/pages/login.php
@@ -2,19 +2,19 @@
 
 return [
 
-    'title' => 'Sisselogimine',
+    'title' => 'Logi sisse',
 
-    'heading' => 'Logige sisse',
+    'heading' => 'Logi sisse',
 
     'actions' => [
 
         'register' => [
             'before' => 'või',
-            'label' => 'registreeruge konto jaoks',
+            'label' => 'loo uus konto',
         ],
 
         'request_password_reset' => [
-            'label' => 'Unustasite parooli?',
+            'label' => 'Unustasid parooli?',
         ],
 
     ],
@@ -36,7 +36,7 @@ return [
         'actions' => [
 
             'authenticate' => [
-                'label' => 'Logige sisse',
+                'label' => 'Logi sisse',
             ],
 
         ],
@@ -45,9 +45,9 @@ return [
 
     'multi_factor' => [
 
-        'heading' => 'Kinnitage oma identiteet',
+        'heading' => 'Kinnita oma identiteet',
 
-        'subheading' => 'Sisselogimise jätkamiseks peate kinnitama oma identiteedi.',
+        'subheading' => 'Sisselogimise jätkamiseks peate oma identiteedi kinnitama.',
 
         'form' => [
 

--- a/packages/panels/resources/lang/et/auth/pages/password-reset/request-password-reset.php
+++ b/packages/panels/resources/lang/et/auth/pages/password-reset/request-password-reset.php
@@ -4,7 +4,7 @@ return [
 
     'title' => 'Taasta oma parool',
 
-    'heading' => 'Unustasite parooli?',
+    'heading' => 'Unustasid parooli?',
 
     'actions' => [
 

--- a/packages/panels/resources/lang/et/auth/pages/register.php
+++ b/packages/panels/resources/lang/et/auth/pages/register.php
@@ -2,15 +2,15 @@
 
 return [
 
-    'title' => 'Registreerimine',
+    'title' => 'Registreeru',
 
-    'heading' => 'Registreeruge',
+    'heading' => 'Registreeru',
 
     'actions' => [
 
         'login' => [
             'before' => 'või',
-            'label' => 'logige sisse oma kontole',
+            'label' => 'logi sisse olemasoleva kontoga',
         ],
 
     ],
@@ -37,7 +37,7 @@ return [
         'actions' => [
 
             'register' => [
-                'label' => 'Registreeruge',
+                'label' => 'Loo uus konto',
             ],
 
         ],

--- a/packages/panels/resources/lang/et/pages/dashboard.php
+++ b/packages/panels/resources/lang/et/pages/dashboard.php
@@ -2,7 +2,7 @@
 
 return [
 
-    'title' => 'Armatuurlaud',
+    'title' => 'Töölaud',
 
     'actions' => [
 

--- a/tests/src/Forms/Components/RichEditor/RichContentRendererTest.php
+++ b/tests/src/Forms/Components/RichEditor/RichContentRendererTest.php
@@ -4,6 +4,7 @@ use Filament\Forms\Components\RichEditor\FileAttachmentProviders\Contracts\FileA
 use Filament\Forms\Components\RichEditor\MentionProvider;
 use Filament\Forms\Components\RichEditor\Plugins\Contracts\HasFileAttachmentProvider;
 use Filament\Forms\Components\RichEditor\Plugins\Contracts\RichContentPlugin;
+use Filament\Forms\Components\RichEditor\RichContentAttribute;
 use Filament\Forms\Components\RichEditor\RichContentCustomBlock;
 use Filament\Forms\Components\RichEditor\RichContentRenderer;
 use Filament\Forms\Components\RichEditor\TextColor;
@@ -1977,7 +1978,7 @@ describe('file attachment URLs', function (): void {
 
             public function cleanUpFileAttachments(array $exceptIds): void {}
 
-            public function attribute(\Filament\Forms\Components\RichEditor\RichContentAttribute $attribute): static
+            public function attribute(RichContentAttribute $attribute): static
             {
                 return $this;
             }
@@ -2018,7 +2019,7 @@ describe('file attachment URLs', function (): void {
 
                     public function cleanUpFileAttachments(array $exceptIds): void {}
 
-                    public function attribute(\Filament\Forms\Components\RichEditor\RichContentAttribute $attribute): static
+                    public function attribute(RichContentAttribute $attribute): static
                     {
                         return $this;
                     }

--- a/tests/src/Forms/Components/RichEditorTest.php
+++ b/tests/src/Forms/Components/RichEditorTest.php
@@ -4,6 +4,7 @@ use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\RichEditor\Plugins\Contracts\HasFileAttachmentProvider;
 use Filament\Forms\Components\RichEditor\RichContentCustomBlock;
 use Filament\Forms\Components\RichEditor\RichContentRenderer;
+use Filament\Forms\Components\RichEditor\StateCasts\RichEditorStateCast;
 use Filament\Forms\Components\RichEditor\ToolbarButtonGroup;
 use Filament\Schemas\Schema;
 use Filament\Tests\Fixtures\Forms\RichEditor\PluginWithFileAttachmentProvider;
@@ -14,9 +15,11 @@ use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\Fixtures\RichEditor\TestRichContentPlugin;
 use Filament\Tests\Fixtures\RichEditor\TestRichContentPluginWithoutToolbarButtons;
 use Filament\Tests\TestCase;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\ValidationException;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 
 use function Filament\Tests\livewire;
 
@@ -1544,7 +1547,7 @@ describe('preventing file attachment tampering', function (): void {
             ->preventFileAttachmentPathTampering()
             ->container(Schema::make(Livewire::make())->model($post)->statePath('data'));
 
-        $cast = new Filament\Forms\Components\RichEditor\StateCasts\RichEditorStateCast($editor);
+        $cast = new RichEditorStateCast($editor);
 
         $result = $cast->set('<p>Hello</p><img src="http://original" data-id="uploads/original.jpg" /><img src="http://evil" data-id="uploads/evil.jpg" />');
 
@@ -1610,7 +1613,7 @@ describe('cross-record file attachment callbacks', function (): void {
 
 describe('`resolveFileAttachmentIds()` behaviour', function (): void {
     it('persists a newly uploaded image and rewrites its `data-id` to the stored path', function (): void {
-        \Illuminate\Support\Facades\Storage::fake('tmp-for-tests');
+        Storage::fake('tmp-for-tests');
 
         $image = imagecreatetruecolor(10, 10);
         ob_start();
@@ -1618,12 +1621,12 @@ describe('`resolveFileAttachmentIds()` behaviour', function (): void {
         $imageContent = ob_get_clean();
         imagedestroy($image);
 
-        $temporaryFileName = \Livewire\Features\SupportFileUploads\TemporaryUploadedFile::generateHashNameWithOriginalNameEmbedded(
-            \Illuminate\Http\UploadedFile::fake()->image('new-upload.jpg'),
+        $temporaryFileName = TemporaryUploadedFile::generateHashNameWithOriginalNameEmbedded(
+            UploadedFile::fake()->image('new-upload.jpg'),
         );
-        \Illuminate\Support\Facades\Storage::disk('tmp-for-tests')->put("livewire-tmp/{$temporaryFileName}", $imageContent);
+        Storage::disk('tmp-for-tests')->put("livewire-tmp/{$temporaryFileName}", $imageContent);
 
-        $temporaryFile = \Livewire\Features\SupportFileUploads\TemporaryUploadedFile::createFromLivewire($temporaryFileName);
+        $temporaryFile = TemporaryUploadedFile::createFromLivewire($temporaryFileName);
 
         $editor = (new RichEditor('content'))
             ->container(Schema::make(Livewire::make())->statePath('data'));

--- a/tests/src/SpatieMediaLibraryPlugin/SpatieMediaLibraryFileUploadTest.php
+++ b/tests/src/SpatieMediaLibraryPlugin/SpatieMediaLibraryFileUploadTest.php
@@ -1,13 +1,21 @@
 <?php
 
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Schemas\Schema;
 use Filament\Tests\Fixtures\Livewire\SpatieMediaLibraryFileUploadForm;
 use Filament\Tests\Fixtures\Models\MediaPost;
 use Filament\Tests\TestCase;
+use Illuminate\Contracts\View\View;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
+use Livewire\Component;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+use Livewire\WithFileUploads;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 use function Filament\Tests\livewire;
@@ -470,11 +478,11 @@ describe('integration', function (): void {
     });
 });
 
-class ReorderableSpatieMediaLibraryFileUploadForm extends \Livewire\Component implements \Filament\Actions\Contracts\HasActions, \Filament\Schemas\Contracts\HasSchemas
+class ReorderableSpatieMediaLibraryFileUploadForm extends Component implements HasActions, HasSchemas
 {
-    use \Filament\Actions\Concerns\InteractsWithActions;
-    use \Filament\Schemas\Concerns\InteractsWithSchemas;
-    use \Livewire\WithFileUploads;
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use WithFileUploads;
 
     public $data = [];
 
@@ -486,7 +494,7 @@ class ReorderableSpatieMediaLibraryFileUploadForm extends \Livewire\Component im
         $this->form->fill([]);
     }
 
-    public function form(\Filament\Schemas\Schema $form): \Filament\Schemas\Schema
+    public function form(Schema $form): Schema
     {
         return $form
             ->schema([
@@ -505,7 +513,7 @@ class ReorderableSpatieMediaLibraryFileUploadForm extends \Livewire\Component im
         $this->form->saveRelationships();
     }
 
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.form');
     }


### PR DESCRIPTION
## Description

Updates Estonian (`et`) translations across several panel auth pages and the dashboard to fix incorrect or awkward phrasings and to adopt a less formal, more natural tone. Specifically:

- Switches from the formal plural ("teie"/"Logige sisse") to the informal singular ("sina"/"Logi sisse") on login, registration, password reset, and email-verification prompts, which reads more naturally in Estonian product UI.
- Rewords several sentences for better grammar and flow, e.g. `notification_sent` and `notification_not_received` on the email-verification page.
- Renames the dashboard title from "Armatuurlaud" (a literal but awkward calque of "dashboard") to "Töölaud", which is the conventional Estonian term.
- Makes call-to-action labels more idiomatic, e.g. "registreeruge konto jaoks" → "loo uus konto", "logige sisse oma kontole" → "logi sisse olemasoleva kontoga".

## Visual changes

No layout or styling changes. Only user-facing Estonian strings on the login, registration, password reset, email verification, and dashboard pages change.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.