### PR TITLE
fix: remount table header and toolbar to refresh x-show after state changes

### DIFF
--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -122,6 +122,14 @@
     $columnManagerTriggerAction = $getColumnManagerTriggerAction();
     $hasHeader = $header || $heading || $description || ($headerActions && (! $isReordering)) || $isReorderable || $areGroupingSettingsVisible || $isGlobalSearchVisible || $hasFilters || count($filterIndicators) || $hasColumnManager;
     $hasHeaderToolbar = $isReorderable || $areGroupingSettingsVisible || $isGlobalSearchVisible || $hasFiltersTrigger || $hasColumnManager;
+
+    // https://github.com/filamentphp/filament/pull/19787
+    $headerVisibilityMode = ($hasHeader || $hasNonBulkToolbarAction)
+        ? 'visible'
+        : (count($toolbarActions) ? 'selection' : 'hidden');
+    $headerToolbarVisibilityMode = ($hasHeaderToolbar || $hasNonBulkToolbarAction)
+        ? 'visible'
+        : (count($toolbarActions) ? 'selection' : 'hidden');
     $headingTag = $getHeadingTag();
     $secondLevelHeadingTag = $heading ? $getHeadingTag(1) : $headingTag;
     $pluralModelLabel = $getPluralModelLabel();
@@ -214,7 +222,7 @@
             <div
                 @if (! $hasHeader) x-cloak @endif
                 x-show="@js($hasHeader) || @js($hasNonBulkToolbarAction) || (getSelectedRecordsCount() && @js(count($toolbarActions)))"
-                wire:key="{{ $this->getId() }}.table.header-{{ (int) $hasHeader }}-{{ (int) $hasNonBulkToolbarAction }}-{{ (int) !!$toolbarActions }}"
+                wire:key="{{ $this->getId() }}.table.header.{{ $headerVisibilityMode }}"
                 class="fi-ta-header-ctn"
             >
                 {{ FilamentView::renderHook(TablesRenderHook::HEADER_BEFORE, scopes: static::class) }}
@@ -294,7 +302,7 @@
                 <div
                     @if (! $hasHeaderToolbar) x-cloak @endif
                     x-show="@js($hasHeaderToolbar) || @js($hasNonBulkToolbarAction) || (getSelectedRecordsCount() && @js(count($toolbarActions)))"
-                    wire:key="{{ $this->getId() }}.table.header-toolbar-{{ (int) $hasHeaderToolbar }}-{{ (int) $hasNonBulkToolbarAction }}-{{ (int) !!$toolbarActions }}"
+                    wire:key="{{ $this->getId() }}.table.header-toolbar.{{ $headerToolbarVisibilityMode }}"
                     class="fi-ta-header-toolbar"
                 >
                     {{ FilamentView::renderHook(TablesRenderHook::TOOLBAR_START, scopes: static::class) }}

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -214,6 +214,7 @@
             <div
                 @if (! $hasHeader) x-cloak @endif
                 x-show="@js($hasHeader) || @js($hasNonBulkToolbarAction) || (getSelectedRecordsCount() && @js(count($toolbarActions)))"
+                wire:key="{{ $this->getId() }}.table.header-{{ (int) $hasHeader }}-{{ (int) $hasNonBulkToolbarAction }}-{{ (int) !!$toolbarActions }}"
                 class="fi-ta-header-ctn"
             >
                 {{ FilamentView::renderHook(TablesRenderHook::HEADER_BEFORE, scopes: static::class) }}
@@ -293,6 +294,7 @@
                 <div
                     @if (! $hasHeaderToolbar) x-cloak @endif
                     x-show="@js($hasHeaderToolbar) || @js($hasNonBulkToolbarAction) || (getSelectedRecordsCount() && @js(count($toolbarActions)))"
+                    wire:key="{{ $this->getId() }}.table.header-toolbar-{{ (int) $hasHeaderToolbar }}-{{ (int) $hasNonBulkToolbarAction }}-{{ (int) !!$toolbarActions }}"
                     class="fi-ta-header-toolbar"
                 >
                     {{ FilamentView::renderHook(TablesRenderHook::TOOLBAR_START, scopes: static::class) }}


### PR DESCRIPTION
x-show attribute never morphed into DOM after Livewire response

## The table setup

```php
        return $table
            ->records( static fn (): array => /* languages api */ )
            ->columns([
                TextColumn::make('language')
                    ->label(__('columns.language.label')),

                TextColumn::make('is_default')
                    ->label(__('columns.is_default.label'))
                    ->formatStateUsing(static fn (bool $state): ?string => $state ? __('columns.is_default.badge') : null)
                    ->badge(static fn (bool $state): bool => $state)
                    ->color('success')
                    ->icon(static fn (bool $state): ?\BackedEnum => $state ? Heroicon::Star : null)
                    ->size(TextSize::Medium)
            ])
            ->recordActions(
                ActionGroup::make([
                    MakeLanguageDefaultAction::make(),
                    DeleteLanguageAction::make()
                ])->color('gray')
            )
            ->reorderable(
                column: 'order',
                condition: static fn () => count($websiteSettingsService->getLanguages()) > 1
            )
            ->paginated(false);
```

The `reorderable()` call uses a `condition:` callback that returns `true` only when there are more than 1 language. This means the reorder trigger button appears and disappears dynamically as languages are added or removed.

## The problem

When the `condition:` evaluates to a different value (e.g. a language is deleted and only 1 remains, or a language is added and there are now 2), the following happens:

- The Livewire round-trip completes successfully
- The reorder action button **correctly** get attached to or detached from the DOM
- **But** the toolbar container's `x-show` attribute **never updates** in the actual DOM

The toolbar stays visible or hidden based on whatever state it was in when the page first loaded, regardless of subsequent Livewire updates.

## What the Filament blade view does

The relevant element in Filament's published table view (`resources/views/vendor/filament-tables/index.blade.php`) is:

```blade
<div
    @if (! $hasHeaderToolbar) x-cloak @endif
    x-show="@js($hasHeaderToolbar) || @js($hasNonBulkToolbarAction) || (getSelectedRecordsCount() && @js(count($toolbarActions)))"
    class="fi-ta-header-toolbar"
>
```

`$hasHeaderToolbar` and `$hasNonBulkToolbarAction` are PHP variables computed in the Blade template and baked into the `x-show` expression as static JS literals via `@js()`. For example, when `$hasHeaderToolbar` is `false`, the rendered HTML is literally:

```html
<div
    x-cloak
    x-show="false || false || (getSelectedRecordsCount() && 0)"
    class="fi-ta-header-toolbar"
>
```

## What was confirmed through investigation

### 1. The Livewire JSON response is correct
Inspecting the network tab, the Livewire response JSON **does** contain the correct, updated `x-show` string. For example, after a language is added, the response contains:

```
x-show="true || false || (getSelectedRecordsCount() && 0)"
```

### 2. The DOM is never updated
Despite the correct value being in the Livewire response, inspecting the live DOM in DevTools after the round-trip completes shows the `x-show` attribute string has **not changed**. It still holds the value from the initial render.

### 3. The reorder action button do update
Other parts of the same Livewire response morph correctly — specifically the reorder action button get added or removed from the DOM as expected. Only the `x-show` on the toolbar div is skipped.

## Parent Element (the table header)

This issue is not limited to the header toolbar itself — it also affects its parent container.

The table header container uses the same pattern:

```blade
<div
    @if (! $hasHeader) x-cloak @endif
    x-show="@js($hasHeader) || @js($hasNonBulkToolbarAction) || (getSelectedRecordsCount() && @js(count($toolbarActions)))"
    class="fi-ta-header-ctn"
>
```

Since both elements rely on `x-show` with server-rendered expressions, they are equally affected by the morphing behavior — meaning their visibility can become stale after Livewire updates.

## Fix

Force Livewire to remount these elements when their controlling state changes by adding a dynamic `wire:key` to each:

**Header container**

```blade
wire:key="{{ $this->getId() }}.table.header-{{ (int) $hasHeader }}-{{ (int) $hasNonBulkToolbarAction }}-{{ (int) !!$toolbarActions }}"
```

**Header toolbar**

```blade
wire:key="{{ $this->getId() }}.table.header-toolbar-{{ (int) $hasHeaderToolbar }}-{{ (int) $hasNonBulkToolbarAction }}-{{ (int) !!$toolbarActions }}"
```

# Result

- The elements are properly re-mounted when their visibility conditions change
- Alpine re-initializes `x-show` with the correct, updated values
- The toolbar and header visibility stay in sync with Livewire state