### PR TITLE
Fix table push columns

### DIFF
--- a/packages/tables/src/Table/Concerns/HasColumns.php
+++ b/packages/tables/src/Table/Concerns/HasColumns.php
@@ -24,6 +24,11 @@ trait HasColumns
      */
     protected array $columnsLayout = [];
 
+    /**
+     * @var array<Column | ColumnLayoutComponent | ColumnGroup>
+     */
+    protected array $pushedColumns = [];
+
     protected ?ColumnLayoutComponent $collapsibleColumnsLayout = null;
 
     protected bool $hasColumnGroups = false;
@@ -40,7 +45,7 @@ trait HasColumns
         $this->columnsLayout = [];
         $this->collapsibleColumnsLayout = null;
         $this->hasColumnsLayout = false;
-        $this->pushColumns($components);
+        $this->appendColumns([...$components, ...$this->pushedColumns]);
 
         return $this;
     }
@@ -49,6 +54,16 @@ trait HasColumns
      * @param  array<Column | ColumnLayoutComponent | ColumnGroup>  $components
      */
     public function pushColumns(array $components): static
+    {
+        $this->pushedColumns = [...$this->pushedColumns, ...$components];
+
+        return $this->appendColumns($components);
+    }
+
+    /**
+     * @param  array<Column | ColumnLayoutComponent | ColumnGroup>  $components
+     */
+    protected function appendColumns(array $components): static
     {
         foreach ($components as $component) {
             $component->table($this);

--- a/tests/src/Tables/TableTest.php
+++ b/tests/src/Tables/TableTest.php
@@ -190,6 +190,22 @@ describe('rendering', function (): void {
     });
 });
 
+describe('pushColumns', function (): void {
+    it('keeps columns pushed via `Table::configureUsing()` when a component later calls `columns()`', function (): void {
+        Table::configureUsing(
+            modifyUsing: fn (Table $table) => $table->pushColumns([
+                Tables\Columns\TextColumn::make('created_at'),
+                Tables\Columns\TextColumn::make('updated_at'),
+            ]),
+            during: function (): void {
+                $table = livewire(TableTestComponent::class)->instance()->getTable();
+
+                expect($table->getColumns())->toHaveKeys(['title', 'created_at', 'updated_at']);
+            },
+        );
+    });
+});
+
 class TableTestComponent extends Component implements HasActions, HasSchemas, Tables\Contracts\HasTable
 {
     use InteractsWithActions;
@@ -264,5 +280,17 @@ class RecordUrlTableTestComponent extends TableTestComponent
     {
         return parent::table($table)
             ->recordUrl(static fn (Post $record): string => "/posts/{$record->getKey()}");
+    }
+}
+
+class PushColumnsTableTestComponent extends TableTestComponent
+{
+    public function table(Table $table): Table
+    {
+        return parent::table($table)
+            ->pushColumns([
+                Tables\Columns\TextColumn::make('created_at'),
+                Tables\Columns\TextColumn::make('updated_at'),
+            ]);
     }
 }


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

- Fix [`Table::pushColumns()`](https://filamentphp.com/docs/4.x/tables/overview#adding-new-columns-alongside-existing-columns) losing columns when `columns()` is called afterwards.
- Tests: adds `pushColumns` describe block covering the `Table::configureUsing()` global-push scenario, asserting      
  `created_at` and `updated_at` remain after a component calls `columns(['title'])`

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.