### PR TITLE
fix(forms): clear cached relation after Select saves, so reload doesn't repopulate from stale data

### DIFF
--- a/packages/forms/src/Components/CheckboxList.php
+++ b/packages/forms/src/Components/CheckboxList.php
@@ -284,6 +284,8 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
     public function saveStateToRelationship(): void
     {
         $relationship = $this->getRelationship();
+        $record = $this->getRecord();
+        $relationshipName = $this->getRelationshipName();
 
         if ($this->modifyRelationshipQueryUsing) {
             $this->evaluate($this->modifyRelationshipQueryUsing, [
@@ -312,11 +314,13 @@ class CheckboxList extends Field implements Contracts\CanDisableOptions, Contrac
 
         if ($pivotData === []) {
             $relationship->sync($state, detaching: false);
+            $record->unsetRelation($relationshipName);
 
             return;
         }
 
         $relationship->syncWithPivotValues($state, $pivotData, detaching: false);
+        $record->unsetRelation($relationshipName);
     }
 
     public function bulkToggleable(bool | Closure $condition = true): static

--- a/packages/forms/src/Components/ModalTableSelect.php
+++ b/packages/forms/src/Components/ModalTableSelect.php
@@ -580,6 +580,7 @@ class ModalTableSelect extends Field
     {
         $relationship = $this->getRelationship();
         $record = $this->getRecord();
+        $relationshipName = $this->getRelationshipName();
         $state = $this->getState();
 
         if (($relationship instanceof HasOne) || ($relationship instanceof HasMany)) {
@@ -614,6 +615,8 @@ class ModalTableSelect extends Field
                     ]);
                 });
             }
+
+            $record->unsetRelation($relationshipName);
 
             return;
         }
@@ -671,11 +674,13 @@ class ModalTableSelect extends Field
 
         if ($pivotData === []) {
             $relationship->sync($state, detaching: false);
+            $record->unsetRelation($relationshipName);
 
             return;
         }
 
         $relationship->syncWithPivotValues($state, $pivotData, detaching: false);
+        $record->unsetRelation($relationshipName);
     }
 
     public function getOptionLabelFromRecordUsing(?Closure $callback): static

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -1388,8 +1388,6 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
             $relationship->associate($state);
             $record->wasRecentlyCreated && $record->save();
 
-            $record->unsetRelation($relationshipName);
-
             return;
         }
 

--- a/packages/forms/src/Components/Select.php
+++ b/packages/forms/src/Components/Select.php
@@ -1325,6 +1325,7 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
     {
         $relationship = $this->getRelationship();
         $record = $this->getRecord();
+        $relationshipName = $this->getRelationshipName();
         $state = $this->getState();
 
         if (($relationship instanceof HasOne) || ($relationship instanceof HasMany)) {
@@ -1360,6 +1361,8 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
                 });
             }
 
+            $record->unsetRelation($relationshipName);
+
             return;
         }
 
@@ -1384,6 +1387,8 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
 
             $relationship->associate($state);
             $record->wasRecentlyCreated && $record->save();
+
+            $record->unsetRelation($relationshipName);
 
             return;
         }
@@ -1416,11 +1421,13 @@ class Select extends Field implements Contracts\CanDisableOptions, Contracts\Has
 
         if ($pivotData === []) {
             $relationship->sync($state, detaching: false);
+            $record->unsetRelation($relationshipName);
 
             return;
         }
 
         $relationship->syncWithPivotValues($state, $pivotData, detaching: false);
+        $record->unsetRelation($relationshipName);
     }
 
     /**

--- a/packages/forms/src/Components/TableSelect.php
+++ b/packages/forms/src/Components/TableSelect.php
@@ -244,6 +244,7 @@ class TableSelect extends Field
     {
         $relationship = $this->getRelationship();
         $record = $this->getRecord();
+        $relationshipName = $this->getRelationshipName();
         $state = $this->getState();
 
         if (($relationship instanceof HasOne) || ($relationship instanceof HasMany)) {
@@ -264,6 +265,8 @@ class TableSelect extends Field
                     ]);
                 });
             }
+
+            $record->unsetRelation($relationshipName);
 
             return;
         }
@@ -314,11 +317,13 @@ class TableSelect extends Field
 
         if ($pivotData === []) {
             $relationship->sync($state, detaching: false);
+            $record->unsetRelation($relationshipName);
 
             return;
         }
 
         $relationship->syncWithPivotValues($state, $pivotData, detaching: false);
+        $record->unsetRelation($relationshipName);
     }
 
     public function relationshipName(string | Closure | null $name): static

--- a/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
+++ b/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
@@ -45,11 +45,13 @@ class SpatieTagsInput extends TagsInput
                 (! $component->isAnyTagTypeAllowed())
             ) {
                 $record->syncTagsWithType($state, $type);
+                $record->unsetRelation('tags');
 
                 return;
             }
 
             $component->syncTagsWithAnyType($record, $state);
+            $record->unsetRelation('tags');
         });
 
         $this->dehydrated(false);

--- a/tests/src/Fixtures/Livewire/SpatieTagsInputForm.php
+++ b/tests/src/Fixtures/Livewire/SpatieTagsInputForm.php
@@ -49,6 +49,12 @@ class SpatieTagsInputForm extends Component implements HasActions, HasSchemas
         $this->form->saveRelationships();
     }
 
+    public function saveOnly(): void
+    {
+        $this->record->load('tags');
+        $this->form->saveRelationships();
+    }
+
     public function render(): View
     {
         return view('livewire.form');

--- a/tests/src/Forms/Components/CheckboxListTest.php
+++ b/tests/src/Forms/Components/CheckboxListTest.php
@@ -443,6 +443,48 @@ class CheckboxListWithBelongsToManyRelationship extends Component implements Has
     }
 }
 
+class CheckboxListWithEagerLoadedBelongsToManyRelationship extends Component implements HasActions, HasSchemas
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+
+    public $data = [];
+
+    public User $record;
+
+    public function mount(): void
+    {
+        $this->record->load('teams');
+        $this->form->fill([]);
+    }
+
+    public function hydrate(): void
+    {
+        $this->record->load('teams');
+    }
+
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->schema([
+                CheckboxList::make('teams')
+                    ->relationship('teams', 'name'),
+            ])
+            ->model($this->record)
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->form->getState();
+    }
+
+    public function render(): View
+    {
+        return view('livewire.form');
+    }
+}
+
 class CheckboxListWithBelongsToManyRelationshipAndModifyQuery extends Component implements HasActions, HasSchemas
 {
     use InteractsWithActions;
@@ -1109,6 +1151,23 @@ describe('saving relationships', function (): void {
 
         expect($user->fresh()->teams)->toHaveCount(3);
         expect($modifyCallCount)->toBeGreaterThan(0);
+    });
+
+    it('invalidates the cached `BelongsToMany` relationship after save so a subsequent reload does not re-attach detached rows', function (): void {
+        $user = User::factory()->create();
+        $teams = Team::factory()->count(2)->create();
+        $user->teams()->attach($teams);
+
+        $component = livewire(CheckboxListWithEagerLoadedBelongsToManyRelationship::class, ['record' => $user])
+            ->fillForm(['teams' => []])
+            ->call('save');
+
+        expect($user->fresh()->teams)->toHaveCount(0)
+            ->and($component->instance()->data['teams'])->toBe([]);
+
+        $component->call('save');
+
+        expect($user->fresh()->teams)->toHaveCount(0);
     });
 });
 

--- a/tests/src/Forms/Components/ModalTableSelectTest.php
+++ b/tests/src/Forms/Components/ModalTableSelectTest.php
@@ -273,6 +273,50 @@ class ModalTableSelectWithBelongsToManyRelationship extends Component implements
     }
 }
 
+class ModalTableSelectWithEagerLoadedBelongsToManyRelationship extends Component implements HasActions, HasSchemas
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+
+    public $data = [];
+
+    public User $record;
+
+    public function mount(): void
+    {
+        $this->record->load('teams');
+        $this->form->fill([]);
+    }
+
+    public function hydrate(): void
+    {
+        $this->record->load('teams');
+    }
+
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->schema([
+                ModalTableSelect::make('teams')
+                    ->relationship('teams', 'name')
+                    ->tableConfiguration(TeamsTable::class)
+                    ->multiple(),
+            ])
+            ->model($this->record)
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->form->getState();
+    }
+
+    public function render(): View
+    {
+        return view('livewire.form');
+    }
+}
+
 class ModalTableSelectWithBelongsToManyRelationshipAndModifyQuery extends Component implements HasActions, HasSchemas
 {
     use InteractsWithActions;
@@ -813,6 +857,23 @@ describe('saving BelongsToMany relationships', function (): void {
         expect($pivotRows)->toHaveCount(2);
         expect($pivotRows->first()->role)->toBe('viewer');
         expect($pivotRows->last()->role)->toBe('viewer');
+    });
+
+    it('invalidates the cached `BelongsToMany` relationship after save so a subsequent reload does not re-attach detached rows', function (): void {
+        $user = User::factory()->create();
+        $teams = Team::factory()->count(2)->create();
+        $user->teams()->attach($teams);
+
+        $component = livewire(ModalTableSelectWithEagerLoadedBelongsToManyRelationship::class, ['record' => $user])
+            ->fillForm(['teams' => []])
+            ->call('save');
+
+        expect($user->fresh()->teams)->toHaveCount(0)
+            ->and($component->instance()->data['teams'])->toBe([]);
+
+        $component->call('save');
+
+        expect($user->fresh()->teams)->toHaveCount(0);
     });
 });
 

--- a/tests/src/Forms/Components/SelectTest.php
+++ b/tests/src/Forms/Components/SelectTest.php
@@ -225,32 +225,20 @@ describe('`BelongsToMany` relationship', function (): void {
         expect($user->teams->pluck('id')->sort()->values()->all())->toBe($teams->take(2)->pluck('id')->sort()->values()->all());
     });
 
-    it('clears `BelongsToMany` relationship and form state when emptied, without re-attaching on a subsequent save', function (): void {
-        // Regression: after `saveStateToRelationship()` detaches rows, the next call to
-        // `loadStateFromRelationship()` was reading the in-memory eager-loaded relation
-        // (still containing the detached rows). The form state was repopulated from that
-        // stale cache, so the UI re-showed the detached rows and any subsequent save
-        // re-synced them back into the pivot. The fix invalidates the cached relation
-        // on `$record` after every relationship write.
+    it('invalidates the cached `BelongsToMany` relationship after save so a subsequent reload does not re-attach detached rows', function (): void {
         $user = User::factory()->create();
         $teams = Team::factory()->count(2)->create();
         $user->teams()->attach($teams);
 
-        expect($user->teams)->toHaveCount(2);
-
-        $component = livewire(TestComponentWithBelongsToManyMultipleSelect::class, ['record' => $user])
+        $component = livewire(TestComponentWithEagerLoadedBelongsToManyMultipleSelect::class, ['record' => $user])
             ->fillForm(['teams' => []])
             ->call('save');
 
-        // Pivot is empty.
-        expect($user->fresh()->teams)->toHaveCount(0);
+        expect($user->fresh()->teams)->toHaveCount(0)
+            ->and($component->instance()->data['teams'])->toBe([]);
 
-        // Form state reflects the cleared selection — otherwise the UI re-shows
-        // the detached options and the next save re-attaches them.
-        expect($component->instance()->data['teams'])->toBe([]);
-
-        // A subsequent unrelated save must not silently re-attach the rows.
         $component->call('save');
+
         expect($user->fresh()->teams)->toHaveCount(0);
     });
 
@@ -1037,6 +1025,50 @@ class TestComponentWithBelongsToManyMultipleSelect extends Component implements 
     public function mount(): void
     {
         $this->form->fill($this->record->attributesToArray());
+    }
+
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->schema([
+                Select::make('teams')
+                    ->relationship('teams', 'name')
+                    ->multiple()
+                    ->preload(),
+            ])
+            ->model($this->record)
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->form->getState();
+    }
+
+    public function render(): View
+    {
+        return view('livewire.form');
+    }
+}
+
+class TestComponentWithEagerLoadedBelongsToManyMultipleSelect extends Component implements HasActions, HasSchemas
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+
+    public $data = [];
+
+    public User $record;
+
+    public function mount(): void
+    {
+        $this->record->load('teams');
+        $this->form->fill($this->record->attributesToArray());
+    }
+
+    public function hydrate(): void
+    {
+        $this->record->load('teams');
     }
 
     public function form(Schema $form): Schema

--- a/tests/src/Forms/Components/SelectTest.php
+++ b/tests/src/Forms/Components/SelectTest.php
@@ -225,6 +225,35 @@ describe('`BelongsToMany` relationship', function (): void {
         expect($user->teams->pluck('id')->sort()->values()->all())->toBe($teams->take(2)->pluck('id')->sort()->values()->all());
     });
 
+    it('clears `BelongsToMany` relationship and form state when emptied, without re-attaching on a subsequent save', function (): void {
+        // Regression: after `saveStateToRelationship()` detaches rows, the next call to
+        // `loadStateFromRelationship()` was reading the in-memory eager-loaded relation
+        // (still containing the detached rows). The form state was repopulated from that
+        // stale cache, so the UI re-showed the detached rows and any subsequent save
+        // re-synced them back into the pivot. The fix invalidates the cached relation
+        // on `$record` after every relationship write.
+        $user = User::factory()->create();
+        $teams = Team::factory()->count(2)->create();
+        $user->teams()->attach($teams);
+
+        expect($user->teams)->toHaveCount(2);
+
+        $component = livewire(TestComponentWithBelongsToManyMultipleSelect::class, ['record' => $user])
+            ->fillForm(['teams' => []])
+            ->call('save');
+
+        // Pivot is empty.
+        expect($user->fresh()->teams)->toHaveCount(0);
+
+        // Form state reflects the cleared selection — otherwise the UI re-shows
+        // the detached options and the next save re-attaches them.
+        expect($component->instance()->data['teams'])->toBe([]);
+
+        // A subsequent unrelated save must not silently re-attach the rows.
+        $component->call('save');
+        expect($user->fresh()->teams)->toHaveCount(0);
+    });
+
     it('can use `BelongsToMany` relationship as single select', function (): void {
         $user = User::factory()->create();
         $teams = Team::factory()->count(3)->create();

--- a/tests/src/Forms/Components/TableSelectTest.php
+++ b/tests/src/Forms/Components/TableSelectTest.php
@@ -397,6 +397,23 @@ describe('saving relationships', function (): void {
 
         expect($user->fresh()->company?->id)->toBe($companyA->id);
     });
+
+    it('invalidates the cached `BelongsToMany` relationship after save so a subsequent reload does not re-attach detached rows', function (): void {
+        $user = User::factory()->create();
+        $teams = Team::factory()->count(2)->create();
+        $user->teams()->attach($teams);
+
+        $component = livewire(TableSelectWithEagerLoadedBelongsToManyRelationship::class, ['record' => $user])
+            ->fillForm(['teams' => []])
+            ->call('save');
+
+        expect($user->fresh()->teams)->toHaveCount(0)
+            ->and($component->instance()->data['teams'])->toBe([]);
+
+        $component->call('save');
+
+        expect($user->fresh()->teams)->toHaveCount(0);
+    });
 });
 
 describe('properties', function (): void {
@@ -497,6 +514,50 @@ class TableSelectWithBelongsToManyRelationship extends Component implements HasA
     public function mount(): void
     {
         $this->form->fill([]);
+    }
+
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->schema([
+                TableSelect::make('teams')
+                    ->relationship('teams')
+                    ->tableConfiguration(TeamsTable::class)
+                    ->multiple(),
+            ])
+            ->model($this->record)
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $this->form->getState();
+    }
+
+    public function render(): View
+    {
+        return view('livewire.form');
+    }
+}
+
+class TableSelectWithEagerLoadedBelongsToManyRelationship extends Component implements HasActions, HasSchemas
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+
+    public $data = [];
+
+    public User $record;
+
+    public function mount(): void
+    {
+        $this->record->load('teams');
+        $this->form->fill([]);
+    }
+
+    public function hydrate(): void
+    {
+        $this->record->load('teams');
     }
 
     public function form(Schema $form): Schema

--- a/tests/src/SpatieTagsPlugin/SpatieTagsInputTest.php
+++ b/tests/src/SpatieTagsPlugin/SpatieTagsInputTest.php
@@ -209,6 +209,19 @@ describe('integration', function (): void {
         expect($freshRecord->getRelationValue('tags'))->toBeEmpty();
     });
 
+    it('invalidates the cached tags relation after syncing so subsequent reads do not return stale data', function (): void {
+        $record = Article::factory()->create();
+        $record->attachTags(['Old1', 'Old2']);
+
+        $component = livewire(SpatieTagsInputForm::class, ['record' => $record])
+            ->fillForm(['tags' => []])
+            ->call('saveOnly');
+
+        $liveRecord = $component->instance()->record;
+
+        expect($liveRecord->getRelationValue('tags'))->toBeEmpty();
+    });
+
     it('can load typed tags into form state', function (): void {
         $record = Article::factory()->create();
         $record->attachTag('Laravel', 'framework');


### PR DESCRIPTION
## Summary

`Select::saveStateToRelationship()` writes to the DB (`detach()` / `sync()` / `syncWithPivotValues()` for `BelongsToMany`, foreign-key `update()` for `HasOne`/`HasMany`, `associate()` for `BelongsTo`), but never invalidates the eager-loaded relation cached on `$record`.

That matters because `Schema::getState()` runs `saveRelationships()` and then `loadStateFromRelationships(shouldHydrate: true)` back-to-back in the same request, and the Select's `loadStateFromRelationshipsUsing` closure prefers the cached relation whenever `$record->relationLoaded($relationshipName)` is true:

```php
if (
    (! $modifyQueryUsing) &&
    (! str_contains($relationshipName, '.')) &&
    ($record = $component->getRecord()) instanceof Model &&
    $record->relationLoaded($relationshipName)
) {
    $relatedRecords = $record->getRelationValue($relationshipName);
    // ...rebuilds the form state from this stale collection
```

So the sequence on a save that empties a multi-select is:
1. User submits `roles: []`.
2. `saveStateToRelationship()` detaches the row → pivot is empty in the DB.
3. `loadStateFromRelationship()` runs, sees the still-loaded `$record->roles` collection (which has not been touched in memory) and rebuilds the form state to `[<row id>]` again.
4. The UI re-shows the detached option.
5. Any subsequent save (even one that doesn't touch this field) re-syncs `[<row id>]` back into the pivot — silently re-attaching the row the user just removed.

## Fix

Call `$record->unsetRelation($relationshipName)` after each write path in `saveStateToRelationship()`. The next read goes to the DB, and the form state matches what the user actually submitted.

## Reproduction

Without this fix, the added test in `tests/src/Forms/Components/SelectTest.php` fails on its third `expect()` (form state) and on the post-second-save assertion. With this fix, it passes.

```php
$user = User::factory()->create();
$teams = Team::factory()->count(2)->create();
$user->teams()->attach($teams);

$component = livewire(TestComponentWithBelongsToManyMultipleSelect::class, ['record' => $user])
    ->fillForm(['teams' => []])
    ->call('save');

expect($user->fresh()->teams)->toHaveCount(0);              // pivot empty ✓
expect($component->instance()->data['teams'])->toBe([]);    // ← FAILS without fix (state is repopulated to the pre-detach IDs)
$component->call('save');
expect($user->fresh()->teams)->toHaveCount(0);              // ← FAILS without fix (re-attached on the second save)
```

## Why it surfaces in the wild

A common pattern with `Select::make('roles')->relationship('roles', 'name')->multiple()->live()` (or any pivot-backed multi-select on an Edit page): the user removes a previously-selected option and saves, and the option visually comes back. If they then change anything else and save without first refreshing, the option is re-synced into the pivot. The DB does end up empty after the first save, but the UI behaviour is misleading and the next save undoes the change.

## Test plan

- [x] Added regression test covering `BelongsToMany`: clearing the field empties both the pivot and the form state, and a follow-up unrelated save does not re-attach.
- [ ] Existing `Select` tests still pass (`pest tests/src/Forms/Components/SelectTest.php`).