### PR TITLE
fix broken Cropper.js documentation link

### DIFF
--- a/packages/forms/docs/09-file-upload.md
+++ b/packages/forms/docs/09-file-upload.md
@@ -323,7 +323,7 @@ FileUpload::make('image')
 
 ### Setting the image editor's mode
 
-You can change the mode of the image editor using the `imageEditorMode()` method, which accepts either `1`, `2` or `3`. These options are explained in the [Cropper.js documentation](https://github.com/fengyuanchen/cropperjs#viewmode):
+You can change the mode of the image editor using the `imageEditorMode()` method, which accepts either `1`, `2` or `3`. These options are explained in the [Cropper.js documentation](https://github.com/fengyuanchen/cropperjs/blob/v1/README.md#viewmode):
 
 ```php
 use Filament\Forms\Components\FileUpload;

--- a/packages/forms/src/Components/FileUpload.php
+++ b/packages/forms/src/Components/FileUpload.php
@@ -488,7 +488,7 @@ class FileUpload extends BaseFileUpload
     public function imageEditorMode(int $mode): static
     {
         if (! in_array($mode, [1, 2, 3])) {
-            throw new InvalidArgumentException("The file upload editor mode must be either 1, 2 or 3. [{$mode}] given, which is unsupported. See https://github.com/fengyuanchen/cropperjs#viewmode for more information on the available modes. Mode 0 is not supported, as it does not allow configuration via manual inputs.");
+            throw new InvalidArgumentException("The file upload editor mode must be either 1, 2 or 3. [{$mode}] given, which is unsupported. See https://github.com/fengyuanchen/cropperjs/blob/v1/README.md#viewmode for more information on the available modes. Mode 0 is not supported, as it does not allow configuration via manual inputs.");
         }
 
         $this->imageEditorMode = $mode;


### PR DESCRIPTION
it seems the link changed with the Cropper.js update to v2 and they introduced a new website

## Description

I just stumbled across the broken link which is fixed in this pr.

## Visual changes

no visual changes, just an updated external link in the docs

## Functional changes

- [ ] ~Code style has been fixed by running the `composer cs` command.~
- [ ] ~Changes have been tested to not break existing functionality.~
- [ ] ~Documentation is up-to-date.~
