### PR TITLE
Fix Chart Centering in RTL Layouts

### DIFF
--- a/packages/actions/resources/views/action-modal.blade.php
+++ b/packages/actions/resources/views/action-modal.blade.php
@@ -1,28 +1,28 @@
 @php
     use Filament\Actions\View\ActionsRenderHook;
-    use Filament\Support\Facades\FilamentView;
+        use Filament\Support\Facades\FilamentView;
 
-    $actionModalAlignment = $action->getModalAlignment();
-    $actionIsModalAutofocused = $action->isModalAutofocused();
-    $actionHasModalCloseButton = $action->hasModalCloseButton();
-    $actionIsModalClosedByClickingAway = $action->isModalClosedByClickingAway();
-    $actionIsModalClosedByEscaping = $action->isModalClosedByEscaping();
-    $actionModalDescription = $action->getModalDescription();
-    $actionExtraModalWindowAttributeBag = $action->getExtraModalWindowAttributeBag();
-    $actionExtraModalOverlayAttributeBag = $action->getExtraModalOverlayAttributeBag();
-    $actionModalFooterActions = $action->getVisibleModalFooterActions();
-    $actionModalFooterActionsAlignment = $action->getModalFooterActionsAlignment();
-    $actionModalHeading = $action->getModalHeading();
-    $actionModalIcon = $action->getModalIcon();
-    $actionModalIconColor = $action->getModalIconColor();
-    $actionModalId = "fi-{$this->getId()}-action-{$action->getNestingIndex()}";
-    $actionIsModalSlideOver = $action->isModalSlideOver();
-    $actionModalSlideOverPosition = $action->getModalSlideOverPosition();
-    $actionIsModalFooterSticky = $action->isModalFooterSticky();
-    $actionIsModalHeaderSticky = $action->isModalHeaderSticky();
-    $actionModalWidth = $action->getModalWidth();
-    $actionLivewireCallMountedActionName = $action->hasFormWrapper() ? $action->getLivewireCallMountedActionName() : null;
-    $actionModalWireKey = "{$this->getId()}.actions.{$action->getName()}.modal";
+        $actionModalAlignment = $action->getModalAlignment();
+        $actionIsModalAutofocused = $action->isModalAutofocused();
+        $actionHasModalCloseButton = $action->hasModalCloseButton();
+        $actionIsModalClosedByClickingAway = $action->isModalClosedByClickingAway();
+        $actionIsModalClosedByEscaping = $action->isModalClosedByEscaping();
+        $actionModalDescription = $action->getModalDescription();
+        $actionExtraModalWindowAttributeBag = $action->getExtraModalWindowAttributeBag();
+        $actionExtraModalOverlayAttributeBag = $action->getExtraModalOverlayAttributeBag();
+        $actionModalFooterActions = $action->getVisibleModalFooterActions();
+        $actionModalFooterActionsAlignment = $action->getModalFooterActionsAlignment();
+        $actionModalHeading = $action->getModalHeading();
+        $actionModalIcon = $action->getModalIcon();
+        $actionModalIconColor = $action->getModalIconColor();
+        $actionModalId = "fi-{$this->getId()}-action-{$action->getNestingIndex()}";
+        $actionIsModalSlideOver = $action->isModalSlideOver();
+        $actionModalSlideOverPosition = $action->getModalSlideOverPosition();
+        $actionIsModalFooterSticky = $action->isModalFooterSticky();
+        $actionIsModalHeaderSticky = $action->isModalHeaderSticky();
+        $actionModalWidth = $action->getModalWidth();
+        $actionLivewireCallMountedActionName = $action->hasFormWrapper() ? $action->getLivewireCallMountedActionName() : null;
+        $actionModalWireKey = "{$this->getId()}.actions.{$action->getName()}.modal";
 @endphp
 
 <x-filament::modal

--- a/packages/actions/resources/views/components/group.blade.php
+++ b/packages/actions/resources/views/components/group.blade.php
@@ -1,64 +1,64 @@
 @props([
-    'actions' => [],
-    'badge' => null,
-    'badgeColor' => null,
-    'button' => false,
-    'buttonGroup' => null,
-    'color' => null,
-    'dropdownMaxHeight' => null,
-    'dropdownOffset' => null,
-    'dropdownPlacement' => null,
-    'dropdownWidth' => null,
-    'group' => null,
-    'icon' => null,
-    'iconSize' => null,
-    'iconButton' => false,
-    'label' => null,
-    'link' => false,
-    'size' => null,
-    'tooltip' => null,
-    'triggerView' => null,
-    'view' => null,
+'actions' => [],
+'badge' => null,
+'badgeColor' => null,
+'button' => false,
+'buttonGroup' => null,
+'color' => null,
+'dropdownMaxHeight' => null,
+'dropdownOffset' => null,
+'dropdownPlacement' => null,
+'dropdownWidth' => null,
+'group' => null,
+'icon' => null,
+'iconSize' => null,
+'iconButton' => false,
+'label' => null,
+'link' => false,
+'size' => null,
+'tooltip' => null,
+'triggerView' => null,
+'view' => null,
 ])
 
 @php
     $group ??= \Filament\Actions\ActionGroup::make($actions)
-        ->badgeColor($badgeColor)
-        ->color($color)
-        ->dropdownMaxHeight($dropdownMaxHeight)
-        ->dropdownOffset($dropdownOffset)
-        ->dropdownPlacement($dropdownPlacement)
-        ->dropdownWidth($dropdownWidth)
-        ->icon($icon)
-        ->iconSize($iconSize)
-        ->label($label)
-        ->size($size)
-        ->tooltip($tooltip)
-        ->triggerView($triggerView)
-        ->view($view);
+            ->badgeColor($badgeColor)
+            ->color($color)
+            ->dropdownMaxHeight($dropdownMaxHeight)
+            ->dropdownOffset($dropdownOffset)
+            ->dropdownPlacement($dropdownPlacement)
+            ->dropdownWidth($dropdownWidth)
+            ->icon($icon)
+            ->iconSize($iconSize)
+            ->label($label)
+            ->size($size)
+            ->tooltip($tooltip)
+            ->triggerView($triggerView)
+            ->view($view);
 
-    $badge === true
-        ? $group->badge()
-        : $group->badge($badge);
+        $badge === true
+            ? $group->badge()
+            : $group->badge($badge);
 
-    if ($button) {
-        $group
-            ->button()
-            ->iconPosition($attributes->get('iconPosition') ?? $attributes->get('icon-position'))
-            ->outlined($attributes->get('outlined') ?? false);
-    }
+        if ($button) {
+            $group
+                ->button()
+                ->iconPosition($attributes->get('iconPosition') ?? $attributes->get('icon-position'))
+                ->outlined($attributes->get('outlined') ?? false);
+        }
 
-    if ($buttonGroup) {
-        $group->buttonGroup();
-    }
+        if ($buttonGroup) {
+            $group->buttonGroup();
+        }
 
-    if ($iconButton) {
-        $group->iconButton();
-    }
+        if ($iconButton) {
+            $group->iconButton();
+        }
 
-    if ($link) {
-        $group->link();
-    }
+        if ($link) {
+            $group->link();
+        }
 @endphp
 
 {{ $group }}

--- a/packages/forms/resources/views/components/builder.blade.php
+++ b/packages/forms/resources/views/components/builder.blade.php
@@ -1,63 +1,63 @@
 @php
     use Filament\Actions\Action;
-    use Filament\Support\Enums\Alignment;
+        use Filament\Support\Enums\Alignment;
 
-    $fieldWrapperView = $getFieldWrapperView();
-    $items = $getItems();
-    $blockPickerBlocks = $getBlockPickerBlocks();
-    $blockPickerColumns = $getBlockPickerColumns();
-    $blockPickerWidth = $getBlockPickerWidth();
-    $hasBlockPreviews = $hasBlockPreviews();
-    $hasInteractiveBlockPreviews = $hasInteractiveBlockPreviews();
+        $fieldWrapperView = $getFieldWrapperView();
+        $items = $getItems();
+        $blockPickerBlocks = $getBlockPickerBlocks();
+        $blockPickerColumns = $getBlockPickerColumns();
+        $blockPickerWidth = $getBlockPickerWidth();
+        $hasBlockPreviews = $hasBlockPreviews();
+        $hasInteractiveBlockPreviews = $hasInteractiveBlockPreviews();
 
-    $addAction = $getAction($getAddActionName());
-    $addActionAlignment = $getAddActionAlignment();
-    $addBetweenAction = $getAction($getAddBetweenActionName());
-    $cloneAction = $getAction($getCloneActionName());
-    $collapseAllAction = $getAction($getCollapseAllActionName());
-    $editAction = $getAction($getEditActionName());
-    $expandAllAction = $getAction($getExpandAllActionName());
-    $deleteAction = $getAction($getDeleteActionName());
-    $moveDownAction = $getAction($getMoveDownActionName());
-    $moveUpAction = $getAction($getMoveUpActionName());
-    $reorderAction = $getAction($getReorderActionName());
-    $extraItemActions = $getExtraItemActions();
+        $addAction = $getAction($getAddActionName());
+        $addActionAlignment = $getAddActionAlignment();
+        $addBetweenAction = $getAction($getAddBetweenActionName());
+        $cloneAction = $getAction($getCloneActionName());
+        $collapseAllAction = $getAction($getCollapseAllActionName());
+        $editAction = $getAction($getEditActionName());
+        $expandAllAction = $getAction($getExpandAllActionName());
+        $deleteAction = $getAction($getDeleteActionName());
+        $moveDownAction = $getAction($getMoveDownActionName());
+        $moveUpAction = $getAction($getMoveUpActionName());
+        $reorderAction = $getAction($getReorderActionName());
+        $extraItemActions = $getExtraItemActions();
 
-    $isAddable = $isAddable();
-    $isCloneable = $isCloneable();
-    $isCollapsible = $isCollapsible();
-    $isDeletable = $isDeletable();
-    $isReorderableWithButtons = $isReorderableWithButtons();
-    $isReorderableWithDragAndDrop = $isReorderableWithDragAndDrop();
+        $isAddable = $isAddable();
+        $isCloneable = $isCloneable();
+        $isCollapsible = $isCollapsible();
+        $isDeletable = $isDeletable();
+        $isReorderableWithButtons = $isReorderableWithButtons();
+        $isReorderableWithDragAndDrop = $isReorderableWithDragAndDrop();
 
-    $collapseAllActionIsVisible = $isCollapsible && $collapseAllAction->isVisible();
-    $expandAllActionIsVisible = $isCollapsible && $expandAllAction->isVisible();
-    $persistCollapsed = $shouldPersistCollapsed();
+        $collapseAllActionIsVisible = $isCollapsible && $collapseAllAction->isVisible();
+        $expandAllActionIsVisible = $isCollapsible && $expandAllAction->isVisible();
+        $persistCollapsed = $shouldPersistCollapsed();
 
-    $key = $getKey();
-    $statePath = $getStatePath();
+        $key = $getKey();
+        $statePath = $getStatePath();
 
-    $blockLabelHeadingTag = $getHeadingTag();
-    $isBlockLabelTruncated = $isBlockLabelTruncated();
-    $labelBetweenItems = $getLabelBetweenItems();
+        $blockLabelHeadingTag = $getHeadingTag();
+        $isBlockLabelTruncated = $isBlockLabelTruncated();
+        $labelBetweenItems = $getLabelBetweenItems();
 @endphp
 
 <x-dynamic-component :component="$fieldWrapperView" :field="$field">
     <div
         {{
             $attributes
-                ->merge($getExtraAttributes(), escape: false)
-                ->class([
-                    'fi-fo-builder',
-                    'fi-collapsible' => $isCollapsible,
-                ])
+            ->merge($getExtraAttributes(), escape: false)
+            ->class([
+            'fi-fo-builder',
+            'fi-collapsible' => $isCollapsible,
+            ])
         }}
     >
         @if ($collapseAllActionIsVisible || $expandAllActionIsVisible)
             <div
                 @class([
-                    'fi-fo-builder-actions',
-                    'fi-hidden' => count($items) < 2,
+                'fi-fo-builder-actions',
+                'fi-hidden' => count($items) < 2,
                 ])
             >
                 @if ($collapseAllActionIsVisible)
@@ -93,29 +93,29 @@
             >
                 @php
                     $hasBlockLabels = $hasBlockLabels();
-                    $hasBlockIcons = $hasBlockIcons();
-                    $hasBlockNumbers = $hasBlockNumbers();
-                    $hasBlockHeaders = $hasBlockHeaders();
+                                        $hasBlockIcons = $hasBlockIcons();
+                                        $hasBlockNumbers = $hasBlockNumbers();
+                                        $hasBlockHeaders = $hasBlockHeaders();
                 @endphp
 
                 @foreach ($items as $itemKey => $item)
                     @php
                         $visibleExtraItemActions = array_filter(
-                            $extraItemActions,
-                            fn (Action $action): bool => $action(['item' => $itemKey])->isVisible(),
-                        );
-                        $cloneAction = $cloneAction(['item' => $itemKey]);
-                        $cloneActionIsVisible = $isCloneable && $cloneAction->isVisible();
-                        $deleteAction = $deleteAction(['item' => $itemKey]);
-                        $deleteActionIsVisible = $isDeletable && $deleteAction->isVisible();
-                        $editAction = $editAction(['item' => $itemKey]);
-                        $editActionIsVisible = $hasBlockPreviews && $editAction->isVisible();
-                        $moveDownAction = $moveDownAction(['item' => $itemKey])->disabled($loop->last);
-                        $moveDownActionIsVisible = $isReorderableWithButtons && $moveDownAction->isVisible();
-                        $moveUpAction = $moveUpAction(['item' => $itemKey])->disabled($loop->first);
-                        $moveUpActionIsVisible = $isReorderableWithButtons && $moveUpAction->isVisible();
-                        $reorderActionIsVisible = $isReorderableWithDragAndDrop && $reorderAction->isVisible();
-                        $hasItemHeader = $hasBlockHeaders && ($reorderActionIsVisible || $moveUpActionIsVisible || $moveDownActionIsVisible || $hasBlockIcons || $hasBlockLabels || $editActionIsVisible || $cloneActionIsVisible || $deleteActionIsVisible || $isCollapsible || $visibleExtraItemActions);
+                                                    $extraItemActions,
+                                                    fn (Action $action): bool => $action(['item' => $itemKey])->isVisible(),
+                                                );
+                                                $cloneAction = $cloneAction(['item' => $itemKey]);
+                                                $cloneActionIsVisible = $isCloneable && $cloneAction->isVisible();
+                                                $deleteAction = $deleteAction(['item' => $itemKey]);
+                                                $deleteActionIsVisible = $isDeletable && $deleteAction->isVisible();
+                                                $editAction = $editAction(['item' => $itemKey]);
+                                                $editActionIsVisible = $hasBlockPreviews && $editAction->isVisible();
+                                                $moveDownAction = $moveDownAction(['item' => $itemKey])->disabled($loop->last);
+                                                $moveDownActionIsVisible = $isReorderableWithButtons && $moveDownAction->isVisible();
+                                                $moveUpAction = $moveUpAction(['item' => $itemKey])->disabled($loop->first);
+                                                $moveUpActionIsVisible = $isReorderableWithButtons && $moveUpAction->isVisible();
+                                                $reorderActionIsVisible = $isReorderableWithDragAndDrop && $reorderAction->isVisible();
+                                                $hasItemHeader = $hasBlockHeaders && ($reorderActionIsVisible || $moveUpActionIsVisible || $moveDownActionIsVisible || $hasBlockIcons || $hasBlockLabels || $editActionIsVisible || $cloneActionIsVisible || $deleteActionIsVisible || $isCollapsible || $visibleExtraItemActions);
                     @endphp
 
                     <li
@@ -130,10 +130,10 @@
                         x-sortable-item="{{ $itemKey }}"
                         {{
                             $item->getParentComponent()->getExtraAttributeBag()
-                                ->class([
-                                    'fi-fo-builder-item',
-                                    'fi-fo-builder-item-has-header' => $hasItemHeader,
-                                ])
+                            ->class([
+                            'fi-fo-builder-item',
+                            'fi-fo-builder-item-has-header' => $hasItemHeader,
+                            ])
                         }}
                         x-bind:class="{ 'fi-collapsed': isCollapsed }"
                     >
@@ -177,8 +177,8 @@
                                 @if ($hasBlockLabels)
                                     <{{ $blockLabelHeadingTag }}
                                         @class([
-                                            'fi-fo-builder-item-header-label',
-                                            'fi-truncated' => $isBlockLabelTruncated,
+                                        'fi-fo-builder-item-header-label',
+                                        'fi-truncated' => $isBlockLabelTruncated,
                                         ])
                                     >
                                         {{ $item->getParentComponent()->getLabel($item->getRawState(), $itemKey, $loop->index) }}
@@ -243,15 +243,15 @@
                         <div
                             x-show="! isCollapsed"
                             @class([
-                                'fi-fo-builder-item-content',
-                                'fi-fo-builder-item-content-has-preview' => $hasBlockPreviews && $item->getParentComponent()->hasPreview(),
+                            'fi-fo-builder-item-content',
+                            'fi-fo-builder-item-content-has-preview' => $hasBlockPreviews && $item->getParentComponent()->hasPreview(),
                             ])
                         >
                             @if ($hasBlockPreviews && $item->getParentComponent()->hasPreview())
                                 <div
                                     @class([
-                                        'fi-fo-builder-item-preview',
-                                        'fi-interactive' => $hasInteractiveBlockPreviews,
+                                    'fi-fo-builder-item-preview',
+                                    'fi-interactive' => $hasInteractiveBlockPreviews,
                                     ])
                                 >
                                     {{ $item->getParentComponent()->renderPreview($item->getRawState()) }}

--- a/packages/forms/resources/views/components/builder/block-picker.blade.php
+++ b/packages/forms/resources/views/components/builder/block-picker.blade.php
@@ -1,18 +1,18 @@
 @php
     use Filament\Support\Enums\Alignment;
-    use Filament\Support\Enums\GridDirection;
-    use Illuminate\View\ComponentAttributeBag;
+        use Filament\Support\Enums\GridDirection;
+        use Illuminate\View\ComponentAttributeBag;
 @endphp
 
 @props([
-    'action',
-    'actionAlignment' => null,
-    'afterItem' => null,
-    'blocks',
-    'columns' => null,
-    'key',
-    'trigger',
-    'width' => null,
+'action',
+'actionAlignment' => null,
+'afterItem' => null,
+'blocks',
+'columns' => null,
+'key',
+'trigger',
+'width' => null,
 ])
 
 <x-filament::dropdown
@@ -46,15 +46,15 @@
                 @php
                     $blockIcon = $block->getIcon();
 
-                    $wireClickActionArguments = ['block' => $block->getName()];
+                                        $wireClickActionArguments = ['block' => $block->getName()];
 
-                    if (filled($afterItem)) {
-                        $wireClickActionArguments['afterItem'] = $afterItem;
-                    }
+                                        if (filled($afterItem)) {
+                                            $wireClickActionArguments['afterItem'] = $afterItem;
+                                        }
 
-                    $wireClickActionArguments = \Illuminate\Support\Js::from($wireClickActionArguments);
+                                        $wireClickActionArguments = \Illuminate\Support\Js::from($wireClickActionArguments);
 
-                    $wireClickAction = "mountAction('{$action->getName()}', {$wireClickActionArguments}, { schemaComponent: '{$key}' })";
+                                        $wireClickAction = "mountAction('{$action->getName()}', {$wireClickActionArguments}, { schemaComponent: '{$key}' })";
                 @endphp
 
                 <x-filament::dropdown.list.item

--- a/packages/forms/resources/views/components/checkbox-list.blade.php
+++ b/packages/forms/resources/views/components/checkbox-list.blade.php
@@ -1,17 +1,17 @@
 @php
     use Filament\Support\Enums\GridDirection;
 
-    $fieldWrapperView = $getFieldWrapperView();
-    $extraInputAttributeBag = $getExtraInputAttributeBag();
-    $isHtmlAllowed = $isHtmlAllowed();
-    $gridDirection = $getGridDirection() ?? GridDirection::Column;
-    $isBulkToggleable = $isBulkToggleable();
-    $isDisabled = $isDisabled();
-    $isSearchable = $isSearchable();
-    $statePath = $getStatePath();
-    $options = $getOptions();
-    $livewireKey = $getLivewireKey();
-    $wireModelAttribute = $applyStateBindingModifiers('wire:model');
+        $fieldWrapperView = $getFieldWrapperView();
+        $extraInputAttributeBag = $getExtraInputAttributeBag();
+        $isHtmlAllowed = $isHtmlAllowed();
+        $gridDirection = $getGridDirection() ?? GridDirection::Column;
+        $isBulkToggleable = $isBulkToggleable();
+        $isDisabled = $isDisabled();
+        $isSearchable = $isSearchable();
+        $statePath = $getStatePath();
+        $options = $getOptions();
+        $livewireKey = $getLivewireKey();
+        $wireModelAttribute = $applyStateBindingModifiers('wire:model');
 @endphp
 
 <x-dynamic-component :component="$fieldWrapperView" :field="$field">
@@ -68,16 +68,16 @@
         <div
             {{
                 $getExtraAttributeBag()
-                    ->grid($getColumns(), $gridDirection)
-                    ->merge([
-                        'x-show' => $isSearchable ? 'visibleCheckboxListOptions.length' : null,
-                    ], escape: false)
-                    ->class([
-                        'fi-fo-checkbox-list-options',
-                    ])
+                ->grid($getColumns(), $gridDirection)
+                ->merge([
+                'x-show' => $isSearchable ? 'visibleCheckboxListOptions.length' : null,
+                ], escape: false)
+                ->class([
+                'fi-fo-checkbox-list-options',
+                ])
             }}
         >
-            @forelse ($options as $value => $label)
+            @forelse (options as $value => $label)
                 <div
                     wire:key="{{ $livewireKey }}.options.{{ $value }}"
                     @if ($isSearchable)
@@ -99,18 +99,18 @@
                             type="checkbox"
                             {{
                                 $extraInputAttributeBag
-                                    ->merge([
-                                        'disabled' => $isDisabled || $isOptionDisabled($value, $label),
-                                        'value' => $value,
-                                        'wire:loading.attr' => 'disabled',
-                                        $wireModelAttribute => $statePath,
-                                        'x-on:change' => $isBulkToggleable ? 'checkIfAllCheckboxesAreChecked()' : null,
-                                    ], escape: false)
-                                    ->class([
-                                        'fi-checkbox-input',
-                                        'fi-valid' => ! $errors->has($statePath),
-                                        'fi-invalid' => $errors->has($statePath),
-                                    ])
+                                ->merge([
+                                'disabled' => $isDisabled || $isOptionDisabled($value, $label),
+                                'value' => $value,
+                                'wire:loading.attr' => 'disabled',
+                                $wireModelAttribute => $statePath,
+                                'x-on:change' => $isBulkToggleable ? 'checkIfAllCheckboxesAreChecked()' : null,
+                                ], escape: false)
+                                ->class([
+                                'fi-checkbox-input',
+                                'fi-valid' => ! $errors->has($statePath),
+                                'fi-invalid' => $errors->has($statePath),
+                                ])
                             }}
                         />
 

--- a/packages/forms/resources/views/components/checkbox.blade.php
+++ b/packages/forms/resources/views/components/checkbox.blade.php
@@ -1,22 +1,22 @@
 @php
     $fieldWrapperView = $getFieldWrapperView();
-    $statePath = $getStatePath();
-    $attributes = $attributes
-        ->merge([
-            'autofocus' => $isAutofocused(),
-            'disabled' => $isDisabled(),
-            'id' => $getId(),
-            'required' => $isRequired() && (! $isConcealed()),
-            'wire:loading.attr' => 'disabled',
-            $applyStateBindingModifiers('wire:model') => $statePath,
-        ], escape: false)
-        ->merge($getExtraAttributes(), escape: false)
-        ->merge($getExtraInputAttributes(), escape: false)
-        ->class([
-            'fi-checkbox-input',
-            'fi-valid' => ! $errors->has($statePath),
-            'fi-invalid' => $errors->has($statePath),
-        ]);
+        $statePath = $getStatePath();
+        $attributes = $attributes
+            ->merge([
+                'autofocus' => $isAutofocused(),
+                'disabled' => $isDisabled(),
+                'id' => $getId(),
+                'required' => $isRequired() && (! $isConcealed()),
+                'wire:loading.attr' => 'disabled',
+                $applyStateBindingModifiers('wire:model') => $statePath,
+            ], escape: false)
+            ->merge($getExtraAttributes(), escape: false)
+            ->merge($getExtraInputAttributes(), escape: false)
+            ->class([
+                'fi-checkbox-input',
+                'fi-valid' => ! $errors->has($statePath),
+                'fi-invalid' => $errors->has($statePath),
+            ]);
 @endphp
 
 <x-dynamic-component

--- a/packages/forms/resources/views/components/code-editor.blade.php
+++ b/packages/forms/resources/views/components/code-editor.blade.php
@@ -1,15 +1,15 @@
 @php
     $fieldWrapperView = $getFieldWrapperView();
-    $extraAttributeBag = $getExtraAttributeBag();
-    $isDisabled = $isDisabled();
-    $isLive = $isLive();
-    $isLiveOnBlur = $isLiveOnBlur();
-    $isLiveDebounced = $isLiveDebounced();
-    $liveDebounce = $getLiveDebounce();
-    $key = $getKey();
-    $language = $getLanguage();
-    $statePath = $getStatePath();
-    $livewireKey = $getLivewireKey();
+        $extraAttributeBag = $getExtraAttributeBag();
+        $isDisabled = $isDisabled();
+        $isLive = $isLive();
+        $isLiveOnBlur = $isLiveOnBlur();
+        $isLiveDebounced = $isLiveDebounced();
+        $liveDebounce = $getLiveDebounce();
+        $key = $getKey();
+        $language = $getLanguage();
+        $statePath = $getStatePath();
+        $livewireKey = $getLivewireKey();
 @endphp
 
 <x-dynamic-component :component="$fieldWrapperView" :field="$field">
@@ -18,7 +18,7 @@
         :valid="! $errors->has($statePath)"
         :attributes="
             \Filament\Support\prepare_inherited_attributes($extraAttributeBag)
-                ->class(['fi-fo-code-editor'])
+            ->class(['fi-fo-code-editor'])
         "
     >
         <div
@@ -37,8 +37,8 @@
             wire:ignore
             wire:key="{{ $livewireKey }}.{{
                 substr(md5(serialize([
-                    $isDisabled,
-                    $language?->value,
+                $isDisabled,
+                $language?->value,
                 ])), 0, 64)
             }}"
             {{ $getExtraAlpineAttributeBag() }}

--- a/packages/forms/resources/views/components/color-picker.blade.php
+++ b/packages/forms/resources/views/components/color-picker.blade.php
@@ -1,23 +1,23 @@
 @php
     $fieldWrapperView = $getFieldWrapperView();
-    $extraAttributeBag = $getExtraAttributeBag();
-    $isDisabled = $isDisabled();
-    $isLive = $isLive();
-    $isLiveOnBlur = $isLiveOnBlur();
-    $isLiveDebounced = $isLiveDebounced();
-    $isPrefixInline = $isPrefixInline();
-    $isSuffixInline = $isSuffixInline();
-    $liveDebounce = $getLiveDebounce();
-    $prefixActions = $getPrefixActions();
-    $prefixIcon = $getPrefixIcon();
-    $prefixIconColor = $getPrefixIconColor();
-    $prefixLabel = $getPrefixLabel();
-    $suffixActions = $getSuffixActions();
-    $suffixIcon = $getSuffixIcon();
-    $suffixIconColor = $getSuffixIconColor();
-    $suffixLabel = $getSuffixLabel();
-    $statePath = $getStatePath();
-    $placeholder = $getPlaceholder();
+        $extraAttributeBag = $getExtraAttributeBag();
+        $isDisabled = $isDisabled();
+        $isLive = $isLive();
+        $isLiveOnBlur = $isLiveOnBlur();
+        $isLiveDebounced = $isLiveDebounced();
+        $isPrefixInline = $isPrefixInline();
+        $isSuffixInline = $isSuffixInline();
+        $liveDebounce = $getLiveDebounce();
+        $prefixActions = $getPrefixActions();
+        $prefixIcon = $getPrefixIcon();
+        $prefixIconColor = $getPrefixIconColor();
+        $prefixLabel = $getPrefixLabel();
+        $suffixActions = $getSuffixActions();
+        $suffixIcon = $getSuffixIcon();
+        $suffixIconColor = $getSuffixIconColor();
+        $suffixLabel = $getSuffixLabel();
+        $statePath = $getStatePath();
+        $placeholder = $getPlaceholder();
 @endphp
 
 <x-dynamic-component
@@ -41,7 +41,7 @@
         x-on:focus-input.stop="$el.querySelector('input')?.focus()"
         :attributes="
             \Filament\Support\prepare_inherited_attributes($extraAttributeBag)
-                ->class('fi-fo-color-picker')
+            ->class('fi-fo-color-picker')
         "
     >
         <div
@@ -66,21 +66,21 @@
                 x-ref="input"
                 {{
                     $getExtraInputAttributeBag()
-                        ->merge([
-                            'autocomplete' => 'off',
-                            'disabled' => $isDisabled,
-                            'id' => $getId(),
-                            'placeholder' => filled($placeholder) ? e($placeholder) : null,
-                            'required' => $isRequired() && (! $isConcealed()),
-                            'type' => 'text',
-                            'x-model' . ($isLiveDebounced ? '.debounce.' . $liveDebounce : null) => 'state',
-                            'x-on:blur' => $isLiveOnBlur ? 'isOpen() ? null : commitState()' : null,
-                        ], escape: false)
-                        ->class([
-                            'fi-input',
-                            'fi-input-has-inline-prefix' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
-                            'fi-input-has-inline-suffix' => $isSuffixInline && (count($suffixActions) || $suffixIcon || filled($suffixLabel)),
-                        ])
+                    ->merge([
+                    'autocomplete' => 'off',
+                    'disabled' => $isDisabled,
+                    'id' => $getId(),
+                    'placeholder' => filled($placeholder) ? e($placeholder) : null,
+                    'required' => $isRequired() && (! $isConcealed()),
+                    'type' => 'text',
+                    'x-model' . ($isLiveDebounced ? '.debounce.' . $liveDebounce : null) => 'state',
+                    'x-on:blur' => $isLiveOnBlur ? 'isOpen() ? null : commitState()' : null,
+                    ], escape: false)
+                    ->class([
+                    'fi-input',
+                    'fi-input-has-inline-prefix' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
+                    'fi-input-has-inline-suffix' => $isSuffixInline && (count($suffixActions) || $suffixIcon || filled($suffixLabel)),
+                    ])
                 }}
             />
 
@@ -103,11 +103,11 @@
             >
                 @php
                     $tag = match ($getFormat()) {
-                        'hsl' => 'hsl-string',
-                        'rgb' => 'rgb-string',
-                        'rgba' => 'rgba-string',
-                        default => 'hex',
-                    } . '-color-picker';
+                                            'hsl' => 'hsl-string',
+                                            'rgb' => 'rgb-string',
+                                            'rgba' => 'rgba-string',
+                                            default => 'hex',
+                                        } . '-color-picker';
                 @endphp
 
                 <{{ $tag }} x-ref="picker" color="{{ $getState() }}" />

--- a/packages/forms/resources/views/components/date-time-picker.blade.php
+++ b/packages/forms/resources/views/components/date-time-picker.blade.php
@@ -1,37 +1,37 @@
 @php
     $fieldWrapperView = $getFieldWrapperView();
-    $datalistOptions = $getDatalistOptions();
-    $disabledDates = $getDisabledDates();
-    $extraAlpineAttributes = $getExtraAlpineAttributes();
-    $extraAttributeBag = $getExtraAttributeBag();
-    $extraInputAttributeBag = $getExtraInputAttributeBag();
-    $hasDate = $hasDate();
-    $hasTime = $hasTime();
-    $hasSeconds = $hasSeconds();
-    $id = $getId();
-    $isDisabled = $isDisabled();
-    $isAutofocused = $isAutofocused();
-    $isPrefixInline = $isPrefixInline();
-    $isSuffixInline = $isSuffixInline();
-    $maxDate = $getMaxDate();
-    $minDate = $getMinDate();
-    $defaultFocusedDate = $getDefaultFocusedDate();
-    $prefixActions = $getPrefixActions();
-    $prefixIcon = $getPrefixIcon();
-    $prefixIconColor = $getPrefixIconColor();
-    $prefixLabel = $getPrefixLabel();
-    $suffixActions = $getSuffixActions();
-    $suffixIcon = $getSuffixIcon();
-    $suffixIconColor = $getSuffixIconColor();
-    $suffixLabel = $getSuffixLabel();
-    $statePath = $getStatePath();
-    $placeholder = $getPlaceholder();
-    $isReadOnly = $isReadOnly();
-    $isRequired = $isRequired();
-    $isConcealed = $isConcealed();
-    $step = $getStep();
-    $type = $getType();
-    $livewireKey = $getLivewireKey();
+        $datalistOptions = $getDatalistOptions();
+        $disabledDates = $getDisabledDates();
+        $extraAlpineAttributes = $getExtraAlpineAttributes();
+        $extraAttributeBag = $getExtraAttributeBag();
+        $extraInputAttributeBag = $getExtraInputAttributeBag();
+        $hasDate = $hasDate();
+        $hasTime = $hasTime();
+        $hasSeconds = $hasSeconds();
+        $id = $getId();
+        $isDisabled = $isDisabled();
+        $isAutofocused = $isAutofocused();
+        $isPrefixInline = $isPrefixInline();
+        $isSuffixInline = $isSuffixInline();
+        $maxDate = $getMaxDate();
+        $minDate = $getMinDate();
+        $defaultFocusedDate = $getDefaultFocusedDate();
+        $prefixActions = $getPrefixActions();
+        $prefixIcon = $getPrefixIcon();
+        $prefixIconColor = $getPrefixIconColor();
+        $prefixLabel = $getPrefixLabel();
+        $suffixActions = $getSuffixActions();
+        $suffixIcon = $getSuffixIcon();
+        $suffixIconColor = $getSuffixIconColor();
+        $suffixLabel = $getSuffixLabel();
+        $statePath = $getStatePath();
+        $placeholder = $getPlaceholder();
+        $isReadOnly = $isReadOnly();
+        $isRequired = $isRequired();
+        $isConcealed = $isConcealed();
+        $step = $getStep();
+        $type = $getType();
+        $livewireKey = $getLivewireKey();
 @endphp
 
 <x-dynamic-component
@@ -59,27 +59,27 @@
             <input
                 {{
                     $extraInputAttributeBag
-                        ->merge($extraAlpineAttributes, escape: false)
-                        ->merge([
-                            'autofocus' => $isAutofocused,
-                            'disabled' => $isDisabled,
-                            'id' => $id,
-                            'list' => $datalistOptions ? $id . '-list' : null,
-                            'max' => $hasTime ? $maxDate : ($maxDate ? \Carbon\Carbon::parse($maxDate)->toDateString() : null),
-                            'min' => $hasTime ? $minDate : ($minDate ? \Carbon\Carbon::parse($minDate)->toDateString() : null),
-                            'placeholder' => filled($placeholder) ? e($placeholder) : null,
-                            'readonly' => $isReadOnly,
-                            'required' => $isRequired && (! $isConcealed),
-                            'step' => $step,
-                            'type' => $type,
-                            $applyStateBindingModifiers('wire:model') => $statePath,
-                            'x-data' => count($extraAlpineAttributes) ? '{}' : null,
-                        ], escape: false)
-                        ->class([
-                            'fi-input',
-                            'fi-input-has-inline-prefix' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
-                            'fi-input-has-inline-suffix' => $isSuffixInline && (count($suffixActions) || $suffixIcon || filled($suffixLabel)),
-                        ])
+                    ->merge($extraAlpineAttributes, escape: false)
+                    ->merge([
+                    'autofocus' => $isAutofocused,
+                    'disabled' => $isDisabled,
+                    'id' => $id,
+                    'list' => $datalistOptions ? $id . '-list' : null,
+                    'max' => $hasTime ? $maxDate : ($maxDate ? \Carbon\Carbon::parse($maxDate)->toDateString() : null),
+                    'min' => $hasTime ? $minDate : ($minDate ? \Carbon\Carbon::parse($minDate)->toDateString() : null),
+                    'placeholder' => filled($placeholder) ? e($placeholder) : null,
+                    'readonly' => $isReadOnly,
+                    'required' => $isRequired && (! $isConcealed),
+                    'step' => $step,
+                    'type' => $type,
+                    $applyStateBindingModifiers('wire:model') => $statePath,
+                    'x-data' => count($extraAlpineAttributes) ? '{}' : null,
+                    ], escape: false)
+                    ->class([
+                    'fi-input',
+                    'fi-input-has-inline-prefix' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
+                    'fi-input-has-inline-suffix' => $isSuffixInline && (count($suffixActions) || $suffixIcon || filled($suffixLabel)),
+                    ])
                 }}
             />
         @else
@@ -99,14 +99,14 @@
                 wire:ignore
                 wire:key="{{ $livewireKey }}.{{
                     substr(md5(serialize([
-                        $disabledDates,
-                        $isDisabled,
-                        $isReadOnly,
-                        $maxDate,
-                        $minDate,
-                        $hasDate,
-                        $hasTime,
-                        $hasSeconds,
+                    $disabledDates,
+                    $isDisabled,
+                    $isReadOnly,
+                    $maxDate,
+                    $minDate,
+                    $hasDate,
+                    $hasTime,
+                    $hasSeconds,
                     ])), 0, 64)
                 }}"
                 x-on:keydown.esc="isOpen() && $event.stopPropagation()"
@@ -143,7 +143,7 @@
                     @disabled($isDisabled || $isReadOnly)
                     {{
                         $getExtraTriggerAttributeBag()->class([
-                            'fi-fo-date-time-picker-trigger',
+                        'fi-fo-date-time-picker-trigger',
                         ])
                     }}
                 >
@@ -155,7 +155,7 @@
                         x-model="displayText"
                         @if ($id = $getId()) id="{{ $id }}" @endif
                         @class([
-                            'fi-fo-date-time-picker-display-text-input',
+                        'fi-fo-date-time-picker-display-text-input',
                         ])
                     />
                 </button>
@@ -167,7 +167,7 @@
                     wire:ignore
                     wire:key="{{ $livewireKey }}.panel"
                     @class([
-                        'fi-fo-date-time-picker-panel',
+                    'fi-fo-date-time-picker-panel',
                     ])
                 >
                     @if ($hasDate)

--- a/packages/forms/resources/views/components/field-wrapper.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper.blade.php
@@ -3,78 +3,78 @@
 @endphp
 
 @props([
-    'areHtmlErrorMessagesAllowed' => null,
-    'errorMessage' => null,
-    'errorMessages' => null,
-    'field' => null,
-    'hasErrors' => true,
-    'hasInlineLabel' => null,
-    'hasNestedRecursiveValidationRules' => null,
-    'id' => null,
-    'inlineLabelVerticalAlignment' => VerticalAlignment::Start,
-    'isDisabled' => null,
-    'label' => null,
-    'labelPrefix' => null,
-    'labelSrOnly' => null,
-    'labelSuffix' => null,
-    'labelTag' => 'label',
-    'required' => null,
-    'shouldShowAllValidationMessages' => null,
-    'statePath' => null,
+'areHtmlErrorMessagesAllowed' => null,
+'errorMessage' => null,
+'errorMessages' => null,
+'field' => null,
+'hasErrors' => true,
+'hasInlineLabel' => null,
+'hasNestedRecursiveValidationRules' => null,
+'id' => null,
+'inlineLabelVerticalAlignment' => VerticalAlignment::Start,
+'isDisabled' => null,
+'label' => null,
+'labelPrefix' => null,
+'labelSrOnly' => null,
+'labelSuffix' => null,
+'labelTag' => 'label',
+'required' => null,
+'shouldShowAllValidationMessages' => null,
+'statePath' => null,
 ])
 
 @php
     use Illuminate\Support\Arr;
 
-    if ($field) {
-        $hasInlineLabel ??= $field->hasInlineLabel();
-        $hasNestedRecursiveValidationRules ??= $field instanceof \Filament\Forms\Components\Contracts\HasNestedRecursiveValidationRules;
-        $id ??= $field->getId();
-        $isDisabled ??= $field->isDisabled();
-        $label ??= $field->getLabel();
-        $labelSrOnly ??= $field->isLabelHidden();
-        $required ??= $field->isMarkedAsRequired();
-        $statePath ??= $field->getStatePath();
-        $areHtmlErrorMessagesAllowed ??= $field->areHtmlValidationMessagesAllowed();
-        $shouldShowAllValidationMessages ??= $field->shouldShowAllValidationMessages();
-    }
-
-    $aboveLabelSchema = $field?->getChildSchema($field::ABOVE_LABEL_SCHEMA_KEY)?->toHtmlString();
-    $belowLabelSchema = $field?->getChildSchema($field::BELOW_LABEL_SCHEMA_KEY)?->toHtmlString();
-    $beforeLabelSchema = $field?->getChildSchema($field::BEFORE_LABEL_SCHEMA_KEY)?->toHtmlString();
-    $afterLabelSchema = $field?->getChildSchema($field::AFTER_LABEL_SCHEMA_KEY)?->toHtmlString();
-    $aboveContentSchema = $field?->getChildSchema($field::ABOVE_CONTENT_SCHEMA_KEY)?->toHtmlString();
-    $belowContentSchema = $field?->getChildSchema($field::BELOW_CONTENT_SCHEMA_KEY)?->toHtmlString();
-    $beforeContentSchema = $field?->getChildSchema($field::BEFORE_CONTENT_SCHEMA_KEY)?->toHtmlString();
-    $afterContentSchema = $field?->getChildSchema($field::AFTER_CONTENT_SCHEMA_KEY)?->toHtmlString();
-    $aboveErrorMessageSchema = $field?->getChildSchema($field::ABOVE_ERROR_MESSAGE_SCHEMA_KEY)?->toHtmlString();
-    $belowErrorMessageSchema = $field?->getChildSchema($field::BELOW_ERROR_MESSAGE_SCHEMA_KEY)?->toHtmlString();
-
-    $hasError = $hasErrors && (filled($errorMessage) || filled($errorMessages) || (filled($statePath) && ($errors->has($statePath) || ($hasNestedRecursiveValidationRules && $errors->has("{$statePath}.*")))));
-
-    if ($hasError && filled($statePath) && blank($errorMessage) && blank($errorMessages)) {
-        if ($shouldShowAllValidationMessages) {
-            $errorMessages = $errors->has($statePath) ? $errors->get($statePath) : ($hasNestedRecursiveValidationRules ? $errors->get("{$statePath}.*") : []);
-
-            if (count($errorMessages) === 1) {
-                $errorMessage = Arr::first($errorMessages);
-                $errorMessages = [];
-            }
-        } else {
-            $errorMessage = $errors->has($statePath) ? $errors->first($statePath) : ($hasNestedRecursiveValidationRules ? $errors->first("{$statePath}.*") : null);
+        if ($field) {
+            $hasInlineLabel ??= $field->hasInlineLabel();
+            $hasNestedRecursiveValidationRules ??= $field instanceof \Filament\Forms\Components\Contracts\HasNestedRecursiveValidationRules;
+            $id ??= $field->getId();
+            $isDisabled ??= $field->isDisabled();
+            $label ??= $field->getLabel();
+            $labelSrOnly ??= $field->isLabelHidden();
+            $required ??= $field->isMarkedAsRequired();
+            $statePath ??= $field->getStatePath();
+            $areHtmlErrorMessagesAllowed ??= $field->areHtmlValidationMessagesAllowed();
+            $shouldShowAllValidationMessages ??= $field->shouldShowAllValidationMessages();
         }
-    }
+
+        $aboveLabelSchema = $field?->getChildSchema($field::ABOVE_LABEL_SCHEMA_KEY)?->toHtmlString();
+        $belowLabelSchema = $field?->getChildSchema($field::BELOW_LABEL_SCHEMA_KEY)?->toHtmlString();
+        $beforeLabelSchema = $field?->getChildSchema($field::BEFORE_LABEL_SCHEMA_KEY)?->toHtmlString();
+        $afterLabelSchema = $field?->getChildSchema($field::AFTER_LABEL_SCHEMA_KEY)?->toHtmlString();
+        $aboveContentSchema = $field?->getChildSchema($field::ABOVE_CONTENT_SCHEMA_KEY)?->toHtmlString();
+        $belowContentSchema = $field?->getChildSchema($field::BELOW_CONTENT_SCHEMA_KEY)?->toHtmlString();
+        $beforeContentSchema = $field?->getChildSchema($field::BEFORE_CONTENT_SCHEMA_KEY)?->toHtmlString();
+        $afterContentSchema = $field?->getChildSchema($field::AFTER_CONTENT_SCHEMA_KEY)?->toHtmlString();
+        $aboveErrorMessageSchema = $field?->getChildSchema($field::ABOVE_ERROR_MESSAGE_SCHEMA_KEY)?->toHtmlString();
+        $belowErrorMessageSchema = $field?->getChildSchema($field::BELOW_ERROR_MESSAGE_SCHEMA_KEY)?->toHtmlString();
+
+        $hasError = $hasErrors && (filled($errorMessage) || filled($errorMessages) || (filled($statePath) && ($errors->has($statePath) || ($hasNestedRecursiveValidationRules && $errors->has("{$statePath}.*")))));
+
+        if ($hasError && filled($statePath) && blank($errorMessage) && blank($errorMessages)) {
+            if ($shouldShowAllValidationMessages) {
+                $errorMessages = $errors->has($statePath) ? $errors->get($statePath) : ($hasNestedRecursiveValidationRules ? $errors->get("{$statePath}.*") : []);
+
+                if (count($errorMessages) === 1) {
+                    $errorMessage = Arr::first($errorMessages);
+                    $errorMessages = [];
+                }
+            } else {
+                $errorMessage = $errors->has($statePath) ? $errors->first($statePath) : ($hasNestedRecursiveValidationRules ? $errors->first("{$statePath}.*") : null);
+            }
+        }
 @endphp
 
 <div
     data-field-wrapper
     {{
         $attributes
-            ->merge($field?->getExtraFieldWrapperAttributes() ?? [], escape: false)
-            ->class([
-                'fi-fo-field',
-                'fi-fo-field-has-inline-label' => $hasInlineLabel,
-            ])
+        ->merge($field?->getExtraFieldWrapperAttributes() ?? [], escape: false)
+        ->class([
+        'fi-fo-field',
+        'fi-fo-field-has-inline-label' => $hasInlineLabel,
+        ])
     }}
 >
     @if (filled($label) && $labelSrOnly)
@@ -93,16 +93,16 @@
     @if ((filled($label) && (! $labelSrOnly)) || $hasInlineLabel || $aboveLabelSchema || $belowLabelSchema || $beforeLabelSchema || $afterLabelSchema || $labelPrefix || $labelSuffix)
         <div
             @class([
-                'fi-fo-field-label-col',
-                "fi-vertical-align-{$inlineLabelVerticalAlignment->value}" => $hasInlineLabel,
+            'fi-fo-field-label-col',
+            "fi-vertical-align-{$inlineLabelVerticalAlignment->value}" => $hasInlineLabel,
             ])
         >
             {{ $aboveLabelSchema }}
 
             <div
                 @class([
-                    'fi-fo-field-label-ctn',
-                    ($label instanceof \Illuminate\View\ComponentSlot) ? $label->attributes->get('class') : null,
+                'fi-fo-field-label-ctn',
+                ($label instanceof \Illuminate\View\ComponentSlot) ? $label->attributes->get('class') : null,
                 ])
             >
                 {{ $beforeLabelSchema }}

--- a/packages/forms/resources/views/components/file-upload.blade.php
+++ b/packages/forms/resources/views/components/file-upload.blade.php
@@ -1,26 +1,26 @@
 @php
     use Filament\Support\Enums\Alignment;
 
-    $fieldWrapperView = $getFieldWrapperView();
-    $id = $getId();
-    $automaticallyCropImagesAspectRatio = $getAutomaticallyCropImagesAspectRatio();
-    $automaticallyResizeImagesHeight = $getAutomaticallyResizeImagesHeight();
-    $automaticallyResizeImagesWidth = $getAutomaticallyResizeImagesWidth();
-    $isAvatar = $isAvatar();
-    $isMultiple = $isMultiple();
-    $key = $getKey();
-    $statePath = $getStatePath();
-    $isDisabled = $isDisabled();
-    $hasImageEditor = $hasImageEditor();
-    $isImageEditorExplicitlyEnabled = $isImageEditorExplicitlyEnabled();
-    $hasCircleCropper = $hasCircleCropper();
-    $livewireKey = $getLivewireKey();
+        $fieldWrapperView = $getFieldWrapperView();
+        $id = $getId();
+        $automaticallyCropImagesAspectRatio = $getAutomaticallyCropImagesAspectRatio();
+        $automaticallyResizeImagesHeight = $getAutomaticallyResizeImagesHeight();
+        $automaticallyResizeImagesWidth = $getAutomaticallyResizeImagesWidth();
+        $isAvatar = $isAvatar();
+        $isMultiple = $isMultiple();
+        $key = $getKey();
+        $statePath = $getStatePath();
+        $isDisabled = $isDisabled();
+        $hasImageEditor = $hasImageEditor();
+        $isImageEditorExplicitlyEnabled = $isImageEditorExplicitlyEnabled();
+        $hasCircleCropper = $hasCircleCropper();
+        $livewireKey = $getLivewireKey();
 
-    $alignment = $getAlignment() ?? Alignment::Start;
+        $alignment = $getAlignment() ?? Alignment::Start;
 
-    if (! $alignment instanceof Alignment) {
-        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
-    }
+        if (! $alignment instanceof Alignment) {
+            $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
+        }
 @endphp
 
 <x-dynamic-component
@@ -127,23 +127,23 @@
         wire:ignore
         wire:key="{{ $livewireKey }}.{{
             substr(md5(serialize([
-                $isDisabled,
+            $isDisabled,
             ])), 0, 64)
         }}"
         {{
             $attributes
-                ->merge([
-                    'aria-labelledby' => "{$id}-label",
-                    'id' => $id,
-                    'role' => 'group',
-                ], escape: false)
-                ->merge($getExtraAttributes(), escape: false)
-                ->merge($getExtraAlpineAttributes(), escape: false)
-                ->class([
-                    'fi-fo-file-upload',
-                    'fi-fo-file-upload-avatar' => $isAvatar,
-                    ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : $alignment,
-                ])
+            ->merge([
+            'aria-labelledby' => "{$id}-label",
+            'id' => $id,
+            'role' => 'group',
+            ], escape: false)
+            ->merge($getExtraAttributes(), escape: false)
+            ->merge($getExtraAlpineAttributes(), escape: false)
+            ->class([
+            'fi-fo-file-upload',
+            'fi-fo-file-upload-avatar' => $isAvatar,
+            ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : $alignment,
+            ])
         }}
     >
         <div class="fi-fo-file-upload-input-ctn">
@@ -151,12 +151,12 @@
                 x-ref="input"
                 {{
                     $getExtraInputAttributeBag()
-                        ->merge([
-                            'aria-labelledby' => "{$id}-label",
-                            'disabled' => $isDisabled,
-                            'multiple' => $isMultiple,
-                            'type' => 'file',
-                        ], escape: false)
+                    ->merge([
+                    'aria-labelledby' => "{$id}-label",
+                    'disabled' => $isDisabled,
+                    'multiple' => $isMultiple,
+                    'type' => 'file',
+                    ], escape: false)
                 }}
             />
         </div>
@@ -176,9 +176,9 @@
                 x-trap.noscroll="isEditorOpen"
                 x-on:keydown.escape.prevent.stop="closeEditor"
                 @class([
-                    'fi-fo-file-upload-editor',
-                    'fi-fo-file-upload-editor-circle-cropper' => $hasCircleCropper,
-                    'fi-fo-file-upload-editor-crop-only' => ! $isImageEditorExplicitlyEnabled,
+                'fi-fo-file-upload-editor',
+                'fi-fo-file-upload-editor-circle-cropper' => $hasCircleCropper,
+                'fi-fo-file-upload-editor-crop-only' => ! $isImageEditorExplicitlyEnabled,
                 ])
             >
                 <div
@@ -327,8 +327,8 @@
                                     x-on:click.prevent.stop="editor.reset()"
                                     {{
                                         (new \Illuminate\View\ComponentAttributeBag)
-                                            ->color(\Filament\Support\View\Components\ButtonComponent::class, 'danger')
-                                            ->class(['fi-btn fi-fo-file-upload-editor-control-panel-reset-action'])
+                                        ->color(\Filament\Support\View\Components\ButtonComponent::class, 'danger')
+                                        ->class(['fi-btn fi-fo-file-upload-editor-control-panel-reset-action'])
                                     }}
                                 >
                                     {{ __('filament-forms::components.file_upload.editor.actions.reset.label') }}
@@ -339,8 +339,8 @@
                                     x-on:click.prevent="saveEditor"
                                     {{
                                         (new \Illuminate\View\ComponentAttributeBag)
-                                            ->color(\Filament\Support\View\Components\ButtonComponent::class, 'success')
-                                            ->class(['fi-btn'])
+                                        ->color(\Filament\Support\View\Components\ButtonComponent::class, 'success')
+                                        ->class(['fi-btn'])
                                     }}
                                 >
                                     {{ __('filament-forms::components.file_upload.editor.actions.save.label') }}
@@ -351,8 +351,8 @@
                                     x-on:click.prevent="saveEditor"
                                     {{
                                         (new \Illuminate\View\ComponentAttributeBag)
-                                            ->color(\Filament\Support\View\Components\ButtonComponent::class, 'success')
-                                            ->class(['fi-btn'])
+                                        ->color(\Filament\Support\View\Components\ButtonComponent::class, 'success')
+                                        ->class(['fi-btn'])
                                     }}
                                 >
                                     {{ __('filament-forms::components.file_upload.editor.actions.save.label') }}

--- a/packages/forms/resources/views/components/hidden.blade.php
+++ b/packages/forms/resources/views/components/hidden.blade.php
@@ -1,12 +1,12 @@
 <input
     {{
         $attributes
-            ->merge([
-                'id' => $getId(),
-                'type' => 'hidden',
-                $applyStateBindingModifiers('wire:model') => $getStatePath(),
-            ], escape: false)
-            ->merge($getExtraAttributes(), escape: false)
-            ->class(['fi-fo-hidden'])
+        ->merge([
+        'id' => $getId(),
+        'type' => 'hidden',
+        $applyStateBindingModifiers('wire:model') => $getStatePath(),
+        ], escape: false)
+        ->merge($getExtraAttributes(), escape: false)
+        ->class(['fi-fo-hidden'])
     }}
 />

--- a/packages/forms/resources/views/components/key-value.blade.php
+++ b/packages/forms/resources/views/components/key-value.blade.php
@@ -1,17 +1,17 @@
 @php
     $fieldWrapperView = $getFieldWrapperView();
-    $extraAttributeBag = $getExtraAttributeBag();
-    $canEditKeys = $canEditKeys();
-    $canEditValues = $canEditValues();
-    $keyPlaceholder = $getKeyPlaceholder();
-    $valuePlaceholder = $getValuePlaceholder();
-    $debounce = $getLiveDebounce();
-    $isAddable = $isAddable();
-    $isDeletable = $isDeletable();
-    $isDisabled = $isDisabled();
-    $isReorderable = $isReorderable();
-    $statePath = $getStatePath();
-    $livewireKey = $getLivewireKey();
+        $extraAttributeBag = $getExtraAttributeBag();
+        $canEditKeys = $canEditKeys();
+        $canEditValues = $canEditValues();
+        $keyPlaceholder = $getKeyPlaceholder();
+        $valuePlaceholder = $getValuePlaceholder();
+        $debounce = $getLiveDebounce();
+        $isAddable = $isAddable();
+        $isDeletable = $isDeletable();
+        $isDisabled = $isDisabled();
+        $isReorderable = $isReorderable();
+        $statePath = $getStatePath();
+        $livewireKey = $getLivewireKey();
 @endphp
 
 <x-dynamic-component
@@ -24,7 +24,7 @@
         :valid="! $errors->has($statePath)"
         :attributes="
             \Filament\Support\prepare_inherited_attributes($extraAttributeBag)
-                ->class(['fi-fo-key-value'])
+            ->class(['fi-fo-key-value'])
         "
     >
         <div
@@ -36,13 +36,13 @@
             wire:ignore
             wire:key="{{ $livewireKey }}.{{
                 substr(md5(serialize([
-                    $isDisabled,
+                $isDisabled,
                 ])), 0, 64)
             }}"
             {{
                 $attributes
-                    ->merge($getExtraAlpineAttributes(), escape: false)
-                    ->class(['fi-fo-key-value-table-ctn'])
+                ->merge($getExtraAlpineAttributes(), escape: false)
+                ->class(['fi-fo-key-value-table-ctn'])
             }}
         >
             <table class="fi-fo-key-value-table">

--- a/packages/forms/resources/views/components/livewire-field.blade.php
+++ b/packages/forms/resources/views/components/livewire-field.blade.php
@@ -1,7 +1,7 @@
 @php
     $fieldWrapperView = $getFieldWrapperView();
-    $extraAttributes = $getExtraAttributes();
-    $id = $getId();
+        $extraAttributes = $getExtraAttributes();
+        $id = $getId();
 @endphp
 
 <x-dynamic-component :component="$fieldWrapperView" :field="$field">
@@ -10,10 +10,10 @@
         {{-- Avoid formatting issues with unclosed elements --}}
         {{
             $attributes
-                ->merge([
-                    'id' => $id,
-                ], escape: false)
-                ->merge($extraAttributes, escape: false)
+            ->merge([
+            'id' => $id,
+            ], escape: false)
+            ->merge($extraAttributes, escape: false)
         }}
         >
     @endif

--- a/packages/forms/resources/views/components/markdown-editor.blade.php
+++ b/packages/forms/resources/views/components/markdown-editor.blade.php
@@ -1,12 +1,12 @@
 @php
     $id = $getId();
-    $fieldWrapperView = $getFieldWrapperView();
-    $extraAttributeBag = $getExtraAttributeBag();
-    $key = $getKey();
-    $label = $getLabel();
-    $statePath = $getStatePath();
-    $fileAttachmentsMaxSize = $getFileAttachmentsMaxSize();
-    $fileAttachmentsAcceptedFileTypes = $getFileAttachmentsAcceptedFileTypes();
+        $fieldWrapperView = $getFieldWrapperView();
+        $extraAttributeBag = $getExtraAttributeBag();
+        $key = $getKey();
+        $label = $getLabel();
+        $statePath = $getStatePath();
+        $fileAttachmentsMaxSize = $getFileAttachmentsMaxSize();
+        $fileAttachmentsAcceptedFileTypes = $getFileAttachmentsAcceptedFileTypes();
 @endphp
 
 <x-dynamic-component :component="$fieldWrapperView" :field="$field">
@@ -19,7 +19,7 @@
             :valid="! $errors->has($statePath)"
             :attributes="
                 \Filament\Support\prepare_inherited_attributes($extraAttributeBag)
-                    ->class(['fi-fo-markdown-editor'])
+                ->class(['fi-fo-markdown-editor'])
             "
         >
             <div

--- a/packages/forms/resources/views/components/modal-table-select.blade.php
+++ b/packages/forms/resources/views/components/modal-table-select.blade.php
@@ -1,28 +1,28 @@
 @php
     use Filament\Forms\Components\TableSelect\Livewire\TableSelectLivewireComponent;
 
-    $fieldWrapperView = $getFieldWrapperView();
-    $extraAttributes = $getExtraAttributes();
-    $id = $getId();
-    $isDisabled = $isDisabled();
-    $isMultiple = $isMultiple();
-    $hasBadges = $hasBadges();
-    $badgeColor = $getBadgeColor();
+        $fieldWrapperView = $getFieldWrapperView();
+        $extraAttributes = $getExtraAttributes();
+        $id = $getId();
+        $isDisabled = $isDisabled();
+        $isMultiple = $isMultiple();
+        $hasBadges = $hasBadges();
+        $badgeColor = $getBadgeColor();
 @endphp
 
 <x-dynamic-component :component="$fieldWrapperView" :field="$field">
     <div
         {{
             $attributes
-                ->merge([
-                    'id' => $id,
-                ], escape: false)
-                ->merge($extraAttributes, escape: false)
-                ->class([
-                    'fi-fo-modal-table-select',
-                    'fi-fo-modal-table-select-disabled' => $isDisabled,
-                    'fi-fo-modal-table-select-multiple' => $isMultiple,
-                ])
+            ->merge([
+            'id' => $id,
+            ], escape: false)
+            ->merge($extraAttributes, escape: false)
+            ->class([
+            'fi-fo-modal-table-select',
+            'fi-fo-modal-table-select-disabled' => $isDisabled,
+            'fi-fo-modal-table-select-multiple' => $isMultiple,
+            ])
         }}
     >
         @if (((! $isMultiple) && filled($optionLabel = $getOptionLabel())) ||

--- a/packages/forms/resources/views/components/one-time-code-input.blade.php
+++ b/packages/forms/resources/views/components/one-time-code-input.blade.php
@@ -1,20 +1,20 @@
 @php
     $fieldWrapperView = $getFieldWrapperView();
-    $placeholder = $getPlaceholder();
-    $extraAttributes = $getExtraAttributeBag()
-        ->merge($getExtraAlpineAttributes(), escape: false);
-    $extraInputAttributes = $getExtraInputAttributeBag()
-        ->merge([
-            'autocomplete' => false,
-            'autofocus' => $isAutofocused(),
-            'disabled' => $isDisabled(),
-            'id' => $getId(),
-            'length' => $getLength(),
-            'placeholder' => filled($placeholder) ? e($placeholder) : null,
-            'readonly' => $isReadOnly(),
-            'required' => $isRequired() && (! $isConcealed()),
-            $applyStateBindingModifiers('wire:model') => $getStatePath(),
-        ], escape: false);
+        $placeholder = $getPlaceholder();
+        $extraAttributes = $getExtraAttributeBag()
+            ->merge($getExtraAlpineAttributes(), escape: false);
+        $extraInputAttributes = $getExtraInputAttributeBag()
+            ->merge([
+                'autocomplete' => false,
+                'autofocus' => $isAutofocused(),
+                'disabled' => $isDisabled(),
+                'id' => $getId(),
+                'length' => $getLength(),
+                'placeholder' => filled($placeholder) ? e($placeholder) : null,
+                'readonly' => $isReadOnly(),
+                'required' => $isRequired() && (! $isConcealed()),
+                $applyStateBindingModifiers('wire:model') => $getStatePath(),
+            ], escape: false);
 @endphp
 
 <x-dynamic-component :component="$fieldWrapperView" :field="$field">

--- a/packages/forms/resources/views/components/plain-field-wrapper.blade.php
+++ b/packages/forms/resources/views/components/plain-field-wrapper.blade.php
@@ -1,27 +1,27 @@
 @props([
-    'field' => null,
-    'id' => null,
-    'label' => null,
-    'labelTag' => 'label',
+'field' => null,
+'id' => null,
+'label' => null,
+'labelTag' => 'label',
 ])
 
 @php
     use Illuminate\View\ComponentAttributeBag;
 
-    if ($field) {
-        $id ??= $field->getId();
-        $label ??= $field->getLabel();
-    }
+        if ($field) {
+            $id ??= $field->getId();
+            $label ??= $field->getLabel();
+        }
 @endphp
 
 <div
     data-field-wrapper
     {{
         (new ComponentAttributeBag)
-            ->merge($field?->getExtraFieldWrapperAttributes() ?? [], escape: false)
-            ->class([
-                'fi-fo-field',
-            ])
+        ->merge($field?->getExtraFieldWrapperAttributes() ?? [], escape: false)
+        ->class([
+        'fi-fo-field',
+        ])
     }}
 >
     @if (filled($label))

--- a/packages/forms/resources/views/components/radio.blade.php
+++ b/packages/forms/resources/views/components/radio.blade.php
@@ -1,39 +1,39 @@
 @php
     use Filament\Support\Enums\GridDirection;
-    use Illuminate\View\ComponentAttributeBag;
+        use Illuminate\View\ComponentAttributeBag;
 
-    $fieldWrapperView = $getFieldWrapperView();
-    $extraInputAttributeBag = $getExtraInputAttributeBag();
-    $gridDirection = $getGridDirection() ?? GridDirection::Column;
-    $id = $getId();
-    $isDisabled = $isDisabled();
-    $isInline = $isInline();
-    $statePath = $getStatePath();
-    $wireModelAttribute = $applyStateBindingModifiers('wire:model');
+        $fieldWrapperView = $getFieldWrapperView();
+        $extraInputAttributeBag = $getExtraInputAttributeBag();
+        $gridDirection = $getGridDirection() ?? GridDirection::Column;
+        $id = $getId();
+        $isDisabled = $isDisabled();
+        $isInline = $isInline();
+        $statePath = $getStatePath();
+        $wireModelAttribute = $applyStateBindingModifiers('wire:model');
 @endphp
 
 <x-dynamic-component :component="$fieldWrapperView" :field="$field">
     <div
         {{
             $getExtraAttributeBag()
-                ->when(! $isInline, fn (ComponentAttributeBag $attributes) => $attributes->grid($getColumns(), $gridDirection))
-                ->class([
-                    'fi-fo-radio',
-                    'fi-inline' => $isInline,
-                ])
+            ->when(! $isInline, fn (ComponentAttributeBag $attributes) => $attributes->grid($getColumns(), $gridDirection))
+            ->class([
+            'fi-fo-radio',
+            'fi-inline' => $isInline,
+            ])
         }}
     >
         @foreach ($getOptions() as $value => $label)
             @php
                 $inputAttributes = $extraInputAttributeBag
-                    ->merge([
-                        'autofocus' => $loop->first && $isAutofocused(),
-                        'disabled' => $isDisabled || $isOptionDisabled($value, $label),
-                        'id' => $id . '-' . $value,
-                        'name' => $id,
-                        'value' => $value,
-                        $wireModelAttribute => $statePath,
-                    ], escape: false);
+                                    ->merge([
+                                        'autofocus' => $loop->first && $isAutofocused(),
+                                        'disabled' => $isDisabled || $isOptionDisabled($value, $label),
+                                        'id' => $id . '-' . $value,
+                                        'name' => $id,
+                                        'value' => $value,
+                                        $wireModelAttribute => $statePath,
+                                    ], escape: false);
             @endphp
 
             <label class="fi-fo-radio-label">
@@ -41,9 +41,9 @@
                     type="radio"
                     {{
                         $inputAttributes->class([
-                            'fi-radio-input',
-                            'fi-valid' => ! $errors->has($statePath),
-                            'fi-invalid' => $errors->has($statePath),
+                        'fi-radio-input',
+                        'fi-valid' => ! $errors->has($statePath),
+                        'fi-invalid' => $errors->has($statePath),
                         ])
                     }}
                 />

--- a/packages/forms/resources/views/components/repeater/index.blade.php
+++ b/packages/forms/resources/views/components/repeater/index.blade.php
@@ -1,61 +1,61 @@
 @php
     use Filament\Actions\Action;
-    use Filament\Support\Enums\Alignment;
-    use Illuminate\View\ComponentAttributeBag;
+        use Filament\Support\Enums\Alignment;
+        use Illuminate\View\ComponentAttributeBag;
 
-    $fieldWrapperView = $getFieldWrapperView();
+        $fieldWrapperView = $getFieldWrapperView();
 
-    $items = $getItems();
+        $items = $getItems();
 
-    $addAction = $getAction($getAddActionName());
-    $addActionAlignment = $getAddActionAlignment();
-    $addBetweenAction = $getAction($getAddBetweenActionName());
-    $cloneAction = $getAction($getCloneActionName());
-    $collapseAllAction = $getAction($getCollapseAllActionName());
-    $expandAllAction = $getAction($getExpandAllActionName());
-    $deleteAction = $getAction($getDeleteActionName());
-    $moveDownAction = $getAction($getMoveDownActionName());
-    $moveUpAction = $getAction($getMoveUpActionName());
-    $reorderAction = $getAction($getReorderActionName());
-    $extraItemActions = $getExtraItemActions();
+        $addAction = $getAction($getAddActionName());
+        $addActionAlignment = $getAddActionAlignment();
+        $addBetweenAction = $getAction($getAddBetweenActionName());
+        $cloneAction = $getAction($getCloneActionName());
+        $collapseAllAction = $getAction($getCollapseAllActionName());
+        $expandAllAction = $getAction($getExpandAllActionName());
+        $deleteAction = $getAction($getDeleteActionName());
+        $moveDownAction = $getAction($getMoveDownActionName());
+        $moveUpAction = $getAction($getMoveUpActionName());
+        $reorderAction = $getAction($getReorderActionName());
+        $extraItemActions = $getExtraItemActions();
 
-    $hasItemNumbers = $hasItemNumbers();
-    $hasItemHeaders = $hasItemHeaders();
-    $isAddable = $isAddable();
-    $isCloneable = $isCloneable();
-    $isCollapsible = $isCollapsible();
-    $isDeletable = $isDeletable();
-    $isReorderableWithButtons = $isReorderableWithButtons();
-    $isReorderableWithDragAndDrop = $isReorderableWithDragAndDrop();
+        $hasItemNumbers = $hasItemNumbers();
+        $hasItemHeaders = $hasItemHeaders();
+        $isAddable = $isAddable();
+        $isCloneable = $isCloneable();
+        $isCollapsible = $isCollapsible();
+        $isDeletable = $isDeletable();
+        $isReorderableWithButtons = $isReorderableWithButtons();
+        $isReorderableWithDragAndDrop = $isReorderableWithDragAndDrop();
 
-    $collapseAllActionIsVisible = $isCollapsible && $collapseAllAction->isVisible();
-    $expandAllActionIsVisible = $isCollapsible && $expandAllAction->isVisible();
-    $persistCollapsed = $shouldPersistCollapsed();
+        $collapseAllActionIsVisible = $isCollapsible && $collapseAllAction->isVisible();
+        $expandAllActionIsVisible = $isCollapsible && $expandAllAction->isVisible();
+        $persistCollapsed = $shouldPersistCollapsed();
 
-    $key = $getKey();
-    $statePath = $getStatePath();
+        $key = $getKey();
+        $statePath = $getStatePath();
 
-    $itemLabelHeadingTag = $getHeadingTag();
-    $isItemLabelTruncated = $isItemLabelTruncated();
-    $labelBetweenItems = $getLabelBetweenItems();
+        $itemLabelHeadingTag = $getHeadingTag();
+        $isItemLabelTruncated = $isItemLabelTruncated();
+        $labelBetweenItems = $getLabelBetweenItems();
 @endphp
 
 <x-dynamic-component :component="$fieldWrapperView" :field="$field">
     <div
         {{
             $attributes
-                ->merge($getExtraAttributes(), escape: false)
-                ->class([
-                    'fi-fo-repeater',
-                    'fi-collapsible' => $isCollapsible,
-                ])
+            ->merge($getExtraAttributes(), escape: false)
+            ->class([
+            'fi-fo-repeater',
+            'fi-collapsible' => $isCollapsible,
+            ])
         }}
     >
         @if ($collapseAllActionIsVisible || $expandAllActionIsVisible)
             <div
                 @class([
-                    'fi-fo-repeater-actions',
-                    'fi-hidden' => count($items) < 2,
+                'fi-fo-repeater-actions',
+                'fi-hidden' => count($items) < 2,
                 ])
             >
                 @if ($collapseAllActionIsVisible)
@@ -81,31 +81,31 @@
                 x-sortable
                 {{
                     (new ComponentAttributeBag)
-                        ->grid($getGridColumns())
-                        ->merge([
-                            'data-sortable-animation-duration' => $getReorderAnimationDuration(),
-                            'x-on:end.stop' => '$wire.mountAction(\'reorder\', { items: $event.target.sortable.toArray() }, { schemaComponent: \'' . $key . '\' })',
-                        ], escape: false)
-                        ->class(['fi-fo-repeater-items'])
+                    ->grid($getGridColumns())
+                    ->merge([
+                    'data-sortable-animation-duration' => $getReorderAnimationDuration(),
+                    'x-on:end.stop' => '$wire.mountAction(\'reorder\', { items: $event.target.sortable.toArray() }, { schemaComponent: \'' . $key . '\' })',
+                    ], escape: false)
+                    ->class(['fi-fo-repeater-items'])
                 }}
             >
                 @foreach ($items as $itemKey => $item)
                     @php
                         $itemLabel = $getItemLabel($itemKey, $loop->index);
-                        $visibleExtraItemActions = array_filter(
-                            $extraItemActions,
-                            fn (Action $action): bool => $action(['item' => $itemKey])->isVisible(),
-                        );
-                        $cloneAction = $cloneAction(['item' => $itemKey]);
-                        $cloneActionIsVisible = $isCloneable && $cloneAction->isVisible();
-                        $deleteAction = $deleteAction(['item' => $itemKey]);
-                        $deleteActionIsVisible = $isDeletable && $deleteAction->isVisible();
-                        $moveDownAction = $moveDownAction(['item' => $itemKey])->disabled($loop->last);
-                        $moveDownActionIsVisible = $isReorderableWithButtons && $moveDownAction->isVisible();
-                        $moveUpAction = $moveUpAction(['item' => $itemKey])->disabled($loop->first);
-                        $moveUpActionIsVisible = $isReorderableWithButtons && $moveUpAction->isVisible();
-                        $reorderActionIsVisible = $isReorderableWithDragAndDrop && $reorderAction->isVisible();
-                        $hasItemHeader = $hasItemHeaders && ($reorderActionIsVisible || $moveUpActionIsVisible || $moveDownActionIsVisible || filled($itemLabel) || $cloneActionIsVisible || $deleteActionIsVisible || $isCollapsible || $visibleExtraItemActions);
+                                                $visibleExtraItemActions = array_filter(
+                                                    $extraItemActions,
+                                                    fn (Action $action): bool => $action(['item' => $itemKey])->isVisible(),
+                                                );
+                                                $cloneAction = $cloneAction(['item' => $itemKey]);
+                                                $cloneActionIsVisible = $isCloneable && $cloneAction->isVisible();
+                                                $deleteAction = $deleteAction(['item' => $itemKey]);
+                                                $deleteActionIsVisible = $isDeletable && $deleteAction->isVisible();
+                                                $moveDownAction = $moveDownAction(['item' => $itemKey])->disabled($loop->last);
+                                                $moveDownActionIsVisible = $isReorderableWithButtons && $moveDownAction->isVisible();
+                                                $moveUpAction = $moveUpAction(['item' => $itemKey])->disabled($loop->first);
+                                                $moveUpActionIsVisible = $isReorderableWithButtons && $moveUpAction->isVisible();
+                                                $reorderActionIsVisible = $isReorderableWithDragAndDrop && $reorderAction->isVisible();
+                                                $hasItemHeader = $hasItemHeaders && ($reorderActionIsVisible || $moveUpActionIsVisible || $moveDownActionIsVisible || filled($itemLabel) || $cloneActionIsVisible || $deleteActionIsVisible || $isCollapsible || $visibleExtraItemActions);
                     @endphp
 
                     <li
@@ -119,8 +119,8 @@
                         x-on:expand="isCollapsed = false"
                         x-sortable-item="{{ $itemKey }}"
                         @class([
-                            'fi-fo-repeater-item',
-                            'fi-fo-repeater-item-has-header' => $hasItemHeader,
+                        'fi-fo-repeater-item',
+                        'fi-fo-repeater-item-has-header' => $hasItemHeader,
                         ])
                         x-bind:class="{ 'fi-collapsed': isCollapsed }"
                     >
@@ -156,8 +156,8 @@
                                 @if (filled($itemLabel))
                                     <{{ $itemLabelHeadingTag }}
                                         @class([
-                                            'fi-fo-repeater-item-header-label',
-                                            'fi-truncated' => $isItemLabelTruncated,
+                                        'fi-fo-repeater-item-header-label',
+                                        'fi-truncated' => $isItemLabelTruncated,
                                         ])
                                     >
                                         {{ $itemLabel }}
@@ -253,8 +253,8 @@
         @if ($isAddable && $addAction->isVisible())
             <div
                 @class([
-                    'fi-fo-repeater-add',
-                    ($addActionAlignment instanceof Alignment) ? ('fi-align-' . $addActionAlignment->value) : $addActionAlignment,
+                'fi-fo-repeater-add',
+                ($addActionAlignment instanceof Alignment) ? ('fi-align-' . $addActionAlignment->value) : $addActionAlignment,
                 ])
             >
                 {{ $addAction }}

--- a/packages/forms/resources/views/components/repeater/simple.blade.php
+++ b/packages/forms/resources/views/components/repeater/simple.blade.php
@@ -1,37 +1,37 @@
 @php
     use Filament\Actions\Action;
-    use Filament\Support\Enums\Alignment;
-    use Illuminate\View\ComponentAttributeBag;
+        use Filament\Support\Enums\Alignment;
+        use Illuminate\View\ComponentAttributeBag;
 
-    $fieldWrapperView = $getFieldWrapperView();
+        $fieldWrapperView = $getFieldWrapperView();
 
-    $items = $getItems();
+        $items = $getItems();
 
-    $addAction = $getAction($getAddActionName());
-    $addActionAlignment = $getAddActionAlignment();
-    $cloneAction = $getAction($getCloneActionName());
-    $deleteAction = $getAction($getDeleteActionName());
-    $moveDownAction = $getAction($getMoveDownActionName());
-    $moveUpAction = $getAction($getMoveUpActionName());
-    $reorderAction = $getAction($getReorderActionName());
-    $extraItemActions = $getExtraItemActions();
+        $addAction = $getAction($getAddActionName());
+        $addActionAlignment = $getAddActionAlignment();
+        $cloneAction = $getAction($getCloneActionName());
+        $deleteAction = $getAction($getDeleteActionName());
+        $moveDownAction = $getAction($getMoveDownActionName());
+        $moveUpAction = $getAction($getMoveUpActionName());
+        $reorderAction = $getAction($getReorderActionName());
+        $extraItemActions = $getExtraItemActions();
 
-    $isAddable = $isAddable();
-    $isCloneable = $isCloneable();
-    $isDeletable = $isDeletable();
-    $isReorderableWithButtons = $isReorderableWithButtons();
-    $isReorderableWithDragAndDrop = $isReorderableWithDragAndDrop();
+        $isAddable = $isAddable();
+        $isCloneable = $isCloneable();
+        $isDeletable = $isDeletable();
+        $isReorderableWithButtons = $isReorderableWithButtons();
+        $isReorderableWithDragAndDrop = $isReorderableWithDragAndDrop();
 
-    $key = $getKey();
-    $statePath = $getStatePath();
+        $key = $getKey();
+        $statePath = $getStatePath();
 @endphp
 
 <x-dynamic-component :component="$fieldWrapperView" :field="$field">
     <div
         {{
             $attributes
-                ->merge($getExtraAttributes(), escape: false)
-                ->class(['fi-fo-simple-repeater'])
+            ->merge($getExtraAttributes(), escape: false)
+            ->class(['fi-fo-simple-repeater'])
         }}
     >
         @if (count($items))
@@ -39,29 +39,29 @@
                 x-sortable
                 {{
                     (new ComponentAttributeBag)
-                        ->grid($getGridColumns())
-                        ->merge([
-                            'data-sortable-animation-duration' => $getReorderAnimationDuration(),
-                            'x-on:end.stop' => '$wire.mountAction(\'reorder\', { items: $event.target.sortable.toArray() }, { schemaComponent: \'' . $key . '\' })',
-                        ], escape: false)
-                        ->class(['fi-fo-simple-repeater-items'])
+                    ->grid($getGridColumns())
+                    ->merge([
+                    'data-sortable-animation-duration' => $getReorderAnimationDuration(),
+                    'x-on:end.stop' => '$wire.mountAction(\'reorder\', { items: $event.target.sortable.toArray() }, { schemaComponent: \'' . $key . '\' })',
+                    ], escape: false)
+                    ->class(['fi-fo-simple-repeater-items'])
                 }}
             >
                 @foreach ($items as $itemKey => $item)
                     @php
                         $visibleExtraItemActions = array_filter(
-                            $extraItemActions,
-                            fn (Action $action): bool => $action(['item' => $itemKey])->isVisible(),
-                        );
-                        $cloneAction = $cloneAction(['item' => $itemKey]);
-                        $cloneActionIsVisible = $isCloneable && $cloneAction->isVisible();
-                        $deleteAction = $deleteAction(['item' => $itemKey]);
-                        $deleteActionIsVisible = $isDeletable && $deleteAction->isVisible();
-                        $moveDownAction = $moveDownAction(['item' => $itemKey])->disabled($loop->last);
-                        $moveDownActionIsVisible = $isReorderableWithButtons && $moveDownAction->isVisible();
-                        $moveUpAction = $moveUpAction(['item' => $itemKey])->disabled($loop->first);
-                        $moveUpActionIsVisible = $isReorderableWithButtons && $moveUpAction->isVisible();
-                        $reorderActionIsVisible = $isReorderableWithDragAndDrop && $reorderAction->isVisible();
+                                                    $extraItemActions,
+                                                    fn (Action $action): bool => $action(['item' => $itemKey])->isVisible(),
+                                                );
+                                                $cloneAction = $cloneAction(['item' => $itemKey]);
+                                                $cloneActionIsVisible = $isCloneable && $cloneAction->isVisible();
+                                                $deleteAction = $deleteAction(['item' => $itemKey]);
+                                                $deleteActionIsVisible = $isDeletable && $deleteAction->isVisible();
+                                                $moveDownAction = $moveDownAction(['item' => $itemKey])->disabled($loop->last);
+                                                $moveDownActionIsVisible = $isReorderableWithButtons && $moveDownAction->isVisible();
+                                                $moveUpAction = $moveUpAction(['item' => $itemKey])->disabled($loop->first);
+                                                $moveUpActionIsVisible = $isReorderableWithButtons && $moveUpAction->isVisible();
+                                                $reorderActionIsVisible = $isReorderableWithDragAndDrop && $reorderAction->isVisible();
                     @endphp
 
                     <li
@@ -118,8 +118,8 @@
         @if ($isAddable && $addAction->isVisible())
             <div
                 @class([
-                    'fi-fo-simple-repeater-add',
-                    ($addActionAlignment instanceof Alignment) ? ('fi-align-' . $addActionAlignment->value) : $addActionAlignment,
+                'fi-fo-simple-repeater-add',
+                ($addActionAlignment instanceof Alignment) ? ('fi-align-' . $addActionAlignment->value) : $addActionAlignment,
                 ])
             >
                 {{ $addAction }}

--- a/packages/forms/resources/views/components/repeater/table.blade.php
+++ b/packages/forms/resources/views/components/repeater/table.blade.php
@@ -1,47 +1,49 @@
 @php
     use Filament\Actions\Action;
-    use Filament\Actions\ActionGroup;
-    use Filament\Support\Enums\Alignment;
-    use Filament\Support\Enums\VerticalAlignment;
-    use Illuminate\Support\Js;
-    use Illuminate\View\ComponentAttributeBag;
+        use Filament\Actions\ActionGroup;
+        use Filament\Support\Enums\Alignment;
+        use Filament\Support\Enums\VerticalAlignment;
+        use Illuminate\Support\Js;
+        use Illuminate\View\ComponentAttributeBag;
 
-    $fieldWrapperView = $getFieldWrapperView();
+        $fieldWrapperView = $getFieldWrapperView();
 
-    $items = $getItems();
+        $items = $getItems();
 
-    $addAction = $getAction($getAddActionName());
-    $addActionAlignment = $getAddActionAlignment();
-    $addBetweenAction = $getAction($getAddBetweenActionName());
-    $cloneAction = $getAction($getCloneActionName());
-    $deleteAction = $getAction($getDeleteActionName());
-    $moveDownAction = $getAction($getMoveDownActionName());
-    $moveUpAction = $getAction($getMoveUpActionName());
-    $reorderAction = $getAction($getReorderActionName());
-    $extraItemActions = $getExtraItemActions();
+        $addAction = $getAction($getAddActionName());
+        $addActionAlignment = $getAddActionAlignment();
+        $addBetweenAction = $getAction($getAddBetweenActionName());
+        $cloneAction = $getAction($getCloneActionName());
+        $deleteAction = $getAction($getDeleteActionName());
+        $moveDownAction = $getAction($getMoveDownActionName());
+        $moveUpAction = $getAction($getMoveUpActionName());
+        $reorderAction = $getAction($getReorderActionName());
+        $extraItemActions = $getExtraItemActions();
 
-    $isAddable = $isAddable();
-    $isCloneable = $isCloneable();
-    $isDeletable = $isDeletable();
-    $isReorderableWithButtons = $isReorderableWithButtons();
-    $isReorderableWithDragAndDrop = $isReorderableWithDragAndDrop();
+        $isAddable = $isAddable();
+        $isCloneable = $isCloneable();
+        $isDeletable = $isDeletable();
+        $isReorderableWithButtons = $isReorderableWithButtons();
+        $isReorderableWithDragAndDrop = $isReorderableWithDragAndDrop();
 
-    $key = $getKey();
-    $statePath = $getStatePath();
+        $key = $getKey();
+        $statePath = $getStatePath();
 
-    $tableColumns = $getTableColumns();
+        $tableColumns = $getTableColumns();
 
-    $isCompact = $isCompact();
+        $isCompact = $isCompact();
 @endphp
 
 <x-dynamic-component :component="$fieldWrapperView" :field="$field">
     <div
-        {{ $attributes
-                ->merge($getExtraAttributes(), escape: false)
-                ->class([
-                    'fi-fo-table-repeater',
-                    'fi-compact' => $isCompact,
-                ]) }}
+        {{
+            $attributes
+            ->merge($getExtraAttributes(), escape: false)
+            ->class([
+            'fi-fo-table-repeater',
+            'fi-compact' => $isCompact,
+            ])
+        }}
     >
         @if (count($items))
             <table>
@@ -56,11 +58,11 @@
                         @foreach ($tableColumns as $column)
                             <th
                                 @class([
-                                    'fi-wrapped' => $column->canHeaderWrap(),
-                                    (($columnAlignment = $column->getAlignment()) instanceof Alignment) ? ('fi-align-' . $columnAlignment->value) : $columnAlignment,
+                                'fi-wrapped' => $column->canHeaderWrap(),
+                                (($columnAlignment = $column->getAlignment()) instanceof Alignment) ? ('fi-align-' . $columnAlignment->value) : $columnAlignment,
                                 ])
                                 @style([
-                                    ('width: ' . ($columnWidth = $column->getWidth())) => filled($columnWidth),
+                                ('width: ' . ($columnWidth = $column->getWidth())) => filled($columnWidth),
                                 ])
                             >
                                 @if (! $column->isHeaderLabelHidden())
@@ -84,28 +86,30 @@
 
                 <tbody
                     x-sortable
-                    {{ (new ComponentAttributeBag)
-                            ->merge([
-                                'data-sortable-animation-duration' => $getReorderAnimationDuration(),
-                                'x-on:end.stop' => '$wire.mountAction(\'reorder\', { items: $event.target.sortable.toArray() }, { schemaComponent: \'' . $key . '\' })',
-                            ], escape: false) }}
+                    {{
+                        (new ComponentAttributeBag)
+                        ->merge([
+                        'data-sortable-animation-duration' => $getReorderAnimationDuration(),
+                        'x-on:end.stop' => '$wire.mountAction(\'reorder\', { items: $event.target.sortable.toArray() }, { schemaComponent: \'' . $key . '\' })',
+                        ], escape: false)
+                    }}
                 >
                     @foreach ($items as $itemKey => $item)
                         @php
                             $visibleExtraItemActions = array_filter(
-                                $extraItemActions,
-                                fn (Action $action): bool => $action(['item' => $itemKey])->isVisible(),
-                            );
-                            $cloneAction = $cloneAction(['item' => $itemKey]);
-                            $cloneActionIsVisible = $isCloneable && $cloneAction->isVisible();
-                            $deleteAction = $deleteAction(['item' => $itemKey]);
-                            $deleteActionIsVisible = $isDeletable && $deleteAction->isVisible();
-                            $moveDownAction = $moveDownAction(['item' => $itemKey])->disabled($loop->last);
-                            $moveDownActionIsVisible = $isReorderableWithButtons && $moveDownAction->isVisible();
-                            $moveUpAction = $moveUpAction(['item' => $itemKey])->disabled($loop->first);
-                            $moveUpActionIsVisible = $isReorderableWithButtons && $moveUpAction->isVisible();
-                            $reorderActionIsVisible = $isReorderableWithDragAndDrop && $reorderAction->isVisible();
-                            $itemStatePath = $item->getStatePath();
+                                                            $extraItemActions,
+                                                            fn (Action $action): bool => $action(['item' => $itemKey])->isVisible(),
+                                                        );
+                                                        $cloneAction = $cloneAction(['item' => $itemKey]);
+                                                        $cloneActionIsVisible = $isCloneable && $cloneAction->isVisible();
+                                                        $deleteAction = $deleteAction(['item' => $itemKey]);
+                                                        $deleteActionIsVisible = $isDeletable && $deleteAction->isVisible();
+                                                        $moveDownAction = $moveDownAction(['item' => $itemKey])->disabled($loop->last);
+                                                        $moveDownActionIsVisible = $isReorderableWithButtons && $moveDownAction->isVisible();
+                                                        $moveUpAction = $moveUpAction(['item' => $itemKey])->disabled($loop->first);
+                                                        $moveUpActionIsVisible = $isReorderableWithButtons && $moveUpAction->isVisible();
+                                                        $reorderActionIsVisible = $isReorderableWithDragAndDrop && $reorderAction->isVisible();
+                                                        $itemStatePath = $item->getStatePath();
                         @endphp
 
                         <tr
@@ -145,9 +149,9 @@
                             @foreach ($item->getComponents(withHidden: true) as $schemaComponent)
                                 @php
                                     throw_unless(
-                                        $schemaComponent instanceof \Filament\Schemas\Components\Component,
-                                        new \Exception('Table repeaters must only contain schema components, but [' . $schemaComponent::class . '] was used.'),
-                                    );
+                                                                            $schemaComponent instanceof \Filament\Schemas\Components\Component,
+                                                                            new \Exception('Table repeaters must only contain schema components, but [' . $schemaComponent::class . '] was used.'),
+                                                                        );
                                 @endphp
 
                                 @if (count($tableColumns) > $counter)
@@ -161,12 +165,12 @@
                                         @if ($schemaComponent->isVisible())
                                             @php
                                                 $currentColumn = $tableColumns[$counter - 1] ?? null;
-                                                $columnVerticalAlignment = $currentColumn?->getVerticalAlignment();
+                                                                                                $columnVerticalAlignment = $currentColumn?->getVerticalAlignment();
                                             @endphp
 
                                             <td
                                                 @class([
-                                                    ($columnVerticalAlignment instanceof VerticalAlignment) ? ('fi-vertical-align-' . $columnVerticalAlignment->value) : (is_string($columnVerticalAlignment) ? $columnVerticalAlignment : ''),
+                                                ($columnVerticalAlignment instanceof VerticalAlignment) ? ('fi-vertical-align-' . $columnVerticalAlignment->value) : (is_string($columnVerticalAlignment) ? $columnVerticalAlignment : ''),
                                                 ])
                                             >
                                                 {!! $schemaComponent->toSchemaHtml() !!}
@@ -214,8 +218,8 @@
         @if ($isAddable && $addAction->isVisible())
             <div
                 @class([
-                    'fi-fo-table-repeater-add',
-                    ($addActionAlignment instanceof Alignment) ? ('fi-align-' . $addActionAlignment->value) : $addActionAlignment,
+                'fi-fo-table-repeater-add',
+                ($addActionAlignment instanceof Alignment) ? ('fi-align-' . $addActionAlignment->value) : $addActionAlignment,
                 ])
             >
                 {{ $addAction }}

--- a/packages/forms/resources/views/components/rich-editor.blade.php
+++ b/packages/forms/resources/views/components/rich-editor.blade.php
@@ -1,22 +1,22 @@
 @php
     $customBlocks = $getCustomBlocks();
-    $groupedCustomBlocks = $getGroupedCustomBlocks();
-    $extraAttributeBag = $getExtraAttributeBag();
-    $fieldWrapperView = $getFieldWrapperView();
-    $id = $getId();
-    $isDisabled = $isDisabled();
-    $label = $getLabel();
-    $livewireKey = $getLivewireKey();
-    $key = $getKey();
-    $mergeTags = $getMergeTags();
-    $statePath = $getStatePath();
-    $mentions = $getMentionsForJs();
-    $toolbarButtons = $getToolbarButtons();
-    $tools = $getTools();
-    $floatingToolbars = $getFloatingToolbars();
-    $linkProtocols = $getLinkProtocols();
-    $fileAttachmentsMaxSize = $getFileAttachmentsMaxSize();
-    $fileAttachmentsAcceptedFileTypes = $getFileAttachmentsAcceptedFileTypes();
+        $groupedCustomBlocks = $getGroupedCustomBlocks();
+        $extraAttributeBag = $getExtraAttributeBag();
+        $fieldWrapperView = $getFieldWrapperView();
+        $id = $getId();
+        $isDisabled = $isDisabled();
+        $label = $getLabel();
+        $livewireKey = $getLivewireKey();
+        $key = $getKey();
+        $mergeTags = $getMergeTags();
+        $statePath = $getStatePath();
+        $mentions = $getMentionsForJs();
+        $toolbarButtons = $getToolbarButtons();
+        $tools = $getTools();
+        $floatingToolbars = $getFloatingToolbars();
+        $linkProtocols = $getLinkProtocols();
+        $fileAttachmentsMaxSize = $getFileAttachmentsMaxSize();
+        $fileAttachmentsAcceptedFileTypes = $getFileAttachmentsAcceptedFileTypes();
 @endphp
 
 <x-dynamic-component :component="$fieldWrapperView" :field="$field">
@@ -26,7 +26,7 @@
         x-cloak
         :attributes="
             \Filament\Support\prepare_inherited_attributes($extraAttributeBag)
-                ->class(['fi-fo-rich-editor'])
+            ->class(['fi-fo-rich-editor'])
         "
     >
         <div
@@ -81,7 +81,7 @@
             wire:ignore
             wire:key="{{ $livewireKey }}.{{
                 substr(md5(serialize([
-                    $isDisabled,
+                $isDisabled,
                 ])), 0, 64)
             }}"
         >
@@ -211,7 +211,7 @@
                                             >
                                                 {{
                                                     \Filament\Support\generate_loading_indicator_html((new \Illuminate\View\ComponentAttributeBag([
-                                                        'x-show' => 'isLoading',
+                                                    'x-show' => 'isLoading',
                                                     ])))
                                                 }}
 

--- a/packages/forms/resources/views/components/select.blade.php
+++ b/packages/forms/resources/views/components/select.blade.php
@@ -1,33 +1,33 @@
 @php
     $fieldWrapperView = $getFieldWrapperView();
-    $extraInputAttributeBag = $getExtraInputAttributeBag();
-    $canSelectPlaceholder = $canSelectPlaceholder();
-    $isAutofocused = $isAutofocused();
-    $isDisabled = $isDisabled();
-    $isMultiple = $isMultiple();
-    $isReorderable = $isReorderable();
-    $isSearchable = $isSearchable();
-    $hasInitialNoOptionsMessage = $hasInitialNoOptionsMessage();
-    $canOptionLabelsWrap = $canOptionLabelsWrap();
-    $isRequired = $isRequired();
-    $isConcealed = $isConcealed();
-    $isHtmlAllowed = $isHtmlAllowed();
-    $isNative = (! ($isSearchable || $isMultiple || $isHtmlAllowed) && $isNative());
-    $isPrefixInline = $isPrefixInline();
-    $isSuffixInline = $isSuffixInline();
-    $key = $getKey();
-    $id = $getId();
-    $prefixActions = $getPrefixActions();
-    $prefixIcon = $getPrefixIcon();
-    $prefixIconColor = $getPrefixIconColor();
-    $prefixLabel = $getPrefixLabel();
-    $suffixActions = $getSuffixActions();
-    $suffixIcon = $getSuffixIcon();
-    $suffixIconColor = $getSuffixIconColor();
-    $suffixLabel = $getSuffixLabel();
-    $statePath = $getStatePath();
-    $state = $getRawState();
-    $livewireKey = $getLivewireKey();
+        $extraInputAttributeBag = $getExtraInputAttributeBag();
+        $canSelectPlaceholder = $canSelectPlaceholder();
+        $isAutofocused = $isAutofocused();
+        $isDisabled = $isDisabled();
+        $isMultiple = $isMultiple();
+        $isReorderable = $isReorderable();
+        $isSearchable = $isSearchable();
+        $hasInitialNoOptionsMessage = $hasInitialNoOptionsMessage();
+        $canOptionLabelsWrap = $canOptionLabelsWrap();
+        $isRequired = $isRequired();
+        $isConcealed = $isConcealed();
+        $isHtmlAllowed = $isHtmlAllowed();
+        $isNative = (! ($isSearchable || $isMultiple || $isHtmlAllowed) && $isNative());
+        $isPrefixInline = $isPrefixInline();
+        $isSuffixInline = $isSuffixInline();
+        $key = $getKey();
+        $id = $getId();
+        $prefixActions = $getPrefixActions();
+        $prefixIcon = $getPrefixIcon();
+        $prefixIconColor = $getPrefixIconColor();
+        $prefixLabel = $getPrefixLabel();
+        $suffixActions = $getSuffixActions();
+        $suffixIcon = $getSuffixIcon();
+        $suffixIconColor = $getSuffixIconColor();
+        $suffixLabel = $getSuffixLabel();
+        $statePath = $getStatePath();
+        $state = $getRawState();
+        $livewireKey = $getLivewireKey();
 @endphp
 
 <x-dynamic-component
@@ -51,28 +51,28 @@
         :x-on:focus-input.stop="$isNative ? '$el.querySelector(\'select\')?.focus()' : '$el.querySelector(\'.fi-select-input-btn\')?.focus()'"
         :attributes="
             \Filament\Support\prepare_inherited_attributes($getExtraAttributeBag())
-                ->class([
-                    'fi-fo-select',
-                    'fi-fo-select-has-inline-prefix' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
-                    'fi-fo-select-native' => $isNative,
-                ])
+            ->class([
+                'fi-fo-select',
+                'fi-fo-select-has-inline-prefix' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
+                'fi-fo-select-native' => $isNative,
+            ])
         "
     >
         @if ($isNative)
             <select
                 {{
                     $extraInputAttributeBag
-                        ->merge([
-                            'autofocus' => $isAutofocused,
-                            'disabled' => $isDisabled,
-                            'id' => $id,
-                            'required' => $isRequired && (! $isConcealed),
-                            $applyStateBindingModifiers('wire:model') => $statePath,
-                        ], escape: false)
-                        ->class([
-                            'fi-select-input',
-                            'fi-select-input-has-inline-prefix' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
-                        ])
+                    ->merge([
+                    'autofocus' => $isAutofocused,
+                    'disabled' => $isDisabled,
+                    'id' => $id,
+                    'required' => $isRequired && (! $isConcealed),
+                    $applyStateBindingModifiers('wire:model') => $statePath,
+                    ], escape: false)
+                    ->class([
+                    'fi-select-input',
+                    'fi-select-input-has-inline-prefix' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
+                    ])
                 }}
             >
                 @if ($canSelectPlaceholder)
@@ -188,16 +188,16 @@
                 wire:ignore
                 wire:key="{{ $livewireKey }}.{{
                     substr(md5(serialize([
-                        $isDisabled,
-                        $isReorderable,
+                    $isDisabled,
+                    $isReorderable,
                     ])), 0, 64)
                 }}"
                 x-on:keydown.esc="select.dropdown.isActive && $event.stopPropagation()"
                 x-on:set-select-property="$event.detail.isDisabled ? select.disable() : select.enable()"
                 {{
                     $attributes
-                        ->merge($getExtraAlpineAttributes(), escape: false)
-                        ->class(['fi-select-input'])
+                    ->merge($getExtraAlpineAttributes(), escape: false)
+                    ->class(['fi-select-input'])
                 }}
             >
                 <div x-ref="select"></div>

--- a/packages/forms/resources/views/components/slider.blade.php
+++ b/packages/forms/resources/views/components/slider.blade.php
@@ -1,9 +1,9 @@
 @php
     $fieldWrapperView = $getFieldWrapperView();
-    $isVertical = $isVertical();
-    $pipsMode = $getPipsMode();
-    $livewireKey = $getLivewireKey();
-    $isDisabled = $isDisabled();
+        $isVertical = $isVertical();
+        $pipsMode = $getPipsMode();
+        $livewireKey = $getLivewireKey();
+        $isDisabled = $isDisabled();
 @endphp
 
 <x-dynamic-component
@@ -40,22 +40,22 @@
         wire:ignore
         wire:key="{{ $livewireKey }}.{{
             substr(md5(serialize([
-                $isDisabled,
+            $isDisabled,
             ])), 0, 64)
         }}"
         {{
             $attributes
-                ->merge([
-                    'id' => $getId(),
-                ], escape: false)
-                ->merge($getExtraAttributes(), escape: false)
-                ->merge($getExtraAlpineAttributes(), escape: false)
-                ->class([
-                    'fi-fo-slider',
-                    'fi-fo-slider-has-pips' => $pipsMode,
-                    'fi-fo-slider-has-tooltips' => $hasTooltips(),
-                    'fi-fo-slider-vertical' => $isVertical,
-                ])
+            ->merge([
+            'id' => $getId(),
+            ], escape: false)
+            ->merge($getExtraAttributes(), escape: false)
+            ->merge($getExtraAlpineAttributes(), escape: false)
+            ->class([
+            'fi-fo-slider',
+            'fi-fo-slider-has-pips' => $pipsMode,
+            'fi-fo-slider-has-tooltips' => $hasTooltips(),
+            'fi-fo-slider-vertical' => $isVertical,
+            ])
         }}
     ></div>
 </x-dynamic-component>

--- a/packages/forms/resources/views/components/table-select.blade.php
+++ b/packages/forms/resources/views/components/table-select.blade.php
@@ -1,19 +1,19 @@
 @php
     use Filament\Forms\Components\TableSelect\Livewire\TableSelectLivewireComponent;
 
-    $fieldWrapperView = $getFieldWrapperView();
-    $extraAttributes = $getExtraAttributes();
-    $id = $getId();
+        $fieldWrapperView = $getFieldWrapperView();
+        $extraAttributes = $getExtraAttributes();
+        $id = $getId();
 @endphp
 
 <x-dynamic-component :component="$fieldWrapperView" :field="$field">
     <div
         {{
             $attributes
-                ->merge([
-                    'id' => $id,
-                ], escape: false)
-                ->merge($extraAttributes, escape: false)
+            ->merge([
+            'id' => $id,
+            ], escape: false)
+            ->merge($extraAttributes, escape: false)
         }}
     >
         @livewire(TableSelectLivewireComponent::class, [

--- a/packages/forms/resources/views/components/tags-input.blade.php
+++ b/packages/forms/resources/views/components/tags-input.blade.php
@@ -1,24 +1,24 @@
 @php
     $fieldWrapperView = $getFieldWrapperView();
-    $extraAttributes = $getExtraAttributes();
-    $extraInputAttributeBag = $getExtraInputAttributeBag();
-    $color = $getColor() ?? 'primary';
-    $id = $getId();
-    $isAutofocused = $isAutofocused();
-    $isDisabled = $isDisabled();
-    $isPrefixInline = $isPrefixInline();
-    $isReorderable = (! $isDisabled) && $isReorderable();
-    $isSuffixInline = $isSuffixInline();
-    $placeholder = $getPlaceholder();
-    $prefixActions = $getPrefixActions();
-    $prefixIcon = $getPrefixIcon();
-    $prefixIconColor = $getPrefixIconColor();
-    $prefixLabel = $getPrefixLabel();
-    $statePath = $getStatePath();
-    $suffixActions = $getSuffixActions();
-    $suffixIcon = $getSuffixIcon();
-    $suffixIconColor = $getSuffixIconColor();
-    $suffixLabel = $getSuffixLabel();
+        $extraAttributes = $getExtraAttributes();
+        $extraInputAttributeBag = $getExtraInputAttributeBag();
+        $color = $getColor() ?? 'primary';
+        $id = $getId();
+        $isAutofocused = $isAutofocused();
+        $isDisabled = $isDisabled();
+        $isPrefixInline = $isPrefixInline();
+        $isReorderable = (! $isDisabled) && $isReorderable();
+        $isSuffixInline = $isSuffixInline();
+        $placeholder = $getPlaceholder();
+        $prefixActions = $getPrefixActions();
+        $prefixIcon = $getPrefixIcon();
+        $prefixIconColor = $getPrefixIconColor();
+        $prefixLabel = $getPrefixLabel();
+        $statePath = $getStatePath();
+        $suffixActions = $getSuffixActions();
+        $suffixIcon = $getSuffixIcon();
+        $suffixIconColor = $getSuffixIconColor();
+        $suffixLabel = $getSuffixLabel();
 @endphp
 
 <x-dynamic-component
@@ -42,11 +42,11 @@
         x-on:focus-input.stop="$el.querySelector('input')?.focus()"
         :attributes="
             \Filament\Support\prepare_inherited_attributes($attributes)
-                ->merge($extraAttributes, escape: false)
-                ->class([
-                    'fi-fo-tags-input',
-                    'fi-disabled' => $isDisabled,
-                ])
+            ->merge($extraAttributes, escape: false)
+            ->class([
+                'fi-fo-tags-input',
+                'fi-disabled' => $isDisabled,
+            ])
         "
     >
         <div
@@ -61,21 +61,21 @@
             <input
                 {{
                     $extraInputAttributeBag
-                        ->merge([
-                            'autocomplete' => 'off',
-                            'autofocus' => $isAutofocused,
-                            'disabled' => $isDisabled,
-                            'id' => $id,
-                            'list' => $id . '-suggestions',
-                            'placeholder' => filled($placeholder) ? e($placeholder) : null,
-                            'type' => 'text',
-                            'x-bind' => 'input',
-                        ], escape: false)
-                        ->class([
-                            'fi-input',
-                            'fi-input-has-inline-prefix' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
-                            'fi-input-has-inline-suffix' => $isSuffixInline && (count($suffixActions) || $suffixIcon || filled($suffixLabel)),
-                        ])
+                    ->merge([
+                    'autocomplete' => 'off',
+                    'autofocus' => $isAutofocused,
+                    'disabled' => $isDisabled,
+                    'id' => $id,
+                    'list' => $id . '-suggestions',
+                    'placeholder' => filled($placeholder) ? e($placeholder) : null,
+                    'type' => 'text',
+                    'x-bind' => 'input',
+                    ], escape: false)
+                    ->class([
+                    'fi-input',
+                    'fi-input-has-inline-prefix' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
+                    'fi-input-has-inline-suffix' => $isSuffixInline && (count($suffixActions) || $suffixIcon || filled($suffixLabel)),
+                    ])
                 }}
             />
 
@@ -109,8 +109,8 @@
                                 :x-bind:x-sortable-item="$isReorderable ? 'index' : null"
                                 :x-sortable-handle="$isReorderable ? '' : null"
                                 @class([
-                                    'fi-reorderable' => $isReorderable,
-                                ])
+                                                                    'fi-reorderable' => $isReorderable,
+                                                                ])
                             >
                                 {{ $getTagPrefix() }}
 

--- a/packages/forms/resources/views/components/text-input.blade.php
+++ b/packages/forms/resources/views/components/text-input.blade.php
@@ -1,73 +1,73 @@
 @php
     use Filament\Forms\Components\TextInput\Actions\HidePasswordAction;
-    use Filament\Forms\Components\TextInput\Actions\ShowPasswordAction;
+        use Filament\Forms\Components\TextInput\Actions\ShowPasswordAction;
 
-    $fieldWrapperView = $getFieldWrapperView();
-    $datalistOptions = $getDatalistOptions();
-    $extraAlpineAttributes = $getExtraAlpineAttributes();
-    $extraAttributeBag = $getExtraAttributeBag();
-    $id = $getId();
-    $isConcealed = $isConcealed();
-    $isDisabled = $isDisabled();
-    $isPasswordRevealable = $isPasswordRevealable();
-    $isPrefixInline = $isPrefixInline();
-    $isSuffixInline = $isSuffixInline();
-    $mask = $getMask();
-    $prefixActions = $getPrefixActions();
-    $prefixIcon = $getPrefixIcon();
-    $prefixIconColor = $getPrefixIconColor();
-    $prefixLabel = $getPrefixLabel();
-    $suffixActions = $getSuffixActions();
-    $suffixIcon = $getSuffixIcon();
-    $suffixIconColor = $getSuffixIconColor();
-    $suffixLabel = $getSuffixLabel();
-    $statePath = $getStatePath();
-    $placeholder = $getPlaceholder();
+        $fieldWrapperView = $getFieldWrapperView();
+        $datalistOptions = $getDatalistOptions();
+        $extraAlpineAttributes = $getExtraAlpineAttributes();
+        $extraAttributeBag = $getExtraAttributeBag();
+        $id = $getId();
+        $isConcealed = $isConcealed();
+        $isDisabled = $isDisabled();
+        $isPasswordRevealable = $isPasswordRevealable();
+        $isPrefixInline = $isPrefixInline();
+        $isSuffixInline = $isSuffixInline();
+        $mask = $getMask();
+        $prefixActions = $getPrefixActions();
+        $prefixIcon = $getPrefixIcon();
+        $prefixIconColor = $getPrefixIconColor();
+        $prefixLabel = $getPrefixLabel();
+        $suffixActions = $getSuffixActions();
+        $suffixIcon = $getSuffixIcon();
+        $suffixIconColor = $getSuffixIconColor();
+        $suffixLabel = $getSuffixLabel();
+        $statePath = $getStatePath();
+        $placeholder = $getPlaceholder();
 
-    if ($isPasswordRevealable) {
-        $xData = '{ isPasswordRevealed: false }';
-    } elseif (count($extraAlpineAttributes) || filled($mask)) {
-        $xData = '{}';
-    } else {
-        $xData = null;
-    }
+        if ($isPasswordRevealable) {
+            $xData = '{ isPasswordRevealed: false }';
+        } elseif (count($extraAlpineAttributes) || filled($mask)) {
+            $xData = '{}';
+        } else {
+            $xData = null;
+        }
 
-    if ($isPasswordRevealable) {
-        $type = null;
-    } elseif (filled($mask)) {
-        $type = 'text';
-    } else {
-        $type = $getType();
-    }
+        if ($isPasswordRevealable) {
+            $type = null;
+        } elseif (filled($mask)) {
+            $type = 'text';
+        } else {
+            $type = $getType();
+        }
 
-    $inputAttributes = $getExtraInputAttributeBag()
-        ->merge($extraAlpineAttributes, escape: false)
-        ->merge([
-            'autocapitalize' => $getAutocapitalize(),
-            'autocomplete' => $getAutocomplete(),
-            'autofocus' => $isAutofocused(),
-            'disabled' => $isDisabled,
-            'id' => $id,
-            'inlinePrefix' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
-            'inlineSuffix' => $isSuffixInline && (count($suffixActions) || $suffixIcon || filled($suffixLabel)),
-            'inputmode' => $getInputMode(),
-            'list' => $datalistOptions ? $id . '-list' : null,
-            'max' => (! $isConcealed) ? $getMaxValue() : null,
-            'maxlength' => (! $isConcealed) ? $getMaxLength() : null,
-            'min' => (! $isConcealed) ? $getMinValue() : null,
-            'minlength' => (! $isConcealed) ? $getMinLength() : null,
-            'placeholder' => filled($placeholder) ? e($placeholder) : null,
-            'readonly' => $isReadOnly(),
-            'required' => $isRequired() && (! $isConcealed),
-            'step' => $getStep(),
-            'type' => $type,
-            $applyStateBindingModifiers('wire:model') => $statePath,
-            'x-bind:type' => $isPasswordRevealable ? 'isPasswordRevealed ? \'text\' : \'password\'' : null,
-            'x-mask' . ($mask instanceof \Filament\Support\RawJs ? ':dynamic' : '') => filled($mask) ? $mask : null,
-        ], escape: false)
-        ->class([
-            'fi-revealable' => $isPasswordRevealable,
-        ]);
+        $inputAttributes = $getExtraInputAttributeBag()
+            ->merge($extraAlpineAttributes, escape: false)
+            ->merge([
+                'autocapitalize' => $getAutocapitalize(),
+                'autocomplete' => $getAutocomplete(),
+                'autofocus' => $isAutofocused(),
+                'disabled' => $isDisabled,
+                'id' => $id,
+                'inlinePrefix' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
+                'inlineSuffix' => $isSuffixInline && (count($suffixActions) || $suffixIcon || filled($suffixLabel)),
+                'inputmode' => $getInputMode(),
+                'list' => $datalistOptions ? $id . '-list' : null,
+                'max' => (! $isConcealed) ? $getMaxValue() : null,
+                'maxlength' => (! $isConcealed) ? $getMaxLength() : null,
+                'min' => (! $isConcealed) ? $getMinValue() : null,
+                'minlength' => (! $isConcealed) ? $getMinLength() : null,
+                'placeholder' => filled($placeholder) ? e($placeholder) : null,
+                'readonly' => $isReadOnly(),
+                'required' => $isRequired() && (! $isConcealed),
+                'step' => $getStep(),
+                'type' => $type,
+                $applyStateBindingModifiers('wire:model') => $statePath,
+                'x-bind:type' => $isPasswordRevealable ? 'isPasswordRevealed ? \'text\' : \'password\'' : null,
+                'x-mask' . ($mask instanceof \Filament\Support\RawJs ? ':dynamic' : '') => filled($mask) ? $mask : null,
+            ], escape: false)
+            ->class([
+                'fi-revealable' => $isPasswordRevealable,
+            ]);
 @endphp
 
 <x-dynamic-component
@@ -92,15 +92,15 @@
         x-on:focus-input.stop="$el.querySelector('input')?.focus()"
         :attributes="
             \Filament\Support\prepare_inherited_attributes($extraAttributeBag)
-                ->class(['fi-fo-text-input'])
+            ->class(['fi-fo-text-input'])
         "
     >
         <input
             {{
                 $inputAttributes->class([
-                    'fi-input',
-                    'fi-input-has-inline-prefix' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
-                    'fi-input-has-inline-suffix' => $isSuffixInline && (count($suffixActions) || $suffixIcon || filled($suffixLabel)),
+                'fi-input',
+                'fi-input-has-inline-prefix' => $isPrefixInline && (count($prefixActions) || $prefixIcon || filled($prefixLabel)),
+                'fi-input-has-inline-suffix' => $isSuffixInline && (count($suffixActions) || $suffixIcon || filled($suffixLabel)),
                 ])
             }}
         />

--- a/packages/forms/resources/views/components/textarea.blade.php
+++ b/packages/forms/resources/views/components/textarea.blade.php
@@ -1,15 +1,15 @@
 @php
     $fieldWrapperView = $getFieldWrapperView();
-    $extraAttributeBag = $getExtraAttributeBag();
-    $isConcealed = $isConcealed();
-    $isDisabled = $isDisabled();
-    $rows = $getRows();
-    $placeholder = $getPlaceholder();
-    $shouldAutosize = $shouldAutosize();
-    $placeholder = $getPlaceholder();
-    $statePath = $getStatePath();
+        $extraAttributeBag = $getExtraAttributeBag();
+        $isConcealed = $isConcealed();
+        $isDisabled = $isDisabled();
+        $rows = $getRows();
+        $placeholder = $getPlaceholder();
+        $shouldAutosize = $shouldAutosize();
+        $placeholder = $getPlaceholder();
+        $statePath = $getStatePath();
 
-    $initialHeight = (($rows ?? 2) * 1.5) + 0.75;
+        $initialHeight = (($rows ?? 2) * 1.5) + 0.75;
 @endphp
 
 <x-dynamic-component
@@ -22,10 +22,10 @@
         :valid="! $errors->has($statePath)"
         :attributes="
             \Filament\Support\prepare_inherited_attributes($extraAttributeBag)
-                ->class([
-                    'fi-fo-textarea',
-                    'fi-autosizable' => $shouldAutosize,
-                ])
+            ->class([
+                'fi-fo-textarea',
+                'fi-autosizable' => $shouldAutosize,
+            ])
         "
     >
         <div wire:ignore.self style="height: '{{ $initialHeight . 'rem' }}'">
@@ -50,20 +50,20 @@
                 {{ $getExtraAlpineAttributeBag() }}
                 {{
                     $getExtraInputAttributeBag()
-                        ->merge([
-                            'autocomplete' => $getAutocomplete(),
-                            'autofocus' => $isAutofocused(),
-                            'cols' => $getCols(),
-                            'disabled' => $isDisabled,
-                            'id' => $getId(),
-                            'maxlength' => (! $isConcealed) ? $getMaxLength() : null,
-                            'minlength' => (! $isConcealed) ? $getMinLength() : null,
-                            'placeholder' => filled($placeholder) ? e($placeholder) : null,
-                            'readonly' => $isReadOnly(),
-                            'required' => $isRequired() && (! $isConcealed),
-                            'rows' => $rows,
-                            $applyStateBindingModifiers('wire:model') => $statePath,
-                        ], escape: false)
+                    ->merge([
+                    'autocomplete' => $getAutocomplete(),
+                    'autofocus' => $isAutofocused(),
+                    'cols' => $getCols(),
+                    'disabled' => $isDisabled,
+                    'id' => $getId(),
+                    'maxlength' => (! $isConcealed) ? $getMaxLength() : null,
+                    'minlength' => (! $isConcealed) ? $getMinLength() : null,
+                    'placeholder' => filled($placeholder) ? e($placeholder) : null,
+                    'readonly' => $isReadOnly(),
+                    'required' => $isRequired() && (! $isConcealed),
+                    'rows' => $rows,
+                    $applyStateBindingModifiers('wire:model') => $statePath,
+                    ], escape: false)
                 }}
             ></textarea>
         </div>

--- a/packages/forms/resources/views/components/toggle-buttons/grouped.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/grouped.blade.php
@@ -1,12 +1,12 @@
 @php
     $fieldWrapperView = $getFieldWrapperView();
-    $id = $getId();
-    $isDisabled = $isDisabled();
-    $isMultiple = $isMultiple();
-    $statePath = $getStatePath();
-    $areButtonLabelsHidden = $areButtonLabelsHidden();
-    $wireModelAttribute = $applyStateBindingModifiers('wire:model');
-    $extraInputAttributeBag = $getExtraInputAttributeBag()->class(['fi-fo-toggle-buttons-input']);
+        $id = $getId();
+        $isDisabled = $isDisabled();
+        $isMultiple = $isMultiple();
+        $statePath = $getStatePath();
+        $areButtonLabelsHidden = $areButtonLabelsHidden();
+        $wireModelAttribute = $applyStateBindingModifiers('wire:model');
+        $extraInputAttributeBag = $getExtraInputAttributeBag()->class(['fi-fo-toggle-buttons-input']);
 @endphp
 
 <x-dynamic-component
@@ -21,10 +21,10 @@
         @foreach ($getOptions() as $value => $label)
             @php
                 $inputId = "{$id}-{$value}";
-                $shouldOptionBeDisabled = $isDisabled || $isOptionDisabled($value, $label);
-                $color = $getColor($value);
-                $icon = $getIcon($value);
-                $tooltip = $getTooltip($value);
+                                $shouldOptionBeDisabled = $isDisabled || $isOptionDisabled($value, $label);
+                                $color = $getColor($value);
+                                $icon = $getIcon($value);
+                                $tooltip = $getTooltip($value);
             @endphp
 
             <input

--- a/packages/forms/resources/views/components/toggle-buttons/index.blade.php
+++ b/packages/forms/resources/views/components/toggle-buttons/index.blade.php
@@ -1,17 +1,17 @@
 @php
     use Filament\Support\Enums\GridDirection;
-    use Illuminate\View\ComponentAttributeBag;
+        use Illuminate\View\ComponentAttributeBag;
 
-    $fieldWrapperView = $getFieldWrapperView();
-    $gridDirection = $getGridDirection() ?? GridDirection::Column;
-    $id = $getId();
-    $isDisabled = $isDisabled();
-    $isInline = $isInline();
-    $isMultiple = $isMultiple();
-    $statePath = $getStatePath();
-    $areButtonLabelsHidden = $areButtonLabelsHidden();
-    $wireModelAttribute = $applyStateBindingModifiers('wire:model');
-    $extraInputAttributeBag = $getExtraInputAttributeBag()->class(['fi-fo-toggle-buttons-input']);
+        $fieldWrapperView = $getFieldWrapperView();
+        $gridDirection = $getGridDirection() ?? GridDirection::Column;
+        $id = $getId();
+        $isDisabled = $isDisabled();
+        $isInline = $isInline();
+        $isMultiple = $isMultiple();
+        $statePath = $getStatePath();
+        $areButtonLabelsHidden = $areButtonLabelsHidden();
+        $wireModelAttribute = $applyStateBindingModifiers('wire:model');
+        $extraInputAttributeBag = $getExtraInputAttributeBag()->class(['fi-fo-toggle-buttons-input']);
 @endphp
 
 <x-dynamic-component
@@ -23,20 +23,20 @@
     <div
         {{
             $getExtraAttributeBag()
-                ->when(! $isInline, fn (ComponentAttributeBag $attributes) => $attributes->grid($getColumns(), $gridDirection))
-                ->class([
-                    'fi-fo-toggle-buttons',
-                    'fi-inline' => $isInline,
-                ])
+            ->when(! $isInline, fn (ComponentAttributeBag $attributes) => $attributes->grid($getColumns(), $gridDirection))
+            ->class([
+            'fi-fo-toggle-buttons',
+            'fi-inline' => $isInline,
+            ])
         }}
     >
         @foreach ($getOptions() as $value => $label)
             @php
                 $inputId = "{$id}-{$value}";
-                $shouldOptionBeDisabled = $isDisabled || $isOptionDisabled($value, $label);
-                $color = $getColor($value);
-                $icon = $getIcon($value);
-                $tooltip = $getTooltip($value);
+                                $shouldOptionBeDisabled = $isDisabled || $isOptionDisabled($value, $label);
+                                $color = $getColor($value);
+                                $icon = $getIcon($value);
+                                $tooltip = $getTooltip($value);
             @endphp
 
             <div class="fi-fo-toggle-buttons-btn-ctn">

--- a/packages/forms/resources/views/components/toggle.blade.php
+++ b/packages/forms/resources/views/components/toggle.blade.php
@@ -1,26 +1,26 @@
 @php
     use Illuminate\View\ComponentAttributeBag;
 
-    $fieldWrapperView = $getFieldWrapperView();
-    $statePath = $getStatePath();
+        $fieldWrapperView = $getFieldWrapperView();
+        $statePath = $getStatePath();
 
-    $attributes = (new ComponentAttributeBag)
-        ->merge([
-            'aria-checked' => 'false',
-            'autofocus' => $isAutofocused(),
-            'disabled' => $isDisabled(),
-            'id' => $getId(),
-            'offColor' => $getOffColor() ?? 'gray',
-            'offIcon' => $getOffIcon(),
-            'onColor' => $getOnColor() ?? 'primary',
-            'onIcon' => $getOnIcon(),
-            'state' => '$wire.' . $applyStateBindingModifiers('$entangle(\'' . $statePath . '\')'),
-            'wire:loading.attr' => 'disabled',
-            'wire:target' => $statePath,
-        ], escape: false)
-        ->merge($getExtraAttributes(), escape: false)
-        ->merge($getExtraAlpineAttributes(), escape: false)
-        ->class(['fi-fo-toggle']);
+        $attributes = (new ComponentAttributeBag)
+            ->merge([
+                'aria-checked' => 'false',
+                'autofocus' => $isAutofocused(),
+                'disabled' => $isDisabled(),
+                'id' => $getId(),
+                'offColor' => $getOffColor() ?? 'gray',
+                'offIcon' => $getOffIcon(),
+                'onColor' => $getOnColor() ?? 'primary',
+                'onIcon' => $getOnIcon(),
+                'state' => '$wire.' . $applyStateBindingModifiers('$entangle(\'' . $statePath . '\')'),
+                'wire:loading.attr' => 'disabled',
+                'wire:target' => $statePath,
+            ], escape: false)
+            ->merge($getExtraAttributes(), escape: false)
+            ->merge($getExtraAlpineAttributes(), escape: false)
+            ->class(['fi-fo-toggle']);
 @endphp
 
 <x-dynamic-component

--- a/packages/infolists/resources/views/components/entry-wrapper.blade.php
+++ b/packages/infolists/resources/views/components/entry-wrapper.blade.php
@@ -1,43 +1,43 @@
 @props([
-    'alignment' => null,
-    'entry' => null,
-    'hasInlineLabel' => null,
-    'label' => null,
-    'labelSrOnly' => null,
+'alignment' => null,
+'entry' => null,
+'hasInlineLabel' => null,
+'label' => null,
+'labelSrOnly' => null,
 ])
 
 @php
     use Filament\Support\Enums\Alignment;
-    use Illuminate\View\ComponentAttributeBag;
+        use Illuminate\View\ComponentAttributeBag;
 
-    if ($entry) {
-        $action ??= $entry->getAction();
-        $alignment ??= $entry->getAlignment();
-        $hasInlineLabel ??= $entry->hasInlineLabel();
-        $label ??= $entry->getLabel();
-        $labelSrOnly ??= $entry->isLabelHidden();
-        $url ??= $entry->getUrl();
-        $shouldOpenUrlInNewTab ??= $entry->shouldOpenUrlInNewTab();
-    }
+        if ($entry) {
+            $action ??= $entry->getAction();
+            $alignment ??= $entry->getAlignment();
+            $hasInlineLabel ??= $entry->hasInlineLabel();
+            $label ??= $entry->getLabel();
+            $labelSrOnly ??= $entry->isLabelHidden();
+            $url ??= $entry->getUrl();
+            $shouldOpenUrlInNewTab ??= $entry->shouldOpenUrlInNewTab();
+        }
 
-    if (! $alignment instanceof Alignment) {
-        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
-    }
+        if (! $alignment instanceof Alignment) {
+            $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
+        }
 
-    $beforeLabelContainer = $entry?->getChildSchema($entry::BEFORE_LABEL_SCHEMA_KEY)?->toHtmlString();
-    $afterLabelContainer = $entry?->getChildSchema($entry::AFTER_LABEL_SCHEMA_KEY)?->toHtmlString();
-    $beforeContentContainer = $entry?->getChildSchema($entry::BEFORE_CONTENT_SCHEMA_KEY)?->toHtmlString();
-    $afterContentContainer = $entry?->getChildSchema($entry::AFTER_CONTENT_SCHEMA_KEY)?->toHtmlString();
+        $beforeLabelContainer = $entry?->getChildSchema($entry::BEFORE_LABEL_SCHEMA_KEY)?->toHtmlString();
+        $afterLabelContainer = $entry?->getChildSchema($entry::AFTER_LABEL_SCHEMA_KEY)?->toHtmlString();
+        $beforeContentContainer = $entry?->getChildSchema($entry::BEFORE_CONTENT_SCHEMA_KEY)?->toHtmlString();
+        $afterContentContainer = $entry?->getChildSchema($entry::AFTER_CONTENT_SCHEMA_KEY)?->toHtmlString();
 @endphp
 
 <div
     {{
         $attributes
-            ->merge($entry?->getExtraEntryWrapperAttributes() ?? [], escape: false)
-            ->class([
-                'fi-in-entry',
-                'fi-in-entry-has-inline-label' => $hasInlineLabel,
-            ])
+        ->merge($entry?->getExtraEntryWrapperAttributes() ?? [], escape: false)
+        ->class([
+        'fi-in-entry',
+        'fi-in-entry-has-inline-label' => $hasInlineLabel,
+        ])
     }}
 >
     @if ($label && $labelSrOnly)
@@ -52,8 +52,8 @@
         @if (($label && (! $labelSrOnly)) || $beforeLabelContainer || $afterLabelContainer)
             <div
                 @class([
-                    'fi-in-entry-label-ctn',
-                    ($label instanceof \Illuminate\View\ComponentSlot) ? $label->attributes->get('class') : null,
+                'fi-in-entry-label-ctn',
+                ($label instanceof \Illuminate\View\ComponentSlot) ? $label->attributes->get('class') : null,
                 ])
             >
                 {{ $beforeLabelContainer }}
@@ -62,11 +62,11 @@
                     <div
                         {{
                             (
-                                ($label instanceof \Illuminate\View\ComponentSlot)
-                                ? $label->attributes
-                                : (new ComponentAttributeBag)
+                            ($label instanceof \Illuminate\View\ComponentSlot)
+                            ? $label->attributes
+                            : (new ComponentAttributeBag)
                             )
-                                ->class(['fi-in-entry-label'])
+                            ->class(['fi-in-entry-label'])
                         }}
                         role="term"
                     >
@@ -91,8 +91,8 @@
                 <a
                     {{ \Filament\Support\generate_href_html($url, $shouldOpenUrlInNewTab) }}
                     @class([
-                        'fi-in-entry-content',
-                        (($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : '')),
+                    'fi-in-entry-content',
+                    (($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : '')),
                     ])
                 >
                     {{ $slot }}
@@ -108,8 +108,8 @@
                     wire:loading.attr="disabled"
                     wire:target="{{ $wireClickAction }}"
                     @class([
-                        'fi-in-entry-content',
-                        (($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : '')),
+                    'fi-in-entry-content',
+                    (($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : '')),
                     ])
                 >
                     {{ $slot }}
@@ -117,8 +117,8 @@
             @else
                 <div
                     @class([
-                        'fi-in-entry-content',
-                        (($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : '')),
+                    'fi-in-entry-content',
+                    (($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : '')),
                     ])
                 >
                     {{ $slot }}

--- a/packages/notifications/resources/views/database-notifications.blade.php
+++ b/packages/notifications/resources/views/database-notifications.blade.php
@@ -1,13 +1,13 @@
 @php
     use Filament\Support\Enums\Alignment;
-    use Filament\Support\View\Components\BadgeComponent;
-    use Illuminate\View\ComponentAttributeBag;
+        use Filament\Support\View\Components\BadgeComponent;
+        use Illuminate\View\ComponentAttributeBag;
 
-    $notifications = $this->getNotifications();
-    $unreadNotificationsCount = $this->getUnreadNotificationsCount();
-    $hasNotifications = $notifications->count();
-    $isPaginated = $notifications instanceof \Illuminate\Contracts\Pagination\Paginator && $notifications->hasPages();
-    $pollingInterval = $this->getPollingInterval();
+        $notifications = $this->getNotifications();
+        $unreadNotificationsCount = $this->getUnreadNotificationsCount();
+        $hasNotifications = $notifications->count();
+        $isPaginated = $notifications instanceof \Illuminate\Contracts\Pagination\Paginator && $notifications->hasPages();
+        $pollingInterval = $this->getPollingInterval();
 @endphp
 
 <div class="fi-no-database">
@@ -51,7 +51,7 @@
                             <span
                                 {{
                                     (new ComponentAttributeBag)->color(BadgeComponent::class, 'primary')->class([
-                                        'fi-badge fi-size-xs',
+                                    'fi-badge fi-size-xs',
                                     ])
                                 }}
                             >
@@ -75,8 +75,8 @@
             @foreach ($notifications as $notification)
                 <div
                     @class([
-                        'fi-no-notification-read-ctn' => ! $notification->unread(),
-                        'fi-no-notification-unread-ctn' => $notification->unread(),
+                    'fi-no-notification-read-ctn' => ! $notification->unread(),
+                    'fi-no-notification-unread-ctn' => $notification->unread(),
                     ])
                 >
                     {{ $this->getNotification($notification)->inline() }}

--- a/packages/notifications/resources/views/notifications.blade.php
+++ b/packages/notifications/resources/views/notifications.blade.php
@@ -1,14 +1,14 @@
 @php
     use Filament\Support\Enums\Alignment;
-    use Filament\Support\Enums\VerticalAlignment;
+        use Filament\Support\Enums\VerticalAlignment;
 @endphp
 
 <div>
     <div
         @class([
-            'fi-no',
-            'fi-align-' . static::$alignment->value,
-            'fi-vertical-align-' . static::$verticalAlignment->value,
+        'fi-no',
+        'fi-align-' . static::$alignment->value,
+        'fi-vertical-align-' . static::$verticalAlignment->value,
         ])
         role="status"
     >

--- a/packages/panels/resources/views/components/avatar/tenant.blade.php
+++ b/packages/panels/resources/views/components/avatar/tenant.blade.php
@@ -1,10 +1,10 @@
 @props([
-    'tenant' => filament()->getTenant(),
+'tenant' => filament()->getTenant(),
 ])
 
 @php
     $src = filament()->getTenantAvatarUrl($tenant);
-    $alt = __('filament-panels::layout.avatar.alt', ['name' => filament()->getTenantName($tenant)]);
+        $alt = __('filament-panels::layout.avatar.alt', ['name' => filament()->getTenantName($tenant)]);
 @endphp
 
 <x-filament::avatar
@@ -13,6 +13,6 @@
     :alt="$alt"
     :attributes="
         \Filament\Support\prepare_inherited_attributes($attributes)
-            ->class(['fi-tenant-avatar'])
+        ->class(['fi-tenant-avatar'])
     "
 />

--- a/packages/panels/resources/views/components/avatar/user.blade.php
+++ b/packages/panels/resources/views/components/avatar/user.blade.php
@@ -1,10 +1,10 @@
 @props([
-    'user' => filament()->auth()->user(),
+'user' => filament()->auth()->user(),
 ])
 
 @php
     $src = filament()->getUserAvatarUrl($user);
-    $alt = __('filament-panels::layout.avatar.alt', ['name' => filament()->getUserName($user)]);
+        $alt = __('filament-panels::layout.avatar.alt', ['name' => filament()->getUserName($user)]);
 @endphp
 
 <x-filament::avatar
@@ -12,6 +12,6 @@
     :alt="$alt"
     :attributes="
         \Filament\Support\prepare_inherited_attributes($attributes)
-            ->class(['fi-user-avatar'])
+        ->class(['fi-user-avatar'])
     "
 />

--- a/packages/panels/resources/views/components/header/index.blade.php
+++ b/packages/panels/resources/views/components/header/index.blade.php
@@ -1,16 +1,16 @@
 @props([
-    'actions' => [],
-    'actionsAlignment' => null,
-    'breadcrumbs' => [],
-    'heading' => null,
-    'subheading' => null,
+'actions' => [],
+'actionsAlignment' => null,
+'breadcrumbs' => [],
+'heading' => null,
+'subheading' => null,
 ])
 
 <header
     {{
         $attributes->class([
-            'fi-header',
-            'fi-header-has-breadcrumbs' => $breadcrumbs,
+        'fi-header',
+        'fi-header-has-breadcrumbs' => $breadcrumbs,
         ])
     }}
 >
@@ -38,7 +38,7 @@
 
     @php
         $beforeActions = \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_HEADER_ACTIONS_BEFORE, scopes: $this->getRenderHookScopes());
-        $afterActions = \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_HEADER_ACTIONS_AFTER, scopes: $this->getRenderHookScopes());
+                $afterActions = \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::PAGE_HEADER_ACTIONS_AFTER, scopes: $this->getRenderHookScopes());
     @endphp
 
     @if (filled($beforeActions) || $actions || filled($afterActions))

--- a/packages/panels/resources/views/components/header/simple.blade.php
+++ b/packages/panels/resources/views/components/header/simple.blade.php
@@ -1,7 +1,7 @@
 @props([
-    'heading' => null,
-    'logo' => true,
-    'subheading' => null,
+'heading' => null,
+'logo' => true,
+'subheading' => null,
 ])
 
 <header class="fi-simple-header">

--- a/packages/panels/resources/views/components/layout/base.blade.php
+++ b/packages/panels/resources/views/components/layout/base.blade.php
@@ -1,5 +1,5 @@
 @props([
-    'livewire' => null,
+'livewire' => null,
 ])
 
 @php
@@ -11,8 +11,8 @@
     lang="{{ str_replace('_', '-', app()->getLocale()) }}"
     dir="{{ __('filament-panels::layout.direction') ?? 'ltr' }}"
     @class([
-        'fi',
-        'dark' => filament()->hasDarkMode() && filament()->hasDarkModeForced(),
+    'fi',
+    'dark' => filament()->hasDarkMode() && filament()->hasDarkModeForced(),
     ])
 >
     <head>
@@ -28,7 +28,7 @@
 
         @php
             $title = trim(strip_tags($livewire?->getTitle() ?? ''));
-            $brandName = trim(strip_tags(filament()->getBrandName()));
+                        $brandName = trim(strip_tags(filament()->getBrandName()));
         @endphp
 
         <title>
@@ -127,11 +127,11 @@
     <body
         {{
             $attributes
-                ->merge($livewire?->getExtraBodyAttributes() ?? [], escape: false)
-                ->class([
-                    'fi-body',
-                    'fi-panel-' . filament()->getId(),
-                ])
+            ->merge($livewire?->getExtraBodyAttributes() ?? [], escape: false)
+            ->class([
+            'fi-body',
+            'fi-panel-' . filament()->getId(),
+            ])
         }}
     >
         {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::BODY_START, scopes: $renderHookScopes) }}

--- a/packages/panels/resources/views/components/layout/index.blade.php
+++ b/packages/panels/resources/views/components/layout/index.blade.php
@@ -1,30 +1,30 @@
 @php
     use Filament\Support\Enums\Width;
 
-    $livewire ??= null;
+        $livewire ??= null;
 
-    $hasTopbar = filament()->hasTopbar();
-    $isSidebarCollapsibleOnDesktop = filament()->isSidebarCollapsibleOnDesktop();
-    $isSidebarFullyCollapsibleOnDesktop = filament()->isSidebarFullyCollapsibleOnDesktop();
-    $hasTopNavigation = filament()->hasTopNavigation();
-    $hasNavigation = filament()->hasNavigation();
-    $renderHookScopes = $livewire?->getRenderHookScopes();
-    $maxContentWidth ??= (filament()->getMaxContentWidth() ?? Width::SevenExtraLarge);
+        $hasTopbar = filament()->hasTopbar();
+        $isSidebarCollapsibleOnDesktop = filament()->isSidebarCollapsibleOnDesktop();
+        $isSidebarFullyCollapsibleOnDesktop = filament()->isSidebarFullyCollapsibleOnDesktop();
+        $hasTopNavigation = filament()->hasTopNavigation();
+        $hasNavigation = filament()->hasNavigation();
+        $renderHookScopes = $livewire?->getRenderHookScopes();
+        $maxContentWidth ??= (filament()->getMaxContentWidth() ?? Width::SevenExtraLarge);
 
-    if (is_string($maxContentWidth)) {
-        $maxContentWidth = Width::tryFrom($maxContentWidth) ?? $maxContentWidth;
-    }
+        if (is_string($maxContentWidth)) {
+            $maxContentWidth = Width::tryFrom($maxContentWidth) ?? $maxContentWidth;
+        }
 @endphp
 
 <x-filament-panels::layout.base
     :livewire="$livewire"
     @class([
-        'fi-body-has-navigation' => $hasNavigation,
-        'fi-body-has-sidebar-collapsible-on-desktop' => $isSidebarCollapsibleOnDesktop,
-        'fi-body-has-sidebar-fully-collapsible-on-desktop' => $isSidebarFullyCollapsibleOnDesktop,
-        'fi-body-has-topbar' => $hasTopbar,
-        'fi-body-has-top-navigation' => $hasTopNavigation,
-    ])
+            'fi-body-has-navigation' => $hasNavigation,
+            'fi-body-has-sidebar-collapsible-on-desktop' => $isSidebarCollapsibleOnDesktop,
+            'fi-body-has-sidebar-fully-collapsible-on-desktop' => $isSidebarFullyCollapsibleOnDesktop,
+            'fi-body-has-topbar' => $hasTopbar,
+            'fi-body-has-top-navigation' => $hasTopNavigation,
+        ])
 >
     @if ($hasTopbar)
         {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::TOPBAR_BEFORE, scopes: $renderHookScopes) }}
@@ -39,8 +39,8 @@
                 x-bind:class="{ 'lg:fi-hidden': $store.sidebar.isOpen }"
             @endif
             @class([
-                'fi-layout-sidebar-toggle-btn-ctn',
-                'lg:fi-hidden' => ! $isSidebarFullyCollapsibleOnDesktop,
+            'fi-layout-sidebar-toggle-btn-ctn',
+            'lg:fi-hidden' => ! $isSidebarFullyCollapsibleOnDesktop,
             ])
         >
             <x-filament::icon-button
@@ -98,8 +98,8 @@
 
             <main
                 @class([
-                    'fi-main',
-                    ($maxContentWidth instanceof Width) ? "fi-width-{$maxContentWidth->value}" : $maxContentWidth,
+                'fi-main',
+                ($maxContentWidth instanceof Width) ? "fi-width-{$maxContentWidth->value}" : $maxContentWidth,
                 ])
             >
                 {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::CONTENT_START, scopes: $renderHookScopes) }}

--- a/packages/panels/resources/views/components/layout/simple.blade.php
+++ b/packages/panels/resources/views/components/layout/simple.blade.php
@@ -1,21 +1,21 @@
 @php
     use Filament\Support\Enums\Width;
 
-    $livewire ??= null;
+        $livewire ??= null;
 
-    $renderHookScopes = $livewire?->getRenderHookScopes();
-    $maxContentWidth ??= (filament()->getSimplePageMaxContentWidth() ?? Width::Large);
+        $renderHookScopes = $livewire?->getRenderHookScopes();
+        $maxContentWidth ??= (filament()->getSimplePageMaxContentWidth() ?? Width::Large);
 
-    if (is_string($maxContentWidth)) {
-        $maxContentWidth = Width::tryFrom($maxContentWidth) ?? $maxContentWidth;
-    }
+        if (is_string($maxContentWidth)) {
+            $maxContentWidth = Width::tryFrom($maxContentWidth) ?? $maxContentWidth;
+        }
 @endphp
 
 <x-filament-panels::layout.base :livewire="$livewire">
     @props([
-        'after' => null,
-        'heading' => null,
-        'subheading' => null,
+    'after' => null,
+    'heading' => null,
+    'subheading' => null,
     ])
 
     <div class="fi-simple-layout">
@@ -39,8 +39,8 @@
         <div class="fi-simple-main-ctn">
             <main
                 @class([
-                    'fi-simple-main',
-                    ($maxContentWidth instanceof Width) ? "fi-width-{$maxContentWidth->value}" : $maxContentWidth,
+                'fi-simple-main',
+                ($maxContentWidth instanceof Width) ? "fi-width-{$maxContentWidth->value}" : $maxContentWidth,
                 ])
             >
                 {{ $slot }}

--- a/packages/panels/resources/views/components/logo.blade.php
+++ b/packages/panels/resources/views/components/logo.blade.php
@@ -1,17 +1,17 @@
 @php
     $brandName = filament()->getBrandName();
-    $brandLogo = filament()->getBrandLogo();
-    $brandLogoHeight = filament()->getBrandLogoHeight() ?? '1.5rem';
-    $darkModeBrandLogo = filament()->getDarkModeBrandLogo();
-    $hasDarkModeBrandLogo = filled($darkModeBrandLogo);
+        $brandLogo = filament()->getBrandLogo();
+        $brandLogoHeight = filament()->getBrandLogoHeight() ?? '1.5rem';
+        $darkModeBrandLogo = filament()->getDarkModeBrandLogo();
+        $hasDarkModeBrandLogo = filled($darkModeBrandLogo);
 
-    $getLogoClasses = fn (bool $isDarkMode): string => \Illuminate\Support\Arr::toCssClasses([
-        'fi-logo',
-        'fi-logo-light' => $hasDarkModeBrandLogo && (! $isDarkMode),
-        'fi-logo-dark' => $isDarkMode,
-    ]);
+        $getLogoClasses = fn (bool $isDarkMode): string => \Illuminate\Support\Arr::toCssClasses([
+            'fi-logo',
+            'fi-logo-light' => $hasDarkModeBrandLogo && (! $isDarkMode),
+            'fi-logo-dark' => $isDarkMode,
+        ]);
 
-    $logoStyles = "height: {$brandLogoHeight}";
+        $logoStyles = "height: {$brandLogoHeight}";
 @endphp
 
 @capture($content, $logo, $isDarkMode = false)
@@ -19,8 +19,8 @@
         <div
             {{
                 $attributes
-                    ->class([$getLogoClasses($isDarkMode)])
-                    ->style([$logoStyles])
+                ->class([$getLogoClasses($isDarkMode)])
+                ->style([$logoStyles])
             }}
         >
             {{ $logo }}
@@ -31,15 +31,15 @@
             src="{{ $logo }}"
             {{
                 $attributes
-                    ->class([$getLogoClasses($isDarkMode)])
-                    ->style([$logoStyles])
+                ->class([$getLogoClasses($isDarkMode)])
+                ->style([$logoStyles])
             }}
         />
     @else
         <div
             {{
                 $attributes->class([
-                    $getLogoClasses($isDarkMode),
+                $getLogoClasses($isDarkMode),
                 ])
             }}
         >

--- a/packages/panels/resources/views/components/page/index.blade.php
+++ b/packages/panels/resources/views/components/page/index.blade.php
@@ -1,23 +1,23 @@
 @props([
-    'fullHeight' => false,
+'fullHeight' => false,
 ])
 
 @php
     use Filament\Pages\Enums\SubNavigationPosition;
 
-    $subNavigation = $this->getCachedSubNavigation();
-    $subNavigationPosition = $this->getSubNavigationPosition();
-    $widgetData = $this->getWidgetData();
+        $subNavigation = $this->getCachedSubNavigation();
+        $subNavigationPosition = $this->getSubNavigationPosition();
+        $widgetData = $this->getWidgetData();
 @endphp
 
 <div
     {{
         $attributes->class([
-            'fi-page',
-            'fi-height-full' => $fullHeight,
-            'fi-page-has-sub-navigation' => $subNavigation,
-            "fi-page-has-sub-navigation-{$subNavigationPosition->value}" => $subNavigation,
-            ...$this->getPageClasses(),
+        'fi-page',
+        'fi-height-full' => $fullHeight,
+        'fi-page-has-sub-navigation' => $subNavigation,
+        "fi-page-has-sub-navigation-{$subNavigationPosition->value}" => $subNavigation,
+        ...$this->getPageClasses(),
         ])
     }}
 >
@@ -47,10 +47,10 @@
         @else
             @php
                 $heading = $this->getHeading();
-                $headerActions = $this->getCachedHeaderActions();
-                $headerActionsAlignment = $this->getHeaderActionsAlignment();
-                $breadcrumbs = filament()->hasBreadcrumbs() ? $this->getBreadcrumbs() : [];
-                $subheading = $this->getSubheading();
+                                $headerActions = $this->getCachedHeaderActions();
+                                $headerActionsAlignment = $this->getHeaderActionsAlignment();
+                                $breadcrumbs = filament()->hasBreadcrumbs() ? $this->getBreadcrumbs() : [];
+                                $subheading = $this->getSubheading();
             @endphp
 
             @if (filled($headerActions) || $breadcrumbs || filled($heading) || filled($subheading))

--- a/packages/panels/resources/views/components/page/simple.blade.php
+++ b/packages/panels/resources/views/components/page/simple.blade.php
@@ -1,12 +1,12 @@
 @props([
-    'heading' => null,
-    'subheading' => null,
+'heading' => null,
+'subheading' => null,
 ])
 
 @php
     $heading ??= $this->getHeading();
-    $subheading ??= $this->getSubHeading();
-    $hasLogo = $this->hasLogo();
+        $subheading ??= $this->getSubHeading();
+        $hasLogo = $this->hasLogo();
 @endphp
 
 <div {{ $attributes->class(['fi-simple-page']) }}>

--- a/packages/panels/resources/views/components/page/sub-navigation/mobile-menu.blade.php
+++ b/packages/panels/resources/views/components/page/sub-navigation/mobile-menu.blade.php
@@ -1,5 +1,5 @@
 @props([
-    'navigation',
+'navigation',
 ])
 
 <x-filament::dropdown
@@ -7,24 +7,24 @@
     width="xs"
     :attributes="
         \Filament\Support\prepare_inherited_attributes($attributes)
-            ->class(['fi-page-sub-navigation-dropdown'])
+        ->class(['fi-page-sub-navigation-dropdown'])
     "
 >
     <x-slot name="trigger">
         @php
             $activeItem = null;
 
-            foreach ($navigation as $navigationGroup) {
-                foreach ($navigationGroup->getItems() as $navigationItem) {
-                    foreach ([$navigationItem, ...$navigationItem->getChildItems()] as $navigationItemChild) {
-                        if ($navigationItemChild->isActive()) {
-                            $activeItem = $navigationItemChild;
+                        foreach ($navigation as $navigationGroup) {
+                            foreach ($navigationGroup->getItems() as $navigationItem) {
+                                foreach ([$navigationItem, ...$navigationItem->getChildItems()] as $navigationItemChild) {
+                                    if ($navigationItemChild->isActive()) {
+                                        $activeItem = $navigationItemChild;
 
-                            break 3;
+                                        break 3;
+                                    }
+                                }
+                            }
                         }
-                    }
-                }
-            }
         @endphp
 
         <x-filament::button
@@ -49,11 +49,11 @@
                 @foreach ([$navigationItem, ...$navigationItem->getChildItems()] as $navigationItemChild)
                     @php
                         $navigationItemBadge = $navigationItem->getBadge();
-                        $navigationItemBadgeColor = $navigationItem->getBadgeColor($navigationItemBadge);
-                        $navigationItemIcon = $navigationItem->isActive() ? ($navigationItem->getActiveIcon() ?? $navigationItem->getIcon()) : $navigationItem->getIcon();
-                        $navigationItemUrl = $navigationItem->getUrl();
-                        $shouldNavigationItemOpenUrlInNewTab = $navigationItem->shouldOpenUrlInNewTab();
-                        $navigationItemExtraAttributes = $navigationItemChild->getExtraAttributeBag();
+                                                $navigationItemBadgeColor = $navigationItem->getBadgeColor($navigationItemBadge);
+                                                $navigationItemIcon = $navigationItem->isActive() ? ($navigationItem->getActiveIcon() ?? $navigationItem->getIcon()) : $navigationItem->getIcon();
+                                                $navigationItemUrl = $navigationItem->getUrl();
+                                                $shouldNavigationItemOpenUrlInNewTab = $navigationItem->shouldOpenUrlInNewTab();
+                                                $navigationItemExtraAttributes = $navigationItemChild->getExtraAttributeBag();
                     @endphp
 
                     <x-filament::dropdown.list.item

--- a/packages/panels/resources/views/components/page/sub-navigation/sidebar.blade.php
+++ b/packages/panels/resources/views/components/page/sub-navigation/sidebar.blade.php
@@ -1,5 +1,5 @@
 @props([
-    'navigation',
+'navigation',
 ])
 
 <div
@@ -11,11 +11,11 @@
         @foreach ($navigation as $navigationGroup)
             @php
                 $isNavigationGroupActive = $navigationGroup->isActive();
-                $isNavigationGroupCollapsible = $navigationGroup->isCollapsible();
-                $navigationGroupIcon = $navigationGroup->getIcon();
-                $navigationGroupItems = $navigationGroup->getItems();
-                $navigationGroupLabel = $navigationGroup->getLabel();
-                $navigationGroupExtraSidebarAttributeBag = $navigationGroup->getExtraSidebarAttributeBag();
+                                $isNavigationGroupCollapsible = $navigationGroup->isCollapsible();
+                                $navigationGroupIcon = $navigationGroup->getIcon();
+                                $navigationGroupItems = $navigationGroup->getItems();
+                                $navigationGroupLabel = $navigationGroup->getLabel();
+                                $navigationGroupExtraSidebarAttributeBag = $navigationGroup->getExtraSidebarAttributeBag();
             @endphp
 
             <x-filament-panels::sidebar.group

--- a/packages/panels/resources/views/components/page/sub-navigation/tabs.blade.php
+++ b/packages/panels/resources/views/components/page/sub-navigation/tabs.blade.php
@@ -1,5 +1,5 @@
 @props([
-    'navigation',
+'navigation',
 ])
 
 <x-filament::tabs
@@ -8,8 +8,8 @@
     @foreach ($navigation as $navigationGroup)
         @php
             $navigationGroupLabel = $navigationGroup->getLabel();
-            $isNavigationGroupActive = $navigationGroup->isActive();
-            $navigationGroupIcon = $navigationGroup->getIcon();
+                        $isNavigationGroupActive = $navigationGroup->isActive();
+                        $navigationGroupIcon = $navigationGroup->getIcon();
         @endphp
 
         @if ($navigationGroupLabel)
@@ -27,12 +27,12 @@
                     @foreach ($navigationGroup->getItems() as $navigationItem)
                         @php
                             $navigationItemBadge = $navigationItem->getBadge();
-                            $navigationItemBadgeColor = $navigationItem->getBadgeColor($navigationItemBadge);
-                            $navigationItemBadgeTooltip = $navigationItem->getBadgeTooltip($navigationItemBadge);
-                            $navigationItemIcon = $navigationItem->isActive() ? ($navigationItem->getActiveIcon() ?? $navigationItem->getIcon()) : $navigationItem->getIcon();
-                            $navigationItemUrl = $navigationItem->getUrl();
-                            $shouldNavigationItemOpenUrlInNewTab = $navigationItem->shouldOpenUrlInNewTab();
-                            $navigationItemExtraAttributes = $navigationItem->getExtraAttributeBag();
+                                                        $navigationItemBadgeColor = $navigationItem->getBadgeColor($navigationItemBadge);
+                                                        $navigationItemBadgeTooltip = $navigationItem->getBadgeTooltip($navigationItemBadge);
+                                                        $navigationItemIcon = $navigationItem->isActive() ? ($navigationItem->getActiveIcon() ?? $navigationItem->getIcon()) : $navigationItem->getIcon();
+                                                        $navigationItemUrl = $navigationItem->getUrl();
+                                                        $shouldNavigationItemOpenUrlInNewTab = $navigationItem->shouldOpenUrlInNewTab();
+                                                        $navigationItemExtraAttributes = $navigationItem->getExtraAttributeBag();
                         @endphp
 
                         <x-filament::dropdown.list.item
@@ -60,13 +60,13 @@
             @foreach ($navigationGroup->getItems() as $navigationItem)
                 @php
                     $isNavigationItemActive = $navigationItem->isActive();
-                    $navigationItemBadge = $navigationItem->getBadge();
-                    $navigationItemBadgeColor = $navigationItem->getBadgeColor($navigationItemBadge);
-                    $navigationItemBadgeTooltip = $navigationItem->getBadgeTooltip($navigationItemBadge);
-                    $navigationItemIcon = $navigationItem->isActive() ? ($navigationItem->getActiveIcon() ?? $navigationItem->getIcon()) : $navigationItem->getIcon();
-                    $navigationItemUrl = $navigationItem->getUrl();
-                    $shouldNavigationItemOpenUrlInNewTab = $navigationItem->shouldOpenUrlInNewTab();
-                    $navigationItemExtraAttributes = $navigationItem->getExtraAttributeBag();
+                                        $navigationItemBadge = $navigationItem->getBadge();
+                                        $navigationItemBadgeColor = $navigationItem->getBadgeColor($navigationItemBadge);
+                                        $navigationItemBadgeTooltip = $navigationItem->getBadgeTooltip($navigationItemBadge);
+                                        $navigationItemIcon = $navigationItem->isActive() ? ($navigationItem->getActiveIcon() ?? $navigationItem->getIcon()) : $navigationItem->getIcon();
+                                        $navigationItemUrl = $navigationItem->getUrl();
+                                        $shouldNavigationItemOpenUrlInNewTab = $navigationItem->shouldOpenUrlInNewTab();
+                                        $navigationItemExtraAttributes = $navigationItem->getExtraAttributeBag();
                 @endphp
 
                 <x-filament::tabs.item

--- a/packages/panels/resources/views/components/sidebar/group.blade.php
+++ b/packages/panels/resources/views/components/sidebar/group.blade.php
@@ -1,16 +1,16 @@
 @props([
-    'active' => false,
-    'collapsible' => true,
-    'icon' => null,
-    'items' => [],
-    'label' => null,
-    'sidebarCollapsible' => true,
-    'subNavigation' => false,
+'active' => false,
+'collapsible' => true,
+'icon' => null,
+'items' => [],
+'label' => null,
+'sidebarCollapsible' => true,
+'subNavigation' => false,
 ])
 
 @php
     $sidebarCollapsible = $sidebarCollapsible && filament()->isSidebarCollapsibleOnDesktop();
-    $hasDropdown = filled($label) && filled($icon) && $sidebarCollapsible;
+        $hasDropdown = filled($label) && filled($icon) && $sidebarCollapsible;
 @endphp
 
 <li
@@ -19,9 +19,9 @@
     x-bind:class="{ 'fi-collapsed': $store.sidebar.groupIsCollapsed(label) }"
     {{
         $attributes->class([
-            'fi-sidebar-group',
-            'fi-active' => $active,
-            'fi-collapsible' => $collapsible,
+        'fi-sidebar-group',
+        'fi-active' => $active,
+        'fi-collapsible' => $collapsible,
         ])
     }}
 >
@@ -87,29 +87,29 @@
             @php
                 $lists = [];
 
-                foreach ($items as $item) {
-                    if ($childItems = $item->getChildItems()) {
-                        $lists[] = [
-                            $item,
-                            ...$childItems,
-                        ];
-                        $lists[] = [];
+                                foreach ($items as $item) {
+                                    if ($childItems = $item->getChildItems()) {
+                                        $lists[] = [
+                                            $item,
+                                            ...$childItems,
+                                        ];
+                                        $lists[] = [];
 
-                        continue;
-                    }
+                                        continue;
+                                    }
 
-                    if (empty($lists)) {
-                        $lists[] = [$item];
+                                    if (empty($lists)) {
+                                        $lists[] = [$item];
 
-                        continue;
-                    }
+                                        continue;
+                                    }
 
-                    $lists[count($lists) - 1][] = $item;
-                }
+                                    $lists[count($lists) - 1][] = $item;
+                                }
 
-                if (empty($lists[count($lists) - 1])) {
-                    array_pop($lists);
-                }
+                                if (empty($lists[count($lists) - 1])) {
+                                    array_pop($lists);
+                                }
             @endphp
 
             @if (filled($label))
@@ -123,13 +123,13 @@
                     @foreach ($list as $item)
                         @php
                             $itemIsActive = $item->isActive();
-                            $itemBadge = $item->getBadge();
-                            $itemBadgeColor = $item->getBadgeColor($itemBadge);
-                            $itemBadgeTooltip = $item->getBadgeTooltip($itemBadge);
-                            $itemUrl = $item->getUrl();
-                            $itemIcon = $itemIsActive ? ($item->getActiveIcon() ?? $item->getIcon()) : $item->getIcon();
-                            $shouldItemOpenUrlInNewTab = $item->shouldOpenUrlInNewTab();
-                            $itemExtraAttributes = $item->getExtraAttributeBag();
+                                                        $itemBadge = $item->getBadge();
+                                                        $itemBadgeColor = $item->getBadgeColor($itemBadge);
+                                                        $itemBadgeTooltip = $item->getBadgeTooltip($itemBadge);
+                                                        $itemUrl = $item->getUrl();
+                                                        $itemIcon = $itemIsActive ? ($item->getActiveIcon() ?? $item->getIcon()) : $item->getIcon();
+                                                        $shouldItemOpenUrlInNewTab = $item->shouldOpenUrlInNewTab();
+                                                        $itemExtraAttributes = $item->getExtraAttributeBag();
                         @endphp
 
                         <x-filament::dropdown.list.item
@@ -170,25 +170,25 @@
         @foreach ($items as $item)
             @php
                 $isItemChildItemsActive = $item->isChildItemsActive();
-                $isItemActive = (! $isItemChildItemsActive) && $item->isActive();
-                $itemActiveIcon = $item->getActiveIcon();
-                $itemBadge = $item->getBadge();
-                $itemBadgeColor = $item->getBadgeColor($itemBadge);
-                $itemBadgeTooltip = $item->getBadgeTooltip($itemBadge);
-                $itemChildItems = $item->getChildItems();
-                $itemIcon = $item->getIcon();
-                $shouldItemOpenUrlInNewTab = $item->shouldOpenUrlInNewTab();
-                $itemUrl = $item->getUrl();
-                $itemExtraAttributes = $item->getExtraAttributeBag();
+                                $isItemActive = (! $isItemChildItemsActive) && $item->isActive();
+                                $itemActiveIcon = $item->getActiveIcon();
+                                $itemBadge = $item->getBadge();
+                                $itemBadgeColor = $item->getBadgeColor($itemBadge);
+                                $itemBadgeTooltip = $item->getBadgeTooltip($itemBadge);
+                                $itemChildItems = $item->getChildItems();
+                                $itemIcon = $item->getIcon();
+                                $shouldItemOpenUrlInNewTab = $item->shouldOpenUrlInNewTab();
+                                $itemUrl = $item->getUrl();
+                                $itemExtraAttributes = $item->getExtraAttributeBag();
 
-                if ($icon) {
-                    if ($hasDropdown || (blank($itemIcon) && blank($itemActiveIcon))) {
-                        $itemIcon = null;
-                        $itemActiveIcon = null;
-                    } else {
-                        throw new \Exception('Navigation group [' . $label . '] has an icon but one or more of its items also have icons. Either the group or its items can have icons, but not both. This is to ensure a proper user experience.');
-                    }
-                }
+                                if ($icon) {
+                                    if ($hasDropdown || (blank($itemIcon) && blank($itemActiveIcon))) {
+                                        $itemIcon = null;
+                                        $itemActiveIcon = null;
+                                    } else {
+                                        throw new \Exception('Navigation group [' . $label . '] has an icon but one or more of its items also have icons. Either the group or its items can have icons, but not both. This is to ensure a proper user experience.');
+                                    }
+                                }
             @endphp
 
             <x-filament-panels::sidebar.item

--- a/packages/panels/resources/views/components/sidebar/item.blade.php
+++ b/packages/panels/resources/views/components/sidebar/item.blade.php
@@ -1,20 +1,20 @@
 @props([
-    'active' => false,
-    'activeChildItems' => false,
-    'activeIcon' => null,
-    'badge' => null,
-    'badgeColor' => null,
-    'badgeTooltip' => null,
-    'childItems' => [],
-    'first' => false,
-    'grouped' => false,
-    'icon' => null,
-    'last' => false,
-    'shouldOpenUrlInNewTab' => false,
-    'sidebarCollapsible' => true,
-    'subGrouped' => false,
-    'subNavigation' => false,
-    'url',
+'active' => false,
+'activeChildItems' => false,
+'activeIcon' => null,
+'badge' => null,
+'badgeColor' => null,
+'badgeTooltip' => null,
+'childItems' => [],
+'first' => false,
+'grouped' => false,
+'icon' => null,
+'last' => false,
+'shouldOpenUrlInNewTab' => false,
+'sidebarCollapsible' => true,
+'subGrouped' => false,
+'subNavigation' => false,
+'url',
 ])
 
 @php
@@ -24,10 +24,10 @@
 <li
     {{
         $attributes->class([
-            'fi-sidebar-item',
-            'fi-active' => $active,
-            'fi-sidebar-item-has-active-child-items' => $activeChildItems,
-            'fi-sidebar-item-has-url' => filled($url),
+        'fi-sidebar-item',
+        'fi-active' => $active,
+        'fi-sidebar-item-has-active-child-items' => $activeChildItems,
+        'fi-sidebar-item-has-url' => filled($url),
         ])
     }}
 >
@@ -52,7 +52,7 @@
         @if (filled($icon) && ((! $subGrouped) || ($sidebarCollapsible && (! $subNavigation))))
             {{
                 \Filament\Support\generate_icon_html(($active && $activeIcon) ? $activeIcon : $icon, attributes: (new \Illuminate\View\ComponentAttributeBag([
-                    'x-show' => ($subGrouped && $sidebarCollapsible) ? '! $store.sidebar.isOpen' : false,
+                'x-show' => ($subGrouped && $sidebarCollapsible) ? '! $store.sidebar.isOpen' : false,
                 ]))->class(['fi-sidebar-item-icon']), size: \Filament\Support\Enums\IconSize::Large)
             }}
         @endif
@@ -117,15 +117,15 @@
             @foreach ($childItems as $childItem)
                 @php
                     $isChildItemChildItemsActive = $childItem->isChildItemsActive();
-                    $isChildActive = (! $isChildItemChildItemsActive) && $childItem->isActive();
-                    $childItemActiveIcon = $childItem->getActiveIcon();
-                    $childItemBadge = $childItem->getBadge();
-                    $childItemBadgeColor = $childItem->getBadgeColor($childItemBadge);
-                    $childItemBadgeTooltip = $childItem->getBadgeTooltip($childItemBadge);
-                    $childItemIcon = $childItem->getIcon();
-                    $shouldChildItemOpenUrlInNewTab = $childItem->shouldOpenUrlInNewTab();
-                    $childItemUrl = $childItem->getUrl();
-                    $childItemExtraAttributes = $childItem->getExtraAttributeBag();
+                                        $isChildActive = (! $isChildItemChildItemsActive) && $childItem->isActive();
+                                        $childItemActiveIcon = $childItem->getActiveIcon();
+                                        $childItemBadge = $childItem->getBadge();
+                                        $childItemBadgeColor = $childItem->getBadgeColor($childItemBadge);
+                                        $childItemBadgeTooltip = $childItem->getBadgeTooltip($childItemBadge);
+                                        $childItemIcon = $childItem->getIcon();
+                                        $shouldChildItemOpenUrlInNewTab = $childItem->shouldOpenUrlInNewTab();
+                                        $childItemUrl = $childItem->getUrl();
+                                        $childItemExtraAttributes = $childItem->getExtraAttributeBag();
                 @endphp
 
                 <x-filament-panels::sidebar.item

--- a/packages/panels/resources/views/components/tenant-menu.blade.php
+++ b/packages/panels/resources/views/components/tenant-menu.blade.php
@@ -1,30 +1,30 @@
 @props([
-    'teleport' => false,
+'teleport' => false,
 ])
 
 @php
     use Filament\Actions\Action;
-    use Illuminate\Support\Arr;
+        use Illuminate\Support\Arr;
 
-    $currentTenant = filament()->getTenant();
-    $currentTenantName = filament()->getTenantName($currentTenant);
+        $currentTenant = filament()->getTenant();
+        $currentTenantName = filament()->getTenantName($currentTenant);
 
-    $items = $this->getTenantMenuItems();
+        $items = $this->getTenantMenuItems();
 
-    $canSwitchTenants = filament()->hasTenantSwitcher() && filled($tenants = array_filter(
-        filament()->getUserTenants(filament()->auth()->user()),
-        fn (\Illuminate\Database\Eloquent\Model $tenant): bool => ! $tenant->is($currentTenant),
-    ));
+        $canSwitchTenants = filament()->hasTenantSwitcher() && filled($tenants = array_filter(
+            filament()->getUserTenants(filament()->auth()->user()),
+            fn (\Illuminate\Database\Eloquent\Model $tenant): bool => ! $tenant->is($currentTenant),
+        ));
 
-    $isSearchable = $canSwitchTenants && (filament()->isTenantMenuSearchable() ?? (count($tenants) >= 10));
+        $isSearchable = $canSwitchTenants && (filament()->isTenantMenuSearchable() ?? (count($tenants) >= 10));
 
-    $itemsBeforeAndAfterTenantSwitcher = collect($items)
-        ->groupBy(fn (Action $item): bool => $canSwitchTenants && ($item->getSort() < 0), preserveKeys: true)
-        ->all();
-    $itemsBeforeTenantSwitcher = $itemsBeforeAndAfterTenantSwitcher[true] ?? collect();
-    $itemsAfterTenantSwitcher = $itemsBeforeAndAfterTenantSwitcher[false] ?? collect();
+        $itemsBeforeAndAfterTenantSwitcher = collect($items)
+            ->groupBy(fn (Action $item): bool => $canSwitchTenants && ($item->getSort() < 0), preserveKeys: true)
+            ->all();
+        $itemsBeforeTenantSwitcher = $itemsBeforeAndAfterTenantSwitcher[true] ?? collect();
+        $itemsAfterTenantSwitcher = $itemsBeforeAndAfterTenantSwitcher[false] ?? collect();
 
-    $isSidebarCollapsibleOnDesktop = filament()->isSidebarCollapsibleOnDesktop();
+        $isSidebarCollapsibleOnDesktop = filament()->isSidebarCollapsibleOnDesktop();
 @endphp
 
 {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::TENANT_MENU_BEFORE) }}
@@ -35,7 +35,7 @@
     :teleport="$teleport"
     :attributes="
         \Filament\Support\prepare_inherited_attributes($attributes)
-            ->class(['fi-tenant-menu'])
+        ->class(['fi-tenant-menu'])
     "
 >
     <x-slot name="trigger">
@@ -80,7 +80,7 @@
 
             {{
                 \Filament\Support\generate_icon_html(\Filament\Support\Icons\Heroicon::ChevronDown, alias: \Filament\View\PanelsIconAlias::TENANT_MENU_TOGGLE_BUTTON, attributes: new \Illuminate\View\ComponentAttributeBag([
-                    'x-show' => $isSidebarCollapsibleOnDesktop ? '$store.sidebar.isOpen' : null,
+                'x-show' => $isSidebarCollapsibleOnDesktop ? '$store.sidebar.isOpen' : null,
                 ]))
             }}
         </button>
@@ -115,8 +115,8 @@
                 @foreach ($tenants as $tenant)
                     @php
                         $tenantImage = filament()->getTenantAvatarUrl($tenant);
-                        $tenantName = filament()->getTenantName($tenant);
-                        $tenantUrl = filament()->getUrl($tenant);
+                                                $tenantName = filament()->getTenantName($tenant);
+                                                $tenantUrl = filament()->getUrl($tenant);
                     @endphp
 
                     <div

--- a/packages/panels/resources/views/components/theme-switcher/button.blade.php
+++ b/packages/panels/resources/views/components/theme-switcher/button.blade.php
@@ -1,6 +1,6 @@
 @props([
-    'icon',
-    'theme',
+'icon',
+'theme',
 ])
 
 @php
@@ -20,9 +20,9 @@
 >
     {{
         \Filament\Support\generate_icon_html($icon, alias: match ($theme) {
-            'light' => \Filament\View\PanelsIconAlias::THEME_SWITCHER_LIGHT_BUTTON,
-            'dark' => \Filament\View\PanelsIconAlias::THEME_SWITCHER_DARK_BUTTON,
-            'system' => \Filament\View\PanelsIconAlias::THEME_SWITCHER_SYSTEM_BUTTON,
+        'light' => \Filament\View\PanelsIconAlias::THEME_SWITCHER_LIGHT_BUTTON,
+        'dark' => \Filament\View\PanelsIconAlias::THEME_SWITCHER_DARK_BUTTON,
+        'system' => \Filament\View\PanelsIconAlias::THEME_SWITCHER_SYSTEM_BUTTON,
         })
     }}
 </button>

--- a/packages/panels/resources/views/components/topbar/item.blade.php
+++ b/packages/panels/resources/views/components/topbar/item.blade.php
@@ -1,12 +1,12 @@
 @props([
-    'active' => false,
-    'activeIcon' => null,
-    'badge' => null,
-    'badgeColor' => null,
-    'badgeTooltip' => null,
-    'icon' => null,
-    'shouldOpenUrlInNewTab' => false,
-    'url' => null,
+'active' => false,
+'activeIcon' => null,
+'badge' => null,
+'badgeColor' => null,
+'badgeTooltip' => null,
+'icon' => null,
+'shouldOpenUrlInNewTab' => false,
+'url' => null,
 ])
 
 @php
@@ -16,8 +16,8 @@
 <li
     {{
         $attributes->class([
-            'fi-topbar-item',
-            'fi-active' => $active,
+        'fi-topbar-item',
+        'fi-active' => $active,
         ])
     }}
 >

--- a/packages/panels/resources/views/components/user-menu.blade.php
+++ b/packages/panels/resources/views/components/user-menu.blade.php
@@ -1,33 +1,33 @@
 @props([
-    'position' => null,
+'position' => null,
 ])
 
 @php
     use Filament\Actions\Action;
-    use Filament\Enums\UserMenuPosition;
-    use Illuminate\Support\Arr;
+        use Filament\Enums\UserMenuPosition;
+        use Illuminate\Support\Arr;
 
-    $user = filament()->auth()->user();
+        $user = filament()->auth()->user();
 
-    $items = $this->getUserMenuItems();
+        $items = $this->getUserMenuItems();
 
-    $itemsBeforeAndAfterThemeSwitcher = collect($items)
-        ->groupBy(fn (Action $item): bool => $item->getSort() < 0, preserveKeys: true)
-        ->all();
-    $itemsBeforeThemeSwitcher = $itemsBeforeAndAfterThemeSwitcher[true] ?? collect();
-    $itemsAfterThemeSwitcher = $itemsBeforeAndAfterThemeSwitcher[false] ?? collect();
+        $itemsBeforeAndAfterThemeSwitcher = collect($items)
+            ->groupBy(fn (Action $item): bool => $item->getSort() < 0, preserveKeys: true)
+            ->all();
+        $itemsBeforeThemeSwitcher = $itemsBeforeAndAfterThemeSwitcher[true] ?? collect();
+        $itemsAfterThemeSwitcher = $itemsBeforeAndAfterThemeSwitcher[false] ?? collect();
 
-    $hasProfileHeader = $itemsBeforeThemeSwitcher->has('profile') &&
-        blank(($item = Arr::first($itemsBeforeThemeSwitcher))->getUrl()) &&
-        (! $item->hasAction());
+        $hasProfileHeader = $itemsBeforeThemeSwitcher->has('profile') &&
+            blank(($item = Arr::first($itemsBeforeThemeSwitcher))->getUrl()) &&
+            (! $item->hasAction());
 
-    if ($itemsBeforeThemeSwitcher->has('profile')) {
-        $itemsBeforeThemeSwitcher = $itemsBeforeThemeSwitcher->prepend($itemsBeforeThemeSwitcher->pull('profile'), 'profile');
-    }
+        if ($itemsBeforeThemeSwitcher->has('profile')) {
+            $itemsBeforeThemeSwitcher = $itemsBeforeThemeSwitcher->prepend($itemsBeforeThemeSwitcher->pull('profile'), 'profile');
+        }
 
-    $position ??= filament()->getUserMenuPosition();
+        $position ??= filament()->getUserMenuPosition();
 
-    $isSidebarCollapsibleOnDesktop = filament()->isSidebarCollapsibleOnDesktop();
+        $isSidebarCollapsibleOnDesktop = filament()->isSidebarCollapsibleOnDesktop();
 @endphp
 
 {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::USER_MENU_BEFORE) }}
@@ -37,7 +37,7 @@
     :teleport="$position === UserMenuPosition::Topbar"
     :attributes="
         \Filament\Support\prepare_inherited_attributes($attributes)
-            ->class(['fi-user-menu'])
+        ->class(['fi-user-menu'])
     "
 >
     <x-slot name="trigger">
@@ -68,7 +68,7 @@
 
                 {{
                     \Filament\Support\generate_icon_html(\Filament\Support\Icons\Heroicon::ChevronUp, alias: \Filament\View\PanelsIconAlias::USER_MENU_TOGGLE_BUTTON, attributes: new \Illuminate\View\ComponentAttributeBag([
-                        'x-show' => $isSidebarCollapsibleOnDesktop ? '$store.sidebar.isOpen' : null,
+                    'x-show' => $isSidebarCollapsibleOnDesktop ? '$store.sidebar.isOpen' : null,
                     ]))
                 }}
             </button>
@@ -78,10 +78,10 @@
     @if ($hasProfileHeader)
         @php
             $item = $itemsBeforeThemeSwitcher['profile'];
-            $itemColor = $item->getColor();
-            $itemIcon = $item->getIcon();
+                        $itemColor = $item->getColor();
+                        $itemIcon = $item->getIcon();
 
-            unset($itemsBeforeThemeSwitcher['profile']);
+                        unset($itemsBeforeThemeSwitcher['profile']);
         @endphp
 
         {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::USER_MENU_PROFILE_BEFORE) }}

--- a/packages/panels/resources/views/livewire/global-search.blade.php
+++ b/packages/panels/resources/views/livewire/global-search.blade.php
@@ -1,7 +1,7 @@
 @php
     $debounce = filament()->getGlobalSearchDebounce();
-    $keyBindings = filament()->getGlobalSearchKeyBindings();
-    $suffix = filament()->getGlobalSearchFieldSuffix();
+        $keyBindings = filament()->getGlobalSearchKeyBindings();
+        $suffix = filament()->getGlobalSearchFieldSuffix();
 @endphp
 
 <div class="fi-global-search-ctn">
@@ -87,8 +87,8 @@
 
                                         <li
                                             @class([
-                                                'fi-global-search-result',
-                                                'fi-global-search-result-has-actions' => $resultVisibleActions,
+                                            'fi-global-search-result',
+                                            'fi-global-search-result-has-actions' => $resultVisibleActions,
                                             ])
                                         >
                                             <a

--- a/packages/panels/resources/views/livewire/sidebar.blade.php
+++ b/packages/panels/resources/views/livewire/sidebar.blade.php
@@ -1,11 +1,11 @@
 <div>
     @php
         $navigation = filament()->getNavigation();
-        $isRtl = __('filament-panels::layout.direction') === 'rtl';
-        $isSidebarCollapsibleOnDesktop = filament()->isSidebarCollapsibleOnDesktop();
-        $isSidebarFullyCollapsibleOnDesktop = filament()->isSidebarFullyCollapsibleOnDesktop();
-        $hasNavigation = filament()->hasNavigation();
-        $hasTopbar = filament()->hasTopbar();
+                $isRtl = __('filament-panels::layout.direction') === 'rtl';
+                $isSidebarCollapsibleOnDesktop = filament()->isSidebarCollapsibleOnDesktop();
+                $isSidebarFullyCollapsibleOnDesktop = filament()->isSidebarFullyCollapsibleOnDesktop();
+                $hasNavigation = filament()->hasNavigation();
+                $hasTopbar = filament()->hasTopbar();
     @endphp
 
     {{-- format-ignore-start --}}

--- a/packages/panels/resources/views/livewire/topbar.blade.php
+++ b/packages/panels/resources/views/livewire/topbar.blade.php
@@ -1,11 +1,11 @@
 <div class="fi-topbar-ctn">
     @php
         $isRtl = __('filament-panels::layout.direction') === 'rtl';
-        $isSidebarCollapsibleOnDesktop = filament()->isSidebarCollapsibleOnDesktop();
-        $isSidebarFullyCollapsibleOnDesktop = filament()->isSidebarFullyCollapsibleOnDesktop();
-        $hasTopNavigation = filament()->hasTopNavigation();
-        $hasNavigation = filament()->hasNavigation();
-        $hasTenancy = filament()->hasTenancy();
+                $isSidebarCollapsibleOnDesktop = filament()->isSidebarCollapsibleOnDesktop();
+                $isSidebarFullyCollapsibleOnDesktop = filament()->isSidebarFullyCollapsibleOnDesktop();
+                $hasTopNavigation = filament()->hasTopNavigation();
+                $hasNavigation = filament()->hasNavigation();
+                $hasTenancy = filament()->hasTenancy();
     @endphp
 
     <nav class="fi-topbar">
@@ -120,9 +120,9 @@
                     @foreach ($navigation as $group)
                         @php
                             $groupLabel = $group->getLabel();
-                            $groupExtraTopbarAttributeBag = $group->getExtraTopbarAttributeBag();
-                            $isGroupActive = $group->isActive();
-                            $groupIcon = $group->getIcon();
+                                                        $groupExtraTopbarAttributeBag = $group->getExtraTopbarAttributeBag();
+                                                        $isGroupActive = $group->isActive();
+                                                        $groupIcon = $group->getIcon();
                         @endphp
 
                         @if ($groupLabel)
@@ -143,29 +143,29 @@
                                 @php
                                     $lists = [];
 
-                                    foreach ($group->getItems() as $item) {
-                                        if ($childItems = $item->getChildItems()) {
-                                            $lists[] = [
-                                                $item,
-                                                ...$childItems,
-                                            ];
-                                            $lists[] = [];
+                                                                        foreach ($group->getItems() as $item) {
+                                                                            if ($childItems = $item->getChildItems()) {
+                                                                                $lists[] = [
+                                                                                    $item,
+                                                                                    ...$childItems,
+                                                                                ];
+                                                                                $lists[] = [];
 
-                                            continue;
-                                        }
+                                                                                continue;
+                                                                            }
 
-                                        if (empty($lists)) {
-                                            $lists[] = [$item];
+                                                                            if (empty($lists)) {
+                                                                                $lists[] = [$item];
 
-                                            continue;
-                                        }
+                                                                                continue;
+                                                                            }
 
-                                        $lists[count($lists) - 1][] = $item;
-                                    }
+                                                                            $lists[count($lists) - 1][] = $item;
+                                                                        }
 
-                                    if (empty($lists[count($lists) - 1])) {
-                                        array_pop($lists);
-                                    }
+                                                                        if (empty($lists[count($lists) - 1])) {
+                                                                            array_pop($lists);
+                                                                        }
                                 @endphp
 
                                 @foreach ($lists as $list)
@@ -173,13 +173,13 @@
                                         @foreach ($list as $item)
                                             @php
                                                 $isItemActive = $item->isActive();
-                                                $itemBadge = $item->getBadge();
-                                                $itemBadgeColor = $item->getBadgeColor($itemBadge);
-                                                $itemBadgeTooltip = $item->getBadgeTooltip($itemBadge);
-                                                $itemUrl = $item->getUrl();
-                                                $itemIcon = $isItemActive ? ($item->getActiveIcon() ?? $item->getIcon()) : $item->getIcon();
-                                                $shouldItemOpenUrlInNewTab = $item->shouldOpenUrlInNewTab();
-                                                $itemExtraAttributes = $item->getExtraAttributeBag();
+                                                                                                $itemBadge = $item->getBadge();
+                                                                                                $itemBadgeColor = $item->getBadgeColor($itemBadge);
+                                                                                                $itemBadgeTooltip = $item->getBadgeTooltip($itemBadge);
+                                                                                                $itemUrl = $item->getUrl();
+                                                                                                $itemIcon = $isItemActive ? ($item->getActiveIcon() ?? $item->getIcon()) : $item->getIcon();
+                                                                                                $shouldItemOpenUrlInNewTab = $item->shouldOpenUrlInNewTab();
+                                                                                                $itemExtraAttributes = $item->getExtraAttributeBag();
                                             @endphp
 
                                             <x-filament::dropdown.list.item
@@ -203,14 +203,14 @@
                             @foreach ($group->getItems() as $item)
                                 @php
                                     $isItemActive = $item->isActive();
-                                    $itemActiveIcon = $item->getActiveIcon();
-                                    $itemBadge = $item->getBadge();
-                                    $itemBadgeColor = $item->getBadgeColor($itemBadge);
-                                    $itemBadgeTooltip = $item->getBadgeTooltip($itemBadge);
-                                    $itemIcon = $item->getIcon();
-                                    $shouldItemOpenUrlInNewTab = $item->shouldOpenUrlInNewTab();
-                                    $itemUrl = $item->getUrl();
-                                    $itemExtraAttributes = $item->getExtraAttributeBag();
+                                                                        $itemActiveIcon = $item->getActiveIcon();
+                                                                        $itemBadge = $item->getBadge();
+                                                                        $itemBadgeColor = $item->getBadgeColor($itemBadge);
+                                                                        $itemBadgeTooltip = $item->getBadgeTooltip($itemBadge);
+                                                                        $itemIcon = $item->getIcon();
+                                                                        $shouldItemOpenUrlInNewTab = $item->shouldOpenUrlInNewTab();
+                                                                        $itemUrl = $item->getUrl();
+                                                                        $itemExtraAttributes = $item->getExtraAttributeBag();
                                 @endphp
 
                                 <x-filament-panels::topbar.item

--- a/packages/schemas/resources/views/components/actions.blade.php
+++ b/packages/schemas/resources/views/components/actions.blade.php
@@ -1,15 +1,15 @@
 @php
     use Filament\Support\Enums\VerticalAlignment;
 
-    $actions = $getChildSchema()->getComponents();
-    $alignment = $getAlignment();
-    $isFullWidth = $isFullWidth();
-    $isSticky = $isSticky();
-    $verticalAlignment = $getVerticalAlignment();
+        $actions = $getChildSchema()->getComponents();
+        $alignment = $getAlignment();
+        $isFullWidth = $isFullWidth();
+        $isSticky = $isSticky();
+        $verticalAlignment = $getVerticalAlignment();
 
-    if (! $verticalAlignment instanceof VerticalAlignment) {
-        $verticalAlignment = filled($verticalAlignment) ? (VerticalAlignment::tryFrom($verticalAlignment) ?? $verticalAlignment) : null;
-    }
+        if (! $verticalAlignment instanceof VerticalAlignment) {
+            $verticalAlignment = filled($verticalAlignment) ? (VerticalAlignment::tryFrom($verticalAlignment) ?? $verticalAlignment) : null;
+        }
 @endphp
 
 <div
@@ -21,14 +21,14 @@
     @endif
     {{
         $attributes
-            ->merge([
-                'id' => $getId(),
-            ], escape: false)
-            ->merge($getExtraAttributes(), escape: false)
-            ->class([
-                'fi-sc-actions',
-                ($verticalAlignment instanceof VerticalAlignment) ? "fi-vertical-align-{$verticalAlignment->value}" : $verticalAlignment,
-            ])
+        ->merge([
+        'id' => $getId(),
+        ], escape: false)
+        ->merge($getExtraAttributes(), escape: false)
+        ->class([
+        'fi-sc-actions',
+        ($verticalAlignment instanceof VerticalAlignment) ? "fi-vertical-align-{$verticalAlignment->value}" : $verticalAlignment,
+        ])
     }}
 >
     @if (filled($label = $getLabel()))

--- a/packages/schemas/resources/views/components/callout.blade.php
+++ b/packages/schemas/resources/views/components/callout.blade.php
@@ -1,21 +1,21 @@
 @php
     use Filament\Support\Enums\IconSize;
 
-    $controls = $getChildSchema($schemaComponent::CONTROLS_SCHEMA_KEY)?->toHtmlString();
-    $extraAttributeBag = $getExtraAttributeBag();
-    $footer = $getChildSchema($schemaComponent::FOOTER_SCHEMA_KEY)?->toHtmlString();
-    $color = $getColor();
-    $description = $getDescription();
-    $heading = $getHeading();
-    $icon = $getIcon();
-    $iconColor = $getIconColor();
-    $iconSize = $getIconSize() ?? IconSize::Large;
+        $controls = $getChildSchema($schemaComponent::CONTROLS_SCHEMA_KEY)?->toHtmlString();
+        $extraAttributeBag = $getExtraAttributeBag();
+        $footer = $getChildSchema($schemaComponent::FOOTER_SCHEMA_KEY)?->toHtmlString();
+        $color = $getColor();
+        $description = $getDescription();
+        $heading = $getHeading();
+        $icon = $getIcon();
+        $iconColor = $getIconColor();
+        $iconSize = $getIconSize() ?? IconSize::Large;
 @endphp
 
 <x-filament::callout
     :attributes="
         \Filament\Support\prepare_inherited_attributes($extraAttributeBag)
-            ->class(['fi-sc-callout'])
+        ->class(['fi-sc-callout'])
     "
     :color="$color ?? 'gray'"
     :description="$description"

--- a/packages/schemas/resources/views/components/empty-state.blade.php
+++ b/packages/schemas/resources/views/components/empty-state.blade.php
@@ -1,20 +1,20 @@
 @php
     $description = $getDescription();
-    $footer = $getChildSchema($schemaComponent::FOOTER_SCHEMA_KEY)?->toHtmlString();
-    $heading = $getHeading();
-    $headingTag = $getHeadingTag();
-    $icon = $getIcon();
-    $iconColor = $getIconColor();
-    $iconSize = $getIconSize();
-    $isCompact = $isCompact();
-    $isContained = $isContained();
+        $footer = $getChildSchema($schemaComponent::FOOTER_SCHEMA_KEY)?->toHtmlString();
+        $heading = $getHeading();
+        $headingTag = $getHeadingTag();
+        $icon = $getIcon();
+        $iconColor = $getIconColor();
+        $iconSize = $getIconSize();
+        $isCompact = $isCompact();
+        $isContained = $isContained();
 @endphp
 
 <div
     {{
         $attributes
-            ->merge($getExtraAttributes(), escape: false)
-            ->class(['fi-sc-empty-state'])
+        ->merge($getExtraAttributes(), escape: false)
+        ->class(['fi-sc-empty-state'])
     }}
 >
     <x-filament::empty-state

--- a/packages/schemas/resources/views/components/fieldset.blade.php
+++ b/packages/schemas/resources/views/components/fieldset.blade.php
@@ -1,9 +1,9 @@
 @php
     $extraAttributes = $getExtraAttributes();
-    $id = $getId();
-    $isLabelHidden = $isLabelHidden();
-    $label = $getLabel();
-    $isContained = $isContained();
+        $id = $getId();
+        $isLabelHidden = $isLabelHidden();
+        $label = $getLabel();
+        $isContained = $isContained();
 @endphp
 
 <x-filament::fieldset
@@ -13,11 +13,11 @@
     :required="isset($isMarkedAsRequired) ? $isMarkedAsRequired() : false"
     :attributes="
         \Filament\Support\prepare_inherited_attributes($attributes)
-            ->merge([
-                'id' => $id,
-            ], escape: false)
-            ->merge($extraAttributes, escape: false)
-            ->class(['fi-sc-fieldset'])
+        ->merge([
+            'id' => $id,
+        ], escape: false)
+        ->merge($extraAttributes, escape: false)
+        ->class(['fi-sc-fieldset'])
     "
 >
     {{ $getChildSchema() }}

--- a/packages/schemas/resources/views/components/flex.blade.php
+++ b/packages/schemas/resources/views/components/flex.blade.php
@@ -1,36 +1,36 @@
 @php
     use Filament\Actions\Action;
-    use Filament\Actions\ActionGroup;
-    use Filament\Schemas\Components\Component;
-    use Filament\Support\Enums\Alignment;
-    use Filament\Support\Enums\VerticalAlignment;
+        use Filament\Actions\ActionGroup;
+        use Filament\Schemas\Components\Component;
+        use Filament\Support\Enums\Alignment;
+        use Filament\Support\Enums\VerticalAlignment;
 
-    $statePath = $getStatePath();
+        $statePath = $getStatePath();
 
-    $fromBreakpoint = $getFromBreakpoint();
-    $verticalAlignment = $getVerticalAlignment();
-    $alignment = $getAlignment();
+        $fromBreakpoint = $getFromBreakpoint();
+        $verticalAlignment = $getVerticalAlignment();
+        $alignment = $getAlignment();
 
-    if (! $verticalAlignment instanceof VerticalAlignment) {
-        $verticalAlignment = filled($verticalAlignment) ? (VerticalAlignment::tryFrom($verticalAlignment) ?? $verticalAlignment) : null;
-    }
+        if (! $verticalAlignment instanceof VerticalAlignment) {
+            $verticalAlignment = filled($verticalAlignment) ? (VerticalAlignment::tryFrom($verticalAlignment) ?? $verticalAlignment) : null;
+        }
 
-    if (! $alignment instanceof Alignment) {
-        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
-    }
+        if (! $alignment instanceof Alignment) {
+            $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
+        }
 @endphp
 
 <div
     {{
         $attributes
-            ->merge($getExtraAttributes(), escape: false)
-            ->class([
-                'fi-sc-flex',
-                'fi-dense' => $isDense(),
-                'fi-from-' . ($fromBreakpoint ?? 'default'),
-                ($verticalAlignment instanceof VerticalAlignment) ? "fi-vertical-align-{$verticalAlignment->value}" : $verticalAlignment,
-                ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : $alignment,
-            ])
+        ->merge($getExtraAttributes(), escape: false)
+        ->class([
+        'fi-sc-flex',
+        'fi-dense' => $isDense(),
+        'fi-from-' . ($fromBreakpoint ?? 'default'),
+        ($verticalAlignment instanceof VerticalAlignment) ? "fi-vertical-align-{$verticalAlignment->value}" : $verticalAlignment,
+        ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : $alignment,
+        ])
     }}
 >
     @foreach ($getChildSchema()->getComponents() as $schemaComponent)
@@ -41,9 +41,9 @@
         @else
             @php
                 $hiddenJs = $schemaComponent->getHiddenJs();
-                $visibleJs = $schemaComponent->getVisibleJs();
+                                $visibleJs = $schemaComponent->getVisibleJs();
 
-                $schemaComponentStatePath = $schemaComponent->getStatePath();
+                                $schemaComponentStatePath = $schemaComponent->getStatePath();
             @endphp
 
             <div
@@ -59,16 +59,16 @@
                     )) !!}"
                 @endif
                 @if (filled($visibilityJs = match ([filled($hiddenJs), filled($visibleJs)]) {
-                         [true, true] => "(! ({$hiddenJs})) && ({$visibleJs})",
-                         [true, false] => "! ({$hiddenJs})",
-                         [false, true] => $visibleJs,
-                         default => null,
+                     [true, true] => "(! ({$hiddenJs})) && ({$visibleJs})",
+                     [true, false] => "! ({$hiddenJs})",
+                     [false, true] => $visibleJs,
+                     default => null,
                      }))
                     x-bind:class="{ 'fi-hidden': ! ({!! $visibilityJs !!}) }"
                     x-cloak
                 @endif
                 @class([
-                    'fi-growable' => ($schemaComponent instanceof Component) && $schemaComponent->canGrow(),
+                'fi-growable' => ($schemaComponent instanceof Component) && $schemaComponent->canGrow(),
                 ])
             >
                 {{ $schemaComponent }}

--- a/packages/schemas/resources/views/components/form.blade.php
+++ b/packages/schemas/resources/views/components/form.blade.php
@@ -1,15 +1,15 @@
 <form
     {{
         $attributes
-            ->merge([
-                'id' => $getId(),
-                'wire:submit' => $getLivewireSubmitHandler(),
-            ], escape: false)
-            ->merge($getExtraAttributes(), escape: false)
-            ->class([
-                'fi-sc-form',
-                'fi-dense' => $isDense(),
-            ])
+        ->merge([
+        'id' => $getId(),
+        'wire:submit' => $getLivewireSubmitHandler(),
+        ], escape: false)
+        ->merge($getExtraAttributes(), escape: false)
+        ->class([
+        'fi-sc-form',
+        'fi-dense' => $isDense(),
+        ])
     }}
 >
     {{ $getChildSchema($schemaComponent::HEADER_SCHEMA_KEY) }}

--- a/packages/schemas/resources/views/components/fused-group.blade.php
+++ b/packages/schemas/resources/views/components/fused-group.blade.php
@@ -1,53 +1,53 @@
 @php
     use Filament\Forms\Components\Contracts\HasNestedRecursiveValidationRules;
-    use Filament\Forms\Components\Field;
+        use Filament\Forms\Components\Field;
 
-    $fieldWrapperView = $getFieldWrapperView();
+        $fieldWrapperView = $getFieldWrapperView();
 
-    $errorMessages = null;
-    $errorMessage = null;
+        $errorMessages = null;
+        $errorMessage = null;
 
-    foreach ($getChildComponentContainer()->getComponents() as $childComponent) {
-        if (! ($childComponent instanceof Field)) {
-            continue;
-        }
-
-        $statePath = $childComponent->getStatePath();
-
-        if (blank($statePath)) {
-            continue;
-        }
-
-        if ($errors->has($statePath)) {
-            if ($childComponent->shouldShowAllValidationMessages()) {
-                $errorMessages = $errors->get($statePath);
-                $shouldShowAllValidationMessages = true;
-            } else {
-                $errorMessage = $errors->first($statePath);
+        foreach ($getChildComponentContainer()->getComponents() as $childComponent) {
+            if (! ($childComponent instanceof Field)) {
+                continue;
             }
 
-            $areHtmlValidationMessagesAllowed = $childComponent->areHtmlValidationMessagesAllowed();
+            $statePath = $childComponent->getStatePath();
 
-            break;
-        }
-
-        if (! ($childComponent instanceof HasNestedRecursiveValidationRules)) {
-            continue;
-        }
-
-        if ($errors->has("{$statePath}.*")) {
-            if ($childComponent->shouldShowAllValidationMessages()) {
-                $errorMessages = $errors->get("{$statePath}.*");
-                $shouldShowAllValidationMessages = true;
-            } else {
-                $errorMessage = $errors->first("{$statePath}.*");
+            if (blank($statePath)) {
+                continue;
             }
 
-            $areHtmlValidationMessagesAllowed = $childComponent->areHtmlValidationMessagesAllowed();
+            if ($errors->has($statePath)) {
+                if ($childComponent->shouldShowAllValidationMessages()) {
+                    $errorMessages = $errors->get($statePath);
+                    $shouldShowAllValidationMessages = true;
+                } else {
+                    $errorMessage = $errors->first($statePath);
+                }
 
-            break;
+                $areHtmlValidationMessagesAllowed = $childComponent->areHtmlValidationMessagesAllowed();
+
+                break;
+            }
+
+            if (! ($childComponent instanceof HasNestedRecursiveValidationRules)) {
+                continue;
+            }
+
+            if ($errors->has("{$statePath}.*")) {
+                if ($childComponent->shouldShowAllValidationMessages()) {
+                    $errorMessages = $errors->get("{$statePath}.*");
+                    $shouldShowAllValidationMessages = true;
+                } else {
+                    $errorMessage = $errors->first("{$statePath}.*");
+                }
+
+                $areHtmlValidationMessagesAllowed = $childComponent->areHtmlValidationMessagesAllowed();
+
+                break;
+            }
         }
-    }
 @endphp
 
 <x-dynamic-component
@@ -61,11 +61,11 @@
     <div
         {{
             $attributes
-                ->merge([
-                    'id' => $getId(),
-                ], escape: false)
-                ->merge($getExtraAttributes(), escape: false)
-                ->class(['fi-sc-fused-group'])
+            ->merge([
+            'id' => $getId(),
+            ], escape: false)
+            ->merge($getExtraAttributes(), escape: false)
+            ->class(['fi-sc-fused-group'])
         }}
     >
         {{ $getChildSchema() }}

--- a/packages/schemas/resources/views/components/grid.blade.php
+++ b/packages/schemas/resources/views/components/grid.blade.php
@@ -1,10 +1,10 @@
 <div
     {{
         $attributes
-            ->merge([
-                'id' => $getId(),
-            ], escape: false)
-            ->merge($getExtraAttributes(), escape: false)
+        ->merge([
+        'id' => $getId(),
+        ], escape: false)
+        ->merge($getExtraAttributes(), escape: false)
     }}
 >
     {{ $getChildSchema() }}

--- a/packages/schemas/resources/views/components/image.blade.php
+++ b/packages/schemas/resources/views/components/image.blade.php
@@ -1,14 +1,14 @@
 @php
     use Filament\Support\Enums\Alignment;
 
-    $alignment = $getAlignment();
-    $height = $getImageHeight() ?? '8rem';
-    $width = $getImageWidth();
-    $tooltip = $getTooltip();
+        $alignment = $getAlignment();
+        $height = $getImageHeight() ?? '8rem';
+        $width = $getImageWidth();
+        $tooltip = $getTooltip();
 
-    if (! $alignment instanceof Alignment) {
-        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
-    }
+        if (! $alignment instanceof Alignment) {
+            $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
+        }
 @endphp
 
 <img
@@ -19,13 +19,13 @@
     @endif
     {{
         $getExtraAttributeBag()
-            ->class([
-                'fi-sc-image',
-                ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : $alignment,
-            ])
-            ->style([
-                "height: {$height}" => $height,
-                "width: {$width}" => $width,
-            ])
+        ->class([
+        'fi-sc-image',
+        ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : $alignment,
+        ])
+        ->style([
+        "height: {$height}" => $height,
+        "width: {$width}" => $width,
+        ])
     }}
 />

--- a/packages/schemas/resources/views/components/livewire.blade.php
+++ b/packages/schemas/resources/views/components/livewire.blade.php
@@ -1,6 +1,6 @@
 @php
     $extraAttributes = $getExtraAttributes();
-    $id = $getId();
+        $id = $getId();
 @endphp
 
 @if (filled($id) || filled($extraAttributes))
@@ -8,10 +8,10 @@
     {{-- Avoid formatting issues with unclosed elements --}}
     {{
         $attributes
-            ->merge([
-                'id' => $id,
-            ], escape: false)
-            ->merge($extraAttributes, escape: false)
+        ->merge([
+        'id' => $id,
+        ], escape: false)
+        ->merge($extraAttributes, escape: false)
     }}
     >
 @endif

--- a/packages/schemas/resources/views/components/section.blade.php
+++ b/packages/schemas/resources/views/components/section.blade.php
@@ -1,33 +1,33 @@
 @php
     $afterHeader = $getChildSchema($schemaComponent::AFTER_HEADER_SCHEMA_KEY)?->toHtmlString();
-    $isAside = $isAside();
-    $isCollapsed = $isCollapsed();
-    $isCollapsible = $isCollapsible();
-    $isCompact = $isCompact();
-    $isContained = $isContained();
-    $isDivided = $isDivided();
-    $isFormBefore = $isFormBefore();
-    $description = $getDescription();
-    $footer = $getChildSchema($schemaComponent::FOOTER_SCHEMA_KEY)?->toHtmlString();
-    $heading = $getHeading();
-    $headingTag = $getHeadingTag();
-    $icon = $getIcon();
-    $iconColor = $getIconColor();
-    $iconSize = $getIconSize();
-    $shouldPersistCollapsed = $shouldPersistCollapsed();
-    $isSecondary = $isSecondary();
-    $id = $getId();
+        $isAside = $isAside();
+        $isCollapsed = $isCollapsed();
+        $isCollapsible = $isCollapsible();
+        $isCompact = $isCompact();
+        $isContained = $isContained();
+        $isDivided = $isDivided();
+        $isFormBefore = $isFormBefore();
+        $description = $getDescription();
+        $footer = $getChildSchema($schemaComponent::FOOTER_SCHEMA_KEY)?->toHtmlString();
+        $heading = $getHeading();
+        $headingTag = $getHeadingTag();
+        $icon = $getIcon();
+        $iconColor = $getIconColor();
+        $iconSize = $getIconSize();
+        $shouldPersistCollapsed = $shouldPersistCollapsed();
+        $isSecondary = $isSecondary();
+        $id = $getId();
 @endphp
 
 <div
     {{
         $attributes
-            ->merge([
-                'id' => $id,
-            ], escape: false)
-            ->merge($getExtraAttributes(), escape: false)
-            ->merge($getExtraAlpineAttributes(), escape: false)
-            ->class(['fi-sc-section'])
+        ->merge([
+        'id' => $id,
+        ], escape: false)
+        ->merge($getExtraAttributes(), escape: false)
+        ->merge($getExtraAlpineAttributes(), escape: false)
+        ->class(['fi-sc-section'])
     }}
 >
     @if (filled($label = $getLabel()))

--- a/packages/schemas/resources/views/components/tabs.blade.php
+++ b/packages/schemas/resources/views/components/tabs.blade.php
@@ -1,45 +1,45 @@
 @php
     use Filament\Schemas\Components\Tabs\Tab;
-    use Filament\Schemas\View\SchemaIconAlias;
-    use Filament\Support\Icons\Heroicon;
+        use Filament\Schemas\View\SchemaIconAlias;
+        use Filament\Support\Icons\Heroicon;
 
-    $activeTab = $getActiveTab();
-    $hasDeferredBadges = $hasDeferredBadges();
-    $id = $getId();
-    $isContained = $isContained();
-    $isScrollable = $isScrollable();
-    $isVertical = $isVertical();
-    $label = $getLabel();
-    $livewireProperty = $getLivewireProperty();
-    $renderHookScopes = $getRenderHookScopes();
-    $tabs = $getChildSchema()->getComponents();
-    $tabsKey = $getKey();
+        $activeTab = $getActiveTab();
+        $hasDeferredBadges = $hasDeferredBadges();
+        $id = $getId();
+        $isContained = $isContained();
+        $isScrollable = $isScrollable();
+        $isVertical = $isVertical();
+        $label = $getLabel();
+        $livewireProperty = $getLivewireProperty();
+        $renderHookScopes = $getRenderHookScopes();
+        $tabs = $getChildSchema()->getComponents();
+        $tabsKey = $getKey();
 
-    $getTabVisibilityJs = function (Tab $tab, ?int $index = null, ?string $mode = null) use ($isScrollable): ?string {
-        $hiddenJs = $tab->getHiddenJs();
-        $visibleJs = $tab->getVisibleJs();
+        $getTabVisibilityJs = function (Tab $tab, ?int $index = null, ?string $mode = null) use ($isScrollable): ?string {
+            $hiddenJs = $tab->getHiddenJs();
+            $visibleJs = $tab->getVisibleJs();
 
-        $baseJs = match ([filled($hiddenJs), filled($visibleJs)]) {
-            [true, true] => "(! ({$hiddenJs})) && ({$visibleJs})",
-            [true, false] => "! ({$hiddenJs})",
-            [false, true] => $visibleJs,
-            default => null,
+            $baseJs = match ([filled($hiddenJs), filled($visibleJs)]) {
+                [true, true] => "(! ({$hiddenJs})) && ({$visibleJs})",
+                [true, false] => "! ({$hiddenJs})",
+                [false, true] => $visibleJs,
+                default => null,
+            };
+
+            if ($isScrollable || $index === null || $mode === null) {
+                return $baseJs;
+            }
+
+            $tabKey = $tab->getKey(isAbsolute: false);
+
+            $dropdownJs = match ($mode) {
+                'inline' => "(!withinDropdownMounted || withinDropdownIndex === null || {$index} < withinDropdownIndex)",
+                'trigger' => "(withinDropdownMounted && withinDropdownIndex !== null && {$index} >= withinDropdownIndex && '{$tabKey}' === tab)",
+                default => null,
+            };
+
+            return $baseJs ? "{$baseJs} && {$dropdownJs}" : $dropdownJs;
         };
-
-        if ($isScrollable || $index === null || $mode === null) {
-            return $baseJs;
-        }
-
-        $tabKey = $tab->getKey(isAbsolute: false);
-
-        $dropdownJs = match ($mode) {
-            'inline' => "(!withinDropdownMounted || withinDropdownIndex === null || {$index} < withinDropdownIndex)",
-            'trigger' => "(withinDropdownMounted && withinDropdownIndex !== null && {$index} >= withinDropdownIndex && '{$tabKey}' === tab)",
-            default => null,
-        };
-
-        return $baseJs ? "{$baseJs} && {$dropdownJs}" : $dropdownJs;
-    };
 @endphp
 
 @if (blank($livewireProperty))
@@ -57,17 +57,17 @@
         wire:ignore.self
         {{
             $attributes
-                ->merge([
-                    'id' => $id,
-                    'wire:key' => $getLivewireKey() . '.container',
-                ], escape: false)
-                ->merge($getExtraAttributes(), escape: false)
-                ->merge($getExtraAlpineAttributes(), escape: false)
-                ->class([
-                    'fi-sc-tabs',
-                    'fi-contained' => $isContained,
-                    'fi-vertical' => $isVertical,
-                ])
+            ->merge([
+            'id' => $id,
+            'wire:key' => $getLivewireKey() . '.container',
+            ], escape: false)
+            ->merge($getExtraAttributes(), escape: false)
+            ->merge($getExtraAlpineAttributes(), escape: false)
+            ->class([
+            'fi-sc-tabs',
+            'fi-contained' => $isContained,
+            'fi-vertical' => $isVertical,
+            ])
         }}
     >
         <input
@@ -105,17 +105,17 @@
             @foreach ($tabs as $index => $tab)
                 @php
                     $isTabBadgeDeferred = $tab->isBadgeDeferred();
-                    $tabBadge = $isTabBadgeDeferred ? null : $tab->getBadge();
-                    $tabBadgeColor = $isTabBadgeDeferred ? null : $tab->getBadgeColor($tabBadge);
-                    $tabBadgeIcon = $isTabBadgeDeferred ? null : $tab->getBadgeIcon($tabBadge);
-                    $tabBadgeIconPosition = $isTabBadgeDeferred ? null : $tab->getBadgeIconPosition($tabBadge);
-                    $tabBadgeTooltip = $isTabBadgeDeferred ? null : $tab->getBadgeTooltip($tabBadge);
-                    $tabExtraAttributeBag = $tab->getExtraAttributeBag();
-                    $tabIcon = $tab->getIcon();
-                    $tabIconPosition = $tab->getIconPosition();
-                    $tabKey = $tab->getKey(isAbsolute: false);
-                    $tabLabel = $tab->getLabel();
-                    $tabVisibilityJs = $getTabVisibilityJs($tab, $index, 'inline');
+                                        $tabBadge = $isTabBadgeDeferred ? null : $tab->getBadge();
+                                        $tabBadgeColor = $isTabBadgeDeferred ? null : $tab->getBadgeColor($tabBadge);
+                                        $tabBadgeIcon = $isTabBadgeDeferred ? null : $tab->getBadgeIcon($tabBadge);
+                                        $tabBadgeIconPosition = $isTabBadgeDeferred ? null : $tab->getBadgeIconPosition($tabBadge);
+                                        $tabBadgeTooltip = $isTabBadgeDeferred ? null : $tab->getBadgeTooltip($tabBadge);
+                                        $tabExtraAttributeBag = $tab->getExtraAttributeBag();
+                                        $tabIcon = $tab->getIcon();
+                                        $tabIconPosition = $tab->getIconPosition();
+                                        $tabKey = $tab->getKey(isAbsolute: false);
+                                        $tabLabel = $tab->getLabel();
+                                        $tabVisibilityJs = $getTabVisibilityJs($tab, $index, 'inline');
                 @endphp
 
                 <x-filament::tabs.item
@@ -147,13 +147,13 @@
                         @foreach ($tabs as $index => $tab)
                             @php
                                 $isTabBadgeDeferred = $tab->isBadgeDeferred();
-                                $tabBadge = $isTabBadgeDeferred ? null : $tab->getBadge();
-                                $tabBadgeColor = $isTabBadgeDeferred ? null : $tab->getBadgeColor($tabBadge);
-                                $tabBadgeTooltip = $isTabBadgeDeferred ? null : $tab->getBadgeTooltip($tabBadge);
-                                $tabExtraAttributeBag = $tab->getExtraAttributeBag();
-                                $tabKey = $tab->getKey(isAbsolute: false);
-                                $tabLabel = $tab->getLabel();
-                                $tabVisibilityJs = $getTabVisibilityJs($tab, $index, 'trigger');
+                                                                $tabBadge = $isTabBadgeDeferred ? null : $tab->getBadge();
+                                                                $tabBadgeColor = $isTabBadgeDeferred ? null : $tab->getBadgeColor($tabBadge);
+                                                                $tabBadgeTooltip = $isTabBadgeDeferred ? null : $tab->getBadgeTooltip($tabBadge);
+                                                                $tabExtraAttributeBag = $tab->getExtraAttributeBag();
+                                                                $tabKey = $tab->getKey(isAbsolute: false);
+                                                                $tabLabel = $tab->getLabel();
+                                                                $tabVisibilityJs = $getTabVisibilityJs($tab, $index, 'trigger');
                             @endphp
 
                             <x-filament::tabs.item
@@ -176,8 +176,8 @@
                         <x-filament::tabs.item x-show="isDropdownButtonVisible">
                             {{
                                 \Filament\Support\generate_icon_html(
-                                    Heroicon::EllipsisHorizontal,
-                                    alias: SchemaIconAlias::COMPONENTS_TABS_MORE_TABS_BUTTON,
+                                Heroicon::EllipsisHorizontal,
+                                alias: SchemaIconAlias::COMPONENTS_TABS_MORE_TABS_BUTTON,
                                 )
                             }}
                         </x-filament::tabs.item>
@@ -187,12 +187,12 @@
                         @foreach ($tabs as $index => $tab)
                             @php
                                 $isTabBadgeDeferred = $tab->isBadgeDeferred();
-                                $tabBadge = $isTabBadgeDeferred ? null : $tab->getBadge();
-                                $tabBadgeColor = $isTabBadgeDeferred ? null : $tab->getBadgeColor($tabBadge);
-                                $tabBadgeTooltip = $isTabBadgeDeferred ? null : $tab->getBadgeTooltip($tabBadge);
-                                $tabIcon = $tab->getIcon();
-                                $tabKey = $tab->getKey(isAbsolute: false);
-                                $tabLabel = $tab->getLabel();
+                                                                $tabBadge = $isTabBadgeDeferred ? null : $tab->getBadge();
+                                                                $tabBadgeColor = $isTabBadgeDeferred ? null : $tab->getBadgeColor($tabBadge);
+                                                                $tabBadgeTooltip = $isTabBadgeDeferred ? null : $tab->getBadgeTooltip($tabBadge);
+                                                                $tabIcon = $tab->getIcon();
+                                                                $tabKey = $tab->getKey(isAbsolute: false);
+                                                                $tabLabel = $tab->getLabel();
                             @endphp
 
                             <x-filament::dropdown.list.item
@@ -259,16 +259,16 @@
         @endif
         {{
             $attributes
-                ->merge([
-                    'id' => $id,
-                    'wire:key' => $getLivewireKey() . '.container',
-                ], escape: false)
-                ->merge($getExtraAttributes(), escape: false)
-                ->class([
-                    'fi-sc-tabs',
-                    'fi-contained' => $isContained,
-                    'fi-vertical' => $isVertical,
-                ])
+            ->merge([
+            'id' => $id,
+            'wire:key' => $getLivewireKey() . '.container',
+            ], escape: false)
+            ->merge($getExtraAttributes(), escape: false)
+            ->class([
+            'fi-sc-tabs',
+            'fi-contained' => $isContained,
+            'fi-vertical' => $isVertical,
+            ])
         }}
     >
         <x-filament::tabs
@@ -283,16 +283,16 @@
             @foreach ($getChildSchema()->getComponents(withOriginalKeys: true) as $tabKey => $tab)
                 @php
                     $isTabBadgeDeferred = $tab->isBadgeDeferred();
-                    $tabBadge = $isTabBadgeDeferred ? null : $tab->getBadge();
-                    $tabBadgeColor = $isTabBadgeDeferred ? null : $tab->getBadgeColor($tabBadge);
-                    $tabBadgeIcon = $isTabBadgeDeferred ? null : $tab->getBadgeIcon($tabBadge);
-                    $tabBadgeIconPosition = $isTabBadgeDeferred ? null : $tab->getBadgeIconPosition($tabBadge);
-                    $tabBadgeTooltip = $isTabBadgeDeferred ? null : $tab->getBadgeTooltip($tabBadge);
-                    $tabExtraAttributeBag = $tab->getExtraAttributeBag();
-                    $tabIcon = $tab->getIcon();
-                    $tabIconPosition = $tab->getIconPosition();
-                    $tabKey = strval($tabKey);
-                    $tabLabel = $tab->getLabel() ?? $this->generateTabLabel($tabKey);
+                                        $tabBadge = $isTabBadgeDeferred ? null : $tab->getBadge();
+                                        $tabBadgeColor = $isTabBadgeDeferred ? null : $tab->getBadgeColor($tabBadge);
+                                        $tabBadgeIcon = $isTabBadgeDeferred ? null : $tab->getBadgeIcon($tabBadge);
+                                        $tabBadgeIconPosition = $isTabBadgeDeferred ? null : $tab->getBadgeIconPosition($tabBadge);
+                                        $tabBadgeTooltip = $isTabBadgeDeferred ? null : $tab->getBadgeTooltip($tabBadge);
+                                        $tabExtraAttributeBag = $tab->getExtraAttributeBag();
+                                        $tabIcon = $tab->getIcon();
+                                        $tabIconPosition = $tab->getIconPosition();
+                                        $tabKey = strval($tabKey);
+                                        $tabLabel = $tab->getLabel() ?? $this->generateTabLabel($tabKey);
                 @endphp
 
                 <x-filament::tabs.item

--- a/packages/schemas/resources/views/components/tabs/tab.blade.php
+++ b/packages/schemas/resources/views/components/tabs/tab.blade.php
@@ -1,11 +1,11 @@
 @php
     $id = $getId();
-    $key = $getKey(isAbsolute: false);
-    $tabs = $getContainer()->getParentComponent();
-    $isContained = $tabs->isContained();
-    $livewireProperty = $tabs->getLivewireProperty();
+        $key = $getKey(isAbsolute: false);
+        $tabs = $getContainer()->getParentComponent();
+        $isContained = $tabs->isContained();
+        $livewireProperty = $tabs->getLivewireProperty();
 
-    $childSchema = $getChildSchema();
+        $childSchema = $getChildSchema();
 @endphp
 
 @if (! empty($childSchema->getComponents()))
@@ -17,14 +17,14 @@
             x-on:expand="tab = @js($key)"
             {{
                 $attributes
-                    ->merge([
-                        'aria-labelledby' => $id,
-                        'id' => $id,
-                        'role' => 'tabpanel',
-                        'wire:key' => $getLivewireKey() . '.container',
-                    ], escape: false)
-                    ->merge($getExtraAttributes(), escape: false)
-                    ->class(['fi-sc-tabs-tab'])
+                ->merge([
+                'aria-labelledby' => $id,
+                'id' => $id,
+                'role' => 'tabpanel',
+                'wire:key' => $getLivewireKey() . '.container',
+                ], escape: false)
+                ->merge($getExtraAttributes(), escape: false)
+                ->class(['fi-sc-tabs-tab'])
             }}
         >
             {{ $childSchema }}
@@ -33,14 +33,14 @@
         <div
             {{
                 $attributes
-                    ->merge([
-                        'aria-labelledby' => $id,
-                        'id' => $id,
-                        'role' => 'tabpanel',
-                        'wire:key' => $getLivewireKey() . '.container',
-                    ], escape: false)
-                    ->merge($getExtraAttributes(), escape: false)
-                    ->class(['fi-sc-tabs-tab fi-active'])
+                ->merge([
+                'aria-labelledby' => $id,
+                'id' => $id,
+                'role' => 'tabpanel',
+                'wire:key' => $getLivewireKey() . '.container',
+                ], escape: false)
+                ->merge($getExtraAttributes(), escape: false)
+                ->class(['fi-sc-tabs-tab fi-active'])
             }}
         >
             {{ $childSchema }}

--- a/packages/schemas/resources/views/components/text.blade.php
+++ b/packages/schemas/resources/views/components/text.blade.php
@@ -1,23 +1,23 @@
 @php
     use Filament\Schemas\View\Components\TextComponent;
-    use Filament\Support\Enums\FontFamily;
-    use Filament\Support\Enums\FontWeight;
-    use Filament\Support\RawJs;
+        use Filament\Support\Enums\FontFamily;
+        use Filament\Support\Enums\FontWeight;
+        use Filament\Support\RawJs;
 
-    $color = $getColor();
-    $content = $getContent();
-    $icon = $getIcon();
-    $iconPosition = $getIconPosition();
-    $iconSize = $getIconSize();
-    $size = $getSize();
-    $tooltip = $getTooltip();
-    $weight = $getWeight();
-    $fontFamily = $getFontFamily();
+        $color = $getColor();
+        $content = $getContent();
+        $icon = $getIcon();
+        $iconPosition = $getIconPosition();
+        $iconSize = $getIconSize();
+        $size = $getSize();
+        $tooltip = $getTooltip();
+        $weight = $getWeight();
+        $fontFamily = $getFontFamily();
 
-    $copyableState = $getCopyableState($content) ?? $content;
-    $copyMessage = $getCopyMessage($copyableState);
-    $copyMessageDuration = $getCopyMessageDuration($copyableState);
-    $isCopyable = $isCopyable($copyableState);
+        $copyableState = $getCopyableState($content) ?? $content;
+        $copyMessage = $getCopyMessage($copyableState);
+        $copyMessageDuration = $getCopyMessageDuration($copyableState);
+        $isCopyable = $isCopyable($copyableState);
 @endphp
 
 @if ($isBadge())
@@ -62,15 +62,15 @@
         @endif
         {{
             (new \Illuminate\View\ComponentAttributeBag)
-                ->color(TextComponent::class, $color)
-                ->class([
-                    'fi-sc-text',
-                    'fi-copyable' => $isCopyable,
-                    ($size instanceof \BackedEnum) ? "fi-size-{$size->value}" : $size,
-                    ($weight instanceof FontWeight) ? "fi-font-{$weight->value}" : $weight,
-                    ($fontFamily instanceof FontFamily) ? "fi-font-{$fontFamily->value}" : $fontFamily,
-                ])
-                ->merge($getExtraAttributes(), escape: false)
+            ->color(TextComponent::class, $color)
+            ->class([
+            'fi-sc-text',
+            'fi-copyable' => $isCopyable,
+            ($size instanceof \BackedEnum) ? "fi-size-{$size->value}" : $size,
+            ($weight instanceof FontWeight) ? "fi-font-{$weight->value}" : $weight,
+            ($fontFamily instanceof FontFamily) ? "fi-font-{$fontFamily->value}" : $fontFamily,
+            ])
+            ->merge($getExtraAttributes(), escape: false)
         }}
     >
         {{ $content }}

--- a/packages/schemas/resources/views/components/unordered-list.blade.php
+++ b/packages/schemas/resources/views/components/unordered-list.blade.php
@@ -1,11 +1,11 @@
 <ul
     {{
         $getExtraAttributeBag()
-            ->grid($getColumns(), \Filament\Support\Enums\GridDirection::Column)
-            ->class([
-                'fi-sc-unordered-list',
-                (($size = $getSize()) instanceof \Filament\Support\Enums\TextSize) ? "fi-size-{$size->value}" : $size,
-            ])
+        ->grid($getColumns(), \Filament\Support\Enums\GridDirection::Column)
+        ->class([
+        'fi-sc-unordered-list',
+        (($size = $getSize()) instanceof \Filament\Support\Enums\TextSize) ? "fi-size-{$size->value}" : $size,
+        ])
     }}
 >
     @foreach ($getChildSchema()->getComponents() as $schemaComponent)

--- a/packages/schemas/resources/views/components/wizard.blade.php
+++ b/packages/schemas/resources/views/components/wizard.blade.php
@@ -1,10 +1,10 @@
 @php
     $isContained = $isContained();
-    $key = $getKey();
-    $previousAction = $getAction('previous');
-    $nextAction = $getAction('next');
-    $steps = $getChildSchema()->getComponents();
-    $isHeaderHidden = $isHeaderHidden();
+        $key = $getKey();
+        $previousAction = $getAction('previous');
+        $nextAction = $getAction('next');
+        $steps = $getChildSchema()->getComponents();
+        $isHeaderHidden = $isHeaderHidden();
 @endphp
 
 <div
@@ -22,26 +22,26 @@
     wire:ignore.self
     {{
         $attributes
-            ->merge([
-                'id' => $getId(),
-            ], escape: false)
-            ->merge($getExtraAttributes(), escape: false)
-            ->merge($getExtraAlpineAttributes(), escape: false)
-            ->class([
-                'fi-sc-wizard',
-                'fi-contained' => $isContained,
-                'fi-sc-wizard-header-hidden' => $isHeaderHidden,
-            ])
+        ->merge([
+        'id' => $getId(),
+        ], escape: false)
+        ->merge($getExtraAttributes(), escape: false)
+        ->merge($getExtraAlpineAttributes(), escape: false)
+        ->class([
+        'fi-sc-wizard',
+        'fi-contained' => $isContained,
+        'fi-sc-wizard-header-hidden' => $isHeaderHidden,
+        ])
     }}
 >
     <input
         type="hidden"
         value="{{
             collect($steps)
-                ->filter(static fn (\Filament\Schemas\Components\Wizard\Step $step): bool => $step->isVisible())
-                ->map(static fn (\Filament\Schemas\Components\Wizard\Step $step): ?string => $step->getKey())
-                ->values()
-                ->toJson()
+            ->filter(static fn (\Filament\Schemas\Components\Wizard\Step $step): bool => $step->isVisible())
+            ->map(static fn (\Filament\Schemas\Components\Wizard\Step $step): ?string => $step->getKey())
+            ->values()
+            ->toJson()
         }}"
         x-ref="stepsData"
     />
@@ -78,25 +78,25 @@
 
                             {{
                                 \Filament\Support\generate_icon_html(
-                                    $completedIcon ?? \Filament\Support\Icons\Heroicon::OutlinedCheck,
-                                    alias: filled($completedIcon) ? null : \Filament\Schemas\View\SchemaIconAlias::COMPONENTS_WIZARD_COMPLETED_STEP,
-                                    attributes: new \Illuminate\View\ComponentAttributeBag([
-                                        'x-cloak' => 'x-cloak',
-                                        'x-show' => "getStepIndex(step) > {$loop->index}",
-                                    ]),
-                                    size: \Filament\Support\Enums\IconSize::Large,
+                                $completedIcon ?? \Filament\Support\Icons\Heroicon::OutlinedCheck,
+                                alias: filled($completedIcon) ? null : \Filament\Schemas\View\SchemaIconAlias::COMPONENTS_WIZARD_COMPLETED_STEP,
+                                attributes: new \Illuminate\View\ComponentAttributeBag([
+                                'x-cloak' => 'x-cloak',
+                                'x-show' => "getStepIndex(step) > {$loop->index}",
+                                ]),
+                                size: \Filament\Support\Enums\IconSize::Large,
                                 )
                             }}
 
                             @if (filled($icon = $step->getIcon()))
                                 {{
                                     \Filament\Support\generate_icon_html(
-                                        $icon,
-                                        attributes: new \Illuminate\View\ComponentAttributeBag([
-                                            'x-cloak' => 'x-cloak',
-                                            'x-show' => "getStepIndex(step) <= {$loop->index}",
-                                        ]),
-                                        size: \Filament\Support\Enums\IconSize::Large,
+                                    $icon,
+                                    attributes: new \Illuminate\View\ComponentAttributeBag([
+                                    'x-cloak' => 'x-cloak',
+                                    'x-show' => "getStepIndex(step) <= {$loop->index}",
+                                    ]),
+                                    size: \Filament\Support\Enums\IconSize::Large,
                                     )
                                 }}
                             @else

--- a/packages/schemas/resources/views/components/wizard/step.blade.php
+++ b/packages/schemas/resources/views/components/wizard/step.blade.php
@@ -1,9 +1,9 @@
 @php
     $id = $getId();
-    $key = $getKey();
-    $wizard = $getContainer()->getParentComponent();
-    $isContained = $wizard->isContained();
-    $alpineSubmitHandler = $hasFormWrapper() ? $wizard->getAlpineSubmitHandler() : null;
+        $key = $getKey();
+        $wizard = $getContainer()->getParentComponent();
+        $isContained = $wizard->isContained();
+        $alpineSubmitHandler = $hasFormWrapper() ? $wizard->getAlpineSubmitHandler() : null;
 @endphp
 
 <{{ filled($alpineSubmitHandler) ? 'form' : 'div' }}
@@ -25,13 +25,13 @@
     x-ref="step-{{ $key }}"
     {{
         $attributes
-            ->merge([
-                'aria-labelledby' => $id,
-                'id' => $id,
-                'role' => 'tabpanel',
-            ], escape: false)
-            ->merge($getExtraAttributes(), escape: false)
-            ->class(['fi-sc-wizard-step'])
+        ->merge([
+        'aria-labelledby' => $id,
+        'id' => $id,
+        'role' => 'tabpanel',
+        ], escape: false)
+        ->merge($getExtraAttributes(), escape: false)
+        ->class(['fi-sc-wizard-step'])
     }}
 >
     {{ $getChildSchema() }}

--- a/packages/support/resources/views/components/actions.blade.php
+++ b/packages/support/resources/views/components/actions.blade.php
@@ -3,44 +3,44 @@
 @endphp
 
 @props([
-    'actions' => [],
-    'alignment' => Alignment::Start,
-    'fullWidth' => false,
+'actions' => [],
+'alignment' => Alignment::Start,
+'fullWidth' => false,
 ])
 
 @php
     if (is_array($actions)) {
-        $actions = array_filter(
-            $actions,
-            fn ($action): bool => $action->isVisible(),
-        );
-    }
+            $actions = array_filter(
+                $actions,
+                fn ($action): bool => $action->isVisible(),
+            );
+        }
 
-    if (! $alignment instanceof Alignment) {
-        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
-    }
+        if (! $alignment instanceof Alignment) {
+            $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
+        }
 
-    $hasActions = false;
+        $hasActions = false;
 
-    $hasSlot = ! \Filament\Support\is_slot_empty($slot);
-    $actionsAreHtmlable = $actions instanceof \Illuminate\Contracts\Support\Htmlable;
+        $hasSlot = ! \Filament\Support\is_slot_empty($slot);
+        $actionsAreHtmlable = $actions instanceof \Illuminate\Contracts\Support\Htmlable;
 
-    if ($hasSlot) {
-        $hasActions = true;
-    } elseif ($actionsAreHtmlable) {
-        $hasActions = ! \Filament\Support\is_slot_empty($actions);
-    } else {
-        $hasActions = filled($actions);
-    }
+        if ($hasSlot) {
+            $hasActions = true;
+        } elseif ($actionsAreHtmlable) {
+            $hasActions = ! \Filament\Support\is_slot_empty($actions);
+        } else {
+            $hasActions = filled($actions);
+        }
 @endphp
 
 @if ($hasActions)
     <div
         {{
             $attributes->class([
-                'fi-ac',
-                'fi-width-full' => $fullWidth,
-                ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : null) => ! $fullWidth,
+            'fi-ac',
+            'fi-width-full' => $fullWidth,
+            ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : null) => ! $fullWidth,
             ])
         }}
     >

--- a/packages/support/resources/views/components/avatar.blade.php
+++ b/packages/support/resources/views/components/avatar.blade.php
@@ -1,18 +1,18 @@
 @props([
-    'circular' => true,
-    'size' => 'md',
+'circular' => true,
+'size' => 'md',
 ])
 
 <img
     {{
         $attributes
-            ->class([
-                'fi-avatar',
-                'fi-circular' => $circular,
-                match ($size) {
-                    'sm', 'md', 'lg' => "fi-size-{$size}",
-                    default => $size,
-                },
-            ])
+        ->class([
+        'fi-avatar',
+        'fi-circular' => $circular,
+        match ($size) {
+        'sm', 'md', 'lg' => "fi-size-{$size}",
+        default => $size,
+        },
+        ])
     }}
 />

--- a/packages/support/resources/views/components/badge.blade.php
+++ b/packages/support/resources/views/components/badge.blade.php
@@ -1,56 +1,56 @@
 @php
     use Filament\Support\Enums\IconPosition;
-    use Filament\Support\Enums\IconSize;
-    use Filament\Support\Enums\Size;
-    use Filament\Support\View\Components\BadgeComponent;
-    use Illuminate\View\ComponentAttributeBag;
+        use Filament\Support\Enums\IconSize;
+        use Filament\Support\Enums\Size;
+        use Filament\Support\View\Components\BadgeComponent;
+        use Illuminate\View\ComponentAttributeBag;
 @endphp
 
 @props([
-    'color' => 'primary',
-    'deleteButton' => null,
-    'disabled' => false,
-    'form' => null,
-    'formId' => null,
-    'href' => null,
-    'icon' => null,
-    'iconAlias' => null,
-    'iconPosition' => IconPosition::Before,
-    'iconSize' => null,
-    'keyBindings' => null,
-    'loadingIndicator' => true,
-    'size' => Size::Medium,
-    'spaMode' => null,
-    'tag' => 'span',
-    'target' => null,
-    'tooltip' => null,
-    'type' => 'button',
+'color' => 'primary',
+'deleteButton' => null,
+'disabled' => false,
+'form' => null,
+'formId' => null,
+'href' => null,
+'icon' => null,
+'iconAlias' => null,
+'iconPosition' => IconPosition::Before,
+'iconSize' => null,
+'keyBindings' => null,
+'loadingIndicator' => true,
+'size' => Size::Medium,
+'spaMode' => null,
+'tag' => 'span',
+'target' => null,
+'tooltip' => null,
+'type' => 'button',
 ])
 
 @php
     if (! $iconPosition instanceof IconPosition) {
-        $iconPosition = filled($iconPosition) ? (IconPosition::tryFrom($iconPosition) ?? $iconPosition) : null;
-    }
+            $iconPosition = filled($iconPosition) ? (IconPosition::tryFrom($iconPosition) ?? $iconPosition) : null;
+        }
 
-    if (! $size instanceof Size) {
-        $size = filled($size) ? (Size::tryFrom($size) ?? $size) : null;
-    }
+        if (! $size instanceof Size) {
+            $size = filled($size) ? (Size::tryFrom($size) ?? $size) : null;
+        }
 
-    if (filled($iconSize) && (! $iconSize instanceof IconSize)) {
-        $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
-    }
+        if (filled($iconSize) && (! $iconSize instanceof IconSize)) {
+            $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
+        }
 
-    $isDeletable = count($deleteButton?->attributes->getAttributes() ?? []) > 0;
+        $isDeletable = count($deleteButton?->attributes->getAttributes() ?? []) > 0;
 
-    $wireTarget = $loadingIndicator ? $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(fn ($value): bool => filled($value))->first() : null;
+        $wireTarget = $loadingIndicator ? $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(fn ($value): bool => filled($value))->first() : null;
 
-    $hasLoadingIndicator = filled($wireTarget) || ($type === 'submit' && filled($form));
+        $hasLoadingIndicator = filled($wireTarget) || ($type === 'submit' && filled($form));
 
-    if ($hasLoadingIndicator) {
-        $loadingIndicatorTarget = html_entity_decode($wireTarget ?: $form, ENT_QUOTES);
-    }
+        if ($hasLoadingIndicator) {
+            $loadingIndicatorTarget = html_entity_decode($wireTarget ?: $form, ENT_QUOTES);
+        }
 
-    $hasTooltip = filled($tooltip);
+        $hasTooltip = filled($tooltip);
 @endphp
 
 <{{ $tag }}
@@ -70,34 +70,34 @@
     @endif
     {{
         $attributes
-            ->merge([
-                'aria-disabled' => $disabled ? 'true' : null,
-                'disabled' => $disabled && blank($tooltip),
-                'form' => $tag === 'button' ? $formId : null,
-                'type' => $tag === 'button' ? $type : null,
-                'wire:loading.attr' => $tag === 'button' ? 'disabled' : null,
-                'wire:target' => ($hasLoadingIndicator && $loadingIndicatorTarget) ? $loadingIndicatorTarget : null,
-            ], escape: false)
-            ->when(
-                $disabled && $hasTooltip,
-                fn (ComponentAttributeBag $attributes) => $attributes->filter(
-                    fn (mixed $value, string $key): bool => ! str($key)->startsWith(['href', 'x-on:', 'wire:click']),
-                ),
-            )
-            ->class([
-                'fi-badge',
-                'fi-disabled' => $disabled,
-                ($size instanceof Size) ? "fi-size-{$size->value}" : (is_string($size) ? $size : ''),
-            ])
-            ->color(BadgeComponent::class, $color)
+        ->merge([
+        'aria-disabled' => $disabled ? 'true' : null,
+        'disabled' => $disabled && blank($tooltip),
+        'form' => $tag === 'button' ? $formId : null,
+        'type' => $tag === 'button' ? $type : null,
+        'wire:loading.attr' => $tag === 'button' ? 'disabled' : null,
+        'wire:target' => ($hasLoadingIndicator && $loadingIndicatorTarget) ? $loadingIndicatorTarget : null,
+        ], escape: false)
+        ->when(
+        $disabled && $hasTooltip,
+        fn (ComponentAttributeBag $attributes) => $attributes->filter(
+        fn (mixed $value, string $key): bool => ! str($key)->startsWith(['href', 'x-on:', 'wire:click']),
+        ),
+        )
+        ->class([
+        'fi-badge',
+        'fi-disabled' => $disabled,
+        ($size instanceof Size) ? "fi-size-{$size->value}" : (is_string($size) ? $size : ''),
+        ])
+        ->color(BadgeComponent::class, $color)
     }}
 >
     @if ($iconPosition === IconPosition::Before)
         @if ($icon)
             {{
                 \Filament\Support\generate_icon_html($icon, $iconAlias, (new \Illuminate\View\ComponentAttributeBag([
-                    'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
-                    'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
+                'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
+                'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
                 ])), size: $iconSize ?? \Filament\Support\Enums\IconSize::Small)
             }}
         @endif
@@ -105,8 +105,8 @@
         @if ($hasLoadingIndicator)
             {{
                 \Filament\Support\generate_loading_indicator_html((new \Illuminate\View\ComponentAttributeBag([
-                    'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
-                    'wire:target' => $loadingIndicatorTarget,
+                'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
+                'wire:target' => $loadingIndicatorTarget,
                 ])), size: $iconSize ?? \Filament\Support\Enums\IconSize::Small)
             }}
         @endif
@@ -122,35 +122,35 @@
         @php
             $deleteButtonWireTarget = $deleteButton->attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(fn ($value): bool => filled($value))->first();
 
-            $deleteButtonHasLoadingIndicator = filled($deleteButtonWireTarget);
+                        $deleteButtonHasLoadingIndicator = filled($deleteButtonWireTarget);
 
-            if ($deleteButtonHasLoadingIndicator) {
-                $deleteButtonLoadingIndicatorTarget = html_entity_decode($deleteButtonWireTarget, ENT_QUOTES);
-            }
+                        if ($deleteButtonHasLoadingIndicator) {
+                            $deleteButtonLoadingIndicatorTarget = html_entity_decode($deleteButtonWireTarget, ENT_QUOTES);
+                        }
         @endphp
 
         <button
             type="button"
             {{
                 $deleteButton->attributes
-                    ->except(['label'])
-                    ->class([
-                        'fi-badge-delete-btn',
-                    ])
+                ->except(['label'])
+                ->class([
+                'fi-badge-delete-btn',
+                ])
             }}
         >
             {{
                 \Filament\Support\generate_icon_html(\Filament\Support\Icons\Heroicon::XMark, alias: \Filament\Support\View\SupportIconAlias::BADGE_DELETE_BUTTON, attributes: (new \Illuminate\View\ComponentAttributeBag([
-                    'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $deleteButtonHasLoadingIndicator,
-                    'wire:target' => $deleteButtonHasLoadingIndicator ? $deleteButtonLoadingIndicatorTarget : false,
+                'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $deleteButtonHasLoadingIndicator,
+                'wire:target' => $deleteButtonHasLoadingIndicator ? $deleteButtonLoadingIndicatorTarget : false,
                 ])), size: \Filament\Support\Enums\IconSize::ExtraSmall)
             }}
 
             @if ($deleteButtonHasLoadingIndicator)
                 {{
                     \Filament\Support\generate_loading_indicator_html((new \Illuminate\View\ComponentAttributeBag([
-                        'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
-                        'wire:target' => $deleteButtonLoadingIndicatorTarget,
+                    'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
+                    'wire:target' => $deleteButtonLoadingIndicatorTarget,
                     ])), size: \Filament\Support\Enums\IconSize::ExtraSmall)
                 }}
             @endif
@@ -165,8 +165,8 @@
         @if ($icon)
             {{
                 \Filament\Support\generate_icon_html($icon, $iconAlias, (new \Illuminate\View\ComponentAttributeBag([
-                    'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
-                    'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
+                'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
+                'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
                 ])), size: $iconSize ?? \Filament\Support\Enums\IconSize::Small)
             }}
         @endif
@@ -174,8 +174,8 @@
         @if ($hasLoadingIndicator)
             {{
                 \Filament\Support\generate_loading_indicator_html((new \Illuminate\View\ComponentAttributeBag([
-                    'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
-                    'wire:target' => $loadingIndicatorTarget,
+                'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
+                'wire:target' => $loadingIndicatorTarget,
                 ])), size: $iconSize ?? \Filament\Support\Enums\IconSize::Small)
             }}
         @endif

--- a/packages/support/resources/views/components/breadcrumbs.blade.php
+++ b/packages/support/resources/views/components/breadcrumbs.blade.php
@@ -1,11 +1,11 @@
 @php
     use Illuminate\View\ComponentAttributeBag;
 
-    use function Filament\Support\generate_icon_html;
+        use function Filament\Support\generate_icon_html;
 @endphp
 
 @props([
-    'breadcrumbs' => [],
+'breadcrumbs' => [],
 ])
 
 <nav {{ $attributes->class(['fi-breadcrumbs']) }}>
@@ -15,13 +15,13 @@
                 @if (! $loop->first)
                     {{
                         generate_icon_html(\Filament\Support\Icons\Heroicon::ChevronRight, alias: \Filament\Support\View\SupportIconAlias::BREADCRUMBS_SEPARATOR, attributes: (new ComponentAttributeBag)->class([
-                            'fi-breadcrumbs-item-separator fi-ltr',
+                        'fi-breadcrumbs-item-separator fi-ltr',
                         ]))
                     }}
 
                     {{
                         generate_icon_html(\Filament\Support\Icons\Heroicon::ChevronLeft, alias: \Filament\Support\View\SupportIconAlias::BREADCRUMBS_SEPARATOR_RTL, attributes: (new ComponentAttributeBag)->class([
-                            'fi-breadcrumbs-item-separator fi-rtl',
+                        'fi-breadcrumbs-item-separator fi-rtl',
                         ]))
                     }}
                 @endif

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -1,70 +1,70 @@
 @php
     use Filament\Support\Enums\IconPosition;
-    use Filament\Support\Enums\IconSize;
-    use Filament\Support\Enums\Size;
-    use Filament\Support\View\Components\BadgeComponent;
-    use Filament\Support\View\Components\ButtonComponent;
-    use Illuminate\View\ComponentAttributeBag;
+        use Filament\Support\Enums\IconSize;
+        use Filament\Support\Enums\Size;
+        use Filament\Support\View\Components\BadgeComponent;
+        use Filament\Support\View\Components\ButtonComponent;
+        use Illuminate\View\ComponentAttributeBag;
 @endphp
 
 @props([
-    'badge' => null,
-    'badgeColor' => 'primary',
-    'badgeSize' => Size::ExtraSmall,
-    'color' => 'primary',
-    'disabled' => false,
-    'form' => null,
-    'formId' => null,
-    'href' => null,
-    'icon' => null,
-    'iconAlias' => null,
-    'iconPosition' => IconPosition::Before,
-    'iconSize' => null,
-    'keyBindings' => null,
-    'labeledFrom' => null,
-    'labelSrOnly' => false,
-    'loadingIndicator' => true,
-    'outlined' => false,
-    'size' => Size::Medium,
-    'spaMode' => null,
-    'tag' => 'button',
-    'target' => null,
-    'tooltip' => null,
-    'type' => 'button',
+'badge' => null,
+'badgeColor' => 'primary',
+'badgeSize' => Size::ExtraSmall,
+'color' => 'primary',
+'disabled' => false,
+'form' => null,
+'formId' => null,
+'href' => null,
+'icon' => null,
+'iconAlias' => null,
+'iconPosition' => IconPosition::Before,
+'iconSize' => null,
+'keyBindings' => null,
+'labeledFrom' => null,
+'labelSrOnly' => false,
+'loadingIndicator' => true,
+'outlined' => false,
+'size' => Size::Medium,
+'spaMode' => null,
+'tag' => 'button',
+'target' => null,
+'tooltip' => null,
+'type' => 'button',
 ])
 
 @php
     if (! $iconPosition instanceof IconPosition) {
-        $iconPosition = filled($iconPosition) ? (IconPosition::tryFrom($iconPosition) ?? $iconPosition) : null;
-    }
+            $iconPosition = filled($iconPosition) ? (IconPosition::tryFrom($iconPosition) ?? $iconPosition) : null;
+        }
 
-    if (! $size instanceof Size) {
-        $size = filled($size) ? (Size::tryFrom($size) ?? $size) : null;
-    }
+        if (! $size instanceof Size) {
+            $size = filled($size) ? (Size::tryFrom($size) ?? $size) : null;
+        }
 
-    if (! $badgeSize instanceof Size) {
-        $badgeSize = filled($badgeSize) ? (Size::tryFrom($badgeSize) ?? $badgeSize) : null;
-    }
+        if (! $badgeSize instanceof Size) {
+            $badgeSize = filled($badgeSize) ? (Size::tryFrom($badgeSize) ?? $badgeSize) : null;
+        }
 
-    if (filled($iconSize) && (! $iconSize instanceof IconSize)) {
-        $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
-    }
+        if (filled($iconSize) && (! $iconSize instanceof IconSize)) {
+            $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
+        }
 
-    $iconSize ??= match ($size) {
-        Size::ExtraSmall, Size::Small => IconSize::Small,
-        default => null,
-    };
+        $iconSize ??= match ($size) {
+            Size::ExtraSmall, Size::Small => IconSize::Small,
+            default => null,
+        };
 
-    $wireTarget = $loadingIndicator ? $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(fn ($value): bool => filled($value))->first() : null;
+        $wireTarget = $loadingIndicator ? $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(fn ($value): bool => filled($value))->first() : null;
 
-    $hasFormProcessingLoadingIndicator = $type === 'submit' && filled($form);
-    $hasLoadingIndicator = filled($wireTarget) || $hasFormProcessingLoadingIndicator;
+        $hasFormProcessingLoadingIndicator = $type === 'submit' && filled($form);
+        $hasLoadingIndicator = filled($wireTarget) || $hasFormProcessingLoadingIndicator;
 
-    if ($hasLoadingIndicator) {
-        $loadingIndicatorTarget = html_entity_decode($wireTarget ?: $form, ENT_QUOTES);
-    }
+        if ($hasLoadingIndicator) {
+            $loadingIndicatorTarget = html_entity_decode($wireTarget ?: $form, ENT_QUOTES);
+        }
 
-    $hasTooltip = filled($tooltip);
+        $hasTooltip = filled($tooltip);
 @endphp
 
 @if ($labeledFrom)
@@ -114,39 +114,39 @@
     @endif
     {{
         $attributes
-            ->merge([
-                'aria-disabled' => $disabled ? 'true' : null,
-                'aria-label' => $labelSrOnly ? trim(strip_tags($slot->toHtml())) : null,
-                'disabled' => $disabled && blank($tooltip),
-                'form' => $formId,
-                'type' => $tag === 'button' ? $type : null,
-                'wire:loading.attr' => $tag === 'button' ? 'disabled' : null,
-                'wire:target' => ($hasLoadingIndicator && $loadingIndicatorTarget) ? $loadingIndicatorTarget : null,
-                'x-bind:disabled' => $hasFormProcessingLoadingIndicator ? 'isProcessing' : null,
-                'x-bind:aria-label' => ($labelSrOnly && $hasFormProcessingLoadingIndicator) ? ('isProcessing ? processingMessage : ' . \Illuminate\Support\Js::from(trim(strip_tags($slot->toHtml())))) : null,
-            ], escape: false)
-            ->when(
-                $disabled && $hasTooltip,
-                fn (ComponentAttributeBag $attributes) => $attributes->filter(
-                    fn (mixed $value, string $key): bool => ! str($key)->startsWith(['href', 'x-on:', 'wire:click']),
-                ),
-            )
-            ->class([
-                'fi-btn',
-                'fi-disabled' => $disabled,
-                'fi-outlined' => $outlined,
-                ($size instanceof Size) ? "fi-size-{$size->value}" : (is_string($size) ? $size : ''),
-                is_string($labeledFrom) ? "fi-labeled-from-{$labeledFrom}" : null,
-            ])
-            ->color(app(ButtonComponent::class, ['isOutlined' => $outlined]), $color)
+        ->merge([
+        'aria-disabled' => $disabled ? 'true' : null,
+        'aria-label' => $labelSrOnly ? trim(strip_tags($slot->toHtml())) : null,
+        'disabled' => $disabled && blank($tooltip),
+        'form' => $formId,
+        'type' => $tag === 'button' ? $type : null,
+        'wire:loading.attr' => $tag === 'button' ? 'disabled' : null,
+        'wire:target' => ($hasLoadingIndicator && $loadingIndicatorTarget) ? $loadingIndicatorTarget : null,
+        'x-bind:disabled' => $hasFormProcessingLoadingIndicator ? 'isProcessing' : null,
+        'x-bind:aria-label' => ($labelSrOnly && $hasFormProcessingLoadingIndicator) ? ('isProcessing ? processingMessage : ' . \Illuminate\Support\Js::from(trim(strip_tags($slot->toHtml())))) : null,
+        ], escape: false)
+        ->when(
+        $disabled && $hasTooltip,
+        fn (ComponentAttributeBag $attributes) => $attributes->filter(
+        fn (mixed $value, string $key): bool => ! str($key)->startsWith(['href', 'x-on:', 'wire:click']),
+        ),
+        )
+        ->class([
+        'fi-btn',
+        'fi-disabled' => $disabled,
+        'fi-outlined' => $outlined,
+        ($size instanceof Size) ? "fi-size-{$size->value}" : (is_string($size) ? $size : ''),
+        is_string($labeledFrom) ? "fi-labeled-from-{$labeledFrom}" : null,
+        ])
+        ->color(app(ButtonComponent::class, ['isOutlined' => $outlined]), $color)
     }}
 >
     @if ($iconPosition === IconPosition::Before)
         @if ($icon)
             {{
                 \Filament\Support\generate_icon_html($icon, $iconAlias, (new \Illuminate\View\ComponentAttributeBag([
-                    'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
-                    'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
+                'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
+                'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
                 ])), size: $iconSize)
             }}
         @endif
@@ -154,8 +154,8 @@
         @if ($hasLoadingIndicator)
             {{
                 \Filament\Support\generate_loading_indicator_html((new \Illuminate\View\ComponentAttributeBag([
-                    'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
-                    'wire:target' => $loadingIndicatorTarget,
+                'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
+                'wire:target' => $loadingIndicatorTarget,
                 ])), size: $iconSize)
             }}
         @endif
@@ -163,8 +163,8 @@
         @if ($hasFormProcessingLoadingIndicator)
             {{
                 \Filament\Support\generate_loading_indicator_html((new \Illuminate\View\ComponentAttributeBag([
-                    'x-cloak' => 'x-cloak',
-                    'x-show' => 'isProcessing',
+                'x-cloak' => 'x-cloak',
+                'x-show' => 'isProcessing',
                 ])), size: $iconSize)
             }}
         @endif
@@ -192,8 +192,8 @@
         @if ($icon)
             {{
                 \Filament\Support\generate_icon_html($icon, $iconAlias, (new \Illuminate\View\ComponentAttributeBag([
-                    'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
-                    'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
+                'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
+                'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
                 ])), size: $iconSize)
             }}
         @endif
@@ -201,8 +201,8 @@
         @if ($hasLoadingIndicator)
             {{
                 \Filament\Support\generate_loading_indicator_html((new \Illuminate\View\ComponentAttributeBag([
-                    'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
-                    'wire:target' => $loadingIndicatorTarget,
+                'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
+                'wire:target' => $loadingIndicatorTarget,
                 ])), size: $iconSize)
             }}
         @endif
@@ -210,8 +210,8 @@
         @if ($hasFormProcessingLoadingIndicator)
             {{
                 \Filament\Support\generate_loading_indicator_html((new \Illuminate\View\ComponentAttributeBag([
-                    'x-cloak' => 'x-cloak',
-                    'x-show' => 'isProcessing',
+                'x-cloak' => 'x-cloak',
+                'x-show' => 'isProcessing',
                 ])), size: $iconSize)
             }}
         @endif
@@ -225,8 +225,8 @@
                 <span
                     {{
                         (new ComponentAttributeBag)->color(BadgeComponent::class, $badgeColor)->class([
-                            'fi-badge',
-                            ($badgeSize instanceof Size) ? "fi-size-{$badgeSize->value}" : (is_string($badgeSize) ? $badgeSize : ''),
+                        'fi-badge',
+                        ($badgeSize instanceof Size) ? "fi-size-{$badgeSize->value}" : (is_string($badgeSize) ? $badgeSize : ''),
                         ])
                     }}
                 >

--- a/packages/support/resources/views/components/callout.blade.php
+++ b/packages/support/resources/views/components/callout.blade.php
@@ -1,51 +1,51 @@
 @php
     use Filament\Support\Enums\IconSize;
-    use Filament\Support\View\Components\CalloutComponent\IconComponent;
+        use Filament\Support\View\Components\CalloutComponent\IconComponent;
 
-    use function Filament\Support\generate_icon_html;
-    use function Filament\Support\is_slot_empty;
+        use function Filament\Support\generate_icon_html;
+        use function Filament\Support\is_slot_empty;
 @endphp
 
 @props([
-    'color' => 'gray',
-    'controls' => null,
-    'description' => null,
-    'footer' => null,
-    'heading' => null,
-    'icon' => null,
-    'iconColor' => null,
-    'iconSize' => null,
+'color' => 'gray',
+'controls' => null,
+'description' => null,
+'footer' => null,
+'heading' => null,
+'icon' => null,
+'iconColor' => null,
+'iconSize' => null,
 ])
 
 @php
     if (filled($iconSize) && (! $iconSize instanceof IconSize)) {
-        $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
-    }
+            $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
+        }
 
-    $iconColor ??= $color;
+        $iconColor ??= $color;
 
-    $hasDescription = filled((string) $description);
-    $hasHeading = filled($heading);
-    $hasFooter = ! is_slot_empty($footer);
-    $hasIcon = filled($icon);
-    $hasControls = ! is_slot_empty($controls);
+        $hasDescription = filled((string) $description);
+        $hasHeading = filled($heading);
+        $hasFooter = ! is_slot_empty($footer);
+        $hasIcon = filled($icon);
+        $hasControls = ! is_slot_empty($controls);
 @endphp
 
 <div
     {{
         $attributes
-            ->color(\Filament\Support\View\Components\CalloutComponent::class, $color)
-            ->class(['fi-callout'])
+        ->color(\Filament\Support\View\Components\CalloutComponent::class, $color)
+        ->class(['fi-callout'])
     }}
 >
     @if ($hasIcon)
         {{
             generate_icon_html(
-                $icon,
-                attributes: (new \Illuminate\View\ComponentAttributeBag)
-                    ->color(IconComponent::class, $iconColor)
-                    ->class(['fi-callout-icon']),
-                size: $iconSize ?? IconSize::Large,
+            $icon,
+            attributes: (new \Illuminate\View\ComponentAttributeBag)
+            ->color(IconComponent::class, $iconColor)
+            ->class(['fi-callout-icon']),
+            size: $iconSize ?? IconSize::Large,
             )
         }}
     @endif

--- a/packages/support/resources/views/components/dropdown/header.blade.php
+++ b/packages/support/resources/views/components/dropdown/header.blade.php
@@ -1,29 +1,29 @@
 @php
     use Filament\Support\Enums\IconSize;
-    use Filament\Support\View\Components\DropdownComponent\HeaderComponent;
-    use Illuminate\View\ComponentAttributeBag;
+        use Filament\Support\View\Components\DropdownComponent\HeaderComponent;
+        use Illuminate\View\ComponentAttributeBag;
 @endphp
 
 @props([
-    'color' => 'gray',
-    'icon' => null,
-    'iconSize' => null,
-    'tag' => 'div',
+'color' => 'gray',
+'icon' => null,
+'iconSize' => null,
+'tag' => 'div',
 ])
 
 @php
     if (! ($iconSize instanceof IconSize)) {
-        $iconSize = filled($iconSize) ? (IconSize::tryFrom($iconSize) ?? $iconSize) : null;
-    }
+            $iconSize = filled($iconSize) ? (IconSize::tryFrom($iconSize) ?? $iconSize) : null;
+        }
 @endphp
 
 <{{ $tag }}
     {{
         $attributes
-            ->class([
-                'fi-dropdown-header',
-            ])
-            ->color(HeaderComponent::class, $color)
+        ->class([
+        'fi-dropdown-header',
+        ])
+        ->color(HeaderComponent::class, $color)
     }}
 >
     {{ \Filament\Support\generate_icon_html($icon, size: $iconSize) }}

--- a/packages/support/resources/views/components/dropdown/index.blade.php
+++ b/packages/support/resources/views/components/dropdown/index.blade.php
@@ -1,30 +1,30 @@
 @props([
-    'availableHeight' => null,
-    'availableWidth' => null,
-    'flip' => true,
-    'maxHeight' => null,
-    'offset' => 8,
-    'placement' => null,
-    'shift' => false,
-    'size' => false,
-    'sizePadding' => 16,
-    'teleport' => false,
-    'trigger' => null,
-    'width' => null,
+'availableHeight' => null,
+'availableWidth' => null,
+'flip' => true,
+'maxHeight' => null,
+'offset' => 8,
+'placement' => null,
+'shift' => false,
+'size' => false,
+'sizePadding' => 16,
+'teleport' => false,
+'trigger' => null,
+'width' => null,
 ])
 
 @php
     use Filament\Support\Enums\Width;
 
-    $sizeConfig = collect([
-        'availableHeight' => $availableHeight,
-        'availableWidth' => $availableWidth,
-        'padding' => $sizePadding,
-    ])->filter()->toJson();
+        $sizeConfig = collect([
+            'availableHeight' => $availableHeight,
+            'availableWidth' => $availableWidth,
+            'padding' => $sizePadding,
+        ])->filter()->toJson();
 
-    if (is_string($width)) {
-        $width = Width::tryFrom($width) ?? $width;
-    }
+        if (is_string($width)) {
+            $width = Width::tryFrom($width) ?? $width;
+        }
 @endphp
 
 <div
@@ -52,12 +52,12 @@
                 wire:key="{{ $attributes->get('wire:key') }}.panel"
             @endif
             @class([
-                'fi-dropdown-panel',
-                ($width instanceof Width) ? "fi-width-{$width->value}" : (is_string($width) ? $width : ''),
-                'fi-scrollable' => $maxHeight || $size,
+            'fi-dropdown-panel',
+            ($width instanceof Width) ? "fi-width-{$width->value}" : (is_string($width) ? $width : ''),
+            'fi-scrollable' => $maxHeight || $size,
             ])
             @style([
-                "max-height: {$maxHeight}" => $maxHeight,
+            "max-height: {$maxHeight}" => $maxHeight,
             ])
         >
             {{ $slot }}

--- a/packages/support/resources/views/components/dropdown/list/item.blade.php
+++ b/packages/support/resources/views/components/dropdown/list/item.blade.php
@@ -1,51 +1,51 @@
 @php
     use Filament\Support\Enums\IconSize;
-    use Filament\Support\Enums\Size;
-    use Filament\Support\View\Components\BadgeComponent;
-    use Filament\Support\View\Components\DropdownComponent\ItemComponent;
-    use Filament\Support\View\Components\DropdownComponent\ItemComponent\IconComponent;
-    use Illuminate\View\ComponentAttributeBag;
+        use Filament\Support\Enums\Size;
+        use Filament\Support\View\Components\BadgeComponent;
+        use Filament\Support\View\Components\DropdownComponent\ItemComponent;
+        use Filament\Support\View\Components\DropdownComponent\ItemComponent\IconComponent;
+        use Illuminate\View\ComponentAttributeBag;
 @endphp
 
 @props([
-    'alpineDeferredBadgeData' => null,
-    'alpineDeferredBadgeLoading' => null,
-    'badge' => null,
-    'badgeColor' => 'primary',
-    'badgeTooltip' => null,
-    'color' => 'gray',
-    'disabled' => false,
-    'href' => null,
-    'icon' => null,
-    'iconAlias' => null,
-    'iconColor' => null,
-    'iconSize' => null,
-    'image' => null,
-    'keyBindings' => null,
-    'loadingIndicator' => true,
-    'spaMode' => null,
-    'tag' => 'button',
-    'target' => null,
-    'tooltip' => null,
+'alpineDeferredBadgeData' => null,
+'alpineDeferredBadgeLoading' => null,
+'badge' => null,
+'badgeColor' => 'primary',
+'badgeTooltip' => null,
+'color' => 'gray',
+'disabled' => false,
+'href' => null,
+'icon' => null,
+'iconAlias' => null,
+'iconColor' => null,
+'iconSize' => null,
+'image' => null,
+'keyBindings' => null,
+'loadingIndicator' => true,
+'spaMode' => null,
+'tag' => 'button',
+'target' => null,
+'tooltip' => null,
 ])
 
 @php
     if (filled($iconSize) && (! $iconSize instanceof IconSize)) {
-        $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
-    }
+            $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
+        }
 
-    $iconColor ??= $color;
+        $iconColor ??= $color;
 
-    $wireTarget = $loadingIndicator ? $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(fn ($value): bool => filled($value))->first() : null;
+        $wireTarget = $loadingIndicator ? $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(fn ($value): bool => filled($value))->first() : null;
 
-    $hasLoadingIndicator = filled($wireTarget);
+        $hasLoadingIndicator = filled($wireTarget);
 
-    if ($hasLoadingIndicator) {
-        $loadingIndicatorTarget = html_entity_decode($wireTarget, ENT_QUOTES);
-    }
+        if ($hasLoadingIndicator) {
+            $loadingIndicatorTarget = html_entity_decode($wireTarget, ENT_QUOTES);
+        }
 
-    $hasDeferredBadge = filled($alpineDeferredBadgeData);
-    $hasTooltip = filled($tooltip);
+        $hasDeferredBadge = filled($alpineDeferredBadgeData);
+        $hasTooltip = filled($tooltip);
 @endphp
 
 {!! ($tag === 'form') ? ('<form ' . $attributes->only(['action', 'class', 'method', 'wire:submit'])->toHtml() . '>') : '' !!}
@@ -71,39 +71,39 @@
     @endif
     {{
         $attributes
-            ->when(
-                $tag === 'form',
-                fn (ComponentAttributeBag $attributes) => $attributes->except(['action', 'class', 'method', 'wire:submit']),
-            )
-            ->merge([
-                'aria-disabled' => $disabled ? 'true' : null,
-                'disabled' => $disabled && blank($tooltip),
-                'type' => match ($tag) {
-                    'button' => 'button',
-                    'form' => 'submit',
-                    default => null,
-                },
-                'wire:loading.attr' => $tag === 'button' ? 'disabled' : null,
-                'wire:target' => ($hasLoadingIndicator && $loadingIndicatorTarget) ? $loadingIndicatorTarget : null,
-            ], escape: false)
-            ->when(
-                $disabled && $hasTooltip,
-                fn (ComponentAttributeBag $attributes) => $attributes->filter(
-                    fn (mixed $value, string $key): bool => ! str($key)->startsWith(['href', 'x-on:', 'wire:click']),
-                ),
-            )
-            ->class([
-                'fi-dropdown-list-item',
-                'fi-disabled' => $disabled,
-            ])
-            ->color(ItemComponent::class, $color)
+        ->when(
+        $tag === 'form',
+        fn (ComponentAttributeBag $attributes) => $attributes->except(['action', 'class', 'method', 'wire:submit']),
+        )
+        ->merge([
+        'aria-disabled' => $disabled ? 'true' : null,
+        'disabled' => $disabled && blank($tooltip),
+        'type' => match ($tag) {
+        'button' => 'button',
+        'form' => 'submit',
+        default => null,
+        },
+        'wire:loading.attr' => $tag === 'button' ? 'disabled' : null,
+        'wire:target' => ($hasLoadingIndicator && $loadingIndicatorTarget) ? $loadingIndicatorTarget : null,
+        ], escape: false)
+        ->when(
+        $disabled && $hasTooltip,
+        fn (ComponentAttributeBag $attributes) => $attributes->filter(
+        fn (mixed $value, string $key): bool => ! str($key)->startsWith(['href', 'x-on:', 'wire:click']),
+        ),
+        )
+        ->class([
+        'fi-dropdown-list-item',
+        'fi-disabled' => $disabled,
+        ])
+        ->color(ItemComponent::class, $color)
     }}
 >
     @if ($icon)
         {{
             \Filament\Support\generate_icon_html($icon, $iconAlias, (new ComponentAttributeBag([
-                'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
-                'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
+            'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
+            'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
             ]))->color(IconComponent::class, $iconColor), size: $iconSize)
         }}
     @endif
@@ -122,8 +122,8 @@
     @if ($hasLoadingIndicator)
         {{
             \Filament\Support\generate_loading_indicator_html((new ComponentAttributeBag([
-                'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
-                'wire:target' => $loadingIndicatorTarget,
+            'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
+            'wire:target' => $loadingIndicatorTarget,
             ]))->color(IconComponent::class, $iconColor), size: $iconSize)
         }}
     @endif

--- a/packages/support/resources/views/components/empty-state.blade.php
+++ b/packages/support/resources/views/components/empty-state.blade.php
@@ -1,35 +1,35 @@
 @php
     use Filament\Support\Enums\IconSize;
-    use Filament\Support\View\Components\SectionComponent\IconComponent;
+        use Filament\Support\View\Components\SectionComponent\IconComponent;
 @endphp
 
 @props([
-    'compact' => false,
-    'contained' => true,
-    'description' => null,
-    'footer' => null,
-    'heading',
-    'headingTag' => 'h2',
-    'icon' => null,
-    'iconColor' => 'primary',
-    'iconSize' => null,
+'compact' => false,
+'contained' => true,
+'description' => null,
+'footer' => null,
+'heading',
+'headingTag' => 'h2',
+'icon' => null,
+'iconColor' => 'primary',
+'iconSize' => null,
 ])
 
 @php
     if (filled($iconSize) && (! $iconSize instanceof IconSize)) {
-        $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
-    }
+            $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
+        }
 
-    $hasDescription = filled((string) $description);
-    $hasIcon = filled($icon);
+        $hasDescription = filled((string) $description);
+        $hasIcon = filled($icon);
 @endphp
 
 <section
     {{
         $attributes->class([
-            'fi-empty-state',
-            'fi-compact' => $compact,
-            'fi-empty-state-not-contained' => ! $contained,
+        'fi-empty-state',
+        'fi-compact' => $compact,
+        'fi-empty-state-not-contained' => ! $contained,
         ])
     }}
 >
@@ -37,13 +37,13 @@
         @if ($hasIcon)
             <div
                 @class([
-                    'fi-empty-state-icon-bg',
-                    'fi-color ' . ('fi-color-' . $iconColor) => $iconColor !== 'gray',
+                'fi-empty-state-icon-bg',
+                'fi-color ' . ('fi-color-' . $iconColor) => $iconColor !== 'gray',
                 ])
             >
                 {{
                     \Filament\Support\generate_icon_html($icon, attributes: (new \Illuminate\View\ComponentAttributeBag)
-                        ->color(IconComponent::class, $iconColor), size: $iconSize ?? IconSize::Large)
+                    ->color(IconComponent::class, $iconColor), size: $iconSize ?? IconSize::Large)
                 }}
             </div>
         @endif

--- a/packages/support/resources/views/components/fieldset.blade.php
+++ b/packages/support/resources/views/components/fieldset.blade.php
@@ -1,16 +1,16 @@
 @props([
-    'contained' => true,
-    'label' => null,
-    'labelHidden' => false,
-    'required' => false,
+'contained' => true,
+'label' => null,
+'labelHidden' => false,
+'required' => false,
 ])
 
 <fieldset
     {{
         $attributes->class([
-            'fi-fieldset',
-            'fi-fieldset-label-hidden' => $labelHidden,
-            'fi-fieldset-not-contained' => ! $contained,
+        'fi-fieldset',
+        'fi-fieldset-label-hidden' => $labelHidden,
+        'fi-fieldset-not-contained' => ! $contained,
         ])
     }}
 >

--- a/packages/support/resources/views/components/icon-button.blade.php
+++ b/packages/support/resources/views/components/icon-button.blade.php
@@ -1,62 +1,62 @@
 @php
     use Filament\Support\Enums\IconSize;
-    use Filament\Support\Enums\Size;
-    use Filament\Support\View\Components\BadgeComponent;
-    use Filament\Support\View\Components\IconButtonComponent;
-    use Illuminate\View\ComponentAttributeBag;
+        use Filament\Support\Enums\Size;
+        use Filament\Support\View\Components\BadgeComponent;
+        use Filament\Support\View\Components\IconButtonComponent;
+        use Illuminate\View\ComponentAttributeBag;
 @endphp
 
 @props([
-    'badge' => null,
-    'badgeColor' => 'primary',
-    'badgeSize' => Size::ExtraSmall,
-    'color' => 'primary',
-    'disabled' => false,
-    'form' => null,
-    'formId' => null,
-    'href' => null,
-    'icon' => null,
-    'iconAlias' => null,
-    'iconSize' => null,
-    'keyBindings' => null,
-    'label' => null,
-    'loadingIndicator' => true,
-    'size' => Size::Medium,
-    'spaMode' => null,
-    'tag' => 'button',
-    'target' => null,
-    'tooltip' => null,
-    'type' => 'button',
+'badge' => null,
+'badgeColor' => 'primary',
+'badgeSize' => Size::ExtraSmall,
+'color' => 'primary',
+'disabled' => false,
+'form' => null,
+'formId' => null,
+'href' => null,
+'icon' => null,
+'iconAlias' => null,
+'iconSize' => null,
+'keyBindings' => null,
+'label' => null,
+'loadingIndicator' => true,
+'size' => Size::Medium,
+'spaMode' => null,
+'tag' => 'button',
+'target' => null,
+'tooltip' => null,
+'type' => 'button',
 ])
 
 @php
     if (! $size instanceof Size) {
-        $size = filled($size) ? (Size::tryFrom($size) ?? $size) : null;
-    }
+            $size = filled($size) ? (Size::tryFrom($size) ?? $size) : null;
+        }
 
-    if (! $badgeSize instanceof Size) {
-        $badgeSize = filled($badgeSize) ? (Size::tryFrom($badgeSize) ?? $badgeSize) : null;
-    }
+        if (! $badgeSize instanceof Size) {
+            $badgeSize = filled($badgeSize) ? (Size::tryFrom($badgeSize) ?? $badgeSize) : null;
+        }
 
-    if (filled($iconSize) && (! $iconSize instanceof IconSize)) {
-        $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
-    }
+        if (filled($iconSize) && (! $iconSize instanceof IconSize)) {
+            $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
+        }
 
-    $iconSize ??= match ($size) {
-        Size::ExtraSmall => IconSize::Small,
-        Size::Large, Size::ExtraLarge => IconSize::Large,
-        default => null,
-    };
+        $iconSize ??= match ($size) {
+            Size::ExtraSmall => IconSize::Small,
+            Size::Large, Size::ExtraLarge => IconSize::Large,
+            default => null,
+        };
 
-    $wireTarget = $loadingIndicator ? $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(fn ($value): bool => filled($value))->first() : null;
+        $wireTarget = $loadingIndicator ? $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(fn ($value): bool => filled($value))->first() : null;
 
-    $hasLoadingIndicator = filled($wireTarget) || ($type === 'submit' && filled($form));
+        $hasLoadingIndicator = filled($wireTarget) || ($type === 'submit' && filled($form));
 
-    if ($hasLoadingIndicator) {
-        $loadingIndicatorTarget = html_entity_decode($wireTarget ?: $form, ENT_QUOTES);
-    }
+        if ($hasLoadingIndicator) {
+            $loadingIndicatorTarget = html_entity_decode($wireTarget ?: $form, ENT_QUOTES);
+        }
 
-    $hasTooltip = $hasTooltip = filled($tooltip);
+        $hasTooltip = $hasTooltip = filled($tooltip);
 @endphp
 
 <{{ $tag }}
@@ -76,44 +76,44 @@
     @endif
     {{
         $attributes
-            ->merge([
-                'aria-disabled' => $disabled ? 'true' : null,
-                'aria-label' => $label,
-                'disabled' => $disabled && blank($tooltip),
-                'form' => $formId,
-                'type' => $tag === 'button' ? $type : null,
-                'wire:loading.attr' => $tag === 'button' ? 'disabled' : null,
-                'wire:target' => ($hasLoadingIndicator && $loadingIndicatorTarget) ? $loadingIndicatorTarget : null,
-            ], escape: false)
-            ->merge([
-                'title' => $hasTooltip ? null : $label,
-            ], escape: true)
-            ->when(
-                $disabled && $hasTooltip,
-                fn (ComponentAttributeBag $attributes) => $attributes->filter(
-                    fn (mixed $value, string $key): bool => ! str($key)->startsWith(['href', 'x-on:', 'wire:click']),
-                ),
-            )
-            ->class([
-                'fi-icon-btn',
-                'fi-disabled' => $disabled,
-                ($size instanceof Size) ? "fi-size-{$size->value}" : (is_string($size) ? $size : ''),
-            ])
-            ->color(IconButtonComponent::class, $color)
+        ->merge([
+        'aria-disabled' => $disabled ? 'true' : null,
+        'aria-label' => $label,
+        'disabled' => $disabled && blank($tooltip),
+        'form' => $formId,
+        'type' => $tag === 'button' ? $type : null,
+        'wire:loading.attr' => $tag === 'button' ? 'disabled' : null,
+        'wire:target' => ($hasLoadingIndicator && $loadingIndicatorTarget) ? $loadingIndicatorTarget : null,
+        ], escape: false)
+        ->merge([
+        'title' => $hasTooltip ? null : $label,
+        ], escape: true)
+        ->when(
+        $disabled && $hasTooltip,
+        fn (ComponentAttributeBag $attributes) => $attributes->filter(
+        fn (mixed $value, string $key): bool => ! str($key)->startsWith(['href', 'x-on:', 'wire:click']),
+        ),
+        )
+        ->class([
+        'fi-icon-btn',
+        'fi-disabled' => $disabled,
+        ($size instanceof Size) ? "fi-size-{$size->value}" : (is_string($size) ? $size : ''),
+        ])
+        ->color(IconButtonComponent::class, $color)
     }}
 >
     {{
         \Filament\Support\generate_icon_html($icon, $iconAlias, (new \Illuminate\View\ComponentAttributeBag([
-            'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
-            'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
+        'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
+        'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
         ])), size: $iconSize)
     }}
 
     @if ($hasLoadingIndicator)
         {{
             \Filament\Support\generate_loading_indicator_html((new \Illuminate\View\ComponentAttributeBag([
-                'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
-                'wire:target' => $loadingIndicatorTarget,
+            'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
+            'wire:target' => $loadingIndicatorTarget,
             ])), size: $iconSize)
         }}
     @endif
@@ -126,8 +126,8 @@
                 <span
                     {{
                         (new ComponentAttributeBag)->color(BadgeComponent::class, $badgeColor)->class([
-                            'fi-badge',
-                            ($badgeSize instanceof Size) ? "fi-size-{$badgeSize->value}" : (is_string($badgeSize) ? $badgeSize : ''),
+                        'fi-badge',
+                        ($badgeSize instanceof Size) ? "fi-size-{$badgeSize->value}" : (is_string($badgeSize) ? $badgeSize : ''),
                         ])
                     }}
                 >

--- a/packages/support/resources/views/components/icon.blade.php
+++ b/packages/support/resources/views/components/icon.blade.php
@@ -1,7 +1,7 @@
 @props([
-    'alias' => null,
-    'icon' => null,
-    'size' => null,
+'alias' => null,
+'icon' => null,
+'size' => null,
 ])
 
 {{ \Filament\Support\generate_icon_html($icon, $alias, $attributes, $size) }}

--- a/packages/support/resources/views/components/input/checkbox.blade.php
+++ b/packages/support/resources/views/components/input/checkbox.blade.php
@@ -1,6 +1,6 @@
 @props([
-    'alpineValid' => null,
-    'valid' => true,
+'alpineValid' => null,
+'valid' => true,
 ])
 
 @php
@@ -17,10 +17,10 @@
     @endif
     {{
         $attributes
-            ->class([
-                'fi-checkbox-input',
-                'fi-valid' => (! $hasAlpineValidClasses) && $valid,
-                'fi-invalid' => (! $hasAlpineValidClasses) && (! $valid),
-            ])
+        ->class([
+        'fi-checkbox-input',
+        'fi-valid' => (! $hasAlpineValidClasses) && $valid,
+        'fi-invalid' => (! $hasAlpineValidClasses) && (! $valid),
+        ])
     }}
 />

--- a/packages/support/resources/views/components/input/index.blade.php
+++ b/packages/support/resources/views/components/input/index.blade.php
@@ -1,14 +1,14 @@
 @props([
-    'inlinePrefix' => false,
-    'inlineSuffix' => false,
+'inlinePrefix' => false,
+'inlineSuffix' => false,
 ])
 
 <input
     {{
         $attributes->class([
-            'fi-input',
-            'fi-input-has-inline-prefix' => $inlinePrefix,
-            'fi-input-has-inline-suffix' => $inlineSuffix,
+        'fi-input',
+        'fi-input-has-inline-prefix' => $inlinePrefix,
+        'fi-input-has-inline-suffix' => $inlineSuffix,
         ])
     }}
 />

--- a/packages/support/resources/views/components/input/one-time-code.blade.php
+++ b/packages/support/resources/views/components/input/one-time-code.blade.php
@@ -1,14 +1,14 @@
 @props([
-    'length' => 6,
+'length' => 6,
 ])
 
 <div
     x-data="{ currentNumberOfDigits: null }"
     {{
         $attributes
-            ->class([
-                'fi-one-time-code-input-ctn',
-            ])
+        ->class([
+        'fi-one-time-code-input-ctn',
+        ])
     }}
 >
     @foreach (range(1, $length) as $digit)

--- a/packages/support/resources/views/components/input/radio.blade.php
+++ b/packages/support/resources/views/components/input/radio.blade.php
@@ -1,14 +1,14 @@
 @props([
-    'valid' => true,
+'valid' => true,
 ])
 
 <input
     type="radio"
     {{
         $attributes
-            ->class([
-                'fi-radio-input',
-                'fi-invalid' => ! $valid,
-            ])
+        ->class([
+        'fi-radio-input',
+        'fi-invalid' => ! $valid,
+        ])
     }}
 />

--- a/packages/support/resources/views/components/input/select.blade.php
+++ b/packages/support/resources/views/components/input/select.blade.php
@@ -1,13 +1,13 @@
 @props([
-    'inlinePrefix' => false,
-    'inlineSuffix' => false,
+'inlinePrefix' => false,
+'inlineSuffix' => false,
 ])
 
 <select
     {{
         $attributes->class([
-            'fi-select-input',
-            'fi-select-input-has-inline-prefix' => $inlinePrefix,
+        'fi-select-input',
+        'fi-select-input-has-inline-prefix' => $inlinePrefix,
         ])
     }}
 >

--- a/packages/support/resources/views/components/input/wrapper.blade.php
+++ b/packages/support/resources/views/components/input/wrapper.blade.php
@@ -1,54 +1,54 @@
 @props([
-    'alpineDisabled' => null,
-    'alpineValid' => null,
-    'disabled' => false,
-    'inlinePrefix' => false,
-    'inlineSuffix' => false,
-    'prefix' => null,
-    'prefixActions' => [],
-    'prefixIcon' => null,
-    'prefixIconColor' => 'gray',
-    'prefixIconAlias' => null,
-    'suffix' => null,
-    'suffixActions' => [],
-    'suffixIcon' => null,
-    'suffixIconColor' => 'gray',
-    'suffixIconAlias' => null,
-    'valid' => true,
+'alpineDisabled' => null,
+'alpineValid' => null,
+'disabled' => false,
+'inlinePrefix' => false,
+'inlineSuffix' => false,
+'prefix' => null,
+'prefixActions' => [],
+'prefixIcon' => null,
+'prefixIconColor' => 'gray',
+'prefixIconAlias' => null,
+'suffix' => null,
+'suffixActions' => [],
+'suffixIcon' => null,
+'suffixIconColor' => 'gray',
+'suffixIconAlias' => null,
+'valid' => true,
 ])
 
 @php
     use Filament\Support\View\Components\InputComponent\WrapperComponent\IconComponent;
-    use Illuminate\View\ComponentAttributeBag;
+        use Illuminate\View\ComponentAttributeBag;
 
-    $prefixActions = array_filter(
-        $prefixActions,
-        fn (\Filament\Actions\Action $prefixAction): bool => $prefixAction->isVisible(),
-    );
+        $prefixActions = array_filter(
+            $prefixActions,
+            fn (\Filament\Actions\Action $prefixAction): bool => $prefixAction->isVisible(),
+        );
 
-    $suffixActions = array_filter(
-        $suffixActions,
-        fn (\Filament\Actions\Action $suffixAction): bool => $suffixAction->isVisible(),
-    );
+        $suffixActions = array_filter(
+            $suffixActions,
+            fn (\Filament\Actions\Action $suffixAction): bool => $suffixAction->isVisible(),
+        );
 
-    $hasPrefix = count($prefixActions) || $prefixIcon || filled($prefix);
-    $hasSuffix = count($suffixActions) || $suffixIcon || filled($suffix);
+        $hasPrefix = count($prefixActions) || $prefixIcon || filled($prefix);
+        $hasSuffix = count($suffixActions) || $suffixIcon || filled($suffix);
 
-    $hasAlpineDisabledClasses = filled($alpineDisabled);
-    $hasAlpineValidClasses = filled($alpineValid);
-    $hasAlpineClasses = $hasAlpineDisabledClasses || $hasAlpineValidClasses;
+        $hasAlpineDisabledClasses = filled($alpineDisabled);
+        $hasAlpineValidClasses = filled($alpineValid);
+        $hasAlpineClasses = $hasAlpineDisabledClasses || $hasAlpineValidClasses;
 
-    $wireTarget = $attributes->whereStartsWith(['wire:target'])->first();
+        $wireTarget = $attributes->whereStartsWith(['wire:target'])->first();
 
-    $hasLoadingIndicator = filled($wireTarget);
+        $hasLoadingIndicator = filled($wireTarget);
 
-    if ($hasLoadingIndicator) {
-        $loadingIndicatorTarget = html_entity_decode($wireTarget, ENT_QUOTES);
-    }
+        if ($hasLoadingIndicator) {
+            $loadingIndicatorTarget = html_entity_decode($wireTarget, ENT_QUOTES);
+        }
 
-    $hasFocusInputListener = $attributes->has('x-on:focus-input.stop');
-    $canClickPrefixAffix = $hasFocusInputListener && ($prefixIcon || filled($prefix));
-    $canClickSuffixAffix = $hasFocusInputListener && ($suffixIcon || filled($suffix));
+        $hasFocusInputListener = $attributes->has('x-on:focus-input.stop');
+        $canClickPrefixAffix = $hasFocusInputListener && ($prefixIcon || filled($prefix));
+        $canClickSuffixAffix = $hasFocusInputListener && ($suffixIcon || filled($suffix));
 @endphp
 
 <div
@@ -60,12 +60,12 @@
     @endif
     {{
         $attributes
-            ->except(['wire:target', 'tabindex'])
-            ->class([
-                'fi-input-wrp',
-                'fi-disabled' => (! $hasAlpineClasses) && $disabled,
-                'fi-invalid' => (! $hasAlpineClasses) && (! $valid),
-            ])
+        ->except(['wire:target', 'tabindex'])
+        ->class([
+        'fi-input-wrp',
+        'fi-disabled' => (! $hasAlpineClasses) && $disabled,
+        'fi-invalid' => (! $hasAlpineClasses) && (! $valid),
+        ])
     }}
 >
     @if ($hasPrefix || $hasLoadingIndicator)
@@ -79,10 +79,10 @@
                 x-on:click="$dispatch('focus-input')"
             @endif
             @class([
-                'fi-input-wrp-prefix',
-                'fi-input-wrp-prefix-has-content' => $hasPrefix,
-                'fi-inline' => $inlinePrefix,
-                'fi-input-wrp-prefix-has-label' => filled($prefix),
+            'fi-input-wrp-prefix',
+            'fi-input-wrp-prefix-has-content' => $hasPrefix,
+            'fi-inline' => $inlinePrefix,
+            'fi-input-wrp-prefix-has-label' => filled($prefix),
             ])
         >
             @if (count($prefixActions))
@@ -98,18 +98,18 @@
 
             {{
                 \Filament\Support\generate_icon_html($prefixIcon, $prefixIconAlias, (new \Illuminate\View\ComponentAttributeBag)
-                    ->merge([
-                        'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
-                        'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
-                    ], escape: false)
-                    ->color(IconComponent::class, $prefixIconColor))
+                ->merge([
+                'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
+                'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
+                ], escape: false)
+                ->color(IconComponent::class, $prefixIconColor))
             }}
 
             @if ($hasLoadingIndicator)
                 {{
                     \Filament\Support\generate_loading_indicator_html((new \Illuminate\View\ComponentAttributeBag([
-                        'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => $hasPrefix,
-                        'wire:target' => $hasPrefix ? $loadingIndicatorTarget : null,
+                    'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => $hasPrefix,
+                    'wire:target' => $hasPrefix ? $loadingIndicatorTarget : null,
                     ]))->color(IconComponent::class, 'gray'))
                 }}
             @endif
@@ -131,8 +131,8 @@
             wire:target="{{ $loadingIndicatorTarget }}"
         @endif
         @class([
-            'fi-input-wrp-content-ctn',
-            'fi-input-wrp-content-ctn-ps' => $hasLoadingIndicator && (! $hasPrefix) && $inlinePrefix,
+        'fi-input-wrp-content-ctn',
+        'fi-input-wrp-content-ctn-ps' => $hasLoadingIndicator && (! $hasPrefix) && $inlinePrefix,
         ])
     >
         {{ $slot }}
@@ -144,9 +144,9 @@
                 x-on:click="$dispatch('focus-input')"
             @endif
             @class([
-                'fi-input-wrp-suffix',
-                'fi-inline' => $inlineSuffix,
-                'fi-input-wrp-suffix-has-label' => filled($suffix),
+            'fi-input-wrp-suffix',
+            'fi-inline' => $inlineSuffix,
+            'fi-input-wrp-suffix-has-label' => filled($suffix),
             ])
         >
             @if (filled($suffix))
@@ -157,11 +157,11 @@
 
             {{
                 \Filament\Support\generate_icon_html($suffixIcon, $suffixIconAlias, (new \Illuminate\View\ComponentAttributeBag)
-                    ->merge([
-                        'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
-                        'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
-                    ], escape: false)
-                    ->color(IconComponent::class, $suffixIconColor))
+                ->merge([
+                'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
+                'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
+                ], escape: false)
+                ->color(IconComponent::class, $suffixIconColor))
             }}
 
             @if (count($suffixActions))

--- a/packages/support/resources/views/components/link.blade.php
+++ b/packages/support/resources/views/components/link.blade.php
@@ -1,73 +1,73 @@
 @php
     use Filament\Support\Enums\FontWeight;
-    use Filament\Support\Enums\IconPosition;
-    use Filament\Support\Enums\IconSize;
-    use Filament\Support\Enums\Size;
-    use Filament\Support\View\Components\BadgeComponent;
-    use Filament\Support\View\Components\LinkComponent;
-    use Illuminate\View\ComponentAttributeBag;
+        use Filament\Support\Enums\IconPosition;
+        use Filament\Support\Enums\IconSize;
+        use Filament\Support\Enums\Size;
+        use Filament\Support\View\Components\BadgeComponent;
+        use Filament\Support\View\Components\LinkComponent;
+        use Illuminate\View\ComponentAttributeBag;
 @endphp
 
 @props([
-    'badge' => null,
-    'badgeColor' => 'primary',
-    'badgeSize' => Size::ExtraSmall,
-    'color' => 'primary',
-    'disabled' => false,
-    'form' => null,
-    'formId' => null,
-    'href' => null,
-    'icon' => null,
-    'iconAlias' => null,
-    'iconPosition' => IconPosition::Before,
-    'iconSize' => null,
-    'keyBindings' => null,
-    'labelSrOnly' => false,
-    'loadingIndicator' => true,
-    'size' => Size::Medium,
-    'spaMode' => null,
-    'tag' => 'a',
-    'target' => null,
-    'tooltip' => null,
-    'type' => 'button',
-    'weight' => null,
+'badge' => null,
+'badgeColor' => 'primary',
+'badgeSize' => Size::ExtraSmall,
+'color' => 'primary',
+'disabled' => false,
+'form' => null,
+'formId' => null,
+'href' => null,
+'icon' => null,
+'iconAlias' => null,
+'iconPosition' => IconPosition::Before,
+'iconSize' => null,
+'keyBindings' => null,
+'labelSrOnly' => false,
+'loadingIndicator' => true,
+'size' => Size::Medium,
+'spaMode' => null,
+'tag' => 'a',
+'target' => null,
+'tooltip' => null,
+'type' => 'button',
+'weight' => null,
 ])
 
 @php
     if (! $iconPosition instanceof IconPosition) {
-        $iconPosition = filled($iconPosition) ? (IconPosition::tryFrom($iconPosition) ?? $iconPosition) : null;
-    }
+            $iconPosition = filled($iconPosition) ? (IconPosition::tryFrom($iconPosition) ?? $iconPosition) : null;
+        }
 
-    if (! $badgeSize instanceof Size) {
-        $badgeSize = filled($badgeSize) ? (Size::tryFrom($badgeSize) ?? $badgeSize) : null;
-    }
+        if (! $badgeSize instanceof Size) {
+            $badgeSize = filled($badgeSize) ? (Size::tryFrom($badgeSize) ?? $badgeSize) : null;
+        }
 
-    if (! $size instanceof Size) {
-        $size = filled($size) ? (Size::tryFrom($size) ?? $size) : null;
-    }
+        if (! $size instanceof Size) {
+            $size = filled($size) ? (Size::tryFrom($size) ?? $size) : null;
+        }
 
-    if (filled($iconSize) && (! $iconSize instanceof IconSize)) {
-        $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
-    }
+        if (filled($iconSize) && (! $iconSize instanceof IconSize)) {
+            $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
+        }
 
-    $iconSize ??= match ($size) {
-        Size::ExtraSmall, Size::Small => IconSize::Small,
-        default => null,
-    };
+        $iconSize ??= match ($size) {
+            Size::ExtraSmall, Size::Small => IconSize::Small,
+            default => null,
+        };
 
-    if (! $weight instanceof FontWeight) {
-        $weight = filled($weight) ? (FontWeight::tryFrom($weight) ?? $weight) : null;
-    }
+        if (! $weight instanceof FontWeight) {
+            $weight = filled($weight) ? (FontWeight::tryFrom($weight) ?? $weight) : null;
+        }
 
-    $wireTarget = $loadingIndicator ? $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(fn ($value): bool => filled($value))->first() : null;
+        $wireTarget = $loadingIndicator ? $attributes->whereStartsWith(['wire:target', 'wire:click'])->filter(fn ($value): bool => filled($value))->first() : null;
 
-    $hasLoadingIndicator = filled($wireTarget) || ($type === 'submit' && filled($form));
+        $hasLoadingIndicator = filled($wireTarget) || ($type === 'submit' && filled($form));
 
-    if ($hasLoadingIndicator) {
-        $loadingIndicatorTarget = html_entity_decode($wireTarget ?: $form, ENT_QUOTES);
-    }
+        if ($hasLoadingIndicator) {
+            $loadingIndicatorTarget = html_entity_decode($wireTarget ?: $form, ENT_QUOTES);
+        }
 
-    $hasTooltip = filled($tooltip);
+        $hasTooltip = filled($tooltip);
 @endphp
 
 <{{ $tag }}
@@ -87,35 +87,35 @@
     @endif
     {{
         $attributes
-            ->merge([
-                'aria-disabled' => $disabled ? 'true' : null,
-                'disabled' => $disabled && blank($tooltip),
-                'form' => $formId,
-                'type' => $tag === 'button' ? $type : null,
-                'wire:loading.attr' => $tag === 'button' ? 'disabled' : null,
-                'wire:target' => ($hasLoadingIndicator && $loadingIndicatorTarget) ? $loadingIndicatorTarget : null,
-            ], escape: false)
-            ->when(
-                $disabled && $hasTooltip,
-                fn (ComponentAttributeBag $attributes) => $attributes->filter(
-                    fn (mixed $value, string $key): bool => ! str($key)->startsWith(['href', 'x-on:', 'wire:click']),
-                ),
-            )
-            ->class([
-                'fi-link',
-                'fi-disabled' => $disabled,
-                ($size instanceof Size) ? "fi-size-{$size->value}" : (is_string($size) ? $size : ''),
-                ($weight instanceof FontWeight) ? "fi-font-{$weight->value}" : (is_string($weight) ? $weight : ''),
-            ])
-            ->color(LinkComponent::class, $color)
+        ->merge([
+        'aria-disabled' => $disabled ? 'true' : null,
+        'disabled' => $disabled && blank($tooltip),
+        'form' => $formId,
+        'type' => $tag === 'button' ? $type : null,
+        'wire:loading.attr' => $tag === 'button' ? 'disabled' : null,
+        'wire:target' => ($hasLoadingIndicator && $loadingIndicatorTarget) ? $loadingIndicatorTarget : null,
+        ], escape: false)
+        ->when(
+        $disabled && $hasTooltip,
+        fn (ComponentAttributeBag $attributes) => $attributes->filter(
+        fn (mixed $value, string $key): bool => ! str($key)->startsWith(['href', 'x-on:', 'wire:click']),
+        ),
+        )
+        ->class([
+        'fi-link',
+        'fi-disabled' => $disabled,
+        ($size instanceof Size) ? "fi-size-{$size->value}" : (is_string($size) ? $size : ''),
+        ($weight instanceof FontWeight) ? "fi-font-{$weight->value}" : (is_string($weight) ? $weight : ''),
+        ])
+        ->color(LinkComponent::class, $color)
     }}
 >
     @if ($iconPosition === IconPosition::Before)
         @if ($icon)
             {{
                 \Filament\Support\generate_icon_html($icon, $iconAlias, (new \Illuminate\View\ComponentAttributeBag([
-                    'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
-                    'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
+                'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
+                'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
                 ])), size: $iconSize)
             }}
         @endif
@@ -123,8 +123,8 @@
         @if ($hasLoadingIndicator)
             {{
                 \Filament\Support\generate_loading_indicator_html((new \Illuminate\View\ComponentAttributeBag([
-                    'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
-                    'wire:target' => $loadingIndicatorTarget,
+                'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
+                'wire:target' => $loadingIndicatorTarget,
                 ])), size: $iconSize)
             }}
         @endif
@@ -138,8 +138,8 @@
         @if ($icon)
             {{
                 \Filament\Support\generate_icon_html($icon, $iconAlias, (new \Illuminate\View\ComponentAttributeBag([
-                    'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
-                    'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
+                'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => $hasLoadingIndicator,
+                'wire:target' => $hasLoadingIndicator ? $loadingIndicatorTarget : false,
                 ])), size: $iconSize)
             }}
         @endif
@@ -147,8 +147,8 @@
         @if ($hasLoadingIndicator)
             {{
                 \Filament\Support\generate_loading_indicator_html((new \Illuminate\View\ComponentAttributeBag([
-                    'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
-                    'wire:target' => $loadingIndicatorTarget,
+                'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
+                'wire:target' => $loadingIndicatorTarget,
                 ])), size: $iconSize)
             }}
         @endif
@@ -162,8 +162,8 @@
                 <span
                     {{
                         (new ComponentAttributeBag)->color(BadgeComponent::class, $badgeColor)->class([
-                            'fi-badge',
-                            ($badgeSize instanceof Size) ? "fi-size-{$badgeSize->value}" : (is_string($badgeSize) ? $badgeSize : ''),
+                        'fi-badge',
+                        ($badgeSize instanceof Size) ? "fi-size-{$badgeSize->value}" : (is_string($badgeSize) ? $badgeSize : ''),
                         ])
                     }}
                 >

--- a/packages/support/resources/views/components/loading-section.blade.php
+++ b/packages/support/resources/views/components/loading-section.blade.php
@@ -1,14 +1,14 @@
 @props([
-    'columnSpan' => [],
-    'columnStart' => [],
-    'height' => null,
+'columnSpan' => [],
+'columnStart' => [],
+'height' => null,
 ])
 
 <div
     {{
         ($attributes ?? new \Illuminate\View\ComponentAttributeBag)
-            ->gridColumn($columnSpan, $columnStart)
-            ->class(['fi-section fi-loading-section'])
-            ->style(['height: ' . ($height ?? '8rem')])
+        ->gridColumn($columnSpan, $columnStart)
+        ->class(['fi-section fi-loading-section'])
+        ->style(['height: ' . ($height ?? '8rem')])
     }}
 ></div>

--- a/packages/support/resources/views/components/modal/index.blade.php
+++ b/packages/support/resources/views/components/modal/index.blade.php
@@ -1,66 +1,66 @@
 @php
     use Filament\Support\Enums\Alignment;
-    use Filament\Support\Enums\SlideOverPosition;
-    use Filament\Support\Enums\Width;
-    use Filament\Support\View\Components\ModalComponent\IconComponent;
-    use Illuminate\View\ComponentAttributeBag;
+        use Filament\Support\Enums\SlideOverPosition;
+        use Filament\Support\Enums\Width;
+        use Filament\Support\View\Components\ModalComponent\IconComponent;
+        use Illuminate\View\ComponentAttributeBag;
 @endphp
 
 @props([
-    'alignment' => Alignment::Start,
-    'ariaLabelledby' => null,
-    'autofocus' => \Filament\Support\View\Components\ModalComponent::$isAutofocused,
-    'closeButton' => \Filament\Support\View\Components\ModalComponent::$hasCloseButton,
-    'closeByClickingAway' => \Filament\Support\View\Components\ModalComponent::$isClosedByClickingAway,
-    'closeByEscaping' => \Filament\Support\View\Components\ModalComponent::$isClosedByEscaping,
-    'closeEventName' => 'close-modal',
-    'closeQuietlyEventName' => 'close-modal-quietly',
-    'description' => null,
-    'extraModalWindowAttributeBag' => null,
-    'extraModalOverlayAttributeBag' => null,
-    'footer' => null,
-    'footerActions' => [],
-    'footerActionsAlignment' => Alignment::Start,
-    'header' => null,
-    'heading' => null,
-    'icon' => null,
-    'iconAlias' => null,
-    'iconColor' => 'primary',
-    'id' => null,
-    'openEventName' => 'open-modal',
-    'slideOver' => false,
-    'slideOverPosition' => SlideOverPosition::End,
-    'stickyFooter' => false,
-    'stickyHeader' => false,
-    'teleport' => null,
-    'trigger' => null,
-    'visible' => true,
-    'width' => 'sm',
+'alignment' => Alignment::Start,
+'ariaLabelledby' => null,
+'autofocus' => \Filament\Support\View\Components\ModalComponent::$isAutofocused,
+'closeButton' => \Filament\Support\View\Components\ModalComponent::$hasCloseButton,
+'closeByClickingAway' => \Filament\Support\View\Components\ModalComponent::$isClosedByClickingAway,
+'closeByEscaping' => \Filament\Support\View\Components\ModalComponent::$isClosedByEscaping,
+'closeEventName' => 'close-modal',
+'closeQuietlyEventName' => 'close-modal-quietly',
+'description' => null,
+'extraModalWindowAttributeBag' => null,
+'extraModalOverlayAttributeBag' => null,
+'footer' => null,
+'footerActions' => [],
+'footerActionsAlignment' => Alignment::Start,
+'header' => null,
+'heading' => null,
+'icon' => null,
+'iconAlias' => null,
+'iconColor' => 'primary',
+'id' => null,
+'openEventName' => 'open-modal',
+'slideOver' => false,
+'slideOverPosition' => SlideOverPosition::End,
+'stickyFooter' => false,
+'stickyHeader' => false,
+'teleport' => null,
+'trigger' => null,
+'visible' => true,
+'width' => 'sm',
 ])
 
 @php
     $hasContent = ! \Filament\Support\is_slot_empty($slot);
-    $hasDescription = filled($description);
-    $hasFooter = (! \Filament\Support\is_slot_empty($footer)) || (is_array($footerActions) && count($footerActions)) || (! is_array($footerActions) && (! \Filament\Support\is_slot_empty($footerActions)));
-    $hasHeading = filled($heading);
-    $hasIcon = filled($icon);
+        $hasDescription = filled($description);
+        $hasFooter = (! \Filament\Support\is_slot_empty($footer)) || (is_array($footerActions) && count($footerActions)) || (! is_array($footerActions) && (! \Filament\Support\is_slot_empty($footerActions)));
+        $hasHeading = filled($heading);
+        $hasIcon = filled($icon);
 
-    if (! $alignment instanceof Alignment) {
-        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
-    }
+        if (! $alignment instanceof Alignment) {
+            $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
+        }
 
-    if (! $footerActionsAlignment instanceof Alignment) {
-        $footerActionsAlignment = filled($footerActionsAlignment) ? (Alignment::tryFrom($footerActionsAlignment) ?? $footerActionsAlignment) : null;
-    }
+        if (! $footerActionsAlignment instanceof Alignment) {
+            $footerActionsAlignment = filled($footerActionsAlignment) ? (Alignment::tryFrom($footerActionsAlignment) ?? $footerActionsAlignment) : null;
+        }
 
-    if (is_string($width)) {
-        $width = Width::tryFrom($width) ?? $width;
-    }
+        if (is_string($width)) {
+            $width = Width::tryFrom($width) ?? $width;
+        }
 
-    $closeEventHandler = filled($id) ? '$dispatch(' . \Illuminate\Support\Js::from($closeEventName) . ', { id: ' . \Illuminate\Support\Js::from($id) . ' })' : 'close()';
+        $closeEventHandler = filled($id) ? '$dispatch(' . \Illuminate\Support\Js::from($closeEventName) . ', { id: ' . \Illuminate\Support\Js::from($id) . ' })' : 'close()';
 
-    $wireSubmitHandler = $attributes->get('wire:submit.prevent');
-    $attributes = $attributes->except(['wire:submit.prevent']);
+        $wireSubmitHandler = $attributes->get('wire:submit.prevent');
+        $attributes = $attributes->except(['wire:submit.prevent']);
 @endphp
 
 @if ($trigger)
@@ -116,14 +116,14 @@
     x-trap.noscroll{{ $autofocus ? '' : '.noautofocus' }}="isOpen"
     {{
         $attributes->class([
-            'fi-modal',
-            'fi-absolute-positioning-context',
-            'fi-modal-slide-over' => $slideOver,
-            'fi-modal-slide-over-from-start' => $slideOver && $slideOverPosition === SlideOverPosition::Start,
-            'fi-modal-slide-over-from-end' => $slideOver && $slideOverPosition === SlideOverPosition::End,
-            'fi-modal-has-sticky-header' => $stickyHeader,
-            'fi-modal-has-sticky-footer' => $stickyFooter,
-            'fi-width-screen' => $width === Width::Screen,
+        'fi-modal',
+        'fi-absolute-positioning-context',
+        'fi-modal-slide-over' => $slideOver,
+        'fi-modal-slide-over-from-start' => $slideOver && $slideOverPosition === SlideOverPosition::Start,
+        'fi-modal-slide-over-from-end' => $slideOver && $slideOverPosition === SlideOverPosition::End,
+        'fi-modal-has-sticky-header' => $stickyHeader,
+        'fi-modal-has-sticky-footer' => $stickyFooter,
+        'fi-width-screen' => $width === Width::Screen,
         ])
     }}
 >
@@ -133,7 +133,7 @@
         x-transition.duration.300ms.opacity
         {{
             ($extraModalOverlayAttributeBag ?? new \Illuminate\View\ComponentAttributeBag)->class([
-                'fi-modal-close-overlay',
+            'fi-modal-close-overlay',
             ])
         }}
     ></div>
@@ -143,8 +143,8 @@
             x-on:click.self="{{ $closeEventHandler }}"
         @endif
         @class([
-            'fi-modal-window-ctn',
-            'fi-clickable' => $closeByClickingAway,
+        'fi-modal-window-ctn',
+        'fi-clickable' => $closeByClickingAway,
         ])
     >
         <{{ filled($wireSubmitHandler) ? 'form' : 'div' }}
@@ -168,14 +168,14 @@
             @endif
             {{
                 ($extraModalWindowAttributeBag ?? new \Illuminate\View\ComponentAttributeBag)->class([
-                    'fi-modal-window',
-                    'fi-modal-window-has-close-btn' => $closeButton,
-                    'fi-modal-window-has-content' => $hasContent,
-                    'fi-modal-window-has-footer' => $hasFooter,
-                    'fi-modal-window-has-icon' => $hasIcon,
-                    'fi-hidden' => ! $visible,
-                    ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : null,
-                    ($width instanceof Width) ? "fi-width-{$width->value}" : (is_string($width) ? $width : null),
+                'fi-modal-window',
+                'fi-modal-window-has-close-btn' => $closeButton,
+                'fi-modal-window-has-content' => $hasContent,
+                'fi-modal-window-has-footer' => $hasFooter,
+                'fi-modal-window-has-icon' => $hasIcon,
+                'fi-hidden' => ! $visible,
+                ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : null,
+                ($width instanceof Width) ? "fi-width-{$width->value}" : (is_string($width) ? $width : null),
                 ])
             }}
         >
@@ -185,8 +185,8 @@
                         wire:key="{{ isset($this) ? "{$this->getId()}." : '' }}modal.{{ $id }}.header"
                     @endif
                     @class([
-                        'fi-modal-header',
-                        'fi-vertical-align-center' => $hasIcon && $hasHeading && (! $hasDescription) && in_array($alignment, [Alignment::Start, Alignment::Left]),
+                    'fi-modal-header',
+                    'fi-vertical-align-center' => $hasIcon && $hasHeading && (! $hasDescription) && in_array($alignment, [Alignment::Start, Alignment::Left]),
                     ])
                 >
                     @if ($closeButton)
@@ -247,8 +247,8 @@
                         wire:key="{{ isset($this) ? "{$this->getId()}." : '' }}modal.{{ $id }}.footer"
                     @endif
                     @class([
-                        'fi-modal-footer',
-                        ($footerActionsAlignment instanceof Alignment) ? "fi-align-{$footerActionsAlignment->value}" : null,
+                    'fi-modal-footer',
+                    ($footerActionsAlignment instanceof Alignment) ? "fi-align-{$footerActionsAlignment->value}" : null,
                     ])
                 >
                     @if (! \Filament\Support\is_slot_empty($footer))

--- a/packages/support/resources/views/components/pagination/index.blade.php
+++ b/packages/support/resources/views/components/pagination/index.blade.php
@@ -1,15 +1,15 @@
 @props([
-    'currentPageOptionProperty' => 'tableRecordsPerPage',
-    'extremeLinks' => false,
-    'paginator',
-    'pageOptions' => [],
+'currentPageOptionProperty' => 'tableRecordsPerPage',
+'extremeLinks' => false,
+'paginator',
+'pageOptions' => [],
 ])
 
 @php
     use Illuminate\Contracts\Pagination\CursorPaginator;
 
-    $isRtl = __('filament-panels::layout.direction') === 'rtl';
-    $isSimple = ! $paginator instanceof \Illuminate\Pagination\LengthAwarePaginator;
+        $isRtl = __('filament-panels::layout.direction') === 'rtl';
+        $isSimple = ! $paginator instanceof \Illuminate\Pagination\LengthAwarePaginator;
 @endphp
 
 <nav
@@ -17,18 +17,18 @@
     role="navigation"
     {{
         $attributes->class([
-            'fi-pagination',
-            'fi-simple' => $isSimple,
+        'fi-pagination',
+        'fi-simple' => $isSimple,
         ])
     }}
 >
     @if (! $paginator->onFirstPage())
         @php
             if ($paginator instanceof CursorPaginator) {
-                $wireClickAction = "setPage('{$paginator->previousCursor()->encode()}', '{$paginator->getCursorName()}')";
-            } else {
-                $wireClickAction = "previousPage('{$paginator->getPageName()}')";
-            }
+                            $wireClickAction = "setPage('{$paginator->previousCursor()->encode()}', '{$paginator->getCursorName()}')";
+                        } else {
+                            $wireClickAction = "previousPage('{$paginator->getPageName()}')";
+                        }
         @endphp
 
         <x-filament::button
@@ -46,13 +46,13 @@
         <span class="fi-pagination-overview">
             {{
                 trans_choice(
-                    'filament::components/pagination.overview',
-                    $paginator->total(),
-                    [
-                        'first' => \Illuminate\Support\Number::format($paginator->firstItem() ?? 0),
-                        'last' => \Illuminate\Support\Number::format($paginator->lastItem() ?? 0),
-                        'total' => \Illuminate\Support\Number::format($paginator->total()),
-                    ],
+                'filament::components/pagination.overview',
+                $paginator->total(),
+                [
+                'first' => \Illuminate\Support\Number::format($paginator->firstItem() ?? 0),
+                'last' => \Illuminate\Support\Number::format($paginator->lastItem() ?? 0),
+                'total' => \Illuminate\Support\Number::format($paginator->total()),
+                ],
                 )
             }}
         </span>
@@ -99,10 +99,10 @@
     @if ($paginator->hasMorePages())
         @php
             if ($paginator instanceof CursorPaginator) {
-                $wireClickAction = "setPage('{$paginator->nextCursor()->encode()}', '{$paginator->getCursorName()}')";
-            } else {
-                $wireClickAction = "nextPage('{$paginator->getPageName()}')";
-            }
+                            $wireClickAction = "setPage('{$paginator->nextCursor()->encode()}', '{$paginator->getCursorName()}')";
+                        } else {
+                            $wireClickAction = "nextPage('{$paginator->getPageName()}')";
+                        }
         @endphp
 
         <x-filament::button

--- a/packages/support/resources/views/components/pagination/item.blade.php
+++ b/packages/support/resources/views/components/pagination/item.blade.php
@@ -1,18 +1,18 @@
 @props([
-    'active' => false,
-    'ariaLabel' => null,
-    'disabled' => false,
-    'icon' => null,
-    'iconAlias' => null,
-    'label' => null,
+'active' => false,
+'ariaLabel' => null,
+'disabled' => false,
+'icon' => null,
+'iconAlias' => null,
+'label' => null,
 ])
 
 <li
     {{
         $attributes->class([
-            'fi-pagination-item',
-            'fi-disabled' => $disabled,
-            'fi-active' => $active,
+        'fi-pagination-item',
+        'fi-disabled' => $disabled,
+        'fi-active' => $active,
         ])
     }}
 >
@@ -25,7 +25,7 @@
         @if (filled($icon))
             {{
                 \Filament\Support\generate_icon_html($icon, $iconAlias, attributes: (new \Illuminate\View\ComponentAttributeBag)->class([
-                    'fi-pagination-item-icon',
+                'fi-pagination-item-icon',
                 ]))
             }}
         @endif

--- a/packages/support/resources/views/components/section/index.blade.php
+++ b/packages/support/resources/views/components/section/index.blade.php
@@ -1,42 +1,42 @@
 @php
     use Filament\Support\Enums\Alignment;
-    use Filament\Support\Enums\IconSize;
-    use Filament\Support\View\Components\SectionComponent\IconComponent;
+        use Filament\Support\Enums\IconSize;
+        use Filament\Support\View\Components\SectionComponent\IconComponent;
 
-    use function Filament\Support\is_slot_empty;
+        use function Filament\Support\is_slot_empty;
 @endphp
 
 @props([
-    'afterHeader' => null,
-    'aside' => false,
-    'collapsed' => false,
-    'collapseId' => null,
-    'collapsible' => false,
-    'compact' => false,
-    'contained' => true,
-    'contentBefore' => false,
-    'description' => null,
-    'divided' => false,
-    'footer' => null,
-    'hasContentEl' => true,
-    'heading' => null,
-    'headingTag' => 'h2',
-    'icon' => null,
-    'iconColor' => 'gray',
-    'iconSize' => null,
-    'persistCollapsed' => false,
-    'secondary' => false,
+'afterHeader' => null,
+'aside' => false,
+'collapsed' => false,
+'collapseId' => null,
+'collapsible' => false,
+'compact' => false,
+'contained' => true,
+'contentBefore' => false,
+'description' => null,
+'divided' => false,
+'footer' => null,
+'hasContentEl' => true,
+'heading' => null,
+'headingTag' => 'h2',
+'icon' => null,
+'iconColor' => 'gray',
+'iconSize' => null,
+'persistCollapsed' => false,
+'secondary' => false,
 ])
 
 @php
     if (filled($iconSize) && (! $iconSize instanceof IconSize)) {
-        $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
-    }
+            $iconSize = IconSize::tryFrom($iconSize) ?? $iconSize;
+        }
 
-    $hasDescription = filled((string) $description);
-    $hasHeading = filled($heading);
-    $hasIcon = filled($icon);
-    $hasHeader = $hasIcon || $hasHeading || $hasDescription || $collapsible || (! is_slot_empty($afterHeader));
+        $hasDescription = filled((string) $description);
+        $hasHeading = filled($heading);
+        $hasIcon = filled($icon);
+        $hasHeader = $hasIcon || $hasHeading || $hasDescription || $collapsible || (! is_slot_empty($afterHeader));
 @endphp
 
 <section
@@ -54,15 +54,15 @@
     @endif
     {{
         $attributes->class([
-            'fi-section',
-            'fi-section-not-contained' => ! $contained,
-            'fi-section-has-content-before' => $contentBefore,
-            'fi-section-has-header' => $hasHeader,
-            'fi-aside' => $aside,
-            'fi-compact' => $compact,
-            'fi-collapsible' => $collapsible,
-            'fi-divided' => $divided,
-            'fi-secondary' => $secondary,
+        'fi-section',
+        'fi-section-not-contained' => ! $contained,
+        'fi-section-has-content-before' => $contentBefore,
+        'fi-section-has-header' => $hasHeader,
+        'fi-aside' => $aside,
+        'fi-compact' => $compact,
+        'fi-collapsible' => $collapsible,
+        'fi-divided' => $divided,
+        'fi-secondary' => $secondary,
         ])
     }}
 >
@@ -75,7 +75,7 @@
         >
             {{
                 \Filament\Support\generate_icon_html($icon, attributes: (new \Illuminate\View\ComponentAttributeBag)
-                    ->color(IconComponent::class, $iconColor), size: $iconSize ?? IconSize::Large)
+                ->color(IconComponent::class, $iconColor), size: $iconSize ?? IconSize::Large)
             }}
 
             @if ($hasHeading || $hasDescription)

--- a/packages/support/resources/views/components/tabs/index.blade.php
+++ b/packages/support/resources/views/components/tabs/index.blade.php
@@ -1,21 +1,21 @@
 @props([
-    'contained' => false,
-    'label' => null,
-    'vertical' => false,
+'contained' => false,
+'label' => null,
+'vertical' => false,
 ])
 
 <nav
     {{
         $attributes
-            ->merge([
-                'aria-label' => $label,
-                'role' => 'tablist',
-            ])
-            ->class([
-                'fi-tabs',
-                'fi-contained' => $contained,
-                'fi-vertical' => $vertical,
-            ])
+        ->merge([
+        'aria-label' => $label,
+        'role' => 'tablist',
+        ])
+        ->class([
+        'fi-tabs',
+        'fi-contained' => $contained,
+        'fi-vertical' => $vertical,
+        ])
     }}
 >
     {{ $slot }}

--- a/packages/support/resources/views/components/tabs/item.blade.php
+++ b/packages/support/resources/views/components/tabs/item.blade.php
@@ -3,32 +3,32 @@
 @endphp
 
 @props([
-    'active' => false,
-    'alpineActive' => null,
-    'alpineDeferredBadgeData' => null,
-    'alpineDeferredBadgeLoading' => null,
-    'badge' => null,
-    'badgeColor' => null,
-    'badgeTooltip' => null,
-    'badgeIcon' => null,
-    'badgeIconPosition' => IconPosition::Before,
-    'href' => null,
-    'icon' => null,
-    'iconColor' => 'gray',
-    'iconPosition' => IconPosition::Before,
-    'spaMode' => null,
-    'tag' => 'button',
-    'target' => null,
-    'type' => 'button',
+'active' => false,
+'alpineActive' => null,
+'alpineDeferredBadgeData' => null,
+'alpineDeferredBadgeLoading' => null,
+'badge' => null,
+'badgeColor' => null,
+'badgeTooltip' => null,
+'badgeIcon' => null,
+'badgeIconPosition' => IconPosition::Before,
+'href' => null,
+'icon' => null,
+'iconColor' => 'gray',
+'iconPosition' => IconPosition::Before,
+'spaMode' => null,
+'tag' => 'button',
+'target' => null,
+'type' => 'button',
 ])
 
 @php
     if (! $iconPosition instanceof IconPosition) {
-        $iconPosition = filled($iconPosition) ? (IconPosition::tryFrom($iconPosition) ?? $iconPosition) : null;
-    }
+            $iconPosition = filled($iconPosition) ? (IconPosition::tryFrom($iconPosition) ?? $iconPosition) : null;
+        }
 
-    $hasAlpineActiveClasses = filled($alpineActive);
-    $hasDeferredBadge = filled($alpineDeferredBadgeData);
+        $hasAlpineActiveClasses = filled($alpineActive);
+        $hasDeferredBadge = filled($alpineDeferredBadgeData);
 @endphp
 
 <{{ $tag }}
@@ -44,14 +44,14 @@
     @endif
     {{
         $attributes
-            ->merge([
-                'aria-selected' => $active,
-                'role' => 'tab',
-            ])
-            ->class([
-                'fi-tabs-item',
-                'fi-active' => (! $hasAlpineActiveClasses) && $active,
-            ])
+        ->merge([
+        'aria-selected' => $active,
+        'role' => 'tab',
+        ])
+        ->class([
+        'fi-tabs-item',
+        'fi-active' => (! $hasAlpineActiveClasses) && $active,
+        ])
     }}
 >
     @if ($icon && $iconPosition === IconPosition::Before)

--- a/packages/support/resources/views/components/toggle.blade.php
+++ b/packages/support/resources/views/components/toggle.blade.php
@@ -1,14 +1,14 @@
 @php
     use Filament\Support\View\Components\ToggleComponent;
-    use Illuminate\Support\Arr;
+        use Illuminate\Support\Arr;
 @endphp
 
 @props([
-    'state',
-    'offColor' => 'gray',
-    'offIcon' => null,
-    'onColor' => 'primary',
-    'onIcon' => null,
+'state',
+'offColor' => 'gray',
+'offIcon' => null,
+'onColor' => 'primary',
+'onIcon' => null,
 ])
 
 <button
@@ -17,11 +17,11 @@
     x-on:click="state = ! state"
     x-bind:class="
         state ? @js(Arr::toCssClasses([
-                    'fi-toggle-on',
-                    ...\Filament\Support\get_component_color_classes(ToggleComponent::class, $onColor),
+                'fi-toggle-on',
+                ...\Filament\Support\get_component_color_classes(ToggleComponent::class, $onColor),
                 ])) : @js(Arr::toCssClasses([
-                            'fi-toggle-off',
-                            ...\Filament\Support\get_component_color_classes(ToggleComponent::class, $offColor),
+                        'fi-toggle-off',
+                        ...\Filament\Support\get_component_color_classes(ToggleComponent::class, $offColor),
                         ]))
     "
     @if ($state)
@@ -29,11 +29,11 @@
     @endif
     {{
         $attributes
-            ->merge([
-                'role' => 'switch',
-                'type' => 'button',
-            ], escape: false)
-            ->class(['fi-toggle'])
+        ->merge([
+        'role' => 'switch',
+        'type' => 'button',
+        ], escape: false)
+        ->class(['fi-toggle'])
     }}
 >
     <div>
@@ -52,8 +52,8 @@
         x-cloak="inline-flex"
         wire:ignore
         @class([
-            'fi-toggle fi-toggle-on fi-hidden',
-            ...\Filament\Support\get_component_color_classes(ToggleComponent::class, $onColor),
+        'fi-toggle fi-toggle-on fi-hidden',
+        ...\Filament\Support\get_component_color_classes(ToggleComponent::class, $onColor),
         ])
     >
         <div>

--- a/packages/tables/resources/views/components/column-manager/content.blade.php
+++ b/packages/tables/resources/views/components/column-manager/content.blade.php
@@ -1,13 +1,13 @@
 @php
     use Filament\Support\Enums\GridDirection;
-    use Illuminate\View\ComponentAttributeBag;
+        use Illuminate\View\ComponentAttributeBag;
 @endphp
 
 @props([
-    'columns' => null,
-    'hasReorderableColumns',
-    'hasToggleableColumns',
-    'reorderAnimationDuration' => 300,
+'columns' => null,
+'hasReorderableColumns',
+'hasToggleableColumns',
+'reorderAnimationDuration' => 300,
 ])
 
 <div
@@ -18,8 +18,8 @@
     @endif
     {{
         (new ComponentAttributeBag)
-            ->grid($columns, GridDirection::Column)
-            ->class(['fi-ta-col-manager-items'])
+        ->grid($columns, GridDirection::Column)
+        ->class(['fi-ta-col-manager-items'])
     }}
 >
     <template

--- a/packages/tables/resources/views/components/column-manager/index.blade.php
+++ b/packages/tables/resources/views/components/column-manager/index.blade.php
@@ -1,16 +1,16 @@
 @php
     use Filament\Tables\Enums\ColumnManagerResetActionPosition;
-    use Illuminate\View\ComponentAttributeBag;
+        use Illuminate\View\ComponentAttributeBag;
 @endphp
 
 @props([
-    'applyAction',
-    'columns' => null,
-    'hasReorderableColumns',
-    'hasToggleableColumns',
-    'headingTag' => 'h3',
-    'reorderAnimationDuration' => 300,
-    'resetActionPosition' => ColumnManagerResetActionPosition::Header,
+'applyAction',
+'columns' => null,
+'hasReorderableColumns',
+'hasToggleableColumns',
+'headingTag' => 'h3',
+'reorderAnimationDuration' => 300,
+'resetActionPosition' => ColumnManagerResetActionPosition::Header,
 ])
 
 <div

--- a/packages/tables/resources/views/components/columns/layout.blade.php
+++ b/packages/tables/resources/views/components/columns/layout.blade.php
@@ -1,18 +1,18 @@
 {{-- @deprecated Copy the code from this view directly into your own view to improve performance. --}}
 
 @props([
-    'components',
-    'record',
-    'recordKey' => null,
-    'rowLoop' => null,
+'components',
+'record',
+'recordKey' => null,
+'rowLoop' => null,
 ])
 
 @foreach ($components as $layoutComponent)
     {{
         $layoutComponent
-            ->record($record)
-            ->recordKey($recordKey)
-            ->rowLoop($rowLoop)
-            ->renderInLayout()
+        ->record($record)
+        ->recordKey($recordKey)
+        ->rowLoop($rowLoop)
+        ->renderInLayout()
     }}
 @endforeach

--- a/packages/tables/resources/views/components/filters.blade.php
+++ b/packages/tables/resources/views/components/filters.blade.php
@@ -3,10 +3,10 @@
 @endphp
 
 @props([
-    'applyAction',
-    'form',
-    'headingTag' => 'h3',
-    'resetActionPosition' => FiltersResetActionPosition::Header,
+'applyAction',
+'form',
+'headingTag' => 'h3',
+'resetActionPosition' => FiltersResetActionPosition::Header,
 ])
 
 <div {{ $attributes->class(['fi-ta-filters']) }}>

--- a/packages/tables/resources/views/components/search-field.blade.php
+++ b/packages/tables/resources/views/components/search-field.blade.php
@@ -3,10 +3,10 @@
 @endphp
 
 @props([
-    'debounce' => '500ms',
-    'onBlur' => false,
-    'placeholder' => __('filament-tables::table.fields.search.placeholder'),
-    'wireModel' => 'tableSearch',
+'debounce' => '500ms',
+'onBlur' => false,
+'placeholder' => __('filament-tables::table.fields.search.placeholder'),
+'wireModel' => 'tableSearch',
 ])
 
 @php

--- a/packages/tables/resources/views/components/summary/index.blade.php
+++ b/packages/tables/resources/views/components/summary/index.blade.php
@@ -1,35 +1,35 @@
 @props([
-    'actions' => false,
-    'actionsPosition' => null,
-    'allTableSummary' => true,
-    'columns',
-    'extraHeadingColumn' => false,
-    'groupColumn' => null,
-    'groupsOnly' => false,
-    'pageSummary' => true,
-    'placeholderColumns' => true,
-    'pluralModelLabel',
-    'recordCheckboxPosition' => null,
-    'records',
-    'selectionEnabled' => false,
+'actions' => false,
+'actionsPosition' => null,
+'allTableSummary' => true,
+'columns',
+'extraHeadingColumn' => false,
+'groupColumn' => null,
+'groupsOnly' => false,
+'pageSummary' => true,
+'placeholderColumns' => true,
+'pluralModelLabel',
+'recordCheckboxPosition' => null,
+'records',
+'selectionEnabled' => false,
 ])
 
 @php
     use Filament\Support\Enums\Alignment;
-    use Filament\Tables\Columns\Column;
-    use Filament\Tables\Enums\RecordActionsPosition;
-    use Filament\Tables\Enums\RecordCheckboxPosition;
+        use Filament\Tables\Columns\Column;
+        use Filament\Tables\Enums\RecordActionsPosition;
+        use Filament\Tables\Enums\RecordCheckboxPosition;
 
-    if ($groupsOnly && $groupColumn) {
-        $columns = collect($columns)
-            ->reject(fn (Column $column): bool => $column->getName() === $groupColumn)
-            ->all();
-    }
+        if ($groupsOnly && $groupColumn) {
+            $columns = collect($columns)
+                ->reject(fn (Column $column): bool => $column->getName() === $groupColumn)
+                ->all();
+        }
 
-    $hasPageSummary = $pageSummary && (! $groupsOnly) && $records instanceof \Illuminate\Contracts\Pagination\Paginator && $records->hasPages();
+        $hasPageSummary = $pageSummary && (! $groupsOnly) && $records instanceof \Illuminate\Contracts\Pagination\Paginator && $records->hasPages();
 
-    $pageTableSummaryQuery = $hasPageSummary ? $this->getPageTableSummaryQuery() : null;
-    $allTableSummaryQuery = $allTableSummary ? $this->getAllTableSummaryQuery() : null;
+        $pageTableSummaryQuery = $hasPageSummary ? $this->getPageTableSummaryQuery() : null;
+        $allTableSummaryQuery = $allTableSummary ? $this->getAllTableSummaryQuery() : null;
 @endphp
 
 @if ($hasPageSummary)
@@ -57,19 +57,19 @@
                 @php
                     $alignment = $column->getAlignment() ?? Alignment::Start;
 
-                    if (! $alignment instanceof Alignment) {
-                        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
-                    }
+                                        if (! $alignment instanceof Alignment) {
+                                            $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
+                                        }
 
-                    $hasColumnHeaderLabel = (! $placeholderColumns) || $columnHasSummary;
+                                        $hasColumnHeaderLabel = (! $placeholderColumns) || $columnHasSummary;
                 @endphp
 
                 <td
                     {{
                         $column->getExtraHeaderAttributeBag()->class([
-                            'fi-ta-cell fi-ta-summary-header-cell',
-                            'fi-wrapped' => $column->canHeaderWrap(),
-                            (($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : '')) => (! ($loop->first && (! $extraHeadingColumn))) && $hasColumnHeaderLabel,
+                        'fi-ta-cell fi-ta-summary-header-cell',
+                        'fi-wrapped' => $column->canHeaderWrap(),
+                        (($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : '')) => (! ($loop->first && (! $extraHeadingColumn))) && $hasColumnHeaderLabel,
                         ])
                     }}
                 >
@@ -127,7 +127,7 @@
         :selected-state="$selectedState"
         :selection-enabled="$selectionEnabled"
         @class([
-            'fi-striped' => ! $hasPageSummary,
-        ])
+                    'fi-striped' => ! $hasPageSummary,
+                ])
     />
 @endif

--- a/packages/tables/resources/views/components/summary/row.blade.php
+++ b/packages/tables/resources/views/components/summary/row.blade.php
@@ -1,29 +1,29 @@
 @props([
-    'actions' => false,
-    'actionsPosition' => null,
-    'columns',
-    'extraHeadingColumn' => false,
-    'groupColumn' => null,
-    'groupsOnly' => false,
-    'heading',
-    'placeholderColumns' => true,
-    'query',
-    'selectionEnabled' => false,
-    'selectedState',
-    'recordCheckboxPosition' => null,
+'actions' => false,
+'actionsPosition' => null,
+'columns',
+'extraHeadingColumn' => false,
+'groupColumn' => null,
+'groupsOnly' => false,
+'heading',
+'placeholderColumns' => true,
+'query',
+'selectionEnabled' => false,
+'selectedState',
+'recordCheckboxPosition' => null,
 ])
 
 @php
     use Filament\Support\Enums\Alignment;
-    use Filament\Tables\Columns\Column;
-    use Filament\Tables\Enums\RecordActionsPosition;
-    use Filament\Tables\Enums\RecordCheckboxPosition;
+        use Filament\Tables\Columns\Column;
+        use Filament\Tables\Enums\RecordActionsPosition;
+        use Filament\Tables\Enums\RecordCheckboxPosition;
 
-    if ($groupsOnly && $groupColumn) {
-        $columns = collect($columns)
-            ->reject(fn (Column $column): bool => $column->getName() === $groupColumn)
-            ->all();
-    }
+        if ($groupsOnly && $groupColumn) {
+            $columns = collect($columns)
+                ->reject(fn (Column $column): bool => $column->getName() === $groupColumn)
+                ->all();
+        }
 @endphp
 
 <tr {{ $attributes->class(['fi-ta-row fi-ta-summary-row']) }}>
@@ -43,17 +43,17 @@
         @php
             $headingColumnSpan = 1;
 
-            foreach ($columns as $index => $column) {
-                if ($index === array_key_first($columns)) {
-                    continue;
-                }
+                        foreach ($columns as $index => $column) {
+                            if ($index === array_key_first($columns)) {
+                                continue;
+                            }
 
-                if ($column->hasSummary($query)) {
-                    break;
-                }
+                            if ($column->hasSummary($query)) {
+                                break;
+                            }
 
-                $headingColumnSpan++;
-            }
+                            $headingColumnSpan++;
+                        }
         @endphp
     @endif
 
@@ -62,17 +62,17 @@
             @php
                 $alignment = $column->getAlignment() ?? Alignment::Start;
 
-                if (! $alignment instanceof Alignment) {
-                    $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
-                }
+                                if (! $alignment instanceof Alignment) {
+                                    $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
+                                }
             @endphp
 
             <td
                 colspan="{{ ($loop->first && (! $extraHeadingColumn) && (! $groupsOnly) && ($headingColumnSpan > 1)) ? $headingColumnSpan : null }}"
                 @class([
-                    'fi-ta-cell',
-                    ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : ''),
-                    'fi-ta-summary-row-heading-cell' => $loop->first && (! $extraHeadingColumn) && (! $groupsOnly),
+                'fi-ta-cell',
+                ($alignment instanceof Alignment) ? "fi-align-{$alignment->value}" : (is_string($alignment) ? $alignment : ''),
+                'fi-ta-summary-row-heading-cell' => $loop->first && (! $extraHeadingColumn) && (! $groupsOnly),
                 ])
             >
                 @if ($loop->first && (! $extraHeadingColumn) && (! $groupsOnly))

--- a/packages/tables/resources/views/index.blade.php
+++ b/packages/tables/resources/views/index.blade.php
@@ -1,157 +1,157 @@
 @php
     use Filament\Support\Enums\Alignment;
-    use Filament\Support\Enums\VerticalAlignment;
-    use Filament\Support\Enums\Width;
-    use Filament\Support\Facades\FilamentView;
-    use Filament\Tables\Actions\HeaderActionsPosition;
-    use Filament\Tables\Columns\Column;
-    use Filament\Tables\Columns\ColumnGroup;
-    use Filament\Tables\Enums\ColumnManagerLayout;
-    use Filament\Tables\Enums\ColumnManagerResetActionPosition;
-    use Filament\Tables\Enums\FiltersLayout;
-    use Filament\Tables\Enums\FiltersResetActionPosition;
-    use Filament\Tables\Enums\RecordActionsPosition;
-    use Filament\Tables\Enums\RecordCheckboxPosition;
-    use Filament\Tables\View\TablesRenderHook;
-    use Illuminate\Support\Str;
-    use Illuminate\View\ComponentAttributeBag;
+        use Filament\Support\Enums\VerticalAlignment;
+        use Filament\Support\Enums\Width;
+        use Filament\Support\Facades\FilamentView;
+        use Filament\Tables\Actions\HeaderActionsPosition;
+        use Filament\Tables\Columns\Column;
+        use Filament\Tables\Columns\ColumnGroup;
+        use Filament\Tables\Enums\ColumnManagerLayout;
+        use Filament\Tables\Enums\ColumnManagerResetActionPosition;
+        use Filament\Tables\Enums\FiltersLayout;
+        use Filament\Tables\Enums\FiltersResetActionPosition;
+        use Filament\Tables\Enums\RecordActionsPosition;
+        use Filament\Tables\Enums\RecordCheckboxPosition;
+        use Filament\Tables\View\TablesRenderHook;
+        use Illuminate\Support\Str;
+        use Illuminate\View\ComponentAttributeBag;
 
-    $defaultRecordActions = $getRecordActions();
-    $flatRecordActionsCount = count($getFlatRecordActions());
-    $recordActionsAlignment = $getRecordActionsAlignment();
-    $recordActionsPosition = $getRecordActionsPosition();
-    $recordActionsColumnLabel = $getRecordActionsColumnLabel();
+        $defaultRecordActions = $getRecordActions();
+        $flatRecordActionsCount = count($getFlatRecordActions());
+        $recordActionsAlignment = $getRecordActionsAlignment();
+        $recordActionsPosition = $getRecordActionsPosition();
+        $recordActionsColumnLabel = $getRecordActionsColumnLabel();
 
-    if (! $recordActionsAlignment instanceof Alignment) {
-        $recordActionsAlignment = filled($recordActionsAlignment) ? (Alignment::tryFrom($recordActionsAlignment) ?? $recordActionsAlignment) : null;
-    }
-
-    $activeFiltersCount = $getActiveFiltersCount();
-    $isSelectionDisabled = $isSelectionDisabled();
-    $maxSelectableRecords = $getMaxSelectableRecords();
-    $columns = $getVisibleColumns();
-    $collapsibleColumnsLayout = $getCollapsibleColumnsLayout();
-    $columnsLayout = $getColumnsLayout();
-    $content = $getContent();
-    $contentGrid = $getContentGrid();
-    $contentFooter = $getContentFooter();
-    $filterIndicators = $getFilterIndicators();
-    $filtersApplyAction = $getFiltersApplyAction();
-    $filtersForm = $getFiltersForm();
-    $filtersFormWidth = $getFiltersFormWidth();
-    $filtersResetActionPosition = $getFiltersResetActionPosition();
-    $columnManagerResetActionPosition = $getColumnManagerResetActionPosition();
-    $hasColumnGroups = $hasColumnGroups();
-    $hasColumnsLayout = $hasColumnsLayout();
-    $hasPageSummary = $hasPageSummary();
-    $hasAllTableSummary = $hasAllTableSummary();
-    $hasSummary = $hasSummary($this->getAllTableSummaryQuery());
-    $hasTopLevelSummary = $hasSummary && ($hasPageSummary || $hasAllTableSummary);
-    $header = $getHeader();
-    $headerActions = array_filter(
-        $getHeaderActions(),
-        fn (\Filament\Actions\Action | \Filament\Actions\ActionGroup $action): bool => $action->isVisible(),
-    );
-    $headerActionsPosition = $getHeaderActionsPosition();
-    $heading = $getHeading();
-    $group = $getGrouping();
-    $toolbarActions = array_filter(
-        $getToolbarActions(),
-        fn (\Filament\Actions\Action | \Filament\Actions\ActionGroup $action): bool => $action->isVisible(),
-    );
-
-    $hasNonBulkToolbarAction = false;
-
-    foreach ($toolbarActions as $toolbarAction) {
-        if ($toolbarAction instanceof \Filament\Actions\BulkActionGroup) {
-            continue;
+        if (! $recordActionsAlignment instanceof Alignment) {
+            $recordActionsAlignment = filled($recordActionsAlignment) ? (Alignment::tryFrom($recordActionsAlignment) ?? $recordActionsAlignment) : null;
         }
 
-        if ($toolbarAction instanceof \Filament\Actions\ActionGroup) {
-            if ($toolbarAction->hasNonBulkAction()) {
+        $activeFiltersCount = $getActiveFiltersCount();
+        $isSelectionDisabled = $isSelectionDisabled();
+        $maxSelectableRecords = $getMaxSelectableRecords();
+        $columns = $getVisibleColumns();
+        $collapsibleColumnsLayout = $getCollapsibleColumnsLayout();
+        $columnsLayout = $getColumnsLayout();
+        $content = $getContent();
+        $contentGrid = $getContentGrid();
+        $contentFooter = $getContentFooter();
+        $filterIndicators = $getFilterIndicators();
+        $filtersApplyAction = $getFiltersApplyAction();
+        $filtersForm = $getFiltersForm();
+        $filtersFormWidth = $getFiltersFormWidth();
+        $filtersResetActionPosition = $getFiltersResetActionPosition();
+        $columnManagerResetActionPosition = $getColumnManagerResetActionPosition();
+        $hasColumnGroups = $hasColumnGroups();
+        $hasColumnsLayout = $hasColumnsLayout();
+        $hasPageSummary = $hasPageSummary();
+        $hasAllTableSummary = $hasAllTableSummary();
+        $hasSummary = $hasSummary($this->getAllTableSummaryQuery());
+        $hasTopLevelSummary = $hasSummary && ($hasPageSummary || $hasAllTableSummary);
+        $header = $getHeader();
+        $headerActions = array_filter(
+            $getHeaderActions(),
+            fn (\Filament\Actions\Action | \Filament\Actions\ActionGroup $action): bool => $action->isVisible(),
+        );
+        $headerActionsPosition = $getHeaderActionsPosition();
+        $heading = $getHeading();
+        $group = $getGrouping();
+        $toolbarActions = array_filter(
+            $getToolbarActions(),
+            fn (\Filament\Actions\Action | \Filament\Actions\ActionGroup $action): bool => $action->isVisible(),
+        );
+
+        $hasNonBulkToolbarAction = false;
+
+        foreach ($toolbarActions as $toolbarAction) {
+            if ($toolbarAction instanceof \Filament\Actions\BulkActionGroup) {
+                continue;
+            }
+
+            if ($toolbarAction instanceof \Filament\Actions\ActionGroup) {
+                if ($toolbarAction->hasNonBulkAction()) {
+                    $hasNonBulkToolbarAction = true;
+
+                    break;
+                }
+
+                continue;
+            }
+
+            if (! $toolbarAction->isBulk()) {
                 $hasNonBulkToolbarAction = true;
 
                 break;
             }
-
-            continue;
         }
 
-        if (! $toolbarAction->isBulk()) {
-            $hasNonBulkToolbarAction = true;
+        $groups = $getGroups();
+        $description = $getDescription();
+        $isGroupsOnly = $isGroupsOnly() && $group;
+        $isReorderable = $isReorderable();
+        $isReordering = $isReordering();
+        $areGroupingSettingsVisible = (! $isReordering) && count($groups) && (! $areGroupingSettingsHidden());
+        $isGroupingDirectionSettingHidden = $isGroupingDirectionSettingHidden();
+        $areGroupsCollapsedByDefault = $areGroupsCollapsedByDefault();
+        $areGroupingSettingsInDropdownOnDesktop = $areGroupingSettingsInDropdownOnDesktop();
+        $isColumnSearchVisible = $isSearchableByColumn();
+        $isGlobalSearchVisible = $isSearchable();
+        $isSearchOnBlur = $isSearchOnBlur();
+        $isSelectionEnabled = $isSelectionEnabled() && (! $isGroupsOnly);
+        $selectsCurrentPageOnly = $selectsCurrentPageOnly();
+        $selectsGroupsOnly = $selectsGroupsOnly();
+        $recordCheckboxPosition = $getRecordCheckboxPosition();
+        $isStriped = $isStriped();
+        $isStackedOnMobile = $isStackedOnMobile();
+        $isLoaded = $isLoaded();
+        $hasFilters = $isFilterable();
+        $filtersLayout = $getFiltersLayout();
+        $filtersTriggerAction = $getFiltersTriggerAction();
+        $hasFiltersDialog = $hasFilters && in_array($filtersLayout, [FiltersLayout::Dropdown, FiltersLayout::Modal]);
+        $hasFiltersAboveContent = $hasFilters && in_array($filtersLayout, [FiltersLayout::AboveContent, FiltersLayout::AboveContentCollapsible]);
+        $hasFiltersBelowContent = $hasFilters && ($filtersLayout === FiltersLayout::BelowContent);
+        $hasFiltersBeforeContent = $hasFilters && in_array($filtersLayout, [FiltersLayout::BeforeContent, FiltersLayout::BeforeContentCollapsible]);
+        $hasFiltersAfterContent = $hasFilters && in_array($filtersLayout, [FiltersLayout::AfterContent, FiltersLayout::AfterContentCollapsible]);
+        $hasCollapsibleFilters = $hasFilters && in_array($filtersLayout, [FiltersLayout::AboveContentCollapsible, FiltersLayout::BeforeContentCollapsible, FiltersLayout::AfterContentCollapsible]);
+        $hasFiltersTrigger = $hasFilters && ($hasFiltersDialog || $hasFiltersBeforeContent || $hasFiltersAfterContent);
+        $filtersFormMaxHeight = $getFiltersFormMaxHeight();
+        $hasColumnManager = $hasColumnManager();
+        $columnManagerLayout = $getColumnManagerLayout();
+        $hasReorderableColumns = $hasReorderableColumns();
+        $hasToggleableColumns = $hasToggleableColumns();
+        $columnManagerApplyAction = $getColumnManagerApplyAction();
+        $columnManagerTriggerAction = $getColumnManagerTriggerAction();
+        $hasHeader = $header || $heading || $description || ($headerActions && (! $isReordering)) || $isReorderable || $areGroupingSettingsVisible || $isGlobalSearchVisible || $hasFilters || count($filterIndicators) || $hasColumnManager;
+        $hasHeaderToolbar = $isReorderable || $areGroupingSettingsVisible || $isGlobalSearchVisible || $hasFiltersTrigger || $hasColumnManager;
+        $headingTag = $getHeadingTag();
+        $secondLevelHeadingTag = $heading ? $getHeadingTag(1) : $headingTag;
+        $pluralModelLabel = $getPluralModelLabel();
+        $records = $isLoaded ? $getRecords() : null;
+        $hasPagination = (($records instanceof \Illuminate\Contracts\Pagination\Paginator) || ($records instanceof \Illuminate\Contracts\Pagination\CursorPaginator)) && (($records instanceof \Illuminate\Contracts\Pagination\LengthAwarePaginator) ? $records->total() : $records->isNotEmpty());
+        $hasEmptyState = ($records !== null) && ! count($records);
+        $hasContentLayout = $content || $hasColumnsLayout;
+        $searchDebounce = $getSearchDebounce();
+        $allSelectableRecordsCount = ($isSelectionEnabled && $isLoaded) ? $getAllSelectableRecordsCount() : null;
+        $columnsCount = count($columns);
+        $reorderRecordsTriggerAction = $getReorderRecordsTriggerAction($isReordering);
+        $page = $this->getTablePage();
+        $defaultSortOptionLabel = $getDefaultSortOptionLabel();
+        $sortDirection = $getSortDirection();
 
-            break;
+        if (count($defaultRecordActions) && (! $isReordering)) {
+            $columnsCount++;
         }
-    }
 
-    $groups = $getGroups();
-    $description = $getDescription();
-    $isGroupsOnly = $isGroupsOnly() && $group;
-    $isReorderable = $isReorderable();
-    $isReordering = $isReordering();
-    $areGroupingSettingsVisible = (! $isReordering) && count($groups) && (! $areGroupingSettingsHidden());
-    $isGroupingDirectionSettingHidden = $isGroupingDirectionSettingHidden();
-    $areGroupsCollapsedByDefault = $areGroupsCollapsedByDefault();
-    $areGroupingSettingsInDropdownOnDesktop = $areGroupingSettingsInDropdownOnDesktop();
-    $isColumnSearchVisible = $isSearchableByColumn();
-    $isGlobalSearchVisible = $isSearchable();
-    $isSearchOnBlur = $isSearchOnBlur();
-    $isSelectionEnabled = $isSelectionEnabled() && (! $isGroupsOnly);
-    $selectsCurrentPageOnly = $selectsCurrentPageOnly();
-    $selectsGroupsOnly = $selectsGroupsOnly();
-    $recordCheckboxPosition = $getRecordCheckboxPosition();
-    $isStriped = $isStriped();
-    $isStackedOnMobile = $isStackedOnMobile();
-    $isLoaded = $isLoaded();
-    $hasFilters = $isFilterable();
-    $filtersLayout = $getFiltersLayout();
-    $filtersTriggerAction = $getFiltersTriggerAction();
-    $hasFiltersDialog = $hasFilters && in_array($filtersLayout, [FiltersLayout::Dropdown, FiltersLayout::Modal]);
-    $hasFiltersAboveContent = $hasFilters && in_array($filtersLayout, [FiltersLayout::AboveContent, FiltersLayout::AboveContentCollapsible]);
-    $hasFiltersBelowContent = $hasFilters && ($filtersLayout === FiltersLayout::BelowContent);
-    $hasFiltersBeforeContent = $hasFilters && in_array($filtersLayout, [FiltersLayout::BeforeContent, FiltersLayout::BeforeContentCollapsible]);
-    $hasFiltersAfterContent = $hasFilters && in_array($filtersLayout, [FiltersLayout::AfterContent, FiltersLayout::AfterContentCollapsible]);
-    $hasCollapsibleFilters = $hasFilters && in_array($filtersLayout, [FiltersLayout::AboveContentCollapsible, FiltersLayout::BeforeContentCollapsible, FiltersLayout::AfterContentCollapsible]);
-    $hasFiltersTrigger = $hasFilters && ($hasFiltersDialog || $hasFiltersBeforeContent || $hasFiltersAfterContent);
-    $filtersFormMaxHeight = $getFiltersFormMaxHeight();
-    $hasColumnManager = $hasColumnManager();
-    $columnManagerLayout = $getColumnManagerLayout();
-    $hasReorderableColumns = $hasReorderableColumns();
-    $hasToggleableColumns = $hasToggleableColumns();
-    $columnManagerApplyAction = $getColumnManagerApplyAction();
-    $columnManagerTriggerAction = $getColumnManagerTriggerAction();
-    $hasHeader = $header || $heading || $description || ($headerActions && (! $isReordering)) || $isReorderable || $areGroupingSettingsVisible || $isGlobalSearchVisible || $hasFilters || count($filterIndicators) || $hasColumnManager;
-    $hasHeaderToolbar = $isReorderable || $areGroupingSettingsVisible || $isGlobalSearchVisible || $hasFiltersTrigger || $hasColumnManager;
-    $headingTag = $getHeadingTag();
-    $secondLevelHeadingTag = $heading ? $getHeadingTag(1) : $headingTag;
-    $pluralModelLabel = $getPluralModelLabel();
-    $records = $isLoaded ? $getRecords() : null;
-    $hasPagination = (($records instanceof \Illuminate\Contracts\Pagination\Paginator) || ($records instanceof \Illuminate\Contracts\Pagination\CursorPaginator)) && (($records instanceof \Illuminate\Contracts\Pagination\LengthAwarePaginator) ? $records->total() : $records->isNotEmpty());
-    $hasEmptyState = ($records !== null) && ! count($records);
-    $hasContentLayout = $content || $hasColumnsLayout;
-    $searchDebounce = $getSearchDebounce();
-    $allSelectableRecordsCount = ($isSelectionEnabled && $isLoaded) ? $getAllSelectableRecordsCount() : null;
-    $columnsCount = count($columns);
-    $reorderRecordsTriggerAction = $getReorderRecordsTriggerAction($isReordering);
-    $page = $this->getTablePage();
-    $defaultSortOptionLabel = $getDefaultSortOptionLabel();
-    $sortDirection = $getSortDirection();
+        if ($isSelectionEnabled || $isReordering) {
+            $columnsCount++;
+        }
 
-    if (count($defaultRecordActions) && (! $isReordering)) {
-        $columnsCount++;
-    }
+        if ($group) {
+            $groupedSummarySelectedState = $this->getTableSummarySelectedState($this->getAllTableSummaryQuery(), modifyQueryUsing: fn (\Illuminate\Database\Query\Builder $query) => $group->groupQuery($query, model: $getQuery()->getModel()));
+        }
 
-    if ($isSelectionEnabled || $isReordering) {
-        $columnsCount++;
-    }
-
-    if ($group) {
-        $groupedSummarySelectedState = $this->getTableSummarySelectedState($this->getAllTableSummaryQuery(), modifyQueryUsing: fn (\Illuminate\Database\Query\Builder $query) => $group->groupQuery($query, model: $getQuery()->getModel()));
-    }
-
-    if (is_string($filtersFormWidth)) {
-        $filtersFormWidth = Width::tryFrom($filtersFormWidth) ?? $filtersFormWidth;
-    }
+        if (is_string($filtersFormWidth)) {
+            $filtersFormWidth = Width::tryFrom($filtersFormWidth) ?? $filtersFormWidth;
+        }
 @endphp
 
 <div
@@ -168,8 +168,8 @@
             })"
     {{
         $getExtraAttributeBag()->class([
-            'fi-ta',
-            'fi-loading' => $records === null,
+        'fi-ta',
+        'fi-loading' => $records === null,
         ])
     }}
 >
@@ -181,10 +181,10 @@
 
     <div
         @class([
-            'fi-ta-ctn',
-            'fi-ta-ctn-with-content-layout' => $hasContentLayout,
-            'fi-ta-ctn-with-footer' => $hasPagination || $hasEmptyState || $hasFiltersBelowContent,
-            'fi-ta-ctn-with-header' => $hasHeader,
+        'fi-ta-ctn',
+        'fi-ta-ctn-with-content-layout' => $hasContentLayout,
+        'fi-ta-ctn-with-footer' => $hasPagination || $hasEmptyState || $hasFiltersBelowContent,
+        'fi-ta-ctn-with-header' => $hasHeader,
         ])
     >
         @if ($hasFiltersBeforeContent)
@@ -195,9 +195,9 @@
                 x-transition:leave-end="fi-opacity-0"
                 x-bind:class="{ 'fi-open': areFiltersOpen }"
                 @class([
-                    'fi-ta-filters-before-content-ctn',
-                    'lg:fi-open' => ! $hasCollapsibleFilters,
-                    (($filtersFormWidth ??= Width::ExtraSmall) instanceof Width) ? "fi-width-{$filtersFormWidth->value}" : (is_string($filtersFormWidth) ? $filtersFormWidth : null),
+                'fi-ta-filters-before-content-ctn',
+                'lg:fi-open' => ! $hasCollapsibleFilters,
+                (($filtersFormWidth ??= Width::ExtraSmall) instanceof Width) ? "fi-width-{$filtersFormWidth->value}" : (is_string($filtersFormWidth) ? $filtersFormWidth : null),
                 ])
             >
                 <x-filament-tables::filters
@@ -223,8 +223,8 @@
                 @elseif (($heading || $description || $headerActions) && ! $isReordering)
                     <div
                         @class([
-                            'fi-ta-header',
-                            'fi-ta-header-adaptive-actions-position' => $headerActions && ($headerActionsPosition === HeaderActionsPosition::Adaptive),
+                        'fi-ta-header',
+                        'fi-ta-header-adaptive-actions-position' => $headerActions && ($headerActionsPosition === HeaderActionsPosition::Adaptive),
                         ])
                     >
                         @if ($heading || $description)
@@ -265,7 +265,7 @@
                             x-bind:class="{ 'fi-open': areFiltersOpen }"
                         @endif
                         @class([
-                            'fi-ta-filters-above-content-ctn',
+                        'fi-ta-filters-above-content-ctn',
                         ])
                     >
                         <x-filament-tables::filters
@@ -369,8 +369,8 @@
                                     width="xs"
                                     wire:key="{{ $this->getId() }}.table.grouping"
                                     @class([
-                                        'sm:fi-hidden' => ! $areGroupingSettingsInDropdownOnDesktop,
-                                    ])
+                                                                            'sm:fi-hidden' => ! $areGroupingSettingsInDropdownOnDesktop,
+                                                                        ])
                                 >
                                     <x-slot name="trigger">
                                         {{ $getGroupRecordsTriggerAction() }}
@@ -499,20 +499,20 @@
                                     @if (($filtersLayout === FiltersLayout::Modal) || $filtersTriggerAction->isModalSlideOver())
                                         @php
                                             $filtersTriggerActionModalAlignment = $filtersTriggerAction->getModalAlignment();
-                                            $filtersTriggerActionIsModalAutofocused = $filtersTriggerAction->isModalAutofocused();
-                                            $filtersTriggerActionHasModalCloseButton = $filtersTriggerAction->hasModalCloseButton();
-                                            $filtersTriggerActionIsModalClosedByClickingAway = $filtersTriggerAction->isModalClosedByClickingAway();
-                                            $filtersTriggerActionIsModalClosedByEscaping = $filtersTriggerAction->isModalClosedByEscaping();
-                                            $filtersTriggerActionModalDescription = $filtersTriggerAction->getModalDescription();
-                                            $filtersTriggerActionVisibleModalFooterActions = $filtersTriggerAction->getVisibleModalFooterActions();
-                                            $filtersTriggerActionModalFooterActionsAlignment = $filtersTriggerAction->getModalFooterActionsAlignment();
-                                            $filtersTriggerActionModalHeading = $filtersTriggerAction->getCustomModalHeading() ?? __('filament-tables::table.filters.heading');
-                                            $filtersTriggerActionModalIcon = $filtersTriggerAction->getModalIcon();
-                                            $filtersTriggerActionModalIconColor = $filtersTriggerAction->getModalIconColor();
-                                            $filtersTriggerActionIsModalSlideOver = $filtersTriggerAction->isModalSlideOver();
-                                            $filtersTriggerActionModalSlideOverPosition = $filtersTriggerAction->getModalSlideOverPosition();
-                                            $filtersTriggerActionIsModalFooterSticky = $filtersTriggerAction->isModalFooterSticky();
-                                            $filtersTriggerActionIsModalHeaderSticky = $filtersTriggerAction->isModalHeaderSticky();
+                                                                                        $filtersTriggerActionIsModalAutofocused = $filtersTriggerAction->isModalAutofocused();
+                                                                                        $filtersTriggerActionHasModalCloseButton = $filtersTriggerAction->hasModalCloseButton();
+                                                                                        $filtersTriggerActionIsModalClosedByClickingAway = $filtersTriggerAction->isModalClosedByClickingAway();
+                                                                                        $filtersTriggerActionIsModalClosedByEscaping = $filtersTriggerAction->isModalClosedByEscaping();
+                                                                                        $filtersTriggerActionModalDescription = $filtersTriggerAction->getModalDescription();
+                                                                                        $filtersTriggerActionVisibleModalFooterActions = $filtersTriggerAction->getVisibleModalFooterActions();
+                                                                                        $filtersTriggerActionModalFooterActionsAlignment = $filtersTriggerAction->getModalFooterActionsAlignment();
+                                                                                        $filtersTriggerActionModalHeading = $filtersTriggerAction->getCustomModalHeading() ?? __('filament-tables::table.filters.heading');
+                                                                                        $filtersTriggerActionModalIcon = $filtersTriggerAction->getModalIcon();
+                                                                                        $filtersTriggerActionModalIconColor = $filtersTriggerAction->getModalIconColor();
+                                                                                        $filtersTriggerActionIsModalSlideOver = $filtersTriggerAction->isModalSlideOver();
+                                                                                        $filtersTriggerActionModalSlideOverPosition = $filtersTriggerAction->getModalSlideOverPosition();
+                                                                                        $filtersTriggerActionIsModalFooterSticky = $filtersTriggerAction->isModalFooterSticky();
+                                                                                        $filtersTriggerActionIsModalHeaderSticky = $filtersTriggerAction->isModalHeaderSticky();
                                         @endphp
 
                                         <x-filament::modal
@@ -572,8 +572,8 @@
                                         x-ref="filtersTriggerActionContainer"
                                         x-on:click="toggleFiltersDropdown"
                                         @class([
-                                            'fi-ta-filters-trigger-action-ctn',
-                                            'lg:fi-hidden' => ! $hasCollapsibleFilters,
+                                        'fi-ta-filters-trigger-action-ctn',
+                                        'lg:fi-hidden' => ! $hasCollapsibleFilters,
                                         ])
                                     >
                                         {{ $filtersTriggerAction->badge($activeFiltersCount) }}
@@ -585,27 +585,27 @@
                                 @if ($hasColumnManager)
                                     @php
                                         $columnManagerMaxHeight = $getColumnManagerMaxHeight();
-                                        $columnManagerWidth = $getColumnManagerWidth();
-                                        $columnManagerColumns = $getColumnManagerColumns();
+                                                                                $columnManagerWidth = $getColumnManagerWidth();
+                                                                                $columnManagerColumns = $getColumnManagerColumns();
                                     @endphp
 
                                     @if (($columnManagerLayout === ColumnManagerLayout::Modal) || $columnManagerTriggerAction->isModalSlideOver())
                                         @php
                                             $columnManagerTriggerActionModalAlignment = $columnManagerTriggerAction->getModalAlignment();
-                                            $columnManagerTriggerActionIsModalAutofocused = $columnManagerTriggerAction->isModalAutofocused();
-                                            $columnManagerTriggerActionHasModalCloseButton = $columnManagerTriggerAction->hasModalCloseButton();
-                                            $columnManagerTriggerActionIsModalClosedByClickingAway = $columnManagerTriggerAction->isModalClosedByClickingAway();
-                                            $columnManagerTriggerActionIsModalClosedByEscaping = $columnManagerTriggerAction->isModalClosedByEscaping();
-                                            $columnManagerTriggerActionModalDescription = $columnManagerTriggerAction->getModalDescription();
-                                            $columnManagerTriggerActionVisibleModalFooterActions = $columnManagerTriggerAction->getVisibleModalFooterActions();
-                                            $columnManagerTriggerActionModalFooterActionsAlignment = $columnManagerTriggerAction->getModalFooterActionsAlignment();
-                                            $columnManagerTriggerActionModalHeading = $columnManagerTriggerAction->getCustomModalHeading() ?? __('filament-tables::table.column_manager.heading');
-                                            $columnManagerTriggerActionModalIcon = $columnManagerTriggerAction->getModalIcon();
-                                            $columnManagerTriggerActionModalIconColor = $columnManagerTriggerAction->getModalIconColor();
-                                            $columnManagerTriggerActionIsModalSlideOver = $columnManagerTriggerAction->isModalSlideOver();
-                                            $columnManagerTriggerActionModalSlideOverPosition = $columnManagerTriggerAction->getModalSlideOverPosition();
-                                            $columnManagerTriggerActionIsModalFooterSticky = $columnManagerTriggerAction->isModalFooterSticky();
-                                            $columnManagerTriggerActionIsModalHeaderSticky = $columnManagerTriggerAction->isModalHeaderSticky();
+                                                                                        $columnManagerTriggerActionIsModalAutofocused = $columnManagerTriggerAction->isModalAutofocused();
+                                                                                        $columnManagerTriggerActionHasModalCloseButton = $columnManagerTriggerAction->hasModalCloseButton();
+                                                                                        $columnManagerTriggerActionIsModalClosedByClickingAway = $columnManagerTriggerAction->isModalClosedByClickingAway();
+                                                                                        $columnManagerTriggerActionIsModalClosedByEscaping = $columnManagerTriggerAction->isModalClosedByEscaping();
+                                                                                        $columnManagerTriggerActionModalDescription = $columnManagerTriggerAction->getModalDescription();
+                                                                                        $columnManagerTriggerActionVisibleModalFooterActions = $columnManagerTriggerAction->getVisibleModalFooterActions();
+                                                                                        $columnManagerTriggerActionModalFooterActionsAlignment = $columnManagerTriggerAction->getModalFooterActionsAlignment();
+                                                                                        $columnManagerTriggerActionModalHeading = $columnManagerTriggerAction->getCustomModalHeading() ?? __('filament-tables::table.column_manager.heading');
+                                                                                        $columnManagerTriggerActionModalIcon = $columnManagerTriggerAction->getModalIcon();
+                                                                                        $columnManagerTriggerActionModalIconColor = $columnManagerTriggerAction->getModalIconColor();
+                                                                                        $columnManagerTriggerActionIsModalSlideOver = $columnManagerTriggerAction->isModalSlideOver();
+                                                                                        $columnManagerTriggerActionModalSlideOverPosition = $columnManagerTriggerAction->getModalSlideOverPosition();
+                                                                                        $columnManagerTriggerActionIsModalFooterSticky = $columnManagerTriggerAction->isModalFooterSticky();
+                                                                                        $columnManagerTriggerActionIsModalHeaderSticky = $columnManagerTriggerAction->isModalHeaderSticky();
                                         @endphp
 
                                         <x-filament::modal
@@ -699,8 +699,8 @@
                 >
                     {{
                         \Filament\Support\generate_loading_indicator_html(new \Illuminate\View\ComponentAttributeBag([
-                            'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
-                            'wire:target' => 'reorderTable',
+                        'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
+                        'wire:target' => 'reorderTable',
                         ]))
                     }}
 
@@ -717,7 +717,7 @@
                     <div>
                         {{
                             \Filament\Support\generate_loading_indicator_html(new \Illuminate\View\ComponentAttributeBag([
-                                'x-show' => 'isLoading',
+                            'x-show' => 'isLoading',
                             ]))
                         }}
 
@@ -820,9 +820,9 @@
                         @if (! $isReordering)
                             @php
                                 $sortableColumns = array_filter(
-                                    $columns,
-                                    fn (\Filament\Tables\Columns\Column $column): bool => $column->isSortable(),
-                                );
+                                                                    $columns,
+                                                                    fn (\Filament\Tables\Columns\Column $column): bool => $column->isSortable(),
+                                                                );
                             @endphp
 
                             @if (($isSelectionEnabled && ($maxSelectableRecords !== 1) && (! $isReordering) && (! $selectsGroupsOnly)) || count($sortableColumns))
@@ -971,60 +971,60 @@
                                 @endif
                                 {{
                                     (new ComponentAttributeBag)
-                                        ->when($contentGrid, fn (ComponentAttributeBag $attributes) => $attributes->grid($contentGrid))
-                                        ->class([
-                                            'fi-ta-content',
-                                            'fi-ta-content-grid' => $contentGrid,
-                                            'fi-ta-content-grouped' => $this->getTableGrouping(),
-                                        ])
+                                    ->when($contentGrid, fn (ComponentAttributeBag $attributes) => $attributes->grid($contentGrid))
+                                    ->class([
+                                    'fi-ta-content',
+                                    'fi-ta-content-grid' => $contentGrid,
+                                    'fi-ta-content-grouped' => $this->getTableGrouping(),
+                                    ])
                                 }}
                             >
                                 @php
                                     $previousRecord = null;
-                                    $previousRecordGroupKey = null;
-                                    $previousRecordGroupTitle = null;
+                                                                        $previousRecordGroupKey = null;
+                                                                        $previousRecordGroupTitle = null;
                                 @endphp
 
                                 @foreach ($records as $record)
                                     @php
                                         $recordAction = $getRecordAction($record);
-                                        $recordKey = $getRecordKey($record);
-                                        $recordUrl = $getRecordUrl($record);
-                                        $openRecordUrlInNewTab = $shouldOpenRecordUrlInNewTab($record);
-                                        $recordGroupKey = $group?->getStringKey($record);
-                                        $recordGroupTitle = $group?->getTitle($record);
-                                        $isRecordGroupCollapsible = $group?->isCollapsible();
+                                                                                $recordKey = $getRecordKey($record);
+                                                                                $recordUrl = $getRecordUrl($record);
+                                                                                $openRecordUrlInNewTab = $shouldOpenRecordUrlInNewTab($record);
+                                                                                $recordGroupKey = $group?->getStringKey($record);
+                                                                                $recordGroupTitle = $group?->getTitle($record);
+                                                                                $isRecordGroupCollapsible = $group?->isCollapsible();
 
-                                        $collapsibleColumnsLayout?->record($record)->recordKey($recordKey);
-                                        $hasCollapsibleColumnsLayout = (bool) $collapsibleColumnsLayout?->isVisible();
+                                                                                $collapsibleColumnsLayout?->record($record)->recordKey($recordKey);
+                                                                                $hasCollapsibleColumnsLayout = (bool) $collapsibleColumnsLayout?->isVisible();
 
-                                        $recordActions = array_reduce(
-                                            $defaultRecordActions,
-                                            function (array $carry, $action) use ($record): array {
-                                                $action = $action->getClone();
+                                                                                $recordActions = array_reduce(
+                                                                                    $defaultRecordActions,
+                                                                                    function (array $carry, $action) use ($record): array {
+                                                                                        $action = $action->getClone();
 
-                                                if (! $action instanceof \Filament\Actions\BulkAction) {
-                                                    $action->record($record);
-                                                }
+                                                                                        if (! $action instanceof \Filament\Actions\BulkAction) {
+                                                                                            $action->record($record);
+                                                                                        }
 
-                                                if ($action->isHidden()) {
-                                                    return $carry;
-                                                }
+                                                                                        if ($action->isHidden()) {
+                                                                                            return $carry;
+                                                                                        }
 
-                                                $carry[] = $action;
+                                                                                        $carry[] = $action;
 
-                                                return $carry;
-                                            },
-                                            initial: [],
-                                        );
+                                                                                        return $carry;
+                                                                                    },
+                                                                                    initial: [],
+                                                                                );
                                     @endphp
 
                                     @if ((string) $recordGroupTitle !== (string) $previousRecordGroupTitle)
                                         @if ($hasSummary && (! $isReordering) && filled($previousRecordGroupTitle))
                                             <table
                                                 @class([
-                                                    'fi-ta-table',
-                                                    'fi-ta-table-reordering' => $isReordering,
+                                                'fi-ta-table',
+                                                'fi-ta-table-reordering' => $isReordering,
                                                 ])
                                             >
                                                 <tbody>
@@ -1057,8 +1057,8 @@
                                                 @endif
                                             @endif
                                             @class([
-                                                'fi-ta-group-header',
-                                                'fi-collapsible' => $isRecordGroupCollapsible,
+                                            'fi-ta-group-header',
+                                            'fi-collapsible' => $isRecordGroupCollapsible,
                                             ])
                                         >
                                             @if ($isSelectionEnabled && ($maxSelectableRecords !== 1))
@@ -1145,11 +1145,11 @@
                                             x-sortable-handle
                                         @endif
                                         @class([
-                                            'fi-ta-record',
-                                            'fi-clickable' => $recordUrl || $recordAction,
-                                            'fi-ta-record-with-content-prefix' => $isReordering || ($isSelectionEnabled && $isRecordSelectable($record)),
-                                            'fi-ta-record-with-content-suffix' => $hasCollapsibleColumnsLayout && (! $isReordering),
-                                            ...$getRecordClasses($record),
+                                        'fi-ta-record',
+                                        'fi-clickable' => $recordUrl || $recordAction,
+                                        'fi-ta-record-with-content-prefix' => $isReordering || ($isSelectionEnabled && $isRecordSelectable($record)),
+                                        'fi-ta-record-with-content-suffix' => $hasCollapsibleColumnsLayout && (! $isReordering),
+                                        ...$getRecordClasses($record),
                                         ])
                                         x-bind:class="{
                                             {{ $group?->isCollapsible() ? '\'fi-collapsed\': isGroupCollapsed(' . \Illuminate\Support\Js::from($recordGroupTitle) . '),' : '' }}
@@ -1158,7 +1158,7 @@
                                     >
                                         @php
                                             $hasItemBeforeRecordContent = $isReordering || ($isSelectionEnabled && $isRecordSelectable($record));
-                                            $hasItemAfterRecordContent = $hasCollapsibleColumnsLayout && (! $isReordering);
+                                                                                        $hasItemAfterRecordContent = $hasCollapsibleColumnsLayout && (! $isReordering);
                                         @endphp
 
                                         @if ($isReordering)
@@ -1197,18 +1197,18 @@
                                                         @foreach ($columnsLayout as $columnsLayoutComponent)
                                                             {{
                                                                 $columnsLayoutComponent
-                                                                    ->record($record)
-                                                                    ->recordKey($recordKey)
-                                                                    ->rowLoop($loop)
-                                                                    ->renderInLayout()
+                                                                ->record($record)
+                                                                ->recordKey($recordKey)
+                                                                ->rowLoop($loop)
+                                                                ->renderInLayout()
                                                             }}
                                                         @endforeach
                                                     </a>
                                                 @elseif ($recordAction)
                                                     @php
                                                         $recordWireClickAction = $getRecordAction($record)
-                                                            ? "mountTableAction('{$recordAction}', '{$recordKey}')"
-                                                            : $recordWireClickAction = "{$recordAction}('{$recordKey}')";
+                                                                                                                    ? "mountTableAction('{$recordAction}', '{$recordKey}')"
+                                                                                                                    : $recordWireClickAction = "{$recordAction}('{$recordKey}')";
                                                     @endphp
 
                                                     <button
@@ -1221,10 +1221,10 @@
                                                         @foreach ($columnsLayout as $columnsLayoutComponent)
                                                             {{
                                                                 $columnsLayoutComponent
-                                                                    ->record($record)
-                                                                    ->recordKey($recordKey)
-                                                                    ->rowLoop($loop)
-                                                                    ->renderInLayout()
+                                                                ->record($record)
+                                                                ->recordKey($recordKey)
+                                                                ->rowLoop($loop)
+                                                                ->renderInLayout()
                                                             }}
                                                         @endforeach
                                                     </button>
@@ -1235,10 +1235,10 @@
                                                         @foreach ($columnsLayout as $columnsLayoutComponent)
                                                             {{
                                                                 $columnsLayoutComponent
-                                                                    ->record($record)
-                                                                    ->recordKey($recordKey)
-                                                                    ->rowLoop($loop)
-                                                                    ->renderInLayout()
+                                                                ->record($record)
+                                                                ->recordKey($recordKey)
+                                                                ->rowLoop($loop)
+                                                                ->renderInLayout()
                                                             }}
                                                         @endforeach
                                                     </div>
@@ -1258,14 +1258,14 @@
                                             @if ($recordActions && (! $isReordering))
                                                 <div
                                                     @class([
-                                                        'fi-ta-actions fi-wrapped sm:fi-not-wrapped',
-                                                        match ($recordActionsAlignment ?? Alignment::Start) {
-                                                            Alignment::Start => 'fi-align-start',
-                                                            Alignment::Center => 'fi-align-center',
-                                                            Alignment::End => 'fi-align-end',
-                                                        } => $contentGrid,
-                                                        'fi-align-start md:fi-align-end' => ! $contentGrid,
-                                                        'fi-ta-actions-before-columns-position' => $recordActionsPosition === RecordActionsPosition::BeforeColumns,
+                                                    'fi-ta-actions fi-wrapped sm:fi-not-wrapped',
+                                                    match ($recordActionsAlignment ?? Alignment::Start) {
+                                                    Alignment::Start => 'fi-align-start',
+                                                    Alignment::Center => 'fi-align-center',
+                                                    Alignment::End => 'fi-align-end',
+                                                    } => $contentGrid,
+                                                    'fi-align-start md:fi-align-end' => ! $contentGrid,
+                                                    'fi-ta-actions-before-columns-position' => $recordActionsPosition === RecordActionsPosition::BeforeColumns,
                                                     ])
                                                 >
                                                     @foreach ($recordActions as $action)
@@ -1288,8 +1288,8 @@
 
                                     @php
                                         $previousRecordGroupKey = $recordGroupKey;
-                                        $previousRecordGroupTitle = $recordGroupTitle;
-                                        $previousRecord = $record;
+                                                                                $previousRecordGroupTitle = $recordGroupTitle;
+                                                                                $previousRecord = $record;
                                     @endphp
                                 @endforeach
 
@@ -1317,8 +1317,8 @@
                         @if (($content || $hasColumnsLayout) && $contentFooter)
                             {{
                                 $contentFooter->with([
-                                    'columns' => $columns,
-                                    'records' => $records,
+                                'columns' => $columns,
+                                'records' => $records,
                                 ])
                             }}
                         @endif
@@ -1341,15 +1341,15 @@
                     @elseif ((! ($content || $hasColumnsLayout)) && ($records !== null))
                         @php
                             $sortableColumns = $isStackedOnMobile ? array_filter(
-                                $columns,
-                                fn (\Filament\Tables\Columns\Column $column): bool => $column->isSortable(),
-                            ) : [];
+                                                            $columns,
+                                                            fn (\Filament\Tables\Columns\Column $column): bool => $column->isSortable(),
+                                                        ) : [];
                         @endphp
 
                         <table
                             @class([
-                                'fi-ta-table',
-                                'fi-ta-table-stacked-on-mobile' => $isStackedOnMobile,
+                            'fi-ta-table',
+                            'fi-ta-table-stacked-on-mobile' => $isStackedOnMobile,
                             ])
                         >
                             <thead>
@@ -1529,11 +1529,11 @@
                                                         colspan="{{ $columnGroupColumnsCount }}"
                                                         {{
                                                             $columnGroup->getExtraHeaderAttributeBag()->class([
-                                                                'fi-ta-header-group-cell',
-                                                                'fi-wrapped' => $columnGroup->canHeaderWrap(),
-                                                                ((($columnGroupAlignment = $columnGroup->getAlignment()) instanceof \Filament\Support\Enums\Alignment) ? "fi-align-{$columnGroupAlignment->value}" : (is_string($columnGroupAlignment) ? $columnGroupAlignment : '')),
-                                                                (filled($columnGroupHiddenFrom = $columnGroup->getHiddenFrom()) ? "{$columnGroupHiddenFrom}:fi-hidden" : ''),
-                                                                (filled($columnGroupVisibleFrom = $columnGroup->getVisibleFrom()) ? "{$columnGroupVisibleFrom}:fi-visible" : ''),
+                                                            'fi-ta-header-group-cell',
+                                                            'fi-wrapped' => $columnGroup->canHeaderWrap(),
+                                                            ((($columnGroupAlignment = $columnGroup->getAlignment()) instanceof \Filament\Support\Enums\Alignment) ? "fi-align-{$columnGroupAlignment->value}" : (is_string($columnGroupAlignment) ? $columnGroupAlignment : '')),
+                                                            (filled($columnGroupHiddenFrom = $columnGroup->getHiddenFrom()) ? "{$columnGroupHiddenFrom}:fi-hidden" : ''),
+                                                            (filled($columnGroupVisibleFrom = $columnGroup->getVisibleFrom()) ? "{$columnGroupVisibleFrom}:fi-visible" : ''),
                                                             ])
                                                         }}
                                                     >
@@ -1639,22 +1639,22 @@
 
                                     @foreach ($columns as $column)
                                         @if ($hasHeaderCellRenderHook && filled($headerCellView = FilamentView::renderHook(TablesRenderHook::HEADER_CELL, scopes: static::class, data: [
-                                                 'column' => $column,
-                                                 'isReordering' => $isReordering,
+                                             'column' => $column,
+                                             'isReordering' => $isReordering,
                                              ])))
                                             {{ $headerCellView }}
                                         @else
                                             @php
                                                 $columnName = $column->getName();
-                                                $columnLabel = $column->getLabel();
-                                                $columnAlignment = $column->getAlignment();
-                                                $columnWidth = $column->getWidth();
-                                                $isColumnActivelySorted = $getSortColumn() === $column->getName();
-                                                $isColumnSortable = $column->isSortable() && (! $isReordering);
-                                                $columnHeaderTooltip = $column->getHeaderTooltip();
-                                                $columnHeaderTooltipAttribute = ($columnHeaderTooltip instanceof \Illuminate\Contracts\Support\Htmlable)
-                                                    ? 'x-tooltip.html'
-                                                    : 'x-tooltip';
+                                                                                                $columnLabel = $column->getLabel();
+                                                                                                $columnAlignment = $column->getAlignment();
+                                                                                                $columnWidth = $column->getWidth();
+                                                                                                $isColumnActivelySorted = $getSortColumn() === $column->getName();
+                                                                                                $isColumnSortable = $column->isSortable() && (! $isReordering);
+                                                                                                $columnHeaderTooltip = $column->getHeaderTooltip();
+                                                                                                $columnHeaderTooltipAttribute = ($columnHeaderTooltip instanceof \Illuminate\Contracts\Support\Htmlable)
+                                                                                                    ? 'x-tooltip.html'
+                                                                                                    : 'x-tooltip';
                                             @endphp
 
                                             <th
@@ -1663,20 +1663,20 @@
                                                 @endif
                                                 {{
                                                     $column->getExtraHeaderAttributeBag()
-                                                        ->class([
-                                                            'fi-ta-header-cell',
-                                                            'fi-ta-header-cell-' . str($columnName)->camel()->kebab(),
-                                                            'fi-growable' => blank($columnWidth) && $column->canGrow(default: false),
-                                                            'fi-grouped' => $column->getGroup(),
-                                                            'fi-wrapped' => $column->canHeaderWrap(),
-                                                            'fi-ta-header-cell-sorted' => $isColumnActivelySorted,
-                                                            ((($columnAlignment = $column->getAlignment()) instanceof \Filament\Support\Enums\Alignment) ? "fi-align-{$columnAlignment->value}" : (is_string($columnAlignment) ? $columnAlignment : '')),
-                                                            (filled($columnHiddenFrom = $column->getHiddenFrom()) ? "{$columnHiddenFrom}:fi-hidden" : ''),
-                                                            (filled($columnVisibleFrom = $column->getVisibleFrom()) ? "{$columnVisibleFrom}:fi-visible" : ''),
-                                                        ])
-                                                        ->style([
-                                                            ('width: ' . $columnWidth) => filled($columnWidth),
-                                                        ])
+                                                    ->class([
+                                                    'fi-ta-header-cell',
+                                                    'fi-ta-header-cell-' . str($columnName)->camel()->kebab(),
+                                                    'fi-growable' => blank($columnWidth) && $column->canGrow(default: false),
+                                                    'fi-grouped' => $column->getGroup(),
+                                                    'fi-wrapped' => $column->canHeaderWrap(),
+                                                    'fi-ta-header-cell-sorted' => $isColumnActivelySorted,
+                                                    ((($columnAlignment = $column->getAlignment()) instanceof \Filament\Support\Enums\Alignment) ? "fi-align-{$columnAlignment->value}" : (is_string($columnAlignment) ? $columnAlignment : '')),
+                                                    (filled($columnHiddenFrom = $column->getHiddenFrom()) ? "{$columnHiddenFrom}:fi-hidden" : ''),
+                                                    (filled($columnVisibleFrom = $column->getVisibleFrom()) ? "{$columnVisibleFrom}:fi-visible" : ''),
+                                                    ])
+                                                    ->style([
+                                                    ('width: ' . $columnWidth) => filled($columnWidth),
+                                                    ])
                                                 }}
                                             >
                                                 @if ($isColumnSortable)
@@ -1706,19 +1706,19 @@
 
                                                         {{
                                                             \Filament\Support\generate_icon_html(($isColumnActivelySorted && $sortDirection === 'asc') ? \Filament\Support\Icons\Heroicon::ChevronUp : \Filament\Support\Icons\Heroicon::ChevronDown, alias: match (true) {
-                                                                $isColumnActivelySorted && ($sortDirection === 'asc') => \Filament\Tables\View\TablesIconAlias::HEADER_CELL_SORT_ASC_BUTTON,
-                                                                $isColumnActivelySorted && ($sortDirection === 'desc') => \Filament\Tables\View\TablesIconAlias::HEADER_CELL_SORT_DESC_BUTTON,
-                                                                default => \Filament\Tables\View\TablesIconAlias::HEADER_CELL_SORT_BUTTON,
+                                                            $isColumnActivelySorted && ($sortDirection === 'asc') => \Filament\Tables\View\TablesIconAlias::HEADER_CELL_SORT_ASC_BUTTON,
+                                                            $isColumnActivelySorted && ($sortDirection === 'desc') => \Filament\Tables\View\TablesIconAlias::HEADER_CELL_SORT_DESC_BUTTON,
+                                                            default => \Filament\Tables\View\TablesIconAlias::HEADER_CELL_SORT_BUTTON,
                                                             }, attributes: (new \Illuminate\View\ComponentAttributeBag([
-                                                                'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => true,
-                                                                'wire:target' => "sortTable('{$columnName}')",
+                                                            'wire:loading.remove.delay.' . config('filament.livewire_loading_delay', 'default') => true,
+                                                            'wire:target' => "sortTable('{$columnName}')",
                                                             ])))
                                                         }}
 
                                                         {{
                                                             \Filament\Support\generate_loading_indicator_html(new \Illuminate\View\ComponentAttributeBag([
-                                                                'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
-                                                                'wire:target' => "sortTable('{$columnName}')",
+                                                            'wire:loading.delay.' . config('filament.livewire_loading_delay', 'default') => '',
+                                                            'wire:target' => "sortTable('{$columnName}')",
                                                             ]))
                                                         }}
                                                     </span>
@@ -1854,9 +1854,9 @@
 
                                                 <td
                                                     @class([
-                                                        'fi-ta-cell',
-                                                        'fi-ta-individual-search-cell' => $isIndividuallySearchable = $column->isIndividuallySearchable(),
-                                                        'fi-ta-individual-search-cell-' . str($columnName)->camel()->kebab() => $isIndividuallySearchable,
+                                                    'fi-ta-cell',
+                                                    'fi-ta-individual-search-cell' => $isIndividuallySearchable = $column->isIndividuallySearchable(),
+                                                    'fi-ta-individual-search-cell-' . str($columnName)->camel()->kebab() => $isIndividuallySearchable,
                                                     ])
                                                 >
                                                     @if ($isIndividuallySearchable)
@@ -1884,46 +1884,46 @@
                                     @if (count($records))
                                         @php
                                             $isRecordRowStriped = false;
-                                            $previousRecord = null;
-                                            $previousRecordGroupKey = null;
-                                            $previousRecordGroupTitle = null;
+                                                                                        $previousRecord = null;
+                                                                                        $previousRecordGroupKey = null;
+                                                                                        $previousRecordGroupTitle = null;
                                         @endphp
 
                                         @foreach ($records as $record)
                                             @php
                                                 $recordAction = $getRecordAction($record);
-                                                $recordKey = $getRecordKey($record);
-                                                $recordUrl = $getRecordUrl($record);
-                                                $openRecordUrlInNewTab = $shouldOpenRecordUrlInNewTab($record);
-                                                $recordGroupKey = $group?->getStringKey($record);
-                                                $recordGroupTitle = $group?->getTitle($record);
+                                                                                                $recordKey = $getRecordKey($record);
+                                                                                                $recordUrl = $getRecordUrl($record);
+                                                                                                $openRecordUrlInNewTab = $shouldOpenRecordUrlInNewTab($record);
+                                                                                                $recordGroupKey = $group?->getStringKey($record);
+                                                                                                $recordGroupTitle = $group?->getTitle($record);
 
-                                                $recordActions = array_reduce(
-                                                    $defaultRecordActions,
-                                                    function (array $carry, $action) use ($record): array {
-                                                        $action = $action->getClone();
+                                                                                                $recordActions = array_reduce(
+                                                                                                    $defaultRecordActions,
+                                                                                                    function (array $carry, $action) use ($record): array {
+                                                                                                        $action = $action->getClone();
 
-                                                        if (! $action instanceof \Filament\Actions\BulkAction) {
-                                                            $action->record($record);
-                                                        }
+                                                                                                        if (! $action instanceof \Filament\Actions\BulkAction) {
+                                                                                                            $action->record($record);
+                                                                                                        }
 
-                                                        if ($action->isHidden()) {
-                                                            return $carry;
-                                                        }
+                                                                                                        if ($action->isHidden()) {
+                                                                                                            return $carry;
+                                                                                                        }
 
-                                                        $carry[] = $action;
+                                                                                                        $carry[] = $action;
 
-                                                        return $carry;
-                                                    },
-                                                    initial: [],
-                                                );
+                                                                                                        return $carry;
+                                                                                                    },
+                                                                                                    initial: [],
+                                                                                                );
                                             @endphp
 
                                             @if ((string) $recordGroupTitle !== (string) $previousRecordGroupTitle)
                                                 @if ($hasSummary && (! $isReordering) && filled($previousRecordGroupTitle))
                                                     @php
                                                         $groupColumn = $group->getColumn();
-                                                        $groupScopedAllTableSummaryQuery = $group->scopeQuery($this->getAllTableSummaryQuery(), $previousRecord);
+                                                                                                                $groupScopedAllTableSummaryQuery = $group->scopeQuery($this->getAllTableSummaryQuery(), $previousRecord);
                                                     @endphp
 
                                                     <x-filament-tables::summary.row
@@ -1946,19 +1946,19 @@
                                                     >
                                                         @php
                                                             $isRecordGroupCollapsible = $group?->isCollapsible();
-                                                            $groupHeaderColspan = $columnsCount;
+                                                                                                                        $groupHeaderColspan = $columnsCount;
 
-                                                            if ($isSelectionEnabled) {
-                                                                $groupHeaderColspan--;
+                                                                                                                        if ($isSelectionEnabled) {
+                                                                                                                            $groupHeaderColspan--;
 
-                                                                if (
-                                                                    ($recordCheckboxPosition === RecordCheckboxPosition::BeforeCells) &&
-                                                                    count($defaultRecordActions) &&
-                                                                    ($recordActionsPosition === RecordActionsPosition::BeforeCells)
-                                                                ) {
-                                                                    $groupHeaderColspan--;
-                                                                }
-                                                            }
+                                                                                                                            if (
+                                                                                                                                ($recordCheckboxPosition === RecordCheckboxPosition::BeforeCells) &&
+                                                                                                                                count($defaultRecordActions) &&
+                                                                                                                                ($recordActionsPosition === RecordActionsPosition::BeforeCells)
+                                                                                                                            ) {
+                                                                                                                                $groupHeaderColspan--;
+                                                                                                                            }
+                                                                                                                        }
                                                         @endphp
 
                                                         @if ($isSelectionEnabled && $recordCheckboxPosition === RecordCheckboxPosition::BeforeCells)
@@ -2018,8 +2018,8 @@
                                                                     x-bind:class="isGroupCollapsed(@js($recordGroupTitle)) ? 'fi-collapsed' : null"
                                                                 @endif
                                                                 @class([
-                                                                    'fi-ta-group-header',
-                                                                    'fi-collapsible' => $isRecordGroupCollapsible,
+                                                                'fi-ta-group-header',
+                                                                'fi-collapsible' => $isRecordGroupCollapsible,
                                                                 ])
                                                             >
                                                                 <div>
@@ -2115,10 +2115,10 @@
                                                         'fi-selected': isRecordSelected(@js($recordKey)),
                                                     }"
                                                     @class([
-                                                        'fi-ta-row',
-                                                        'fi-clickable' => $recordAction || $recordUrl,
-                                                        'fi-striped' => $isStriped && $isRecordRowStriped,
-                                                        ...$getRecordClasses($record),
+                                                    'fi-ta-row',
+                                                    'fi-clickable' => $recordAction || $recordUrl,
+                                                    'fi-striped' => $isStriped && $isRecordRowStriped,
+                                                    ...$getRecordClasses($record),
                                                     ])
                                                 >
                                                     @if ($isReordering)
@@ -2136,14 +2136,14 @@
                                                         <td class="fi-ta-cell">
                                                             <div
                                                                 @class([
-                                                                    'fi-ta-actions',
-                                                                    match ($recordActionsAlignment) {
-                                                                        Alignment::Center => 'fi-align-center',
-                                                                        Alignment::Start, Alignment::Left => 'fi-align-start',
-                                                                        Alignment::Between, Alignment::Justify => 'fi-align-between',
-                                                                        Alignment::End, Alignment::Right => '',
-                                                                        default => is_string($recordActionsAlignment) ? $recordActionsAlignment : '',
-                                                                    },
+                                                                'fi-ta-actions',
+                                                                match ($recordActionsAlignment) {
+                                                                Alignment::Center => 'fi-align-center',
+                                                                Alignment::Start, Alignment::Left => 'fi-align-start',
+                                                                Alignment::Between, Alignment::Justify => 'fi-align-between',
+                                                                Alignment::End, Alignment::Right => '',
+                                                                default => is_string($recordActionsAlignment) ? $recordActionsAlignment : '',
+                                                                },
                                                                 ])
                                                             >
                                                                 @foreach ($recordActions as $action)
@@ -2182,14 +2182,14 @@
                                                         <td class="fi-ta-cell">
                                                             <div
                                                                 @class([
-                                                                    'fi-ta-actions',
-                                                                    match ($recordActionsAlignment) {
-                                                                        Alignment::Center => 'fi-align-center',
-                                                                        Alignment::Start, Alignment::Left => 'fi-align-start',
-                                                                        Alignment::Between, Alignment::Justify => 'fi-align-between',
-                                                                        Alignment::End, Alignment::Right => '',
-                                                                        default => is_string($recordActionsAlignment) ? $recordActionsAlignment : '',
-                                                                    },
+                                                                'fi-ta-actions',
+                                                                match ($recordActionsAlignment) {
+                                                                Alignment::Center => 'fi-align-center',
+                                                                Alignment::Start, Alignment::Left => 'fi-align-start',
+                                                                Alignment::Between, Alignment::Justify => 'fi-align-between',
+                                                                Alignment::End, Alignment::Right => '',
+                                                                default => is_string($recordActionsAlignment) ? $recordActionsAlignment : '',
+                                                                },
                                                                 ])
                                                             >
                                                                 @foreach ($recordActions as $action)
@@ -2202,45 +2202,45 @@
                                                     @foreach ($columns as $column)
                                                         @php
                                                             $column->record($record);
-                                                            $column->rowLoop($loop->parent);
-                                                            $column->recordKey($recordKey);
+                                                                                                                        $column->rowLoop($loop->parent);
+                                                                                                                        $column->recordKey($recordKey);
 
-                                                            $columnAction = $column->getAction();
-                                                            $columnUrl = $column->getUrl();
-                                                            $columnHasStateBasedUrls = $column->hasStateBasedUrls();
-                                                            $isColumnClickDisabled = $column->isClickDisabled() || $isReordering;
+                                                                                                                        $columnAction = $column->getAction();
+                                                                                                                        $columnUrl = $column->getUrl();
+                                                                                                                        $columnHasStateBasedUrls = $column->hasStateBasedUrls();
+                                                                                                                        $isColumnClickDisabled = $column->isClickDisabled() || $isReordering;
 
-                                                            $columnWrapperTag = match (true) {
-                                                                ($columnUrl || ($recordUrl && $columnAction === null)) && (! $columnHasStateBasedUrls) && (! $isColumnClickDisabled) => 'a',
-                                                                ($columnAction || $recordAction) && (! $columnHasStateBasedUrls) && (! $isColumnClickDisabled) => 'button',
-                                                                default => 'div',
-                                                            };
+                                                                                                                        $columnWrapperTag = match (true) {
+                                                                                                                            ($columnUrl || ($recordUrl && $columnAction === null)) && (! $columnHasStateBasedUrls) && (! $isColumnClickDisabled) => 'a',
+                                                                                                                            ($columnAction || $recordAction) && (! $columnHasStateBasedUrls) && (! $isColumnClickDisabled) => 'button',
+                                                                                                                            default => 'div',
+                                                                                                                        };
 
-                                                            if ($columnWrapperTag === 'button') {
-                                                                if ($columnAction instanceof \Filament\Actions\Action) {
-                                                                    $columnWireClickAction = "mountTableAction('{$columnAction->getName()}', '{$recordKey}')";
-                                                                } elseif ($columnAction) {
-                                                                    $columnWireClickAction = "callTableColumnAction('{$column->getName()}', '{$recordKey}')";
-                                                                } else {
-                                                                    if ($this->getTable()->getAction($recordAction)) {
-                                                                        $columnWireClickAction = "mountTableAction('{$recordAction}', '{$recordKey}')";
-                                                                    } else {
-                                                                        $columnWireClickAction = "{$recordAction}('{$recordKey}')";
-                                                                    }
-                                                                }
-                                                            }
+                                                                                                                        if ($columnWrapperTag === 'button') {
+                                                                                                                            if ($columnAction instanceof \Filament\Actions\Action) {
+                                                                                                                                $columnWireClickAction = "mountTableAction('{$columnAction->getName()}', '{$recordKey}')";
+                                                                                                                            } elseif ($columnAction) {
+                                                                                                                                $columnWireClickAction = "callTableColumnAction('{$column->getName()}', '{$recordKey}')";
+                                                                                                                            } else {
+                                                                                                                                if ($this->getTable()->getAction($recordAction)) {
+                                                                                                                                    $columnWireClickAction = "mountTableAction('{$recordAction}', '{$recordKey}')";
+                                                                                                                                } else {
+                                                                                                                                    $columnWireClickAction = "{$recordAction}('{$recordKey}')";
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
                                                         @endphp
 
                                                         <td
                                                             wire:key="{{ $this->getId() }}.table.record.{{ $recordKey }}.column.{{ $column->getName() }}"
                                                             {{
                                                                 $column->getExtraCellAttributeBag()->class([
-                                                                    'fi-ta-cell',
-                                                                    'fi-ta-cell-' . str($column->getName())->camel()->kebab(),
-                                                                    ((($columnAlignment = $column->getAlignment()) instanceof \Filament\Support\Enums\Alignment) ? "fi-align-{$columnAlignment->value}" : (is_string($columnAlignment) ? $columnAlignment : '')),
-                                                                    ((($columnVerticalAlignment = $column->getVerticalAlignment()) instanceof \Filament\Support\Enums\VerticalAlignment) ? "fi-vertical-align-{$columnVerticalAlignment->value}" : (is_string($columnVerticalAlignment) ? $columnVerticalAlignment : '')),
-                                                                    (filled($columnHiddenFrom = $column->getHiddenFrom()) ? "{$columnHiddenFrom}:fi-hidden" : ''),
-                                                                    (filled($columnVisibleFrom = $column->getVisibleFrom()) ? "{$columnVisibleFrom}:fi-visible" : ''),
+                                                                'fi-ta-cell',
+                                                                'fi-ta-cell-' . str($column->getName())->camel()->kebab(),
+                                                                ((($columnAlignment = $column->getAlignment()) instanceof \Filament\Support\Enums\Alignment) ? "fi-align-{$columnAlignment->value}" : (is_string($columnAlignment) ? $columnAlignment : '')),
+                                                                ((($columnVerticalAlignment = $column->getVerticalAlignment()) instanceof \Filament\Support\Enums\VerticalAlignment) ? "fi-vertical-align-{$columnVerticalAlignment->value}" : (is_string($columnVerticalAlignment) ? $columnVerticalAlignment : '')),
+                                                                (filled($columnHiddenFrom = $column->getHiddenFrom()) ? "{$columnHiddenFrom}:fi-hidden" : ''),
+                                                                (filled($columnVisibleFrom = $column->getVisibleFrom()) ? "{$columnVisibleFrom}:fi-visible" : ''),
                                                                 ])
                                                             }}
                                                         >
@@ -2258,8 +2258,8 @@
                                                                     wire:target="{{ $columnWireClickAction }}"
                                                                 @endif
                                                                 @class([
-                                                                    'fi-ta-col',
-                                                                    'fi-ta-col-has-column-url' => ($columnWrapperTag === 'a') && filled($columnUrl),
+                                                                'fi-ta-col',
+                                                                'fi-ta-col-has-column-url' => ($columnWrapperTag === 'a') && filled($columnUrl),
                                                                 ])
                                                             >
                                                                 {{ $column }}
@@ -2272,14 +2272,14 @@
                                                         <td class="fi-ta-cell">
                                                             <div
                                                                 @class([
-                                                                    'fi-ta-actions',
-                                                                    match ($recordActionsAlignment) {
-                                                                        Alignment::Center => 'fi-align-center',
-                                                                        Alignment::Start, Alignment::Left => 'fi-align-start',
-                                                                        Alignment::Between, Alignment::Justify => 'fi-align-between',
-                                                                        Alignment::End, Alignment::Right => '',
-                                                                        default => is_string($recordActionsAlignment) ? $recordActionsAlignment : '',
-                                                                    },
+                                                                'fi-ta-actions',
+                                                                match ($recordActionsAlignment) {
+                                                                Alignment::Center => 'fi-align-center',
+                                                                Alignment::Start, Alignment::Left => 'fi-align-start',
+                                                                Alignment::Between, Alignment::Justify => 'fi-align-between',
+                                                                Alignment::End, Alignment::Right => '',
+                                                                default => is_string($recordActionsAlignment) ? $recordActionsAlignment : '',
+                                                                },
                                                                 ])
                                                             >
                                                                 @foreach ($recordActions as $action)
@@ -2318,14 +2318,14 @@
                                                         <td class="fi-ta-cell">
                                                             <div
                                                                 @class([
-                                                                    'fi-ta-actions',
-                                                                    match ($recordActionsAlignment) {
-                                                                        Alignment::Center => 'fi-align-center',
-                                                                        Alignment::Start, Alignment::Left => 'fi-align-start',
-                                                                        Alignment::Between, Alignment::Justify => 'fi-align-between',
-                                                                        Alignment::End, Alignment::Right => '',
-                                                                        default => is_string($recordActionsAlignment) ? $recordActionsAlignment : '',
-                                                                    },
+                                                                'fi-ta-actions',
+                                                                match ($recordActionsAlignment) {
+                                                                Alignment::Center => 'fi-align-center',
+                                                                Alignment::Start, Alignment::Left => 'fi-align-start',
+                                                                Alignment::Between, Alignment::Justify => 'fi-align-between',
+                                                                Alignment::End, Alignment::Right => '',
+                                                                default => is_string($recordActionsAlignment) ? $recordActionsAlignment : '',
+                                                                },
                                                                 ])
                                                             >
                                                                 @foreach ($recordActions as $action)
@@ -2339,16 +2339,16 @@
 
                                             @php
                                                 $isRecordRowStriped = ! $isRecordRowStriped;
-                                                $previousRecord = $record;
-                                                $previousRecordGroupKey = $recordGroupKey;
-                                                $previousRecordGroupTitle = $recordGroupTitle;
+                                                                                                $previousRecord = $record;
+                                                                                                $previousRecordGroupKey = $recordGroupKey;
+                                                                                                $previousRecordGroupTitle = $recordGroupTitle;
                                             @endphp
                                         @endforeach
 
                                         @if ($hasSummary && (! $isReordering) && filled($previousRecordGroupTitle) && $this->shouldRenderTrailingGroupedTableSummary($previousRecord))
                                             @php
                                                 $groupColumn = $group->getColumn();
-                                                $groupScopedAllTableSummaryQuery = $group->scopeQuery($this->getAllTableSummaryQuery(), $previousRecord);
+                                                                                                        $groupScopedAllTableSummaryQuery = $group->scopeQuery($this->getAllTableSummaryQuery(), $previousRecord);
                                             @endphp
 
                                             <x-filament-tables::summary.row
@@ -2393,8 +2393,8 @@
                                     <tr>
                                         {{
                                             $contentFooter->with([
-                                                'columns' => $columns,
-                                                'records' => $records,
+                                            'columns' => $columns,
+                                            'records' => $records,
                                             ])
                                         }}
                                     </tr>
@@ -2432,8 +2432,8 @@
                             @endif
 
                             @if ($emptyStateActions = array_filter(
-                                     $getEmptyStateActions(),
-                                     fn (\Filament\Actions\Action | \Filament\Actions\ActionGroup $action): bool => $action->isVisible(),
+                                 $getEmptyStateActions(),
+                                 fn (\Filament\Actions\Action | \Filament\Actions\ActionGroup $action): bool => $action->isVisible(),
                                  ))
                                 <div
                                     class="fi-ta-actions fi-align-center fi-wrapped"
@@ -2451,7 +2451,7 @@
             @if ($hasPagination)
                 @php
                     $hasExtremePaginationLinks = $hasExtremePaginationLinks();
-                    $paginationPageOptions = $getPaginationPageOptions();
+                                        $paginationPageOptions = $getPaginationPageOptions();
                 @endphp
 
                 <x-filament::pagination
@@ -2480,9 +2480,9 @@
                 x-transition:leave-end="fi-opacity-0"
                 x-bind:class="{ 'fi-open': areFiltersOpen }"
                 @class([
-                    'fi-ta-filters-after-content-ctn',
-                    'lg:fi-open' => ! $hasCollapsibleFilters,
-                    (($filtersFormWidth ??= Width::ExtraSmall) instanceof Width) ? "fi-width-{$filtersFormWidth->value}" : (is_string($filtersFormWidth) ? $filtersFormWidth : null),
+                'fi-ta-filters-after-content-ctn',
+                'lg:fi-open' => ! $hasCollapsibleFilters,
+                (($filtersFormWidth ??= Width::ExtraSmall) instanceof Width) ? "fi-width-{$filtersFormWidth->value}" : (is_string($filtersFormWidth) ? $filtersFormWidth : null),
                 ])
             >
                 <x-filament-tables::filters

--- a/packages/widgets/resources/css/chart-widget.css
+++ b/packages/widgets/resources/css/chart-widget.css
@@ -1,6 +1,6 @@
 .fi-wi-chart {
     & .fi-wi-chart-canvas-ctn {
-        @apply mx-auto;
+        @apply mx-auto flex w-full justify-center;
 
         &:not(.fi-wi-chart-canvas-ctn-no-aspect-ratio) {
             @apply aspect-square;

--- a/packages/widgets/resources/views/chart-widget.blade.php
+++ b/packages/widgets/resources/views/chart-widget.blade.php
@@ -1,13 +1,13 @@
 @php
     use Filament\Widgets\View\Components\ChartWidgetComponent;
-    use Illuminate\View\ComponentAttributeBag;
+        use Illuminate\View\ComponentAttributeBag;
 
-    $color = $this->getColor();
-    $heading = $this->getHeading();
-    $description = $this->getDescription();
-    $filters = $this->getFilters();
-    $isCollapsible = $this->isCollapsible();
-    $type = $this->getType();
+        $color = $this->getColor();
+        $heading = $this->getHeading();
+        $description = $this->getDescription();
+        $filters = $this->getFilters();
+        $isCollapsible = $this->isCollapsible();
+        $type = $this->getType();
 @endphp
 
 <x-filament-widgets::widget class="fi-wi-chart">
@@ -84,11 +84,11 @@
                         })"
                 {{
                     (new ComponentAttributeBag)
-                        ->color(ChartWidgetComponent::class, $color)
-                        ->class([
-                            'fi-wi-chart-canvas-ctn',
-                            'fi-wi-chart-canvas-ctn-no-aspect-ratio' => filled($maxHeight),
-                        ])
+                    ->color(ChartWidgetComponent::class, $color)
+                    ->class([
+                    'fi-wi-chart-canvas-ctn',
+                    'fi-wi-chart-canvas-ctn-no-aspect-ratio' => filled($maxHeight),
+                    ])
                 }}
             >
                 <canvas

--- a/packages/widgets/resources/views/components/widgets.blade.php
+++ b/packages/widgets/resources/views/components/widgets.blade.php
@@ -1,28 +1,28 @@
 {{-- @deprecated Use a schema to render widgets. --}}
 
 @props([
-    'columns' => [
-        'lg' => 2,
-    ],
-    'data' => [],
-    'widgets' => [],
+'columns' => [
+'lg' => 2,
+],
+'data' => [],
+'widgets' => [],
 ])
 
 @php
     if (is_array($columns)) {
-        $columns['lg'] ??= ($columns ? (is_array($columns) ? null : $columns) : 2);
-    }
+            $columns['lg'] ??= ($columns ? (is_array($columns) ? null : $columns) : 2);
+        }
 @endphp
 
 <div {{ $attributes->grid($columns)->class(['fi-wi']) }}>
     @php
         $normalizeWidgetClass = function (string | Filament\Widgets\WidgetConfiguration $widget): string {
-            if ($widget instanceof \Filament\Widgets\WidgetConfiguration) {
-                return $widget->widget;
-            }
+                    if ($widget instanceof \Filament\Widgets\WidgetConfiguration) {
+                        return $widget->widget;
+                    }
 
-            return $widget;
-        };
+                    return $widget;
+                };
     @endphp
 
     @foreach ($widgets as $widgetKey => $widget)

--- a/packages/widgets/resources/views/stats-overview-widget.blade.php
+++ b/packages/widgets/resources/views/stats-overview-widget.blade.php
@@ -1,22 +1,22 @@
 @php
     $columns = $this->getColumns();
-    $pollingInterval = $this->getPollingInterval();
+        $pollingInterval = $this->getPollingInterval();
 
-    $heading = $this->getHeading();
-    $description = $this->getDescription();
-    $hasHeading = filled($heading);
-    $hasDescription = filled($description);
+        $heading = $this->getHeading();
+        $description = $this->getDescription();
+        $hasHeading = filled($heading);
+        $hasDescription = filled($description);
 @endphp
 
 <x-filament-widgets::widget
     :attributes="
         (new \Illuminate\View\ComponentAttributeBag)
-            ->merge([
-                'wire:poll.' . $pollingInterval => $pollingInterval ? true : null,
-            ], escape: false)
-            ->class([
-                'fi-wi-stats-overview',
-            ])
+        ->merge([
+            'wire:poll.' . $pollingInterval => $pollingInterval ? true : null,
+        ], escape: false)
+        ->class([
+            'fi-wi-stats-overview',
+        ])
     "
 >
     {{ $this->content }}

--- a/packages/widgets/resources/views/stats-overview-widget/stat.blade.php
+++ b/packages/widgets/resources/views/stats-overview-widget/stat.blade.php
@@ -1,16 +1,16 @@
 @php
     use Filament\Support\Enums\IconPosition;
-    use Filament\Widgets\View\Components\StatsOverviewWidgetComponent\StatComponent\DescriptionComponent;
-    use Filament\Widgets\View\Components\StatsOverviewWidgetComponent\StatComponent\StatsOverviewWidgetStatChartComponent;
-    use Illuminate\View\ComponentAttributeBag;
+        use Filament\Widgets\View\Components\StatsOverviewWidgetComponent\StatComponent\DescriptionComponent;
+        use Filament\Widgets\View\Components\StatsOverviewWidgetComponent\StatComponent\StatsOverviewWidgetStatChartComponent;
+        use Illuminate\View\ComponentAttributeBag;
 
-    $chartColor = $getChartColor() ?? 'gray';
-    $descriptionColor = $getDescriptionColor() ?? 'gray';
-    $descriptionIcon = $getDescriptionIcon();
-    $descriptionIconPosition = $getDescriptionIconPosition();
-    $url = $getUrl();
-    $tag = $url ? 'a' : 'div';
-    $chartDataChecksum = $generateChartDataChecksum();
+        $chartColor = $getChartColor() ?? 'gray';
+        $descriptionColor = $getDescriptionColor() ?? 'gray';
+        $descriptionIcon = $getDescriptionIcon();
+        $descriptionIconPosition = $getDescriptionIconPosition();
+        $url = $getUrl();
+        $tag = $url ? 'a' : 'div';
+        $chartDataChecksum = $generateChartDataChecksum();
 @endphp
 
 <{!! $tag !!}
@@ -19,9 +19,9 @@
     @endif
     {{
         $getExtraAttributeBag()
-            ->class([
-                'fi-wi-stats-overview-stat',
-            ])
+        ->class([
+        'fi-wi-stats-overview-stat',
+        ])
     }}
 >
     <div class="fi-wi-stats-overview-stat-content">


### PR DESCRIPTION
This PR fixes an alignment issue where chart widgets were appearing incorrectly aligned to the right in RTL (Right-to-Left) layouts. 

By applying `@apply mx-auto flex w-full justify-center;` to the `.fi-wi-chart-canvas-ctn` class, the chart container is now correctly centered across all text directions.

## Visual changes

### befor
<img width="1080" height="448" alt="Screenshot 2026-04-30 at 11 59 49 AM" src="https://github.com/user-attachments/assets/2f2dadc8-a931-42e1-abcd-13643a5b414c" />

### after
<img width="1080" height="448" alt="Screenshot 2026-04-30 at 12 00 18 PM" src="https://github.com/user-attachments/assets/bb142c7b-6b4b-4d16-9eaf-12eba81d9d6e" />


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
