### PR TITLE
feat: add translate*() methods and translatable() for heading, description, tooltip, and placeholder

### DIFF
--- a/packages/actions/src/Concerns/HasTooltip.php
+++ b/packages/actions/src/Concerns/HasTooltip.php
@@ -9,9 +9,18 @@ trait HasTooltip
 {
     protected string | Htmlable | Closure | null $tooltip = null;
 
+    protected bool $shouldTranslateTooltip = false;
+
     public function tooltip(string | Htmlable | Closure | null $tooltip): static
     {
         $this->tooltip = $tooltip;
+
+        return $this;
+    }
+
+    public function translateTooltip(bool $shouldTranslateTooltip = true): static
+    {
+        $this->shouldTranslateTooltip = $shouldTranslateTooltip;
 
         return $this;
     }
@@ -26,6 +35,10 @@ trait HasTooltip
             return $responseMessage;
         }
 
-        return $this->evaluate($this->tooltip);
+        $tooltip = $this->evaluate($this->tooltip);
+
+        return (is_string($tooltip) && $this->shouldTranslateTooltip) ?
+            __($tooltip) :
+            $tooltip;
     }
 }

--- a/packages/actions/src/Concerns/InteractsWithRecord.php
+++ b/packages/actions/src/Concerns/InteractsWithRecord.php
@@ -321,7 +321,7 @@ trait InteractsWithRecord
         $defaultModel = $this instanceof Action ? $this->getHasActionsLivewire()?->getDefaultActionModel($this) : null;
 
         if (($this instanceof Action) && ($model === $defaultModel)) {
-            return $this->getHasActionsLivewire()?->getDefaultActionModelLabel($this);
+            return $this->getHasActionsLivewire()->getDefaultActionModelLabel($this);
         }
 
         return get_model_label($model);

--- a/packages/forms/src/Components/Concerns/HasPlaceholder.php
+++ b/packages/forms/src/Components/Concerns/HasPlaceholder.php
@@ -8,6 +8,8 @@ trait HasPlaceholder
 {
     protected string | Closure | null $placeholder = null;
 
+    protected bool $shouldTranslatePlaceholder = false;
+
     public function placeholder(string | Closure | null $placeholder): static
     {
         $this->placeholder = $placeholder;
@@ -15,8 +17,19 @@ trait HasPlaceholder
         return $this;
     }
 
+    public function translatePlaceholder(bool $shouldTranslatePlaceholder = true): static
+    {
+        $this->shouldTranslatePlaceholder = $shouldTranslatePlaceholder;
+
+        return $this;
+    }
+
     public function getPlaceholder(): ?string
     {
-        return $this->evaluate($this->placeholder);
+        $placeholder = $this->evaluate($this->placeholder);
+
+        return (is_string($placeholder) && $this->shouldTranslatePlaceholder) ?
+            __($placeholder) :
+            $placeholder;
     }
 }

--- a/packages/infolists/src/Components/Concerns/HasTooltip.php
+++ b/packages/infolists/src/Components/Concerns/HasTooltip.php
@@ -11,6 +11,10 @@ trait HasTooltip
 
     protected string | Htmlable | Closure | null $emptyTooltip = null;
 
+    protected bool $shouldTranslateTooltip = false;
+
+    protected bool $shouldTranslateEmptyTooltip = false;
+
     public function tooltip(string | Htmlable | Closure | null $tooltip): static
     {
         $this->tooltip = $tooltip;
@@ -18,11 +22,22 @@ trait HasTooltip
         return $this;
     }
 
+    public function translateTooltip(bool $shouldTranslateTooltip = true): static
+    {
+        $this->shouldTranslateTooltip = $shouldTranslateTooltip;
+
+        return $this;
+    }
+
     public function getTooltip(mixed $state = null): string | Htmlable | null
     {
-        return $this->evaluate($this->tooltip, [
+        $tooltip = $this->evaluate($this->tooltip, [
             'state' => $state,
         ]);
+
+        return (is_string($tooltip) && $this->shouldTranslateTooltip) ?
+            __($tooltip) :
+            $tooltip;
     }
 
     public function emptyTooltip(string | Htmlable | Closure | null $tooltip): static
@@ -32,8 +47,19 @@ trait HasTooltip
         return $this;
     }
 
+    public function translateEmptyTooltip(bool $shouldTranslateEmptyTooltip = true): static
+    {
+        $this->shouldTranslateEmptyTooltip = $shouldTranslateEmptyTooltip;
+
+        return $this;
+    }
+
     public function getEmptyTooltip(): string | Htmlable | null
     {
-        return $this->evaluate($this->emptyTooltip);
+        $tooltip = $this->evaluate($this->emptyTooltip);
+
+        return (is_string($tooltip) && $this->shouldTranslateEmptyTooltip) ?
+            __($tooltip) :
+            $tooltip;
     }
 }

--- a/packages/schemas/docs/03-sections.md
+++ b/packages/schemas/docs/03-sections.md
@@ -300,3 +300,39 @@ Section::make('Heading')
 <AutoScreenshot name="schemas/layout/section/columns" alt="Section with grid columns" version="4.x" />
 
 <UtilityInjection set="schemaComponents" version="4.x">As well as allowing a static value, the `columns()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
+
+## Using translation strings in headings and descriptions
+
+If you want to use [translation strings](https://laravel.com/docs/localization#retrieving-translation-strings) as the section heading or description without wrapping them with `__()`, call `translatable()` globally in a service provider:
+
+```php
+use Filament\Schemas\Components\Section;
+
+Section::configureUsing(function (Section $section): void {
+    $section->translatable();
+});
+```
+
+Once configured, raw translation keys work directly in `make()` and `description()`:
+
+```php
+use Filament\Schemas\Components\Section;
+
+Section::make('app/labels.details')
+    ->description('app/labels.details_description')
+    ->schema([
+        // ...
+    ])
+```
+
+The `translatable()` method enables translation for all string properties on the component at once (heading, description, and label). You can also opt individual components in explicitly using `translateHeading()` and `translateDescription()`:
+
+```php
+Section::make('app/labels.details')
+    ->translateHeading()
+    ->description('app/labels.details_description')
+    ->translateDescription()
+    ->schema([
+        // ...
+    ])
+```

--- a/packages/schemas/src/Components/Component.php
+++ b/packages/schemas/src/Components/Component.php
@@ -116,6 +116,31 @@ class Component extends ViewComponent
         };
     }
 
+    public function translatable(bool $should = true): static
+    {
+        if (method_exists($this, 'translateLabel')) {
+            $this->translateLabel($should);
+        }
+
+        if (method_exists($this, 'translateHeading')) {
+            $this->translateHeading($should);
+        }
+
+        if (method_exists($this, 'translateDescription')) {
+            $this->translateDescription($should);
+        }
+
+        if (method_exists($this, 'translateTooltip')) {
+            $this->translateTooltip($should);
+        }
+
+        if (method_exists($this, 'translatePlaceholder')) {
+            $this->translatePlaceholder($should);
+        }
+
+        return $this;
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/packages/schemas/src/Components/Concerns/HasDescription.php
+++ b/packages/schemas/src/Components/Concerns/HasDescription.php
@@ -9,6 +9,8 @@ trait HasDescription
 {
     protected string | Htmlable | Closure | null $description = null;
 
+    protected bool $shouldTranslateDescription = false;
+
     public function description(string | Htmlable | Closure | null $description = null): static
     {
         $this->description = $description;
@@ -16,8 +18,19 @@ trait HasDescription
         return $this;
     }
 
+    public function translateDescription(bool $shouldTranslateDescription = true): static
+    {
+        $this->shouldTranslateDescription = $shouldTranslateDescription;
+
+        return $this;
+    }
+
     public function getDescription(): string | Htmlable | null
     {
-        return $this->evaluate($this->description);
+        $description = $this->evaluate($this->description);
+
+        return (is_string($description) && $this->shouldTranslateDescription) ?
+            __($description) :
+            $description;
     }
 }

--- a/packages/schemas/src/Components/Concerns/HasHeading.php
+++ b/packages/schemas/src/Components/Concerns/HasHeading.php
@@ -9,6 +9,8 @@ trait HasHeading
 {
     protected string | Htmlable | Closure | null $heading = null;
 
+    protected bool $shouldTranslateHeading = false;
+
     public function heading(string | Htmlable | Closure | null $heading = null): static
     {
         $this->heading = $heading;
@@ -16,8 +18,19 @@ trait HasHeading
         return $this;
     }
 
+    public function translateHeading(bool $shouldTranslateHeading = true): static
+    {
+        $this->shouldTranslateHeading = $shouldTranslateHeading;
+
+        return $this;
+    }
+
     public function getHeading(): string | Htmlable | null
     {
-        return $this->evaluate($this->heading);
+        $heading = $this->evaluate($this->heading);
+
+        return (is_string($heading) && $this->shouldTranslateHeading) ?
+            __($heading) :
+            $heading;
     }
 }

--- a/packages/support/src/Concerns/HasPlaceholder.php
+++ b/packages/support/src/Concerns/HasPlaceholder.php
@@ -9,6 +9,8 @@ trait HasPlaceholder
 {
     protected string | Htmlable | Closure | null $placeholder = null;
 
+    protected bool $shouldTranslatePlaceholder = false;
+
     public function placeholder(string | Htmlable | Closure | null $placeholder): static
     {
         $this->placeholder = $placeholder;
@@ -16,8 +18,19 @@ trait HasPlaceholder
         return $this;
     }
 
+    public function translatePlaceholder(bool $shouldTranslatePlaceholder = true): static
+    {
+        $this->shouldTranslatePlaceholder = $shouldTranslatePlaceholder;
+
+        return $this;
+    }
+
     public function getPlaceholder(): string | Htmlable | null
     {
-        return $this->evaluate($this->placeholder);
+        $placeholder = $this->evaluate($this->placeholder);
+
+        return (is_string($placeholder) && $this->shouldTranslatePlaceholder) ?
+            __($placeholder) :
+            $placeholder;
     }
 }

--- a/packages/support/src/Concerns/HasTooltip.php
+++ b/packages/support/src/Concerns/HasTooltip.php
@@ -9,6 +9,8 @@ trait HasTooltip
 {
     protected string | Htmlable | Closure | null $tooltip = null;
 
+    protected bool $shouldTranslateTooltip = false;
+
     public function tooltip(string | Htmlable | Closure | null $tooltip): static
     {
         $this->tooltip = $tooltip;
@@ -16,8 +18,19 @@ trait HasTooltip
         return $this;
     }
 
+    public function translateTooltip(bool $shouldTranslateTooltip = true): static
+    {
+        $this->shouldTranslateTooltip = $shouldTranslateTooltip;
+
+        return $this;
+    }
+
     public function getTooltip(): string | Htmlable | null
     {
-        return $this->evaluate($this->tooltip);
+        $tooltip = $this->evaluate($this->tooltip);
+
+        return (is_string($tooltip) && $this->shouldTranslateTooltip) ?
+            __($tooltip) :
+            $tooltip;
     }
 }

--- a/packages/tables/docs/02-columns/01-overview.md
+++ b/packages/tables/docs/02-columns/01-overview.md
@@ -98,6 +98,26 @@ TextColumn::make('title')
 
 <AutoScreenshot name="tables/columns/placeholder" alt="Column with a placeholder for empty state" version="4.x" />
 
+If you want to use [translation strings](https://laravel.com/docs/localization#retrieving-translation-strings) for placeholders and tooltips without wrapping them with `__()`, use `translatePlaceholder()` and `translateTooltip()`, or enable them globally for all columns in a service provider:
+
+```php
+use Filament\Tables\Columns\Column;
+
+Column::configureUsing(function (Column $column): void {
+    $column->translatePlaceholder()->translateTooltip();
+});
+```
+
+Once configured globally, raw translation keys work directly:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('title')
+    ->placeholder('app/labels.not_applicable')
+    ->tooltip('app/labels.title_tooltip')
+```
+
 ### Displaying data from relationships
 
 You may use "dot notation" to access columns within relationships. The name of the relationship comes first, followed by a period, followed by the name of the column to display:
@@ -198,6 +218,19 @@ use Filament\Tables\Columns\TextColumn;
 TextColumn::make('name')
     ->label(__('columns.name'))
 ```
+
+## Tooltips
+
+You may specify a tooltip to display when hovering over a column cell using the `tooltip()` method:
+
+```php
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('name')
+    ->tooltip('The full name of the user')
+```
+
+<UtilityInjection set="tableColumns" version="4.x">As well as allowing a static value, the `tooltip()` method also accepts a function to dynamically calculate it. You can inject various utilities into the function as parameters.</UtilityInjection>
 
 ## Sorting
 

--- a/packages/tables/src/Columns/Concerns/HasTooltip.php
+++ b/packages/tables/src/Columns/Concerns/HasTooltip.php
@@ -13,6 +13,12 @@ trait HasTooltip
 
     protected string | Htmlable | Closure | null $emptyTooltip = null;
 
+    protected bool $shouldTranslateTooltip = false;
+
+    protected bool $shouldTranslateHeaderTooltip = false;
+
+    protected bool $shouldTranslateEmptyTooltip = false;
+
     public function tooltip(string | Htmlable | Closure | null $tooltip): static
     {
         $this->tooltip = $tooltip;
@@ -20,11 +26,22 @@ trait HasTooltip
         return $this;
     }
 
+    public function translateTooltip(bool $shouldTranslateTooltip = true): static
+    {
+        $this->shouldTranslateTooltip = $shouldTranslateTooltip;
+
+        return $this;
+    }
+
     public function getTooltip(mixed $state = null): string | Htmlable | null
     {
-        return $this->evaluate($this->tooltip, [
+        $tooltip = $this->evaluate($this->tooltip, [
             'state' => $state,
         ]);
+
+        return (is_string($tooltip) && $this->shouldTranslateTooltip) ?
+            __($tooltip) :
+            $tooltip;
     }
 
     public function headerTooltip(string | Htmlable | Closure | null $tooltip): static
@@ -34,9 +51,20 @@ trait HasTooltip
         return $this;
     }
 
+    public function translateHeaderTooltip(bool $shouldTranslateHeaderTooltip = true): static
+    {
+        $this->shouldTranslateHeaderTooltip = $shouldTranslateHeaderTooltip;
+
+        return $this;
+    }
+
     public function getHeaderTooltip(): string | Htmlable | null
     {
-        return $this->evaluate($this->headerTooltip);
+        $tooltip = $this->evaluate($this->headerTooltip);
+
+        return (is_string($tooltip) && $this->shouldTranslateHeaderTooltip) ?
+            __($tooltip) :
+            $tooltip;
     }
 
     public function emptyTooltip(string | Htmlable | Closure | null $tooltip): static
@@ -46,8 +74,19 @@ trait HasTooltip
         return $this;
     }
 
+    public function translateEmptyTooltip(bool $shouldTranslateEmptyTooltip = true): static
+    {
+        $this->shouldTranslateEmptyTooltip = $shouldTranslateEmptyTooltip;
+
+        return $this;
+    }
+
     public function getEmptyTooltip(): string | Htmlable | null
     {
-        return $this->evaluate($this->emptyTooltip);
+        $tooltip = $this->evaluate($this->emptyTooltip);
+
+        return (is_string($tooltip) && $this->shouldTranslateEmptyTooltip) ?
+            __($tooltip) :
+            $tooltip;
     }
 }

--- a/packages/tables/src/Filters/Concerns/HasPlaceholder.php
+++ b/packages/tables/src/Filters/Concerns/HasPlaceholder.php
@@ -8,6 +8,8 @@ trait HasPlaceholder
 {
     protected string | Closure | null $placeholder = null;
 
+    protected bool $shouldTranslatePlaceholder = false;
+
     public function placeholder(string | Closure | null $placeholder): static
     {
         $this->placeholder = $placeholder;
@@ -15,8 +17,19 @@ trait HasPlaceholder
         return $this;
     }
 
+    public function translatePlaceholder(bool $shouldTranslatePlaceholder = true): static
+    {
+        $this->shouldTranslatePlaceholder = $shouldTranslatePlaceholder;
+
+        return $this;
+    }
+
     public function getPlaceholder(): ?string
     {
-        return $this->evaluate($this->placeholder);
+        $placeholder = $this->evaluate($this->placeholder);
+
+        return (is_string($placeholder) && $this->shouldTranslatePlaceholder) ?
+            __($placeholder) :
+            $placeholder;
     }
 }

--- a/tests/src/Forms/Components/TextInputTest.php
+++ b/tests/src/Forms/Components/TextInputTest.php
@@ -462,6 +462,36 @@ class TestComponentWithUrlTextInput extends Livewire
     }
 }
 
+describe('placeholder', function (): void {
+    it('returns `null` for `getPlaceholder()` by default', function (): void {
+        $field = TextInput::make('name');
+
+        expect($field->getPlaceholder())->toBeNull();
+    });
+
+    it('can set `placeholder()`', function (): void {
+        $field = TextInput::make('name')
+            ->placeholder('Enter name...');
+
+        expect($field->getPlaceholder())->toBe('Enter name...');
+    });
+
+    it('can translate placeholder with `translatePlaceholder()`', function (): void {
+        $field = TextInput::make('name')
+            ->placeholder('validation.required')
+            ->translatePlaceholder();
+
+        expect($field->getPlaceholder())->toBe(__('validation.required'));
+    });
+
+    it('does not translate placeholder when `translatePlaceholder()` is not called', function (): void {
+        $field = TextInput::make('name')
+            ->placeholder('validation.required');
+
+        expect($field->getPlaceholder())->toBe('validation.required');
+    });
+});
+
 describe('rendering', function (): void {
     it('can render with `password()`', function (): void {
         livewire(RenderTextInputWithPassword::class)->assertSuccessful();

--- a/tests/src/Infolists/EntryTest.php
+++ b/tests/src/Infolists/EntryTest.php
@@ -21,6 +21,40 @@ test('can ignore the default name if another is specified', function (): void {
         ->toBe('identifier');
 });
 
+describe('tooltip', function (): void {
+    it('returns `null` for `getTooltip()` by default', function (): void {
+        $entry = TextEntry::make('name')
+            ->container(Schema::make(Livewire::make()));
+
+        expect($entry->getTooltip())->toBeNull();
+    });
+
+    it('can set `tooltip()`', function (): void {
+        $entry = TextEntry::make('name')
+            ->container(Schema::make(Livewire::make()))
+            ->tooltip('Some tooltip');
+
+        expect($entry->getTooltip())->toBe('Some tooltip');
+    });
+
+    it('can translate tooltip with `translateTooltip()`', function (): void {
+        $entry = TextEntry::make('name')
+            ->container(Schema::make(Livewire::make()))
+            ->tooltip('validation.required')
+            ->translateTooltip();
+
+        expect($entry->getTooltip())->toBe(__('validation.required'));
+    });
+
+    it('does not translate tooltip when `translateTooltip()` is not called', function (): void {
+        $entry = TextEntry::make('name')
+            ->container(Schema::make(Livewire::make()))
+            ->tooltip('validation.required');
+
+        expect($entry->getTooltip())->toBe('validation.required');
+    });
+});
+
 describe('hint icon tooltip', function (): void {
     it('can set a hint icon tooltip via `hintIcon()` second parameter', function (): void {
         $entry = TextEntry::make('test')

--- a/tests/src/Schemas/Components/SectionTest.php
+++ b/tests/src/Schemas/Components/SectionTest.php
@@ -355,6 +355,21 @@ describe('heading', function (): void {
 
         expect($section->getHeading())->toBeNull();
     });
+
+    it('can translate heading with `translateHeading()`', function (): void {
+        $section = Section::make()
+            ->heading('validation.required')
+            ->translateHeading();
+
+        expect($section->getHeading())->toBe(__('validation.required'));
+    });
+
+    it('does not translate heading when `translateHeading()` is not called', function (): void {
+        $section = Section::make()
+            ->heading('validation.required');
+
+        expect($section->getHeading())->toBe('validation.required');
+    });
 });
 
 describe('description', function (): void {
@@ -390,6 +405,21 @@ describe('description', function (): void {
             ->description(null);
 
         expect($section->getDescription())->toBeNull();
+    });
+
+    it('can translate description with `translateDescription()`', function (): void {
+        $section = Section::make('Test')
+            ->description('validation.required')
+            ->translateDescription();
+
+        expect($section->getDescription())->toBe(__('validation.required'));
+    });
+
+    it('does not translate description when `translateDescription()` is not called', function (): void {
+        $section = Section::make('Test')
+            ->description('validation.required');
+
+        expect($section->getDescription())->toBe('validation.required');
     });
 });
 
@@ -450,6 +480,29 @@ describe('label', function (): void {
             ->translateLabel();
 
         expect($section->getLabel())->toBe(__('validation.required'));
+    });
+});
+
+describe('translatable', function (): void {
+    it('translates heading, description, and label with `translatable()`', function (): void {
+        $section = Section::make()
+            ->heading('validation.required')
+            ->description('validation.required')
+            ->label('validation.required')
+            ->translatable();
+
+        expect($section->getHeading())->toBe(__('validation.required'))
+            ->and($section->getDescription())->toBe(__('validation.required'))
+            ->and($section->getLabel())->toBe(__('validation.required'));
+    });
+
+    it('can disable translation with `translatable(false)`', function (): void {
+        $section = Section::make()
+            ->heading('validation.required')
+            ->translatable()
+            ->translatable(false);
+
+        expect($section->getHeading())->toBe('validation.required');
     });
 });
 

--- a/tests/src/Tables/Columns/ColumnTest.php
+++ b/tests/src/Tables/Columns/ColumnTest.php
@@ -144,6 +144,51 @@ describe('placeholder', function (): void {
 
         expect($column->getPlaceholder())->toBe('N/A');
     });
+
+    it('can translate placeholder with `translatePlaceholder()`', function (): void {
+        $column = TextColumn::make('title')
+            ->placeholder('validation.required')
+            ->translatePlaceholder();
+
+        expect($column->getPlaceholder())->toBe(__('validation.required'));
+    });
+
+    it('does not translate placeholder when `translatePlaceholder()` is not called', function (): void {
+        $column = TextColumn::make('title')
+            ->placeholder('validation.required');
+
+        expect($column->getPlaceholder())->toBe('validation.required');
+    });
+});
+
+describe('tooltip', function (): void {
+    it('returns `null` for `getTooltip()` by default', function (): void {
+        $column = TextColumn::make('title');
+
+        expect($column->getTooltip())->toBeNull();
+    });
+
+    it('can set `tooltip()`', function (): void {
+        $column = TextColumn::make('title')
+            ->tooltip('Click to sort');
+
+        expect($column->getTooltip())->toBe('Click to sort');
+    });
+
+    it('can translate tooltip with `translateTooltip()`', function (): void {
+        $column = TextColumn::make('title')
+            ->tooltip('validation.required')
+            ->translateTooltip();
+
+        expect($column->getTooltip())->toBe(__('validation.required'));
+    });
+
+    it('does not translate tooltip when `translateTooltip()` is not called', function (): void {
+        $column = TextColumn::make('title')
+            ->tooltip('validation.required');
+
+        expect($column->getTooltip())->toBe('validation.required');
+    });
 });
 
 describe('width', function (): void {


### PR DESCRIPTION
## Description

Extends Filament's existing `translateLabel()` pattern to four additional string-bearing traits that currently have no translation support. Each trait gains a `translate*()` boolean-flag method following the same pattern already established in `HasLabel`.

**Traits updated:**
- `HasHeading` (schemas) → `translateHeading()`
- `HasDescription` (schemas) → `translateDescription()`
- `HasTooltip` (support, actions, tables/columns, infolists) → `translateTooltip()`, `translateHeaderTooltip()`, `translateEmptyTooltip()`
- `HasPlaceholder` (support, forms, tables/filters) → `translatePlaceholder()`

A new `translatable()` convenience method on the base schema `Component` calls all available `translate*()` methods via `method_exists`, so applications can enable full translation for a component type in a single `configureUsing` call:

```php
// Enable globally for all sections
Section::configureUsing(function (Section $section): void {
    $section->translatable();
});

// Raw translation keys now work without __()
Section::make('app/labels.details')
    ->description('app/labels.details_description')
    ->schema([...])
```

```php
// Enable globally for all columns
Column::configureUsing(function (Column $column): void {
    $column->translatePlaceholder()->translateTooltip();
});

// Raw keys work directly
TextColumn::make('title')
    ->placeholder('app/labels.not_applicable')
    ->tooltip('app/labels.title_tooltip')
```

## Visual changes

N/A — behaviour-only change. No UI is altered; strings passed as raw translation keys are now passed through `__()` when the relevant flag is enabled. Without the flag, behaviour is identical to before.

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.